### PR TITLE
[IMP] l10n_br,l10n_br_website_sale: better Brazilian addresses support

### DIFF
--- a/addons/l10n_br/__manifest__.py
+++ b/addons/l10n_br/__manifest__.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Brazilian - Accounting',
+    'version': '1.0',
     'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/brazil.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['br'],
@@ -61,6 +62,7 @@ Create electronic sales invoices with Avatax.
         'views/res_partner_views.xml',
         'data/account_tax_report_data.xml',
         'data/res_country_data.xml',
+        'data/res.city.csv',
         'data/l10n_latam.identification.type.csv',
         'data/l10n_latam.document.type.csv',
         'views/account_view.xml',

--- a/addons/l10n_br/data/res.city.csv
+++ b/addons/l10n_br/data/res.city.csv
@@ -1,0 +1,5571 @@
+id,country_id:id,state_id:id,name
+city_br_001,base.br,base.state_br_sp,São Paulo
+city_br_002,base.br,base.state_br_rj,Rio de Janeiro
+city_br_003,base.br,base.state_br_df,Brasília
+city_br_004,base.br,base.state_br_ce,Fortaleza
+city_br_005,base.br,base.state_br_ba,Salvador
+city_br_006,base.br,base.state_br_mg,Belo Horizonte
+city_br_007,base.br,base.state_br_am,Manaus
+city_br_008,base.br,base.state_br_pr,Curitiba
+city_br_009,base.br,base.state_br_pe,Recife
+city_br_010,base.br,base.state_br_go,Goiânia
+city_br_011,base.br,base.state_br_rs,Porto Alegre
+city_br_012,base.br,base.state_br_pa,Belém
+city_br_013,base.br,base.state_br_sp,Guarulhos
+city_br_014,base.br,base.state_br_sp,Campinas
+city_br_015,base.br,base.state_br_ma,São Luís
+city_br_016,base.br,base.state_br_al,Maceió
+city_br_017,base.br,base.state_br_ms,Campo Grande
+city_br_018,base.br,base.state_br_rj,São Gonçalo
+city_br_019,base.br,base.state_br_pi,Teresina
+city_br_020,base.br,base.state_br_pb,João Pessoa
+city_br_021,base.br,base.state_br_sp,São Bernardo do Campo
+city_br_022,base.br,base.state_br_rj,Duque de Caxias
+city_br_023,base.br,base.state_br_rj,Nova Iguaçu
+city_br_024,base.br,base.state_br_rn,Natal
+city_br_025,base.br,base.state_br_sp,Santo André
+city_br_026,base.br,base.state_br_sp,Osasco
+city_br_027,base.br,base.state_br_sp,Sorocaba
+city_br_028,base.br,base.state_br_mg,Uberlândia
+city_br_029,base.br,base.state_br_sp,Ribeirão Preto
+city_br_030,base.br,base.state_br_sp,São José dos Campos
+city_br_031,base.br,base.state_br_mt,Cuiabá
+city_br_032,base.br,base.state_br_pe,Jaboatão dos Guararapes
+city_br_033,base.br,base.state_br_mg,Contagem
+city_br_034,base.br,base.state_br_sc,Joinville
+city_br_035,base.br,base.state_br_ba,Feira de Santana
+city_br_036,base.br,base.state_br_se,Aracaju
+city_br_037,base.br,base.state_br_pr,Londrina
+city_br_038,base.br,base.state_br_mg,Juiz de Fora
+city_br_039,base.br,base.state_br_sc,Florianópolis
+city_br_040,base.br,base.state_br_go,Aparecida de Goiânia
+city_br_041,base.br,base.state_br_es,Serra
+city_br_042,base.br,base.state_br_rj,Campos dos Goytacazes
+city_br_043,base.br,base.state_br_rj,Belford Roxo
+city_br_044,base.br,base.state_br_rj,Niterói
+city_br_045,base.br,base.state_br_sp,São José do Rio Preto
+city_br_046,base.br,base.state_br_pa,Ananindeua
+city_br_047,base.br,base.state_br_es,Vila Velha
+city_br_048,base.br,base.state_br_rs,Caxias do Sul
+city_br_049,base.br,base.state_br_ro,Porto Velho
+city_br_050,base.br,base.state_br_sp,Mogi das Cruzes
+city_br_051,base.br,base.state_br_sp,Jundiaí
+city_br_052,base.br,base.state_br_ap,Macapá
+city_br_053,base.br,base.state_br_rj,São João de Meriti
+city_br_054,base.br,base.state_br_sp,Piracicaba
+city_br_055,base.br,base.state_br_pb,Campina Grande
+city_br_056,base.br,base.state_br_sp,Santos
+city_br_057,base.br,base.state_br_sp,Mauá
+city_br_058,base.br,base.state_br_mg,Montes Claros
+city_br_059,base.br,base.state_br_rr,Boa Vista
+city_br_060,base.br,base.state_br_mg,Betim
+city_br_061,base.br,base.state_br_pr,Maringá
+city_br_062,base.br,base.state_br_go,Anápolis
+city_br_063,base.br,base.state_br_sp,Diadema
+city_br_064,base.br,base.state_br_sp,Carapicuíba
+city_br_065,base.br,base.state_br_pe,Petrolina
+city_br_066,base.br,base.state_br_sp,Bauru
+city_br_067,base.br,base.state_br_pe,Caruaru
+city_br_068,base.br,base.state_br_ba,Vitória da Conquista
+city_br_069,base.br,base.state_br_sp,Itaquaquecetuba
+city_br_070,base.br,base.state_br_ac,Rio Branco
+city_br_071,base.br,base.state_br_sc,Blumenau
+city_br_072,base.br,base.state_br_pr,Ponta Grossa
+city_br_073,base.br,base.state_br_ce,Caucaia
+city_br_074,base.br,base.state_br_es,Cariacica
+city_br_075,base.br,base.state_br_sp,Franca
+city_br_076,base.br,base.state_br_pe,Olinda
+city_br_077,base.br,base.state_br_sp,Praia Grande
+city_br_078,base.br,base.state_br_pr,Cascavel
+city_br_079,base.br,base.state_br_rs,Canoas
+city_br_080,base.br,base.state_br_pe,Paulista
+city_br_081,base.br,base.state_br_mg,Uberaba
+city_br_082,base.br,base.state_br_pa,Santarém
+city_br_083,base.br,base.state_br_sp,São Vicente
+city_br_084,base.br,base.state_br_mg,Ribeirão das Neves
+city_br_085,base.br,base.state_br_pr,São José dos Pinhais
+city_br_086,base.br,base.state_br_rs,Pelotas
+city_br_087,base.br,base.state_br_es,Vitória
+city_br_088,base.br,base.state_br_sp,Barueri
+city_br_089,base.br,base.state_br_sp,Taubaté
+city_br_090,base.br,base.state_br_sp,Suzano
+city_br_091,base.br,base.state_br_to,Palmas
+city_br_092,base.br,base.state_br_ba,Camaçari
+city_br_093,base.br,base.state_br_mt,Várzea Grande
+city_br_094,base.br,base.state_br_sp,Limeira
+city_br_095,base.br,base.state_br_sp,Guarujá
+city_br_096,base.br,base.state_br_ce,Juazeiro do Norte
+city_br_097,base.br,base.state_br_pr,Foz do Iguaçu
+city_br_098,base.br,base.state_br_sp,Sumaré
+city_br_099,base.br,base.state_br_rj,Petrópolis
+city_br_100,base.br,base.state_br_sp,Cotia
+city_br_101,base.br,base.state_br_sp,Taboão da Serra
+city_br_102,base.br,base.state_br_ma,Imperatriz
+city_br_103,base.br,base.state_br_rs,Santa Maria
+city_br_104,base.br,base.state_br_sc,São José
+city_br_105,base.br,base.state_br_pa,Marabá
+city_br_106,base.br,base.state_br_pa,Parauapebas
+city_br_107,base.br,base.state_br_rs,Gravataí
+city_br_108,base.br,base.state_br_rn,Mossoró
+city_br_109,base.br,base.state_br_sc,Itajaí
+city_br_110,base.br,base.state_br_rj,Volta Redonda
+city_br_111,base.br,base.state_br_mg,Governador Valadares
+city_br_112,base.br,base.state_br_sp,Indaiatuba
+city_br_113,base.br,base.state_br_sp,São Carlos
+city_br_114,base.br,base.state_br_sc,Chapecó
+city_br_115,base.br,base.state_br_rn,Parnamirim
+city_br_116,base.br,base.state_br_sp,Embu das Artes
+city_br_117,base.br,base.state_br_rj,Macaé
+city_br_118,base.br,base.state_br_mt,Rondonópolis
+city_br_119,base.br,base.state_br_ma,São José de Ribamar
+city_br_120,base.br,base.state_br_ms,Dourados
+city_br_121,base.br,base.state_br_sp,Araraquara
+city_br_122,base.br,base.state_br_sp,Jacareí
+city_br_123,base.br,base.state_br_sp,Marília
+city_br_124,base.br,base.state_br_sp,Americana
+city_br_125,base.br,base.state_br_sp,Hortolândia
+city_br_126,base.br,base.state_br_ba,Juazeiro
+city_br_127,base.br,base.state_br_al,Arapiraca
+city_br_128,base.br,base.state_br_ce,Maracanaú
+city_br_129,base.br,base.state_br_sp,Itapevi
+city_br_130,base.br,base.state_br_pr,Colombo
+city_br_131,base.br,base.state_br_mg,Divinópolis
+city_br_132,base.br,base.state_br_rj,Magé
+city_br_133,base.br,base.state_br_rs,Novo Hamburgo
+city_br_134,base.br,base.state_br_mg,Ipatinga
+city_br_135,base.br,base.state_br_mg,Sete Lagoas
+city_br_136,base.br,base.state_br_go,Rio Verde
+city_br_137,base.br,base.state_br_go,Águas Lindas de Goiás
+city_br_138,base.br,base.state_br_sp,Presidente Prudente
+city_br_139,base.br,base.state_br_rj,Itaboraí
+city_br_140,base.br,base.state_br_rs,Viamão
+city_br_141,base.br,base.state_br_sc,Palhoça
+city_br_142,base.br,base.state_br_rj,Cabo Frio
+city_br_143,base.br,base.state_br_mg,Santa Luzia
+city_br_144,base.br,base.state_br_rs,São Leopoldo
+city_br_145,base.br,base.state_br_sc,Criciúma
+city_br_146,base.br,base.state_br_go,Luziânia
+city_br_147,base.br,base.state_br_rs,Passo Fundo
+city_br_148,base.br,base.state_br_ba,Lauro de Freitas
+city_br_149,base.br,base.state_br_pe,Cabo de Santo Agostinho
+city_br_150,base.br,base.state_br_ce,Sobral
+city_br_151,base.br,base.state_br_sp,Rio Claro
+city_br_152,base.br,base.state_br_sp,Araçatuba
+city_br_153,base.br,base.state_br_go,Valparaíso de Goiás
+city_br_154,base.br,base.state_br_rj,Maricá
+city_br_155,base.br,base.state_br_mt,Sinop
+city_br_156,base.br,base.state_br_se,Nossa Senhora do Socorro
+city_br_157,base.br,base.state_br_pa,Castanhal
+city_br_158,base.br,base.state_br_rs,Rio Grande
+city_br_159,base.br,base.state_br_rj,Nova Friburgo
+city_br_160,base.br,base.state_br_rs,Alvorada
+city_br_161,base.br,base.state_br_ba,Itabuna
+city_br_162,base.br,base.state_br_es,Cachoeiro de Itapemirim
+city_br_163,base.br,base.state_br_sp,Santa Bárbara d'Oeste
+city_br_164,base.br,base.state_br_sc,Jaraguá do Sul
+city_br_165,base.br,base.state_br_pr,Guarapuava
+city_br_166,base.br,base.state_br_sp,Ferraz de Vasconcelos
+city_br_167,base.br,base.state_br_ba,Ilhéus
+city_br_168,base.br,base.state_br_sp,Bragança Paulista
+city_br_169,base.br,base.state_br_ma,Timon
+city_br_170,base.br,base.state_br_to,Araguaína
+city_br_171,base.br,base.state_br_mg,Ibirité
+city_br_172,base.br,base.state_br_rj,Barra Mansa
+city_br_173,base.br,base.state_br_sp,Itu
+city_br_174,base.br,base.state_br_ba,Porto Seguro
+city_br_175,base.br,base.state_br_rj,Angra dos Reis
+city_br_176,base.br,base.state_br_rj,Mesquita
+city_br_177,base.br,base.state_br_es,Linhares
+city_br_178,base.br,base.state_br_sp,São Caetano do Sul
+city_br_179,base.br,base.state_br_sp,Pindamonhangaba
+city_br_180,base.br,base.state_br_sp,Francisco Morato
+city_br_181,base.br,base.state_br_rj,Teresópolis
+city_br_182,base.br,base.state_br_sc,Lages
+city_br_183,base.br,base.state_br_mg,Poços de Caldas
+city_br_184,base.br,base.state_br_pi,Parnaíba
+city_br_185,base.br,base.state_br_ba,Barreiras
+city_br_186,base.br,base.state_br_mg,Patos de Minas
+city_br_187,base.br,base.state_br_ba,Jequié
+city_br_188,base.br,base.state_br_sp,Atibaia
+city_br_189,base.br,base.state_br_sp,Itapecerica da Serra
+city_br_190,base.br,base.state_br_pa,Abaetetuba
+city_br_191,base.br,base.state_br_sp,Itapetininga
+city_br_192,base.br,base.state_br_ma,Caxias
+city_br_193,base.br,base.state_br_rj,Rio das Ostras
+city_br_194,base.br,base.state_br_go,Senador Canedo
+city_br_195,base.br,base.state_br_sp,Santana de Parnaíba
+city_br_196,base.br,base.state_br_sp,Mogi Guaçu
+city_br_197,base.br,base.state_br_mg,Pouso Alegre
+city_br_198,base.br,base.state_br_pr,Araucária
+city_br_199,base.br,base.state_br_ba,Alagoinhas
+city_br_200,base.br,base.state_br_pr,Toledo
+city_br_201,base.br,base.state_br_pb,Santa Rita
+city_br_202,base.br,base.state_br_pr,Fazenda Rio Grande
+city_br_203,base.br,base.state_br_pe,Camaragibe
+city_br_204,base.br,base.state_br_rj,Nilópolis
+city_br_205,base.br,base.state_br_pr,Paranaguá
+city_br_206,base.br,base.state_br_ma,Paço do Lumiar
+city_br_207,base.br,base.state_br_ba,Teixeira de Freitas
+city_br_208,base.br,base.state_br_sp,Botucatu
+city_br_209,base.br,base.state_br_sp,Franco da Rocha
+city_br_210,base.br,base.state_br_pe,Garanhuns
+city_br_211,base.br,base.state_br_go,Trindade
+city_br_212,base.br,base.state_br_sc,Brusque
+city_br_213,base.br,base.state_br_rj,Queimados
+city_br_214,base.br,base.state_br_sc,Balneário Camboriú
+city_br_215,base.br,base.state_br_mg,Teófilo Otoni
+city_br_216,base.br,base.state_br_mg,Varginha
+city_br_217,base.br,base.state_br_pr,Campo Largo
+city_br_218,base.br,base.state_br_rs,Cachoeirinha
+city_br_219,base.br,base.state_br_sp,Caraguatatuba
+city_br_220,base.br,base.state_br_sp,Salto
+city_br_221,base.br,base.state_br_pa,Cametá
+city_br_222,base.br,base.state_br_pe,Vitória de Santo Antão
+city_br_223,base.br,base.state_br_sp,Jaú
+city_br_224,base.br,base.state_br_rs,Santa Cruz do Sul
+city_br_225,base.br,base.state_br_ms,Três Lagoas
+city_br_226,base.br,base.state_br_rs,Sapucaia do Sul
+city_br_227,base.br,base.state_br_mg,Conselheiro Lafaiete
+city_br_228,base.br,base.state_br_ce,Itapipoca
+city_br_229,base.br,base.state_br_ce,Crato
+city_br_230,base.br,base.state_br_sp,Araras
+city_br_231,base.br,base.state_br_pr,Apucarana
+city_br_232,base.br,base.state_br_rj,Araruama
+city_br_233,base.br,base.state_br_rj,Resende
+city_br_234,base.br,base.state_br_mg,Sabará
+city_br_235,base.br,base.state_br_mg,Vespasiano
+city_br_236,base.br,base.state_br_sp,Votorantim
+city_br_237,base.br,base.state_br_pr,Pinhais
+city_br_238,base.br,base.state_br_sp,Sertãozinho
+city_br_239,base.br,base.state_br_pa,Barcarena
+city_br_240,base.br,base.state_br_sp,Valinhos
+city_br_241,base.br,base.state_br_pa,Altamira
+city_br_242,base.br,base.state_br_mg,Barbacena
+city_br_243,base.br,base.state_br_es,Guarapari
+city_br_244,base.br,base.state_br_ro,Ji-Paraná
+city_br_245,base.br,base.state_br_sp,Tatuí
+city_br_246,base.br,base.state_br_es,São Mateus
+city_br_247,base.br,base.state_br_pa,Itaituba
+city_br_248,base.br,base.state_br_rs,Bento Gonçalves
+city_br_249,base.br,base.state_br_pa,Bragança
+city_br_250,base.br,base.state_br_sp,Barretos
+city_br_251,base.br,base.state_br_sp,Itatiba
+city_br_252,base.br,base.state_br_es,Colatina
+city_br_253,base.br,base.state_br_pr,Almirante Tamandaré
+city_br_254,base.br,base.state_br_pr,Arapongas
+city_br_255,base.br,base.state_br_sp,Birigui
+city_br_256,base.br,base.state_br_pr,Piraquara
+city_br_257,base.br,base.state_br_pr,Sarandi
+city_br_258,base.br,base.state_br_sp,Jandira
+city_br_259,base.br,base.state_br_sp,Guaratinguetá
+city_br_260,base.br,base.state_br_rs,Bagé
+city_br_261,base.br,base.state_br_mg,Araguari
+city_br_262,base.br,base.state_br_rs,Uruguaiana
+city_br_263,base.br,base.state_br_pr,Umuarama
+city_br_264,base.br,base.state_br_rj,Itaguaí
+city_br_265,base.br,base.state_br_rn,São Gonçalo do Amarante
+city_br_266,base.br,base.state_br_sp,Catanduva
+city_br_267,base.br,base.state_br_sp,Várzea Paulista
+city_br_268,base.br,base.state_br_go,Formosa
+city_br_269,base.br,base.state_br_sp,Ribeirão Pires
+city_br_270,base.br,base.state_br_pe,Igarassu
+city_br_271,base.br,base.state_br_ba,Simões Filho
+city_br_272,base.br,base.state_br_go,Catalão
+city_br_273,base.br,base.state_br_ma,Codó
+city_br_274,base.br,base.state_br_ba,Eunápolis
+city_br_275,base.br,base.state_br_mg,Itabira
+city_br_276,base.br,base.state_br_ba,Paulo Afonso
+city_br_277,base.br,base.state_br_sp,Itanhaém
+city_br_278,base.br,base.state_br_sp,Cubatão
+city_br_279,base.br,base.state_br_mg,Passos
+city_br_280,base.br,base.state_br_mg,Nova Lima
+city_br_281,base.br,base.state_br_mg,Araxá
+city_br_282,base.br,base.state_br_pe,São Lourenço da Mata
+city_br_283,base.br,base.state_br_mt,Sorriso
+city_br_284,base.br,base.state_br_sp,Paulínia
+city_br_285,base.br,base.state_br_pa,Marituba
+city_br_286,base.br,base.state_br_sc,Tubarão
+city_br_287,base.br,base.state_br_go,Itumbiara
+city_br_288,base.br,base.state_br_ba,Luís Eduardo Magalhães
+city_br_289,base.br,base.state_br_ap,Santana
+city_br_290,base.br,base.state_br_pr,Cambé
+city_br_291,base.br,base.state_br_pa,Breves
+city_br_292,base.br,base.state_br_ma,Açailândia
+city_br_293,base.br,base.state_br_mt,Tangará da Serra
+city_br_294,base.br,base.state_br_go,Jataí
+city_br_295,base.br,base.state_br_rs,Erechim
+city_br_296,base.br,base.state_br_mg,Nova Serrana
+city_br_297,base.br,base.state_br_pa,Paragominas
+city_br_298,base.br,base.state_br_ce,Maranguape
+city_br_299,base.br,base.state_br_go,Planaltina
+city_br_300,base.br,base.state_br_mg,Lavras
+city_br_301,base.br,base.state_br_mg,Coronel Fabriciano
+city_br_302,base.br,base.state_br_mg,Muriaé
+city_br_303,base.br,base.state_br_rj,São Pedro da Aldeia
+city_br_304,base.br,base.state_br_sp,Ourinhos
+city_br_305,base.br,base.state_br_go,Novo Gama
+city_br_306,base.br,base.state_br_sp,Poá
+city_br_307,base.br,base.state_br_ma,Bacabal
+city_br_308,base.br,base.state_br_am,Itacoatiara
+city_br_309,base.br,base.state_br_se,Itabaiana
+city_br_310,base.br,base.state_br_mg,Ubá
+city_br_311,base.br,base.state_br_pb,Patos
+city_br_312,base.br,base.state_br_sc,Camboriú
+city_br_313,base.br,base.state_br_ba,Santo Antônio de Jesus
+city_br_314,base.br,base.state_br_mg,Ituiutaba
+city_br_315,base.br,base.state_br_am,Manacapuru
+city_br_316,base.br,base.state_br_ma,Balsas
+city_br_317,base.br,base.state_br_se,Lagarto
+city_br_318,base.br,base.state_br_sp,Assis
+city_br_319,base.br,base.state_br_rj,Itaperuna
+city_br_320,base.br,base.state_br_go,Abadia de Goiás
+city_br_321,base.br,base.state_br_mg,Abadia dos Dourados
+city_br_322,base.br,base.state_br_go,Abadiânia
+city_br_323,base.br,base.state_br_mg,Abaeté
+city_br_324,base.br,base.state_br_ce,Abaiara
+city_br_325,base.br,base.state_br_ba,Abaíra
+city_br_326,base.br,base.state_br_ba,Abaré
+city_br_327,base.br,base.state_br_pr,Abatiá
+city_br_328,base.br,base.state_br_sc,Abdon Batista
+city_br_329,base.br,base.state_br_pa,Abel Figueiredo
+city_br_330,base.br,base.state_br_sc,Abelardo Luz
+city_br_331,base.br,base.state_br_mg,Abre Campo
+city_br_332,base.br,base.state_br_pe,Abreu e Lima
+city_br_333,base.br,base.state_br_to,Abreulândia
+city_br_334,base.br,base.state_br_mg,Acaiaca
+city_br_335,base.br,base.state_br_ba,Acajutiba
+city_br_336,base.br,base.state_br_pa,Acará
+city_br_337,base.br,base.state_br_ce,Acarape
+city_br_338,base.br,base.state_br_ce,Acaraú
+city_br_339,base.br,base.state_br_rn,Acari
+city_br_340,base.br,base.state_br_pi,Acauã
+city_br_341,base.br,base.state_br_rs,Aceguá
+city_br_342,base.br,base.state_br_ce,Acopiara
+city_br_343,base.br,base.state_br_mt,Acorizal
+city_br_344,base.br,base.state_br_ac,Acrelândia
+city_br_345,base.br,base.state_br_go,Acreúna
+city_br_346,base.br,base.state_br_rn,Açu
+city_br_347,base.br,base.state_br_mg,Açucena
+city_br_348,base.br,base.state_br_sp,Adamantina
+city_br_349,base.br,base.state_br_go,Adelândia
+city_br_350,base.br,base.state_br_sp,Adolfo
+city_br_351,base.br,base.state_br_pr,Adrianópolis
+city_br_352,base.br,base.state_br_ba,Adustina
+city_br_353,base.br,base.state_br_pe,Afogados da Ingazeira
+city_br_354,base.br,base.state_br_rn,Afonso Bezerra
+city_br_355,base.br,base.state_br_es,Afonso Cláudio
+city_br_356,base.br,base.state_br_ma,Afonso Cunha
+city_br_357,base.br,base.state_br_pe,Afrânio
+city_br_358,base.br,base.state_br_pa,Afuá
+city_br_359,base.br,base.state_br_pe,Agrestina
+city_br_360,base.br,base.state_br_pi,Agricolândia
+city_br_361,base.br,base.state_br_sc,Agrolândia
+city_br_362,base.br,base.state_br_sc,Agronômica
+city_br_363,base.br,base.state_br_pa,Água Azul do Norte
+city_br_364,base.br,base.state_br_mg,Água Boa
+city_br_365,base.br,base.state_br_mt,Água Boa
+city_br_366,base.br,base.state_br_al,Água Branca
+city_br_367,base.br,base.state_br_pb,Água Branca
+city_br_368,base.br,base.state_br_pi,Água Branca
+city_br_369,base.br,base.state_br_ms,Água Clara
+city_br_370,base.br,base.state_br_mg,Água Comprida
+city_br_371,base.br,base.state_br_sc,Água Doce
+city_br_372,base.br,base.state_br_ma,Água Doce do Maranhão
+city_br_373,base.br,base.state_br_es,Água Doce do Norte
+city_br_374,base.br,base.state_br_ba,Água Fria
+city_br_375,base.br,base.state_br_go,Água Fria de Goiás
+city_br_376,base.br,base.state_br_go,Água Limpa
+city_br_377,base.br,base.state_br_rn,Água Nova
+city_br_378,base.br,base.state_br_pe,Água Preta
+city_br_379,base.br,base.state_br_rs,Água Santa
+city_br_380,base.br,base.state_br_sp,Aguaí
+city_br_381,base.br,base.state_br_mg,Aguanil
+city_br_382,base.br,base.state_br_pe,Águas Belas
+city_br_383,base.br,base.state_br_sp,Águas da Prata
+city_br_384,base.br,base.state_br_sc,Águas de Chapecó
+city_br_385,base.br,base.state_br_sp,Águas de Lindóia
+city_br_386,base.br,base.state_br_sp,Águas de Santa Bárbara
+city_br_387,base.br,base.state_br_sp,Águas de São Pedro
+city_br_388,base.br,base.state_br_mg,Águas Formosas
+city_br_389,base.br,base.state_br_sc,Águas Frias
+city_br_390,base.br,base.state_br_sc,Águas Mornas
+city_br_391,base.br,base.state_br_mg,Águas Vermelhas
+city_br_392,base.br,base.state_br_rs,Agudo
+city_br_393,base.br,base.state_br_sp,Agudos
+city_br_394,base.br,base.state_br_pr,Agudos do Sul
+city_br_395,base.br,base.state_br_es,Águia Branca
+city_br_396,base.br,base.state_br_pb,Aguiar
+city_br_397,base.br,base.state_br_to,Aguiarnópolis
+city_br_398,base.br,base.state_br_mg,Aimorés
+city_br_399,base.br,base.state_br_ba,Aiquara
+city_br_400,base.br,base.state_br_ce,Aiuaba
+city_br_401,base.br,base.state_br_mg,Aiuruoca
+city_br_402,base.br,base.state_br_rs,Ajuricaba
+city_br_403,base.br,base.state_br_mg,Alagoa
+city_br_404,base.br,base.state_br_pb,Alagoa Grande
+city_br_405,base.br,base.state_br_pb,Alagoa Nova
+city_br_406,base.br,base.state_br_pb,Alagoinha
+city_br_407,base.br,base.state_br_pe,Alagoinha
+city_br_408,base.br,base.state_br_pi,Alagoinha do Piauí
+city_br_409,base.br,base.state_br_sp,Alambari
+city_br_410,base.br,base.state_br_mg,Albertina
+city_br_411,base.br,base.state_br_ma,Alcântara
+city_br_412,base.br,base.state_br_ce,Alcântaras
+city_br_413,base.br,base.state_br_pb,Alcantil
+city_br_414,base.br,base.state_br_ms,Alcinópolis
+city_br_415,base.br,base.state_br_ba,Alcobaça
+city_br_416,base.br,base.state_br_ma,Aldeias Altas
+city_br_417,base.br,base.state_br_rs,Alecrim
+city_br_418,base.br,base.state_br_es,Alegre
+city_br_419,base.br,base.state_br_rs,Alegrete
+city_br_420,base.br,base.state_br_pi,Alegrete do Piauí
+city_br_421,base.br,base.state_br_rs,Alegria
+city_br_422,base.br,base.state_br_mg,Além Paraíba
+city_br_423,base.br,base.state_br_pa,Alenquer
+city_br_424,base.br,base.state_br_rn,Alexandria
+city_br_425,base.br,base.state_br_go,Alexânia
+city_br_426,base.br,base.state_br_mg,Alfenas
+city_br_427,base.br,base.state_br_es,Alfredo Chaves
+city_br_428,base.br,base.state_br_sp,Alfredo Marcondes
+city_br_429,base.br,base.state_br_mg,Alfredo Vasconcelos
+city_br_430,base.br,base.state_br_sc,Alfredo Wagner
+city_br_431,base.br,base.state_br_pb,Algodão de Jandaíra
+city_br_432,base.br,base.state_br_pb,Alhandra
+city_br_433,base.br,base.state_br_pe,Aliança
+city_br_434,base.br,base.state_br_to,Aliança do Tocantins
+city_br_435,base.br,base.state_br_ba,Almadina
+city_br_436,base.br,base.state_br_to,Almas
+city_br_437,base.br,base.state_br_pa,Almeirim
+city_br_438,base.br,base.state_br_mg,Almenara
+city_br_439,base.br,base.state_br_rn,Almino Afonso
+city_br_440,base.br,base.state_br_rs,Almirante Tamandaré do Sul
+city_br_441,base.br,base.state_br_go,Aloândia
+city_br_442,base.br,base.state_br_mg,Alpercata
+city_br_443,base.br,base.state_br_rs,Alpestre
+city_br_444,base.br,base.state_br_mg,Alpinópolis
+city_br_445,base.br,base.state_br_mt,Alta Floresta
+city_br_446,base.br,base.state_br_ro,Alta Floresta D'Oeste
+city_br_447,base.br,base.state_br_sp,Altair
+city_br_448,base.br,base.state_br_ma,Altamira do Maranhão
+city_br_449,base.br,base.state_br_pr,Altamira do Paraná
+city_br_450,base.br,base.state_br_ce,Altaneira
+city_br_451,base.br,base.state_br_mg,Alterosa
+city_br_452,base.br,base.state_br_pe,Altinho
+city_br_453,base.br,base.state_br_sp,Altinópolis
+city_br_454,base.br,base.state_br_rr,Alto Alegre
+city_br_455,base.br,base.state_br_rs,Alto Alegre
+city_br_456,base.br,base.state_br_sp,Alto Alegre
+city_br_457,base.br,base.state_br_ma,Alto Alegre do Maranhão
+city_br_458,base.br,base.state_br_ma,Alto Alegre do Pindaré
+city_br_459,base.br,base.state_br_ro,Alto Alegre dos Parecis
+city_br_460,base.br,base.state_br_mt,Alto Araguaia
+city_br_461,base.br,base.state_br_sc,Alto Bela Vista
+city_br_462,base.br,base.state_br_mt,Alto Boa Vista
+city_br_463,base.br,base.state_br_mg,Alto Caparaó
+city_br_464,base.br,base.state_br_rn,Alto do Rodrigues
+city_br_465,base.br,base.state_br_rs,Alto Feliz
+city_br_466,base.br,base.state_br_mt,Alto Garças
+city_br_467,base.br,base.state_br_go,Alto Horizonte
+city_br_468,base.br,base.state_br_mg,Alto Jequitibá
+city_br_469,base.br,base.state_br_pi,Alto Longá
+city_br_470,base.br,base.state_br_mt,Alto Paraguai
+city_br_471,base.br,base.state_br_pr,Alto Paraíso
+city_br_472,base.br,base.state_br_ro,Alto Paraíso
+city_br_473,base.br,base.state_br_go,Alto Paraíso de Goiás
+city_br_474,base.br,base.state_br_pr,Alto Paraná
+city_br_475,base.br,base.state_br_ma,Alto Parnaíba
+city_br_476,base.br,base.state_br_pr,Alto Piquiri
+city_br_477,base.br,base.state_br_mg,Alto Rio Doce
+city_br_478,base.br,base.state_br_es,Alto Rio Novo
+city_br_479,base.br,base.state_br_ce,Alto Santo
+city_br_480,base.br,base.state_br_mt,Alto Taquari
+city_br_481,base.br,base.state_br_pr,Altônia
+city_br_482,base.br,base.state_br_pi,Altos
+city_br_483,base.br,base.state_br_sp,Alumínio
+city_br_484,base.br,base.state_br_am,Alvarães
+city_br_485,base.br,base.state_br_mg,Alvarenga
+city_br_486,base.br,base.state_br_sp,Álvares Florence
+city_br_487,base.br,base.state_br_sp,Álvares Machado
+city_br_488,base.br,base.state_br_sp,Álvaro de Carvalho
+city_br_489,base.br,base.state_br_sp,Alvinlândia
+city_br_490,base.br,base.state_br_mg,Alvinópolis
+city_br_491,base.br,base.state_br_to,Alvorada
+city_br_492,base.br,base.state_br_ro,Alvorada D'Oeste
+city_br_493,base.br,base.state_br_mg,Alvorada de Minas
+city_br_494,base.br,base.state_br_pi,Alvorada do Gurguéia
+city_br_495,base.br,base.state_br_go,Alvorada do Norte
+city_br_496,base.br,base.state_br_pr,Alvorada do Sul
+city_br_497,base.br,base.state_br_rr,Amajari
+city_br_498,base.br,base.state_br_ms,Amambai
+city_br_499,base.br,base.state_br_ap,Amapá
+city_br_500,base.br,base.state_br_ma,Amapá do Maranhão
+city_br_501,base.br,base.state_br_pr,Amaporã
+city_br_502,base.br,base.state_br_pe,Amaraji
+city_br_503,base.br,base.state_br_rs,Amaral Ferrador
+city_br_504,base.br,base.state_br_go,Amaralina
+city_br_505,base.br,base.state_br_pi,Amarante
+city_br_506,base.br,base.state_br_ma,Amarante do Maranhão
+city_br_507,base.br,base.state_br_ba,Amargosa
+city_br_508,base.br,base.state_br_am,Amaturá
+city_br_509,base.br,base.state_br_ba,Amélia Rodrigues
+city_br_510,base.br,base.state_br_ba,América Dourada
+city_br_511,base.br,base.state_br_go,Americano do Brasil
+city_br_512,base.br,base.state_br_sp,Américo Brasiliense
+city_br_513,base.br,base.state_br_sp,Américo de Campos
+city_br_514,base.br,base.state_br_rs,Ametista do Sul
+city_br_515,base.br,base.state_br_ce,Amontada
+city_br_516,base.br,base.state_br_go,Amorinópolis
+city_br_517,base.br,base.state_br_pb,Amparo
+city_br_518,base.br,base.state_br_sp,Amparo
+city_br_519,base.br,base.state_br_se,Amparo de São Francisco
+city_br_520,base.br,base.state_br_mg,Amparo do Serra
+city_br_521,base.br,base.state_br_pr,Ampére
+city_br_522,base.br,base.state_br_al,Anadia
+city_br_523,base.br,base.state_br_ba,Anagé
+city_br_524,base.br,base.state_br_pr,Anahy
+city_br_525,base.br,base.state_br_pa,Anajás
+city_br_526,base.br,base.state_br_ma,Anajatuba
+city_br_527,base.br,base.state_br_sp,Analândia
+city_br_528,base.br,base.state_br_am,Anamã
+city_br_529,base.br,base.state_br_to,Ananás
+city_br_530,base.br,base.state_br_pa,Anapu
+city_br_531,base.br,base.state_br_ma,Anapurus
+city_br_532,base.br,base.state_br_ms,Anastácio
+city_br_533,base.br,base.state_br_ms,Anaurilândia
+city_br_534,base.br,base.state_br_es,Anchieta
+city_br_535,base.br,base.state_br_sc,Anchieta
+city_br_536,base.br,base.state_br_ba,Andaraí
+city_br_537,base.br,base.state_br_pr,Andirá
+city_br_538,base.br,base.state_br_ba,Andorinha
+city_br_539,base.br,base.state_br_mg,Andradas
+city_br_540,base.br,base.state_br_sp,Andradina
+city_br_541,base.br,base.state_br_rs,André da Rocha
+city_br_542,base.br,base.state_br_mg,Andrelândia
+city_br_543,base.br,base.state_br_sp,Angatuba
+city_br_544,base.br,base.state_br_mg,Angelândia
+city_br_545,base.br,base.state_br_ms,Angélica
+city_br_546,base.br,base.state_br_pe,Angelim
+city_br_547,base.br,base.state_br_sc,Angelina
+city_br_548,base.br,base.state_br_ba,Angical
+city_br_549,base.br,base.state_br_pi,Angical do Piauí
+city_br_550,base.br,base.state_br_to,Angico
+city_br_551,base.br,base.state_br_rn,Angicos
+city_br_552,base.br,base.state_br_ba,Anguera
+city_br_553,base.br,base.state_br_pr,Ângulo
+city_br_554,base.br,base.state_br_go,Anhanguera
+city_br_555,base.br,base.state_br_sp,Anhembi
+city_br_556,base.br,base.state_br_sp,Anhumas
+city_br_557,base.br,base.state_br_go,Anicuns
+city_br_558,base.br,base.state_br_pi,Anísio de Abreu
+city_br_559,base.br,base.state_br_sc,Anita Garibaldi
+city_br_560,base.br,base.state_br_sc,Anitápolis
+city_br_561,base.br,base.state_br_am,Anori
+city_br_562,base.br,base.state_br_rs,Anta Gorda
+city_br_563,base.br,base.state_br_ba,Antas
+city_br_564,base.br,base.state_br_pr,Antonina
+city_br_565,base.br,base.state_br_ce,Antonina do Norte
+city_br_566,base.br,base.state_br_pi,Antônio Almeida
+city_br_567,base.br,base.state_br_ba,Antônio Cardoso
+city_br_568,base.br,base.state_br_mg,Antônio Carlos
+city_br_569,base.br,base.state_br_sc,Antônio Carlos
+city_br_570,base.br,base.state_br_mg,Antônio Dias
+city_br_571,base.br,base.state_br_ba,Antônio Gonçalves
+city_br_572,base.br,base.state_br_ms,Antônio João
+city_br_573,base.br,base.state_br_rn,Antônio Martins
+city_br_574,base.br,base.state_br_pr,Antônio Olinto
+city_br_575,base.br,base.state_br_rs,Antônio Prado
+city_br_576,base.br,base.state_br_mg,Antônio Prado de Minas
+city_br_577,base.br,base.state_br_pb,Aparecida
+city_br_578,base.br,base.state_br_sp,Aparecida
+city_br_579,base.br,base.state_br_sp,Aparecida d'Oeste
+city_br_580,base.br,base.state_br_go,Aparecida do Rio Doce
+city_br_581,base.br,base.state_br_to,Aparecida do Rio Negro
+city_br_582,base.br,base.state_br_ms,Aparecida do Taboado
+city_br_583,base.br,base.state_br_rj,Aperibé
+city_br_584,base.br,base.state_br_es,Apiacá
+city_br_585,base.br,base.state_br_mt,Apiacás
+city_br_586,base.br,base.state_br_sp,Apiaí
+city_br_587,base.br,base.state_br_ma,Apicum-Açu
+city_br_588,base.br,base.state_br_sc,Apiúna
+city_br_589,base.br,base.state_br_rn,Apodi
+city_br_590,base.br,base.state_br_ba,Aporá
+city_br_591,base.br,base.state_br_go,Aporé
+city_br_592,base.br,base.state_br_ba,Apuarema
+city_br_593,base.br,base.state_br_am,Apuí
+city_br_594,base.br,base.state_br_ce,Apuiarés
+city_br_595,base.br,base.state_br_se,Aquidabã
+city_br_596,base.br,base.state_br_ms,Aquidauana
+city_br_597,base.br,base.state_br_ce,Aquiraz
+city_br_598,base.br,base.state_br_sc,Arabutã
+city_br_599,base.br,base.state_br_pb,Araçagi
+city_br_600,base.br,base.state_br_mg,Araçaí
+city_br_601,base.br,base.state_br_sp,Araçariguama
+city_br_602,base.br,base.state_br_ba,Araçás
+city_br_603,base.br,base.state_br_ce,Aracati
+city_br_604,base.br,base.state_br_ba,Aracatu
+city_br_605,base.br,base.state_br_ba,Araci
+city_br_606,base.br,base.state_br_mg,Aracitaba
+city_br_607,base.br,base.state_br_ce,Aracoiaba
+city_br_608,base.br,base.state_br_pe,Araçoiaba
+city_br_609,base.br,base.state_br_sp,Araçoiaba da Serra
+city_br_610,base.br,base.state_br_es,Aracruz
+city_br_611,base.br,base.state_br_go,Araçu
+city_br_612,base.br,base.state_br_mg,Araçuaí
+city_br_613,base.br,base.state_br_go,Aragarças
+city_br_614,base.br,base.state_br_go,Aragoiânia
+city_br_615,base.br,base.state_br_to,Aragominas
+city_br_616,base.br,base.state_br_to,Araguacema
+city_br_617,base.br,base.state_br_to,Araguaçu
+city_br_618,base.br,base.state_br_mt,Araguaiana
+city_br_619,base.br,base.state_br_mt,Araguainha
+city_br_620,base.br,base.state_br_ma,Araguanã
+city_br_621,base.br,base.state_br_to,Araguanã
+city_br_622,base.br,base.state_br_go,Araguapaz
+city_br_623,base.br,base.state_br_to,Araguatins
+city_br_624,base.br,base.state_br_ma,Araioses
+city_br_625,base.br,base.state_br_ms,Aral Moreira
+city_br_626,base.br,base.state_br_ba,Aramari
+city_br_627,base.br,base.state_br_rs,Arambaré
+city_br_628,base.br,base.state_br_ma,Arame
+city_br_629,base.br,base.state_br_sp,Aramina
+city_br_630,base.br,base.state_br_sp,Arandu
+city_br_631,base.br,base.state_br_mg,Arantina
+city_br_632,base.br,base.state_br_sp,Arapeí
+city_br_633,base.br,base.state_br_to,Arapoema
+city_br_634,base.br,base.state_br_mg,Araponga
+city_br_635,base.br,base.state_br_mg,Araporã
+city_br_636,base.br,base.state_br_pr,Arapoti
+city_br_637,base.br,base.state_br_mg,Arapuá
+city_br_638,base.br,base.state_br_pr,Arapuã
+city_br_639,base.br,base.state_br_mt,Araputanga
+city_br_640,base.br,base.state_br_sc,Araquari
+city_br_641,base.br,base.state_br_pb,Arara
+city_br_642,base.br,base.state_br_sc,Araranguá
+city_br_643,base.br,base.state_br_ce,Ararendá
+city_br_644,base.br,base.state_br_ma,Arari
+city_br_645,base.br,base.state_br_rs,Araricá
+city_br_646,base.br,base.state_br_ce,Araripe
+city_br_647,base.br,base.state_br_pe,Araripina
+city_br_648,base.br,base.state_br_pb,Araruna
+city_br_649,base.br,base.state_br_pr,Araruna
+city_br_650,base.br,base.state_br_ba,Arataca
+city_br_651,base.br,base.state_br_rs,Aratiba
+city_br_652,base.br,base.state_br_ce,Aratuba
+city_br_653,base.br,base.state_br_ba,Aratuípe
+city_br_654,base.br,base.state_br_se,Arauá
+city_br_655,base.br,base.state_br_mg,Araújos
+city_br_656,base.br,base.state_br_mg,Arceburgo
+city_br_657,base.br,base.state_br_sp,Arco-Íris
+city_br_658,base.br,base.state_br_mg,Arcos
+city_br_659,base.br,base.state_br_pe,Arcoverde
+city_br_660,base.br,base.state_br_mg,Areado
+city_br_661,base.br,base.state_br_rj,Areal
+city_br_662,base.br,base.state_br_sp,Arealva
+city_br_663,base.br,base.state_br_pb,Areia
+city_br_664,base.br,base.state_br_rn,Areia Branca
+city_br_665,base.br,base.state_br_se,Areia Branca
+city_br_666,base.br,base.state_br_pb,Areia de Baraúnas
+city_br_667,base.br,base.state_br_pb,Areial
+city_br_668,base.br,base.state_br_sp,Areias
+city_br_669,base.br,base.state_br_sp,Areiópolis
+city_br_670,base.br,base.state_br_mt,Arenápolis
+city_br_671,base.br,base.state_br_go,Arenópolis
+city_br_672,base.br,base.state_br_rn,Arês
+city_br_673,base.br,base.state_br_mg,Argirita
+city_br_674,base.br,base.state_br_mg,Aricanduva
+city_br_675,base.br,base.state_br_mg,Arinos
+city_br_676,base.br,base.state_br_mt,Aripuanã
+city_br_677,base.br,base.state_br_ro,Ariquemes
+city_br_678,base.br,base.state_br_sp,Ariranha
+city_br_679,base.br,base.state_br_pr,Ariranha do Ivaí
+city_br_680,base.br,base.state_br_rj,Armação dos Búzios
+city_br_681,base.br,base.state_br_sc,Armazém
+city_br_682,base.br,base.state_br_ce,Arneiroz
+city_br_683,base.br,base.state_br_pi,Aroazes
+city_br_684,base.br,base.state_br_pb,Aroeiras
+city_br_685,base.br,base.state_br_pi,Aroeiras do Itaim
+city_br_686,base.br,base.state_br_pi,Arraial
+city_br_687,base.br,base.state_br_rj,Arraial do Cabo
+city_br_688,base.br,base.state_br_to,Arraias
+city_br_689,base.br,base.state_br_rs,Arroio do Meio
+city_br_690,base.br,base.state_br_rs,Arroio do Padre
+city_br_691,base.br,base.state_br_rs,Arroio do Sal
+city_br_692,base.br,base.state_br_rs,Arroio do Tigre
+city_br_693,base.br,base.state_br_rs,Arroio dos Ratos
+city_br_694,base.br,base.state_br_rs,Arroio Grande
+city_br_695,base.br,base.state_br_sc,Arroio Trinta
+city_br_696,base.br,base.state_br_sp,Artur Nogueira
+city_br_697,base.br,base.state_br_go,Aruanã
+city_br_698,base.br,base.state_br_sp,Arujá
+city_br_699,base.br,base.state_br_sc,Arvoredo
+city_br_700,base.br,base.state_br_rs,Arvorezinha
+city_br_701,base.br,base.state_br_sc,Ascurra
+city_br_702,base.br,base.state_br_sp,Aspásia
+city_br_703,base.br,base.state_br_pr,Assaí
+city_br_704,base.br,base.state_br_ce,Assaré
+city_br_705,base.br,base.state_br_ac,Assis Brasil
+city_br_706,base.br,base.state_br_pr,Assis Chateaubriand
+city_br_707,base.br,base.state_br_pb,Assunção
+city_br_708,base.br,base.state_br_pi,Assunção do Piauí
+city_br_709,base.br,base.state_br_mg,Astolfo Dutra
+city_br_710,base.br,base.state_br_pr,Astorga
+city_br_711,base.br,base.state_br_al,Atalaia
+city_br_712,base.br,base.state_br_pr,Atalaia
+city_br_713,base.br,base.state_br_am,Atalaia do Norte
+city_br_714,base.br,base.state_br_sc,Atalanta
+city_br_715,base.br,base.state_br_mg,Ataléia
+city_br_716,base.br,base.state_br_es,Atílio Vivacqua
+city_br_717,base.br,base.state_br_to,Augustinópolis
+city_br_718,base.br,base.state_br_pa,Augusto Corrêa
+city_br_719,base.br,base.state_br_mg,Augusto de Lima
+city_br_720,base.br,base.state_br_rs,Augusto Pestana
+city_br_721,base.br,base.state_br_rs,Áurea
+city_br_722,base.br,base.state_br_ba,Aurelino Leal
+city_br_723,base.br,base.state_br_sp,Auriflama
+city_br_724,base.br,base.state_br_go,Aurilândia
+city_br_725,base.br,base.state_br_ce,Aurora
+city_br_726,base.br,base.state_br_sc,Aurora
+city_br_727,base.br,base.state_br_pa,Aurora do Pará
+city_br_728,base.br,base.state_br_to,Aurora do Tocantins
+city_br_729,base.br,base.state_br_am,Autazes
+city_br_730,base.br,base.state_br_sp,Avaí
+city_br_731,base.br,base.state_br_sp,Avanhandava
+city_br_732,base.br,base.state_br_sp,Avaré
+city_br_733,base.br,base.state_br_pa,Aveiro
+city_br_734,base.br,base.state_br_pi,Avelino Lopes
+city_br_735,base.br,base.state_br_go,Avelinópolis
+city_br_736,base.br,base.state_br_ma,Axixá
+city_br_737,base.br,base.state_br_to,Axixá do Tocantins
+city_br_738,base.br,base.state_br_to,Babaçulândia
+city_br_739,base.br,base.state_br_ma,Bacabeira
+city_br_740,base.br,base.state_br_ma,Bacuri
+city_br_741,base.br,base.state_br_ma,Bacurituba
+city_br_742,base.br,base.state_br_sp,Bady Bassitt
+city_br_743,base.br,base.state_br_mg,Baependi
+city_br_744,base.br,base.state_br_pa,Bagre
+city_br_745,base.br,base.state_br_pb,Baía da Traição
+city_br_746,base.br,base.state_br_rn,Baía Formosa
+city_br_747,base.br,base.state_br_ba,Baianópolis
+city_br_748,base.br,base.state_br_pa,Baião
+city_br_749,base.br,base.state_br_ba,Baixa Grande
+city_br_750,base.br,base.state_br_pi,Baixa Grande do Ribeiro
+city_br_751,base.br,base.state_br_ce,Baixio
+city_br_752,base.br,base.state_br_es,Baixo Guandu
+city_br_753,base.br,base.state_br_sp,Balbinos
+city_br_754,base.br,base.state_br_mg,Baldim
+city_br_755,base.br,base.state_br_go,Baliza
+city_br_756,base.br,base.state_br_sc,Balneário Arroio do Silva
+city_br_757,base.br,base.state_br_sc,Balneário Barra do Sul
+city_br_758,base.br,base.state_br_sc,Balneário Gaivota
+city_br_759,base.br,base.state_br_sc,Balneário Piçarras
+city_br_760,base.br,base.state_br_rs,Balneário Pinhal
+city_br_761,base.br,base.state_br_sc,Balneário Rincão
+city_br_762,base.br,base.state_br_pr,Balsa Nova
+city_br_763,base.br,base.state_br_sp,Bálsamo
+city_br_764,base.br,base.state_br_mg,Bambuí
+city_br_765,base.br,base.state_br_ce,Banabuiú
+city_br_766,base.br,base.state_br_sp,Bananal
+city_br_767,base.br,base.state_br_pb,Bananeiras
+city_br_768,base.br,base.state_br_mg,Bandeira
+city_br_769,base.br,base.state_br_mg,Bandeira do Sul
+city_br_770,base.br,base.state_br_sc,Bandeirante
+city_br_771,base.br,base.state_br_ms,Bandeirantes
+city_br_772,base.br,base.state_br_pr,Bandeirantes
+city_br_773,base.br,base.state_br_to,Bandeirantes do Tocantins
+city_br_774,base.br,base.state_br_pa,Bannach
+city_br_775,base.br,base.state_br_ba,Banzaê
+city_br_776,base.br,base.state_br_rs,Barão
+city_br_777,base.br,base.state_br_sp,Barão de Antonina
+city_br_778,base.br,base.state_br_mg,Barão de Cocais
+city_br_779,base.br,base.state_br_rs,Barão de Cotegipe
+city_br_780,base.br,base.state_br_ma,Barão de Grajaú
+city_br_781,base.br,base.state_br_mt,Barão de Melgaço
+city_br_782,base.br,base.state_br_mg,Barão de Monte Alto
+city_br_783,base.br,base.state_br_rs,Barão do Triunfo
+city_br_784,base.br,base.state_br_pb,Baraúna
+city_br_785,base.br,base.state_br_rn,Baraúna
+city_br_786,base.br,base.state_br_ce,Barbalha
+city_br_787,base.br,base.state_br_sp,Barbosa
+city_br_788,base.br,base.state_br_pr,Barbosa Ferraz
+city_br_789,base.br,base.state_br_rn,Barcelona
+city_br_790,base.br,base.state_br_am,Barcelos
+city_br_791,base.br,base.state_br_sp,Bariri
+city_br_792,base.br,base.state_br_ba,Barra
+city_br_793,base.br,base.state_br_sc,Barra Bonita
+city_br_794,base.br,base.state_br_sp,Barra Bonita
+city_br_795,base.br,base.state_br_pi,Barra D'Alcântara
+city_br_796,base.br,base.state_br_ba,Barra da Estiva
+city_br_797,base.br,base.state_br_pe,Barra de Guabiraba
+city_br_798,base.br,base.state_br_pb,Barra de Santa Rosa
+city_br_799,base.br,base.state_br_pb,Barra de Santana
+city_br_800,base.br,base.state_br_al,Barra de Santo Antônio
+city_br_801,base.br,base.state_br_es,Barra de São Francisco
+city_br_802,base.br,base.state_br_al,Barra de São Miguel
+city_br_803,base.br,base.state_br_pb,Barra de São Miguel
+city_br_804,base.br,base.state_br_mt,Barra do Bugres
+city_br_805,base.br,base.state_br_sp,Barra do Chapéu
+city_br_806,base.br,base.state_br_ba,Barra do Choça
+city_br_807,base.br,base.state_br_ma,Barra do Corda
+city_br_808,base.br,base.state_br_mt,Barra do Garças
+city_br_809,base.br,base.state_br_rs,Barra do Guarita
+city_br_810,base.br,base.state_br_pr,Barra do Jacaré
+city_br_811,base.br,base.state_br_ba,Barra do Mendes
+city_br_812,base.br,base.state_br_to,Barra do Ouro
+city_br_813,base.br,base.state_br_rj,Barra do Piraí
+city_br_814,base.br,base.state_br_rs,Barra do Quaraí
+city_br_815,base.br,base.state_br_rs,Barra do Ribeiro
+city_br_816,base.br,base.state_br_rs,Barra do Rio Azul
+city_br_817,base.br,base.state_br_ba,Barra do Rocha
+city_br_818,base.br,base.state_br_sp,Barra do Turvo
+city_br_819,base.br,base.state_br_se,Barra dos Coqueiros
+city_br_820,base.br,base.state_br_rs,Barra Funda
+city_br_821,base.br,base.state_br_mg,Barra Longa
+city_br_822,base.br,base.state_br_sc,Barra Velha
+city_br_823,base.br,base.state_br_pr,Barracão
+city_br_824,base.br,base.state_br_rs,Barracão
+city_br_825,base.br,base.state_br_pi,Barras
+city_br_826,base.br,base.state_br_ce,Barreira
+city_br_827,base.br,base.state_br_pi,Barreiras do Piauí
+city_br_828,base.br,base.state_br_am,Barreirinha
+city_br_829,base.br,base.state_br_ma,Barreirinhas
+city_br_830,base.br,base.state_br_pe,Barreiros
+city_br_831,base.br,base.state_br_sp,Barrinha
+city_br_832,base.br,base.state_br_ce,Barro
+city_br_833,base.br,base.state_br_ba,Barro Alto
+city_br_834,base.br,base.state_br_go,Barro Alto
+city_br_835,base.br,base.state_br_pi,Barro Duro
+city_br_836,base.br,base.state_br_ba,Barro Preto
+city_br_837,base.br,base.state_br_ba,Barrocas
+city_br_838,base.br,base.state_br_to,Barrolândia
+city_br_839,base.br,base.state_br_ce,Barroquinha
+city_br_840,base.br,base.state_br_rs,Barros Cassal
+city_br_841,base.br,base.state_br_mg,Barroso
+city_br_842,base.br,base.state_br_sp,Bastos
+city_br_843,base.br,base.state_br_ms,Bataguassu
+city_br_844,base.br,base.state_br_al,Batalha
+city_br_845,base.br,base.state_br_pi,Batalha
+city_br_846,base.br,base.state_br_sp,Batatais
+city_br_847,base.br,base.state_br_ms,Batayporã
+city_br_848,base.br,base.state_br_ce,Baturité
+city_br_849,base.br,base.state_br_pb,Bayeux
+city_br_850,base.br,base.state_br_sp,Bebedouro
+city_br_851,base.br,base.state_br_ce,Beberibe
+city_br_852,base.br,base.state_br_ce,Bela Cruz
+city_br_853,base.br,base.state_br_ms,Bela Vista
+city_br_854,base.br,base.state_br_pr,Bela Vista da Caroba
+city_br_855,base.br,base.state_br_go,Bela Vista de Goiás
+city_br_856,base.br,base.state_br_mg,Bela Vista de Minas
+city_br_857,base.br,base.state_br_ma,Bela Vista do Maranhão
+city_br_858,base.br,base.state_br_pr,Bela Vista do Paraíso
+city_br_859,base.br,base.state_br_pi,Bela Vista do Piauí
+city_br_860,base.br,base.state_br_sc,Bela Vista do Toldo
+city_br_861,base.br,base.state_br_ma,Belágua
+city_br_862,base.br,base.state_br_al,Belém
+city_br_863,base.br,base.state_br_pb,Belém
+city_br_864,base.br,base.state_br_pe,Belém de Maria
+city_br_865,base.br,base.state_br_pb,Belém do Brejo do Cruz
+city_br_866,base.br,base.state_br_pi,Belém do Piauí
+city_br_867,base.br,base.state_br_pe,Belém do São Francisco
+city_br_868,base.br,base.state_br_mg,Belmiro Braga
+city_br_869,base.br,base.state_br_ba,Belmonte
+city_br_870,base.br,base.state_br_sc,Belmonte
+city_br_871,base.br,base.state_br_ba,Belo Campo
+city_br_872,base.br,base.state_br_pe,Belo Jardim
+city_br_873,base.br,base.state_br_al,Belo Monte
+city_br_874,base.br,base.state_br_mg,Belo Oriente
+city_br_875,base.br,base.state_br_mg,Belo Vale
+city_br_876,base.br,base.state_br_pa,Belterra
+city_br_877,base.br,base.state_br_pi,Beneditinos
+city_br_878,base.br,base.state_br_ma,Benedito Leite
+city_br_879,base.br,base.state_br_sc,Benedito Novo
+city_br_880,base.br,base.state_br_pa,Benevides
+city_br_881,base.br,base.state_br_am,Benjamin Constant
+city_br_882,base.br,base.state_br_rs,Benjamin Constant do Sul
+city_br_883,base.br,base.state_br_sp,Bento de Abreu
+city_br_884,base.br,base.state_br_rn,Bento Fernandes
+city_br_885,base.br,base.state_br_ma,Bequimão
+city_br_886,base.br,base.state_br_mg,Berilo
+city_br_887,base.br,base.state_br_mg,Berizal
+city_br_888,base.br,base.state_br_pb,Bernardino Batista
+city_br_889,base.br,base.state_br_sp,Bernardino de Campos
+city_br_890,base.br,base.state_br_ma,Bernardo do Mearim
+city_br_891,base.br,base.state_br_to,Bernardo Sayão
+city_br_892,base.br,base.state_br_sp,Bertioga
+city_br_893,base.br,base.state_br_pi,Bertolínia
+city_br_894,base.br,base.state_br_mg,Bertópolis
+city_br_895,base.br,base.state_br_am,Beruri
+city_br_896,base.br,base.state_br_pe,Betânia
+city_br_897,base.br,base.state_br_pi,Betânia do Piauí
+city_br_898,base.br,base.state_br_pe,Bezerros
+city_br_899,base.br,base.state_br_mg,Bias Fortes
+city_br_900,base.br,base.state_br_mg,Bicas
+city_br_901,base.br,base.state_br_sc,Biguaçu
+city_br_902,base.br,base.state_br_sp,Bilac
+city_br_903,base.br,base.state_br_mg,Biquinhas
+city_br_904,base.br,base.state_br_sp,Biritiba-Mirim
+city_br_905,base.br,base.state_br_ba,Biritinga
+city_br_906,base.br,base.state_br_pr,Bituruna
+city_br_907,base.br,base.state_br_es,Boa Esperança
+city_br_908,base.br,base.state_br_mg,Boa Esperança
+city_br_909,base.br,base.state_br_pr,Boa Esperança
+city_br_910,base.br,base.state_br_pr,Boa Esperança do Iguaçu
+city_br_911,base.br,base.state_br_sp,Boa Esperança do Sul
+city_br_912,base.br,base.state_br_pi,Boa Hora
+city_br_913,base.br,base.state_br_ba,Boa Nova
+city_br_914,base.br,base.state_br_rn,Boa Saúde
+city_br_915,base.br,base.state_br_pb,Boa Ventura
+city_br_916,base.br,base.state_br_pr,Boa Ventura de São Roque
+city_br_917,base.br,base.state_br_ce,Boa Viagem
+city_br_918,base.br,base.state_br_pb,Boa Vista
+city_br_919,base.br,base.state_br_pr,Boa Vista da Aparecida
+city_br_920,base.br,base.state_br_rs,Boa Vista das Missões
+city_br_921,base.br,base.state_br_rs,Boa Vista do Buricá
+city_br_922,base.br,base.state_br_rs,Boa Vista do Cadeado
+city_br_923,base.br,base.state_br_ma,Boa Vista do Gurupi
+city_br_924,base.br,base.state_br_rs,Boa Vista do Incra
+city_br_925,base.br,base.state_br_am,Boa Vista do Ramos
+city_br_926,base.br,base.state_br_rs,Boa Vista do Sul
+city_br_927,base.br,base.state_br_ba,Boa Vista do Tupim
+city_br_928,base.br,base.state_br_al,Boca da Mata
+city_br_929,base.br,base.state_br_am,Boca do Acre
+city_br_930,base.br,base.state_br_pi,Bocaina
+city_br_931,base.br,base.state_br_sp,Bocaina
+city_br_932,base.br,base.state_br_mg,Bocaina de Minas
+city_br_933,base.br,base.state_br_sc,Bocaina do Sul
+city_br_934,base.br,base.state_br_mg,Bocaiúva
+city_br_935,base.br,base.state_br_pr,Bocaiúva do Sul
+city_br_936,base.br,base.state_br_rn,Bodó
+city_br_937,base.br,base.state_br_pe,Bodocó
+city_br_938,base.br,base.state_br_ms,Bodoquena
+city_br_939,base.br,base.state_br_sp,Bofete
+city_br_940,base.br,base.state_br_sp,Boituva
+city_br_941,base.br,base.state_br_pe,Bom Conselho
+city_br_942,base.br,base.state_br_mg,Bom Despacho
+city_br_943,base.br,base.state_br_ma,Bom Jardim
+city_br_944,base.br,base.state_br_pe,Bom Jardim
+city_br_945,base.br,base.state_br_rj,Bom Jardim
+city_br_946,base.br,base.state_br_sc,Bom Jardim da Serra
+city_br_947,base.br,base.state_br_go,Bom Jardim de Goiás
+city_br_948,base.br,base.state_br_mg,Bom Jardim de Minas
+city_br_949,base.br,base.state_br_pb,Bom Jesus
+city_br_950,base.br,base.state_br_pi,Bom Jesus
+city_br_951,base.br,base.state_br_rn,Bom Jesus
+city_br_952,base.br,base.state_br_rs,Bom Jesus
+city_br_953,base.br,base.state_br_sc,Bom Jesus
+city_br_954,base.br,base.state_br_ba,Bom Jesus da Lapa
+city_br_955,base.br,base.state_br_mg,Bom Jesus da Penha
+city_br_956,base.br,base.state_br_ba,Bom Jesus da Serra
+city_br_957,base.br,base.state_br_ma,Bom Jesus das Selvas
+city_br_958,base.br,base.state_br_go,Bom Jesus de Goiás
+city_br_959,base.br,base.state_br_mg,Bom Jesus do Amparo
+city_br_960,base.br,base.state_br_mt,Bom Jesus do Araguaia
+city_br_961,base.br,base.state_br_mg,Bom Jesus do Galho
+city_br_962,base.br,base.state_br_rj,Bom Jesus do Itabapoana
+city_br_963,base.br,base.state_br_es,Bom Jesus do Norte
+city_br_964,base.br,base.state_br_sc,Bom Jesus do Oeste
+city_br_965,base.br,base.state_br_pr,Bom Jesus do Sul
+city_br_966,base.br,base.state_br_pa,Bom Jesus do Tocantins
+city_br_967,base.br,base.state_br_to,Bom Jesus do Tocantins
+city_br_968,base.br,base.state_br_sp,Bom Jesus dos Perdões
+city_br_969,base.br,base.state_br_ma,Bom Lugar
+city_br_970,base.br,base.state_br_rs,Bom Princípio
+city_br_971,base.br,base.state_br_pi,Bom Princípio do Piauí
+city_br_972,base.br,base.state_br_rs,Bom Progresso
+city_br_973,base.br,base.state_br_mg,Bom Repouso
+city_br_974,base.br,base.state_br_sc,Bom Retiro
+city_br_975,base.br,base.state_br_rs,Bom Retiro do Sul
+city_br_976,base.br,base.state_br_mg,Bom Sucesso
+city_br_977,base.br,base.state_br_pb,Bom Sucesso
+city_br_978,base.br,base.state_br_pr,Bom Sucesso
+city_br_979,base.br,base.state_br_sp,Bom Sucesso de Itararé
+city_br_980,base.br,base.state_br_pr,Bom Sucesso do Sul
+city_br_981,base.br,base.state_br_sc,Bombinhas
+city_br_982,base.br,base.state_br_mg,Bonfim
+city_br_983,base.br,base.state_br_rr,Bonfim
+city_br_984,base.br,base.state_br_pi,Bonfim do Piauí
+city_br_985,base.br,base.state_br_go,Bonfinópolis
+city_br_986,base.br,base.state_br_mg,Bonfinópolis de Minas
+city_br_987,base.br,base.state_br_ba,Boninal
+city_br_988,base.br,base.state_br_ba,Bonito
+city_br_989,base.br,base.state_br_ms,Bonito
+city_br_990,base.br,base.state_br_pa,Bonito
+city_br_991,base.br,base.state_br_pe,Bonito
+city_br_992,base.br,base.state_br_mg,Bonito de Minas
+city_br_993,base.br,base.state_br_pb,Bonito de Santa Fé
+city_br_994,base.br,base.state_br_go,Bonópolis
+city_br_995,base.br,base.state_br_pb,Boqueirão
+city_br_996,base.br,base.state_br_rs,Boqueirão do Leão
+city_br_997,base.br,base.state_br_pi,Boqueirão do Piauí
+city_br_998,base.br,base.state_br_se,Boquim
+city_br_999,base.br,base.state_br_ba,Boquira
+city_br_1000,base.br,base.state_br_sp,Borá
+city_br_1001,base.br,base.state_br_sp,Boracéia
+city_br_1002,base.br,base.state_br_am,Borba
+city_br_1003,base.br,base.state_br_pb,Borborema
+city_br_1004,base.br,base.state_br_sp,Borborema
+city_br_1005,base.br,base.state_br_mg,Borda da Mata
+city_br_1006,base.br,base.state_br_sp,Borebi
+city_br_1007,base.br,base.state_br_pr,Borrazópolis
+city_br_1008,base.br,base.state_br_rs,Bossoroca
+city_br_1009,base.br,base.state_br_mg,Botelhos
+city_br_1010,base.br,base.state_br_mg,Botumirim
+city_br_1011,base.br,base.state_br_ba,Botuporã
+city_br_1012,base.br,base.state_br_sc,Botuverá
+city_br_1013,base.br,base.state_br_rs,Bozano
+city_br_1014,base.br,base.state_br_sc,Braço do Norte
+city_br_1015,base.br,base.state_br_sc,Braço do Trombudo
+city_br_1016,base.br,base.state_br_rs,Braga
+city_br_1017,base.br,base.state_br_pr,Braganey
+city_br_1018,base.br,base.state_br_al,Branquinha
+city_br_1019,base.br,base.state_br_mg,Brás Pires
+city_br_1020,base.br,base.state_br_pa,Brasil Novo
+city_br_1021,base.br,base.state_br_ms,Brasilândia
+city_br_1022,base.br,base.state_br_mg,Brasilândia de Minas
+city_br_1023,base.br,base.state_br_pr,Brasilândia do Sul
+city_br_1024,base.br,base.state_br_to,Brasilândia do Tocantins
+city_br_1025,base.br,base.state_br_ac,Brasiléia
+city_br_1026,base.br,base.state_br_pi,Brasileira
+city_br_1027,base.br,base.state_br_mg,Brasília de Minas
+city_br_1028,base.br,base.state_br_mt,Brasnorte
+city_br_1029,base.br,base.state_br_sp,Braúna
+city_br_1030,base.br,base.state_br_mg,Braúnas
+city_br_1031,base.br,base.state_br_go,Brazabrantes
+city_br_1032,base.br,base.state_br_mg,Brazópolis
+city_br_1033,base.br,base.state_br_pe,Brejão
+city_br_1034,base.br,base.state_br_es,Brejetuba
+city_br_1035,base.br,base.state_br_pe,Brejinho
+city_br_1036,base.br,base.state_br_rn,Brejinho
+city_br_1037,base.br,base.state_br_to,Brejinho de Nazaré
+city_br_1038,base.br,base.state_br_ma,Brejo
+city_br_1039,base.br,base.state_br_sp,Brejo Alegre
+city_br_1040,base.br,base.state_br_pe,Brejo da Madre de Deus
+city_br_1041,base.br,base.state_br_ma,Brejo de Areia
+city_br_1042,base.br,base.state_br_pb,Brejo do Cruz
+city_br_1043,base.br,base.state_br_pi,Brejo do Piauí
+city_br_1044,base.br,base.state_br_pb,Brejo dos Santos
+city_br_1045,base.br,base.state_br_se,Brejo Grande
+city_br_1046,base.br,base.state_br_pa,Brejo Grande do Araguaia
+city_br_1047,base.br,base.state_br_ce,Brejo Santo
+city_br_1048,base.br,base.state_br_ba,Brejões
+city_br_1049,base.br,base.state_br_ba,Brejolândia
+city_br_1050,base.br,base.state_br_pa,Breu Branco
+city_br_1051,base.br,base.state_br_go,Britânia
+city_br_1052,base.br,base.state_br_rs,Brochier
+city_br_1053,base.br,base.state_br_sp,Brodowski
+city_br_1054,base.br,base.state_br_sp,Brotas
+city_br_1055,base.br,base.state_br_ba,Brotas de Macaúbas
+city_br_1056,base.br,base.state_br_mg,Brumadinho
+city_br_1057,base.br,base.state_br_ba,Brumado
+city_br_1058,base.br,base.state_br_sc,Brunópolis
+city_br_1059,base.br,base.state_br_mg,Bueno Brandão
+city_br_1060,base.br,base.state_br_mg,Buenópolis
+city_br_1061,base.br,base.state_br_pe,Buenos Aires
+city_br_1062,base.br,base.state_br_ba,Buerarema
+city_br_1063,base.br,base.state_br_mg,Bugre
+city_br_1064,base.br,base.state_br_pe,Buíque
+city_br_1065,base.br,base.state_br_ac,Bujari
+city_br_1066,base.br,base.state_br_pa,Bujaru
+city_br_1067,base.br,base.state_br_sp,Buri
+city_br_1068,base.br,base.state_br_sp,Buritama
+city_br_1069,base.br,base.state_br_ma,Buriti
+city_br_1070,base.br,base.state_br_go,Buriti Alegre
+city_br_1071,base.br,base.state_br_ma,Buriti Bravo
+city_br_1072,base.br,base.state_br_go,Buriti de Goiás
+city_br_1073,base.br,base.state_br_to,Buriti do Tocantins
+city_br_1074,base.br,base.state_br_pi,Buriti dos Lopes
+city_br_1075,base.br,base.state_br_pi,Buriti dos Montes
+city_br_1076,base.br,base.state_br_ma,Buriticupu
+city_br_1077,base.br,base.state_br_go,Buritinópolis
+city_br_1078,base.br,base.state_br_ba,Buritirama
+city_br_1079,base.br,base.state_br_ma,Buritirana
+city_br_1080,base.br,base.state_br_mg,Buritis
+city_br_1081,base.br,base.state_br_ro,Buritis
+city_br_1082,base.br,base.state_br_sp,Buritizal
+city_br_1083,base.br,base.state_br_mg,Buritizeiro
+city_br_1084,base.br,base.state_br_rs,Butiá
+city_br_1085,base.br,base.state_br_am,Caapiranga
+city_br_1086,base.br,base.state_br_pb,Caaporã
+city_br_1087,base.br,base.state_br_ms,Caarapó
+city_br_1088,base.br,base.state_br_ba,Caatiba
+city_br_1089,base.br,base.state_br_pb,Cabaceiras
+city_br_1090,base.br,base.state_br_ba,Cabaceiras do Paraguaçu
+city_br_1091,base.br,base.state_br_mg,Cabeceira Grande
+city_br_1092,base.br,base.state_br_go,Cabeceiras
+city_br_1093,base.br,base.state_br_pi,Cabeceiras do Piauí
+city_br_1094,base.br,base.state_br_pb,Cabedelo
+city_br_1095,base.br,base.state_br_ro,Cabixi
+city_br_1096,base.br,base.state_br_mg,Cabo Verde
+city_br_1097,base.br,base.state_br_sp,Cabrália Paulista
+city_br_1098,base.br,base.state_br_sp,Cabreúva
+city_br_1099,base.br,base.state_br_pe,Cabrobó
+city_br_1100,base.br,base.state_br_sc,Caçador
+city_br_1101,base.br,base.state_br_sp,Caçapava
+city_br_1102,base.br,base.state_br_rs,Caçapava do Sul
+city_br_1103,base.br,base.state_br_ro,Cacaulândia
+city_br_1104,base.br,base.state_br_rs,Cacequi
+city_br_1105,base.br,base.state_br_mt,Cáceres
+city_br_1106,base.br,base.state_br_ba,Cachoeira
+city_br_1107,base.br,base.state_br_go,Cachoeira Alta
+city_br_1108,base.br,base.state_br_mg,Cachoeira da Prata
+city_br_1109,base.br,base.state_br_go,Cachoeira de Goiás
+city_br_1110,base.br,base.state_br_mg,Cachoeira de Minas
+city_br_1111,base.br,base.state_br_mg,Cachoeira de Pajeú
+city_br_1112,base.br,base.state_br_pa,Cachoeira do Arari
+city_br_1113,base.br,base.state_br_pa,Cachoeira do Piriá
+city_br_1114,base.br,base.state_br_rs,Cachoeira do Sul
+city_br_1115,base.br,base.state_br_pb,Cachoeira dos Índios
+city_br_1116,base.br,base.state_br_go,Cachoeira Dourada
+city_br_1117,base.br,base.state_br_mg,Cachoeira Dourada
+city_br_1118,base.br,base.state_br_ma,Cachoeira Grande
+city_br_1119,base.br,base.state_br_sp,Cachoeira Paulista
+city_br_1120,base.br,base.state_br_rj,Cachoeiras de Macacu
+city_br_1121,base.br,base.state_br_pe,Cachoeirinha
+city_br_1122,base.br,base.state_br_to,Cachoeirinha
+city_br_1123,base.br,base.state_br_pb,Cacimba de Areia
+city_br_1124,base.br,base.state_br_pb,Cacimba de Dentro
+city_br_1125,base.br,base.state_br_pb,Cacimbas
+city_br_1126,base.br,base.state_br_al,Cacimbinhas
+city_br_1127,base.br,base.state_br_rs,Cacique Doble
+city_br_1128,base.br,base.state_br_ro,Cacoal
+city_br_1129,base.br,base.state_br_sp,Caconde
+city_br_1130,base.br,base.state_br_go,Caçu
+city_br_1131,base.br,base.state_br_ba,Caculé
+city_br_1132,base.br,base.state_br_ba,Caém
+city_br_1133,base.br,base.state_br_mg,Caetanópolis
+city_br_1134,base.br,base.state_br_ba,Caetanos
+city_br_1135,base.br,base.state_br_mg,Caeté
+city_br_1136,base.br,base.state_br_pe,Caetés
+city_br_1137,base.br,base.state_br_ba,Caetité
+city_br_1138,base.br,base.state_br_ba,Cafarnaum
+city_br_1139,base.br,base.state_br_pr,Cafeara
+city_br_1140,base.br,base.state_br_pr,Cafelândia
+city_br_1141,base.br,base.state_br_sp,Cafelândia
+city_br_1142,base.br,base.state_br_pr,Cafezal do Sul
+city_br_1143,base.br,base.state_br_sp,Caiabu
+city_br_1144,base.br,base.state_br_mg,Caiana
+city_br_1145,base.br,base.state_br_go,Caiapônia
+city_br_1146,base.br,base.state_br_rs,Caibaté
+city_br_1147,base.br,base.state_br_sc,Caibi
+city_br_1148,base.br,base.state_br_pb,Caiçara
+city_br_1149,base.br,base.state_br_rs,Caiçara
+city_br_1150,base.br,base.state_br_rn,Caiçara do Norte
+city_br_1151,base.br,base.state_br_rn,Caiçara do Rio do Vento
+city_br_1152,base.br,base.state_br_rn,Caicó
+city_br_1153,base.br,base.state_br_sp,Caieiras
+city_br_1154,base.br,base.state_br_ba,Cairu
+city_br_1155,base.br,base.state_br_sp,Caiuá
+city_br_1156,base.br,base.state_br_sp,Cajamar
+city_br_1157,base.br,base.state_br_ma,Cajapió
+city_br_1158,base.br,base.state_br_ma,Cajari
+city_br_1159,base.br,base.state_br_sp,Cajati
+city_br_1160,base.br,base.state_br_pb,Cajazeiras
+city_br_1161,base.br,base.state_br_pi,Cajazeiras do Piauí
+city_br_1162,base.br,base.state_br_pb,Cajazeirinhas
+city_br_1163,base.br,base.state_br_sp,Cajobi
+city_br_1164,base.br,base.state_br_al,Cajueiro
+city_br_1165,base.br,base.state_br_pi,Cajueiro da Praia
+city_br_1166,base.br,base.state_br_mg,Cajuri
+city_br_1167,base.br,base.state_br_sp,Cajuru
+city_br_1168,base.br,base.state_br_pe,Calçado
+city_br_1169,base.br,base.state_br_ap,Calçoene
+city_br_1170,base.br,base.state_br_mg,Caldas
+city_br_1171,base.br,base.state_br_pb,Caldas Brandão
+city_br_1172,base.br,base.state_br_go,Caldas Novas
+city_br_1173,base.br,base.state_br_go,Caldazinha
+city_br_1174,base.br,base.state_br_ba,Caldeirão Grande
+city_br_1175,base.br,base.state_br_pi,Caldeirão Grande do Piauí
+city_br_1176,base.br,base.state_br_pr,Califórnia
+city_br_1177,base.br,base.state_br_sc,Calmon
+city_br_1178,base.br,base.state_br_pe,Calumbi
+city_br_1179,base.br,base.state_br_ba,Camacan
+city_br_1180,base.br,base.state_br_mg,Camacho
+city_br_1181,base.br,base.state_br_pb,Camalaú
+city_br_1182,base.br,base.state_br_ba,Camamu
+city_br_1183,base.br,base.state_br_mg,Camanducaia
+city_br_1184,base.br,base.state_br_ms,Camapuã
+city_br_1185,base.br,base.state_br_rs,Camaquã
+city_br_1186,base.br,base.state_br_rs,Camargo
+city_br_1187,base.br,base.state_br_pr,Cambará
+city_br_1188,base.br,base.state_br_rs,Cambará do Sul
+city_br_1189,base.br,base.state_br_pr,Cambira
+city_br_1190,base.br,base.state_br_rj,Cambuci
+city_br_1191,base.br,base.state_br_mg,Cambuí
+city_br_1192,base.br,base.state_br_mg,Cambuquira
+city_br_1193,base.br,base.state_br_ce,Camocim
+city_br_1194,base.br,base.state_br_pe,Camocim de São Félix
+city_br_1195,base.br,base.state_br_mg,Campanário
+city_br_1196,base.br,base.state_br_mg,Campanha
+city_br_1197,base.br,base.state_br_al,Campestre
+city_br_1198,base.br,base.state_br_mg,Campestre
+city_br_1199,base.br,base.state_br_rs,Campestre da Serra
+city_br_1200,base.br,base.state_br_go,Campestre de Goiás
+city_br_1201,base.br,base.state_br_ma,Campestre do Maranhão
+city_br_1202,base.br,base.state_br_pr,Campina da Lagoa
+city_br_1203,base.br,base.state_br_rs,Campina das Missões
+city_br_1204,base.br,base.state_br_sp,Campina do Monte Alegre
+city_br_1205,base.br,base.state_br_pr,Campina do Simão
+city_br_1206,base.br,base.state_br_pr,Campina Grande do Sul
+city_br_1207,base.br,base.state_br_mg,Campina Verde
+city_br_1208,base.br,base.state_br_go,Campinaçu
+city_br_1209,base.br,base.state_br_mt,Campinápolis
+city_br_1210,base.br,base.state_br_pi,Campinas do Piauí
+city_br_1211,base.br,base.state_br_rs,Campinas do Sul
+city_br_1212,base.br,base.state_br_go,Campinorte
+city_br_1213,base.br,base.state_br_al,Campo Alegre
+city_br_1214,base.br,base.state_br_sc,Campo Alegre
+city_br_1215,base.br,base.state_br_go,Campo Alegre de Goiás
+city_br_1216,base.br,base.state_br_ba,Campo Alegre de Lourdes
+city_br_1217,base.br,base.state_br_pi,Campo Alegre do Fidalgo
+city_br_1218,base.br,base.state_br_mg,Campo Azul
+city_br_1219,base.br,base.state_br_mg,Campo Belo
+city_br_1220,base.br,base.state_br_sc,Campo Belo do Sul
+city_br_1221,base.br,base.state_br_rs,Campo Bom
+city_br_1222,base.br,base.state_br_pr,Campo Bonito
+city_br_1223,base.br,base.state_br_se,Campo do Brito
+city_br_1224,base.br,base.state_br_mg,Campo do Meio
+city_br_1225,base.br,base.state_br_pr,Campo do Tenente
+city_br_1226,base.br,base.state_br_sc,Campo Erê
+city_br_1227,base.br,base.state_br_mg,Campo Florido
+city_br_1228,base.br,base.state_br_ba,Campo Formoso
+city_br_1229,base.br,base.state_br_al,Campo Grande
+city_br_1230,base.br,base.state_br_rn,Campo Grande
+city_br_1231,base.br,base.state_br_pi,Campo Grande do Piauí
+city_br_1232,base.br,base.state_br_pi,Campo Largo do Piauí
+city_br_1233,base.br,base.state_br_go,Campo Limpo de Goiás
+city_br_1234,base.br,base.state_br_sp,Campo Limpo Paulista
+city_br_1235,base.br,base.state_br_pr,Campo Magro
+city_br_1236,base.br,base.state_br_pi,Campo Maior
+city_br_1237,base.br,base.state_br_pr,Campo Mourão
+city_br_1238,base.br,base.state_br_rs,Campo Novo
+city_br_1239,base.br,base.state_br_ro,Campo Novo de Rondônia
+city_br_1240,base.br,base.state_br_mt,Campo Novo do Parecis
+city_br_1241,base.br,base.state_br_rn,Campo Redondo
+city_br_1242,base.br,base.state_br_mt,Campo Verde
+city_br_1243,base.br,base.state_br_mg,Campos Altos
+city_br_1244,base.br,base.state_br_go,Campos Belos
+city_br_1245,base.br,base.state_br_rs,Campos Borges
+city_br_1246,base.br,base.state_br_mt,Campos de Júlio
+city_br_1247,base.br,base.state_br_sp,Campos do Jordão
+city_br_1248,base.br,base.state_br_mg,Campos Gerais
+city_br_1249,base.br,base.state_br_to,Campos Lindos
+city_br_1250,base.br,base.state_br_sc,Campos Novos
+city_br_1251,base.br,base.state_br_sp,Campos Novos Paulista
+city_br_1252,base.br,base.state_br_ce,Campos Sales
+city_br_1253,base.br,base.state_br_go,Campos Verdes
+city_br_1254,base.br,base.state_br_pe,Camutanga
+city_br_1255,base.br,base.state_br_mg,Cana Verde
+city_br_1256,base.br,base.state_br_mg,Canaã
+city_br_1257,base.br,base.state_br_pa,Canaã dos Carajás
+city_br_1258,base.br,base.state_br_mt,Canabrava do Norte
+city_br_1259,base.br,base.state_br_sp,Cananéia
+city_br_1260,base.br,base.state_br_al,Canapi
+city_br_1261,base.br,base.state_br_ba,Canápolis
+city_br_1262,base.br,base.state_br_mg,Canápolis
+city_br_1263,base.br,base.state_br_ba,Canarana
+city_br_1264,base.br,base.state_br_mt,Canarana
+city_br_1265,base.br,base.state_br_sp,Canas
+city_br_1266,base.br,base.state_br_pi,Canavieira
+city_br_1267,base.br,base.state_br_ba,Canavieiras
+city_br_1268,base.br,base.state_br_ba,Candeal
+city_br_1269,base.br,base.state_br_ba,Candeias
+city_br_1270,base.br,base.state_br_mg,Candeias
+city_br_1271,base.br,base.state_br_ro,Candeias do Jamari
+city_br_1272,base.br,base.state_br_rs,Candelária
+city_br_1273,base.br,base.state_br_ba,Candiba
+city_br_1274,base.br,base.state_br_pr,Cândido de Abreu
+city_br_1275,base.br,base.state_br_rs,Cândido Godói
+city_br_1276,base.br,base.state_br_ma,Cândido Mendes
+city_br_1277,base.br,base.state_br_sp,Cândido Mota
+city_br_1278,base.br,base.state_br_sp,Cândido Rodrigues
+city_br_1279,base.br,base.state_br_ba,Cândido Sales
+city_br_1280,base.br,base.state_br_rs,Candiota
+city_br_1281,base.br,base.state_br_pr,Candói
+city_br_1282,base.br,base.state_br_rs,Canela
+city_br_1283,base.br,base.state_br_sc,Canelinha
+city_br_1284,base.br,base.state_br_rn,Canguaretama
+city_br_1285,base.br,base.state_br_rs,Canguçu
+city_br_1286,base.br,base.state_br_se,Canhoba
+city_br_1287,base.br,base.state_br_pe,Canhotinho
+city_br_1288,base.br,base.state_br_ce,Canindé
+city_br_1289,base.br,base.state_br_se,Canindé de São Francisco
+city_br_1290,base.br,base.state_br_sp,Canitar
+city_br_1291,base.br,base.state_br_sc,Canoinhas
+city_br_1292,base.br,base.state_br_ba,Cansanção
+city_br_1293,base.br,base.state_br_rr,Cantá
+city_br_1294,base.br,base.state_br_mg,Cantagalo
+city_br_1295,base.br,base.state_br_pr,Cantagalo
+city_br_1296,base.br,base.state_br_rj,Cantagalo
+city_br_1297,base.br,base.state_br_ma,Cantanhede
+city_br_1298,base.br,base.state_br_pi,Canto do Buriti
+city_br_1299,base.br,base.state_br_ba,Canudos
+city_br_1300,base.br,base.state_br_rs,Canudos do Vale
+city_br_1301,base.br,base.state_br_am,Canutama
+city_br_1302,base.br,base.state_br_pa,Capanema
+city_br_1303,base.br,base.state_br_pr,Capanema
+city_br_1304,base.br,base.state_br_sc,Capão Alto
+city_br_1305,base.br,base.state_br_sp,Capão Bonito
+city_br_1306,base.br,base.state_br_rs,Capão Bonito do Sul
+city_br_1307,base.br,base.state_br_rs,Capão da Canoa
+city_br_1308,base.br,base.state_br_rs,Capão do Cipó
+city_br_1309,base.br,base.state_br_rs,Capão do Leão
+city_br_1310,base.br,base.state_br_mg,Caparaó
+city_br_1311,base.br,base.state_br_al,Capela
+city_br_1312,base.br,base.state_br_se,Capela
+city_br_1313,base.br,base.state_br_rs,Capela de Santana
+city_br_1314,base.br,base.state_br_sp,Capela do Alto
+city_br_1315,base.br,base.state_br_ba,Capela do Alto Alegre
+city_br_1316,base.br,base.state_br_mg,Capela Nova
+city_br_1317,base.br,base.state_br_mg,Capelinha
+city_br_1318,base.br,base.state_br_mg,Capetinga
+city_br_1319,base.br,base.state_br_pb,Capim
+city_br_1320,base.br,base.state_br_mg,Capim Branco
+city_br_1321,base.br,base.state_br_ba,Capim Grosso
+city_br_1322,base.br,base.state_br_mg,Capinópolis
+city_br_1323,base.br,base.state_br_sc,Capinzal
+city_br_1324,base.br,base.state_br_ma,Capinzal do Norte
+city_br_1325,base.br,base.state_br_ce,Capistrano
+city_br_1326,base.br,base.state_br_rs,Capitão
+city_br_1327,base.br,base.state_br_mg,Capitão Andrade
+city_br_1328,base.br,base.state_br_pi,Capitão de Campos
+city_br_1329,base.br,base.state_br_mg,Capitão Enéas
+city_br_1330,base.br,base.state_br_pi,Capitão Gervásio Oliveira
+city_br_1331,base.br,base.state_br_pr,Capitão Leônidas Marques
+city_br_1332,base.br,base.state_br_pa,Capitão Poço
+city_br_1333,base.br,base.state_br_mg,Capitólio
+city_br_1334,base.br,base.state_br_sp,Capivari
+city_br_1335,base.br,base.state_br_sc,Capivari de Baixo
+city_br_1336,base.br,base.state_br_rs,Capivari do Sul
+city_br_1337,base.br,base.state_br_ac,Capixaba
+city_br_1338,base.br,base.state_br_pe,Capoeiras
+city_br_1339,base.br,base.state_br_mg,Caputira
+city_br_1340,base.br,base.state_br_rs,Caraá
+city_br_1341,base.br,base.state_br_rr,Caracaraí
+city_br_1342,base.br,base.state_br_ms,Caracol
+city_br_1343,base.br,base.state_br_pi,Caracol
+city_br_1344,base.br,base.state_br_mg,Caraí
+city_br_1345,base.br,base.state_br_ba,Caraíbas
+city_br_1346,base.br,base.state_br_pr,Carambeí
+city_br_1347,base.br,base.state_br_mg,Caranaíba
+city_br_1348,base.br,base.state_br_mg,Carandaí
+city_br_1349,base.br,base.state_br_mg,Carangola
+city_br_1350,base.br,base.state_br_rj,Carapebus
+city_br_1351,base.br,base.state_br_mg,Caratinga
+city_br_1352,base.br,base.state_br_am,Carauari
+city_br_1353,base.br,base.state_br_pb,Caraúbas
+city_br_1354,base.br,base.state_br_rn,Caraúbas
+city_br_1355,base.br,base.state_br_pi,Caraúbas do Piauí
+city_br_1356,base.br,base.state_br_ba,Caravelas
+city_br_1357,base.br,base.state_br_rs,Carazinho
+city_br_1358,base.br,base.state_br_mg,Carbonita
+city_br_1359,base.br,base.state_br_ba,Cardeal da Silva
+city_br_1360,base.br,base.state_br_sp,Cardoso
+city_br_1361,base.br,base.state_br_rj,Cardoso Moreira
+city_br_1362,base.br,base.state_br_mg,Careaçu
+city_br_1363,base.br,base.state_br_am,Careiro
+city_br_1364,base.br,base.state_br_am,Careiro da Várzea
+city_br_1365,base.br,base.state_br_ce,Caridade
+city_br_1366,base.br,base.state_br_pi,Caridade do Piauí
+city_br_1367,base.br,base.state_br_ba,Carinhanha
+city_br_1368,base.br,base.state_br_se,Carira
+city_br_1369,base.br,base.state_br_ce,Cariré
+city_br_1370,base.br,base.state_br_to,Cariri do Tocantins
+city_br_1371,base.br,base.state_br_ce,Caririaçu
+city_br_1372,base.br,base.state_br_ce,Cariús
+city_br_1373,base.br,base.state_br_mt,Carlinda
+city_br_1374,base.br,base.state_br_pr,Carlópolis
+city_br_1375,base.br,base.state_br_rs,Carlos Barbosa
+city_br_1376,base.br,base.state_br_mg,Carlos Chagas
+city_br_1377,base.br,base.state_br_rs,Carlos Gomes
+city_br_1378,base.br,base.state_br_mg,Carmésia
+city_br_1379,base.br,base.state_br_rj,Carmo
+city_br_1380,base.br,base.state_br_mg,Carmo da Cachoeira
+city_br_1381,base.br,base.state_br_mg,Carmo da Mata
+city_br_1382,base.br,base.state_br_mg,Carmo de Minas
+city_br_1383,base.br,base.state_br_mg,Carmo do Cajuru
+city_br_1384,base.br,base.state_br_mg,Carmo do Paranaíba
+city_br_1385,base.br,base.state_br_mg,Carmo do Rio Claro
+city_br_1386,base.br,base.state_br_go,Carmo do Rio Verde
+city_br_1387,base.br,base.state_br_to,Carmolândia
+city_br_1388,base.br,base.state_br_se,Carmópolis
+city_br_1389,base.br,base.state_br_mg,Carmópolis de Minas
+city_br_1390,base.br,base.state_br_pe,Carnaíba
+city_br_1391,base.br,base.state_br_rn,Carnaúba dos Dantas
+city_br_1392,base.br,base.state_br_rn,Carnaubais
+city_br_1393,base.br,base.state_br_ce,Carnaubal
+city_br_1394,base.br,base.state_br_pe,Carnaubeira da Penha
+city_br_1395,base.br,base.state_br_mg,Carneirinho
+city_br_1396,base.br,base.state_br_al,Carneiros
+city_br_1397,base.br,base.state_br_rr,Caroebe
+city_br_1398,base.br,base.state_br_ma,Carolina
+city_br_1399,base.br,base.state_br_pe,Carpina
+city_br_1400,base.br,base.state_br_mg,Carrancas
+city_br_1401,base.br,base.state_br_pb,Carrapateira
+city_br_1402,base.br,base.state_br_to,Carrasco Bonito
+city_br_1403,base.br,base.state_br_ma,Carutapera
+city_br_1404,base.br,base.state_br_mg,Carvalhópolis
+city_br_1405,base.br,base.state_br_mg,Carvalhos
+city_br_1406,base.br,base.state_br_sp,Casa Branca
+city_br_1407,base.br,base.state_br_mg,Casa Grande
+city_br_1408,base.br,base.state_br_ba,Casa Nova
+city_br_1409,base.br,base.state_br_rs,Casca
+city_br_1410,base.br,base.state_br_mg,Cascalho Rico
+city_br_1411,base.br,base.state_br_ce,Cascavel
+city_br_1412,base.br,base.state_br_to,Caseara
+city_br_1413,base.br,base.state_br_rs,Caseiros
+city_br_1414,base.br,base.state_br_rj,Casimiro de Abreu
+city_br_1415,base.br,base.state_br_pe,Casinhas
+city_br_1416,base.br,base.state_br_pb,Casserengue
+city_br_1417,base.br,base.state_br_mg,Cássia
+city_br_1418,base.br,base.state_br_sp,Cássia dos Coqueiros
+city_br_1419,base.br,base.state_br_ms,Cassilândia
+city_br_1420,base.br,base.state_br_mt,Castanheira
+city_br_1421,base.br,base.state_br_ro,Castanheiras
+city_br_1422,base.br,base.state_br_go,Castelândia
+city_br_1423,base.br,base.state_br_es,Castelo
+city_br_1424,base.br,base.state_br_pi,Castelo do Piauí
+city_br_1425,base.br,base.state_br_sp,Castilho
+city_br_1426,base.br,base.state_br_pr,Castro
+city_br_1427,base.br,base.state_br_ba,Castro Alves
+city_br_1428,base.br,base.state_br_mg,Cataguases
+city_br_1429,base.br,base.state_br_pr,Catanduvas
+city_br_1430,base.br,base.state_br_sc,Catanduvas
+city_br_1431,base.br,base.state_br_ce,Catarina
+city_br_1432,base.br,base.state_br_mg,Catas Altas
+city_br_1433,base.br,base.state_br_mg,Catas Altas da Noruega
+city_br_1434,base.br,base.state_br_pe,Catende
+city_br_1435,base.br,base.state_br_sp,Catiguá
+city_br_1436,base.br,base.state_br_pb,Catingueira
+city_br_1437,base.br,base.state_br_ba,Catolândia
+city_br_1438,base.br,base.state_br_pb,Catolé do Rocha
+city_br_1439,base.br,base.state_br_ba,Catu
+city_br_1440,base.br,base.state_br_rs,Catuípe
+city_br_1441,base.br,base.state_br_mg,Catuji
+city_br_1442,base.br,base.state_br_ce,Catunda
+city_br_1443,base.br,base.state_br_go,Caturaí
+city_br_1444,base.br,base.state_br_ba,Caturama
+city_br_1445,base.br,base.state_br_pb,Caturité
+city_br_1446,base.br,base.state_br_mg,Catuti
+city_br_1447,base.br,base.state_br_go,Cavalcante
+city_br_1448,base.br,base.state_br_mg,Caxambu
+city_br_1449,base.br,base.state_br_sc,Caxambu do Sul
+city_br_1450,base.br,base.state_br_pi,Caxingó
+city_br_1451,base.br,base.state_br_rn,Ceará-Mirim
+city_br_1452,base.br,base.state_br_ma,Cedral
+city_br_1453,base.br,base.state_br_sp,Cedral
+city_br_1454,base.br,base.state_br_ce,Cedro
+city_br_1455,base.br,base.state_br_pe,Cedro
+city_br_1456,base.br,base.state_br_se,Cedro de São João
+city_br_1457,base.br,base.state_br_mg,Cedro do Abaeté
+city_br_1458,base.br,base.state_br_sc,Celso Ramos
+city_br_1459,base.br,base.state_br_rs,Centenário
+city_br_1460,base.br,base.state_br_to,Centenário
+city_br_1461,base.br,base.state_br_pr,Centenário do Sul
+city_br_1462,base.br,base.state_br_ba,Central
+city_br_1463,base.br,base.state_br_mg,Central de Minas
+city_br_1464,base.br,base.state_br_ma,Central do Maranhão
+city_br_1465,base.br,base.state_br_mg,Centralina
+city_br_1466,base.br,base.state_br_ma,Centro do Guilherme
+city_br_1467,base.br,base.state_br_ma,Centro Novo do Maranhão
+city_br_1468,base.br,base.state_br_ro,Cerejeiras
+city_br_1469,base.br,base.state_br_go,Ceres
+city_br_1470,base.br,base.state_br_sp,Cerqueira César
+city_br_1471,base.br,base.state_br_sp,Cerquilho
+city_br_1472,base.br,base.state_br_rs,Cerrito
+city_br_1473,base.br,base.state_br_pr,Cerro Azul
+city_br_1474,base.br,base.state_br_rs,Cerro Branco
+city_br_1475,base.br,base.state_br_rn,Cerro Corá
+city_br_1476,base.br,base.state_br_rs,Cerro Grande
+city_br_1477,base.br,base.state_br_rs,Cerro Grande do Sul
+city_br_1478,base.br,base.state_br_rs,Cerro Largo
+city_br_1479,base.br,base.state_br_sc,Cerro Negro
+city_br_1480,base.br,base.state_br_sp,Cesário Lange
+city_br_1481,base.br,base.state_br_pr,Céu Azul
+city_br_1482,base.br,base.state_br_go,Cezarina
+city_br_1483,base.br,base.state_br_pe,Chã de Alegria
+city_br_1484,base.br,base.state_br_pe,Chã Grande
+city_br_1485,base.br,base.state_br_al,Chã Preta
+city_br_1486,base.br,base.state_br_mg,Chácara
+city_br_1487,base.br,base.state_br_mg,Chalé
+city_br_1488,base.br,base.state_br_rs,Chapada
+city_br_1489,base.br,base.state_br_to,Chapada da Natividade
+city_br_1490,base.br,base.state_br_to,Chapada de Areia
+city_br_1491,base.br,base.state_br_mg,Chapada do Norte
+city_br_1492,base.br,base.state_br_mt,Chapada dos Guimarães
+city_br_1493,base.br,base.state_br_mg,Chapada Gaúcha
+city_br_1494,base.br,base.state_br_go,Chapadão do Céu
+city_br_1495,base.br,base.state_br_sc,Chapadão do Lageado
+city_br_1496,base.br,base.state_br_ms,Chapadão do Sul
+city_br_1497,base.br,base.state_br_ma,Chapadinha
+city_br_1498,base.br,base.state_br_sp,Charqueada
+city_br_1499,base.br,base.state_br_rs,Charqueadas
+city_br_1500,base.br,base.state_br_rs,Charrua
+city_br_1501,base.br,base.state_br_ce,Chaval
+city_br_1502,base.br,base.state_br_sp,Chavantes
+city_br_1503,base.br,base.state_br_pa,Chaves
+city_br_1504,base.br,base.state_br_mg,Chiador
+city_br_1505,base.br,base.state_br_rs,Chiapetta
+city_br_1506,base.br,base.state_br_pr,Chopinzinho
+city_br_1507,base.br,base.state_br_ce,Choró
+city_br_1508,base.br,base.state_br_ce,Chorozinho
+city_br_1509,base.br,base.state_br_ba,Chorrochó
+city_br_1510,base.br,base.state_br_rs,Chuí
+city_br_1511,base.br,base.state_br_ro,Chupinguaia
+city_br_1512,base.br,base.state_br_rs,Chuvisca
+city_br_1513,base.br,base.state_br_pr,Cianorte
+city_br_1514,base.br,base.state_br_ba,Cícero Dantas
+city_br_1515,base.br,base.state_br_pr,Cidade Gaúcha
+city_br_1516,base.br,base.state_br_go,Cidade Ocidental
+city_br_1517,base.br,base.state_br_ma,Cidelândia
+city_br_1518,base.br,base.state_br_rs,Cidreira
+city_br_1519,base.br,base.state_br_ba,Cipó
+city_br_1520,base.br,base.state_br_mg,Cipotânea
+city_br_1521,base.br,base.state_br_rs,Ciríaco
+city_br_1522,base.br,base.state_br_mg,Claraval
+city_br_1523,base.br,base.state_br_mg,Claro dos Poções
+city_br_1524,base.br,base.state_br_mt,Cláudia
+city_br_1525,base.br,base.state_br_mg,Cláudio
+city_br_1526,base.br,base.state_br_sp,Clementina
+city_br_1527,base.br,base.state_br_pr,Clevelândia
+city_br_1528,base.br,base.state_br_ba,Coaraci
+city_br_1529,base.br,base.state_br_am,Coari
+city_br_1530,base.br,base.state_br_pi,Cocal
+city_br_1531,base.br,base.state_br_pi,Cocal de Telha
+city_br_1532,base.br,base.state_br_sc,Cocal do Sul
+city_br_1533,base.br,base.state_br_pi,Cocal dos Alves
+city_br_1534,base.br,base.state_br_mt,Cocalinho
+city_br_1535,base.br,base.state_br_go,Cocalzinho de Goiás
+city_br_1536,base.br,base.state_br_ba,Cocos
+city_br_1537,base.br,base.state_br_am,Codajás
+city_br_1538,base.br,base.state_br_ma,Coelho Neto
+city_br_1539,base.br,base.state_br_mg,Coimbra
+city_br_1540,base.br,base.state_br_al,Coité do Nóia
+city_br_1541,base.br,base.state_br_pi,Coivaras
+city_br_1542,base.br,base.state_br_pa,Colares
+city_br_1543,base.br,base.state_br_mt,Colíder
+city_br_1544,base.br,base.state_br_sp,Colina
+city_br_1545,base.br,base.state_br_ma,Colinas
+city_br_1546,base.br,base.state_br_rs,Colinas
+city_br_1547,base.br,base.state_br_go,Colinas do Sul
+city_br_1548,base.br,base.state_br_to,Colinas do Tocantins
+city_br_1549,base.br,base.state_br_to,Colméia
+city_br_1550,base.br,base.state_br_mt,Colniza
+city_br_1551,base.br,base.state_br_sp,Colômbia
+city_br_1552,base.br,base.state_br_pi,Colônia do Gurguéia
+city_br_1553,base.br,base.state_br_pi,Colônia do Piauí
+city_br_1554,base.br,base.state_br_al,Colônia Leopoldina
+city_br_1555,base.br,base.state_br_pr,Colorado
+city_br_1556,base.br,base.state_br_rs,Colorado
+city_br_1557,base.br,base.state_br_ro,Colorado do Oeste
+city_br_1558,base.br,base.state_br_mg,Coluna
+city_br_1559,base.br,base.state_br_to,Combinado
+city_br_1560,base.br,base.state_br_mg,Comendador Gomes
+city_br_1561,base.br,base.state_br_rj,Comendador Levy Gasparian
+city_br_1562,base.br,base.state_br_mg,Comercinho
+city_br_1563,base.br,base.state_br_mt,Comodoro
+city_br_1564,base.br,base.state_br_pb,Conceição
+city_br_1565,base.br,base.state_br_mg,Conceição da Aparecida
+city_br_1566,base.br,base.state_br_es,Conceição da Barra
+city_br_1567,base.br,base.state_br_mg,Conceição da Barra de Minas
+city_br_1568,base.br,base.state_br_ba,Conceição da Feira
+city_br_1569,base.br,base.state_br_mg,Conceição das Alagoas
+city_br_1570,base.br,base.state_br_mg,Conceição das Pedras
+city_br_1571,base.br,base.state_br_mg,Conceição de Ipanema
+city_br_1572,base.br,base.state_br_rj,Conceição de Macabu
+city_br_1573,base.br,base.state_br_ba,Conceição do Almeida
+city_br_1574,base.br,base.state_br_pa,Conceição do Araguaia
+city_br_1575,base.br,base.state_br_pi,Conceição do Canindé
+city_br_1576,base.br,base.state_br_es,Conceição do Castelo
+city_br_1577,base.br,base.state_br_ba,Conceição do Coité
+city_br_1578,base.br,base.state_br_ba,Conceição do Jacuípe
+city_br_1579,base.br,base.state_br_ma,Conceição do Lago-Açu
+city_br_1580,base.br,base.state_br_mg,Conceição do Mato Dentro
+city_br_1581,base.br,base.state_br_mg,Conceição do Pará
+city_br_1582,base.br,base.state_br_mg,Conceição do Rio Verde
+city_br_1583,base.br,base.state_br_to,Conceição do Tocantins
+city_br_1584,base.br,base.state_br_mg,Conceição dos Ouros
+city_br_1585,base.br,base.state_br_sp,Conchal
+city_br_1586,base.br,base.state_br_sp,Conchas
+city_br_1587,base.br,base.state_br_sc,Concórdia
+city_br_1588,base.br,base.state_br_pa,Concórdia do Pará
+city_br_1589,base.br,base.state_br_pb,Condado
+city_br_1590,base.br,base.state_br_pe,Condado
+city_br_1591,base.br,base.state_br_ba,Conde
+city_br_1592,base.br,base.state_br_pb,Conde
+city_br_1593,base.br,base.state_br_ba,Condeúba
+city_br_1594,base.br,base.state_br_rs,Condor
+city_br_1595,base.br,base.state_br_mg,Cônego Marinho
+city_br_1596,base.br,base.state_br_mg,Confins
+city_br_1597,base.br,base.state_br_mt,Confresa
+city_br_1598,base.br,base.state_br_pb,Congo
+city_br_1599,base.br,base.state_br_mg,Congonhal
+city_br_1600,base.br,base.state_br_mg,Congonhas
+city_br_1601,base.br,base.state_br_mg,Congonhas do Norte
+city_br_1602,base.br,base.state_br_pr,Congonhinhas
+city_br_1603,base.br,base.state_br_mg,Conquista
+city_br_1604,base.br,base.state_br_mt,Conquista D'Oeste
+city_br_1605,base.br,base.state_br_pr,Conselheiro Mairinck
+city_br_1606,base.br,base.state_br_mg,Conselheiro Pena
+city_br_1607,base.br,base.state_br_mg,Consolação
+city_br_1608,base.br,base.state_br_rs,Constantina
+city_br_1609,base.br,base.state_br_pr,Contenda
+city_br_1610,base.br,base.state_br_ba,Contendas do Sincorá
+city_br_1611,base.br,base.state_br_mg,Coqueiral
+city_br_1612,base.br,base.state_br_rs,Coqueiro Baixo
+city_br_1613,base.br,base.state_br_al,Coqueiro Seco
+city_br_1614,base.br,base.state_br_rs,Coqueiros do Sul
+city_br_1615,base.br,base.state_br_mg,Coração de Jesus
+city_br_1616,base.br,base.state_br_ba,Coração de Maria
+city_br_1617,base.br,base.state_br_pr,Corbélia
+city_br_1618,base.br,base.state_br_rj,Cordeiro
+city_br_1619,base.br,base.state_br_sp,Cordeirópolis
+city_br_1620,base.br,base.state_br_ba,Cordeiros
+city_br_1621,base.br,base.state_br_sc,Cordilheira Alta
+city_br_1622,base.br,base.state_br_mg,Cordisburgo
+city_br_1623,base.br,base.state_br_mg,Cordislândia
+city_br_1624,base.br,base.state_br_ce,Coreaú
+city_br_1625,base.br,base.state_br_pb,Coremas
+city_br_1626,base.br,base.state_br_ms,Corguinho
+city_br_1627,base.br,base.state_br_ba,Coribe
+city_br_1628,base.br,base.state_br_mg,Corinto
+city_br_1629,base.br,base.state_br_pr,Cornélio Procópio
+city_br_1630,base.br,base.state_br_mg,Coroaci
+city_br_1631,base.br,base.state_br_sp,Coroados
+city_br_1632,base.br,base.state_br_ma,Coroatá
+city_br_1633,base.br,base.state_br_mg,Coromandel
+city_br_1634,base.br,base.state_br_rs,Coronel Barros
+city_br_1635,base.br,base.state_br_rs,Coronel Bicaco
+city_br_1636,base.br,base.state_br_pr,Coronel Domingos Soares
+city_br_1637,base.br,base.state_br_rn,Coronel Ezequiel
+city_br_1638,base.br,base.state_br_sc,Coronel Freitas
+city_br_1639,base.br,base.state_br_rn,Coronel João Pessoa
+city_br_1640,base.br,base.state_br_ba,Coronel João Sá
+city_br_1641,base.br,base.state_br_pi,Coronel José Dias
+city_br_1642,base.br,base.state_br_sp,Coronel Macedo
+city_br_1643,base.br,base.state_br_sc,Coronel Martins
+city_br_1644,base.br,base.state_br_mg,Coronel Murta
+city_br_1645,base.br,base.state_br_mg,Coronel Pacheco
+city_br_1646,base.br,base.state_br_rs,Coronel Pilar
+city_br_1647,base.br,base.state_br_ms,Coronel Sapucaia
+city_br_1648,base.br,base.state_br_pr,Coronel Vivida
+city_br_1649,base.br,base.state_br_mg,Coronel Xavier Chaves
+city_br_1650,base.br,base.state_br_mg,Córrego Danta
+city_br_1651,base.br,base.state_br_mg,Córrego do Bom Jesus
+city_br_1652,base.br,base.state_br_go,Córrego do Ouro
+city_br_1653,base.br,base.state_br_mg,Córrego Fundo
+city_br_1654,base.br,base.state_br_mg,Córrego Novo
+city_br_1655,base.br,base.state_br_sc,Correia Pinto
+city_br_1656,base.br,base.state_br_pi,Corrente
+city_br_1657,base.br,base.state_br_pe,Correntes
+city_br_1658,base.br,base.state_br_ba,Correntina
+city_br_1659,base.br,base.state_br_pe,Cortês
+city_br_1660,base.br,base.state_br_ms,Corumbá
+city_br_1661,base.br,base.state_br_go,Corumbá de Goiás
+city_br_1662,base.br,base.state_br_go,Corumbaíba
+city_br_1663,base.br,base.state_br_sp,Corumbataí
+city_br_1664,base.br,base.state_br_pr,Corumbataí do Sul
+city_br_1665,base.br,base.state_br_ro,Corumbiara
+city_br_1666,base.br,base.state_br_sc,Corupá
+city_br_1667,base.br,base.state_br_al,Coruripe
+city_br_1668,base.br,base.state_br_sp,Cosmópolis
+city_br_1669,base.br,base.state_br_sp,Cosmorama
+city_br_1670,base.br,base.state_br_ro,Costa Marques
+city_br_1671,base.br,base.state_br_ms,Costa Rica
+city_br_1672,base.br,base.state_br_ba,Cotegipe
+city_br_1673,base.br,base.state_br_rs,Cotiporã
+city_br_1674,base.br,base.state_br_mt,Cotriguaçu
+city_br_1675,base.br,base.state_br_mg,Couto de Magalhães de Minas
+city_br_1676,base.br,base.state_br_to,Couto Magalhães
+city_br_1677,base.br,base.state_br_rs,Coxilha
+city_br_1678,base.br,base.state_br_ms,Coxim
+city_br_1679,base.br,base.state_br_pb,Coxixola
+city_br_1680,base.br,base.state_br_al,Craíbas
+city_br_1681,base.br,base.state_br_ce,Crateús
+city_br_1682,base.br,base.state_br_sp,Cravinhos
+city_br_1683,base.br,base.state_br_ba,Cravolândia
+city_br_1684,base.br,base.state_br_mg,Crisólita
+city_br_1685,base.br,base.state_br_ba,Crisópolis
+city_br_1686,base.br,base.state_br_rs,Crissiumal
+city_br_1687,base.br,base.state_br_mg,Cristais
+city_br_1688,base.br,base.state_br_sp,Cristais Paulista
+city_br_1689,base.br,base.state_br_rs,Cristal
+city_br_1690,base.br,base.state_br_rs,Cristal do Sul
+city_br_1691,base.br,base.state_br_to,Cristalândia
+city_br_1692,base.br,base.state_br_pi,Cristalândia do Piauí
+city_br_1693,base.br,base.state_br_mg,Cristália
+city_br_1694,base.br,base.state_br_go,Cristalina
+city_br_1695,base.br,base.state_br_mg,Cristiano Otoni
+city_br_1696,base.br,base.state_br_go,Cristianópolis
+city_br_1697,base.br,base.state_br_mg,Cristina
+city_br_1698,base.br,base.state_br_se,Cristinápolis
+city_br_1699,base.br,base.state_br_pi,Cristino Castro
+city_br_1700,base.br,base.state_br_ba,Cristópolis
+city_br_1701,base.br,base.state_br_go,Crixás
+city_br_1702,base.br,base.state_br_to,Crixás do Tocantins
+city_br_1703,base.br,base.state_br_ce,Croatá
+city_br_1704,base.br,base.state_br_go,Cromínia
+city_br_1705,base.br,base.state_br_mg,Crucilândia
+city_br_1706,base.br,base.state_br_ce,Cruz
+city_br_1707,base.br,base.state_br_rs,Cruz Alta
+city_br_1708,base.br,base.state_br_ba,Cruz das Almas
+city_br_1709,base.br,base.state_br_pb,Cruz do Espírito Santo
+city_br_1710,base.br,base.state_br_pr,Cruz Machado
+city_br_1711,base.br,base.state_br_sp,Cruzália
+city_br_1712,base.br,base.state_br_rs,Cruzaltense
+city_br_1713,base.br,base.state_br_sp,Cruzeiro
+city_br_1714,base.br,base.state_br_mg,Cruzeiro da Fortaleza
+city_br_1715,base.br,base.state_br_pr,Cruzeiro do Iguaçu
+city_br_1716,base.br,base.state_br_pr,Cruzeiro do Oeste
+city_br_1717,base.br,base.state_br_ac,Cruzeiro do Sul
+city_br_1718,base.br,base.state_br_pr,Cruzeiro do Sul
+city_br_1719,base.br,base.state_br_rs,Cruzeiro do Sul
+city_br_1720,base.br,base.state_br_rn,Cruzeta
+city_br_1721,base.br,base.state_br_mg,Cruzília
+city_br_1722,base.br,base.state_br_pr,Cruzmaltina
+city_br_1723,base.br,base.state_br_pb,Cubati
+city_br_1724,base.br,base.state_br_pb,Cuité
+city_br_1725,base.br,base.state_br_pb,Cuité de Mamanguape
+city_br_1726,base.br,base.state_br_pb,Cuitegi
+city_br_1727,base.br,base.state_br_ro,Cujubim
+city_br_1728,base.br,base.state_br_go,Cumari
+city_br_1729,base.br,base.state_br_pe,Cumaru
+city_br_1730,base.br,base.state_br_pa,Cumaru do Norte
+city_br_1731,base.br,base.state_br_se,Cumbe
+city_br_1732,base.br,base.state_br_sp,Cunha
+city_br_1733,base.br,base.state_br_sc,Cunha Porã
+city_br_1734,base.br,base.state_br_sc,Cunhataí
+city_br_1735,base.br,base.state_br_mg,Cuparaque
+city_br_1736,base.br,base.state_br_pe,Cupira
+city_br_1737,base.br,base.state_br_ba,Curaçá
+city_br_1738,base.br,base.state_br_pi,Curimatá
+city_br_1739,base.br,base.state_br_pa,Curionópolis
+city_br_1740,base.br,base.state_br_sc,Curitibanos
+city_br_1741,base.br,base.state_br_pr,Curiúva
+city_br_1742,base.br,base.state_br_pi,Currais
+city_br_1743,base.br,base.state_br_rn,Currais Novos
+city_br_1744,base.br,base.state_br_pb,Curral de Cima
+city_br_1745,base.br,base.state_br_mg,Curral de Dentro
+city_br_1746,base.br,base.state_br_pi,Curral Novo do Piauí
+city_br_1747,base.br,base.state_br_pb,Curral Velho
+city_br_1748,base.br,base.state_br_pa,Curralinho
+city_br_1749,base.br,base.state_br_pi,Curralinhos
+city_br_1750,base.br,base.state_br_pa,Curuá
+city_br_1751,base.br,base.state_br_pa,Curuçá
+city_br_1752,base.br,base.state_br_ma,Cururupu
+city_br_1753,base.br,base.state_br_mt,Curvelândia
+city_br_1754,base.br,base.state_br_mg,Curvelo
+city_br_1755,base.br,base.state_br_pe,Custódia
+city_br_1756,base.br,base.state_br_ap,Cutias
+city_br_1757,base.br,base.state_br_go,Damianópolis
+city_br_1758,base.br,base.state_br_pb,Damião
+city_br_1759,base.br,base.state_br_go,Damolândia
+city_br_1760,base.br,base.state_br_to,Darcinópolis
+city_br_1761,base.br,base.state_br_ba,Dário Meira
+city_br_1762,base.br,base.state_br_mg,Datas
+city_br_1763,base.br,base.state_br_rs,David Canabarro
+city_br_1764,base.br,base.state_br_go,Davinópolis
+city_br_1765,base.br,base.state_br_ma,Davinópolis
+city_br_1766,base.br,base.state_br_mg,Delfim Moreira
+city_br_1767,base.br,base.state_br_mg,Delfinópolis
+city_br_1768,base.br,base.state_br_al,Delmiro Gouveia
+city_br_1769,base.br,base.state_br_mg,Delta
+city_br_1770,base.br,base.state_br_pi,Demerval Lobão
+city_br_1771,base.br,base.state_br_mt,Denise
+city_br_1772,base.br,base.state_br_ms,Deodápolis
+city_br_1773,base.br,base.state_br_ce,Deputado Irapuan Pinheiro
+city_br_1774,base.br,base.state_br_rs,Derrubadas
+city_br_1775,base.br,base.state_br_sp,Descalvado
+city_br_1776,base.br,base.state_br_sc,Descanso
+city_br_1777,base.br,base.state_br_mg,Descoberto
+city_br_1778,base.br,base.state_br_pb,Desterro
+city_br_1779,base.br,base.state_br_mg,Desterro de Entre Rios
+city_br_1780,base.br,base.state_br_mg,Desterro do Melo
+city_br_1781,base.br,base.state_br_rs,Dezesseis de Novembro
+city_br_1782,base.br,base.state_br_pb,Diamante
+city_br_1783,base.br,base.state_br_pr,Diamante D'Oeste
+city_br_1784,base.br,base.state_br_pr,Diamante do Norte
+city_br_1785,base.br,base.state_br_pr,Diamante do Sul
+city_br_1786,base.br,base.state_br_mg,Diamantina
+city_br_1787,base.br,base.state_br_mt,Diamantino
+city_br_1788,base.br,base.state_br_to,Dianópolis
+city_br_1789,base.br,base.state_br_ba,Dias d'Ávila
+city_br_1790,base.br,base.state_br_rs,Dilermando de Aguiar
+city_br_1791,base.br,base.state_br_mg,Diogo de Vasconcelos
+city_br_1792,base.br,base.state_br_mg,Dionísio
+city_br_1793,base.br,base.state_br_sc,Dionísio Cerqueira
+city_br_1794,base.br,base.state_br_go,Diorama
+city_br_1795,base.br,base.state_br_sp,Dirce Reis
+city_br_1796,base.br,base.state_br_pi,Dirceu Arcoverde
+city_br_1797,base.br,base.state_br_se,Divina Pastora
+city_br_1798,base.br,base.state_br_mg,Divinésia
+city_br_1799,base.br,base.state_br_mg,Divino
+city_br_1800,base.br,base.state_br_mg,Divino das Laranjeiras
+city_br_1801,base.br,base.state_br_es,Divino de São Lourenço
+city_br_1802,base.br,base.state_br_sp,Divinolândia
+city_br_1803,base.br,base.state_br_mg,Divinolândia de Minas
+city_br_1804,base.br,base.state_br_go,Divinópolis de Goiás
+city_br_1805,base.br,base.state_br_to,Divinópolis do Tocantins
+city_br_1806,base.br,base.state_br_mg,Divisa Alegre
+city_br_1807,base.br,base.state_br_mg,Divisa Nova
+city_br_1808,base.br,base.state_br_mg,Divisópolis
+city_br_1809,base.br,base.state_br_sp,Dobrada
+city_br_1810,base.br,base.state_br_sp,Dois Córregos
+city_br_1811,base.br,base.state_br_rs,Dois Irmãos
+city_br_1812,base.br,base.state_br_rs,Dois Irmãos das Missões
+city_br_1813,base.br,base.state_br_ms,Dois Irmãos do Buriti
+city_br_1814,base.br,base.state_br_to,Dois Irmãos do Tocantins
+city_br_1815,base.br,base.state_br_rs,Dois Lajeados
+city_br_1816,base.br,base.state_br_al,Dois Riachos
+city_br_1817,base.br,base.state_br_pr,Dois Vizinhos
+city_br_1818,base.br,base.state_br_sp,Dolcinópolis
+city_br_1819,base.br,base.state_br_mt,Dom Aquino
+city_br_1820,base.br,base.state_br_ba,Dom Basílio
+city_br_1821,base.br,base.state_br_mg,Dom Bosco
+city_br_1822,base.br,base.state_br_mg,Dom Cavati
+city_br_1823,base.br,base.state_br_pa,Dom Eliseu
+city_br_1824,base.br,base.state_br_pi,Dom Expedito Lopes
+city_br_1825,base.br,base.state_br_rs,Dom Feliciano
+city_br_1826,base.br,base.state_br_pi,Dom Inocêncio
+city_br_1827,base.br,base.state_br_mg,Dom Joaquim
+city_br_1828,base.br,base.state_br_ba,Dom Macedo Costa
+city_br_1829,base.br,base.state_br_rs,Dom Pedrito
+city_br_1830,base.br,base.state_br_ma,Dom Pedro
+city_br_1831,base.br,base.state_br_rs,Dom Pedro de Alcântara
+city_br_1832,base.br,base.state_br_mg,Dom Silvério
+city_br_1833,base.br,base.state_br_mg,Dom Viçoso
+city_br_1834,base.br,base.state_br_es,Domingos Martins
+city_br_1835,base.br,base.state_br_pi,Domingos Mourão
+city_br_1836,base.br,base.state_br_sc,Dona Emma
+city_br_1837,base.br,base.state_br_mg,Dona Eusébia
+city_br_1838,base.br,base.state_br_rs,Dona Francisca
+city_br_1839,base.br,base.state_br_pb,Dona Inês
+city_br_1840,base.br,base.state_br_mg,Dores de Campos
+city_br_1841,base.br,base.state_br_mg,Dores de Guanhães
+city_br_1842,base.br,base.state_br_mg,Dores do Indaiá
+city_br_1843,base.br,base.state_br_es,Dores do Rio Preto
+city_br_1844,base.br,base.state_br_mg,Dores do Turvo
+city_br_1845,base.br,base.state_br_mg,Doresópolis
+city_br_1846,base.br,base.state_br_pe,Dormentes
+city_br_1847,base.br,base.state_br_ms,Douradina
+city_br_1848,base.br,base.state_br_pr,Douradina
+city_br_1849,base.br,base.state_br_sp,Dourado
+city_br_1850,base.br,base.state_br_mg,Douradoquara
+city_br_1851,base.br,base.state_br_pr,Doutor Camargo
+city_br_1852,base.br,base.state_br_rs,Doutor Maurício Cardoso
+city_br_1853,base.br,base.state_br_sc,Doutor Pedrinho
+city_br_1854,base.br,base.state_br_rs,Doutor Ricardo
+city_br_1855,base.br,base.state_br_rn,Doutor Severiano
+city_br_1856,base.br,base.state_br_pr,Doutor Ulysses
+city_br_1857,base.br,base.state_br_go,Doverlândia
+city_br_1858,base.br,base.state_br_sp,Dracena
+city_br_1859,base.br,base.state_br_sp,Duartina
+city_br_1860,base.br,base.state_br_rj,Duas Barras
+city_br_1861,base.br,base.state_br_pb,Duas Estradas
+city_br_1862,base.br,base.state_br_to,Dueré
+city_br_1863,base.br,base.state_br_sp,Dumont
+city_br_1864,base.br,base.state_br_ma,Duque Bacelar
+city_br_1865,base.br,base.state_br_mg,Durandé
+city_br_1866,base.br,base.state_br_sp,Echaporã
+city_br_1867,base.br,base.state_br_es,Ecoporanga
+city_br_1868,base.br,base.state_br_go,Edealina
+city_br_1869,base.br,base.state_br_go,Edéia
+city_br_1870,base.br,base.state_br_am,Eirunepé
+city_br_1871,base.br,base.state_br_ms,Eldorado
+city_br_1872,base.br,base.state_br_sp,Eldorado
+city_br_1873,base.br,base.state_br_pa,Eldorado do Carajás
+city_br_1874,base.br,base.state_br_rs,Eldorado do Sul
+city_br_1875,base.br,base.state_br_pi,Elesbão Veloso
+city_br_1876,base.br,base.state_br_sp,Elias Fausto
+city_br_1877,base.br,base.state_br_pi,Eliseu Martins
+city_br_1878,base.br,base.state_br_sp,Elisiário
+city_br_1879,base.br,base.state_br_ba,Elísio Medrado
+city_br_1880,base.br,base.state_br_mg,Elói Mendes
+city_br_1881,base.br,base.state_br_pb,Emas
+city_br_1882,base.br,base.state_br_sp,Embaúba
+city_br_1883,base.br,base.state_br_sp,Embu-Guaçu
+city_br_1884,base.br,base.state_br_sp,Emilianópolis
+city_br_1885,base.br,base.state_br_rs,Encantado
+city_br_1886,base.br,base.state_br_rn,Encanto
+city_br_1887,base.br,base.state_br_ba,Encruzilhada
+city_br_1888,base.br,base.state_br_rs,Encruzilhada do Sul
+city_br_1889,base.br,base.state_br_pr,Enéas Marques
+city_br_1890,base.br,base.state_br_pr,Engenheiro Beltrão
+city_br_1891,base.br,base.state_br_mg,Engenheiro Caldas
+city_br_1892,base.br,base.state_br_sp,Engenheiro Coelho
+city_br_1893,base.br,base.state_br_mg,Engenheiro Navarro
+city_br_1894,base.br,base.state_br_rj,Engenheiro Paulo de Frontin
+city_br_1895,base.br,base.state_br_rs,Engenho Velho
+city_br_1896,base.br,base.state_br_mg,Entre Folhas
+city_br_1897,base.br,base.state_br_rs,Entre-Ijuís
+city_br_1898,base.br,base.state_br_ba,Entre Rios
+city_br_1899,base.br,base.state_br_sc,Entre Rios
+city_br_1900,base.br,base.state_br_mg,Entre Rios de Minas
+city_br_1901,base.br,base.state_br_pr,Entre Rios do Oeste
+city_br_1902,base.br,base.state_br_rs,Entre Rios do Sul
+city_br_1903,base.br,base.state_br_am,Envira
+city_br_1904,base.br,base.state_br_ac,Epitaciolândia
+city_br_1905,base.br,base.state_br_rn,Equador
+city_br_1906,base.br,base.state_br_rs,Erebango
+city_br_1907,base.br,base.state_br_ce,Ererê
+city_br_1908,base.br,base.state_br_ba,Érico Cardoso
+city_br_1909,base.br,base.state_br_sc,Ermo
+city_br_1910,base.br,base.state_br_rs,Ernestina
+city_br_1911,base.br,base.state_br_rs,Erval Grande
+city_br_1912,base.br,base.state_br_rs,Erval Seco
+city_br_1913,base.br,base.state_br_sc,Erval Velho
+city_br_1914,base.br,base.state_br_mg,Ervália
+city_br_1915,base.br,base.state_br_pe,Escada
+city_br_1916,base.br,base.state_br_rs,Esmeralda
+city_br_1917,base.br,base.state_br_mg,Esmeraldas
+city_br_1918,base.br,base.state_br_mg,Espera Feliz
+city_br_1919,base.br,base.state_br_pb,Esperança
+city_br_1920,base.br,base.state_br_rs,Esperança do Sul
+city_br_1921,base.br,base.state_br_pr,Esperança Nova
+city_br_1922,base.br,base.state_br_pi,Esperantina
+city_br_1923,base.br,base.state_br_to,Esperantina
+city_br_1924,base.br,base.state_br_ma,Esperantinópolis
+city_br_1925,base.br,base.state_br_pr,Espigão Alto do Iguaçu
+city_br_1926,base.br,base.state_br_ro,Espigão D'Oeste
+city_br_1927,base.br,base.state_br_mg,Espinosa
+city_br_1928,base.br,base.state_br_rn,Espírito Santo
+city_br_1929,base.br,base.state_br_mg,Espírito Santo do Dourado
+city_br_1930,base.br,base.state_br_sp,Espírito Santo do Pinhal
+city_br_1931,base.br,base.state_br_sp,Espírito Santo do Turvo
+city_br_1932,base.br,base.state_br_ba,Esplanada
+city_br_1933,base.br,base.state_br_rs,Espumoso
+city_br_1934,base.br,base.state_br_rs,Estação
+city_br_1935,base.br,base.state_br_se,Estância
+city_br_1936,base.br,base.state_br_rs,Estância Velha
+city_br_1937,base.br,base.state_br_rs,Esteio
+city_br_1938,base.br,base.state_br_mg,Estiva
+city_br_1939,base.br,base.state_br_sp,Estiva Gerbi
+city_br_1940,base.br,base.state_br_ma,Estreito
+city_br_1941,base.br,base.state_br_rs,Estrela
+city_br_1942,base.br,base.state_br_sp,Estrela d'Oeste
+city_br_1943,base.br,base.state_br_mg,Estrela Dalva
+city_br_1944,base.br,base.state_br_al,Estrela de Alagoas
+city_br_1945,base.br,base.state_br_mg,Estrela do Indaiá
+city_br_1946,base.br,base.state_br_go,Estrela do Norte
+city_br_1947,base.br,base.state_br_sp,Estrela do Norte
+city_br_1948,base.br,base.state_br_mg,Estrela do Sul
+city_br_1949,base.br,base.state_br_rs,Estrela Velha
+city_br_1950,base.br,base.state_br_ba,Euclides da Cunha
+city_br_1951,base.br,base.state_br_sp,Euclides da Cunha Paulista
+city_br_1952,base.br,base.state_br_rs,Eugênio de Castro
+city_br_1953,base.br,base.state_br_mg,Eugenópolis
+city_br_1954,base.br,base.state_br_ce,Eusébio
+city_br_1955,base.br,base.state_br_mg,Ewbank da Câmara
+city_br_1956,base.br,base.state_br_mg,Extrema
+city_br_1957,base.br,base.state_br_rn,Extremoz
+city_br_1958,base.br,base.state_br_pe,Exu
+city_br_1959,base.br,base.state_br_pb,Fagundes
+city_br_1960,base.br,base.state_br_rs,Fagundes Varela
+city_br_1961,base.br,base.state_br_go,Faina
+city_br_1962,base.br,base.state_br_mg,Fama
+city_br_1963,base.br,base.state_br_mg,Faria Lemos
+city_br_1964,base.br,base.state_br_ce,Farias Brito
+city_br_1965,base.br,base.state_br_pa,Faro
+city_br_1966,base.br,base.state_br_pr,Farol
+city_br_1967,base.br,base.state_br_rs,Farroupilha
+city_br_1968,base.br,base.state_br_sp,Fartura
+city_br_1969,base.br,base.state_br_pi,Fartura do Piauí
+city_br_1970,base.br,base.state_br_ba,Fátima
+city_br_1971,base.br,base.state_br_to,Fátima
+city_br_1972,base.br,base.state_br_ms,Fátima do Sul
+city_br_1973,base.br,base.state_br_pr,Faxinal
+city_br_1974,base.br,base.state_br_rs,Faxinal do Soturno
+city_br_1975,base.br,base.state_br_sc,Faxinal dos Guedes
+city_br_1976,base.br,base.state_br_rs,Faxinalzinho
+city_br_1977,base.br,base.state_br_go,Fazenda Nova
+city_br_1978,base.br,base.state_br_rs,Fazenda Vilanova
+city_br_1979,base.br,base.state_br_ac,Feijó
+city_br_1980,base.br,base.state_br_ba,Feira da Mata
+city_br_1981,base.br,base.state_br_al,Feira Grande
+city_br_1982,base.br,base.state_br_pe,Feira Nova
+city_br_1983,base.br,base.state_br_se,Feira Nova
+city_br_1984,base.br,base.state_br_ma,Feira Nova do Maranhão
+city_br_1985,base.br,base.state_br_mg,Felício dos Santos
+city_br_1986,base.br,base.state_br_rn,Felipe Guerra
+city_br_1987,base.br,base.state_br_mg,Felisburgo
+city_br_1988,base.br,base.state_br_mg,Felixlândia
+city_br_1989,base.br,base.state_br_rs,Feliz
+city_br_1990,base.br,base.state_br_al,Feliz Deserto
+city_br_1991,base.br,base.state_br_mt,Feliz Natal
+city_br_1992,base.br,base.state_br_pr,Fênix
+city_br_1993,base.br,base.state_br_pr,Fernandes Pinheiro
+city_br_1994,base.br,base.state_br_mg,Fernandes Tourinho
+city_br_1995,base.br,base.state_br_pe,Fernando de Noronha
+city_br_1996,base.br,base.state_br_ma,Fernando Falcão
+city_br_1997,base.br,base.state_br_rn,Fernando Pedroza
+city_br_1998,base.br,base.state_br_sp,Fernando Prestes
+city_br_1999,base.br,base.state_br_sp,Fernandópolis
+city_br_2000,base.br,base.state_br_sp,Fernão
+city_br_2001,base.br,base.state_br_ap,Ferreira Gomes
+city_br_2002,base.br,base.state_br_pe,Ferreiros
+city_br_2003,base.br,base.state_br_mg,Ferros
+city_br_2004,base.br,base.state_br_mg,Fervedouro
+city_br_2005,base.br,base.state_br_pr,Figueira
+city_br_2006,base.br,base.state_br_ms,Figueirão
+city_br_2007,base.br,base.state_br_to,Figueirópolis
+city_br_2008,base.br,base.state_br_mt,Figueirópolis D'Oeste
+city_br_2009,base.br,base.state_br_ba,Filadélfia
+city_br_2010,base.br,base.state_br_to,Filadélfia
+city_br_2011,base.br,base.state_br_ba,Firmino Alves
+city_br_2012,base.br,base.state_br_go,Firminópolis
+city_br_2013,base.br,base.state_br_al,Flexeiras
+city_br_2014,base.br,base.state_br_pr,Flor da Serra do Sul
+city_br_2015,base.br,base.state_br_sc,Flor do Sertão
+city_br_2016,base.br,base.state_br_sp,Flora Rica
+city_br_2017,base.br,base.state_br_pr,Floraí
+city_br_2018,base.br,base.state_br_rn,Florânia
+city_br_2019,base.br,base.state_br_sp,Floreal
+city_br_2020,base.br,base.state_br_pe,Flores
+city_br_2021,base.br,base.state_br_rs,Flores da Cunha
+city_br_2022,base.br,base.state_br_go,Flores de Goiás
+city_br_2023,base.br,base.state_br_pi,Flores do Piauí
+city_br_2024,base.br,base.state_br_pe,Floresta
+city_br_2025,base.br,base.state_br_pr,Floresta
+city_br_2026,base.br,base.state_br_ba,Floresta Azul
+city_br_2027,base.br,base.state_br_pa,Floresta do Araguaia
+city_br_2028,base.br,base.state_br_pi,Floresta do Piauí
+city_br_2029,base.br,base.state_br_mg,Florestal
+city_br_2030,base.br,base.state_br_pr,Florestópolis
+city_br_2031,base.br,base.state_br_pi,Floriano
+city_br_2032,base.br,base.state_br_rs,Floriano Peixoto
+city_br_2033,base.br,base.state_br_pr,Flórida
+city_br_2034,base.br,base.state_br_sp,Flórida Paulista
+city_br_2035,base.br,base.state_br_sp,Florínea
+city_br_2036,base.br,base.state_br_am,Fonte Boa
+city_br_2037,base.br,base.state_br_rs,Fontoura Xavier
+city_br_2038,base.br,base.state_br_mg,Formiga
+city_br_2039,base.br,base.state_br_rs,Formigueiro
+city_br_2040,base.br,base.state_br_ma,Formosa da Serra Negra
+city_br_2041,base.br,base.state_br_pr,Formosa do Oeste
+city_br_2042,base.br,base.state_br_ba,Formosa do Rio Preto
+city_br_2043,base.br,base.state_br_sc,Formosa do Sul
+city_br_2044,base.br,base.state_br_go,Formoso
+city_br_2045,base.br,base.state_br_mg,Formoso
+city_br_2046,base.br,base.state_br_to,Formoso do Araguaia
+city_br_2047,base.br,base.state_br_rs,Forquetinha
+city_br_2048,base.br,base.state_br_ce,Forquilha
+city_br_2049,base.br,base.state_br_sc,Forquilhinha
+city_br_2050,base.br,base.state_br_mg,Fortaleza de Minas
+city_br_2051,base.br,base.state_br_to,Fortaleza do Tabocão
+city_br_2052,base.br,base.state_br_ma,Fortaleza dos Nogueiras
+city_br_2053,base.br,base.state_br_rs,Fortaleza dos Valos
+city_br_2054,base.br,base.state_br_ce,Fortim
+city_br_2055,base.br,base.state_br_ma,Fortuna
+city_br_2056,base.br,base.state_br_mg,Fortuna de Minas
+city_br_2057,base.br,base.state_br_pr,Foz do Jordão
+city_br_2058,base.br,base.state_br_sc,Fraiburgo
+city_br_2059,base.br,base.state_br_pi,Francinópolis
+city_br_2060,base.br,base.state_br_pr,Francisco Alves
+city_br_2061,base.br,base.state_br_pi,Francisco Ayres
+city_br_2062,base.br,base.state_br_mg,Francisco Badaró
+city_br_2063,base.br,base.state_br_pr,Francisco Beltrão
+city_br_2064,base.br,base.state_br_rn,Francisco Dantas
+city_br_2065,base.br,base.state_br_mg,Francisco Dumont
+city_br_2066,base.br,base.state_br_pi,Francisco Macedo
+city_br_2067,base.br,base.state_br_mg,Francisco Sá
+city_br_2068,base.br,base.state_br_pi,Francisco Santos
+city_br_2069,base.br,base.state_br_mg,Franciscópolis
+city_br_2070,base.br,base.state_br_ce,Frecheirinha
+city_br_2071,base.br,base.state_br_rs,Frederico Westphalen
+city_br_2072,base.br,base.state_br_mg,Frei Gaspar
+city_br_2073,base.br,base.state_br_mg,Frei Inocêncio
+city_br_2074,base.br,base.state_br_mg,Frei Lagonegro
+city_br_2075,base.br,base.state_br_pb,Frei Martinho
+city_br_2076,base.br,base.state_br_pe,Frei Miguelinho
+city_br_2077,base.br,base.state_br_se,Frei Paulo
+city_br_2078,base.br,base.state_br_sc,Frei Rogério
+city_br_2079,base.br,base.state_br_mg,Fronteira
+city_br_2080,base.br,base.state_br_mg,Fronteira dos Vales
+city_br_2081,base.br,base.state_br_pi,Fronteiras
+city_br_2082,base.br,base.state_br_mg,Fruta de Leite
+city_br_2083,base.br,base.state_br_mg,Frutal
+city_br_2084,base.br,base.state_br_rn,Frutuoso Gomes
+city_br_2085,base.br,base.state_br_es,Fundão
+city_br_2086,base.br,base.state_br_mg,Funilândia
+city_br_2087,base.br,base.state_br_sp,Gabriel Monteiro
+city_br_2088,base.br,base.state_br_pb,Gado Bravo
+city_br_2089,base.br,base.state_br_sp,Gália
+city_br_2090,base.br,base.state_br_mg,Galiléia
+city_br_2091,base.br,base.state_br_rn,Galinhos
+city_br_2092,base.br,base.state_br_sc,Galvão
+city_br_2093,base.br,base.state_br_pe,Gameleira
+city_br_2094,base.br,base.state_br_go,Gameleira de Goiás
+city_br_2095,base.br,base.state_br_mg,Gameleiras
+city_br_2096,base.br,base.state_br_ba,Gandu
+city_br_2097,base.br,base.state_br_se,Gararu
+city_br_2098,base.br,base.state_br_sp,Garça
+city_br_2099,base.br,base.state_br_rs,Garibaldi
+city_br_2100,base.br,base.state_br_sc,Garopaba
+city_br_2101,base.br,base.state_br_pa,Garrafão do Norte
+city_br_2102,base.br,base.state_br_rs,Garruchos
+city_br_2103,base.br,base.state_br_sc,Garuva
+city_br_2104,base.br,base.state_br_sc,Gaspar
+city_br_2105,base.br,base.state_br_sp,Gastão Vidigal
+city_br_2106,base.br,base.state_br_mt,Gaúcha do Norte
+city_br_2107,base.br,base.state_br_rs,Gaurama
+city_br_2108,base.br,base.state_br_ba,Gavião
+city_br_2109,base.br,base.state_br_sp,Gavião Peixoto
+city_br_2110,base.br,base.state_br_pi,Geminiano
+city_br_2111,base.br,base.state_br_rs,General Câmara
+city_br_2112,base.br,base.state_br_mt,General Carneiro
+city_br_2113,base.br,base.state_br_pr,General Carneiro
+city_br_2114,base.br,base.state_br_se,General Maynard
+city_br_2115,base.br,base.state_br_sp,General Salgado
+city_br_2116,base.br,base.state_br_ce,General Sampaio
+city_br_2117,base.br,base.state_br_rs,Gentil
+city_br_2118,base.br,base.state_br_ba,Gentio do Ouro
+city_br_2119,base.br,base.state_br_sp,Getulina
+city_br_2120,base.br,base.state_br_rs,Getúlio Vargas
+city_br_2121,base.br,base.state_br_pi,Gilbués
+city_br_2122,base.br,base.state_br_al,Girau do Ponciano
+city_br_2123,base.br,base.state_br_rs,Giruá
+city_br_2124,base.br,base.state_br_mg,Glaucilândia
+city_br_2125,base.br,base.state_br_sp,Glicério
+city_br_2126,base.br,base.state_br_ba,Glória
+city_br_2127,base.br,base.state_br_mt,Glória D'Oeste
+city_br_2128,base.br,base.state_br_ms,Glória de Dourados
+city_br_2129,base.br,base.state_br_pe,Glória do Goitá
+city_br_2130,base.br,base.state_br_rs,Glorinha
+city_br_2131,base.br,base.state_br_ma,Godofredo Viana
+city_br_2132,base.br,base.state_br_pr,Godoy Moreira
+city_br_2133,base.br,base.state_br_mg,Goiabeira
+city_br_2134,base.br,base.state_br_pe,Goiana
+city_br_2135,base.br,base.state_br_mg,Goianá
+city_br_2136,base.br,base.state_br_go,Goianápolis
+city_br_2137,base.br,base.state_br_go,Goiandira
+city_br_2138,base.br,base.state_br_go,Goianésia
+city_br_2139,base.br,base.state_br_pa,Goianésia do Pará
+city_br_2140,base.br,base.state_br_rn,Goianinha
+city_br_2141,base.br,base.state_br_go,Goianira
+city_br_2142,base.br,base.state_br_to,Goianorte
+city_br_2143,base.br,base.state_br_go,Goiás
+city_br_2144,base.br,base.state_br_to,Goiatins
+city_br_2145,base.br,base.state_br_go,Goiatuba
+city_br_2146,base.br,base.state_br_pr,Goioerê
+city_br_2147,base.br,base.state_br_pr,Goioxim
+city_br_2148,base.br,base.state_br_mg,Gonçalves
+city_br_2149,base.br,base.state_br_ma,Gonçalves Dias
+city_br_2150,base.br,base.state_br_ba,Gongogi
+city_br_2151,base.br,base.state_br_mg,Gonzaga
+city_br_2152,base.br,base.state_br_mg,Gouveia
+city_br_2153,base.br,base.state_br_go,Gouvelândia
+city_br_2154,base.br,base.state_br_ma,Governador Archer
+city_br_2155,base.br,base.state_br_sc,Governador Celso Ramos
+city_br_2156,base.br,base.state_br_rn,Governador Dix-Sept Rosado
+city_br_2157,base.br,base.state_br_ma,Governador Edison Lobão
+city_br_2158,base.br,base.state_br_ma,Governador Eugênio Barros
+city_br_2159,base.br,base.state_br_ro,Governador Jorge Teixeira
+city_br_2160,base.br,base.state_br_es,Governador Lindenberg
+city_br_2161,base.br,base.state_br_ma,Governador Luiz Rocha
+city_br_2162,base.br,base.state_br_ba,Governador Mangabeira
+city_br_2163,base.br,base.state_br_ma,Governador Newton Bello
+city_br_2164,base.br,base.state_br_ma,Governador Nunes Freire
+city_br_2165,base.br,base.state_br_ce,Graça
+city_br_2166,base.br,base.state_br_ma,Graça Aranha
+city_br_2167,base.br,base.state_br_se,Gracho Cardoso
+city_br_2168,base.br,base.state_br_ma,Grajaú
+city_br_2169,base.br,base.state_br_rs,Gramado
+city_br_2170,base.br,base.state_br_rs,Gramado dos Loureiros
+city_br_2171,base.br,base.state_br_rs,Gramado Xavier
+city_br_2172,base.br,base.state_br_pr,Grandes Rios
+city_br_2173,base.br,base.state_br_pe,Granito
+city_br_2174,base.br,base.state_br_ce,Granja
+city_br_2175,base.br,base.state_br_ce,Granjeiro
+city_br_2176,base.br,base.state_br_mg,Grão Mogol
+city_br_2177,base.br,base.state_br_sc,Grão Pará
+city_br_2178,base.br,base.state_br_pe,Gravatá
+city_br_2179,base.br,base.state_br_sc,Gravatal
+city_br_2180,base.br,base.state_br_ce,Groaíras
+city_br_2181,base.br,base.state_br_rn,Grossos
+city_br_2182,base.br,base.state_br_mg,Grupiara
+city_br_2183,base.br,base.state_br_rs,Guabiju
+city_br_2184,base.br,base.state_br_sc,Guabiruba
+city_br_2185,base.br,base.state_br_es,Guaçuí
+city_br_2186,base.br,base.state_br_pi,Guadalupe
+city_br_2187,base.br,base.state_br_rs,Guaíba
+city_br_2188,base.br,base.state_br_sp,Guaiçara
+city_br_2189,base.br,base.state_br_sp,Guaimbê
+city_br_2190,base.br,base.state_br_pr,Guaíra
+city_br_2191,base.br,base.state_br_sp,Guaíra
+city_br_2192,base.br,base.state_br_pr,Guairaçá
+city_br_2193,base.br,base.state_br_ce,Guaiúba
+city_br_2194,base.br,base.state_br_am,Guajará
+city_br_2195,base.br,base.state_br_ro,Guajará-Mirim
+city_br_2196,base.br,base.state_br_ba,Guajeru
+city_br_2197,base.br,base.state_br_rn,Guamaré
+city_br_2198,base.br,base.state_br_pr,Guamiranga
+city_br_2199,base.br,base.state_br_ba,Guanambi
+city_br_2200,base.br,base.state_br_mg,Guanhães
+city_br_2201,base.br,base.state_br_mg,Guapé
+city_br_2202,base.br,base.state_br_sp,Guapiaçu
+city_br_2203,base.br,base.state_br_sp,Guapiara
+city_br_2204,base.br,base.state_br_rj,Guapimirim
+city_br_2205,base.br,base.state_br_pr,Guapirama
+city_br_2206,base.br,base.state_br_go,Guapó
+city_br_2207,base.br,base.state_br_rs,Guaporé
+city_br_2208,base.br,base.state_br_pr,Guaporema
+city_br_2209,base.br,base.state_br_sp,Guará
+city_br_2210,base.br,base.state_br_pb,Guarabira
+city_br_2211,base.br,base.state_br_sp,Guaraçaí
+city_br_2212,base.br,base.state_br_pr,Guaraci
+city_br_2213,base.br,base.state_br_sp,Guaraci
+city_br_2214,base.br,base.state_br_mg,Guaraciaba
+city_br_2215,base.br,base.state_br_sc,Guaraciaba
+city_br_2216,base.br,base.state_br_ce,Guaraciaba do Norte
+city_br_2217,base.br,base.state_br_mg,Guaraciama
+city_br_2218,base.br,base.state_br_to,Guaraí
+city_br_2219,base.br,base.state_br_go,Guaraíta
+city_br_2220,base.br,base.state_br_ce,Guaramiranga
+city_br_2221,base.br,base.state_br_sc,Guaramirim
+city_br_2222,base.br,base.state_br_mg,Guaranésia
+city_br_2223,base.br,base.state_br_mg,Guarani
+city_br_2224,base.br,base.state_br_sp,Guarani d'Oeste
+city_br_2225,base.br,base.state_br_rs,Guarani das Missões
+city_br_2226,base.br,base.state_br_go,Guarani de Goiás
+city_br_2227,base.br,base.state_br_pr,Guaraniaçu
+city_br_2228,base.br,base.state_br_sp,Guarantã
+city_br_2229,base.br,base.state_br_mt,Guarantã do Norte
+city_br_2230,base.br,base.state_br_pr,Guaraqueçaba
+city_br_2231,base.br,base.state_br_mg,Guarará
+city_br_2232,base.br,base.state_br_sp,Guararapes
+city_br_2233,base.br,base.state_br_sp,Guararema
+city_br_2234,base.br,base.state_br_ba,Guaratinga
+city_br_2235,base.br,base.state_br_pr,Guaratuba
+city_br_2236,base.br,base.state_br_mg,Guarda-Mor
+city_br_2237,base.br,base.state_br_sp,Guareí
+city_br_2238,base.br,base.state_br_sp,Guariba
+city_br_2239,base.br,base.state_br_pi,Guaribas
+city_br_2240,base.br,base.state_br_go,Guarinos
+city_br_2241,base.br,base.state_br_sc,Guarujá do Sul
+city_br_2242,base.br,base.state_br_sc,Guatambú
+city_br_2243,base.br,base.state_br_sp,Guatapará
+city_br_2244,base.br,base.state_br_mg,Guaxupé
+city_br_2245,base.br,base.state_br_ms,Guia Lopes da Laguna
+city_br_2246,base.br,base.state_br_mg,Guidoval
+city_br_2247,base.br,base.state_br_ma,Guimarães
+city_br_2248,base.br,base.state_br_mg,Guimarânia
+city_br_2249,base.br,base.state_br_mt,Guiratinga
+city_br_2250,base.br,base.state_br_mg,Guiricema
+city_br_2251,base.br,base.state_br_mg,Gurinhatã
+city_br_2252,base.br,base.state_br_pb,Gurinhém
+city_br_2253,base.br,base.state_br_pb,Gurjão
+city_br_2254,base.br,base.state_br_pa,Gurupá
+city_br_2255,base.br,base.state_br_to,Gurupi
+city_br_2256,base.br,base.state_br_sp,Guzolândia
+city_br_2257,base.br,base.state_br_rs,Harmonia
+city_br_2258,base.br,base.state_br_go,Heitoraí
+city_br_2259,base.br,base.state_br_mg,Heliodora
+city_br_2260,base.br,base.state_br_ba,Heliópolis
+city_br_2261,base.br,base.state_br_sp,Herculândia
+city_br_2262,base.br,base.state_br_rs,Herval
+city_br_2263,base.br,base.state_br_sc,Herval d'Oeste
+city_br_2264,base.br,base.state_br_rs,Herveiras
+city_br_2265,base.br,base.state_br_ce,Hidrolândia
+city_br_2266,base.br,base.state_br_go,Hidrolândia
+city_br_2267,base.br,base.state_br_go,Hidrolina
+city_br_2268,base.br,base.state_br_sp,Holambra
+city_br_2269,base.br,base.state_br_pr,Honório Serpa
+city_br_2270,base.br,base.state_br_ce,Horizonte
+city_br_2271,base.br,base.state_br_rs,Horizontina
+city_br_2272,base.br,base.state_br_pi,Hugo Napoleão
+city_br_2273,base.br,base.state_br_rs,Hulha Negra
+city_br_2274,base.br,base.state_br_am,Humaitá
+city_br_2275,base.br,base.state_br_rs,Humaitá
+city_br_2276,base.br,base.state_br_ma,Humberto de Campos
+city_br_2277,base.br,base.state_br_sp,Iacanga
+city_br_2278,base.br,base.state_br_go,Iaciara
+city_br_2279,base.br,base.state_br_sp,Iacri
+city_br_2280,base.br,base.state_br_ba,Iaçu
+city_br_2281,base.br,base.state_br_mg,Iapu
+city_br_2282,base.br,base.state_br_sp,Iaras
+city_br_2283,base.br,base.state_br_pe,Iati
+city_br_2284,base.br,base.state_br_pr,Ibaiti
+city_br_2285,base.br,base.state_br_rs,Ibarama
+city_br_2286,base.br,base.state_br_ce,Ibaretama
+city_br_2287,base.br,base.state_br_sp,Ibaté
+city_br_2288,base.br,base.state_br_al,Ibateguara
+city_br_2289,base.br,base.state_br_es,Ibatiba
+city_br_2290,base.br,base.state_br_pr,Ibema
+city_br_2291,base.br,base.state_br_mg,Ibertioga
+city_br_2292,base.br,base.state_br_mg,Ibiá
+city_br_2293,base.br,base.state_br_rs,Ibiaçá
+city_br_2294,base.br,base.state_br_mg,Ibiaí
+city_br_2295,base.br,base.state_br_sc,Ibiam
+city_br_2296,base.br,base.state_br_ce,Ibiapina
+city_br_2297,base.br,base.state_br_pb,Ibiara
+city_br_2298,base.br,base.state_br_ba,Ibiassucê
+city_br_2299,base.br,base.state_br_ba,Ibicaraí
+city_br_2300,base.br,base.state_br_sc,Ibicaré
+city_br_2301,base.br,base.state_br_ba,Ibicoara
+city_br_2302,base.br,base.state_br_ba,Ibicuí
+city_br_2303,base.br,base.state_br_ce,Ibicuitinga
+city_br_2304,base.br,base.state_br_pe,Ibimirim
+city_br_2305,base.br,base.state_br_ba,Ibipeba
+city_br_2306,base.br,base.state_br_ba,Ibipitanga
+city_br_2307,base.br,base.state_br_pr,Ibiporã
+city_br_2308,base.br,base.state_br_ba,Ibiquera
+city_br_2309,base.br,base.state_br_sp,Ibirá
+city_br_2310,base.br,base.state_br_mg,Ibiracatu
+city_br_2311,base.br,base.state_br_mg,Ibiraci
+city_br_2312,base.br,base.state_br_es,Ibiraçu
+city_br_2313,base.br,base.state_br_rs,Ibiraiaras
+city_br_2314,base.br,base.state_br_pe,Ibirajuba
+city_br_2315,base.br,base.state_br_sc,Ibirama
+city_br_2316,base.br,base.state_br_ba,Ibirapitanga
+city_br_2317,base.br,base.state_br_ba,Ibirapuã
+city_br_2318,base.br,base.state_br_rs,Ibirapuitã
+city_br_2319,base.br,base.state_br_sp,Ibirarema
+city_br_2320,base.br,base.state_br_ba,Ibirataia
+city_br_2321,base.br,base.state_br_rs,Ibirubá
+city_br_2322,base.br,base.state_br_ba,Ibitiara
+city_br_2323,base.br,base.state_br_sp,Ibitinga
+city_br_2324,base.br,base.state_br_es,Ibitirama
+city_br_2325,base.br,base.state_br_ba,Ibititá
+city_br_2326,base.br,base.state_br_mg,Ibitiúra de Minas
+city_br_2327,base.br,base.state_br_mg,Ibituruna
+city_br_2328,base.br,base.state_br_sp,Ibiúna
+city_br_2329,base.br,base.state_br_ba,Ibotirama
+city_br_2330,base.br,base.state_br_ce,Icapuí
+city_br_2331,base.br,base.state_br_sc,Içara
+city_br_2332,base.br,base.state_br_mg,Icaraí de Minas
+city_br_2333,base.br,base.state_br_pr,Icaraíma
+city_br_2334,base.br,base.state_br_ma,Icatu
+city_br_2335,base.br,base.state_br_sp,Icém
+city_br_2336,base.br,base.state_br_ba,Ichu
+city_br_2337,base.br,base.state_br_ce,Icó
+city_br_2338,base.br,base.state_br_es,Iconha
+city_br_2339,base.br,base.state_br_rn,Ielmo Marinho
+city_br_2340,base.br,base.state_br_sp,Iepê
+city_br_2341,base.br,base.state_br_al,Igaci
+city_br_2342,base.br,base.state_br_ba,Igaporã
+city_br_2343,base.br,base.state_br_sp,Igaraçu do Tietê
+city_br_2344,base.br,base.state_br_pb,Igaracy
+city_br_2345,base.br,base.state_br_sp,Igarapava
+city_br_2346,base.br,base.state_br_mg,Igarapé
+city_br_2347,base.br,base.state_br_pa,Igarapé-Açu
+city_br_2348,base.br,base.state_br_ma,Igarapé do Meio
+city_br_2349,base.br,base.state_br_ma,Igarapé Grande
+city_br_2350,base.br,base.state_br_pa,Igarapé-Miri
+city_br_2351,base.br,base.state_br_sp,Igaratá
+city_br_2352,base.br,base.state_br_mg,Igaratinga
+city_br_2353,base.br,base.state_br_ba,Igrapiúna
+city_br_2354,base.br,base.state_br_al,Igreja Nova
+city_br_2355,base.br,base.state_br_rs,Igrejinha
+city_br_2356,base.br,base.state_br_rj,Iguaba Grande
+city_br_2357,base.br,base.state_br_ba,Iguaí
+city_br_2358,base.br,base.state_br_sp,Iguape
+city_br_2359,base.br,base.state_br_pr,Iguaraçu
+city_br_2360,base.br,base.state_br_pe,Iguaracy
+city_br_2361,base.br,base.state_br_mg,Iguatama
+city_br_2362,base.br,base.state_br_ms,Iguatemi
+city_br_2363,base.br,base.state_br_ce,Iguatu
+city_br_2364,base.br,base.state_br_pr,Iguatu
+city_br_2365,base.br,base.state_br_mg,Ijaci
+city_br_2366,base.br,base.state_br_rs,Ijuí
+city_br_2367,base.br,base.state_br_sp,Ilha Comprida
+city_br_2368,base.br,base.state_br_se,Ilha das Flores
+city_br_2369,base.br,base.state_br_pe,Ilha de Itamaracá
+city_br_2370,base.br,base.state_br_pi,Ilha Grande
+city_br_2371,base.br,base.state_br_sp,Ilha Solteira
+city_br_2372,base.br,base.state_br_sp,Ilhabela
+city_br_2373,base.br,base.state_br_sc,Ilhota
+city_br_2374,base.br,base.state_br_mg,Ilicínea
+city_br_2375,base.br,base.state_br_rs,Ilópolis
+city_br_2376,base.br,base.state_br_pb,Imaculada
+city_br_2377,base.br,base.state_br_sc,Imaruí
+city_br_2378,base.br,base.state_br_pr,Imbaú
+city_br_2379,base.br,base.state_br_rs,Imbé
+city_br_2380,base.br,base.state_br_mg,Imbé de Minas
+city_br_2381,base.br,base.state_br_sc,Imbituba
+city_br_2382,base.br,base.state_br_pr,Imbituva
+city_br_2383,base.br,base.state_br_sc,Imbuia
+city_br_2384,base.br,base.state_br_rs,Imigrante
+city_br_2385,base.br,base.state_br_pr,Inácio Martins
+city_br_2386,base.br,base.state_br_go,Inaciolândia
+city_br_2387,base.br,base.state_br_pe,Inajá
+city_br_2388,base.br,base.state_br_pr,Inajá
+city_br_2389,base.br,base.state_br_mg,Inconfidentes
+city_br_2390,base.br,base.state_br_mg,Indaiabira
+city_br_2391,base.br,base.state_br_sc,Indaial
+city_br_2392,base.br,base.state_br_ce,Independência
+city_br_2393,base.br,base.state_br_rs,Independência
+city_br_2394,base.br,base.state_br_sp,Indiana
+city_br_2395,base.br,base.state_br_mg,Indianópolis
+city_br_2396,base.br,base.state_br_pr,Indianópolis
+city_br_2397,base.br,base.state_br_sp,Indiaporã
+city_br_2398,base.br,base.state_br_go,Indiara
+city_br_2399,base.br,base.state_br_se,Indiaroba
+city_br_2400,base.br,base.state_br_mt,Indiavaí
+city_br_2401,base.br,base.state_br_pb,Ingá
+city_br_2402,base.br,base.state_br_mg,Ingaí
+city_br_2403,base.br,base.state_br_pe,Ingazeira
+city_br_2404,base.br,base.state_br_rs,Inhacorá
+city_br_2405,base.br,base.state_br_ba,Inhambupe
+city_br_2406,base.br,base.state_br_pa,Inhangapi
+city_br_2407,base.br,base.state_br_al,Inhapi
+city_br_2408,base.br,base.state_br_mg,Inhapim
+city_br_2409,base.br,base.state_br_mg,Inhaúma
+city_br_2410,base.br,base.state_br_pi,Inhuma
+city_br_2411,base.br,base.state_br_go,Inhumas
+city_br_2412,base.br,base.state_br_mg,Inimutaba
+city_br_2413,base.br,base.state_br_ms,Inocência
+city_br_2414,base.br,base.state_br_sp,Inúbia Paulista
+city_br_2415,base.br,base.state_br_sc,Iomerê
+city_br_2416,base.br,base.state_br_mg,Ipaba
+city_br_2417,base.br,base.state_br_go,Ipameri
+city_br_2418,base.br,base.state_br_mg,Ipanema
+city_br_2419,base.br,base.state_br_rn,Ipanguaçu
+city_br_2420,base.br,base.state_br_ce,Ipaporanga
+city_br_2421,base.br,base.state_br_ce,Ipaumirim
+city_br_2422,base.br,base.state_br_sp,Ipaussu
+city_br_2423,base.br,base.state_br_rs,Ipê
+city_br_2424,base.br,base.state_br_ba,Ipecaetá
+city_br_2425,base.br,base.state_br_sp,Iperó
+city_br_2426,base.br,base.state_br_sp,Ipeúna
+city_br_2427,base.br,base.state_br_mg,Ipiaçu
+city_br_2428,base.br,base.state_br_ba,Ipiaú
+city_br_2429,base.br,base.state_br_sp,Ipiguá
+city_br_2430,base.br,base.state_br_sc,Ipira
+city_br_2431,base.br,base.state_br_ba,Ipirá
+city_br_2432,base.br,base.state_br_pr,Ipiranga
+city_br_2433,base.br,base.state_br_go,Ipiranga de Goiás
+city_br_2434,base.br,base.state_br_mt,Ipiranga do Norte
+city_br_2435,base.br,base.state_br_pi,Ipiranga do Piauí
+city_br_2436,base.br,base.state_br_rs,Ipiranga do Sul
+city_br_2437,base.br,base.state_br_am,Ipixuna
+city_br_2438,base.br,base.state_br_pa,Ipixuna do Pará
+city_br_2439,base.br,base.state_br_pe,Ipojuca
+city_br_2440,base.br,base.state_br_go,Iporá
+city_br_2441,base.br,base.state_br_pr,Iporã
+city_br_2442,base.br,base.state_br_sc,Iporã do Oeste
+city_br_2443,base.br,base.state_br_sp,Iporanga
+city_br_2444,base.br,base.state_br_ce,Ipu
+city_br_2445,base.br,base.state_br_sp,Ipuã
+city_br_2446,base.br,base.state_br_sc,Ipuaçu
+city_br_2447,base.br,base.state_br_pe,Ipubi
+city_br_2448,base.br,base.state_br_rn,Ipueira
+city_br_2449,base.br,base.state_br_ce,Ipueiras
+city_br_2450,base.br,base.state_br_to,Ipueiras
+city_br_2451,base.br,base.state_br_mg,Ipuiúna
+city_br_2452,base.br,base.state_br_sc,Ipumirim
+city_br_2453,base.br,base.state_br_ba,Ipupiara
+city_br_2454,base.br,base.state_br_ce,Iracema
+city_br_2455,base.br,base.state_br_rr,Iracema
+city_br_2456,base.br,base.state_br_pr,Iracema do Oeste
+city_br_2457,base.br,base.state_br_sp,Iracemápolis
+city_br_2458,base.br,base.state_br_sc,Iraceminha
+city_br_2459,base.br,base.state_br_rs,Iraí
+city_br_2460,base.br,base.state_br_mg,Iraí de Minas
+city_br_2461,base.br,base.state_br_ba,Irajuba
+city_br_2462,base.br,base.state_br_ba,Iramaia
+city_br_2463,base.br,base.state_br_am,Iranduba
+city_br_2464,base.br,base.state_br_sc,Irani
+city_br_2465,base.br,base.state_br_sp,Irapuã
+city_br_2466,base.br,base.state_br_sp,Irapuru
+city_br_2467,base.br,base.state_br_ba,Iraquara
+city_br_2468,base.br,base.state_br_ba,Irará
+city_br_2469,base.br,base.state_br_pr,Irati
+city_br_2470,base.br,base.state_br_sc,Irati
+city_br_2471,base.br,base.state_br_ce,Irauçuba
+city_br_2472,base.br,base.state_br_ba,Irecê
+city_br_2473,base.br,base.state_br_pr,Iretama
+city_br_2474,base.br,base.state_br_sc,Irineópolis
+city_br_2475,base.br,base.state_br_pa,Irituia
+city_br_2476,base.br,base.state_br_es,Irupi
+city_br_2477,base.br,base.state_br_pi,Isaías Coelho
+city_br_2478,base.br,base.state_br_go,Israelândia
+city_br_2479,base.br,base.state_br_sc,Itá
+city_br_2480,base.br,base.state_br_rs,Itaara
+city_br_2481,base.br,base.state_br_pb,Itabaiana
+city_br_2482,base.br,base.state_br_se,Itabaianinha
+city_br_2483,base.br,base.state_br_ba,Itabela
+city_br_2484,base.br,base.state_br_sp,Itaberá
+city_br_2485,base.br,base.state_br_ba,Itaberaba
+city_br_2486,base.br,base.state_br_go,Itaberaí
+city_br_2487,base.br,base.state_br_se,Itabi
+city_br_2488,base.br,base.state_br_mg,Itabirinha
+city_br_2489,base.br,base.state_br_mg,Itabirito
+city_br_2490,base.br,base.state_br_to,Itacajá
+city_br_2491,base.br,base.state_br_mg,Itacambira
+city_br_2492,base.br,base.state_br_mg,Itacarambi
+city_br_2493,base.br,base.state_br_ba,Itacaré
+city_br_2494,base.br,base.state_br_pe,Itacuruba
+city_br_2495,base.br,base.state_br_rs,Itacurubi
+city_br_2496,base.br,base.state_br_ba,Itaeté
+city_br_2497,base.br,base.state_br_ba,Itagi
+city_br_2498,base.br,base.state_br_ba,Itagibá
+city_br_2499,base.br,base.state_br_ba,Itagimirim
+city_br_2500,base.br,base.state_br_es,Itaguaçu
+city_br_2501,base.br,base.state_br_ba,Itaguaçu da Bahia
+city_br_2502,base.br,base.state_br_pr,Itaguajé
+city_br_2503,base.br,base.state_br_mg,Itaguara
+city_br_2504,base.br,base.state_br_go,Itaguari
+city_br_2505,base.br,base.state_br_go,Itaguaru
+city_br_2506,base.br,base.state_br_to,Itaguatins
+city_br_2507,base.br,base.state_br_sp,Itaí
+city_br_2508,base.br,base.state_br_pe,Itaíba
+city_br_2509,base.br,base.state_br_ce,Itaiçaba
+city_br_2510,base.br,base.state_br_pi,Itainópolis
+city_br_2511,base.br,base.state_br_sc,Itaiópolis
+city_br_2512,base.br,base.state_br_ma,Itaipava do Grajaú
+city_br_2513,base.br,base.state_br_mg,Itaipé
+city_br_2514,base.br,base.state_br_pr,Itaipulândia
+city_br_2515,base.br,base.state_br_ce,Itaitinga
+city_br_2516,base.br,base.state_br_go,Itajá
+city_br_2517,base.br,base.state_br_rn,Itajá
+city_br_2518,base.br,base.state_br_sp,Itajobi
+city_br_2519,base.br,base.state_br_sp,Itaju
+city_br_2520,base.br,base.state_br_ba,Itaju do Colônia
+city_br_2521,base.br,base.state_br_mg,Itajubá
+city_br_2522,base.br,base.state_br_ba,Itajuípe
+city_br_2523,base.br,base.state_br_rj,Italva
+city_br_2524,base.br,base.state_br_ba,Itamaraju
+city_br_2525,base.br,base.state_br_mg,Itamarandiba
+city_br_2526,base.br,base.state_br_am,Itamarati
+city_br_2527,base.br,base.state_br_mg,Itamarati de Minas
+city_br_2528,base.br,base.state_br_ba,Itamari
+city_br_2529,base.br,base.state_br_mg,Itambacuri
+city_br_2530,base.br,base.state_br_pr,Itambaracá
+city_br_2531,base.br,base.state_br_ba,Itambé
+city_br_2532,base.br,base.state_br_pe,Itambé
+city_br_2533,base.br,base.state_br_pr,Itambé
+city_br_2534,base.br,base.state_br_mg,Itambé do Mato Dentro
+city_br_2535,base.br,base.state_br_mg,Itamogi
+city_br_2536,base.br,base.state_br_mg,Itamonte
+city_br_2537,base.br,base.state_br_ba,Itanagra
+city_br_2538,base.br,base.state_br_mg,Itanhandu
+city_br_2539,base.br,base.state_br_mt,Itanhangá
+city_br_2540,base.br,base.state_br_ba,Itanhém
+city_br_2541,base.br,base.state_br_mg,Itanhomi
+city_br_2542,base.br,base.state_br_mg,Itaobim
+city_br_2543,base.br,base.state_br_sp,Itaóca
+city_br_2544,base.br,base.state_br_rj,Itaocara
+city_br_2545,base.br,base.state_br_go,Itapaci
+city_br_2546,base.br,base.state_br_mg,Itapagipe
+city_br_2547,base.br,base.state_br_ce,Itapajé
+city_br_2548,base.br,base.state_br_ba,Itaparica
+city_br_2549,base.br,base.state_br_ba,Itapé
+city_br_2550,base.br,base.state_br_ba,Itapebi
+city_br_2551,base.br,base.state_br_mg,Itapecerica
+city_br_2552,base.br,base.state_br_ma,Itapecuru Mirim
+city_br_2553,base.br,base.state_br_pr,Itapejara d'Oeste
+city_br_2554,base.br,base.state_br_sc,Itapema
+city_br_2555,base.br,base.state_br_es,Itapemirim
+city_br_2556,base.br,base.state_br_pr,Itaperuçu
+city_br_2557,base.br,base.state_br_pe,Itapetim
+city_br_2558,base.br,base.state_br_ba,Itapetinga
+city_br_2559,base.br,base.state_br_mg,Itapeva
+city_br_2560,base.br,base.state_br_sp,Itapeva
+city_br_2561,base.br,base.state_br_ba,Itapicuru
+city_br_2562,base.br,base.state_br_sp,Itapira
+city_br_2563,base.br,base.state_br_am,Itapiranga
+city_br_2564,base.br,base.state_br_sc,Itapiranga
+city_br_2565,base.br,base.state_br_go,Itapirapuã
+city_br_2566,base.br,base.state_br_sp,Itapirapuã Paulista
+city_br_2567,base.br,base.state_br_to,Itapiratins
+city_br_2568,base.br,base.state_br_pe,Itapissuma
+city_br_2569,base.br,base.state_br_ba,Itapitanga
+city_br_2570,base.br,base.state_br_ce,Itapiúna
+city_br_2571,base.br,base.state_br_sc,Itapoá
+city_br_2572,base.br,base.state_br_sp,Itápolis
+city_br_2573,base.br,base.state_br_ms,Itaporã
+city_br_2574,base.br,base.state_br_to,Itaporã do Tocantins
+city_br_2575,base.br,base.state_br_pb,Itaporanga
+city_br_2576,base.br,base.state_br_sp,Itaporanga
+city_br_2577,base.br,base.state_br_se,Itaporanga d'Ajuda
+city_br_2578,base.br,base.state_br_pb,Itapororoca
+city_br_2579,base.br,base.state_br_ro,Itapuã do Oeste
+city_br_2580,base.br,base.state_br_rs,Itapuca
+city_br_2581,base.br,base.state_br_sp,Itapuí
+city_br_2582,base.br,base.state_br_sp,Itapura
+city_br_2583,base.br,base.state_br_go,Itapuranga
+city_br_2584,base.br,base.state_br_ba,Itaquara
+city_br_2585,base.br,base.state_br_rs,Itaqui
+city_br_2586,base.br,base.state_br_ms,Itaquiraí
+city_br_2587,base.br,base.state_br_pe,Itaquitinga
+city_br_2588,base.br,base.state_br_es,Itarana
+city_br_2589,base.br,base.state_br_ba,Itarantim
+city_br_2590,base.br,base.state_br_sp,Itararé
+city_br_2591,base.br,base.state_br_ce,Itarema
+city_br_2592,base.br,base.state_br_sp,Itariri
+city_br_2593,base.br,base.state_br_go,Itarumã
+city_br_2594,base.br,base.state_br_rs,Itati
+city_br_2595,base.br,base.state_br_rj,Itatiaia
+city_br_2596,base.br,base.state_br_mg,Itatiaiuçu
+city_br_2597,base.br,base.state_br_rs,Itatiba do Sul
+city_br_2598,base.br,base.state_br_ba,Itatim
+city_br_2599,base.br,base.state_br_sp,Itatinga
+city_br_2600,base.br,base.state_br_ce,Itatira
+city_br_2601,base.br,base.state_br_pb,Itatuba
+city_br_2602,base.br,base.state_br_rn,Itaú
+city_br_2603,base.br,base.state_br_mg,Itaú de Minas
+city_br_2604,base.br,base.state_br_mt,Itaúba
+city_br_2605,base.br,base.state_br_ap,Itaubal
+city_br_2606,base.br,base.state_br_go,Itauçu
+city_br_2607,base.br,base.state_br_pi,Itaueira
+city_br_2608,base.br,base.state_br_mg,Itaúna
+city_br_2609,base.br,base.state_br_pr,Itaúna do Sul
+city_br_2610,base.br,base.state_br_mg,Itaverava
+city_br_2611,base.br,base.state_br_mg,Itinga
+city_br_2612,base.br,base.state_br_ma,Itinga do Maranhão
+city_br_2613,base.br,base.state_br_mt,Itiquira
+city_br_2614,base.br,base.state_br_sp,Itirapina
+city_br_2615,base.br,base.state_br_sp,Itirapuã
+city_br_2616,base.br,base.state_br_ba,Itiruçu
+city_br_2617,base.br,base.state_br_ba,Itiúba
+city_br_2618,base.br,base.state_br_sp,Itobi
+city_br_2619,base.br,base.state_br_ba,Itororó
+city_br_2620,base.br,base.state_br_ba,Ituaçu
+city_br_2621,base.br,base.state_br_ba,Ituberá
+city_br_2622,base.br,base.state_br_mg,Itueta
+city_br_2623,base.br,base.state_br_mg,Itumirim
+city_br_2624,base.br,base.state_br_sp,Itupeva
+city_br_2625,base.br,base.state_br_pa,Itupiranga
+city_br_2626,base.br,base.state_br_sc,Ituporanga
+city_br_2627,base.br,base.state_br_mg,Iturama
+city_br_2628,base.br,base.state_br_mg,Itutinga
+city_br_2629,base.br,base.state_br_sp,Ituverava
+city_br_2630,base.br,base.state_br_ba,Iuiú
+city_br_2631,base.br,base.state_br_es,Iúna
+city_br_2632,base.br,base.state_br_pr,Ivaí
+city_br_2633,base.br,base.state_br_pr,Ivaiporã
+city_br_2634,base.br,base.state_br_pr,Ivaté
+city_br_2635,base.br,base.state_br_pr,Ivatuba
+city_br_2636,base.br,base.state_br_ms,Ivinhema
+city_br_2637,base.br,base.state_br_go,Ivolândia
+city_br_2638,base.br,base.state_br_rs,Ivorá
+city_br_2639,base.br,base.state_br_rs,Ivoti
+city_br_2640,base.br,base.state_br_sc,Jaborá
+city_br_2641,base.br,base.state_br_ba,Jaborandi
+city_br_2642,base.br,base.state_br_sp,Jaborandi
+city_br_2643,base.br,base.state_br_pr,Jaboti
+city_br_2644,base.br,base.state_br_rs,Jaboticaba
+city_br_2645,base.br,base.state_br_sp,Jaboticabal
+city_br_2646,base.br,base.state_br_mg,Jaboticatubas
+city_br_2647,base.br,base.state_br_rn,Jaçanã
+city_br_2648,base.br,base.state_br_ba,Jacaraci
+city_br_2649,base.br,base.state_br_pb,Jacaraú
+city_br_2650,base.br,base.state_br_al,Jacaré dos Homens
+city_br_2651,base.br,base.state_br_pa,Jacareacanga
+city_br_2652,base.br,base.state_br_pr,Jacarezinho
+city_br_2653,base.br,base.state_br_sp,Jaci
+city_br_2654,base.br,base.state_br_mt,Jaciara
+city_br_2655,base.br,base.state_br_mg,Jacinto
+city_br_2656,base.br,base.state_br_sc,Jacinto Machado
+city_br_2657,base.br,base.state_br_ba,Jacobina
+city_br_2658,base.br,base.state_br_pi,Jacobina do Piauí
+city_br_2659,base.br,base.state_br_mg,Jacuí
+city_br_2660,base.br,base.state_br_al,Jacuípe
+city_br_2661,base.br,base.state_br_rs,Jacuizinho
+city_br_2662,base.br,base.state_br_pa,Jacundá
+city_br_2663,base.br,base.state_br_sp,Jacupiranga
+city_br_2664,base.br,base.state_br_mg,Jacutinga
+city_br_2665,base.br,base.state_br_rs,Jacutinga
+city_br_2666,base.br,base.state_br_pr,Jaguapitã
+city_br_2667,base.br,base.state_br_ba,Jaguaquara
+city_br_2668,base.br,base.state_br_mg,Jaguaraçu
+city_br_2669,base.br,base.state_br_rs,Jaguarão
+city_br_2670,base.br,base.state_br_ba,Jaguarari
+city_br_2671,base.br,base.state_br_es,Jaguaré
+city_br_2672,base.br,base.state_br_ce,Jaguaretama
+city_br_2673,base.br,base.state_br_rs,Jaguari
+city_br_2674,base.br,base.state_br_pr,Jaguariaíva
+city_br_2675,base.br,base.state_br_ce,Jaguaribara
+city_br_2676,base.br,base.state_br_ce,Jaguaribe
+city_br_2677,base.br,base.state_br_ba,Jaguaripe
+city_br_2678,base.br,base.state_br_sp,Jaguariúna
+city_br_2679,base.br,base.state_br_ce,Jaguaruana
+city_br_2680,base.br,base.state_br_sc,Jaguaruna
+city_br_2681,base.br,base.state_br_mg,Jaíba
+city_br_2682,base.br,base.state_br_pi,Jaicós
+city_br_2683,base.br,base.state_br_sp,Jales
+city_br_2684,base.br,base.state_br_sp,Jambeiro
+city_br_2685,base.br,base.state_br_mg,Jampruca
+city_br_2686,base.br,base.state_br_mg,Janaúba
+city_br_2687,base.br,base.state_br_go,Jandaia
+city_br_2688,base.br,base.state_br_pr,Jandaia do Sul
+city_br_2689,base.br,base.state_br_ba,Jandaíra
+city_br_2690,base.br,base.state_br_rn,Jandaíra
+city_br_2691,base.br,base.state_br_rn,Janduís
+city_br_2692,base.br,base.state_br_mt,Jangada
+city_br_2693,base.br,base.state_br_pr,Janiópolis
+city_br_2694,base.br,base.state_br_mg,Januária
+city_br_2695,base.br,base.state_br_mg,Japaraíba
+city_br_2696,base.br,base.state_br_al,Japaratinga
+city_br_2697,base.br,base.state_br_se,Japaratuba
+city_br_2698,base.br,base.state_br_rj,Japeri
+city_br_2699,base.br,base.state_br_rn,Japi
+city_br_2700,base.br,base.state_br_pr,Japira
+city_br_2701,base.br,base.state_br_se,Japoatã
+city_br_2702,base.br,base.state_br_mg,Japonvar
+city_br_2703,base.br,base.state_br_ms,Japorã
+city_br_2704,base.br,base.state_br_am,Japurá
+city_br_2705,base.br,base.state_br_pr,Japurá
+city_br_2706,base.br,base.state_br_pe,Jaqueira
+city_br_2707,base.br,base.state_br_rs,Jaquirana
+city_br_2708,base.br,base.state_br_go,Jaraguá
+city_br_2709,base.br,base.state_br_ms,Jaraguari
+city_br_2710,base.br,base.state_br_al,Jaramataia
+city_br_2711,base.br,base.state_br_ce,Jardim
+city_br_2712,base.br,base.state_br_ms,Jardim
+city_br_2713,base.br,base.state_br_pr,Jardim Alegre
+city_br_2714,base.br,base.state_br_rn,Jardim de Angicos
+city_br_2715,base.br,base.state_br_rn,Jardim de Piranhas
+city_br_2716,base.br,base.state_br_pi,Jardim do Mulato
+city_br_2717,base.br,base.state_br_rn,Jardim do Seridó
+city_br_2718,base.br,base.state_br_pr,Jardim Olinda
+city_br_2719,base.br,base.state_br_sc,Jardinópolis
+city_br_2720,base.br,base.state_br_sp,Jardinópolis
+city_br_2721,base.br,base.state_br_rs,Jari
+city_br_2722,base.br,base.state_br_sp,Jarinu
+city_br_2723,base.br,base.state_br_ro,Jaru
+city_br_2724,base.br,base.state_br_pr,Jataizinho
+city_br_2725,base.br,base.state_br_pe,Jataúba
+city_br_2726,base.br,base.state_br_ms,Jateí
+city_br_2727,base.br,base.state_br_ce,Jati
+city_br_2728,base.br,base.state_br_ma,Jatobá
+city_br_2729,base.br,base.state_br_pe,Jatobá
+city_br_2730,base.br,base.state_br_pi,Jatobá do Piauí
+city_br_2731,base.br,base.state_br_to,Jaú do Tocantins
+city_br_2732,base.br,base.state_br_go,Jaupaci
+city_br_2733,base.br,base.state_br_mt,Jauru
+city_br_2734,base.br,base.state_br_mg,Jeceaba
+city_br_2735,base.br,base.state_br_mg,Jenipapo de Minas
+city_br_2736,base.br,base.state_br_ma,Jenipapo dos Vieiras
+city_br_2737,base.br,base.state_br_mg,Jequeri
+city_br_2738,base.br,base.state_br_al,Jequiá da Praia
+city_br_2739,base.br,base.state_br_mg,Jequitaí
+city_br_2740,base.br,base.state_br_mg,Jequitibá
+city_br_2741,base.br,base.state_br_mg,Jequitinhonha
+city_br_2742,base.br,base.state_br_ba,Jeremoabo
+city_br_2743,base.br,base.state_br_pb,Jericó
+city_br_2744,base.br,base.state_br_sp,Jeriquara
+city_br_2745,base.br,base.state_br_es,Jerônimo Monteiro
+city_br_2746,base.br,base.state_br_pi,Jerumenha
+city_br_2747,base.br,base.state_br_mg,Jesuânia
+city_br_2748,base.br,base.state_br_pr,Jesuítas
+city_br_2749,base.br,base.state_br_go,Jesúpolis
+city_br_2750,base.br,base.state_br_ce,Jijoca de Jericoacoara
+city_br_2751,base.br,base.state_br_ba,Jiquiriçá
+city_br_2752,base.br,base.state_br_ba,Jitaúna
+city_br_2753,base.br,base.state_br_sc,Joaçaba
+city_br_2754,base.br,base.state_br_mg,Joaíma
+city_br_2755,base.br,base.state_br_mg,Joanésia
+city_br_2756,base.br,base.state_br_sp,Joanópolis
+city_br_2757,base.br,base.state_br_pe,João Alfredo
+city_br_2758,base.br,base.state_br_rn,João Câmara
+city_br_2759,base.br,base.state_br_pi,João Costa
+city_br_2760,base.br,base.state_br_rn,João Dias
+city_br_2761,base.br,base.state_br_ba,João Dourado
+city_br_2762,base.br,base.state_br_ma,João Lisboa
+city_br_2763,base.br,base.state_br_mg,João Monlevade
+city_br_2764,base.br,base.state_br_es,João Neiva
+city_br_2765,base.br,base.state_br_mg,João Pinheiro
+city_br_2766,base.br,base.state_br_sp,João Ramalho
+city_br_2767,base.br,base.state_br_mg,Joaquim Felício
+city_br_2768,base.br,base.state_br_al,Joaquim Gomes
+city_br_2769,base.br,base.state_br_pe,Joaquim Nabuco
+city_br_2770,base.br,base.state_br_pi,Joaquim Pires
+city_br_2771,base.br,base.state_br_pr,Joaquim Távora
+city_br_2772,base.br,base.state_br_pb,Joca Claudino
+city_br_2773,base.br,base.state_br_pi,Joca Marques
+city_br_2774,base.br,base.state_br_rs,Jóia
+city_br_2775,base.br,base.state_br_mg,Jordânia
+city_br_2776,base.br,base.state_br_ac,Jordão
+city_br_2777,base.br,base.state_br_sc,José Boiteux
+city_br_2778,base.br,base.state_br_sp,José Bonifácio
+city_br_2779,base.br,base.state_br_rn,José da Penha
+city_br_2780,base.br,base.state_br_pi,José de Freitas
+city_br_2781,base.br,base.state_br_mg,José Gonçalves de Minas
+city_br_2782,base.br,base.state_br_mg,José Raydan
+city_br_2783,base.br,base.state_br_ma,Joselândia
+city_br_2784,base.br,base.state_br_mg,Josenópolis
+city_br_2785,base.br,base.state_br_go,Joviânia
+city_br_2786,base.br,base.state_br_mt,Juara
+city_br_2787,base.br,base.state_br_pb,Juarez Távora
+city_br_2788,base.br,base.state_br_to,Juarina
+city_br_2789,base.br,base.state_br_mg,Juatuba
+city_br_2790,base.br,base.state_br_pb,Juazeirinho
+city_br_2791,base.br,base.state_br_pi,Juazeiro do Piauí
+city_br_2792,base.br,base.state_br_ce,Jucás
+city_br_2793,base.br,base.state_br_pe,Jucati
+city_br_2794,base.br,base.state_br_ba,Jucuruçu
+city_br_2795,base.br,base.state_br_rn,Jucurutu
+city_br_2796,base.br,base.state_br_mt,Juína
+city_br_2797,base.br,base.state_br_pi,Júlio Borges
+city_br_2798,base.br,base.state_br_rs,Júlio de Castilhos
+city_br_2799,base.br,base.state_br_sp,Júlio Mesquita
+city_br_2800,base.br,base.state_br_sp,Jumirim
+city_br_2801,base.br,base.state_br_ma,Junco do Maranhão
+city_br_2802,base.br,base.state_br_pb,Junco do Seridó
+city_br_2803,base.br,base.state_br_al,Jundiá
+city_br_2804,base.br,base.state_br_rn,Jundiá
+city_br_2805,base.br,base.state_br_pr,Jundiaí do Sul
+city_br_2806,base.br,base.state_br_al,Junqueiro
+city_br_2807,base.br,base.state_br_sp,Junqueirópolis
+city_br_2808,base.br,base.state_br_pe,Jupi
+city_br_2809,base.br,base.state_br_sc,Jupiá
+city_br_2810,base.br,base.state_br_sp,Juquiá
+city_br_2811,base.br,base.state_br_sp,Juquitiba
+city_br_2812,base.br,base.state_br_mg,Juramento
+city_br_2813,base.br,base.state_br_pr,Juranda
+city_br_2814,base.br,base.state_br_pe,Jurema
+city_br_2815,base.br,base.state_br_pi,Jurema
+city_br_2816,base.br,base.state_br_pb,Juripiranga
+city_br_2817,base.br,base.state_br_pb,Juru
+city_br_2818,base.br,base.state_br_am,Juruá
+city_br_2819,base.br,base.state_br_mg,Juruaia
+city_br_2820,base.br,base.state_br_mt,Juruena
+city_br_2821,base.br,base.state_br_pa,Juruti
+city_br_2822,base.br,base.state_br_mt,Juscimeira
+city_br_2823,base.br,base.state_br_ba,Jussara
+city_br_2824,base.br,base.state_br_go,Jussara
+city_br_2825,base.br,base.state_br_pr,Jussara
+city_br_2826,base.br,base.state_br_ba,Jussari
+city_br_2827,base.br,base.state_br_ba,Jussiape
+city_br_2828,base.br,base.state_br_am,Jutaí
+city_br_2829,base.br,base.state_br_ms,Juti
+city_br_2830,base.br,base.state_br_mg,Juvenília
+city_br_2831,base.br,base.state_br_pr,Kaloré
+city_br_2832,base.br,base.state_br_am,Lábrea
+city_br_2833,base.br,base.state_br_sc,Lacerdópolis
+city_br_2834,base.br,base.state_br_mg,Ladainha
+city_br_2835,base.br,base.state_br_ms,Ladário
+city_br_2836,base.br,base.state_br_ba,Lafaiete Coutinho
+city_br_2837,base.br,base.state_br_mg,Lagamar
+city_br_2838,base.br,base.state_br_ma,Lago da Pedra
+city_br_2839,base.br,base.state_br_ma,Lago do Junco
+city_br_2840,base.br,base.state_br_ma,Lago dos Rodrigues
+city_br_2841,base.br,base.state_br_ma,Lago Verde
+city_br_2842,base.br,base.state_br_pb,Lagoa
+city_br_2843,base.br,base.state_br_pi,Lagoa Alegre
+city_br_2844,base.br,base.state_br_rs,Lagoa Bonita do Sul
+city_br_2845,base.br,base.state_br_rn,Lagoa d'Anta
+city_br_2846,base.br,base.state_br_al,Lagoa da Canoa
+city_br_2847,base.br,base.state_br_to,Lagoa da Confusão
+city_br_2848,base.br,base.state_br_mg,Lagoa da Prata
+city_br_2849,base.br,base.state_br_pb,Lagoa de Dentro
+city_br_2850,base.br,base.state_br_pe,Lagoa de Itaenga
+city_br_2851,base.br,base.state_br_rn,Lagoa de Pedras
+city_br_2852,base.br,base.state_br_pi,Lagoa de São Francisco
+city_br_2853,base.br,base.state_br_rn,Lagoa de Velhos
+city_br_2854,base.br,base.state_br_pi,Lagoa do Barro do Piauí
+city_br_2855,base.br,base.state_br_pe,Lagoa do Carro
+city_br_2856,base.br,base.state_br_ma,Lagoa do Mato
+city_br_2857,base.br,base.state_br_pe,Lagoa do Ouro
+city_br_2858,base.br,base.state_br_pi,Lagoa do Piauí
+city_br_2859,base.br,base.state_br_pi,Lagoa do Sítio
+city_br_2860,base.br,base.state_br_to,Lagoa do Tocantins
+city_br_2861,base.br,base.state_br_pe,Lagoa dos Gatos
+city_br_2862,base.br,base.state_br_mg,Lagoa dos Patos
+city_br_2863,base.br,base.state_br_rs,Lagoa dos Três Cantos
+city_br_2864,base.br,base.state_br_mg,Lagoa Dourada
+city_br_2865,base.br,base.state_br_mg,Lagoa Formosa
+city_br_2866,base.br,base.state_br_mg,Lagoa Grande
+city_br_2867,base.br,base.state_br_pe,Lagoa Grande
+city_br_2868,base.br,base.state_br_ma,Lagoa Grande do Maranhão
+city_br_2869,base.br,base.state_br_rn,Lagoa Nova
+city_br_2870,base.br,base.state_br_ba,Lagoa Real
+city_br_2871,base.br,base.state_br_rn,Lagoa Salgada
+city_br_2872,base.br,base.state_br_go,Lagoa Santa
+city_br_2873,base.br,base.state_br_mg,Lagoa Santa
+city_br_2874,base.br,base.state_br_pb,Lagoa Seca
+city_br_2875,base.br,base.state_br_rs,Lagoa Vermelha
+city_br_2876,base.br,base.state_br_rs,Lagoão
+city_br_2877,base.br,base.state_br_sp,Lagoinha
+city_br_2878,base.br,base.state_br_pi,Lagoinha do Piauí
+city_br_2879,base.br,base.state_br_sc,Laguna
+city_br_2880,base.br,base.state_br_ms,Laguna Carapã
+city_br_2881,base.br,base.state_br_ba,Laje
+city_br_2882,base.br,base.state_br_rj,Laje do Muriaé
+city_br_2883,base.br,base.state_br_rs,Lajeado
+city_br_2884,base.br,base.state_br_to,Lajeado
+city_br_2885,base.br,base.state_br_rs,Lajeado do Bugre
+city_br_2886,base.br,base.state_br_sc,Lajeado Grande
+city_br_2887,base.br,base.state_br_ma,Lajeado Novo
+city_br_2888,base.br,base.state_br_ba,Lajedão
+city_br_2889,base.br,base.state_br_ba,Lajedinho
+city_br_2890,base.br,base.state_br_pe,Lajedo
+city_br_2891,base.br,base.state_br_ba,Lajedo do Tabocal
+city_br_2892,base.br,base.state_br_rn,Lajes
+city_br_2893,base.br,base.state_br_rn,Lajes Pintadas
+city_br_2894,base.br,base.state_br_mg,Lajinha
+city_br_2895,base.br,base.state_br_ba,Lamarão
+city_br_2896,base.br,base.state_br_mg,Lambari
+city_br_2897,base.br,base.state_br_mt,Lambari D'Oeste
+city_br_2898,base.br,base.state_br_mg,Lamim
+city_br_2899,base.br,base.state_br_pi,Landri Sales
+city_br_2900,base.br,base.state_br_pr,Lapa
+city_br_2901,base.br,base.state_br_ba,Lapão
+city_br_2902,base.br,base.state_br_es,Laranja da Terra
+city_br_2903,base.br,base.state_br_mg,Laranjal
+city_br_2904,base.br,base.state_br_pr,Laranjal
+city_br_2905,base.br,base.state_br_ap,Laranjal do Jari
+city_br_2906,base.br,base.state_br_sp,Laranjal Paulista
+city_br_2907,base.br,base.state_br_se,Laranjeiras
+city_br_2908,base.br,base.state_br_pr,Laranjeiras do Sul
+city_br_2909,base.br,base.state_br_mg,Lassance
+city_br_2910,base.br,base.state_br_pb,Lastro
+city_br_2911,base.br,base.state_br_sc,Laurentino
+city_br_2912,base.br,base.state_br_sc,Lauro Müller
+city_br_2913,base.br,base.state_br_to,Lavandeira
+city_br_2914,base.br,base.state_br_sp,Lavínia
+city_br_2915,base.br,base.state_br_ce,Lavras da Mangabeira
+city_br_2916,base.br,base.state_br_rs,Lavras do Sul
+city_br_2917,base.br,base.state_br_sp,Lavrinhas
+city_br_2918,base.br,base.state_br_mg,Leandro Ferreira
+city_br_2919,base.br,base.state_br_sc,Lebon Régis
+city_br_2920,base.br,base.state_br_sp,Leme
+city_br_2921,base.br,base.state_br_mg,Leme do Prado
+city_br_2922,base.br,base.state_br_ba,Lençóis
+city_br_2923,base.br,base.state_br_sp,Lençóis Paulista
+city_br_2924,base.br,base.state_br_sc,Leoberto Leal
+city_br_2925,base.br,base.state_br_mg,Leopoldina
+city_br_2926,base.br,base.state_br_go,Leopoldo de Bulhões
+city_br_2927,base.br,base.state_br_pr,Leópolis
+city_br_2928,base.br,base.state_br_rs,Liberato Salzano
+city_br_2929,base.br,base.state_br_mg,Liberdade
+city_br_2930,base.br,base.state_br_ba,Licínio de Almeida
+city_br_2931,base.br,base.state_br_pr,Lidianópolis
+city_br_2932,base.br,base.state_br_ma,Lima Campos
+city_br_2933,base.br,base.state_br_mg,Lima Duarte
+city_br_2934,base.br,base.state_br_mg,Limeira do Oeste
+city_br_2935,base.br,base.state_br_pe,Limoeiro
+city_br_2936,base.br,base.state_br_al,Limoeiro de Anadia
+city_br_2937,base.br,base.state_br_pa,Limoeiro do Ajuru
+city_br_2938,base.br,base.state_br_ce,Limoeiro do Norte
+city_br_2939,base.br,base.state_br_pr,Lindoeste
+city_br_2940,base.br,base.state_br_sp,Lindóia
+city_br_2941,base.br,base.state_br_sc,Lindóia do Sul
+city_br_2942,base.br,base.state_br_rs,Lindolfo Collor
+city_br_2943,base.br,base.state_br_rs,Linha Nova
+city_br_2944,base.br,base.state_br_sp,Lins
+city_br_2945,base.br,base.state_br_pb,Livramento
+city_br_2946,base.br,base.state_br_ba,Livramento de Nossa Senhora
+city_br_2947,base.br,base.state_br_to,Lizarda
+city_br_2948,base.br,base.state_br_pr,Loanda
+city_br_2949,base.br,base.state_br_pr,Lobato
+city_br_2950,base.br,base.state_br_pb,Logradouro
+city_br_2951,base.br,base.state_br_mg,Lontra
+city_br_2952,base.br,base.state_br_sc,Lontras
+city_br_2953,base.br,base.state_br_sp,Lorena
+city_br_2954,base.br,base.state_br_ma,Loreto
+city_br_2955,base.br,base.state_br_sp,Lourdes
+city_br_2956,base.br,base.state_br_sp,Louveira
+city_br_2957,base.br,base.state_br_mt,Lucas do Rio Verde
+city_br_2958,base.br,base.state_br_sp,Lucélia
+city_br_2959,base.br,base.state_br_pb,Lucena
+city_br_2960,base.br,base.state_br_sp,Lucianópolis
+city_br_2961,base.br,base.state_br_mt,Luciara
+city_br_2962,base.br,base.state_br_rn,Lucrécia
+city_br_2963,base.br,base.state_br_sp,Luís Antônio
+city_br_2964,base.br,base.state_br_pi,Luís Correia
+city_br_2965,base.br,base.state_br_ma,Luís Domingues
+city_br_2966,base.br,base.state_br_rn,Luís Gomes
+city_br_2967,base.br,base.state_br_mg,Luisburgo
+city_br_2968,base.br,base.state_br_mg,Luislândia
+city_br_2969,base.br,base.state_br_sc,Luiz Alves
+city_br_2970,base.br,base.state_br_pr,Luiziana
+city_br_2971,base.br,base.state_br_sp,Luiziânia
+city_br_2972,base.br,base.state_br_mg,Luminárias
+city_br_2973,base.br,base.state_br_pr,Lunardelli
+city_br_2974,base.br,base.state_br_sp,Lupércio
+city_br_2975,base.br,base.state_br_pr,Lupionópolis
+city_br_2976,base.br,base.state_br_sp,Lutécia
+city_br_2977,base.br,base.state_br_mg,Luz
+city_br_2978,base.br,base.state_br_sc,Luzerna
+city_br_2979,base.br,base.state_br_pi,Luzilândia
+city_br_2980,base.br,base.state_br_to,Luzinópolis
+city_br_2981,base.br,base.state_br_rn,Macaíba
+city_br_2982,base.br,base.state_br_ba,Macajuba
+city_br_2983,base.br,base.state_br_rs,Maçambará
+city_br_2984,base.br,base.state_br_se,Macambira
+city_br_2985,base.br,base.state_br_pe,Macaparana
+city_br_2986,base.br,base.state_br_ba,Macarani
+city_br_2987,base.br,base.state_br_sp,Macatuba
+city_br_2988,base.br,base.state_br_rn,Macau
+city_br_2989,base.br,base.state_br_sp,Macaubal
+city_br_2990,base.br,base.state_br_ba,Macaúbas
+city_br_2991,base.br,base.state_br_sp,Macedônia
+city_br_2992,base.br,base.state_br_mg,Machacalis
+city_br_2993,base.br,base.state_br_rs,Machadinho
+city_br_2994,base.br,base.state_br_ro,Machadinho D'Oeste
+city_br_2995,base.br,base.state_br_mg,Machado
+city_br_2996,base.br,base.state_br_pe,Machados
+city_br_2997,base.br,base.state_br_sc,Macieira
+city_br_2998,base.br,base.state_br_rj,Macuco
+city_br_2999,base.br,base.state_br_ba,Macururé
+city_br_3000,base.br,base.state_br_ce,Madalena
+city_br_3001,base.br,base.state_br_pi,Madeiro
+city_br_3002,base.br,base.state_br_ba,Madre de Deus
+city_br_3003,base.br,base.state_br_mg,Madre de Deus de Minas
+city_br_3004,base.br,base.state_br_pb,Mãe d'Água
+city_br_3005,base.br,base.state_br_pa,Mãe do Rio
+city_br_3006,base.br,base.state_br_ba,Maetinga
+city_br_3007,base.br,base.state_br_sc,Mafra
+city_br_3008,base.br,base.state_br_pa,Magalhães Barata
+city_br_3009,base.br,base.state_br_ma,Magalhães de Almeida
+city_br_3010,base.br,base.state_br_sp,Magda
+city_br_3011,base.br,base.state_br_ba,Maiquinique
+city_br_3012,base.br,base.state_br_ba,Mairi
+city_br_3013,base.br,base.state_br_sp,Mairinque
+city_br_3014,base.br,base.state_br_sp,Mairiporã
+city_br_3015,base.br,base.state_br_go,Mairipotaba
+city_br_3016,base.br,base.state_br_sc,Major Gercino
+city_br_3017,base.br,base.state_br_al,Major Isidoro
+city_br_3018,base.br,base.state_br_rn,Major Sales
+city_br_3019,base.br,base.state_br_sc,Major Vieira
+city_br_3020,base.br,base.state_br_mg,Malacacheta
+city_br_3021,base.br,base.state_br_ba,Malhada
+city_br_3022,base.br,base.state_br_ba,Malhada de Pedras
+city_br_3023,base.br,base.state_br_se,Malhada dos Bois
+city_br_3024,base.br,base.state_br_se,Malhador
+city_br_3025,base.br,base.state_br_pr,Mallet
+city_br_3026,base.br,base.state_br_pb,Malta
+city_br_3027,base.br,base.state_br_pb,Mamanguape
+city_br_3028,base.br,base.state_br_go,Mambaí
+city_br_3029,base.br,base.state_br_pr,Mamborê
+city_br_3030,base.br,base.state_br_mg,Mamonas
+city_br_3031,base.br,base.state_br_rs,Mampituba
+city_br_3032,base.br,base.state_br_pb,Manaíra
+city_br_3033,base.br,base.state_br_am,Manaquiri
+city_br_3034,base.br,base.state_br_pe,Manari
+city_br_3035,base.br,base.state_br_ac,Mâncio Lima
+city_br_3036,base.br,base.state_br_pr,Mandaguaçu
+city_br_3037,base.br,base.state_br_pr,Mandaguari
+city_br_3038,base.br,base.state_br_pr,Mandirituba
+city_br_3039,base.br,base.state_br_sp,Manduri
+city_br_3040,base.br,base.state_br_pr,Manfrinópolis
+city_br_3041,base.br,base.state_br_mg,Manga
+city_br_3042,base.br,base.state_br_rj,Mangaratiba
+city_br_3043,base.br,base.state_br_pr,Mangueirinha
+city_br_3044,base.br,base.state_br_mg,Manhuaçu
+city_br_3045,base.br,base.state_br_mg,Manhumirim
+city_br_3046,base.br,base.state_br_am,Manicoré
+city_br_3047,base.br,base.state_br_pi,Manoel Emídio
+city_br_3048,base.br,base.state_br_pr,Manoel Ribas
+city_br_3049,base.br,base.state_br_ac,Manoel Urbano
+city_br_3050,base.br,base.state_br_rs,Manoel Viana
+city_br_3051,base.br,base.state_br_ba,Manoel Vitorino
+city_br_3052,base.br,base.state_br_ba,Mansidão
+city_br_3053,base.br,base.state_br_mg,Mantena
+city_br_3054,base.br,base.state_br_es,Mantenópolis
+city_br_3055,base.br,base.state_br_rs,Maquiné
+city_br_3056,base.br,base.state_br_mg,Mar de Espanha
+city_br_3057,base.br,base.state_br_al,Mar Vermelho
+city_br_3058,base.br,base.state_br_go,Mara Rosa
+city_br_3059,base.br,base.state_br_am,Maraã
+city_br_3060,base.br,base.state_br_sp,Marabá Paulista
+city_br_3061,base.br,base.state_br_ma,Maracaçumé
+city_br_3062,base.br,base.state_br_sp,Maracaí
+city_br_3063,base.br,base.state_br_sc,Maracajá
+city_br_3064,base.br,base.state_br_ms,Maracaju
+city_br_3065,base.br,base.state_br_pa,Maracanã
+city_br_3066,base.br,base.state_br_ba,Maracás
+city_br_3067,base.br,base.state_br_al,Maragogi
+city_br_3068,base.br,base.state_br_ba,Maragogipe
+city_br_3069,base.br,base.state_br_pe,Maraial
+city_br_3070,base.br,base.state_br_ma,Marajá do Sena
+city_br_3071,base.br,base.state_br_ma,Maranhãozinho
+city_br_3072,base.br,base.state_br_pa,Marapanim
+city_br_3073,base.br,base.state_br_sp,Marapoama
+city_br_3074,base.br,base.state_br_rs,Maratá
+city_br_3075,base.br,base.state_br_es,Marataízes
+city_br_3076,base.br,base.state_br_rs,Marau
+city_br_3077,base.br,base.state_br_ba,Maraú
+city_br_3078,base.br,base.state_br_al,Maravilha
+city_br_3079,base.br,base.state_br_sc,Maravilha
+city_br_3080,base.br,base.state_br_mg,Maravilhas
+city_br_3081,base.br,base.state_br_pb,Marcação
+city_br_3082,base.br,base.state_br_mt,Marcelândia
+city_br_3083,base.br,base.state_br_rs,Marcelino Ramos
+city_br_3084,base.br,base.state_br_rn,Marcelino Vieira
+city_br_3085,base.br,base.state_br_ba,Marcionílio Souza
+city_br_3086,base.br,base.state_br_ce,Marco
+city_br_3087,base.br,base.state_br_pi,Marcolândia
+city_br_3088,base.br,base.state_br_pi,Marcos Parente
+city_br_3089,base.br,base.state_br_pr,Marechal Cândido Rondon
+city_br_3090,base.br,base.state_br_al,Marechal Deodoro
+city_br_3091,base.br,base.state_br_es,Marechal Floriano
+city_br_3092,base.br,base.state_br_ac,Marechal Thaumaturgo
+city_br_3093,base.br,base.state_br_sc,Marema
+city_br_3094,base.br,base.state_br_pb,Mari
+city_br_3095,base.br,base.state_br_mg,Maria da Fé
+city_br_3096,base.br,base.state_br_pr,Maria Helena
+city_br_3097,base.br,base.state_br_pr,Marialva
+city_br_3098,base.br,base.state_br_mg,Mariana
+city_br_3099,base.br,base.state_br_rs,Mariana Pimentel
+city_br_3100,base.br,base.state_br_rs,Mariano Moro
+city_br_3101,base.br,base.state_br_to,Marianópolis do Tocantins
+city_br_3102,base.br,base.state_br_sp,Mariápolis
+city_br_3103,base.br,base.state_br_al,Maribondo
+city_br_3104,base.br,base.state_br_mg,Marilac
+city_br_3105,base.br,base.state_br_es,Marilândia
+city_br_3106,base.br,base.state_br_pr,Marilândia do Sul
+city_br_3107,base.br,base.state_br_pr,Marilena
+city_br_3108,base.br,base.state_br_pr,Mariluz
+city_br_3109,base.br,base.state_br_sp,Marinópolis
+city_br_3110,base.br,base.state_br_mg,Mário Campos
+city_br_3111,base.br,base.state_br_pr,Mariópolis
+city_br_3112,base.br,base.state_br_pr,Maripá
+city_br_3113,base.br,base.state_br_mg,Maripá de Minas
+city_br_3114,base.br,base.state_br_pb,Marizópolis
+city_br_3115,base.br,base.state_br_mg,Marliéria
+city_br_3116,base.br,base.state_br_pr,Marmeleiro
+city_br_3117,base.br,base.state_br_mg,Marmelópolis
+city_br_3118,base.br,base.state_br_rs,Marques de Souza
+city_br_3119,base.br,base.state_br_pr,Marquinho
+city_br_3120,base.br,base.state_br_mg,Martinho Campos
+city_br_3121,base.br,base.state_br_ce,Martinópole
+city_br_3122,base.br,base.state_br_sp,Martinópolis
+city_br_3123,base.br,base.state_br_rn,Martins
+city_br_3124,base.br,base.state_br_mg,Martins Soares
+city_br_3125,base.br,base.state_br_se,Maruim
+city_br_3126,base.br,base.state_br_pr,Marumbi
+city_br_3127,base.br,base.state_br_go,Marzagão
+city_br_3128,base.br,base.state_br_ba,Mascote
+city_br_3129,base.br,base.state_br_ce,Massapê
+city_br_3130,base.br,base.state_br_pi,Massapê do Piauí
+city_br_3131,base.br,base.state_br_pb,Massaranduba
+city_br_3132,base.br,base.state_br_sc,Massaranduba
+city_br_3133,base.br,base.state_br_rs,Mata
+city_br_3134,base.br,base.state_br_ba,Mata de São João
+city_br_3135,base.br,base.state_br_al,Mata Grande
+city_br_3136,base.br,base.state_br_ma,Mata Roma
+city_br_3137,base.br,base.state_br_mg,Mata Verde
+city_br_3138,base.br,base.state_br_sp,Matão
+city_br_3139,base.br,base.state_br_pb,Mataraca
+city_br_3140,base.br,base.state_br_to,Mateiros
+city_br_3141,base.br,base.state_br_pr,Matelândia
+city_br_3142,base.br,base.state_br_mg,Materlândia
+city_br_3143,base.br,base.state_br_mg,Mateus Leme
+city_br_3144,base.br,base.state_br_mg,Mathias Lobato
+city_br_3145,base.br,base.state_br_mg,Matias Barbosa
+city_br_3146,base.br,base.state_br_mg,Matias Cardoso
+city_br_3147,base.br,base.state_br_pi,Matias Olímpio
+city_br_3148,base.br,base.state_br_ba,Matina
+city_br_3149,base.br,base.state_br_ma,Matinha
+city_br_3150,base.br,base.state_br_pb,Matinhas
+city_br_3151,base.br,base.state_br_pr,Matinhos
+city_br_3152,base.br,base.state_br_mg,Matipó
+city_br_3153,base.br,base.state_br_rs,Mato Castelhano
+city_br_3154,base.br,base.state_br_pb,Mato Grosso
+city_br_3155,base.br,base.state_br_rs,Mato Leitão
+city_br_3156,base.br,base.state_br_rs,Mato Queimado
+city_br_3157,base.br,base.state_br_pr,Mato Rico
+city_br_3158,base.br,base.state_br_mg,Mato Verde
+city_br_3159,base.br,base.state_br_ma,Matões
+city_br_3160,base.br,base.state_br_ma,Matões do Norte
+city_br_3161,base.br,base.state_br_sc,Matos Costa
+city_br_3162,base.br,base.state_br_mg,Matozinhos
+city_br_3163,base.br,base.state_br_go,Matrinchã
+city_br_3164,base.br,base.state_br_al,Matriz de Camaragibe
+city_br_3165,base.br,base.state_br_mt,Matupá
+city_br_3166,base.br,base.state_br_pb,Maturéia
+city_br_3167,base.br,base.state_br_mg,Matutina
+city_br_3168,base.br,base.state_br_pr,Mauá da Serra
+city_br_3169,base.br,base.state_br_am,Maués
+city_br_3170,base.br,base.state_br_go,Maurilândia
+city_br_3171,base.br,base.state_br_to,Maurilândia do Tocantins
+city_br_3172,base.br,base.state_br_ce,Mauriti
+city_br_3173,base.br,base.state_br_rn,Maxaranguape
+city_br_3174,base.br,base.state_br_rs,Maximiliano de Almeida
+city_br_3175,base.br,base.state_br_ap,Mazagão
+city_br_3176,base.br,base.state_br_mg,Medeiros
+city_br_3177,base.br,base.state_br_ba,Medeiros Neto
+city_br_3178,base.br,base.state_br_pr,Medianeira
+city_br_3179,base.br,base.state_br_pa,Medicilândia
+city_br_3180,base.br,base.state_br_mg,Medina
+city_br_3181,base.br,base.state_br_sc,Meleiro
+city_br_3182,base.br,base.state_br_pa,Melgaço
+city_br_3183,base.br,base.state_br_rj,Mendes
+city_br_3184,base.br,base.state_br_mg,Mendes Pimentel
+city_br_3185,base.br,base.state_br_sp,Mendonça
+city_br_3186,base.br,base.state_br_pr,Mercedes
+city_br_3187,base.br,base.state_br_mg,Mercês
+city_br_3188,base.br,base.state_br_sp,Meridiano
+city_br_3189,base.br,base.state_br_ce,Meruoca
+city_br_3190,base.br,base.state_br_sp,Mesópolis
+city_br_3191,base.br,base.state_br_mg,Mesquita
+city_br_3192,base.br,base.state_br_al,Messias
+city_br_3193,base.br,base.state_br_rn,Messias Targino
+city_br_3194,base.br,base.state_br_pi,Miguel Alves
+city_br_3195,base.br,base.state_br_ba,Miguel Calmon
+city_br_3196,base.br,base.state_br_pi,Miguel Leão
+city_br_3197,base.br,base.state_br_rj,Miguel Pereira
+city_br_3198,base.br,base.state_br_sp,Miguelópolis
+city_br_3199,base.br,base.state_br_ba,Milagres
+city_br_3200,base.br,base.state_br_ce,Milagres
+city_br_3201,base.br,base.state_br_ma,Milagres do Maranhão
+city_br_3202,base.br,base.state_br_ce,Milhã
+city_br_3203,base.br,base.state_br_pi,Milton Brandão
+city_br_3204,base.br,base.state_br_go,Mimoso de Goiás
+city_br_3205,base.br,base.state_br_es,Mimoso do Sul
+city_br_3206,base.br,base.state_br_go,Minaçu
+city_br_3207,base.br,base.state_br_al,Minador do Negrão
+city_br_3208,base.br,base.state_br_rs,Minas do Leão
+city_br_3209,base.br,base.state_br_mg,Minas Novas
+city_br_3210,base.br,base.state_br_mg,Minduri
+city_br_3211,base.br,base.state_br_go,Mineiros
+city_br_3212,base.br,base.state_br_sp,Mineiros do Tietê
+city_br_3213,base.br,base.state_br_ro,Ministro Andreazza
+city_br_3214,base.br,base.state_br_sp,Mira Estrela
+city_br_3215,base.br,base.state_br_mg,Mirabela
+city_br_3216,base.br,base.state_br_sp,Miracatu
+city_br_3217,base.br,base.state_br_rj,Miracema
+city_br_3218,base.br,base.state_br_to,Miracema do Tocantins
+city_br_3219,base.br,base.state_br_ma,Mirador
+city_br_3220,base.br,base.state_br_pr,Mirador
+city_br_3221,base.br,base.state_br_mg,Miradouro
+city_br_3222,base.br,base.state_br_rs,Miraguaí
+city_br_3223,base.br,base.state_br_mg,Miraí
+city_br_3224,base.br,base.state_br_ce,Miraíma
+city_br_3225,base.br,base.state_br_ms,Miranda
+city_br_3226,base.br,base.state_br_ma,Miranda do Norte
+city_br_3227,base.br,base.state_br_pe,Mirandiba
+city_br_3228,base.br,base.state_br_sp,Mirandópolis
+city_br_3229,base.br,base.state_br_ba,Mirangaba
+city_br_3230,base.br,base.state_br_to,Miranorte
+city_br_3231,base.br,base.state_br_ba,Mirante
+city_br_3232,base.br,base.state_br_ro,Mirante da Serra
+city_br_3233,base.br,base.state_br_sp,Mirante do Paranapanema
+city_br_3234,base.br,base.state_br_pr,Miraselva
+city_br_3235,base.br,base.state_br_sp,Mirassol
+city_br_3236,base.br,base.state_br_mt,Mirassol d'Oeste
+city_br_3237,base.br,base.state_br_sp,Mirassolândia
+city_br_3238,base.br,base.state_br_mg,Miravânia
+city_br_3239,base.br,base.state_br_sc,Mirim Doce
+city_br_3240,base.br,base.state_br_ma,Mirinzal
+city_br_3241,base.br,base.state_br_pr,Missal
+city_br_3242,base.br,base.state_br_ce,Missão Velha
+city_br_3243,base.br,base.state_br_pa,Mocajuba
+city_br_3244,base.br,base.state_br_sp,Mococa
+city_br_3245,base.br,base.state_br_sc,Modelo
+city_br_3246,base.br,base.state_br_mg,Moeda
+city_br_3247,base.br,base.state_br_mg,Moema
+city_br_3248,base.br,base.state_br_pb,Mogeiro
+city_br_3249,base.br,base.state_br_sp,Mogi Mirim
+city_br_3250,base.br,base.state_br_go,Moiporá
+city_br_3251,base.br,base.state_br_se,Moita Bonita
+city_br_3252,base.br,base.state_br_pa,Moju
+city_br_3253,base.br,base.state_br_pa,Mojuí dos Campos
+city_br_3254,base.br,base.state_br_ce,Mombaça
+city_br_3255,base.br,base.state_br_sp,Mombuca
+city_br_3256,base.br,base.state_br_ma,Monção
+city_br_3257,base.br,base.state_br_sp,Monções
+city_br_3258,base.br,base.state_br_sc,Mondaí
+city_br_3259,base.br,base.state_br_sp,Mongaguá
+city_br_3260,base.br,base.state_br_mg,Monjolos
+city_br_3261,base.br,base.state_br_pi,Monsenhor Gil
+city_br_3262,base.br,base.state_br_pi,Monsenhor Hipólito
+city_br_3263,base.br,base.state_br_mg,Monsenhor Paulo
+city_br_3264,base.br,base.state_br_ce,Monsenhor Tabosa
+city_br_3265,base.br,base.state_br_pb,Montadas
+city_br_3266,base.br,base.state_br_mg,Montalvânia
+city_br_3267,base.br,base.state_br_es,Montanha
+city_br_3268,base.br,base.state_br_rn,Montanhas
+city_br_3269,base.br,base.state_br_rs,Montauri
+city_br_3270,base.br,base.state_br_pa,Monte Alegre
+city_br_3271,base.br,base.state_br_rn,Monte Alegre
+city_br_3272,base.br,base.state_br_go,Monte Alegre de Goiás
+city_br_3273,base.br,base.state_br_mg,Monte Alegre de Minas
+city_br_3274,base.br,base.state_br_se,Monte Alegre de Sergipe
+city_br_3275,base.br,base.state_br_pi,Monte Alegre do Piauí
+city_br_3276,base.br,base.state_br_sp,Monte Alegre do Sul
+city_br_3277,base.br,base.state_br_rs,Monte Alegre dos Campos
+city_br_3278,base.br,base.state_br_sp,Monte Alto
+city_br_3279,base.br,base.state_br_sp,Monte Aprazível
+city_br_3280,base.br,base.state_br_mg,Monte Azul
+city_br_3281,base.br,base.state_br_sp,Monte Azul Paulista
+city_br_3282,base.br,base.state_br_mg,Monte Belo
+city_br_3283,base.br,base.state_br_rs,Monte Belo do Sul
+city_br_3284,base.br,base.state_br_sc,Monte Carlo
+city_br_3285,base.br,base.state_br_mg,Monte Carmelo
+city_br_3286,base.br,base.state_br_sc,Monte Castelo
+city_br_3287,base.br,base.state_br_sp,Monte Castelo
+city_br_3288,base.br,base.state_br_rn,Monte das Gameleiras
+city_br_3289,base.br,base.state_br_to,Monte do Carmo
+city_br_3290,base.br,base.state_br_mg,Monte Formoso
+city_br_3291,base.br,base.state_br_pb,Monte Horebe
+city_br_3292,base.br,base.state_br_sp,Monte Mor
+city_br_3293,base.br,base.state_br_ro,Monte Negro
+city_br_3294,base.br,base.state_br_ba,Monte Santo
+city_br_3295,base.br,base.state_br_mg,Monte Santo de Minas
+city_br_3296,base.br,base.state_br_to,Monte Santo do Tocantins
+city_br_3297,base.br,base.state_br_mg,Monte Sião
+city_br_3298,base.br,base.state_br_pb,Monteiro
+city_br_3299,base.br,base.state_br_sp,Monteiro Lobato
+city_br_3300,base.br,base.state_br_al,Monteirópolis
+city_br_3301,base.br,base.state_br_rs,Montenegro
+city_br_3302,base.br,base.state_br_ma,Montes Altos
+city_br_3303,base.br,base.state_br_go,Montes Claros de Goiás
+city_br_3304,base.br,base.state_br_mg,Montezuma
+city_br_3305,base.br,base.state_br_go,Montividiu
+city_br_3306,base.br,base.state_br_go,Montividiu do Norte
+city_br_3307,base.br,base.state_br_ce,Morada Nova
+city_br_3308,base.br,base.state_br_mg,Morada Nova de Minas
+city_br_3309,base.br,base.state_br_ce,Moraújo
+city_br_3310,base.br,base.state_br_pe,Moreilândia
+city_br_3311,base.br,base.state_br_pr,Moreira Sales
+city_br_3312,base.br,base.state_br_pe,Moreno
+city_br_3313,base.br,base.state_br_rs,Mormaço
+city_br_3314,base.br,base.state_br_ba,Morpará
+city_br_3315,base.br,base.state_br_pr,Morretes
+city_br_3316,base.br,base.state_br_ce,Morrinhos
+city_br_3317,base.br,base.state_br_go,Morrinhos
+city_br_3318,base.br,base.state_br_rs,Morrinhos do Sul
+city_br_3319,base.br,base.state_br_sp,Morro Agudo
+city_br_3320,base.br,base.state_br_go,Morro Agudo de Goiás
+city_br_3321,base.br,base.state_br_pi,Morro Cabeça no Tempo
+city_br_3322,base.br,base.state_br_sc,Morro da Fumaça
+city_br_3323,base.br,base.state_br_mg,Morro da Garça
+city_br_3324,base.br,base.state_br_ba,Morro do Chapéu
+city_br_3325,base.br,base.state_br_pi,Morro do Chapéu do Piauí
+city_br_3326,base.br,base.state_br_mg,Morro do Pilar
+city_br_3327,base.br,base.state_br_sc,Morro Grande
+city_br_3328,base.br,base.state_br_rs,Morro Redondo
+city_br_3329,base.br,base.state_br_rs,Morro Reuter
+city_br_3330,base.br,base.state_br_ma,Morros
+city_br_3331,base.br,base.state_br_ba,Mortugaba
+city_br_3332,base.br,base.state_br_sp,Morungaba
+city_br_3333,base.br,base.state_br_go,Mossâmedes
+city_br_3334,base.br,base.state_br_rs,Mostardas
+city_br_3335,base.br,base.state_br_sp,Motuca
+city_br_3336,base.br,base.state_br_go,Mozarlândia
+city_br_3337,base.br,base.state_br_pa,Muaná
+city_br_3338,base.br,base.state_br_rr,Mucajaí
+city_br_3339,base.br,base.state_br_ce,Mucambo
+city_br_3340,base.br,base.state_br_ba,Mucugê
+city_br_3341,base.br,base.state_br_rs,Muçum
+city_br_3342,base.br,base.state_br_ba,Mucuri
+city_br_3343,base.br,base.state_br_es,Mucurici
+city_br_3344,base.br,base.state_br_rs,Muitos Capões
+city_br_3345,base.br,base.state_br_rs,Muliterno
+city_br_3346,base.br,base.state_br_ce,Mulungu
+city_br_3347,base.br,base.state_br_pb,Mulungu
+city_br_3348,base.br,base.state_br_ba,Mulungu do Morro
+city_br_3349,base.br,base.state_br_ba,Mundo Novo
+city_br_3350,base.br,base.state_br_go,Mundo Novo
+city_br_3351,base.br,base.state_br_ms,Mundo Novo
+city_br_3352,base.br,base.state_br_mg,Munhoz
+city_br_3353,base.br,base.state_br_pr,Munhoz de Melo
+city_br_3354,base.br,base.state_br_ba,Muniz Ferreira
+city_br_3355,base.br,base.state_br_es,Muniz Freire
+city_br_3356,base.br,base.state_br_ba,Muquém de São Francisco
+city_br_3357,base.br,base.state_br_es,Muqui
+city_br_3358,base.br,base.state_br_se,Muribeca
+city_br_3359,base.br,base.state_br_al,Murici
+city_br_3360,base.br,base.state_br_pi,Murici dos Portelas
+city_br_3361,base.br,base.state_br_to,Muricilândia
+city_br_3362,base.br,base.state_br_ba,Muritiba
+city_br_3363,base.br,base.state_br_sp,Murutinga do Sul
+city_br_3364,base.br,base.state_br_ba,Mutuípe
+city_br_3365,base.br,base.state_br_mg,Mutum
+city_br_3366,base.br,base.state_br_go,Mutunópolis
+city_br_3367,base.br,base.state_br_mg,Muzambinho
+city_br_3368,base.br,base.state_br_mg,Nacip Raydan
+city_br_3369,base.br,base.state_br_sp,Nantes
+city_br_3370,base.br,base.state_br_mg,Nanuque
+city_br_3371,base.br,base.state_br_rs,Não-Me-Toque
+city_br_3372,base.br,base.state_br_mg,Naque
+city_br_3373,base.br,base.state_br_sp,Narandiba
+city_br_3374,base.br,base.state_br_mg,Natalândia
+city_br_3375,base.br,base.state_br_mg,Natércia
+city_br_3376,base.br,base.state_br_rj,Natividade
+city_br_3377,base.br,base.state_br_to,Natividade
+city_br_3378,base.br,base.state_br_sp,Natividade da Serra
+city_br_3379,base.br,base.state_br_pb,Natuba
+city_br_3380,base.br,base.state_br_sc,Navegantes
+city_br_3381,base.br,base.state_br_ms,Naviraí
+city_br_3382,base.br,base.state_br_ba,Nazaré
+city_br_3383,base.br,base.state_br_to,Nazaré
+city_br_3384,base.br,base.state_br_pe,Nazaré da Mata
+city_br_3385,base.br,base.state_br_pi,Nazaré do Piauí
+city_br_3386,base.br,base.state_br_sp,Nazaré Paulista
+city_br_3387,base.br,base.state_br_mg,Nazareno
+city_br_3388,base.br,base.state_br_pb,Nazarezinho
+city_br_3389,base.br,base.state_br_pi,Nazária
+city_br_3390,base.br,base.state_br_go,Nazário
+city_br_3391,base.br,base.state_br_se,Neópolis
+city_br_3392,base.br,base.state_br_mg,Nepomuceno
+city_br_3393,base.br,base.state_br_go,Nerópolis
+city_br_3394,base.br,base.state_br_sp,Neves Paulista
+city_br_3395,base.br,base.state_br_am,Nhamundá
+city_br_3396,base.br,base.state_br_sp,Nhandeara
+city_br_3397,base.br,base.state_br_rs,Nicolau Vergueiro
+city_br_3398,base.br,base.state_br_ba,Nilo Peçanha
+city_br_3399,base.br,base.state_br_ma,Nina Rodrigues
+city_br_3400,base.br,base.state_br_mg,Ninheira
+city_br_3401,base.br,base.state_br_ms,Nioaque
+city_br_3402,base.br,base.state_br_sp,Nipoã
+city_br_3403,base.br,base.state_br_go,Niquelândia
+city_br_3404,base.br,base.state_br_rn,Nísia Floresta
+city_br_3405,base.br,base.state_br_mt,Nobres
+city_br_3406,base.br,base.state_br_rs,Nonoai
+city_br_3407,base.br,base.state_br_ba,Nordestina
+city_br_3408,base.br,base.state_br_rr,Normandia
+city_br_3409,base.br,base.state_br_mt,Nortelândia
+city_br_3410,base.br,base.state_br_se,Nossa Senhora Aparecida
+city_br_3411,base.br,base.state_br_se,Nossa Senhora da Glória
+city_br_3412,base.br,base.state_br_se,Nossa Senhora das Dores
+city_br_3413,base.br,base.state_br_pr,Nossa Senhora das Graças
+city_br_3414,base.br,base.state_br_se,Nossa Senhora de Lourdes
+city_br_3415,base.br,base.state_br_pi,Nossa Senhora de Nazaré
+city_br_3416,base.br,base.state_br_mt,Nossa Senhora do Livramento
+city_br_3417,base.br,base.state_br_pi,Nossa Senhora dos Remédios
+city_br_3418,base.br,base.state_br_sp,Nova Aliança
+city_br_3419,base.br,base.state_br_pr,Nova Aliança do Ivaí
+city_br_3420,base.br,base.state_br_rs,Nova Alvorada
+city_br_3421,base.br,base.state_br_ms,Nova Alvorada do Sul
+city_br_3422,base.br,base.state_br_go,Nova América
+city_br_3423,base.br,base.state_br_pr,Nova América da Colina
+city_br_3424,base.br,base.state_br_ms,Nova Andradina
+city_br_3425,base.br,base.state_br_rs,Nova Araçá
+city_br_3426,base.br,base.state_br_go,Nova Aurora
+city_br_3427,base.br,base.state_br_pr,Nova Aurora
+city_br_3428,base.br,base.state_br_mt,Nova Bandeirantes
+city_br_3429,base.br,base.state_br_rs,Nova Bassano
+city_br_3430,base.br,base.state_br_mg,Nova Belém
+city_br_3431,base.br,base.state_br_rs,Nova Boa Vista
+city_br_3432,base.br,base.state_br_mt,Nova Brasilândia
+city_br_3433,base.br,base.state_br_ro,Nova Brasilândia D'Oeste
+city_br_3434,base.br,base.state_br_rs,Nova Bréscia
+city_br_3435,base.br,base.state_br_sp,Nova Campina
+city_br_3436,base.br,base.state_br_ba,Nova Canaã
+city_br_3437,base.br,base.state_br_mt,Nova Canaã do Norte
+city_br_3438,base.br,base.state_br_sp,Nova Canaã Paulista
+city_br_3439,base.br,base.state_br_rs,Nova Candelária
+city_br_3440,base.br,base.state_br_pr,Nova Cantu
+city_br_3441,base.br,base.state_br_sp,Nova Castilho
+city_br_3442,base.br,base.state_br_ma,Nova Colinas
+city_br_3443,base.br,base.state_br_go,Nova Crixás
+city_br_3444,base.br,base.state_br_rn,Nova Cruz
+city_br_3445,base.br,base.state_br_mg,Nova Era
+city_br_3446,base.br,base.state_br_sc,Nova Erechim
+city_br_3447,base.br,base.state_br_pr,Nova Esperança
+city_br_3448,base.br,base.state_br_pa,Nova Esperança do Piriá
+city_br_3449,base.br,base.state_br_pr,Nova Esperança do Sudoeste
+city_br_3450,base.br,base.state_br_rs,Nova Esperança do Sul
+city_br_3451,base.br,base.state_br_sp,Nova Europa
+city_br_3452,base.br,base.state_br_ba,Nova Fátima
+city_br_3453,base.br,base.state_br_pr,Nova Fátima
+city_br_3454,base.br,base.state_br_pb,Nova Floresta
+city_br_3455,base.br,base.state_br_go,Nova Glória
+city_br_3456,base.br,base.state_br_sp,Nova Granada
+city_br_3457,base.br,base.state_br_mt,Nova Guarita
+city_br_3458,base.br,base.state_br_sp,Nova Guataporanga
+city_br_3459,base.br,base.state_br_rs,Nova Hartz
+city_br_3460,base.br,base.state_br_ba,Nova Ibiá
+city_br_3461,base.br,base.state_br_go,Nova Iguaçu de Goiás
+city_br_3462,base.br,base.state_br_sp,Nova Independência
+city_br_3463,base.br,base.state_br_ma,Nova Iorque
+city_br_3464,base.br,base.state_br_pa,Nova Ipixuna
+city_br_3465,base.br,base.state_br_sc,Nova Itaberaba
+city_br_3466,base.br,base.state_br_ba,Nova Itarana
+city_br_3467,base.br,base.state_br_mt,Nova Lacerda
+city_br_3468,base.br,base.state_br_pr,Nova Laranjeiras
+city_br_3469,base.br,base.state_br_pr,Nova Londrina
+city_br_3470,base.br,base.state_br_sp,Nova Luzitânia
+city_br_3471,base.br,base.state_br_ro,Nova Mamoré
+city_br_3472,base.br,base.state_br_mt,Nova Marilândia
+city_br_3473,base.br,base.state_br_mt,Nova Maringá
+city_br_3474,base.br,base.state_br_mg,Nova Módica
+city_br_3475,base.br,base.state_br_mt,Nova Monte Verde
+city_br_3476,base.br,base.state_br_mt,Nova Mutum
+city_br_3477,base.br,base.state_br_mt,Nova Nazaré
+city_br_3478,base.br,base.state_br_sp,Nova Odessa
+city_br_3479,base.br,base.state_br_mt,Nova Olímpia
+city_br_3480,base.br,base.state_br_pr,Nova Olímpia
+city_br_3481,base.br,base.state_br_ce,Nova Olinda
+city_br_3482,base.br,base.state_br_pb,Nova Olinda
+city_br_3483,base.br,base.state_br_to,Nova Olinda
+city_br_3484,base.br,base.state_br_ma,Nova Olinda do Maranhão
+city_br_3485,base.br,base.state_br_am,Nova Olinda do Norte
+city_br_3486,base.br,base.state_br_rs,Nova Pádua
+city_br_3487,base.br,base.state_br_rs,Nova Palma
+city_br_3488,base.br,base.state_br_pb,Nova Palmeira
+city_br_3489,base.br,base.state_br_rs,Nova Petrópolis
+city_br_3490,base.br,base.state_br_mg,Nova Ponte
+city_br_3491,base.br,base.state_br_mg,Nova Porteirinha
+city_br_3492,base.br,base.state_br_rs,Nova Prata
+city_br_3493,base.br,base.state_br_pr,Nova Prata do Iguaçu
+city_br_3494,base.br,base.state_br_rs,Nova Ramada
+city_br_3495,base.br,base.state_br_ba,Nova Redenção
+city_br_3496,base.br,base.state_br_mg,Nova Resende
+city_br_3497,base.br,base.state_br_go,Nova Roma
+city_br_3498,base.br,base.state_br_rs,Nova Roma do Sul
+city_br_3499,base.br,base.state_br_to,Nova Rosalândia
+city_br_3500,base.br,base.state_br_ce,Nova Russas
+city_br_3501,base.br,base.state_br_pr,Nova Santa Bárbara
+city_br_3502,base.br,base.state_br_mt,Nova Santa Helena
+city_br_3503,base.br,base.state_br_pi,Nova Santa Rita
+city_br_3504,base.br,base.state_br_rs,Nova Santa Rita
+city_br_3505,base.br,base.state_br_pr,Nova Santa Rosa
+city_br_3506,base.br,base.state_br_ba,Nova Soure
+city_br_3507,base.br,base.state_br_pr,Nova Tebas
+city_br_3508,base.br,base.state_br_pa,Nova Timboteua
+city_br_3509,base.br,base.state_br_sc,Nova Trento
+city_br_3510,base.br,base.state_br_mt,Nova Ubiratã
+city_br_3511,base.br,base.state_br_mg,Nova União
+city_br_3512,base.br,base.state_br_ro,Nova União
+city_br_3513,base.br,base.state_br_es,Nova Venécia
+city_br_3514,base.br,base.state_br_go,Nova Veneza
+city_br_3515,base.br,base.state_br_sc,Nova Veneza
+city_br_3516,base.br,base.state_br_ba,Nova Viçosa
+city_br_3517,base.br,base.state_br_mt,Nova Xavantina
+city_br_3518,base.br,base.state_br_sp,Novais
+city_br_3519,base.br,base.state_br_to,Novo Acordo
+city_br_3520,base.br,base.state_br_am,Novo Airão
+city_br_3521,base.br,base.state_br_to,Novo Alegre
+city_br_3522,base.br,base.state_br_am,Novo Aripuanã
+city_br_3523,base.br,base.state_br_rs,Novo Barreiro
+city_br_3524,base.br,base.state_br_go,Novo Brasil
+city_br_3525,base.br,base.state_br_rs,Novo Cabrais
+city_br_3526,base.br,base.state_br_mg,Novo Cruzeiro
+city_br_3527,base.br,base.state_br_ba,Novo Horizonte
+city_br_3528,base.br,base.state_br_sc,Novo Horizonte
+city_br_3529,base.br,base.state_br_sp,Novo Horizonte
+city_br_3530,base.br,base.state_br_mt,Novo Horizonte do Norte
+city_br_3531,base.br,base.state_br_ro,Novo Horizonte do Oeste
+city_br_3532,base.br,base.state_br_ms,Novo Horizonte do Sul
+city_br_3533,base.br,base.state_br_pr,Novo Itacolomi
+city_br_3534,base.br,base.state_br_to,Novo Jardim
+city_br_3535,base.br,base.state_br_al,Novo Lino
+city_br_3536,base.br,base.state_br_rs,Novo Machado
+city_br_3537,base.br,base.state_br_mt,Novo Mundo
+city_br_3538,base.br,base.state_br_ce,Novo Oriente
+city_br_3539,base.br,base.state_br_mg,Novo Oriente de Minas
+city_br_3540,base.br,base.state_br_pi,Novo Oriente do Piauí
+city_br_3541,base.br,base.state_br_go,Novo Planalto
+city_br_3542,base.br,base.state_br_pa,Novo Progresso
+city_br_3543,base.br,base.state_br_pa,Novo Repartimento
+city_br_3544,base.br,base.state_br_mt,Novo Santo Antônio
+city_br_3545,base.br,base.state_br_pi,Novo Santo Antônio
+city_br_3546,base.br,base.state_br_mt,Novo São Joaquim
+city_br_3547,base.br,base.state_br_rs,Novo Tiradentes
+city_br_3548,base.br,base.state_br_ba,Novo Triunfo
+city_br_3549,base.br,base.state_br_rs,Novo Xingu
+city_br_3550,base.br,base.state_br_mg,Novorizonte
+city_br_3551,base.br,base.state_br_sp,Nuporanga
+city_br_3552,base.br,base.state_br_pa,Óbidos
+city_br_3553,base.br,base.state_br_ce,Ocara
+city_br_3554,base.br,base.state_br_sp,Ocauçu
+city_br_3555,base.br,base.state_br_pi,Oeiras
+city_br_3556,base.br,base.state_br_pa,Oeiras do Pará
+city_br_3557,base.br,base.state_br_ap,Oiapoque
+city_br_3558,base.br,base.state_br_mg,Olaria
+city_br_3559,base.br,base.state_br_sp,Óleo
+city_br_3560,base.br,base.state_br_pb,Olho d'Água
+city_br_3561,base.br,base.state_br_ma,Olho d'Água das Cunhãs
+city_br_3562,base.br,base.state_br_al,Olho d'Água das Flores
+city_br_3563,base.br,base.state_br_rn,Olho-d'Água do Borges
+city_br_3564,base.br,base.state_br_al,Olho d'Água do Casado
+city_br_3565,base.br,base.state_br_pi,Olho D'Água do Piauí
+city_br_3566,base.br,base.state_br_al,Olho d'Água Grande
+city_br_3567,base.br,base.state_br_mg,Olhos-d'Água
+city_br_3568,base.br,base.state_br_sp,Olímpia
+city_br_3569,base.br,base.state_br_mg,Olímpio Noronha
+city_br_3570,base.br,base.state_br_ma,Olinda Nova do Maranhão
+city_br_3571,base.br,base.state_br_ba,Olindina
+city_br_3572,base.br,base.state_br_pb,Olivedos
+city_br_3573,base.br,base.state_br_mg,Oliveira
+city_br_3574,base.br,base.state_br_to,Oliveira de Fátima
+city_br_3575,base.br,base.state_br_ba,Oliveira dos Brejinhos
+city_br_3576,base.br,base.state_br_mg,Oliveira Fortes
+city_br_3577,base.br,base.state_br_al,Olivença
+city_br_3578,base.br,base.state_br_mg,Onça de Pitangui
+city_br_3579,base.br,base.state_br_sp,Onda Verde
+city_br_3580,base.br,base.state_br_mg,Oratórios
+city_br_3581,base.br,base.state_br_sp,Oriente
+city_br_3582,base.br,base.state_br_sp,Orindiúva
+city_br_3583,base.br,base.state_br_pa,Oriximiná
+city_br_3584,base.br,base.state_br_mg,Orizânia
+city_br_3585,base.br,base.state_br_go,Orizona
+city_br_3586,base.br,base.state_br_sp,Orlândia
+city_br_3587,base.br,base.state_br_sc,Orleans
+city_br_3588,base.br,base.state_br_pe,Orobó
+city_br_3589,base.br,base.state_br_pe,Orocó
+city_br_3590,base.br,base.state_br_ce,Orós
+city_br_3591,base.br,base.state_br_pr,Ortigueira
+city_br_3592,base.br,base.state_br_sp,Oscar Bressane
+city_br_3593,base.br,base.state_br_rs,Osório
+city_br_3594,base.br,base.state_br_sp,Osvaldo Cruz
+city_br_3595,base.br,base.state_br_sc,Otacílio Costa
+city_br_3596,base.br,base.state_br_pa,Ourém
+city_br_3597,base.br,base.state_br_ba,Ouriçangas
+city_br_3598,base.br,base.state_br_pe,Ouricuri
+city_br_3599,base.br,base.state_br_pa,Ourilândia do Norte
+city_br_3600,base.br,base.state_br_pr,Ourizona
+city_br_3601,base.br,base.state_br_sc,Ouro
+city_br_3602,base.br,base.state_br_al,Ouro Branco
+city_br_3603,base.br,base.state_br_mg,Ouro Branco
+city_br_3604,base.br,base.state_br_rn,Ouro Branco
+city_br_3605,base.br,base.state_br_mg,Ouro Fino
+city_br_3606,base.br,base.state_br_mg,Ouro Preto
+city_br_3607,base.br,base.state_br_ro,Ouro Preto do Oeste
+city_br_3608,base.br,base.state_br_pb,Ouro Velho
+city_br_3609,base.br,base.state_br_sc,Ouro Verde
+city_br_3610,base.br,base.state_br_sp,Ouro Verde
+city_br_3611,base.br,base.state_br_go,Ouro Verde de Goiás
+city_br_3612,base.br,base.state_br_mg,Ouro Verde de Minas
+city_br_3613,base.br,base.state_br_pr,Ouro Verde do Oeste
+city_br_3614,base.br,base.state_br_sp,Ouroeste
+city_br_3615,base.br,base.state_br_ba,Ourolândia
+city_br_3616,base.br,base.state_br_go,Ouvidor
+city_br_3617,base.br,base.state_br_sp,Pacaembu
+city_br_3618,base.br,base.state_br_pa,Pacajá
+city_br_3619,base.br,base.state_br_ce,Pacajus
+city_br_3620,base.br,base.state_br_rr,Pacaraima
+city_br_3621,base.br,base.state_br_ce,Pacatuba
+city_br_3622,base.br,base.state_br_se,Pacatuba
+city_br_3623,base.br,base.state_br_ce,Pacoti
+city_br_3624,base.br,base.state_br_ce,Pacujá
+city_br_3625,base.br,base.state_br_go,Padre Bernardo
+city_br_3626,base.br,base.state_br_mg,Padre Carvalho
+city_br_3627,base.br,base.state_br_pi,Padre Marcos
+city_br_3628,base.br,base.state_br_mg,Padre Paraíso
+city_br_3629,base.br,base.state_br_pi,Paes Landim
+city_br_3630,base.br,base.state_br_mg,Pai Pedro
+city_br_3631,base.br,base.state_br_sc,Paial
+city_br_3632,base.br,base.state_br_pr,Paiçandu
+city_br_3633,base.br,base.state_br_rs,Paim Filho
+city_br_3634,base.br,base.state_br_mg,Paineiras
+city_br_3635,base.br,base.state_br_sc,Painel
+city_br_3636,base.br,base.state_br_mg,Pains
+city_br_3637,base.br,base.state_br_mg,Paiva
+city_br_3638,base.br,base.state_br_pi,Pajeú do Piauí
+city_br_3639,base.br,base.state_br_al,Palestina
+city_br_3640,base.br,base.state_br_sp,Palestina
+city_br_3641,base.br,base.state_br_go,Palestina de Goiás
+city_br_3642,base.br,base.state_br_pa,Palestina do Pará
+city_br_3643,base.br,base.state_br_ce,Palhano
+city_br_3644,base.br,base.state_br_mg,Palma
+city_br_3645,base.br,base.state_br_sc,Palma Sola
+city_br_3646,base.br,base.state_br_ce,Palmácia
+city_br_3647,base.br,base.state_br_pe,Palmares
+city_br_3648,base.br,base.state_br_rs,Palmares do Sul
+city_br_3649,base.br,base.state_br_sp,Palmares Paulista
+city_br_3650,base.br,base.state_br_pr,Palmas
+city_br_3651,base.br,base.state_br_ba,Palmas de Monte Alto
+city_br_3652,base.br,base.state_br_pr,Palmeira
+city_br_3653,base.br,base.state_br_sc,Palmeira
+city_br_3654,base.br,base.state_br_sp,Palmeira d'Oeste
+city_br_3655,base.br,base.state_br_rs,Palmeira das Missões
+city_br_3656,base.br,base.state_br_pi,Palmeira do Piauí
+city_br_3657,base.br,base.state_br_al,Palmeira dos Índios
+city_br_3658,base.br,base.state_br_pi,Palmeirais
+city_br_3659,base.br,base.state_br_ma,Palmeirândia
+city_br_3660,base.br,base.state_br_to,Palmeirante
+city_br_3661,base.br,base.state_br_ba,Palmeiras
+city_br_3662,base.br,base.state_br_go,Palmeiras de Goiás
+city_br_3663,base.br,base.state_br_to,Palmeiras do Tocantins
+city_br_3664,base.br,base.state_br_pe,Palmeirina
+city_br_3665,base.br,base.state_br_to,Palmeirópolis
+city_br_3666,base.br,base.state_br_go,Palmelo
+city_br_3667,base.br,base.state_br_go,Palminópolis
+city_br_3668,base.br,base.state_br_pr,Palmital
+city_br_3669,base.br,base.state_br_sp,Palmital
+city_br_3670,base.br,base.state_br_rs,Palmitinho
+city_br_3671,base.br,base.state_br_sc,Palmitos
+city_br_3672,base.br,base.state_br_mg,Palmópolis
+city_br_3673,base.br,base.state_br_pr,Palotina
+city_br_3674,base.br,base.state_br_go,Panamá
+city_br_3675,base.br,base.state_br_rs,Panambi
+city_br_3676,base.br,base.state_br_es,Pancas
+city_br_3677,base.br,base.state_br_pe,Panelas
+city_br_3678,base.br,base.state_br_sp,Panorama
+city_br_3679,base.br,base.state_br_rs,Pantano Grande
+city_br_3680,base.br,base.state_br_al,Pão de Açúcar
+city_br_3681,base.br,base.state_br_mg,Papagaios
+city_br_3682,base.br,base.state_br_sc,Papanduva
+city_br_3683,base.br,base.state_br_pi,Paquetá
+city_br_3684,base.br,base.state_br_mg,Pará de Minas
+city_br_3685,base.br,base.state_br_rj,Paracambi
+city_br_3686,base.br,base.state_br_mg,Paracatu
+city_br_3687,base.br,base.state_br_ce,Paracuru
+city_br_3688,base.br,base.state_br_mg,Paraguaçu
+city_br_3689,base.br,base.state_br_sp,Paraguaçu Paulista
+city_br_3690,base.br,base.state_br_rs,Paraí
+city_br_3691,base.br,base.state_br_rj,Paraíba do Sul
+city_br_3692,base.br,base.state_br_ma,Paraibano
+city_br_3693,base.br,base.state_br_sp,Paraibuna
+city_br_3694,base.br,base.state_br_ce,Paraipaba
+city_br_3695,base.br,base.state_br_sc,Paraíso
+city_br_3696,base.br,base.state_br_sp,Paraíso
+city_br_3697,base.br,base.state_br_ms,Paraíso das Águas
+city_br_3698,base.br,base.state_br_pr,Paraíso do Norte
+city_br_3699,base.br,base.state_br_rs,Paraíso do Sul
+city_br_3700,base.br,base.state_br_to,Paraíso do Tocantins
+city_br_3701,base.br,base.state_br_mg,Paraisópolis
+city_br_3702,base.br,base.state_br_ce,Parambu
+city_br_3703,base.br,base.state_br_ba,Paramirim
+city_br_3704,base.br,base.state_br_ce,Paramoti
+city_br_3705,base.br,base.state_br_rn,Paraná
+city_br_3706,base.br,base.state_br_to,Paranã
+city_br_3707,base.br,base.state_br_pr,Paranacity
+city_br_3708,base.br,base.state_br_ms,Paranaíba
+city_br_3709,base.br,base.state_br_go,Paranaiguara
+city_br_3710,base.br,base.state_br_mt,Paranaíta
+city_br_3711,base.br,base.state_br_sp,Paranapanema
+city_br_3712,base.br,base.state_br_pr,Paranapoema
+city_br_3713,base.br,base.state_br_sp,Paranapuã
+city_br_3714,base.br,base.state_br_pe,Paranatama
+city_br_3715,base.br,base.state_br_mt,Paranatinga
+city_br_3716,base.br,base.state_br_pr,Paranavaí
+city_br_3717,base.br,base.state_br_ms,Paranhos
+city_br_3718,base.br,base.state_br_mg,Paraopeba
+city_br_3719,base.br,base.state_br_sp,Parapuã
+city_br_3720,base.br,base.state_br_pb,Parari
+city_br_3721,base.br,base.state_br_ba,Paratinga
+city_br_3722,base.br,base.state_br_rj,Paraty
+city_br_3723,base.br,base.state_br_rn,Paraú
+city_br_3724,base.br,base.state_br_go,Paraúna
+city_br_3725,base.br,base.state_br_rn,Parazinho
+city_br_3726,base.br,base.state_br_sp,Pardinho
+city_br_3727,base.br,base.state_br_rs,Pareci Novo
+city_br_3728,base.br,base.state_br_ro,Parecis
+city_br_3729,base.br,base.state_br_rn,Parelhas
+city_br_3730,base.br,base.state_br_al,Pariconha
+city_br_3731,base.br,base.state_br_am,Parintins
+city_br_3732,base.br,base.state_br_ba,Paripiranga
+city_br_3733,base.br,base.state_br_al,Paripueira
+city_br_3734,base.br,base.state_br_sp,Pariquera-Açu
+city_br_3735,base.br,base.state_br_sp,Parisi
+city_br_3736,base.br,base.state_br_pi,Parnaguá
+city_br_3737,base.br,base.state_br_pe,Parnamirim
+city_br_3738,base.br,base.state_br_ma,Parnarama
+city_br_3739,base.br,base.state_br_rs,Parobé
+city_br_3740,base.br,base.state_br_rn,Passa e Fica
+city_br_3741,base.br,base.state_br_mg,Passa Quatro
+city_br_3742,base.br,base.state_br_rs,Passa Sete
+city_br_3743,base.br,base.state_br_mg,Passa Tempo
+city_br_3744,base.br,base.state_br_mg,Passa-Vinte
+city_br_3745,base.br,base.state_br_mg,Passabém
+city_br_3746,base.br,base.state_br_pb,Passagem
+city_br_3747,base.br,base.state_br_rn,Passagem
+city_br_3748,base.br,base.state_br_ma,Passagem Franca
+city_br_3749,base.br,base.state_br_pi,Passagem Franca do Piauí
+city_br_3750,base.br,base.state_br_pe,Passira
+city_br_3751,base.br,base.state_br_al,Passo de Camaragibe
+city_br_3752,base.br,base.state_br_sc,Passo de Torres
+city_br_3753,base.br,base.state_br_rs,Passo do Sobrado
+city_br_3754,base.br,base.state_br_sc,Passos Maia
+city_br_3755,base.br,base.state_br_ma,Pastos Bons
+city_br_3756,base.br,base.state_br_mg,Patis
+city_br_3757,base.br,base.state_br_pr,Pato Bragado
+city_br_3758,base.br,base.state_br_pr,Pato Branco
+city_br_3759,base.br,base.state_br_pi,Patos do Piauí
+city_br_3760,base.br,base.state_br_mg,Patrocínio
+city_br_3761,base.br,base.state_br_mg,Patrocínio do Muriaé
+city_br_3762,base.br,base.state_br_sp,Patrocínio Paulista
+city_br_3763,base.br,base.state_br_rn,Patu
+city_br_3764,base.br,base.state_br_rj,Paty do Alferes
+city_br_3765,base.br,base.state_br_ba,Pau Brasil
+city_br_3766,base.br,base.state_br_pa,Pau D'Arco
+city_br_3767,base.br,base.state_br_to,Pau D'Arco
+city_br_3768,base.br,base.state_br_pi,Pau D'Arco do Piauí
+city_br_3769,base.br,base.state_br_rn,Pau dos Ferros
+city_br_3770,base.br,base.state_br_pe,Paudalho
+city_br_3771,base.br,base.state_br_am,Pauini
+city_br_3772,base.br,base.state_br_mg,Paula Cândido
+city_br_3773,base.br,base.state_br_pr,Paula Freitas
+city_br_3774,base.br,base.state_br_sp,Paulicéia
+city_br_3775,base.br,base.state_br_ma,Paulino Neves
+city_br_3776,base.br,base.state_br_pb,Paulista
+city_br_3777,base.br,base.state_br_pi,Paulistana
+city_br_3778,base.br,base.state_br_sp,Paulistânia
+city_br_3779,base.br,base.state_br_mg,Paulistas
+city_br_3780,base.br,base.state_br_rs,Paulo Bento
+city_br_3781,base.br,base.state_br_sp,Paulo de Faria
+city_br_3782,base.br,base.state_br_pr,Paulo Frontin
+city_br_3783,base.br,base.state_br_al,Paulo Jacinto
+city_br_3784,base.br,base.state_br_sc,Paulo Lopes
+city_br_3785,base.br,base.state_br_ma,Paulo Ramos
+city_br_3786,base.br,base.state_br_mg,Pavão
+city_br_3787,base.br,base.state_br_rs,Paverama
+city_br_3788,base.br,base.state_br_pi,Pavussu
+city_br_3789,base.br,base.state_br_ba,Pé de Serra
+city_br_3790,base.br,base.state_br_pr,Peabiru
+city_br_3791,base.br,base.state_br_mg,Peçanha
+city_br_3792,base.br,base.state_br_sp,Pederneiras
+city_br_3793,base.br,base.state_br_pe,Pedra
+city_br_3794,base.br,base.state_br_mg,Pedra Azul
+city_br_3795,base.br,base.state_br_sp,Pedra Bela
+city_br_3796,base.br,base.state_br_mg,Pedra Bonita
+city_br_3797,base.br,base.state_br_ce,Pedra Branca
+city_br_3798,base.br,base.state_br_pb,Pedra Branca
+city_br_3799,base.br,base.state_br_ap,Pedra Branca do Amapari
+city_br_3800,base.br,base.state_br_mg,Pedra do Anta
+city_br_3801,base.br,base.state_br_mg,Pedra do Indaiá
+city_br_3802,base.br,base.state_br_mg,Pedra Dourada
+city_br_3803,base.br,base.state_br_rn,Pedra Grande
+city_br_3804,base.br,base.state_br_pb,Pedra Lavrada
+city_br_3805,base.br,base.state_br_se,Pedra Mole
+city_br_3806,base.br,base.state_br_mt,Pedra Preta
+city_br_3807,base.br,base.state_br_rn,Pedra Preta
+city_br_3808,base.br,base.state_br_mg,Pedralva
+city_br_3809,base.br,base.state_br_sp,Pedranópolis
+city_br_3810,base.br,base.state_br_ba,Pedrão
+city_br_3811,base.br,base.state_br_rs,Pedras Altas
+city_br_3812,base.br,base.state_br_pb,Pedras de Fogo
+city_br_3813,base.br,base.state_br_mg,Pedras de Maria da Cruz
+city_br_3814,base.br,base.state_br_sc,Pedras Grandes
+city_br_3815,base.br,base.state_br_sp,Pedregulho
+city_br_3816,base.br,base.state_br_sp,Pedreira
+city_br_3817,base.br,base.state_br_ma,Pedreiras
+city_br_3818,base.br,base.state_br_se,Pedrinhas
+city_br_3819,base.br,base.state_br_sp,Pedrinhas Paulista
+city_br_3820,base.br,base.state_br_mg,Pedrinópolis
+city_br_3821,base.br,base.state_br_to,Pedro Afonso
+city_br_3822,base.br,base.state_br_ba,Pedro Alexandre
+city_br_3823,base.br,base.state_br_rn,Pedro Avelino
+city_br_3824,base.br,base.state_br_es,Pedro Canário
+city_br_3825,base.br,base.state_br_sp,Pedro de Toledo
+city_br_3826,base.br,base.state_br_ma,Pedro do Rosário
+city_br_3827,base.br,base.state_br_ms,Pedro Gomes
+city_br_3828,base.br,base.state_br_pi,Pedro II
+city_br_3829,base.br,base.state_br_pi,Pedro Laurentino
+city_br_3830,base.br,base.state_br_mg,Pedro Leopoldo
+city_br_3831,base.br,base.state_br_rs,Pedro Osório
+city_br_3832,base.br,base.state_br_pb,Pedro Régis
+city_br_3833,base.br,base.state_br_mg,Pedro Teixeira
+city_br_3834,base.br,base.state_br_rn,Pedro Velho
+city_br_3835,base.br,base.state_br_to,Peixe
+city_br_3836,base.br,base.state_br_pa,Peixe-Boi
+city_br_3837,base.br,base.state_br_mt,Peixoto de Azevedo
+city_br_3838,base.br,base.state_br_rs,Pejuçara
+city_br_3839,base.br,base.state_br_ce,Penaforte
+city_br_3840,base.br,base.state_br_ma,Penalva
+city_br_3841,base.br,base.state_br_sp,Penápolis
+city_br_3842,base.br,base.state_br_rn,Pendências
+city_br_3843,base.br,base.state_br_al,Penedo
+city_br_3844,base.br,base.state_br_sc,Penha
+city_br_3845,base.br,base.state_br_ce,Pentecoste
+city_br_3846,base.br,base.state_br_mg,Pequeri
+city_br_3847,base.br,base.state_br_mg,Pequi
+city_br_3848,base.br,base.state_br_to,Pequizeiro
+city_br_3849,base.br,base.state_br_mg,Perdigão
+city_br_3850,base.br,base.state_br_mg,Perdizes
+city_br_3851,base.br,base.state_br_mg,Perdões
+city_br_3852,base.br,base.state_br_sp,Pereira Barreto
+city_br_3853,base.br,base.state_br_sp,Pereiras
+city_br_3854,base.br,base.state_br_ce,Pereiro
+city_br_3855,base.br,base.state_br_ma,Peri Mirim
+city_br_3856,base.br,base.state_br_mg,Periquito
+city_br_3857,base.br,base.state_br_sc,Peritiba
+city_br_3858,base.br,base.state_br_ma,Peritoró
+city_br_3859,base.br,base.state_br_pr,Perobal
+city_br_3860,base.br,base.state_br_pr,Pérola
+city_br_3861,base.br,base.state_br_pr,Pérola d'Oeste
+city_br_3862,base.br,base.state_br_go,Perolândia
+city_br_3863,base.br,base.state_br_sp,Peruíbe
+city_br_3864,base.br,base.state_br_mg,Pescador
+city_br_3865,base.br,base.state_br_sc,Pescaria Brava
+city_br_3866,base.br,base.state_br_pe,Pesqueira
+city_br_3867,base.br,base.state_br_pe,Petrolândia
+city_br_3868,base.br,base.state_br_sc,Petrolândia
+city_br_3869,base.br,base.state_br_go,Petrolina de Goiás
+city_br_3870,base.br,base.state_br_al,Piaçabuçu
+city_br_3871,base.br,base.state_br_sp,Piacatu
+city_br_3872,base.br,base.state_br_pb,Piancó
+city_br_3873,base.br,base.state_br_ba,Piatã
+city_br_3874,base.br,base.state_br_mg,Piau
+city_br_3875,base.br,base.state_br_rs,Picada Café
+city_br_3876,base.br,base.state_br_pa,Piçarra
+city_br_3877,base.br,base.state_br_pi,Picos
+city_br_3878,base.br,base.state_br_pb,Picuí
+city_br_3879,base.br,base.state_br_sp,Piedade
+city_br_3880,base.br,base.state_br_mg,Piedade de Caratinga
+city_br_3881,base.br,base.state_br_mg,Piedade de Ponte Nova
+city_br_3882,base.br,base.state_br_mg,Piedade do Rio Grande
+city_br_3883,base.br,base.state_br_mg,Piedade dos Gerais
+city_br_3884,base.br,base.state_br_pr,Piên
+city_br_3885,base.br,base.state_br_ba,Pilão Arcado
+city_br_3886,base.br,base.state_br_al,Pilar
+city_br_3887,base.br,base.state_br_pb,Pilar
+city_br_3888,base.br,base.state_br_go,Pilar de Goiás
+city_br_3889,base.br,base.state_br_sp,Pilar do Sul
+city_br_3890,base.br,base.state_br_pb,Pilões
+city_br_3891,base.br,base.state_br_rn,Pilões
+city_br_3892,base.br,base.state_br_pb,Pilõezinhos
+city_br_3893,base.br,base.state_br_mg,Pimenta
+city_br_3894,base.br,base.state_br_ro,Pimenta Bueno
+city_br_3895,base.br,base.state_br_pi,Pimenteiras
+city_br_3896,base.br,base.state_br_ro,Pimenteiras do Oeste
+city_br_3897,base.br,base.state_br_ba,Pindaí
+city_br_3898,base.br,base.state_br_ma,Pindaré-Mirim
+city_br_3899,base.br,base.state_br_al,Pindoba
+city_br_3900,base.br,base.state_br_ba,Pindobaçu
+city_br_3901,base.br,base.state_br_sp,Pindorama
+city_br_3902,base.br,base.state_br_to,Pindorama do Tocantins
+city_br_3903,base.br,base.state_br_ce,Pindoretama
+city_br_3904,base.br,base.state_br_mg,Pingo-d'Água
+city_br_3905,base.br,base.state_br_rs,Pinhal
+city_br_3906,base.br,base.state_br_rs,Pinhal da Serra
+city_br_3907,base.br,base.state_br_pr,Pinhal de São Bento
+city_br_3908,base.br,base.state_br_rs,Pinhal Grande
+city_br_3909,base.br,base.state_br_pr,Pinhalão
+city_br_3910,base.br,base.state_br_sc,Pinhalzinho
+city_br_3911,base.br,base.state_br_sp,Pinhalzinho
+city_br_3912,base.br,base.state_br_pr,Pinhão
+city_br_3913,base.br,base.state_br_se,Pinhão
+city_br_3914,base.br,base.state_br_rj,Pinheiral
+city_br_3915,base.br,base.state_br_rs,Pinheirinho do Vale
+city_br_3916,base.br,base.state_br_ma,Pinheiro
+city_br_3917,base.br,base.state_br_rs,Pinheiro Machado
+city_br_3918,base.br,base.state_br_sc,Pinheiro Preto
+city_br_3919,base.br,base.state_br_es,Pinheiros
+city_br_3920,base.br,base.state_br_ba,Pintadas
+city_br_3921,base.br,base.state_br_rs,Pinto Bandeira
+city_br_3922,base.br,base.state_br_mg,Pintópolis
+city_br_3923,base.br,base.state_br_pi,Pio IX
+city_br_3924,base.br,base.state_br_ma,Pio XII
+city_br_3925,base.br,base.state_br_sp,Piquerobi
+city_br_3926,base.br,base.state_br_ce,Piquet Carneiro
+city_br_3927,base.br,base.state_br_sp,Piquete
+city_br_3928,base.br,base.state_br_sp,Piracaia
+city_br_3929,base.br,base.state_br_go,Piracanjuba
+city_br_3930,base.br,base.state_br_mg,Piracema
+city_br_3931,base.br,base.state_br_pi,Piracuruca
+city_br_3932,base.br,base.state_br_rj,Piraí
+city_br_3933,base.br,base.state_br_ba,Piraí do Norte
+city_br_3934,base.br,base.state_br_pr,Piraí do Sul
+city_br_3935,base.br,base.state_br_sp,Piraju
+city_br_3936,base.br,base.state_br_mg,Pirajuba
+city_br_3937,base.br,base.state_br_sp,Pirajuí
+city_br_3938,base.br,base.state_br_se,Pirambu
+city_br_3939,base.br,base.state_br_mg,Piranga
+city_br_3940,base.br,base.state_br_sp,Pirangi
+city_br_3941,base.br,base.state_br_mg,Piranguçu
+city_br_3942,base.br,base.state_br_mg,Piranguinho
+city_br_3943,base.br,base.state_br_al,Piranhas
+city_br_3944,base.br,base.state_br_go,Piranhas
+city_br_3945,base.br,base.state_br_ma,Pirapemas
+city_br_3946,base.br,base.state_br_mg,Pirapetinga
+city_br_3947,base.br,base.state_br_rs,Pirapó
+city_br_3948,base.br,base.state_br_mg,Pirapora
+city_br_3949,base.br,base.state_br_sp,Pirapora do Bom Jesus
+city_br_3950,base.br,base.state_br_sp,Pirapozinho
+city_br_3951,base.br,base.state_br_to,Piraquê
+city_br_3952,base.br,base.state_br_sp,Pirassununga
+city_br_3953,base.br,base.state_br_rs,Piratini
+city_br_3954,base.br,base.state_br_sp,Piratininga
+city_br_3955,base.br,base.state_br_sc,Piratuba
+city_br_3956,base.br,base.state_br_mg,Piraúba
+city_br_3957,base.br,base.state_br_go,Pirenópolis
+city_br_3958,base.br,base.state_br_go,Pires do Rio
+city_br_3959,base.br,base.state_br_ce,Pires Ferreira
+city_br_3960,base.br,base.state_br_ba,Piripá
+city_br_3961,base.br,base.state_br_pi,Piripiri
+city_br_3962,base.br,base.state_br_ba,Piritiba
+city_br_3963,base.br,base.state_br_pb,Pirpirituba
+city_br_3964,base.br,base.state_br_pr,Pitanga
+city_br_3965,base.br,base.state_br_pr,Pitangueiras
+city_br_3966,base.br,base.state_br_sp,Pitangueiras
+city_br_3967,base.br,base.state_br_mg,Pitangui
+city_br_3968,base.br,base.state_br_pb,Pitimbu
+city_br_3969,base.br,base.state_br_to,Pium
+city_br_3970,base.br,base.state_br_es,Piúma
+city_br_3971,base.br,base.state_br_mg,Piumhi
+city_br_3972,base.br,base.state_br_pa,Placas
+city_br_3973,base.br,base.state_br_ac,Plácido de Castro
+city_br_3974,base.br,base.state_br_pr,Planaltina do Paraná
+city_br_3975,base.br,base.state_br_ba,Planaltino
+city_br_3976,base.br,base.state_br_ba,Planalto
+city_br_3977,base.br,base.state_br_pr,Planalto
+city_br_3978,base.br,base.state_br_rs,Planalto
+city_br_3979,base.br,base.state_br_sp,Planalto
+city_br_3980,base.br,base.state_br_sc,Planalto Alegre
+city_br_3981,base.br,base.state_br_mt,Planalto da Serra
+city_br_3982,base.br,base.state_br_mg,Planura
+city_br_3983,base.br,base.state_br_sp,Platina
+city_br_3984,base.br,base.state_br_pe,Poção
+city_br_3985,base.br,base.state_br_ma,Poção de Pedras
+city_br_3986,base.br,base.state_br_pb,Pocinhos
+city_br_3987,base.br,base.state_br_rn,Poço Branco
+city_br_3988,base.br,base.state_br_pb,Poço Dantas
+city_br_3989,base.br,base.state_br_rs,Poço das Antas
+city_br_3990,base.br,base.state_br_al,Poço das Trincheiras
+city_br_3991,base.br,base.state_br_pb,Poço de José de Moura
+city_br_3992,base.br,base.state_br_mg,Poço Fundo
+city_br_3993,base.br,base.state_br_se,Poço Redondo
+city_br_3994,base.br,base.state_br_se,Poço Verde
+city_br_3995,base.br,base.state_br_ba,Poções
+city_br_3996,base.br,base.state_br_mt,Poconé
+city_br_3997,base.br,base.state_br_mg,Pocrane
+city_br_3998,base.br,base.state_br_ba,Pojuca
+city_br_3999,base.br,base.state_br_sp,Poloni
+city_br_4000,base.br,base.state_br_pb,Pombal
+city_br_4001,base.br,base.state_br_pe,Pombos
+city_br_4002,base.br,base.state_br_sc,Pomerode
+city_br_4003,base.br,base.state_br_sp,Pompéia
+city_br_4004,base.br,base.state_br_mg,Pompéu
+city_br_4005,base.br,base.state_br_sp,Pongaí
+city_br_4006,base.br,base.state_br_pa,Ponta de Pedras
+city_br_4007,base.br,base.state_br_ms,Ponta Porã
+city_br_4008,base.br,base.state_br_sp,Pontal
+city_br_4009,base.br,base.state_br_mt,Pontal do Araguaia
+city_br_4010,base.br,base.state_br_pr,Pontal do Paraná
+city_br_4011,base.br,base.state_br_go,Pontalina
+city_br_4012,base.br,base.state_br_sp,Pontalinda
+city_br_4013,base.br,base.state_br_rs,Pontão
+city_br_4014,base.br,base.state_br_sc,Ponte Alta
+city_br_4015,base.br,base.state_br_to,Ponte Alta do Bom Jesus
+city_br_4016,base.br,base.state_br_sc,Ponte Alta do Norte
+city_br_4017,base.br,base.state_br_to,Ponte Alta do Tocantins
+city_br_4018,base.br,base.state_br_mt,Ponte Branca
+city_br_4019,base.br,base.state_br_mg,Ponte Nova
+city_br_4020,base.br,base.state_br_rs,Ponte Preta
+city_br_4021,base.br,base.state_br_sc,Ponte Serrada
+city_br_4022,base.br,base.state_br_mt,Pontes e Lacerda
+city_br_4023,base.br,base.state_br_sp,Pontes Gestal
+city_br_4024,base.br,base.state_br_es,Ponto Belo
+city_br_4025,base.br,base.state_br_mg,Ponto Chique
+city_br_4026,base.br,base.state_br_mg,Ponto dos Volantes
+city_br_4027,base.br,base.state_br_ba,Ponto Novo
+city_br_4028,base.br,base.state_br_sp,Populina
+city_br_4029,base.br,base.state_br_ce,Poranga
+city_br_4030,base.br,base.state_br_sp,Porangaba
+city_br_4031,base.br,base.state_br_go,Porangatu
+city_br_4032,base.br,base.state_br_rj,Porciúncula
+city_br_4033,base.br,base.state_br_pr,Porecatu
+city_br_4034,base.br,base.state_br_rn,Portalegre
+city_br_4035,base.br,base.state_br_rs,Portão
+city_br_4036,base.br,base.state_br_go,Porteirão
+city_br_4037,base.br,base.state_br_ce,Porteiras
+city_br_4038,base.br,base.state_br_mg,Porteirinha
+city_br_4039,base.br,base.state_br_pa,Portel
+city_br_4040,base.br,base.state_br_go,Portelândia
+city_br_4041,base.br,base.state_br_pi,Porto
+city_br_4042,base.br,base.state_br_ac,Porto Acre
+city_br_4043,base.br,base.state_br_mt,Porto Alegre do Norte
+city_br_4044,base.br,base.state_br_pi,Porto Alegre do Piauí
+city_br_4045,base.br,base.state_br_to,Porto Alegre do Tocantins
+city_br_4046,base.br,base.state_br_pr,Porto Amazonas
+city_br_4047,base.br,base.state_br_pr,Porto Barreiro
+city_br_4048,base.br,base.state_br_sc,Porto Belo
+city_br_4049,base.br,base.state_br_al,Porto Calvo
+city_br_4050,base.br,base.state_br_se,Porto da Folha
+city_br_4051,base.br,base.state_br_pa,Porto de Moz
+city_br_4052,base.br,base.state_br_al,Porto de Pedras
+city_br_4053,base.br,base.state_br_rn,Porto do Mangue
+city_br_4054,base.br,base.state_br_mt,Porto dos Gaúchos
+city_br_4055,base.br,base.state_br_mt,Porto Esperidião
+city_br_4056,base.br,base.state_br_mt,Porto Estrela
+city_br_4057,base.br,base.state_br_sp,Porto Feliz
+city_br_4058,base.br,base.state_br_sp,Porto Ferreira
+city_br_4059,base.br,base.state_br_mg,Porto Firme
+city_br_4060,base.br,base.state_br_ma,Porto Franco
+city_br_4061,base.br,base.state_br_ap,Porto Grande
+city_br_4062,base.br,base.state_br_rs,Porto Lucena
+city_br_4063,base.br,base.state_br_rs,Porto Mauá
+city_br_4064,base.br,base.state_br_ms,Porto Murtinho
+city_br_4065,base.br,base.state_br_to,Porto Nacional
+city_br_4066,base.br,base.state_br_rj,Porto Real
+city_br_4067,base.br,base.state_br_al,Porto Real do Colégio
+city_br_4068,base.br,base.state_br_pr,Porto Rico
+city_br_4069,base.br,base.state_br_ma,Porto Rico do Maranhão
+city_br_4070,base.br,base.state_br_sc,Porto União
+city_br_4071,base.br,base.state_br_rs,Porto Vera Cruz
+city_br_4072,base.br,base.state_br_pr,Porto Vitória
+city_br_4073,base.br,base.state_br_ac,Porto Walter
+city_br_4074,base.br,base.state_br_rs,Porto Xavier
+city_br_4075,base.br,base.state_br_go,Posse
+city_br_4076,base.br,base.state_br_mg,Poté
+city_br_4077,base.br,base.state_br_ce,Potengi
+city_br_4078,base.br,base.state_br_sp,Potim
+city_br_4079,base.br,base.state_br_ba,Potiraguá
+city_br_4080,base.br,base.state_br_sp,Potirendaba
+city_br_4081,base.br,base.state_br_ce,Potiretama
+city_br_4082,base.br,base.state_br_mg,Pouso Alto
+city_br_4083,base.br,base.state_br_rs,Pouso Novo
+city_br_4084,base.br,base.state_br_sc,Pouso Redondo
+city_br_4085,base.br,base.state_br_mt,Poxoréu
+city_br_4086,base.br,base.state_br_sp,Pracinha
+city_br_4087,base.br,base.state_br_ap,Pracuúba
+city_br_4088,base.br,base.state_br_ba,Prado
+city_br_4089,base.br,base.state_br_pr,Prado Ferreira
+city_br_4090,base.br,base.state_br_sp,Pradópolis
+city_br_4091,base.br,base.state_br_mg,Prados
+city_br_4092,base.br,base.state_br_sc,Praia Grande
+city_br_4093,base.br,base.state_br_to,Praia Norte
+city_br_4094,base.br,base.state_br_pa,Prainha
+city_br_4095,base.br,base.state_br_pr,Pranchita
+city_br_4096,base.br,base.state_br_mg,Prata
+city_br_4097,base.br,base.state_br_pb,Prata
+city_br_4098,base.br,base.state_br_pi,Prata do Piauí
+city_br_4099,base.br,base.state_br_sp,Pratânia
+city_br_4100,base.br,base.state_br_mg,Pratápolis
+city_br_4101,base.br,base.state_br_mg,Pratinha
+city_br_4102,base.br,base.state_br_sp,Presidente Alves
+city_br_4103,base.br,base.state_br_mg,Presidente Bernardes
+city_br_4104,base.br,base.state_br_sp,Presidente Bernardes
+city_br_4105,base.br,base.state_br_sc,Presidente Castello Branco
+city_br_4106,base.br,base.state_br_pr,Presidente Castelo Branco
+city_br_4107,base.br,base.state_br_ba,Presidente Dutra
+city_br_4108,base.br,base.state_br_ma,Presidente Dutra
+city_br_4109,base.br,base.state_br_sp,Presidente Epitácio
+city_br_4110,base.br,base.state_br_am,Presidente Figueiredo
+city_br_4111,base.br,base.state_br_sc,Presidente Getúlio
+city_br_4112,base.br,base.state_br_ba,Presidente Jânio Quadros
+city_br_4113,base.br,base.state_br_ma,Presidente Juscelino
+city_br_4114,base.br,base.state_br_mg,Presidente Juscelino
+city_br_4115,base.br,base.state_br_es,Presidente Kennedy
+city_br_4116,base.br,base.state_br_to,Presidente Kennedy
+city_br_4117,base.br,base.state_br_mg,Presidente Kubitschek
+city_br_4118,base.br,base.state_br_rs,Presidente Lucena
+city_br_4119,base.br,base.state_br_ma,Presidente Médici
+city_br_4120,base.br,base.state_br_ro,Presidente Médici
+city_br_4121,base.br,base.state_br_sc,Presidente Nereu
+city_br_4122,base.br,base.state_br_mg,Presidente Olegário
+city_br_4123,base.br,base.state_br_ma,Presidente Sarney
+city_br_4124,base.br,base.state_br_ba,Presidente Tancredo Neves
+city_br_4125,base.br,base.state_br_ma,Presidente Vargas
+city_br_4126,base.br,base.state_br_sp,Presidente Venceslau
+city_br_4127,base.br,base.state_br_pa,Primavera
+city_br_4128,base.br,base.state_br_pe,Primavera
+city_br_4129,base.br,base.state_br_ro,Primavera de Rondônia
+city_br_4130,base.br,base.state_br_mt,Primavera do Leste
+city_br_4131,base.br,base.state_br_ma,Primeira Cruz
+city_br_4132,base.br,base.state_br_pr,Primeiro de Maio
+city_br_4133,base.br,base.state_br_sc,Princesa
+city_br_4134,base.br,base.state_br_pb,Princesa Isabel
+city_br_4135,base.br,base.state_br_go,Professor Jamil
+city_br_4136,base.br,base.state_br_rs,Progresso
+city_br_4137,base.br,base.state_br_sp,Promissão
+city_br_4138,base.br,base.state_br_se,Propriá
+city_br_4139,base.br,base.state_br_rs,Protásio Alves
+city_br_4140,base.br,base.state_br_mg,Prudente de Morais
+city_br_4141,base.br,base.state_br_pr,Prudentópolis
+city_br_4142,base.br,base.state_br_to,Pugmil
+city_br_4143,base.br,base.state_br_rn,Pureza
+city_br_4144,base.br,base.state_br_rs,Putinga
+city_br_4145,base.br,base.state_br_pb,Puxinanã
+city_br_4146,base.br,base.state_br_sp,Quadra
+city_br_4147,base.br,base.state_br_rs,Quaraí
+city_br_4148,base.br,base.state_br_mg,Quartel Geral
+city_br_4149,base.br,base.state_br_pr,Quarto Centenário
+city_br_4150,base.br,base.state_br_sp,Quatá
+city_br_4151,base.br,base.state_br_pr,Quatiguá
+city_br_4152,base.br,base.state_br_pa,Quatipuru
+city_br_4153,base.br,base.state_br_rj,Quatis
+city_br_4154,base.br,base.state_br_pr,Quatro Barras
+city_br_4155,base.br,base.state_br_rs,Quatro Irmãos
+city_br_4156,base.br,base.state_br_pr,Quatro Pontes
+city_br_4157,base.br,base.state_br_al,Quebrangulo
+city_br_4158,base.br,base.state_br_pr,Quedas do Iguaçu
+city_br_4159,base.br,base.state_br_pi,Queimada Nova
+city_br_4160,base.br,base.state_br_ba,Queimadas
+city_br_4161,base.br,base.state_br_pb,Queimadas
+city_br_4162,base.br,base.state_br_sp,Queiroz
+city_br_4163,base.br,base.state_br_sp,Queluz
+city_br_4164,base.br,base.state_br_mg,Queluzito
+city_br_4165,base.br,base.state_br_mt,Querência
+city_br_4166,base.br,base.state_br_pr,Querência do Norte
+city_br_4167,base.br,base.state_br_rs,Quevedos
+city_br_4168,base.br,base.state_br_ba,Quijingue
+city_br_4169,base.br,base.state_br_sc,Quilombo
+city_br_4170,base.br,base.state_br_pr,Quinta do Sol
+city_br_4171,base.br,base.state_br_sp,Quintana
+city_br_4172,base.br,base.state_br_rs,Quinze de Novembro
+city_br_4173,base.br,base.state_br_pe,Quipapá
+city_br_4174,base.br,base.state_br_go,Quirinópolis
+city_br_4175,base.br,base.state_br_rj,Quissamã
+city_br_4176,base.br,base.state_br_pr,Quitandinha
+city_br_4177,base.br,base.state_br_ce,Quiterianópolis
+city_br_4178,base.br,base.state_br_pb,Quixaba
+city_br_4179,base.br,base.state_br_pe,Quixaba
+city_br_4180,base.br,base.state_br_ba,Quixabeira
+city_br_4181,base.br,base.state_br_ce,Quixadá
+city_br_4182,base.br,base.state_br_ce,Quixelô
+city_br_4183,base.br,base.state_br_ce,Quixeramobim
+city_br_4184,base.br,base.state_br_ce,Quixeré
+city_br_4185,base.br,base.state_br_rn,Rafael Fernandes
+city_br_4186,base.br,base.state_br_rn,Rafael Godeiro
+city_br_4187,base.br,base.state_br_ba,Rafael Jambeiro
+city_br_4188,base.br,base.state_br_sp,Rafard
+city_br_4189,base.br,base.state_br_pr,Ramilândia
+city_br_4190,base.br,base.state_br_sp,Rancharia
+city_br_4191,base.br,base.state_br_pr,Rancho Alegre
+city_br_4192,base.br,base.state_br_pr,Rancho Alegre D'Oeste
+city_br_4193,base.br,base.state_br_sc,Rancho Queimado
+city_br_4194,base.br,base.state_br_ma,Raposa
+city_br_4195,base.br,base.state_br_mg,Raposos
+city_br_4196,base.br,base.state_br_mg,Raul Soares
+city_br_4197,base.br,base.state_br_pr,Realeza
+city_br_4198,base.br,base.state_br_pr,Rebouças
+city_br_4199,base.br,base.state_br_mg,Recreio
+city_br_4200,base.br,base.state_br_to,Recursolândia
+city_br_4201,base.br,base.state_br_ce,Redenção
+city_br_4202,base.br,base.state_br_pa,Redenção
+city_br_4203,base.br,base.state_br_sp,Redenção da Serra
+city_br_4204,base.br,base.state_br_pi,Redenção do Gurguéia
+city_br_4205,base.br,base.state_br_rs,Redentora
+city_br_4206,base.br,base.state_br_mg,Reduto
+city_br_4207,base.br,base.state_br_pi,Regeneração
+city_br_4208,base.br,base.state_br_sp,Regente Feijó
+city_br_4209,base.br,base.state_br_sp,Reginópolis
+city_br_4210,base.br,base.state_br_sp,Registro
+city_br_4211,base.br,base.state_br_rs,Relvado
+city_br_4212,base.br,base.state_br_ba,Remanso
+city_br_4213,base.br,base.state_br_pb,Remígio
+city_br_4214,base.br,base.state_br_pr,Renascença
+city_br_4215,base.br,base.state_br_ce,Reriutaba
+city_br_4216,base.br,base.state_br_mg,Resende Costa
+city_br_4217,base.br,base.state_br_pr,Reserva
+city_br_4218,base.br,base.state_br_mt,Reserva do Cabaçal
+city_br_4219,base.br,base.state_br_pr,Reserva do Iguaçu
+city_br_4220,base.br,base.state_br_mg,Resplendor
+city_br_4221,base.br,base.state_br_mg,Ressaquinha
+city_br_4222,base.br,base.state_br_sp,Restinga
+city_br_4223,base.br,base.state_br_rs,Restinga Sêca
+city_br_4224,base.br,base.state_br_ba,Retirolândia
+city_br_4225,base.br,base.state_br_ma,Riachão
+city_br_4226,base.br,base.state_br_pb,Riachão
+city_br_4227,base.br,base.state_br_ba,Riachão das Neves
+city_br_4228,base.br,base.state_br_pb,Riachão do Bacamarte
+city_br_4229,base.br,base.state_br_se,Riachão do Dantas
+city_br_4230,base.br,base.state_br_ba,Riachão do Jacuípe
+city_br_4231,base.br,base.state_br_pb,Riachão do Poço
+city_br_4232,base.br,base.state_br_mg,Riachinho
+city_br_4233,base.br,base.state_br_to,Riachinho
+city_br_4234,base.br,base.state_br_rn,Riacho da Cruz
+city_br_4235,base.br,base.state_br_pe,Riacho das Almas
+city_br_4236,base.br,base.state_br_ba,Riacho de Santana
+city_br_4237,base.br,base.state_br_rn,Riacho de Santana
+city_br_4238,base.br,base.state_br_pb,Riacho de Santo Antônio
+city_br_4239,base.br,base.state_br_pb,Riacho dos Cavalos
+city_br_4240,base.br,base.state_br_mg,Riacho dos Machados
+city_br_4241,base.br,base.state_br_pi,Riacho Frio
+city_br_4242,base.br,base.state_br_rn,Riachuelo
+city_br_4243,base.br,base.state_br_se,Riachuelo
+city_br_4244,base.br,base.state_br_go,Rialma
+city_br_4245,base.br,base.state_br_go,Rianápolis
+city_br_4246,base.br,base.state_br_ma,Ribamar Fiquene
+city_br_4247,base.br,base.state_br_ms,Ribas do Rio Pardo
+city_br_4248,base.br,base.state_br_sp,Ribeira
+city_br_4249,base.br,base.state_br_ba,Ribeira do Amparo
+city_br_4250,base.br,base.state_br_pi,Ribeira do Piauí
+city_br_4251,base.br,base.state_br_ba,Ribeira do Pombal
+city_br_4252,base.br,base.state_br_pe,Ribeirão
+city_br_4253,base.br,base.state_br_sp,Ribeirão Bonito
+city_br_4254,base.br,base.state_br_sp,Ribeirão Branco
+city_br_4255,base.br,base.state_br_mt,Ribeirão Cascalheira
+city_br_4256,base.br,base.state_br_pr,Ribeirão Claro
+city_br_4257,base.br,base.state_br_sp,Ribeirão Corrente
+city_br_4258,base.br,base.state_br_ba,Ribeirão do Largo
+city_br_4259,base.br,base.state_br_pr,Ribeirão do Pinhal
+city_br_4260,base.br,base.state_br_sp,Ribeirão do Sul
+city_br_4261,base.br,base.state_br_sp,Ribeirão dos Índios
+city_br_4262,base.br,base.state_br_sp,Ribeirão Grande
+city_br_4263,base.br,base.state_br_mg,Ribeirão Vermelho
+city_br_4264,base.br,base.state_br_mt,Ribeirãozinho
+city_br_4265,base.br,base.state_br_pi,Ribeiro Gonçalves
+city_br_4266,base.br,base.state_br_se,Ribeirópolis
+city_br_4267,base.br,base.state_br_sp,Rifaina
+city_br_4268,base.br,base.state_br_sp,Rincão
+city_br_4269,base.br,base.state_br_sp,Rinópolis
+city_br_4270,base.br,base.state_br_mg,Rio Acima
+city_br_4271,base.br,base.state_br_pr,Rio Azul
+city_br_4272,base.br,base.state_br_es,Rio Bananal
+city_br_4273,base.br,base.state_br_pr,Rio Bom
+city_br_4274,base.br,base.state_br_rj,Rio Bonito
+city_br_4275,base.br,base.state_br_pr,Rio Bonito do Iguaçu
+city_br_4276,base.br,base.state_br_mt,Rio Branco
+city_br_4277,base.br,base.state_br_pr,Rio Branco do Ivaí
+city_br_4278,base.br,base.state_br_pr,Rio Branco do Sul
+city_br_4279,base.br,base.state_br_ms,Rio Brilhante
+city_br_4280,base.br,base.state_br_mg,Rio Casca
+city_br_4281,base.br,base.state_br_rj,Rio Claro
+city_br_4282,base.br,base.state_br_ro,Rio Crespo
+city_br_4283,base.br,base.state_br_to,Rio da Conceição
+city_br_4284,base.br,base.state_br_sc,Rio das Antas
+city_br_4285,base.br,base.state_br_rj,Rio das Flores
+city_br_4286,base.br,base.state_br_sp,Rio das Pedras
+city_br_4287,base.br,base.state_br_ba,Rio de Contas
+city_br_4288,base.br,base.state_br_ba,Rio do Antônio
+city_br_4289,base.br,base.state_br_sc,Rio do Campo
+city_br_4290,base.br,base.state_br_rn,Rio do Fogo
+city_br_4291,base.br,base.state_br_sc,Rio do Oeste
+city_br_4292,base.br,base.state_br_ba,Rio do Pires
+city_br_4293,base.br,base.state_br_mg,Rio do Prado
+city_br_4294,base.br,base.state_br_sc,Rio do Sul
+city_br_4295,base.br,base.state_br_mg,Rio Doce
+city_br_4296,base.br,base.state_br_to,Rio dos Bois
+city_br_4297,base.br,base.state_br_sc,Rio dos Cedros
+city_br_4298,base.br,base.state_br_rs,Rio dos Índios
+city_br_4299,base.br,base.state_br_mg,Rio Espera
+city_br_4300,base.br,base.state_br_pe,Rio Formoso
+city_br_4301,base.br,base.state_br_sc,Rio Fortuna
+city_br_4302,base.br,base.state_br_sp,Rio Grande da Serra
+city_br_4303,base.br,base.state_br_pi,Rio Grande do Piauí
+city_br_4304,base.br,base.state_br_al,Rio Largo
+city_br_4305,base.br,base.state_br_mg,Rio Manso
+city_br_4306,base.br,base.state_br_pa,Rio Maria
+city_br_4307,base.br,base.state_br_sc,Rio Negrinho
+city_br_4308,base.br,base.state_br_ms,Rio Negro
+city_br_4309,base.br,base.state_br_pr,Rio Negro
+city_br_4310,base.br,base.state_br_mg,Rio Novo
+city_br_4311,base.br,base.state_br_es,Rio Novo do Sul
+city_br_4312,base.br,base.state_br_mg,Rio Paranaíba
+city_br_4313,base.br,base.state_br_rs,Rio Pardo
+city_br_4314,base.br,base.state_br_mg,Rio Pardo de Minas
+city_br_4315,base.br,base.state_br_mg,Rio Piracicaba
+city_br_4316,base.br,base.state_br_mg,Rio Pomba
+city_br_4317,base.br,base.state_br_mg,Rio Preto
+city_br_4318,base.br,base.state_br_am,Rio Preto da Eva
+city_br_4319,base.br,base.state_br_go,Rio Quente
+city_br_4320,base.br,base.state_br_ba,Rio Real
+city_br_4321,base.br,base.state_br_sc,Rio Rufino
+city_br_4322,base.br,base.state_br_to,Rio Sono
+city_br_4323,base.br,base.state_br_pb,Rio Tinto
+city_br_4324,base.br,base.state_br_ms,Rio Verde de Mato Grosso
+city_br_4325,base.br,base.state_br_mg,Rio Vermelho
+city_br_4326,base.br,base.state_br_sp,Riolândia
+city_br_4327,base.br,base.state_br_rs,Riozinho
+city_br_4328,base.br,base.state_br_sc,Riqueza
+city_br_4329,base.br,base.state_br_mg,Ritápolis
+city_br_4330,base.br,base.state_br_sp,Riversul
+city_br_4331,base.br,base.state_br_rs,Roca Sales
+city_br_4332,base.br,base.state_br_ms,Rochedo
+city_br_4333,base.br,base.state_br_mg,Rochedo de Minas
+city_br_4334,base.br,base.state_br_sc,Rodeio
+city_br_4335,base.br,base.state_br_rs,Rodeio Bonito
+city_br_4336,base.br,base.state_br_mg,Rodeiro
+city_br_4337,base.br,base.state_br_ba,Rodelas
+city_br_4338,base.br,base.state_br_rn,Rodolfo Fernandes
+city_br_4339,base.br,base.state_br_ac,Rodrigues Alves
+city_br_4340,base.br,base.state_br_rs,Rolador
+city_br_4341,base.br,base.state_br_pr,Rolândia
+city_br_4342,base.br,base.state_br_rs,Rolante
+city_br_4343,base.br,base.state_br_ro,Rolim de Moura
+city_br_4344,base.br,base.state_br_mg,Romaria
+city_br_4345,base.br,base.state_br_sc,Romelândia
+city_br_4346,base.br,base.state_br_pr,Roncador
+city_br_4347,base.br,base.state_br_rs,Ronda Alta
+city_br_4348,base.br,base.state_br_rs,Rondinha
+city_br_4349,base.br,base.state_br_mt,Rondolândia
+city_br_4350,base.br,base.state_br_pr,Rondon
+city_br_4351,base.br,base.state_br_pa,Rondon do Pará
+city_br_4352,base.br,base.state_br_rs,Roque Gonzales
+city_br_4353,base.br,base.state_br_rr,Rorainópolis
+city_br_4354,base.br,base.state_br_sp,Rosana
+city_br_4355,base.br,base.state_br_ma,Rosário
+city_br_4356,base.br,base.state_br_mg,Rosário da Limeira
+city_br_4357,base.br,base.state_br_se,Rosário do Catete
+city_br_4358,base.br,base.state_br_pr,Rosário do Ivaí
+city_br_4359,base.br,base.state_br_rs,Rosário do Sul
+city_br_4360,base.br,base.state_br_mt,Rosário Oeste
+city_br_4361,base.br,base.state_br_sp,Roseira
+city_br_4362,base.br,base.state_br_al,Roteiro
+city_br_4363,base.br,base.state_br_mg,Rubelita
+city_br_4364,base.br,base.state_br_sp,Rubiácea
+city_br_4365,base.br,base.state_br_go,Rubiataba
+city_br_4366,base.br,base.state_br_mg,Rubim
+city_br_4367,base.br,base.state_br_sp,Rubinéia
+city_br_4368,base.br,base.state_br_pa,Rurópolis
+city_br_4369,base.br,base.state_br_ce,Russas
+city_br_4370,base.br,base.state_br_ba,Ruy Barbosa
+city_br_4371,base.br,base.state_br_rn,Ruy Barbosa
+city_br_4372,base.br,base.state_br_pr,Sabáudia
+city_br_4373,base.br,base.state_br_sp,Sabino
+city_br_4374,base.br,base.state_br_mg,Sabinópolis
+city_br_4375,base.br,base.state_br_ce,Saboeiro
+city_br_4376,base.br,base.state_br_mg,Sacramento
+city_br_4377,base.br,base.state_br_rs,Sagrada Família
+city_br_4378,base.br,base.state_br_sp,Sagres
+city_br_4379,base.br,base.state_br_pe,Sairé
+city_br_4380,base.br,base.state_br_rs,Saldanha Marinho
+city_br_4381,base.br,base.state_br_sp,Sales
+city_br_4382,base.br,base.state_br_sp,Sales Oliveira
+city_br_4383,base.br,base.state_br_sp,Salesópolis
+city_br_4384,base.br,base.state_br_sc,Salete
+city_br_4385,base.br,base.state_br_pb,Salgadinho
+city_br_4386,base.br,base.state_br_pe,Salgadinho
+city_br_4387,base.br,base.state_br_se,Salgado
+city_br_4388,base.br,base.state_br_pb,Salgado de São Félix
+city_br_4389,base.br,base.state_br_pr,Salgado Filho
+city_br_4390,base.br,base.state_br_pe,Salgueiro
+city_br_4391,base.br,base.state_br_mg,Salinas
+city_br_4392,base.br,base.state_br_ba,Salinas da Margarida
+city_br_4393,base.br,base.state_br_pa,Salinópolis
+city_br_4394,base.br,base.state_br_ce,Salitre
+city_br_4395,base.br,base.state_br_sp,Salmourão
+city_br_4396,base.br,base.state_br_pe,Saloá
+city_br_4397,base.br,base.state_br_sc,Saltinho
+city_br_4398,base.br,base.state_br_sp,Saltinho
+city_br_4399,base.br,base.state_br_mg,Salto da Divisa
+city_br_4400,base.br,base.state_br_sp,Salto de Pirapora
+city_br_4401,base.br,base.state_br_mt,Salto do Céu
+city_br_4402,base.br,base.state_br_pr,Salto do Itararé
+city_br_4403,base.br,base.state_br_rs,Salto do Jacuí
+city_br_4404,base.br,base.state_br_pr,Salto do Lontra
+city_br_4405,base.br,base.state_br_sp,Salto Grande
+city_br_4406,base.br,base.state_br_sc,Salto Veloso
+city_br_4407,base.br,base.state_br_rs,Salvador das Missões
+city_br_4408,base.br,base.state_br_rs,Salvador do Sul
+city_br_4409,base.br,base.state_br_pa,Salvaterra
+city_br_4410,base.br,base.state_br_ma,Sambaíba
+city_br_4411,base.br,base.state_br_to,Sampaio
+city_br_4412,base.br,base.state_br_rs,Sananduva
+city_br_4413,base.br,base.state_br_go,Sanclerlândia
+city_br_4414,base.br,base.state_br_to,Sandolândia
+city_br_4415,base.br,base.state_br_sp,Sandovalina
+city_br_4416,base.br,base.state_br_sc,Sangão
+city_br_4417,base.br,base.state_br_pe,Sanharó
+city_br_4418,base.br,base.state_br_rs,Sant'Ana do Livramento
+city_br_4419,base.br,base.state_br_sp,Santa Adélia
+city_br_4420,base.br,base.state_br_sp,Santa Albertina
+city_br_4421,base.br,base.state_br_pr,Santa Amélia
+city_br_4422,base.br,base.state_br_ba,Santa Bárbara
+city_br_4423,base.br,base.state_br_mg,Santa Bárbara
+city_br_4424,base.br,base.state_br_go,Santa Bárbara de Goiás
+city_br_4425,base.br,base.state_br_mg,Santa Bárbara do Leste
+city_br_4426,base.br,base.state_br_mg,Santa Bárbara do Monte Verde
+city_br_4427,base.br,base.state_br_pa,Santa Bárbara do Pará
+city_br_4428,base.br,base.state_br_rs,Santa Bárbara do Sul
+city_br_4429,base.br,base.state_br_mg,Santa Bárbara do Tugúrio
+city_br_4430,base.br,base.state_br_sp,Santa Branca
+city_br_4431,base.br,base.state_br_ba,Santa Brígida
+city_br_4432,base.br,base.state_br_mt,Santa Carmem
+city_br_4433,base.br,base.state_br_pb,Santa Cecília
+city_br_4434,base.br,base.state_br_sc,Santa Cecília
+city_br_4435,base.br,base.state_br_pr,Santa Cecília do Pavão
+city_br_4436,base.br,base.state_br_rs,Santa Cecília do Sul
+city_br_4437,base.br,base.state_br_sp,Santa Clara d'Oeste
+city_br_4438,base.br,base.state_br_rs,Santa Clara do Sul
+city_br_4439,base.br,base.state_br_pb,Santa Cruz
+city_br_4440,base.br,base.state_br_pe,Santa Cruz
+city_br_4441,base.br,base.state_br_rn,Santa Cruz
+city_br_4442,base.br,base.state_br_ba,Santa Cruz Cabrália
+city_br_4443,base.br,base.state_br_pe,Santa Cruz da Baixa Verde
+city_br_4444,base.br,base.state_br_sp,Santa Cruz da Conceição
+city_br_4445,base.br,base.state_br_sp,Santa Cruz da Esperança
+city_br_4446,base.br,base.state_br_ba,Santa Cruz da Vitória
+city_br_4447,base.br,base.state_br_sp,Santa Cruz das Palmeiras
+city_br_4448,base.br,base.state_br_go,Santa Cruz de Goiás
+city_br_4449,base.br,base.state_br_mg,Santa Cruz de Minas
+city_br_4450,base.br,base.state_br_pr,Santa Cruz de Monte Castelo
+city_br_4451,base.br,base.state_br_mg,Santa Cruz de Salinas
+city_br_4452,base.br,base.state_br_pa,Santa Cruz do Arari
+city_br_4453,base.br,base.state_br_pe,Santa Cruz do Capibaribe
+city_br_4454,base.br,base.state_br_mg,Santa Cruz do Escalvado
+city_br_4455,base.br,base.state_br_pi,Santa Cruz do Piauí
+city_br_4456,base.br,base.state_br_sp,Santa Cruz do Rio Pardo
+city_br_4457,base.br,base.state_br_mt,Santa Cruz do Xingu
+city_br_4458,base.br,base.state_br_pi,Santa Cruz dos Milagres
+city_br_4459,base.br,base.state_br_mg,Santa Efigênia de Minas
+city_br_4460,base.br,base.state_br_sp,Santa Ernestina
+city_br_4461,base.br,base.state_br_pr,Santa Fé
+city_br_4462,base.br,base.state_br_go,Santa Fé de Goiás
+city_br_4463,base.br,base.state_br_mg,Santa Fé de Minas
+city_br_4464,base.br,base.state_br_to,Santa Fé do Araguaia
+city_br_4465,base.br,base.state_br_sp,Santa Fé do Sul
+city_br_4466,base.br,base.state_br_pe,Santa Filomena
+city_br_4467,base.br,base.state_br_pi,Santa Filomena
+city_br_4468,base.br,base.state_br_ma,Santa Filomena do Maranhão
+city_br_4469,base.br,base.state_br_sp,Santa Gertrudes
+city_br_4470,base.br,base.state_br_ma,Santa Helena
+city_br_4471,base.br,base.state_br_pb,Santa Helena
+city_br_4472,base.br,base.state_br_pr,Santa Helena
+city_br_4473,base.br,base.state_br_sc,Santa Helena
+city_br_4474,base.br,base.state_br_go,Santa Helena de Goiás
+city_br_4475,base.br,base.state_br_mg,Santa Helena de Minas
+city_br_4476,base.br,base.state_br_ba,Santa Inês
+city_br_4477,base.br,base.state_br_ma,Santa Inês
+city_br_4478,base.br,base.state_br_pb,Santa Inês
+city_br_4479,base.br,base.state_br_pr,Santa Inês
+city_br_4480,base.br,base.state_br_go,Santa Isabel
+city_br_4481,base.br,base.state_br_sp,Santa Isabel
+city_br_4482,base.br,base.state_br_pr,Santa Isabel do Ivaí
+city_br_4483,base.br,base.state_br_am,Santa Isabel do Rio Negro
+city_br_4484,base.br,base.state_br_pr,Santa Izabel do Oeste
+city_br_4485,base.br,base.state_br_pa,Santa Izabel do Pará
+city_br_4486,base.br,base.state_br_mg,Santa Juliana
+city_br_4487,base.br,base.state_br_es,Santa Leopoldina
+city_br_4488,base.br,base.state_br_pr,Santa Lúcia
+city_br_4489,base.br,base.state_br_sp,Santa Lúcia
+city_br_4490,base.br,base.state_br_pi,Santa Luz
+city_br_4491,base.br,base.state_br_ba,Santa Luzia
+city_br_4492,base.br,base.state_br_ma,Santa Luzia
+city_br_4493,base.br,base.state_br_pb,Santa Luzia
+city_br_4494,base.br,base.state_br_ro,Santa Luzia D'Oeste
+city_br_4495,base.br,base.state_br_se,Santa Luzia do Itanhy
+city_br_4496,base.br,base.state_br_al,Santa Luzia do Norte
+city_br_4497,base.br,base.state_br_pa,Santa Luzia do Pará
+city_br_4498,base.br,base.state_br_ma,Santa Luzia do Paruá
+city_br_4499,base.br,base.state_br_mg,Santa Margarida
+city_br_4500,base.br,base.state_br_rs,Santa Margarida do Sul
+city_br_4501,base.br,base.state_br_rn,Santa Maria
+city_br_4502,base.br,base.state_br_pe,Santa Maria da Boa Vista
+city_br_4503,base.br,base.state_br_sp,Santa Maria da Serra
+city_br_4504,base.br,base.state_br_ba,Santa Maria da Vitória
+city_br_4505,base.br,base.state_br_pa,Santa Maria das Barreiras
+city_br_4506,base.br,base.state_br_mg,Santa Maria de Itabira
+city_br_4507,base.br,base.state_br_es,Santa Maria de Jetibá
+city_br_4508,base.br,base.state_br_pe,Santa Maria do Cambucá
+city_br_4509,base.br,base.state_br_rs,Santa Maria do Herval
+city_br_4510,base.br,base.state_br_pr,Santa Maria do Oeste
+city_br_4511,base.br,base.state_br_pa,Santa Maria do Pará
+city_br_4512,base.br,base.state_br_mg,Santa Maria do Salto
+city_br_4513,base.br,base.state_br_mg,Santa Maria do Suaçuí
+city_br_4514,base.br,base.state_br_to,Santa Maria do Tocantins
+city_br_4515,base.br,base.state_br_rj,Santa Maria Madalena
+city_br_4516,base.br,base.state_br_pr,Santa Mariana
+city_br_4517,base.br,base.state_br_sp,Santa Mercedes
+city_br_4518,base.br,base.state_br_pr,Santa Mônica
+city_br_4519,base.br,base.state_br_ce,Santa Quitéria
+city_br_4520,base.br,base.state_br_ma,Santa Quitéria do Maranhão
+city_br_4521,base.br,base.state_br_ma,Santa Rita
+city_br_4522,base.br,base.state_br_sp,Santa Rita d'Oeste
+city_br_4523,base.br,base.state_br_mg,Santa Rita de Caldas
+city_br_4524,base.br,base.state_br_ba,Santa Rita de Cássia
+city_br_4525,base.br,base.state_br_mg,Santa Rita de Ibitipoca
+city_br_4526,base.br,base.state_br_mg,Santa Rita de Jacutinga
+city_br_4527,base.br,base.state_br_mg,Santa Rita de Minas
+city_br_4528,base.br,base.state_br_go,Santa Rita do Araguaia
+city_br_4529,base.br,base.state_br_mg,Santa Rita do Itueto
+city_br_4530,base.br,base.state_br_go,Santa Rita do Novo Destino
+city_br_4531,base.br,base.state_br_ms,Santa Rita do Pardo
+city_br_4532,base.br,base.state_br_sp,Santa Rita do Passa Quatro
+city_br_4533,base.br,base.state_br_mg,Santa Rita do Sapucaí
+city_br_4534,base.br,base.state_br_to,Santa Rita do Tocantins
+city_br_4535,base.br,base.state_br_mt,Santa Rita do Trivelato
+city_br_4536,base.br,base.state_br_rs,Santa Rosa
+city_br_4537,base.br,base.state_br_mg,Santa Rosa da Serra
+city_br_4538,base.br,base.state_br_go,Santa Rosa de Goiás
+city_br_4539,base.br,base.state_br_sc,Santa Rosa de Lima
+city_br_4540,base.br,base.state_br_se,Santa Rosa de Lima
+city_br_4541,base.br,base.state_br_sp,Santa Rosa de Viterbo
+city_br_4542,base.br,base.state_br_pi,Santa Rosa do Piauí
+city_br_4543,base.br,base.state_br_ac,Santa Rosa do Purus
+city_br_4544,base.br,base.state_br_sc,Santa Rosa do Sul
+city_br_4545,base.br,base.state_br_to,Santa Rosa do Tocantins
+city_br_4546,base.br,base.state_br_sp,Santa Salete
+city_br_4547,base.br,base.state_br_es,Santa Teresa
+city_br_4548,base.br,base.state_br_ba,Santa Teresinha
+city_br_4549,base.br,base.state_br_pb,Santa Teresinha
+city_br_4550,base.br,base.state_br_rs,Santa Tereza
+city_br_4551,base.br,base.state_br_go,Santa Tereza de Goiás
+city_br_4552,base.br,base.state_br_pr,Santa Tereza do Oeste
+city_br_4553,base.br,base.state_br_to,Santa Tereza do Tocantins
+city_br_4554,base.br,base.state_br_mt,Santa Terezinha
+city_br_4555,base.br,base.state_br_pe,Santa Terezinha
+city_br_4556,base.br,base.state_br_sc,Santa Terezinha
+city_br_4557,base.br,base.state_br_go,Santa Terezinha de Goiás
+city_br_4558,base.br,base.state_br_pr,Santa Terezinha de Itaipu
+city_br_4559,base.br,base.state_br_sc,Santa Terezinha do Progresso
+city_br_4560,base.br,base.state_br_to,Santa Terezinha do Tocantins
+city_br_4561,base.br,base.state_br_mg,Santa Vitória
+city_br_4562,base.br,base.state_br_rs,Santa Vitória do Palmar
+city_br_4563,base.br,base.state_br_ba,Santaluz
+city_br_4564,base.br,base.state_br_ba,Santana
+city_br_4565,base.br,base.state_br_rs,Santana da Boa Vista
+city_br_4566,base.br,base.state_br_sp,Santana da Ponte Pensa
+city_br_4567,base.br,base.state_br_mg,Santana da Vargem
+city_br_4568,base.br,base.state_br_mg,Santana de Cataguases
+city_br_4569,base.br,base.state_br_pb,Santana de Mangueira
+city_br_4570,base.br,base.state_br_mg,Santana de Pirapama
+city_br_4571,base.br,base.state_br_ce,Santana do Acaraú
+city_br_4572,base.br,base.state_br_pa,Santana do Araguaia
+city_br_4573,base.br,base.state_br_ce,Santana do Cariri
+city_br_4574,base.br,base.state_br_mg,Santana do Deserto
+city_br_4575,base.br,base.state_br_mg,Santana do Garambéu
+city_br_4576,base.br,base.state_br_al,Santana do Ipanema
+city_br_4577,base.br,base.state_br_pr,Santana do Itararé
+city_br_4578,base.br,base.state_br_mg,Santana do Jacaré
+city_br_4579,base.br,base.state_br_mg,Santana do Manhuaçu
+city_br_4580,base.br,base.state_br_ma,Santana do Maranhão
+city_br_4581,base.br,base.state_br_rn,Santana do Matos
+city_br_4582,base.br,base.state_br_al,Santana do Mundaú
+city_br_4583,base.br,base.state_br_mg,Santana do Paraíso
+city_br_4584,base.br,base.state_br_pi,Santana do Piauí
+city_br_4585,base.br,base.state_br_mg,Santana do Riacho
+city_br_4586,base.br,base.state_br_se,Santana do São Francisco
+city_br_4587,base.br,base.state_br_rn,Santana do Seridó
+city_br_4588,base.br,base.state_br_pb,Santana dos Garrotes
+city_br_4589,base.br,base.state_br_mg,Santana dos Montes
+city_br_4590,base.br,base.state_br_ba,Santanópolis
+city_br_4591,base.br,base.state_br_pa,Santarém Novo
+city_br_4592,base.br,base.state_br_rs,Santiago
+city_br_4593,base.br,base.state_br_sc,Santiago do Sul
+city_br_4594,base.br,base.state_br_mt,Santo Afonso
+city_br_4595,base.br,base.state_br_ba,Santo Amaro
+city_br_4596,base.br,base.state_br_sc,Santo Amaro da Imperatriz
+city_br_4597,base.br,base.state_br_se,Santo Amaro das Brotas
+city_br_4598,base.br,base.state_br_ma,Santo Amaro do Maranhão
+city_br_4599,base.br,base.state_br_sp,Santo Anastácio
+city_br_4600,base.br,base.state_br_pb,Santo André
+city_br_4601,base.br,base.state_br_rs,Santo Ângelo
+city_br_4602,base.br,base.state_br_rn,Santo Antônio
+city_br_4603,base.br,base.state_br_sp,Santo Antônio da Alegria
+city_br_4604,base.br,base.state_br_go,Santo Antônio da Barra
+city_br_4605,base.br,base.state_br_rs,Santo Antônio da Patrulha
+city_br_4606,base.br,base.state_br_pr,Santo Antônio da Platina
+city_br_4607,base.br,base.state_br_rs,Santo Antônio das Missões
+city_br_4608,base.br,base.state_br_go,Santo Antônio de Goiás
+city_br_4609,base.br,base.state_br_pi,Santo Antônio de Lisboa
+city_br_4610,base.br,base.state_br_rj,Santo Antônio de Pádua
+city_br_4611,base.br,base.state_br_sp,Santo Antônio de Posse
+city_br_4612,base.br,base.state_br_mg,Santo Antônio do Amparo
+city_br_4613,base.br,base.state_br_sp,Santo Antônio do Aracanguá
+city_br_4614,base.br,base.state_br_mg,Santo Antônio do Aventureiro
+city_br_4615,base.br,base.state_br_pr,Santo Antônio do Caiuá
+city_br_4616,base.br,base.state_br_go,Santo Antônio do Descoberto
+city_br_4617,base.br,base.state_br_mg,Santo Antônio do Grama
+city_br_4618,base.br,base.state_br_am,Santo Antônio do Içá
+city_br_4619,base.br,base.state_br_mg,Santo Antônio do Itambé
+city_br_4620,base.br,base.state_br_mg,Santo Antônio do Jacinto
+city_br_4621,base.br,base.state_br_sp,Santo Antônio do Jardim
+city_br_4622,base.br,base.state_br_mt,Santo Antônio do Leste
+city_br_4623,base.br,base.state_br_mt,Santo Antônio do Leverger
+city_br_4624,base.br,base.state_br_mg,Santo Antônio do Monte
+city_br_4625,base.br,base.state_br_rs,Santo Antônio do Palma
+city_br_4626,base.br,base.state_br_pr,Santo Antônio do Paraíso
+city_br_4627,base.br,base.state_br_sp,Santo Antônio do Pinhal
+city_br_4628,base.br,base.state_br_rs,Santo Antônio do Planalto
+city_br_4629,base.br,base.state_br_mg,Santo Antônio do Retiro
+city_br_4630,base.br,base.state_br_mg,Santo Antônio do Rio Abaixo
+city_br_4631,base.br,base.state_br_pr,Santo Antônio do Sudoeste
+city_br_4632,base.br,base.state_br_pa,Santo Antônio do Tauá
+city_br_4633,base.br,base.state_br_ma,Santo Antônio dos Lopes
+city_br_4634,base.br,base.state_br_pi,Santo Antônio dos Milagres
+city_br_4635,base.br,base.state_br_rs,Santo Augusto
+city_br_4636,base.br,base.state_br_rs,Santo Cristo
+city_br_4637,base.br,base.state_br_ba,Santo Estêvão
+city_br_4638,base.br,base.state_br_sp,Santo Expedito
+city_br_4639,base.br,base.state_br_rs,Santo Expedito do Sul
+city_br_4640,base.br,base.state_br_mg,Santo Hipólito
+city_br_4641,base.br,base.state_br_pr,Santo Inácio
+city_br_4642,base.br,base.state_br_pi,Santo Inácio do Piauí
+city_br_4643,base.br,base.state_br_sp,Santópolis do Aguapeí
+city_br_4644,base.br,base.state_br_mg,Santos Dumont
+city_br_4645,base.br,base.state_br_ce,São Benedito
+city_br_4646,base.br,base.state_br_ma,São Benedito do Rio Preto
+city_br_4647,base.br,base.state_br_pe,São Benedito do Sul
+city_br_4648,base.br,base.state_br_pb,São Bentinho
+city_br_4649,base.br,base.state_br_ma,São Bento
+city_br_4650,base.br,base.state_br_pb,São Bento
+city_br_4651,base.br,base.state_br_mg,São Bento Abade
+city_br_4652,base.br,base.state_br_rn,São Bento do Norte
+city_br_4653,base.br,base.state_br_sp,São Bento do Sapucaí
+city_br_4654,base.br,base.state_br_sc,São Bento do Sul
+city_br_4655,base.br,base.state_br_to,São Bento do Tocantins
+city_br_4656,base.br,base.state_br_rn,São Bento do Trairí
+city_br_4657,base.br,base.state_br_pe,São Bento do Una
+city_br_4658,base.br,base.state_br_sc,São Bernardino
+city_br_4659,base.br,base.state_br_ma,São Bernardo
+city_br_4660,base.br,base.state_br_sc,São Bonifácio
+city_br_4661,base.br,base.state_br_rs,São Borja
+city_br_4662,base.br,base.state_br_al,São Brás
+city_br_4663,base.br,base.state_br_mg,São Brás do Suaçuí
+city_br_4664,base.br,base.state_br_pi,São Braz do Piauí
+city_br_4665,base.br,base.state_br_pa,São Caetano de Odivelas
+city_br_4666,base.br,base.state_br_pe,São Caitano
+city_br_4667,base.br,base.state_br_sc,São Carlos
+city_br_4668,base.br,base.state_br_pr,São Carlos do Ivaí
+city_br_4669,base.br,base.state_br_se,São Cristóvão
+city_br_4670,base.br,base.state_br_sc,São Cristóvão do Sul
+city_br_4671,base.br,base.state_br_ba,São Desidério
+city_br_4672,base.br,base.state_br_ba,São Domingos
+city_br_4673,base.br,base.state_br_go,São Domingos
+city_br_4674,base.br,base.state_br_pb,São Domingos
+city_br_4675,base.br,base.state_br_sc,São Domingos
+city_br_4676,base.br,base.state_br_se,São Domingos
+city_br_4677,base.br,base.state_br_mg,São Domingos das Dores
+city_br_4678,base.br,base.state_br_pa,São Domingos do Araguaia
+city_br_4679,base.br,base.state_br_ma,São Domingos do Azeitão
+city_br_4680,base.br,base.state_br_pa,São Domingos do Capim
+city_br_4681,base.br,base.state_br_pb,São Domingos do Cariri
+city_br_4682,base.br,base.state_br_ma,São Domingos do Maranhão
+city_br_4683,base.br,base.state_br_es,São Domingos do Norte
+city_br_4684,base.br,base.state_br_mg,São Domingos do Prata
+city_br_4685,base.br,base.state_br_rs,São Domingos do Sul
+city_br_4686,base.br,base.state_br_ba,São Felipe
+city_br_4687,base.br,base.state_br_ro,São Felipe D'Oeste
+city_br_4688,base.br,base.state_br_ba,São Félix
+city_br_4689,base.br,base.state_br_ma,São Félix de Balsas
+city_br_4690,base.br,base.state_br_mg,São Félix de Minas
+city_br_4691,base.br,base.state_br_mt,São Félix do Araguaia
+city_br_4692,base.br,base.state_br_ba,São Félix do Coribe
+city_br_4693,base.br,base.state_br_pi,São Félix do Piauí
+city_br_4694,base.br,base.state_br_to,São Félix do Tocantins
+city_br_4695,base.br,base.state_br_pa,São Félix do Xingu
+city_br_4696,base.br,base.state_br_rn,São Fernando
+city_br_4697,base.br,base.state_br_rj,São Fidélis
+city_br_4698,base.br,base.state_br_mg,São Francisco
+city_br_4699,base.br,base.state_br_pb,São Francisco
+city_br_4700,base.br,base.state_br_se,São Francisco
+city_br_4701,base.br,base.state_br_sp,São Francisco
+city_br_4702,base.br,base.state_br_rs,São Francisco de Assis
+city_br_4703,base.br,base.state_br_pi,São Francisco de Assis do Piauí
+city_br_4704,base.br,base.state_br_go,São Francisco de Goiás
+city_br_4705,base.br,base.state_br_rj,São Francisco de Itabapoana
+city_br_4706,base.br,base.state_br_mg,São Francisco de Paula
+city_br_4707,base.br,base.state_br_rs,São Francisco de Paula
+city_br_4708,base.br,base.state_br_mg,São Francisco de Sales
+city_br_4709,base.br,base.state_br_ma,São Francisco do Brejão
+city_br_4710,base.br,base.state_br_ba,São Francisco do Conde
+city_br_4711,base.br,base.state_br_mg,São Francisco do Glória
+city_br_4712,base.br,base.state_br_ro,São Francisco do Guaporé
+city_br_4713,base.br,base.state_br_ma,São Francisco do Maranhão
+city_br_4714,base.br,base.state_br_rn,São Francisco do Oeste
+city_br_4715,base.br,base.state_br_pa,São Francisco do Pará
+city_br_4716,base.br,base.state_br_pi,São Francisco do Piauí
+city_br_4717,base.br,base.state_br_sc,São Francisco do Sul
+city_br_4718,base.br,base.state_br_ba,São Gabriel
+city_br_4719,base.br,base.state_br_rs,São Gabriel
+city_br_4720,base.br,base.state_br_am,São Gabriel da Cachoeira
+city_br_4721,base.br,base.state_br_es,São Gabriel da Palha
+city_br_4722,base.br,base.state_br_ms,São Gabriel do Oeste
+city_br_4723,base.br,base.state_br_mg,São Geraldo
+city_br_4724,base.br,base.state_br_mg,São Geraldo da Piedade
+city_br_4725,base.br,base.state_br_pa,São Geraldo do Araguaia
+city_br_4726,base.br,base.state_br_mg,São Geraldo do Baixio
+city_br_4727,base.br,base.state_br_mg,São Gonçalo do Abaeté
+city_br_4728,base.br,base.state_br_ce,São Gonçalo do Amarante
+city_br_4729,base.br,base.state_br_pi,São Gonçalo do Gurguéia
+city_br_4730,base.br,base.state_br_mg,São Gonçalo do Pará
+city_br_4731,base.br,base.state_br_pi,São Gonçalo do Piauí
+city_br_4732,base.br,base.state_br_mg,São Gonçalo do Rio Abaixo
+city_br_4733,base.br,base.state_br_mg,São Gonçalo do Rio Preto
+city_br_4734,base.br,base.state_br_mg,São Gonçalo do Sapucaí
+city_br_4735,base.br,base.state_br_ba,São Gonçalo dos Campos
+city_br_4736,base.br,base.state_br_mg,São Gotardo
+city_br_4737,base.br,base.state_br_rs,São Jerônimo
+city_br_4738,base.br,base.state_br_pr,São Jerônimo da Serra
+city_br_4739,base.br,base.state_br_pe,São João
+city_br_4740,base.br,base.state_br_pr,São João
+city_br_4741,base.br,base.state_br_ma,São João Batista
+city_br_4742,base.br,base.state_br_sc,São João Batista
+city_br_4743,base.br,base.state_br_mg,São João Batista do Glória
+city_br_4744,base.br,base.state_br_go,São João d'Aliança
+city_br_4745,base.br,base.state_br_rr,São João da Baliza
+city_br_4746,base.br,base.state_br_rj,São João da Barra
+city_br_4747,base.br,base.state_br_sp,São João da Boa Vista
+city_br_4748,base.br,base.state_br_pi,São João da Canabrava
+city_br_4749,base.br,base.state_br_pi,São João da Fronteira
+city_br_4750,base.br,base.state_br_mg,São João da Lagoa
+city_br_4751,base.br,base.state_br_mg,São João da Mata
+city_br_4752,base.br,base.state_br_go,São João da Paraúna
+city_br_4753,base.br,base.state_br_pa,São João da Ponta
+city_br_4754,base.br,base.state_br_mg,São João da Ponte
+city_br_4755,base.br,base.state_br_pi,São João da Serra
+city_br_4756,base.br,base.state_br_rs,São João da Urtiga
+city_br_4757,base.br,base.state_br_pi,São João da Varjota
+city_br_4758,base.br,base.state_br_sp,São João das Duas Pontes
+city_br_4759,base.br,base.state_br_mg,São João das Missões
+city_br_4760,base.br,base.state_br_sp,São João de Iracema
+city_br_4761,base.br,base.state_br_pa,São João de Pirabas
+city_br_4762,base.br,base.state_br_mg,São João del Rei
+city_br_4763,base.br,base.state_br_pa,São João do Araguaia
+city_br_4764,base.br,base.state_br_pi,São João do Arraial
+city_br_4765,base.br,base.state_br_pr,São João do Caiuá
+city_br_4766,base.br,base.state_br_pb,São João do Cariri
+city_br_4767,base.br,base.state_br_ma,São João do Carú
+city_br_4768,base.br,base.state_br_sc,São João do Itaperiú
+city_br_4769,base.br,base.state_br_pr,São João do Ivaí
+city_br_4770,base.br,base.state_br_ce,São João do Jaguaribe
+city_br_4771,base.br,base.state_br_mg,São João do Manhuaçu
+city_br_4772,base.br,base.state_br_mg,São João do Manteninha
+city_br_4773,base.br,base.state_br_sc,São João do Oeste
+city_br_4774,base.br,base.state_br_mg,São João do Oriente
+city_br_4775,base.br,base.state_br_mg,São João do Pacuí
+city_br_4776,base.br,base.state_br_ma,São João do Paraíso
+city_br_4777,base.br,base.state_br_mg,São João do Paraíso
+city_br_4778,base.br,base.state_br_sp,São João do Pau d'Alho
+city_br_4779,base.br,base.state_br_pi,São João do Piauí
+city_br_4780,base.br,base.state_br_rs,São João do Polêsine
+city_br_4781,base.br,base.state_br_pb,São João do Rio do Peixe
+city_br_4782,base.br,base.state_br_rn,São João do Sabugi
+city_br_4783,base.br,base.state_br_ma,São João do Soter
+city_br_4784,base.br,base.state_br_sc,São João do Sul
+city_br_4785,base.br,base.state_br_pb,São João do Tigre
+city_br_4786,base.br,base.state_br_pr,São João do Triunfo
+city_br_4787,base.br,base.state_br_ma,São João dos Patos
+city_br_4788,base.br,base.state_br_mg,São João Evangelista
+city_br_4789,base.br,base.state_br_mg,São João Nepomuceno
+city_br_4790,base.br,base.state_br_sc,São Joaquim
+city_br_4791,base.br,base.state_br_sp,São Joaquim da Barra
+city_br_4792,base.br,base.state_br_mg,São Joaquim de Bicas
+city_br_4793,base.br,base.state_br_pe,São Joaquim do Monte
+city_br_4794,base.br,base.state_br_rs,São Jorge
+city_br_4795,base.br,base.state_br_pr,São Jorge d'Oeste
+city_br_4796,base.br,base.state_br_pr,São Jorge do Ivaí
+city_br_4797,base.br,base.state_br_pr,São Jorge do Patrocínio
+city_br_4798,base.br,base.state_br_mg,São José da Barra
+city_br_4799,base.br,base.state_br_sp,São José da Bela Vista
+city_br_4800,base.br,base.state_br_pr,São José da Boa Vista
+city_br_4801,base.br,base.state_br_pe,São José da Coroa Grande
+city_br_4802,base.br,base.state_br_pb,São José da Lagoa Tapada
+city_br_4803,base.br,base.state_br_al,São José da Laje
+city_br_4804,base.br,base.state_br_mg,São José da Lapa
+city_br_4805,base.br,base.state_br_mg,São José da Safira
+city_br_4806,base.br,base.state_br_al,São José da Tapera
+city_br_4807,base.br,base.state_br_mg,São José da Varginha
+city_br_4808,base.br,base.state_br_ba,São José da Vitória
+city_br_4809,base.br,base.state_br_rs,São José das Missões
+city_br_4810,base.br,base.state_br_pr,São José das Palmeiras
+city_br_4811,base.br,base.state_br_pb,São José de Caiana
+city_br_4812,base.br,base.state_br_pb,São José de Espinharas
+city_br_4813,base.br,base.state_br_rn,São José de Mipibu
+city_br_4814,base.br,base.state_br_pb,São José de Piranhas
+city_br_4815,base.br,base.state_br_pb,São José de Princesa
+city_br_4816,base.br,base.state_br_rj,São José de Ubá
+city_br_4817,base.br,base.state_br_mg,São José do Alegre
+city_br_4818,base.br,base.state_br_sp,São José do Barreiro
+city_br_4819,base.br,base.state_br_pe,São José do Belmonte
+city_br_4820,base.br,base.state_br_pb,São José do Bonfim
+city_br_4821,base.br,base.state_br_pb,São José do Brejo do Cruz
+city_br_4822,base.br,base.state_br_es,São José do Calçado
+city_br_4823,base.br,base.state_br_rn,São José do Campestre
+city_br_4824,base.br,base.state_br_sc,São José do Cedro
+city_br_4825,base.br,base.state_br_sc,São José do Cerrito
+city_br_4826,base.br,base.state_br_mg,São José do Divino
+city_br_4827,base.br,base.state_br_pi,São José do Divino
+city_br_4828,base.br,base.state_br_pe,São José do Egito
+city_br_4829,base.br,base.state_br_mg,São José do Goiabal
+city_br_4830,base.br,base.state_br_rs,São José do Herval
+city_br_4831,base.br,base.state_br_rs,São José do Hortêncio
+city_br_4832,base.br,base.state_br_rs,São José do Inhacorá
+city_br_4833,base.br,base.state_br_ba,São José do Jacuípe
+city_br_4834,base.br,base.state_br_mg,São José do Jacuri
+city_br_4835,base.br,base.state_br_mg,São José do Mantimento
+city_br_4836,base.br,base.state_br_rs,São José do Norte
+city_br_4837,base.br,base.state_br_rs,São José do Ouro
+city_br_4838,base.br,base.state_br_pi,São José do Peixe
+city_br_4839,base.br,base.state_br_pi,São José do Piauí
+city_br_4840,base.br,base.state_br_mt,São José do Povo
+city_br_4841,base.br,base.state_br_mt,São José do Rio Claro
+city_br_4842,base.br,base.state_br_sp,São José do Rio Pardo
+city_br_4843,base.br,base.state_br_pb,São José do Sabugi
+city_br_4844,base.br,base.state_br_rn,São José do Seridó
+city_br_4845,base.br,base.state_br_rs,São José do Sul
+city_br_4846,base.br,base.state_br_rj,São José do Vale do Rio Preto
+city_br_4847,base.br,base.state_br_mt,São José do Xingu
+city_br_4848,base.br,base.state_br_rs,São José dos Ausentes
+city_br_4849,base.br,base.state_br_ma,São José dos Basílios
+city_br_4850,base.br,base.state_br_pb,São José dos Cordeiros
+city_br_4851,base.br,base.state_br_mt,São José dos Quatro Marcos
+city_br_4852,base.br,base.state_br_pb,São José dos Ramos
+city_br_4853,base.br,base.state_br_pi,São Julião
+city_br_4854,base.br,base.state_br_mg,São Lourenço
+city_br_4855,base.br,base.state_br_sp,São Lourenço da Serra
+city_br_4856,base.br,base.state_br_sc,São Lourenço do Oeste
+city_br_4857,base.br,base.state_br_pi,São Lourenço do Piauí
+city_br_4858,base.br,base.state_br_rs,São Lourenço do Sul
+city_br_4859,base.br,base.state_br_sc,São Ludgero
+city_br_4860,base.br,base.state_br_go,São Luís de Montes Belos
+city_br_4861,base.br,base.state_br_ce,São Luís do Curu
+city_br_4862,base.br,base.state_br_pi,São Luis do Piauí
+city_br_4863,base.br,base.state_br_al,São Luís do Quitunde
+city_br_4864,base.br,base.state_br_ma,São Luís Gonzaga do Maranhão
+city_br_4865,base.br,base.state_br_rr,São Luiz
+city_br_4866,base.br,base.state_br_go,São Luiz do Norte
+city_br_4867,base.br,base.state_br_sp,São Luiz do Paraitinga
+city_br_4868,base.br,base.state_br_rs,São Luiz Gonzaga
+city_br_4869,base.br,base.state_br_pb,São Mamede
+city_br_4870,base.br,base.state_br_pr,São Manoel do Paraná
+city_br_4871,base.br,base.state_br_sp,São Manuel
+city_br_4872,base.br,base.state_br_rs,São Marcos
+city_br_4873,base.br,base.state_br_rs,São Martinho
+city_br_4874,base.br,base.state_br_sc,São Martinho
+city_br_4875,base.br,base.state_br_rs,São Martinho da Serra
+city_br_4876,base.br,base.state_br_ma,São Mateus do Maranhão
+city_br_4877,base.br,base.state_br_pr,São Mateus do Sul
+city_br_4878,base.br,base.state_br_rn,São Miguel
+city_br_4879,base.br,base.state_br_sp,São Miguel Arcanjo
+city_br_4880,base.br,base.state_br_pi,São Miguel da Baixa Grande
+city_br_4881,base.br,base.state_br_sc,São Miguel da Boa Vista
+city_br_4882,base.br,base.state_br_ba,São Miguel das Matas
+city_br_4883,base.br,base.state_br_rs,São Miguel das Missões
+city_br_4884,base.br,base.state_br_pb,São Miguel de Taipu
+city_br_4885,base.br,base.state_br_se,São Miguel do Aleixo
+city_br_4886,base.br,base.state_br_mg,São Miguel do Anta
+city_br_4887,base.br,base.state_br_go,São Miguel do Araguaia
+city_br_4888,base.br,base.state_br_pi,São Miguel do Fidalgo
+city_br_4889,base.br,base.state_br_rn,São Miguel do Gostoso
+city_br_4890,base.br,base.state_br_pa,São Miguel do Guamá
+city_br_4891,base.br,base.state_br_ro,São Miguel do Guaporé
+city_br_4892,base.br,base.state_br_pr,São Miguel do Iguaçu
+city_br_4893,base.br,base.state_br_sc,São Miguel do Oeste
+city_br_4894,base.br,base.state_br_go,São Miguel do Passa Quatro
+city_br_4895,base.br,base.state_br_pi,São Miguel do Tapuio
+city_br_4896,base.br,base.state_br_to,São Miguel do Tocantins
+city_br_4897,base.br,base.state_br_al,São Miguel dos Campos
+city_br_4898,base.br,base.state_br_al,São Miguel dos Milagres
+city_br_4899,base.br,base.state_br_rs,São Nicolau
+city_br_4900,base.br,base.state_br_go,São Patrício
+city_br_4901,base.br,base.state_br_rs,São Paulo das Missões
+city_br_4902,base.br,base.state_br_am,São Paulo de Olivença
+city_br_4903,base.br,base.state_br_rn,São Paulo do Potengi
+city_br_4904,base.br,base.state_br_rn,São Pedro
+city_br_4905,base.br,base.state_br_sp,São Pedro
+city_br_4906,base.br,base.state_br_ma,São Pedro da Água Branca
+city_br_4907,base.br,base.state_br_mt,São Pedro da Cipa
+city_br_4908,base.br,base.state_br_rs,São Pedro da Serra
+city_br_4909,base.br,base.state_br_mg,São Pedro da União
+city_br_4910,base.br,base.state_br_rs,São Pedro das Missões
+city_br_4911,base.br,base.state_br_sc,São Pedro de Alcântara
+city_br_4912,base.br,base.state_br_rs,São Pedro do Butiá
+city_br_4913,base.br,base.state_br_pr,São Pedro do Iguaçu
+city_br_4914,base.br,base.state_br_pr,São Pedro do Ivaí
+city_br_4915,base.br,base.state_br_pr,São Pedro do Paraná
+city_br_4916,base.br,base.state_br_pi,São Pedro do Piauí
+city_br_4917,base.br,base.state_br_mg,São Pedro do Suaçuí
+city_br_4918,base.br,base.state_br_rs,São Pedro do Sul
+city_br_4919,base.br,base.state_br_sp,São Pedro do Turvo
+city_br_4920,base.br,base.state_br_ma,São Pedro dos Crentes
+city_br_4921,base.br,base.state_br_mg,São Pedro dos Ferros
+city_br_4922,base.br,base.state_br_rn,São Rafael
+city_br_4923,base.br,base.state_br_ma,São Raimundo das Mangabeiras
+city_br_4924,base.br,base.state_br_ma,São Raimundo do Doca Bezerra
+city_br_4925,base.br,base.state_br_pi,São Raimundo Nonato
+city_br_4926,base.br,base.state_br_ma,São Roberto
+city_br_4927,base.br,base.state_br_mg,São Romão
+city_br_4928,base.br,base.state_br_sp,São Roque
+city_br_4929,base.br,base.state_br_mg,São Roque de Minas
+city_br_4930,base.br,base.state_br_es,São Roque do Canaã
+city_br_4931,base.br,base.state_br_to,São Salvador do Tocantins
+city_br_4932,base.br,base.state_br_al,São Sebastião
+city_br_4933,base.br,base.state_br_sp,São Sebastião
+city_br_4934,base.br,base.state_br_pr,São Sebastião da Amoreira
+city_br_4935,base.br,base.state_br_mg,São Sebastião da Bela Vista
+city_br_4936,base.br,base.state_br_pa,São Sebastião da Boa Vista
+city_br_4937,base.br,base.state_br_sp,São Sebastião da Grama
+city_br_4938,base.br,base.state_br_mg,São Sebastião da Vargem Alegre
+city_br_4939,base.br,base.state_br_pb,São Sebastião de Lagoa de Roça
+city_br_4940,base.br,base.state_br_rj,São Sebastião do Alto
+city_br_4941,base.br,base.state_br_mg,São Sebastião do Anta
+city_br_4942,base.br,base.state_br_rs,São Sebastião do Caí
+city_br_4943,base.br,base.state_br_mg,São Sebastião do Maranhão
+city_br_4944,base.br,base.state_br_mg,São Sebastião do Oeste
+city_br_4945,base.br,base.state_br_mg,São Sebastião do Paraíso
+city_br_4946,base.br,base.state_br_ba,São Sebastião do Passé
+city_br_4947,base.br,base.state_br_mg,São Sebastião do Rio Preto
+city_br_4948,base.br,base.state_br_mg,São Sebastião do Rio Verde
+city_br_4949,base.br,base.state_br_to,São Sebastião do Tocantins
+city_br_4950,base.br,base.state_br_am,São Sebastião do Uatumã
+city_br_4951,base.br,base.state_br_pb,São Sebastião do Umbuzeiro
+city_br_4952,base.br,base.state_br_rs,São Sepé
+city_br_4953,base.br,base.state_br_go,São Simão
+city_br_4954,base.br,base.state_br_sp,São Simão
+city_br_4955,base.br,base.state_br_mg,São Thomé das Letras
+city_br_4956,base.br,base.state_br_mg,São Tiago
+city_br_4957,base.br,base.state_br_mg,São Tomás de Aquino
+city_br_4958,base.br,base.state_br_pr,São Tomé
+city_br_4959,base.br,base.state_br_rn,São Tomé
+city_br_4960,base.br,base.state_br_rs,São Valentim
+city_br_4961,base.br,base.state_br_rs,São Valentim do Sul
+city_br_4962,base.br,base.state_br_to,São Valério
+city_br_4963,base.br,base.state_br_rs,São Valério do Sul
+city_br_4964,base.br,base.state_br_rs,São Vendelino
+city_br_4965,base.br,base.state_br_rn,São Vicente
+city_br_4966,base.br,base.state_br_mg,São Vicente de Minas
+city_br_4967,base.br,base.state_br_pb,São Vicente do Seridó
+city_br_4968,base.br,base.state_br_rs,São Vicente do Sul
+city_br_4969,base.br,base.state_br_ma,São Vicente Ferrer
+city_br_4970,base.br,base.state_br_pe,São Vicente Férrer
+city_br_4971,base.br,base.state_br_pb,Sapé
+city_br_4972,base.br,base.state_br_ba,Sapeaçu
+city_br_4973,base.br,base.state_br_mt,Sapezal
+city_br_4974,base.br,base.state_br_rs,Sapiranga
+city_br_4975,base.br,base.state_br_pr,Sapopema
+city_br_4976,base.br,base.state_br_mg,Sapucaí-Mirim
+city_br_4977,base.br,base.state_br_pa,Sapucaia
+city_br_4978,base.br,base.state_br_rj,Sapucaia
+city_br_4979,base.br,base.state_br_rj,Saquarema
+city_br_4980,base.br,base.state_br_rs,Sarandi
+city_br_4981,base.br,base.state_br_sp,Sarapuí
+city_br_4982,base.br,base.state_br_mg,Sardoá
+city_br_4983,base.br,base.state_br_sp,Sarutaiá
+city_br_4984,base.br,base.state_br_mg,Sarzedo
+city_br_4985,base.br,base.state_br_ba,Sátiro Dias
+city_br_4986,base.br,base.state_br_al,Satuba
+city_br_4987,base.br,base.state_br_ma,Satubinha
+city_br_4988,base.br,base.state_br_ba,Saubara
+city_br_4989,base.br,base.state_br_pr,Saudade do Iguaçu
+city_br_4990,base.br,base.state_br_sc,Saudades
+city_br_4991,base.br,base.state_br_ba,Saúde
+city_br_4992,base.br,base.state_br_sc,Schroeder
+city_br_4993,base.br,base.state_br_ba,Seabra
+city_br_4994,base.br,base.state_br_sc,Seara
+city_br_4995,base.br,base.state_br_sp,Sebastianópolis do Sul
+city_br_4996,base.br,base.state_br_pi,Sebastião Barros
+city_br_4997,base.br,base.state_br_ba,Sebastião Laranjeiras
+city_br_4998,base.br,base.state_br_pi,Sebastião Leal
+city_br_4999,base.br,base.state_br_rs,Seberi
+city_br_5000,base.br,base.state_br_rs,Sede Nova
+city_br_5001,base.br,base.state_br_rs,Segredo
+city_br_5002,base.br,base.state_br_rs,Selbach
+city_br_5003,base.br,base.state_br_ms,Selvíria
+city_br_5004,base.br,base.state_br_mg,Sem-Peixe
+city_br_5005,base.br,base.state_br_ac,Sena Madureira
+city_br_5006,base.br,base.state_br_ma,Senador Alexandre Costa
+city_br_5007,base.br,base.state_br_mg,Senador Amaral
+city_br_5008,base.br,base.state_br_mg,Senador Cortes
+city_br_5009,base.br,base.state_br_rn,Senador Elói de Souza
+city_br_5010,base.br,base.state_br_mg,Senador Firmino
+city_br_5011,base.br,base.state_br_rn,Senador Georgino Avelino
+city_br_5012,base.br,base.state_br_ac,Senador Guiomard
+city_br_5013,base.br,base.state_br_mg,Senador José Bento
+city_br_5014,base.br,base.state_br_pa,Senador José Porfírio
+city_br_5015,base.br,base.state_br_ma,Senador La Rocque
+city_br_5016,base.br,base.state_br_mg,Senador Modestino Gonçalves
+city_br_5017,base.br,base.state_br_ce,Senador Pompeu
+city_br_5018,base.br,base.state_br_al,Senador Rui Palmeira
+city_br_5019,base.br,base.state_br_ce,Senador Sá
+city_br_5020,base.br,base.state_br_rs,Senador Salgado Filho
+city_br_5021,base.br,base.state_br_pr,Sengés
+city_br_5022,base.br,base.state_br_ba,Senhor do Bonfim
+city_br_5023,base.br,base.state_br_mg,Senhora de Oliveira
+city_br_5024,base.br,base.state_br_mg,Senhora do Porto
+city_br_5025,base.br,base.state_br_mg,Senhora dos Remédios
+city_br_5026,base.br,base.state_br_rs,Sentinela do Sul
+city_br_5027,base.br,base.state_br_ba,Sento Sé
+city_br_5028,base.br,base.state_br_rs,Serafina Corrêa
+city_br_5029,base.br,base.state_br_mg,Sericita
+city_br_5030,base.br,base.state_br_ro,Seringueiras
+city_br_5031,base.br,base.state_br_rs,Sério
+city_br_5032,base.br,base.state_br_mg,Seritinga
+city_br_5033,base.br,base.state_br_rj,Seropédica
+city_br_5034,base.br,base.state_br_sc,Serra Alta
+city_br_5035,base.br,base.state_br_sp,Serra Azul
+city_br_5036,base.br,base.state_br_mg,Serra Azul de Minas
+city_br_5037,base.br,base.state_br_pb,Serra Branca
+city_br_5038,base.br,base.state_br_rn,Serra Caiada
+city_br_5039,base.br,base.state_br_pb,Serra da Raiz
+city_br_5040,base.br,base.state_br_mg,Serra da Saudade
+city_br_5041,base.br,base.state_br_rn,Serra de São Bento
+city_br_5042,base.br,base.state_br_rn,Serra do Mel
+city_br_5043,base.br,base.state_br_ap,Serra do Navio
+city_br_5044,base.br,base.state_br_ba,Serra do Ramalho
+city_br_5045,base.br,base.state_br_mg,Serra do Salitre
+city_br_5046,base.br,base.state_br_mg,Serra dos Aimorés
+city_br_5047,base.br,base.state_br_ba,Serra Dourada
+city_br_5048,base.br,base.state_br_pb,Serra Grande
+city_br_5049,base.br,base.state_br_sp,Serra Negra
+city_br_5050,base.br,base.state_br_rn,Serra Negra do Norte
+city_br_5051,base.br,base.state_br_mt,Serra Nova Dourada
+city_br_5052,base.br,base.state_br_ba,Serra Preta
+city_br_5053,base.br,base.state_br_pb,Serra Redonda
+city_br_5054,base.br,base.state_br_pe,Serra Talhada
+city_br_5055,base.br,base.state_br_sp,Serrana
+city_br_5056,base.br,base.state_br_mg,Serrania
+city_br_5057,base.br,base.state_br_ma,Serrano do Maranhão
+city_br_5058,base.br,base.state_br_go,Serranópolis
+city_br_5059,base.br,base.state_br_mg,Serranópolis de Minas
+city_br_5060,base.br,base.state_br_pr,Serranópolis do Iguaçu
+city_br_5061,base.br,base.state_br_mg,Serranos
+city_br_5062,base.br,base.state_br_pb,Serraria
+city_br_5063,base.br,base.state_br_ba,Serrinha
+city_br_5064,base.br,base.state_br_rn,Serrinha
+city_br_5065,base.br,base.state_br_rn,Serrinha dos Pintos
+city_br_5066,base.br,base.state_br_pe,Serrita
+city_br_5067,base.br,base.state_br_mg,Serro
+city_br_5068,base.br,base.state_br_ba,Serrolândia
+city_br_5069,base.br,base.state_br_pr,Sertaneja
+city_br_5070,base.br,base.state_br_pe,Sertânia
+city_br_5071,base.br,base.state_br_pr,Sertanópolis
+city_br_5072,base.br,base.state_br_rs,Sertão
+city_br_5073,base.br,base.state_br_rs,Sertão Santana
+city_br_5074,base.br,base.state_br_pb,Sertãozinho
+city_br_5075,base.br,base.state_br_sp,Sete Barras
+city_br_5076,base.br,base.state_br_rs,Sete de Setembro
+city_br_5077,base.br,base.state_br_ms,Sete Quedas
+city_br_5078,base.br,base.state_br_mg,Setubinha
+city_br_5079,base.br,base.state_br_rs,Severiano de Almeida
+city_br_5080,base.br,base.state_br_rn,Severiano Melo
+city_br_5081,base.br,base.state_br_sp,Severínia
+city_br_5082,base.br,base.state_br_sc,Siderópolis
+city_br_5083,base.br,base.state_br_ms,Sidrolândia
+city_br_5084,base.br,base.state_br_pi,Sigefredo Pacheco
+city_br_5085,base.br,base.state_br_rj,Silva Jardim
+city_br_5086,base.br,base.state_br_go,Silvânia
+city_br_5087,base.br,base.state_br_to,Silvanópolis
+city_br_5088,base.br,base.state_br_rs,Silveira Martins
+city_br_5089,base.br,base.state_br_mg,Silveirânia
+city_br_5090,base.br,base.state_br_sp,Silveiras
+city_br_5091,base.br,base.state_br_am,Silves
+city_br_5092,base.br,base.state_br_mg,Silvianópolis
+city_br_5093,base.br,base.state_br_se,Simão Dias
+city_br_5094,base.br,base.state_br_mg,Simão Pereira
+city_br_5095,base.br,base.state_br_pi,Simões
+city_br_5096,base.br,base.state_br_go,Simolândia
+city_br_5097,base.br,base.state_br_mg,Simonésia
+city_br_5098,base.br,base.state_br_pi,Simplício Mendes
+city_br_5099,base.br,base.state_br_rs,Sinimbu
+city_br_5100,base.br,base.state_br_pr,Siqueira Campos
+city_br_5101,base.br,base.state_br_pe,Sirinhaém
+city_br_5102,base.br,base.state_br_se,Siriri
+city_br_5103,base.br,base.state_br_go,Sítio d'Abadia
+city_br_5104,base.br,base.state_br_ba,Sítio do Mato
+city_br_5105,base.br,base.state_br_ba,Sítio do Quinto
+city_br_5106,base.br,base.state_br_ma,Sítio Novo
+city_br_5107,base.br,base.state_br_rn,Sítio Novo
+city_br_5108,base.br,base.state_br_to,Sítio Novo do Tocantins
+city_br_5109,base.br,base.state_br_ba,Sobradinho
+city_br_5110,base.br,base.state_br_rs,Sobradinho
+city_br_5111,base.br,base.state_br_pb,Sobrado
+city_br_5112,base.br,base.state_br_mg,Sobrália
+city_br_5113,base.br,base.state_br_sp,Socorro
+city_br_5114,base.br,base.state_br_pi,Socorro do Piauí
+city_br_5115,base.br,base.state_br_pb,Solânea
+city_br_5116,base.br,base.state_br_pb,Soledade
+city_br_5117,base.br,base.state_br_rs,Soledade
+city_br_5118,base.br,base.state_br_mg,Soledade de Minas
+city_br_5119,base.br,base.state_br_pe,Solidão
+city_br_5120,base.br,base.state_br_ce,Solonópole
+city_br_5121,base.br,base.state_br_sc,Sombrio
+city_br_5122,base.br,base.state_br_ms,Sonora
+city_br_5123,base.br,base.state_br_es,Sooretama
+city_br_5124,base.br,base.state_br_pb,Sossêgo
+city_br_5125,base.br,base.state_br_pa,Soure
+city_br_5126,base.br,base.state_br_pb,Sousa
+city_br_5127,base.br,base.state_br_ba,Souto Soares
+city_br_5128,base.br,base.state_br_to,Sucupira
+city_br_5129,base.br,base.state_br_ma,Sucupira do Norte
+city_br_5130,base.br,base.state_br_ma,Sucupira do Riachão
+city_br_5131,base.br,base.state_br_sp,Sud Mennucci
+city_br_5132,base.br,base.state_br_sc,Sul Brasil
+city_br_5133,base.br,base.state_br_pr,Sulina
+city_br_5134,base.br,base.state_br_pb,Sumé
+city_br_5135,base.br,base.state_br_rj,Sumidouro
+city_br_5136,base.br,base.state_br_pe,Surubim
+city_br_5137,base.br,base.state_br_pi,Sussuapara
+city_br_5138,base.br,base.state_br_sp,Suzanápolis
+city_br_5139,base.br,base.state_br_rs,Tabaí
+city_br_5140,base.br,base.state_br_mt,Tabaporã
+city_br_5141,base.br,base.state_br_sp,Tabapuã
+city_br_5142,base.br,base.state_br_am,Tabatinga
+city_br_5143,base.br,base.state_br_sp,Tabatinga
+city_br_5144,base.br,base.state_br_pe,Tabira
+city_br_5145,base.br,base.state_br_ba,Tabocas do Brejo Velho
+city_br_5146,base.br,base.state_br_rn,Taboleiro Grande
+city_br_5147,base.br,base.state_br_mg,Tabuleiro
+city_br_5148,base.br,base.state_br_ce,Tabuleiro do Norte
+city_br_5149,base.br,base.state_br_pe,Tacaimbó
+city_br_5150,base.br,base.state_br_pe,Tacaratu
+city_br_5151,base.br,base.state_br_sp,Taciba
+city_br_5152,base.br,base.state_br_pb,Tacima
+city_br_5153,base.br,base.state_br_ms,Tacuru
+city_br_5154,base.br,base.state_br_sp,Taguaí
+city_br_5155,base.br,base.state_br_to,Taguatinga
+city_br_5156,base.br,base.state_br_sp,Taiaçu
+city_br_5157,base.br,base.state_br_pa,Tailândia
+city_br_5158,base.br,base.state_br_sc,Taió
+city_br_5159,base.br,base.state_br_mg,Taiobeiras
+city_br_5160,base.br,base.state_br_to,Taipas do Tocantins
+city_br_5161,base.br,base.state_br_rn,Taipu
+city_br_5162,base.br,base.state_br_sp,Taiúva
+city_br_5163,base.br,base.state_br_to,Talismã
+city_br_5164,base.br,base.state_br_pe,Tamandaré
+city_br_5165,base.br,base.state_br_pr,Tamarana
+city_br_5166,base.br,base.state_br_sp,Tambaú
+city_br_5167,base.br,base.state_br_pr,Tamboara
+city_br_5168,base.br,base.state_br_ce,Tamboril
+city_br_5169,base.br,base.state_br_pi,Tamboril do Piauí
+city_br_5170,base.br,base.state_br_sp,Tanabi
+city_br_5171,base.br,base.state_br_rn,Tangará
+city_br_5172,base.br,base.state_br_sc,Tangará
+city_br_5173,base.br,base.state_br_rj,Tanguá
+city_br_5174,base.br,base.state_br_ba,Tanhaçu
+city_br_5175,base.br,base.state_br_al,Tanque d'Arca
+city_br_5176,base.br,base.state_br_pi,Tanque do Piauí
+city_br_5177,base.br,base.state_br_ba,Tanque Novo
+city_br_5178,base.br,base.state_br_ba,Tanquinho
+city_br_5179,base.br,base.state_br_mg,Taparuba
+city_br_5180,base.br,base.state_br_am,Tapauá
+city_br_5181,base.br,base.state_br_pr,Tapejara
+city_br_5182,base.br,base.state_br_rs,Tapejara
+city_br_5183,base.br,base.state_br_rs,Tapera
+city_br_5184,base.br,base.state_br_ba,Taperoá
+city_br_5185,base.br,base.state_br_pb,Taperoá
+city_br_5186,base.br,base.state_br_rs,Tapes
+city_br_5187,base.br,base.state_br_mg,Tapira
+city_br_5188,base.br,base.state_br_pr,Tapira
+city_br_5189,base.br,base.state_br_mg,Tapiraí
+city_br_5190,base.br,base.state_br_sp,Tapiraí
+city_br_5191,base.br,base.state_br_ba,Tapiramutá
+city_br_5192,base.br,base.state_br_sp,Tapiratiba
+city_br_5193,base.br,base.state_br_mt,Tapurah
+city_br_5194,base.br,base.state_br_rs,Taquara
+city_br_5195,base.br,base.state_br_mg,Taquaraçu de Minas
+city_br_5196,base.br,base.state_br_sp,Taquaral
+city_br_5197,base.br,base.state_br_go,Taquaral de Goiás
+city_br_5198,base.br,base.state_br_al,Taquarana
+city_br_5199,base.br,base.state_br_rs,Taquari
+city_br_5200,base.br,base.state_br_sp,Taquaritinga
+city_br_5201,base.br,base.state_br_pe,Taquaritinga do Norte
+city_br_5202,base.br,base.state_br_sp,Taquarituba
+city_br_5203,base.br,base.state_br_sp,Taquarivaí
+city_br_5204,base.br,base.state_br_rs,Taquaruçu do Sul
+city_br_5205,base.br,base.state_br_ms,Taquarussu
+city_br_5206,base.br,base.state_br_sp,Tarabai
+city_br_5207,base.br,base.state_br_ac,Tarauacá
+city_br_5208,base.br,base.state_br_ce,Tarrafas
+city_br_5209,base.br,base.state_br_ap,Tartarugalzinho
+city_br_5210,base.br,base.state_br_sp,Tarumã
+city_br_5211,base.br,base.state_br_mg,Tarumirim
+city_br_5212,base.br,base.state_br_ma,Tasso Fragoso
+city_br_5213,base.br,base.state_br_ce,Tauá
+city_br_5214,base.br,base.state_br_pb,Tavares
+city_br_5215,base.br,base.state_br_rs,Tavares
+city_br_5216,base.br,base.state_br_am,Tefé
+city_br_5217,base.br,base.state_br_pb,Teixeira
+city_br_5218,base.br,base.state_br_pr,Teixeira Soares
+city_br_5219,base.br,base.state_br_mg,Teixeiras
+city_br_5220,base.br,base.state_br_ro,Teixeirópolis
+city_br_5221,base.br,base.state_br_ce,Tejuçuoca
+city_br_5222,base.br,base.state_br_sp,Tejupá
+city_br_5223,base.br,base.state_br_pr,Telêmaco Borba
+city_br_5224,base.br,base.state_br_se,Telha
+city_br_5225,base.br,base.state_br_rn,Tenente Ananias
+city_br_5226,base.br,base.state_br_rn,Tenente Laurentino Cruz
+city_br_5227,base.br,base.state_br_rs,Tenente Portela
+city_br_5228,base.br,base.state_br_pb,Tenório
+city_br_5229,base.br,base.state_br_ba,Teodoro Sampaio
+city_br_5230,base.br,base.state_br_sp,Teodoro Sampaio
+city_br_5231,base.br,base.state_br_ba,Teofilândia
+city_br_5232,base.br,base.state_br_ba,Teolândia
+city_br_5233,base.br,base.state_br_al,Teotônio Vilela
+city_br_5234,base.br,base.state_br_ms,Terenos
+city_br_5235,base.br,base.state_br_go,Teresina de Goiás
+city_br_5236,base.br,base.state_br_pe,Terezinha
+city_br_5237,base.br,base.state_br_go,Terezópolis de Goiás
+city_br_5238,base.br,base.state_br_pa,Terra Alta
+city_br_5239,base.br,base.state_br_pr,Terra Boa
+city_br_5240,base.br,base.state_br_rs,Terra de Areia
+city_br_5241,base.br,base.state_br_ba,Terra Nova
+city_br_5242,base.br,base.state_br_pe,Terra Nova
+city_br_5243,base.br,base.state_br_mt,Terra Nova do Norte
+city_br_5244,base.br,base.state_br_pr,Terra Rica
+city_br_5245,base.br,base.state_br_pr,Terra Roxa
+city_br_5246,base.br,base.state_br_sp,Terra Roxa
+city_br_5247,base.br,base.state_br_pa,Terra Santa
+city_br_5248,base.br,base.state_br_mt,Tesouro
+city_br_5249,base.br,base.state_br_rs,Teutônia
+city_br_5250,base.br,base.state_br_ro,Theobroma
+city_br_5251,base.br,base.state_br_ce,Tianguá
+city_br_5252,base.br,base.state_br_pr,Tibagi
+city_br_5253,base.br,base.state_br_rn,Tibau
+city_br_5254,base.br,base.state_br_rn,Tibau do Sul
+city_br_5255,base.br,base.state_br_sp,Tietê
+city_br_5256,base.br,base.state_br_sc,Tigrinhos
+city_br_5257,base.br,base.state_br_sc,Tijucas
+city_br_5258,base.br,base.state_br_pr,Tijucas do Sul
+city_br_5259,base.br,base.state_br_pe,Timbaúba
+city_br_5260,base.br,base.state_br_rn,Timbaúba dos Batistas
+city_br_5261,base.br,base.state_br_sc,Timbé do Sul
+city_br_5262,base.br,base.state_br_ma,Timbiras
+city_br_5263,base.br,base.state_br_sc,Timbó
+city_br_5264,base.br,base.state_br_sc,Timbó Grande
+city_br_5265,base.br,base.state_br_sp,Timburi
+city_br_5266,base.br,base.state_br_mg,Timóteo
+city_br_5267,base.br,base.state_br_rs,Tio Hugo
+city_br_5268,base.br,base.state_br_mg,Tiradentes
+city_br_5269,base.br,base.state_br_rs,Tiradentes do Sul
+city_br_5270,base.br,base.state_br_mg,Tiros
+city_br_5271,base.br,base.state_br_se,Tobias Barreto
+city_br_5272,base.br,base.state_br_to,Tocantínia
+city_br_5273,base.br,base.state_br_to,Tocantinópolis
+city_br_5274,base.br,base.state_br_mg,Tocantins
+city_br_5275,base.br,base.state_br_mg,Tocos do Moji
+city_br_5276,base.br,base.state_br_mg,Toledo
+city_br_5277,base.br,base.state_br_se,Tomar do Geru
+city_br_5278,base.br,base.state_br_pr,Tomazina
+city_br_5279,base.br,base.state_br_mg,Tombos
+city_br_5280,base.br,base.state_br_pa,Tomé-Açu
+city_br_5281,base.br,base.state_br_am,Tonantins
+city_br_5282,base.br,base.state_br_pe,Toritama
+city_br_5283,base.br,base.state_br_mt,Torixoréu
+city_br_5284,base.br,base.state_br_rs,Toropi
+city_br_5285,base.br,base.state_br_sp,Torre de Pedra
+city_br_5286,base.br,base.state_br_rs,Torres
+city_br_5287,base.br,base.state_br_sp,Torrinha
+city_br_5288,base.br,base.state_br_rn,Touros
+city_br_5289,base.br,base.state_br_sp,Trabiju
+city_br_5290,base.br,base.state_br_pa,Tracuateua
+city_br_5291,base.br,base.state_br_pe,Tracunhaém
+city_br_5292,base.br,base.state_br_al,Traipu
+city_br_5293,base.br,base.state_br_pa,Trairão
+city_br_5294,base.br,base.state_br_ce,Trairi
+city_br_5295,base.br,base.state_br_rj,Trajano de Moraes
+city_br_5296,base.br,base.state_br_rs,Tramandaí
+city_br_5297,base.br,base.state_br_rs,Travesseiro
+city_br_5298,base.br,base.state_br_ba,Tremedal
+city_br_5299,base.br,base.state_br_sp,Tremembé
+city_br_5300,base.br,base.state_br_rs,Três Arroios
+city_br_5301,base.br,base.state_br_sc,Três Barras
+city_br_5302,base.br,base.state_br_pr,Três Barras do Paraná
+city_br_5303,base.br,base.state_br_rs,Três Cachoeiras
+city_br_5304,base.br,base.state_br_mg,Três Corações
+city_br_5305,base.br,base.state_br_rs,Três Coroas
+city_br_5306,base.br,base.state_br_rs,Três de Maio
+city_br_5307,base.br,base.state_br_rs,Três Forquilhas
+city_br_5308,base.br,base.state_br_sp,Três Fronteiras
+city_br_5309,base.br,base.state_br_mg,Três Marias
+city_br_5310,base.br,base.state_br_rs,Três Palmeiras
+city_br_5311,base.br,base.state_br_rs,Três Passos
+city_br_5312,base.br,base.state_br_mg,Três Pontas
+city_br_5313,base.br,base.state_br_go,Três Ranchos
+city_br_5314,base.br,base.state_br_rj,Três Rios
+city_br_5315,base.br,base.state_br_sc,Treviso
+city_br_5316,base.br,base.state_br_sc,Treze de Maio
+city_br_5317,base.br,base.state_br_sc,Treze Tílias
+city_br_5318,base.br,base.state_br_pe,Trindade
+city_br_5319,base.br,base.state_br_rs,Trindade do Sul
+city_br_5320,base.br,base.state_br_pb,Triunfo
+city_br_5321,base.br,base.state_br_pe,Triunfo
+city_br_5322,base.br,base.state_br_rs,Triunfo
+city_br_5323,base.br,base.state_br_rn,Triunfo Potiguar
+city_br_5324,base.br,base.state_br_ma,Trizidela do Vale
+city_br_5325,base.br,base.state_br_go,Trombas
+city_br_5326,base.br,base.state_br_sc,Trombudo Central
+city_br_5327,base.br,base.state_br_ba,Tucano
+city_br_5328,base.br,base.state_br_pa,Tucumã
+city_br_5329,base.br,base.state_br_rs,Tucunduva
+city_br_5330,base.br,base.state_br_pa,Tucuruí
+city_br_5331,base.br,base.state_br_ma,Tufilândia
+city_br_5332,base.br,base.state_br_sp,Tuiuti
+city_br_5333,base.br,base.state_br_mg,Tumiritinga
+city_br_5334,base.br,base.state_br_sc,Tunápolis
+city_br_5335,base.br,base.state_br_rs,Tunas
+city_br_5336,base.br,base.state_br_pr,Tunas do Paraná
+city_br_5337,base.br,base.state_br_pr,Tuneiras do Oeste
+city_br_5338,base.br,base.state_br_ma,Tuntum
+city_br_5339,base.br,base.state_br_sp,Tupã
+city_br_5340,base.br,base.state_br_mg,Tupaciguara
+city_br_5341,base.br,base.state_br_pe,Tupanatinga
+city_br_5342,base.br,base.state_br_rs,Tupanci do Sul
+city_br_5343,base.br,base.state_br_rs,Tupanciretã
+city_br_5344,base.br,base.state_br_rs,Tupandi
+city_br_5345,base.br,base.state_br_rs,Tuparendi
+city_br_5346,base.br,base.state_br_pe,Tuparetama
+city_br_5347,base.br,base.state_br_pr,Tupãssi
+city_br_5348,base.br,base.state_br_sp,Tupi Paulista
+city_br_5349,base.br,base.state_br_to,Tupirama
+city_br_5350,base.br,base.state_br_to,Tupiratins
+city_br_5351,base.br,base.state_br_ma,Turiaçu
+city_br_5352,base.br,base.state_br_ma,Turilândia
+city_br_5353,base.br,base.state_br_sp,Turiúba
+city_br_5354,base.br,base.state_br_mg,Turmalina
+city_br_5355,base.br,base.state_br_sp,Turmalina
+city_br_5356,base.br,base.state_br_rs,Turuçu
+city_br_5357,base.br,base.state_br_ce,Tururu
+city_br_5358,base.br,base.state_br_go,Turvânia
+city_br_5359,base.br,base.state_br_go,Turvelândia
+city_br_5360,base.br,base.state_br_pr,Turvo
+city_br_5361,base.br,base.state_br_sc,Turvo
+city_br_5362,base.br,base.state_br_mg,Turvolândia
+city_br_5363,base.br,base.state_br_ma,Tutóia
+city_br_5364,base.br,base.state_br_am,Uarini
+city_br_5365,base.br,base.state_br_ba,Uauá
+city_br_5366,base.br,base.state_br_mg,Ubaí
+city_br_5367,base.br,base.state_br_ba,Ubaíra
+city_br_5368,base.br,base.state_br_ba,Ubaitaba
+city_br_5369,base.br,base.state_br_ce,Ubajara
+city_br_5370,base.br,base.state_br_mg,Ubaporanga
+city_br_5371,base.br,base.state_br_sp,Ubarana
+city_br_5372,base.br,base.state_br_ba,Ubatã
+city_br_5373,base.br,base.state_br_sp,Ubatuba
+city_br_5374,base.br,base.state_br_sp,Ubirajara
+city_br_5375,base.br,base.state_br_pr,Ubiratã
+city_br_5376,base.br,base.state_br_rs,Ubiretama
+city_br_5377,base.br,base.state_br_sp,Uchoa
+city_br_5378,base.br,base.state_br_ba,Uibaí
+city_br_5379,base.br,base.state_br_rr,Uiramutã
+city_br_5380,base.br,base.state_br_go,Uirapuru
+city_br_5381,base.br,base.state_br_pb,Uiraúna
+city_br_5382,base.br,base.state_br_pa,Ulianópolis
+city_br_5383,base.br,base.state_br_ce,Umari
+city_br_5384,base.br,base.state_br_rn,Umarizal
+city_br_5385,base.br,base.state_br_se,Umbaúba
+city_br_5386,base.br,base.state_br_ba,Umburanas
+city_br_5387,base.br,base.state_br_mg,Umburatiba
+city_br_5388,base.br,base.state_br_pb,Umbuzeiro
+city_br_5389,base.br,base.state_br_ce,Umirim
+city_br_5390,base.br,base.state_br_ba,Una
+city_br_5391,base.br,base.state_br_mg,Unaí
+city_br_5392,base.br,base.state_br_pi,União
+city_br_5393,base.br,base.state_br_rs,União da Serra
+city_br_5394,base.br,base.state_br_pr,União da Vitória
+city_br_5395,base.br,base.state_br_mg,União de Minas
+city_br_5396,base.br,base.state_br_sc,União do Oeste
+city_br_5397,base.br,base.state_br_mt,União do Sul
+city_br_5398,base.br,base.state_br_al,União dos Palmares
+city_br_5399,base.br,base.state_br_sp,União Paulista
+city_br_5400,base.br,base.state_br_pr,Uniflor
+city_br_5401,base.br,base.state_br_rs,Unistalda
+city_br_5402,base.br,base.state_br_rn,Upanema
+city_br_5403,base.br,base.state_br_pr,Uraí
+city_br_5404,base.br,base.state_br_ba,Urandi
+city_br_5405,base.br,base.state_br_sp,Urânia
+city_br_5406,base.br,base.state_br_ma,Urbano Santos
+city_br_5407,base.br,base.state_br_sp,Uru
+city_br_5408,base.br,base.state_br_go,Uruaçu
+city_br_5409,base.br,base.state_br_go,Uruana
+city_br_5410,base.br,base.state_br_mg,Uruana de Minas
+city_br_5411,base.br,base.state_br_pa,Uruará
+city_br_5412,base.br,base.state_br_sc,Urubici
+city_br_5413,base.br,base.state_br_ce,Uruburetama
+city_br_5414,base.br,base.state_br_mg,Urucânia
+city_br_5415,base.br,base.state_br_am,Urucará
+city_br_5416,base.br,base.state_br_ba,Uruçuca
+city_br_5417,base.br,base.state_br_pi,Uruçuí
+city_br_5418,base.br,base.state_br_mg,Urucuia
+city_br_5419,base.br,base.state_br_am,Urucurituba
+city_br_5420,base.br,base.state_br_ce,Uruoca
+city_br_5421,base.br,base.state_br_ro,Urupá
+city_br_5422,base.br,base.state_br_sc,Urupema
+city_br_5423,base.br,base.state_br_sp,Urupês
+city_br_5424,base.br,base.state_br_sc,Urussanga
+city_br_5425,base.br,base.state_br_go,Urutaí
+city_br_5426,base.br,base.state_br_ba,Utinga
+city_br_5427,base.br,base.state_br_rs,Vacaria
+city_br_5428,base.br,base.state_br_mt,Vale de São Domingos
+city_br_5429,base.br,base.state_br_ro,Vale do Anari
+city_br_5430,base.br,base.state_br_ro,Vale do Paraíso
+city_br_5431,base.br,base.state_br_rs,Vale do Sol
+city_br_5432,base.br,base.state_br_rs,Vale Real
+city_br_5433,base.br,base.state_br_rs,Vale Verde
+city_br_5434,base.br,base.state_br_ba,Valença
+city_br_5435,base.br,base.state_br_rj,Valença
+city_br_5436,base.br,base.state_br_pi,Valença do Piauí
+city_br_5437,base.br,base.state_br_ba,Valente
+city_br_5438,base.br,base.state_br_sp,Valentim Gentil
+city_br_5439,base.br,base.state_br_sp,Valparaíso
+city_br_5440,base.br,base.state_br_rs,Vanini
+city_br_5441,base.br,base.state_br_sc,Vargeão
+city_br_5442,base.br,base.state_br_sc,Vargem
+city_br_5443,base.br,base.state_br_sp,Vargem
+city_br_5444,base.br,base.state_br_mg,Vargem Alegre
+city_br_5445,base.br,base.state_br_es,Vargem Alta
+city_br_5446,base.br,base.state_br_mg,Vargem Bonita
+city_br_5447,base.br,base.state_br_sc,Vargem Bonita
+city_br_5448,base.br,base.state_br_ma,Vargem Grande
+city_br_5449,base.br,base.state_br_mg,Vargem Grande do Rio Pardo
+city_br_5450,base.br,base.state_br_sp,Vargem Grande do Sul
+city_br_5451,base.br,base.state_br_sp,Vargem Grande Paulista
+city_br_5452,base.br,base.state_br_go,Varjão
+city_br_5453,base.br,base.state_br_mg,Varjão de Minas
+city_br_5454,base.br,base.state_br_ce,Varjota
+city_br_5455,base.br,base.state_br_rj,Varre-Sai
+city_br_5456,base.br,base.state_br_pb,Várzea
+city_br_5457,base.br,base.state_br_rn,Várzea
+city_br_5458,base.br,base.state_br_ce,Várzea Alegre
+city_br_5459,base.br,base.state_br_pi,Várzea Branca
+city_br_5460,base.br,base.state_br_mg,Várzea da Palma
+city_br_5461,base.br,base.state_br_ba,Várzea da Roça
+city_br_5462,base.br,base.state_br_ba,Várzea do Poço
+city_br_5463,base.br,base.state_br_pi,Várzea Grande
+city_br_5464,base.br,base.state_br_ba,Várzea Nova
+city_br_5465,base.br,base.state_br_ba,Varzedo
+city_br_5466,base.br,base.state_br_mg,Varzelândia
+city_br_5467,base.br,base.state_br_rj,Vassouras
+city_br_5468,base.br,base.state_br_mg,Vazante
+city_br_5469,base.br,base.state_br_rs,Venâncio Aires
+city_br_5470,base.br,base.state_br_es,Venda Nova do Imigrante
+city_br_5471,base.br,base.state_br_rn,Venha-Ver
+city_br_5472,base.br,base.state_br_pr,Ventania
+city_br_5473,base.br,base.state_br_pe,Venturosa
+city_br_5474,base.br,base.state_br_mt,Vera
+city_br_5475,base.br,base.state_br_ba,Vera Cruz
+city_br_5476,base.br,base.state_br_rn,Vera Cruz
+city_br_5477,base.br,base.state_br_rs,Vera Cruz
+city_br_5478,base.br,base.state_br_sp,Vera Cruz
+city_br_5479,base.br,base.state_br_pr,Vera Cruz do Oeste
+city_br_5480,base.br,base.state_br_pi,Vera Mendes
+city_br_5481,base.br,base.state_br_rs,Veranópolis
+city_br_5482,base.br,base.state_br_pe,Verdejante
+city_br_5483,base.br,base.state_br_mg,Verdelândia
+city_br_5484,base.br,base.state_br_pr,Verê
+city_br_5485,base.br,base.state_br_ba,Vereda
+city_br_5486,base.br,base.state_br_mg,Veredinha
+city_br_5487,base.br,base.state_br_mg,Veríssimo
+city_br_5488,base.br,base.state_br_mg,Vermelho Novo
+city_br_5489,base.br,base.state_br_pe,Vertente do Lério
+city_br_5490,base.br,base.state_br_pe,Vertentes
+city_br_5491,base.br,base.state_br_rs,Vespasiano Corrêa
+city_br_5492,base.br,base.state_br_rs,Viadutos
+city_br_5493,base.br,base.state_br_es,Viana
+city_br_5494,base.br,base.state_br_ma,Viana
+city_br_5495,base.br,base.state_br_go,Vianópolis
+city_br_5496,base.br,base.state_br_pe,Vicência
+city_br_5497,base.br,base.state_br_rs,Vicente Dutra
+city_br_5498,base.br,base.state_br_ms,Vicentina
+city_br_5499,base.br,base.state_br_go,Vicentinópolis
+city_br_5500,base.br,base.state_br_al,Viçosa
+city_br_5501,base.br,base.state_br_mg,Viçosa
+city_br_5502,base.br,base.state_br_rn,Viçosa
+city_br_5503,base.br,base.state_br_ce,Viçosa do Ceará
+city_br_5504,base.br,base.state_br_rs,Victor Graeff
+city_br_5505,base.br,base.state_br_sc,Vidal Ramos
+city_br_5506,base.br,base.state_br_sc,Videira
+city_br_5507,base.br,base.state_br_mg,Vieiras
+city_br_5508,base.br,base.state_br_pb,Vieirópolis
+city_br_5509,base.br,base.state_br_pa,Vigia
+city_br_5510,base.br,base.state_br_mt,Vila Bela da Santíssima Trindade
+city_br_5511,base.br,base.state_br_go,Vila Boa
+city_br_5512,base.br,base.state_br_rn,Vila Flor
+city_br_5513,base.br,base.state_br_rs,Vila Flores
+city_br_5514,base.br,base.state_br_rs,Vila Lângaro
+city_br_5515,base.br,base.state_br_rs,Vila Maria
+city_br_5516,base.br,base.state_br_pi,Vila Nova do Piauí
+city_br_5517,base.br,base.state_br_rs,Vila Nova do Sul
+city_br_5518,base.br,base.state_br_ma,Vila Nova dos Martírios
+city_br_5519,base.br,base.state_br_es,Vila Pavão
+city_br_5520,base.br,base.state_br_go,Vila Propício
+city_br_5521,base.br,base.state_br_mt,Vila Rica
+city_br_5522,base.br,base.state_br_es,Vila Valério
+city_br_5523,base.br,base.state_br_ro,Vilhena
+city_br_5524,base.br,base.state_br_sp,Vinhedo
+city_br_5525,base.br,base.state_br_sp,Viradouro
+city_br_5526,base.br,base.state_br_mg,Virgem da Lapa
+city_br_5527,base.br,base.state_br_mg,Virgínia
+city_br_5528,base.br,base.state_br_mg,Virginópolis
+city_br_5529,base.br,base.state_br_mg,Virgolândia
+city_br_5530,base.br,base.state_br_pr,Virmond
+city_br_5531,base.br,base.state_br_mg,Visconde do Rio Branco
+city_br_5532,base.br,base.state_br_pa,Viseu
+city_br_5533,base.br,base.state_br_rs,Vista Alegre
+city_br_5534,base.br,base.state_br_sp,Vista Alegre do Alto
+city_br_5535,base.br,base.state_br_rs,Vista Alegre do Prata
+city_br_5536,base.br,base.state_br_rs,Vista Gaúcha
+city_br_5537,base.br,base.state_br_pb,Vista Serrana
+city_br_5538,base.br,base.state_br_sc,Vitor Meireles
+city_br_5539,base.br,base.state_br_sp,Vitória Brasil
+city_br_5540,base.br,base.state_br_rs,Vitória das Missões
+city_br_5541,base.br,base.state_br_ap,Vitória do Jari
+city_br_5542,base.br,base.state_br_ma,Vitória do Mearim
+city_br_5543,base.br,base.state_br_pa,Vitória do Xingu
+city_br_5544,base.br,base.state_br_pr,Vitorino
+city_br_5545,base.br,base.state_br_ma,Vitorino Freire
+city_br_5546,base.br,base.state_br_mg,Volta Grande
+city_br_5547,base.br,base.state_br_sp,Votuporanga
+city_br_5548,base.br,base.state_br_ba,Wagner
+city_br_5549,base.br,base.state_br_pi,Wall Ferraz
+city_br_5550,base.br,base.state_br_to,Wanderlândia
+city_br_5551,base.br,base.state_br_ba,Wanderley
+city_br_5552,base.br,base.state_br_mg,Wenceslau Braz
+city_br_5553,base.br,base.state_br_pr,Wenceslau Braz
+city_br_5554,base.br,base.state_br_ba,Wenceslau Guimarães
+city_br_5555,base.br,base.state_br_rs,Westfália
+city_br_5556,base.br,base.state_br_sc,Witmarsum
+city_br_5557,base.br,base.state_br_to,Xambioá
+city_br_5558,base.br,base.state_br_pr,Xambrê
+city_br_5559,base.br,base.state_br_rs,Xangri-lá
+city_br_5560,base.br,base.state_br_sc,Xanxerê
+city_br_5561,base.br,base.state_br_ac,Xapuri
+city_br_5562,base.br,base.state_br_sc,Xavantina
+city_br_5563,base.br,base.state_br_sc,Xaxim
+city_br_5564,base.br,base.state_br_pe,Xexéu
+city_br_5565,base.br,base.state_br_pa,Xinguara
+city_br_5566,base.br,base.state_br_ba,Xique-Xique
+city_br_5567,base.br,base.state_br_pb,Zabelê
+city_br_5568,base.br,base.state_br_sp,Zacarias
+city_br_5569,base.br,base.state_br_ma,Zé Doca
+city_br_5570,base.br,base.state_br_sc,Zortéa

--- a/addons/l10n_br/i18n/l10n_br.pot
+++ b/addons/l10n_br/i18n/l10n_br.pot
@@ -4,16 +4,143 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0\n"
+"Project-Id-Version: Odoo Server 17.5alpha1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-03 12:22+0000\n"
-"PO-Revision-Date: 2023-01-03 12:22+0000\n"
+"POT-Creation-Date: 2024-09-18 23:21+0000\n"
+"PO-Revision-Date: 2024-09-18 23:21+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: l10n_br
+#. odoo-python
+#: code:addons/l10n_br/models/res_partner_bank.py:0
+msgid "%s is not a valid CPF or CNPJ (don't include periods or dashes)."
+msgstr ""
+
+#. module: l10n_br
+#. odoo-python
+#: code:addons/l10n_br/models/res_partner_bank.py:0
+msgid "%s is not a valid email."
+msgstr ""
+
+#. module: l10n_br
+#: model_terms:ir.ui.view,arch_db:l10n_br.br_partner_address_form
+msgid "<span> - </span>"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_320
+msgid "Abadia de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_321
+msgid "Abadia dos Dourados"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_322
+msgid "Abadiânia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_190
+msgid "Abaetetuba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_323
+msgid "Abaeté"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_324
+msgid "Abaiara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_326
+msgid "Abaré"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_327
+msgid "Abatiá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_325
+msgid "Abaíra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_328
+msgid "Abdon Batista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_329
+msgid "Abel Figueiredo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_330
+msgid "Abelardo Luz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_331
+msgid "Abre Campo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_332
+msgid "Abreu e Lima"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_333
+msgid "Abreulândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_334
+msgid "Acaiaca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_335
+msgid "Acajutiba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_337
+msgid "Acarape"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_338
+msgid "Acaraú"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_339
+msgid "Acari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_336
+msgid "Acará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_340
+msgid "Acauã"
+msgstr ""
 
 #. module: l10n_br
 #: model:ir.model,name:l10n_br.model_account_chart_template
@@ -26,8 +153,1967 @@ msgid "Account Move Reversal"
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_341
+msgid "Aceguá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_342
+msgid "Acopiara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_343
+msgid "Acorizal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_344
+msgid "Acrelândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_345
+msgid "Acreúna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_348
+msgid "Adamantina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_349
+msgid "Adelândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_350
+msgid "Adolfo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_351
+msgid "Adrianópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_352
+msgid "Adustina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_353
+msgid "Afogados da Ingazeira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_354
+msgid "Afonso Bezerra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_355
+msgid "Afonso Cláudio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_356
+msgid "Afonso Cunha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_357
+msgid "Afrânio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_358
+msgid "Afuá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_359
+msgid "Agrestina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_360
+msgid "Agricolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_361
+msgid "Agrolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_362
+msgid "Agronômica"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_381
+msgid "Aguanil"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_380
+msgid "Aguaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_392
+msgid "Agudo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_393
+msgid "Agudos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_394
+msgid "Agudos do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_396
+msgid "Aguiar"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_397
+msgid "Aguiarnópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_398
+msgid "Aimorés"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_399
+msgid "Aiquara"
+msgstr ""
+
+#. module: l10n_br
 #: model:l10n_latam.document.type,name:l10n_br.dt_10
 msgid "Aircraft Knowledge"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_400
+msgid "Aiuaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_401
+msgid "Aiuruoca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_402
+msgid "Ajuricaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_403
+msgid "Alagoa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_404
+msgid "Alagoa Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_405
+msgid "Alagoa Nova"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_406
+#: model:res.city,name:l10n_br.city_br_407
+msgid "Alagoinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_408
+msgid "Alagoinha do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_199
+msgid "Alagoinhas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_409
+msgid "Alambari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_410
+msgid "Albertina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_413
+msgid "Alcantil"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_414
+msgid "Alcinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_415
+msgid "Alcobaça"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_411
+msgid "Alcântara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_412
+msgid "Alcântaras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_416
+msgid "Aldeias Altas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_417
+msgid "Alecrim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_418
+msgid "Alegre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_419
+msgid "Alegrete"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_420
+msgid "Alegrete do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_421
+msgid "Alegria"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_423
+msgid "Alenquer"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_424
+msgid "Alexandria"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_425
+msgid "Alexânia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_426
+msgid "Alfenas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_427
+msgid "Alfredo Chaves"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_428
+msgid "Alfredo Marcondes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_429
+msgid "Alfredo Vasconcelos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_430
+msgid "Alfredo Wagner"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_431
+msgid "Algodão de Jandaíra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_432
+msgid "Alhandra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_433
+msgid "Aliança"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_434
+msgid "Aliança do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_435
+msgid "Almadina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_436
+msgid "Almas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_437
+msgid "Almeirim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_438
+msgid "Almenara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_439
+msgid "Almino Afonso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_253
+msgid "Almirante Tamandaré"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_440
+msgid "Almirante Tamandaré do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_441
+msgid "Aloândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_442
+msgid "Alpercata"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_443
+msgid "Alpestre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_444
+msgid "Alpinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_445
+msgid "Alta Floresta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_446
+msgid "Alta Floresta D'Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_447
+msgid "Altair"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_241
+msgid "Altamira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_448
+msgid "Altamira do Maranhão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_449
+msgid "Altamira do Paraná"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_450
+msgid "Altaneira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_451
+msgid "Alterosa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_452
+msgid "Altinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_453
+msgid "Altinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_454
+#: model:res.city,name:l10n_br.city_br_455
+#: model:res.city,name:l10n_br.city_br_456
+msgid "Alto Alegre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_457
+msgid "Alto Alegre do Maranhão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_458
+msgid "Alto Alegre do Pindaré"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_459
+msgid "Alto Alegre dos Parecis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_460
+msgid "Alto Araguaia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_461
+msgid "Alto Bela Vista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_462
+msgid "Alto Boa Vista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_463
+msgid "Alto Caparaó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_465
+msgid "Alto Feliz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_466
+msgid "Alto Garças"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_467
+msgid "Alto Horizonte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_468
+msgid "Alto Jequitibá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_469
+msgid "Alto Longá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_470
+msgid "Alto Paraguai"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_474
+msgid "Alto Paraná"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_471
+#: model:res.city,name:l10n_br.city_br_472
+msgid "Alto Paraíso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_473
+msgid "Alto Paraíso de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_475
+msgid "Alto Parnaíba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_476
+msgid "Alto Piquiri"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_477
+msgid "Alto Rio Doce"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_478
+msgid "Alto Rio Novo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_479
+msgid "Alto Santo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_480
+msgid "Alto Taquari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_464
+msgid "Alto do Rodrigues"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_482
+msgid "Altos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_481
+msgid "Altônia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_483
+msgid "Alumínio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_485
+msgid "Alvarenga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_484
+msgid "Alvarães"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_489
+msgid "Alvinlândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_490
+msgid "Alvinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_160
+#: model:res.city,name:l10n_br.city_br_491
+msgid "Alvorada"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_492
+msgid "Alvorada D'Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_493
+msgid "Alvorada de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_494
+msgid "Alvorada do Gurguéia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_495
+msgid "Alvorada do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_496
+msgid "Alvorada do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_422
+msgid "Além Paraíba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_497
+msgid "Amajari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_498
+msgid "Amambai"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_501
+msgid "Amaporã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_499
+msgid "Amapá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_500
+msgid "Amapá do Maranhão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_502
+msgid "Amaraji"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_503
+msgid "Amaral Ferrador"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_504
+msgid "Amaralina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_505
+msgid "Amarante"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_506
+msgid "Amarante do Maranhão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_507
+msgid "Amargosa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_508
+msgid "Amaturá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_124
+msgid "Americana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_511
+msgid "Americano do Brasil"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_514
+msgid "Ametista do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_515
+msgid "Amontada"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_516
+msgid "Amorinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_517
+#: model:res.city,name:l10n_br.city_br_518
+msgid "Amparo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_519
+msgid "Amparo de São Francisco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_520
+msgid "Amparo do Serra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_521
+msgid "Ampére"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_509
+msgid "Amélia Rodrigues"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_510
+msgid "América Dourada"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_512
+msgid "Américo Brasiliense"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_513
+msgid "Américo de Campos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_522
+msgid "Anadia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_523
+msgid "Anagé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_524
+msgid "Anahy"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_526
+msgid "Anajatuba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_525
+msgid "Anajás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_527
+msgid "Analândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_528
+msgid "Anamã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_046
+msgid "Ananindeua"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_529
+msgid "Ananás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_530
+msgid "Anapu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_531
+msgid "Anapurus"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_532
+msgid "Anastácio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_533
+msgid "Anaurilândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_534
+#: model:res.city,name:l10n_br.city_br_535
+msgid "Anchieta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_536
+msgid "Andaraí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_537
+msgid "Andirá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_538
+msgid "Andorinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_539
+msgid "Andradas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_540
+msgid "Andradina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_542
+msgid "Andrelândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_541
+msgid "André da Rocha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_543
+msgid "Angatuba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_546
+msgid "Angelim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_547
+msgid "Angelina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_544
+msgid "Angelândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_548
+msgid "Angical"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_549
+msgid "Angical do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_550
+msgid "Angico"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_551
+msgid "Angicos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_175
+msgid "Angra dos Reis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_552
+msgid "Anguera"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_545
+msgid "Angélica"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_554
+msgid "Anhanguera"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_555
+msgid "Anhembi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_556
+msgid "Anhumas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_557
+msgid "Anicuns"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_559
+msgid "Anita Garibaldi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_560
+msgid "Anitápolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_561
+msgid "Anori"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_562
+msgid "Anta Gorda"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_563
+msgid "Antas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_564
+msgid "Antonina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_565
+msgid "Antonina do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_566
+msgid "Antônio Almeida"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_567
+msgid "Antônio Cardoso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_568
+#: model:res.city,name:l10n_br.city_br_569
+msgid "Antônio Carlos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_570
+msgid "Antônio Dias"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_571
+msgid "Antônio Gonçalves"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_572
+msgid "Antônio João"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_573
+msgid "Antônio Martins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_574
+msgid "Antônio Olinto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_575
+msgid "Antônio Prado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_576
+msgid "Antônio Prado de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_062
+msgid "Anápolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_558
+msgid "Anísio de Abreu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_577
+#: model:res.city,name:l10n_br.city_br_578
+msgid "Aparecida"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_579
+msgid "Aparecida d'Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_040
+msgid "Aparecida de Goiânia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_580
+msgid "Aparecida do Rio Doce"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_581
+msgid "Aparecida do Rio Negro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_582
+msgid "Aparecida do Taboado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_583
+msgid "Aperibé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_584
+msgid "Apiacá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_585
+msgid "Apiacás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_586
+msgid "Apiaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_587
+msgid "Apicum-Açu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_588
+msgid "Apiúna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_589
+msgid "Apodi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_590
+msgid "Aporá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_591
+msgid "Aporé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_592
+msgid "Apuarema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_231
+msgid "Apucarana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_594
+msgid "Apuiarés"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_593
+msgid "Apuí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_595
+msgid "Aquidabã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_596
+msgid "Aquidauana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_597
+msgid "Aquiraz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_598
+msgid "Arabutã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_036
+msgid "Aracaju"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_603
+msgid "Aracati"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_604
+msgid "Aracatu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_605
+msgid "Araci"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_606
+msgid "Aracitaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_607
+msgid "Aracoiaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_610
+msgid "Aracruz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_613
+msgid "Aragarças"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_614
+msgid "Aragoiânia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_615
+msgid "Aragominas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_616
+msgid "Araguacema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_618
+msgid "Araguaiana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_619
+msgid "Araguainha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_620
+#: model:res.city,name:l10n_br.city_br_621
+msgid "Araguanã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_622
+msgid "Araguapaz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_261
+msgid "Araguari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_623
+msgid "Araguatins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_617
+msgid "Araguaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_170
+msgid "Araguaína"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_624
+msgid "Araioses"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_625
+msgid "Aral Moreira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_626
+msgid "Aramari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_627
+msgid "Arambaré"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_628
+msgid "Arame"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_629
+msgid "Aramina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_630
+msgid "Arandu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_631
+msgid "Arantina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_632
+msgid "Arapeí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_127
+msgid "Arapiraca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_633
+msgid "Arapoema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_634
+msgid "Araponga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_254
+msgid "Arapongas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_635
+msgid "Araporã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_636
+msgid "Arapoti"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_639
+msgid "Araputanga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_637
+msgid "Arapuá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_638
+msgid "Arapuã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_640
+msgid "Araquari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_641
+msgid "Arara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_642
+msgid "Araranguá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_121
+msgid "Araraquara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_230
+msgid "Araras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_643
+msgid "Ararendá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_644
+msgid "Arari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_645
+msgid "Araricá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_646
+msgid "Araripe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_647
+msgid "Araripina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_232
+msgid "Araruama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_648
+#: model:res.city,name:l10n_br.city_br_649
+msgid "Araruna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_650
+msgid "Arataca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_651
+msgid "Aratiba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_652
+msgid "Aratuba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_653
+msgid "Aratuípe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_198
+msgid "Araucária"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_654
+msgid "Arauá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_281
+msgid "Araxá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_599
+msgid "Araçagi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_601
+msgid "Araçariguama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_152
+msgid "Araçatuba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_600
+msgid "Araçaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_608
+msgid "Araçoiaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_609
+msgid "Araçoiaba da Serra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_611
+msgid "Araçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_612
+msgid "Araçuaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_602
+msgid "Araçás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_655
+msgid "Araújos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_656
+msgid "Arceburgo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_657
+msgid "Arco-Íris"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_658
+msgid "Arcos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_659
+msgid "Arcoverde"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_660
+msgid "Areado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_661
+msgid "Areal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_662
+msgid "Arealva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_663
+msgid "Areia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_664
+#: model:res.city,name:l10n_br.city_br_665
+msgid "Areia Branca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_666
+msgid "Areia de Baraúnas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_667
+msgid "Areial"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_668
+msgid "Areias"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_669
+msgid "Areiópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_670
+msgid "Arenápolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_671
+msgid "Arenópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_673
+msgid "Argirita"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_674
+msgid "Aricanduva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_675
+msgid "Arinos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_676
+msgid "Aripuanã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_677
+msgid "Ariquemes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_678
+msgid "Ariranha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_679
+msgid "Ariranha do Ivaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_681
+msgid "Armazém"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_680
+msgid "Armação dos Búzios"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_682
+msgid "Arneiroz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_683
+msgid "Aroazes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_684
+msgid "Aroeiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_685
+msgid "Aroeiras do Itaim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_686
+msgid "Arraial"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_687
+msgid "Arraial do Cabo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_688
+msgid "Arraias"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_694
+msgid "Arroio Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_695
+msgid "Arroio Trinta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_689
+msgid "Arroio do Meio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_690
+msgid "Arroio do Padre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_691
+msgid "Arroio do Sal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_692
+msgid "Arroio do Tigre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_693
+msgid "Arroio dos Ratos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_696
+msgid "Artur Nogueira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_697
+msgid "Aruanã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_698
+msgid "Arujá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_699
+msgid "Arvoredo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_700
+msgid "Arvorezinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_672
+msgid "Arês"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_701
+msgid "Ascurra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_702
+msgid "Aspásia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_704
+msgid "Assaré"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_703
+msgid "Assaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_318
+msgid "Assis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_705
+msgid "Assis Brasil"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_706
+msgid "Assis Chateaubriand"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_707
+msgid "Assunção"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_708
+msgid "Assunção do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_709
+msgid "Astolfo Dutra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_710
+msgid "Astorga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_711
+#: model:res.city,name:l10n_br.city_br_712
+msgid "Atalaia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_713
+msgid "Atalaia do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_714
+msgid "Atalanta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_715
+msgid "Ataléia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_188
+msgid "Atibaia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_716
+msgid "Atílio Vivacqua"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_717
+msgid "Augustinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_718
+msgid "Augusto Corrêa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_720
+msgid "Augusto Pestana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_719
+msgid "Augusto de Lima"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_722
+msgid "Aurelino Leal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_723
+msgid "Auriflama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_724
+msgid "Aurilândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_725
+#: model:res.city,name:l10n_br.city_br_726
+msgid "Aurora"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_727
+msgid "Aurora do Pará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_728
+msgid "Aurora do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_729
+msgid "Autazes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_731
+msgid "Avanhandava"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_732
+msgid "Avaré"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_730
+msgid "Avaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_733
+msgid "Aveiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_734
+msgid "Avelino Lopes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_735
+msgid "Avelinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_736
+msgid "Axixá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_737
+msgid "Axixá do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_292
+msgid "Açailândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_346
+msgid "Açu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_347
+msgid "Açucena"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_738
+msgid "Babaçulândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_307
+msgid "Bacabal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_739
+msgid "Bacabeira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_740
+msgid "Bacuri"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_741
+msgid "Bacurituba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_742
+msgid "Bady Bassitt"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_743
+msgid "Baependi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_744
+msgid "Bagre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_260
+msgid "Bagé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_747
+msgid "Baianópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_749
+msgid "Baixa Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_750
+msgid "Baixa Grande do Ribeiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_751
+msgid "Baixio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_752
+msgid "Baixo Guandu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_748
+msgid "Baião"
 msgstr ""
 
 #. module: l10n_br
@@ -36,8 +2122,1386 @@ msgid "Balance"
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_753
+msgid "Balbinos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_754
+msgid "Baldim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_755
+msgid "Baliza"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_756
+msgid "Balneário Arroio do Silva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_757
+msgid "Balneário Barra do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_214
+msgid "Balneário Camboriú"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_758
+msgid "Balneário Gaivota"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_760
+msgid "Balneário Pinhal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_759
+msgid "Balneário Piçarras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_761
+msgid "Balneário Rincão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_762
+msgid "Balsa Nova"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_316
+msgid "Balsas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_764
+msgid "Bambuí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_765
+msgid "Banabuiú"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_766
+msgid "Bananal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_767
+msgid "Bananeiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_768
+msgid "Bandeira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_769
+msgid "Bandeira do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_770
+msgid "Bandeirante"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_771
+#: model:res.city,name:l10n_br.city_br_772
+msgid "Bandeirantes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_773
+msgid "Bandeirantes do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:ir.model,name:l10n_br.model_res_partner_bank
+msgid "Bank Accounts"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_774
+msgid "Bannach"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_775
+msgid "Banzaê"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_784
+#: model:res.city,name:l10n_br.city_br_785
+msgid "Baraúna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_242
+msgid "Barbacena"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_786
+msgid "Barbalha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_787
+msgid "Barbosa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_788
+msgid "Barbosa Ferraz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_239
+msgid "Barcarena"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_789
+msgid "Barcelona"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_790
+msgid "Barcelos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_791
+msgid "Bariri"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_792
+msgid "Barra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_793
+#: model:res.city,name:l10n_br.city_br_794
+msgid "Barra Bonita"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_795
+msgid "Barra D'Alcântara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_820
+msgid "Barra Funda"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_821
+msgid "Barra Longa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_172
+msgid "Barra Mansa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_822
+msgid "Barra Velha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_796
+msgid "Barra da Estiva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_797
+msgid "Barra de Guabiraba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_798
+msgid "Barra de Santa Rosa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_799
+msgid "Barra de Santana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_800
+msgid "Barra de Santo Antônio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_801
+msgid "Barra de São Francisco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_802
+#: model:res.city,name:l10n_br.city_br_803
+msgid "Barra de São Miguel"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_804
+msgid "Barra do Bugres"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_805
+msgid "Barra do Chapéu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_806
+msgid "Barra do Choça"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_807
+msgid "Barra do Corda"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_808
+msgid "Barra do Garças"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_809
+msgid "Barra do Guarita"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_810
+msgid "Barra do Jacaré"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_811
+msgid "Barra do Mendes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_812
+msgid "Barra do Ouro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_813
+msgid "Barra do Piraí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_814
+msgid "Barra do Quaraí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_815
+msgid "Barra do Ribeiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_816
+msgid "Barra do Rio Azul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_817
+msgid "Barra do Rocha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_818
+msgid "Barra do Turvo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_819
+msgid "Barra dos Coqueiros"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_823
+#: model:res.city,name:l10n_br.city_br_824
+msgid "Barracão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_825
+msgid "Barras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_826
+msgid "Barreira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_185
+msgid "Barreiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_827
+msgid "Barreiras do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_828
+msgid "Barreirinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_829
+msgid "Barreirinhas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_830
+msgid "Barreiros"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_250
+msgid "Barretos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_831
+msgid "Barrinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_832
+msgid "Barro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_833
+#: model:res.city,name:l10n_br.city_br_834
+msgid "Barro Alto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_835
+msgid "Barro Duro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_836
+msgid "Barro Preto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_837
+msgid "Barrocas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_838
+msgid "Barrolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_839
+msgid "Barroquinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_840
+msgid "Barros Cassal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_841
+msgid "Barroso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_088
+msgid "Barueri"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_776
+msgid "Barão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_777
+msgid "Barão de Antonina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_778
+msgid "Barão de Cocais"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_779
+msgid "Barão de Cotegipe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_780
+msgid "Barão de Grajaú"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_781
+msgid "Barão de Melgaço"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_782
+msgid "Barão de Monte Alto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_783
+msgid "Barão do Triunfo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_842
+msgid "Bastos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_843
+msgid "Bataguassu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_844
+#: model:res.city,name:l10n_br.city_br_845
+msgid "Batalha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_846
+msgid "Batatais"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_847
+msgid "Batayporã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_848
+msgid "Baturité"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_066
+msgid "Bauru"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_849
+msgid "Bayeux"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_746
+msgid "Baía Formosa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_745
+msgid "Baía da Traição"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_850
+msgid "Bebedouro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_851
+msgid "Beberibe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_852
+msgid "Bela Cruz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_853
+msgid "Bela Vista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_854
+msgid "Bela Vista da Caroba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_855
+msgid "Bela Vista de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_856
+msgid "Bela Vista de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_857
+msgid "Bela Vista do Maranhão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_858
+msgid "Bela Vista do Paraíso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_859
+msgid "Bela Vista do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_860
+msgid "Bela Vista do Toldo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_043
+msgid "Belford Roxo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_868
+msgid "Belmiro Braga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_869
+#: model:res.city,name:l10n_br.city_br_870
+msgid "Belmonte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_871
+msgid "Belo Campo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_006
+msgid "Belo Horizonte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_872
+msgid "Belo Jardim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_873
+msgid "Belo Monte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_874
+msgid "Belo Oriente"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_875
+msgid "Belo Vale"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_876
+msgid "Belterra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_861
+msgid "Belágua"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_012
+#: model:res.city,name:l10n_br.city_br_862
+#: model:res.city,name:l10n_br.city_br_863
+msgid "Belém"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_864
+msgid "Belém de Maria"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_865
+msgid "Belém do Brejo do Cruz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_866
+msgid "Belém do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_867
+msgid "Belém do São Francisco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_877
+msgid "Beneditinos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_878
+msgid "Benedito Leite"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_879
+msgid "Benedito Novo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_880
+msgid "Benevides"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_881
+msgid "Benjamin Constant"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_882
+msgid "Benjamin Constant do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_884
+msgid "Bento Fernandes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_248
+msgid "Bento Gonçalves"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_883
+msgid "Bento de Abreu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_885
+msgid "Bequimão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_886
+msgid "Berilo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_887
+msgid "Berizal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_888
+msgid "Bernardino Batista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_889
+msgid "Bernardino de Campos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_891
+msgid "Bernardo Sayão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_890
+msgid "Bernardo do Mearim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_892
+msgid "Bertioga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_893
+msgid "Bertolínia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_894
+msgid "Bertópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_895
+msgid "Beruri"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_060
+msgid "Betim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_896
+msgid "Betânia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_897
+msgid "Betânia do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_898
+msgid "Bezerros"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_899
+msgid "Bias Fortes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_900
+msgid "Bicas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_901
+msgid "Biguaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_902
+msgid "Bilac"
+msgstr ""
+
+#. module: l10n_br
 #: model:l10n_latam.document.type,name:l10n_br.dt_26
 msgid "Bill of Lading Multimodal Transport"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_903
+msgid "Biquinhas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_255
+msgid "Birigui"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_904
+msgid "Biritiba-Mirim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_905
+msgid "Biritinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_906
+msgid "Bituruna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_071
+msgid "Blumenau"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_907
+#: model:res.city,name:l10n_br.city_br_908
+#: model:res.city,name:l10n_br.city_br_909
+msgid "Boa Esperança"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_910
+msgid "Boa Esperança do Iguaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_911
+msgid "Boa Esperança do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_912
+msgid "Boa Hora"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_913
+msgid "Boa Nova"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_914
+msgid "Boa Saúde"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_915
+msgid "Boa Ventura"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_916
+msgid "Boa Ventura de São Roque"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_917
+msgid "Boa Viagem"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_059
+#: model:res.city,name:l10n_br.city_br_918
+msgid "Boa Vista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_919
+msgid "Boa Vista da Aparecida"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_920
+msgid "Boa Vista das Missões"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_921
+msgid "Boa Vista do Buricá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_922
+msgid "Boa Vista do Cadeado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_923
+msgid "Boa Vista do Gurupi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_924
+msgid "Boa Vista do Incra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_925
+msgid "Boa Vista do Ramos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_926
+msgid "Boa Vista do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_927
+msgid "Boa Vista do Tupim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_928
+msgid "Boca da Mata"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_929
+msgid "Boca do Acre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_930
+#: model:res.city,name:l10n_br.city_br_931
+msgid "Bocaina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_932
+msgid "Bocaina de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_933
+msgid "Bocaina do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_934
+msgid "Bocaiúva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_935
+msgid "Bocaiúva do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_937
+msgid "Bodocó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_938
+msgid "Bodoquena"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_936
+msgid "Bodó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_939
+msgid "Bofete"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_940
+msgid "Boituva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_941
+msgid "Bom Conselho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_942
+msgid "Bom Despacho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_943
+#: model:res.city,name:l10n_br.city_br_944
+#: model:res.city,name:l10n_br.city_br_945
+msgid "Bom Jardim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_946
+msgid "Bom Jardim da Serra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_947
+msgid "Bom Jardim de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_948
+msgid "Bom Jardim de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_949
+#: model:res.city,name:l10n_br.city_br_950
+#: model:res.city,name:l10n_br.city_br_951
+#: model:res.city,name:l10n_br.city_br_952
+#: model:res.city,name:l10n_br.city_br_953
+msgid "Bom Jesus"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_954
+msgid "Bom Jesus da Lapa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_955
+msgid "Bom Jesus da Penha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_956
+msgid "Bom Jesus da Serra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_957
+msgid "Bom Jesus das Selvas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_958
+msgid "Bom Jesus de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_959
+msgid "Bom Jesus do Amparo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_960
+msgid "Bom Jesus do Araguaia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_961
+msgid "Bom Jesus do Galho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_962
+msgid "Bom Jesus do Itabapoana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_963
+msgid "Bom Jesus do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_964
+msgid "Bom Jesus do Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_965
+msgid "Bom Jesus do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_966
+#: model:res.city,name:l10n_br.city_br_967
+msgid "Bom Jesus do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_968
+msgid "Bom Jesus dos Perdões"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_969
+msgid "Bom Lugar"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_970
+msgid "Bom Princípio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_971
+msgid "Bom Princípio do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_972
+msgid "Bom Progresso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_973
+msgid "Bom Repouso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_974
+msgid "Bom Retiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_975
+msgid "Bom Retiro do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_976
+#: model:res.city,name:l10n_br.city_br_977
+#: model:res.city,name:l10n_br.city_br_978
+msgid "Bom Sucesso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_979
+msgid "Bom Sucesso de Itararé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_980
+msgid "Bom Sucesso do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_981
+msgid "Bombinhas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_982
+#: model:res.city,name:l10n_br.city_br_983
+msgid "Bonfim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_984
+msgid "Bonfim do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_985
+msgid "Bonfinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_986
+msgid "Bonfinópolis de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_987
+msgid "Boninal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_988
+#: model:res.city,name:l10n_br.city_br_989
+#: model:res.city,name:l10n_br.city_br_990
+#: model:res.city,name:l10n_br.city_br_991
+msgid "Bonito"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_992
+msgid "Bonito de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_993
+msgid "Bonito de Santa Fé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_994
+msgid "Bonópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_995
+msgid "Boqueirão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_996
+msgid "Boqueirão do Leão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_997
+msgid "Boqueirão do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_998
+msgid "Boquim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_999
+msgid "Boquira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1001
+msgid "Boracéia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1002
+msgid "Borba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1003
+#: model:res.city,name:l10n_br.city_br_1004
+msgid "Borborema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1005
+msgid "Borda da Mata"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1006
+msgid "Borebi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1007
+msgid "Borrazópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1000
+msgid "Borá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1008
+msgid "Bossoroca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1009
+msgid "Botelhos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_208
+msgid "Botucatu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1010
+msgid "Botumirim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1011
+msgid "Botuporã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1012
+msgid "Botuverá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1013
+msgid "Bozano"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1016
+msgid "Braga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1017
+msgid "Braganey"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_249
+msgid "Bragança"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_168
+msgid "Bragança Paulista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1018
+msgid "Branquinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1020
+msgid "Brasil Novo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1026
+msgid "Brasileira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1021
+msgid "Brasilândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1022
+msgid "Brasilândia de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1023
+msgid "Brasilândia do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1024
+msgid "Brasilândia do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1025
+msgid "Brasiléia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1028
+msgid "Brasnorte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_003
+msgid "Brasília"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1027
+msgid "Brasília de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1031
+msgid "Brazabrantes"
+msgstr ""
+
+#. module: l10n_br
+#: model:ir.ui.menu,name:l10n_br.brazilian_accounting_menu
+msgid "Brazil"
 msgstr ""
 
 #. module: l10n_br
@@ -46,6 +3510,303 @@ msgid ""
 "Brazil: Series number associated with this Journal. If more than one Series "
 "needs to be used, duplicate this Journal and assign the new Series to the "
 "duplicated Journal."
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1032
+msgid "Brazópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1014
+msgid "Braço do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1015
+msgid "Braço do Trombudo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1029
+msgid "Braúna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1030
+msgid "Braúnas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1034
+msgid "Brejetuba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1035
+#: model:res.city,name:l10n_br.city_br_1036
+msgid "Brejinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1037
+msgid "Brejinho de Nazaré"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1038
+msgid "Brejo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1039
+msgid "Brejo Alegre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1045
+msgid "Brejo Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1046
+msgid "Brejo Grande do Araguaia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1047
+msgid "Brejo Santo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1040
+msgid "Brejo da Madre de Deus"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1041
+msgid "Brejo de Areia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1042
+msgid "Brejo do Cruz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1043
+msgid "Brejo do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1044
+msgid "Brejo dos Santos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1049
+msgid "Brejolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1033
+msgid "Brejão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1048
+msgid "Brejões"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1050
+msgid "Breu Branco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_291
+msgid "Breves"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1051
+msgid "Britânia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1052
+msgid "Brochier"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1053
+msgid "Brodowski"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1054
+msgid "Brotas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1055
+msgid "Brotas de Macaúbas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1056
+msgid "Brumadinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1057
+msgid "Brumado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1058
+msgid "Brunópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_212
+msgid "Brusque"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1019
+msgid "Brás Pires"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1059
+msgid "Bueno Brandão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1061
+msgid "Buenos Aires"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1060
+msgid "Buenópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1062
+msgid "Buerarema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1063
+msgid "Bugre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1065
+msgid "Bujari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1066
+msgid "Bujaru"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1067
+msgid "Buri"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1068
+msgid "Buritama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1069
+msgid "Buriti"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1070
+msgid "Buriti Alegre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1071
+msgid "Buriti Bravo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1072
+msgid "Buriti de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1073
+msgid "Buriti do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1074
+msgid "Buriti dos Lopes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1075
+msgid "Buriti dos Montes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1076
+msgid "Buriticupu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1077
+msgid "Buritinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1078
+msgid "Buritirama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1079
+msgid "Buritirana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1080
+#: model:res.city,name:l10n_br.city_br_1081
+msgid "Buritis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1082
+msgid "Buritizal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1083
+msgid "Buritizeiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1084
+msgid "Butiá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1064
+msgid "Buíque"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_763
+msgid "Bálsamo"
 msgstr ""
 
 #. module: l10n_br
@@ -75,6 +3836,11 @@ msgid "CPF"
 msgstr ""
 
 #. module: l10n_br
+#: model:ir.model.fields.selection,name:l10n_br.selection__res_partner_bank__proxy_type__br_cpf_cnpj
+msgid "CPF/CNPJ (BR)"
+msgstr ""
+
+#. module: l10n_br
 #: model:account.report.line,name:l10n_br.tax_report_csll
 msgid "CSLL"
 msgstr ""
@@ -90,8 +3856,2631 @@ msgid "CSLL tax"
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1085
+msgid "Caapiranga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1086
+msgid "Caaporã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1087
+msgid "Caarapó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1088
+msgid "Caatiba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1089
+msgid "Cabaceiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1090
+msgid "Cabaceiras do Paraguaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1091
+msgid "Cabeceira Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1092
+msgid "Cabeceiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1093
+msgid "Cabeceiras do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1094
+msgid "Cabedelo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1095
+msgid "Cabixi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_142
+msgid "Cabo Frio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1096
+msgid "Cabo Verde"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_149
+msgid "Cabo de Santo Agostinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1098
+msgid "Cabreúva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1099
+msgid "Cabrobó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1097
+msgid "Cabrália Paulista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1103
+msgid "Cacaulândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1104
+msgid "Cacequi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1106
+msgid "Cachoeira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1107
+msgid "Cachoeira Alta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1116
+#: model:res.city,name:l10n_br.city_br_1117
+msgid "Cachoeira Dourada"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1118
+msgid "Cachoeira Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1119
+msgid "Cachoeira Paulista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1108
+msgid "Cachoeira da Prata"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1109
+msgid "Cachoeira de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1110
+msgid "Cachoeira de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1111
+msgid "Cachoeira de Pajeú"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1112
+msgid "Cachoeira do Arari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1113
+msgid "Cachoeira do Piriá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1114
+msgid "Cachoeira do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1115
+msgid "Cachoeira dos Índios"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1120
+msgid "Cachoeiras de Macacu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1121
+#: model:res.city,name:l10n_br.city_br_1122
+#: model:res.city,name:l10n_br.city_br_218
+msgid "Cachoeirinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_162
+msgid "Cachoeiro de Itapemirim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1123
+msgid "Cacimba de Areia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1124
+msgid "Cacimba de Dentro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1125
+msgid "Cacimbas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1126
+msgid "Cacimbinhas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1127
+msgid "Cacique Doble"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1128
+msgid "Cacoal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1129
+msgid "Caconde"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1131
+msgid "Caculé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1134
+msgid "Caetanos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1133
+msgid "Caetanópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1137
+msgid "Caetité"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1135
+msgid "Caeté"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1136
+msgid "Caetés"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1138
+msgid "Cafarnaum"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1139
+msgid "Cafeara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1140
+#: model:res.city,name:l10n_br.city_br_1141
+msgid "Cafelândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1142
+msgid "Cafezal do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1143
+msgid "Caiabu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1144
+msgid "Caiana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1145
+msgid "Caiapônia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1146
+msgid "Caibaté"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1147
+msgid "Caibi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1152
+msgid "Caicó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1153
+msgid "Caieiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1154
+msgid "Cairu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1155
+msgid "Caiuá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1148
+#: model:res.city,name:l10n_br.city_br_1149
+msgid "Caiçara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1150
+msgid "Caiçara do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1151
+msgid "Caiçara do Rio do Vento"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1156
+msgid "Cajamar"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1157
+msgid "Cajapió"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1158
+msgid "Cajari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1159
+msgid "Cajati"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1160
+msgid "Cajazeiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1161
+msgid "Cajazeiras do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1162
+msgid "Cajazeirinhas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1163
+msgid "Cajobi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1164
+msgid "Cajueiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1165
+msgid "Cajueiro da Praia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1166
+msgid "Cajuri"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1167
+msgid "Cajuru"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1170
+msgid "Caldas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1171
+msgid "Caldas Brandão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1172
+msgid "Caldas Novas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1173
+msgid "Caldazinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1174
+msgid "Caldeirão Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1175
+msgid "Caldeirão Grande do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1176
+msgid "Califórnia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1177
+msgid "Calmon"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1178
+msgid "Calumbi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1168
+msgid "Calçado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1169
+msgid "Calçoene"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1179
+msgid "Camacan"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1180
+msgid "Camacho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1181
+msgid "Camalaú"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1182
+msgid "Camamu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1183
+msgid "Camanducaia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1184
+msgid "Camapuã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1185
+msgid "Camaquã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_203
+msgid "Camaragibe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1186
+msgid "Camargo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_092
+msgid "Camaçari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1187
+msgid "Cambará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1188
+msgid "Cambará do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1189
+msgid "Cambira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_312
+msgid "Camboriú"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1190
+msgid "Cambuci"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1192
+msgid "Cambuquira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1191
+msgid "Cambuí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_290
+msgid "Cambé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_221
+msgid "Cametá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1193
+msgid "Camocim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1194
+msgid "Camocim de São Félix"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1196
+msgid "Campanha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1195
+msgid "Campanário"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1197
+#: model:res.city,name:l10n_br.city_br_1198
+msgid "Campestre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1199
+msgid "Campestre da Serra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1200
+msgid "Campestre de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1201
+msgid "Campestre do Maranhão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_055
+msgid "Campina Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1206
+msgid "Campina Grande do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1207
+msgid "Campina Verde"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1202
+msgid "Campina da Lagoa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1203
+msgid "Campina das Missões"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1204
+msgid "Campina do Monte Alegre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1205
+msgid "Campina do Simão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_014
+msgid "Campinas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1210
+msgid "Campinas do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1211
+msgid "Campinas do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1208
+msgid "Campinaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1212
+msgid "Campinorte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1209
+msgid "Campinápolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1213
+#: model:res.city,name:l10n_br.city_br_1214
+msgid "Campo Alegre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1215
+msgid "Campo Alegre de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1216
+msgid "Campo Alegre de Lourdes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1217
+msgid "Campo Alegre do Fidalgo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1218
+msgid "Campo Azul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1219
+msgid "Campo Belo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1220
+msgid "Campo Belo do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1221
+msgid "Campo Bom"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1222
+msgid "Campo Bonito"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1226
+msgid "Campo Erê"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1227
+msgid "Campo Florido"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1228
+msgid "Campo Formoso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_017
+#: model:res.city,name:l10n_br.city_br_1229
+#: model:res.city,name:l10n_br.city_br_1230
+msgid "Campo Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1231
+msgid "Campo Grande do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_217
+msgid "Campo Largo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1232
+msgid "Campo Largo do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1234
+msgid "Campo Limpo Paulista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1233
+msgid "Campo Limpo de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1235
+msgid "Campo Magro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1236
+msgid "Campo Maior"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1237
+msgid "Campo Mourão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1238
+msgid "Campo Novo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1239
+msgid "Campo Novo de Rondônia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1240
+msgid "Campo Novo do Parecis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1241
+msgid "Campo Redondo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1242
+msgid "Campo Verde"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1223
+msgid "Campo do Brito"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1224
+msgid "Campo do Meio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1225
+msgid "Campo do Tenente"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1243
+msgid "Campos Altos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1244
+msgid "Campos Belos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1245
+msgid "Campos Borges"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1248
+msgid "Campos Gerais"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1249
+msgid "Campos Lindos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1250
+msgid "Campos Novos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1251
+msgid "Campos Novos Paulista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1252
+msgid "Campos Sales"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1253
+msgid "Campos Verdes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1246
+msgid "Campos de Júlio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1247
+msgid "Campos do Jordão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_042
+msgid "Campos dos Goytacazes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1254
+msgid "Camutanga"
+msgstr ""
+
+#. module: l10n_br
+#. odoo-python
+#: code:addons/l10n_br/models/res_partner_bank.py:0
+msgid "Can't generate a Pix QR code with a currency other than BRL."
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1255
+msgid "Cana Verde"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1258
+msgid "Canabrava do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1259
+msgid "Cananéia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1260
+msgid "Canapi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1263
+#: model:res.city,name:l10n_br.city_br_1264
+msgid "Canarana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1265
+msgid "Canas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1266
+msgid "Canavieira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1267
+msgid "Canavieiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1256
+msgid "Canaã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1257
+msgid "Canaã dos Carajás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1268
+msgid "Candeal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1269
+#: model:res.city,name:l10n_br.city_br_1270
+msgid "Candeias"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1271
+msgid "Candeias do Jamari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1272
+msgid "Candelária"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1273
+msgid "Candiba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1280
+msgid "Candiota"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1281
+msgid "Candói"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1282
+msgid "Canela"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1283
+msgid "Canelinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1284
+msgid "Canguaretama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1285
+msgid "Canguçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1286
+msgid "Canhoba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1287
+msgid "Canhotinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1288
+msgid "Canindé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1289
+msgid "Canindé de São Francisco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1290
+msgid "Canitar"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_079
+msgid "Canoas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1291
+msgid "Canoinhas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1292
+msgid "Cansanção"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1294
+#: model:res.city,name:l10n_br.city_br_1295
+#: model:res.city,name:l10n_br.city_br_1296
+msgid "Cantagalo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1297
+msgid "Cantanhede"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1298
+msgid "Canto do Buriti"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1293
+msgid "Cantá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1299
+msgid "Canudos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1300
+msgid "Canudos do Vale"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1301
+msgid "Canutama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1261
+#: model:res.city,name:l10n_br.city_br_1262
+msgid "Canápolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1302
+#: model:res.city,name:l10n_br.city_br_1303
+msgid "Capanema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1310
+msgid "Caparaó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1311
+#: model:res.city,name:l10n_br.city_br_1312
+msgid "Capela"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1316
+msgid "Capela Nova"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1313
+msgid "Capela de Santana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1314
+msgid "Capela do Alto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1315
+msgid "Capela do Alto Alegre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1317
+msgid "Capelinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1318
+msgid "Capetinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1319
+msgid "Capim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1320
+msgid "Capim Branco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1321
+msgid "Capim Grosso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1323
+msgid "Capinzal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1324
+msgid "Capinzal do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1322
+msgid "Capinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1325
+msgid "Capistrano"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1326
+msgid "Capitão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1327
+msgid "Capitão Andrade"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1329
+msgid "Capitão Enéas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1330
+msgid "Capitão Gervásio Oliveira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1331
+msgid "Capitão Leônidas Marques"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1332
+msgid "Capitão Poço"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1328
+msgid "Capitão de Campos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1333
+msgid "Capitólio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1334
+msgid "Capivari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1335
+msgid "Capivari de Baixo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1336
+msgid "Capivari do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1337
+msgid "Capixaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1338
+msgid "Capoeiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1339
+msgid "Caputira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1304
+msgid "Capão Alto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1305
+msgid "Capão Bonito"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1306
+msgid "Capão Bonito do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1307
+msgid "Capão da Canoa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1308
+msgid "Capão do Cipó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1309
+msgid "Capão do Leão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1341
+msgid "Caracaraí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1342
+#: model:res.city,name:l10n_br.city_br_1343
+msgid "Caracol"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_219
+msgid "Caraguatatuba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1346
+msgid "Carambeí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1347
+msgid "Caranaíba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1348
+msgid "Carandaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1349
+msgid "Carangola"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1350
+msgid "Carapebus"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_064
+msgid "Carapicuíba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1351
+msgid "Caratinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1352
+msgid "Carauari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1356
+msgid "Caravelas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1357
+msgid "Carazinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1340
+msgid "Caraá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1344
+msgid "Caraí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1345
+msgid "Caraíbas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1353
+#: model:res.city,name:l10n_br.city_br_1354
+msgid "Caraúbas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1355
+msgid "Caraúbas do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1358
+msgid "Carbonita"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1359
+msgid "Cardeal da Silva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1360
+msgid "Cardoso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1361
+msgid "Cardoso Moreira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1362
+msgid "Careaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1363
+msgid "Careiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1364
+msgid "Careiro da Várzea"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_074
+msgid "Cariacica"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1365
+msgid "Caridade"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1366
+msgid "Caridade do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1367
+msgid "Carinhanha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1368
+msgid "Carira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1370
+msgid "Cariri do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1371
+msgid "Caririaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1369
+msgid "Cariré"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1372
+msgid "Cariús"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1373
+msgid "Carlinda"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1375
+msgid "Carlos Barbosa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1376
+msgid "Carlos Chagas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1377
+msgid "Carlos Gomes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1374
+msgid "Carlópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1379
+msgid "Carmo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1380
+msgid "Carmo da Cachoeira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1381
+msgid "Carmo da Mata"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1382
+msgid "Carmo de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1383
+msgid "Carmo do Cajuru"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1384
+msgid "Carmo do Paranaíba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1385
+msgid "Carmo do Rio Claro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1386
+msgid "Carmo do Rio Verde"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1387
+msgid "Carmolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1378
+msgid "Carmésia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1388
+msgid "Carmópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1389
+msgid "Carmópolis de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1392
+msgid "Carnaubais"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1393
+msgid "Carnaubal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1394
+msgid "Carnaubeira da Penha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1390
+msgid "Carnaíba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1391
+msgid "Carnaúba dos Dantas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1395
+msgid "Carneirinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1396
+msgid "Carneiros"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1397
+msgid "Caroebe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1398
+msgid "Carolina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1399
+msgid "Carpina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1400
+msgid "Carrancas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1401
+msgid "Carrapateira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1402
+msgid "Carrasco Bonito"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_067
+msgid "Caruaru"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1403
+msgid "Carutapera"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1405
+msgid "Carvalhos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1404
+msgid "Carvalhópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1406
+msgid "Casa Branca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1407
+msgid "Casa Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1408
+msgid "Casa Nova"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1409
+msgid "Casca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1410
+msgid "Cascalho Rico"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_078
+#: model:res.city,name:l10n_br.city_br_1411
+msgid "Cascavel"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1412
+msgid "Caseara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1413
+msgid "Caseiros"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1414
+msgid "Casimiro de Abreu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1415
+msgid "Casinhas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1416
+msgid "Casserengue"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1419
+msgid "Cassilândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_157
+msgid "Castanhal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1420
+msgid "Castanheira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1421
+msgid "Castanheiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1423
+msgid "Castelo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1424
+msgid "Castelo do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1422
+msgid "Castelândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1425
+msgid "Castilho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1426
+msgid "Castro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1427
+msgid "Castro Alves"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1428
+msgid "Cataguases"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_272
+msgid "Catalão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_266
+msgid "Catanduva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1429
+#: model:res.city,name:l10n_br.city_br_1430
+msgid "Catanduvas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1431
+msgid "Catarina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1432
+msgid "Catas Altas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1433
+msgid "Catas Altas da Noruega"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1434
+msgid "Catende"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1435
+msgid "Catiguá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1436
+msgid "Catingueira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1437
+msgid "Catolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1438
+msgid "Catolé do Rocha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1439
+msgid "Catu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1441
+msgid "Catuji"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1442
+msgid "Catunda"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1444
+msgid "Caturama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1443
+msgid "Caturaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1445
+msgid "Caturité"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1446
+msgid "Catuti"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1440
+msgid "Catuípe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_073
+msgid "Caucaia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1447
+msgid "Cavalcante"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1448
+msgid "Caxambu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1449
+msgid "Caxambu do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_192
+msgid "Caxias"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_048
+msgid "Caxias do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1450
+msgid "Caxingó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1100
+msgid "Caçador"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1101
+msgid "Caçapava"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1102
+msgid "Caçapava do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1130
+msgid "Caçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1132
+msgid "Caém"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1451
+msgid "Ceará-Mirim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1452
+#: model:res.city,name:l10n_br.city_br_1453
+msgid "Cedral"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1454
+#: model:res.city,name:l10n_br.city_br_1455
+msgid "Cedro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1456
+msgid "Cedro de São João"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1457
+msgid "Cedro do Abaeté"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1458
+msgid "Celso Ramos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1459
+#: model:res.city,name:l10n_br.city_br_1460
+msgid "Centenário"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1461
+msgid "Centenário do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1462
+msgid "Central"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1463
+msgid "Central de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1464
+msgid "Central do Maranhão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1465
+msgid "Centralina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1467
+msgid "Centro Novo do Maranhão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1466
+msgid "Centro do Guilherme"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1468
+msgid "Cerejeiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1469
+msgid "Ceres"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1470
+msgid "Cerqueira César"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1471
+msgid "Cerquilho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1472
+msgid "Cerrito"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1473
+msgid "Cerro Azul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1474
+msgid "Cerro Branco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1475
+msgid "Cerro Corá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1476
+msgid "Cerro Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1477
+msgid "Cerro Grande do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1478
+msgid "Cerro Largo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1479
+msgid "Cerro Negro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1480
+msgid "Cesário Lange"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1482
+msgid "Cezarina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1487
+msgid "Chalé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1488
+msgid "Chapada"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1493
+msgid "Chapada Gaúcha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1489
+msgid "Chapada da Natividade"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1490
+msgid "Chapada de Areia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1491
+msgid "Chapada do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1492
+msgid "Chapada dos Guimarães"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1497
+msgid "Chapadinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1494
+msgid "Chapadão do Céu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1495
+msgid "Chapadão do Lageado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1496
+msgid "Chapadão do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_114
+msgid "Chapecó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1498
+msgid "Charqueada"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1499
+msgid "Charqueadas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1500
+msgid "Charrua"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1501
+msgid "Chaval"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1502
+msgid "Chavantes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1503
+msgid "Chaves"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1504
+msgid "Chiador"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1505
+msgid "Chiapetta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1506
+msgid "Chopinzinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1508
+msgid "Chorozinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1509
+msgid "Chorrochó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1507
+msgid "Choró"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1511
+msgid "Chupinguaia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1512
+msgid "Chuvisca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1510
+msgid "Chuí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1486
+msgid "Chácara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1484
+msgid "Chã Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1485
+msgid "Chã Preta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1483
+msgid "Chã de Alegria"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1513
+msgid "Cianorte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1515
+msgid "Cidade Gaúcha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1516
+msgid "Cidade Ocidental"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1517
+msgid "Cidelândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1518
+msgid "Cidreira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1520
+msgid "Cipotânea"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1519
+msgid "Cipó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1521
+msgid "Ciríaco"
+msgstr ""
+
+#. module: l10n_br
+#: model_terms:ir.ui.view,arch_db:l10n_br.br_partner_address_form
+msgid "City"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1522
+msgid "Claraval"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1523
+msgid "Claro dos Poções"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1526
+msgid "Clementina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1527
+msgid "Clevelândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1524
+msgid "Cláudia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1525
+msgid "Cláudio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1528
+msgid "Coaraci"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1529
+msgid "Coari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1530
+msgid "Cocal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1531
+msgid "Cocal de Telha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1532
+msgid "Cocal do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1533
+msgid "Cocal dos Alves"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1534
+msgid "Cocalinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1535
+msgid "Cocalzinho de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1536
+msgid "Cocos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1537
+msgid "Codajás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_273
+msgid "Codó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1538
+msgid "Coelho Neto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1539
+msgid "Coimbra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1540
+msgid "Coité do Nóia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1541
+msgid "Coivaras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1542
+msgid "Colares"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_252
+msgid "Colatina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1544
+msgid "Colina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1545
+#: model:res.city,name:l10n_br.city_br_1546
+msgid "Colinas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1547
+msgid "Colinas do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1548
+msgid "Colinas do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1549
+msgid "Colméia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1550
+msgid "Colniza"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_130
+msgid "Colombo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1555
+#: model:res.city,name:l10n_br.city_br_1556
+msgid "Colorado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1557
+msgid "Colorado do Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1558
+msgid "Coluna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1543
+msgid "Colíder"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1551
+msgid "Colômbia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1554
+msgid "Colônia Leopoldina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1552
+msgid "Colônia do Gurguéia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1553
+msgid "Colônia do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1559
+msgid "Combinado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1560
+msgid "Comendador Gomes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1561
+msgid "Comendador Levy Gasparian"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1562
+msgid "Comercinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1563
+msgid "Comodoro"
+msgstr ""
+
+#. module: l10n_br
 #: model:ir.model,name:l10n_br.model_res_company
 msgid "Companies"
+msgstr ""
+
+#. module: l10n_br
+#: model_terms:ir.ui.view,arch_db:l10n_br.br_partner_address_form
+msgid "Complement"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1564
+msgid "Conceição"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1565
+msgid "Conceição da Aparecida"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1566
+msgid "Conceição da Barra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1567
+msgid "Conceição da Barra de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1568
+msgid "Conceição da Feira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1569
+msgid "Conceição das Alagoas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1570
+msgid "Conceição das Pedras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1571
+msgid "Conceição de Ipanema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1572
+msgid "Conceição de Macabu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1573
+msgid "Conceição do Almeida"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1574
+msgid "Conceição do Araguaia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1575
+msgid "Conceição do Canindé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1576
+msgid "Conceição do Castelo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1577
+msgid "Conceição do Coité"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1578
+msgid "Conceição do Jacuípe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1579
+msgid "Conceição do Lago-Açu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1580
+msgid "Conceição do Mato Dentro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1581
+msgid "Conceição do Pará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1582
+msgid "Conceição do Rio Verde"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1583
+msgid "Conceição do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1584
+msgid "Conceição dos Ouros"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1585
+msgid "Conchal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1586
+msgid "Conchas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1587
+msgid "Concórdia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1588
+msgid "Concórdia do Pará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1589
+#: model:res.city,name:l10n_br.city_br_1590
+msgid "Condado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1591
+#: model:res.city,name:l10n_br.city_br_1592
+msgid "Conde"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1593
+msgid "Condeúba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1594
+msgid "Condor"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1596
+msgid "Confins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1597
+msgid "Confresa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1598
+msgid "Congo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1599
+msgid "Congonhal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1600
+msgid "Congonhas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1601
+msgid "Congonhas do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1602
+msgid "Congonhinhas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1603
+msgid "Conquista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1604
+msgid "Conquista D'Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_227
+msgid "Conselheiro Lafaiete"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1605
+msgid "Conselheiro Mairinck"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1606
+msgid "Conselheiro Pena"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1607
+msgid "Consolação"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1608
+msgid "Constantina"
 msgstr ""
 
 #. module: l10n_br
@@ -100,13 +6489,1453 @@ msgid "Contact"
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_033
+msgid "Contagem"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1609
+msgid "Contenda"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1610
+msgid "Contendas do Sincorá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1611
+msgid "Coqueiral"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1612
+msgid "Coqueiro Baixo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1613
+msgid "Coqueiro Seco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1614
+msgid "Coqueiros do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1615
+msgid "Coração de Jesus"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1616
+msgid "Coração de Maria"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1617
+msgid "Corbélia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1618
+msgid "Cordeiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1620
+msgid "Cordeiros"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1619
+msgid "Cordeirópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1621
+msgid "Cordilheira Alta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1622
+msgid "Cordisburgo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1623
+msgid "Cordislândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1624
+msgid "Coreaú"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1625
+msgid "Coremas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1626
+msgid "Corguinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1627
+msgid "Coribe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1628
+msgid "Corinto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1629
+msgid "Cornélio Procópio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1630
+msgid "Coroaci"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1631
+msgid "Coroados"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1632
+msgid "Coroatá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1633
+msgid "Coromandel"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1634
+msgid "Coronel Barros"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1635
+msgid "Coronel Bicaco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1636
+msgid "Coronel Domingos Soares"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1637
+msgid "Coronel Ezequiel"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_301
+msgid "Coronel Fabriciano"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1638
+msgid "Coronel Freitas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1641
+msgid "Coronel José Dias"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1639
+msgid "Coronel João Pessoa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1640
+msgid "Coronel João Sá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1642
+msgid "Coronel Macedo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1643
+msgid "Coronel Martins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1644
+msgid "Coronel Murta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1645
+msgid "Coronel Pacheco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1646
+msgid "Coronel Pilar"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1647
+msgid "Coronel Sapucaia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1648
+msgid "Coronel Vivida"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1649
+msgid "Coronel Xavier Chaves"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1655
+msgid "Correia Pinto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1656
+msgid "Corrente"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1657
+msgid "Correntes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1658
+msgid "Correntina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1659
+msgid "Cortês"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1663
+msgid "Corumbataí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1664
+msgid "Corumbataí do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1662
+msgid "Corumbaíba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1665
+msgid "Corumbiara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1660
+msgid "Corumbá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1661
+msgid "Corumbá de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1666
+msgid "Corupá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1667
+msgid "Coruripe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1669
+msgid "Cosmorama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1668
+msgid "Cosmópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1670
+msgid "Costa Marques"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1671
+msgid "Costa Rica"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1672
+msgid "Cotegipe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_100
+msgid "Cotia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1673
+msgid "Cotiporã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1674
+msgid "Cotriguaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model_terms:ir.ui.view,arch_db:l10n_br.br_partner_address_form
+msgid "Country"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1676
+msgid "Couto Magalhães"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1675
+msgid "Couto de Magalhães de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1677
+msgid "Coxilha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1678
+msgid "Coxim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1679
+msgid "Coxixola"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1681
+msgid "Crateús"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_229
+msgid "Crato"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1682
+msgid "Cravinhos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1683
+msgid "Cravolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1680
+msgid "Craíbas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_145
+msgid "Criciúma"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1686
+msgid "Crissiumal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1687
+msgid "Cristais"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1688
+msgid "Cristais Paulista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1689
+msgid "Cristal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1690
+msgid "Cristal do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1694
+msgid "Cristalina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1691
+msgid "Cristalândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1692
+msgid "Cristalândia do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1695
+msgid "Cristiano Otoni"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1696
+msgid "Cristianópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1697
+msgid "Cristina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1699
+msgid "Cristino Castro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1698
+msgid "Cristinápolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1693
+msgid "Cristália"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1700
+msgid "Cristópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1684
+msgid "Crisólita"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1685
+msgid "Crisópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1701
+msgid "Crixás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1702
+msgid "Crixás do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1703
+msgid "Croatá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1704
+msgid "Cromínia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1705
+msgid "Crucilândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1706
+msgid "Cruz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1707
+msgid "Cruz Alta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1710
+msgid "Cruz Machado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1708
+msgid "Cruz das Almas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1709
+msgid "Cruz do Espírito Santo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1712
+msgid "Cruzaltense"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1713
+msgid "Cruzeiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1714
+msgid "Cruzeiro da Fortaleza"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1715
+msgid "Cruzeiro do Iguaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1716
+msgid "Cruzeiro do Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1717
+#: model:res.city,name:l10n_br.city_br_1718
+#: model:res.city,name:l10n_br.city_br_1719
+msgid "Cruzeiro do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1720
+msgid "Cruzeta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1722
+msgid "Cruzmaltina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1711
+msgid "Cruzália"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1721
+msgid "Cruzília"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1723
+msgid "Cubati"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_278
+msgid "Cubatão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_031
+msgid "Cuiabá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1726
+msgid "Cuitegi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1724
+msgid "Cuité"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1725
+msgid "Cuité de Mamanguape"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1727
+msgid "Cujubim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1728
+msgid "Cumari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1729
+msgid "Cumaru"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1730
+msgid "Cumaru do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1731
+msgid "Cumbe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1732
+msgid "Cunha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1733
+msgid "Cunha Porã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1734
+msgid "Cunhataí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1735
+msgid "Cuparaque"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1736
+msgid "Cupira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1737
+msgid "Curaçá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1738
+msgid "Curimatá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1739
+msgid "Curionópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_008
+msgid "Curitiba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1740
+msgid "Curitibanos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1741
+msgid "Curiúva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1742
+msgid "Currais"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1743
+msgid "Currais Novos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1746
+msgid "Curral Novo do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1747
+msgid "Curral Velho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1744
+msgid "Curral de Cima"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1745
+msgid "Curral de Dentro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1748
+msgid "Curralinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1749
+msgid "Curralinhos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1752
+msgid "Cururupu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1750
+msgid "Curuá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1751
+msgid "Curuçá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1754
+msgid "Curvelo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1753
+msgid "Curvelândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1755
+msgid "Custódia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1756
+msgid "Cutias"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1105
+msgid "Cáceres"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1417
+msgid "Cássia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1418
+msgid "Cássia dos Coqueiros"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1275
+msgid "Cândido Godói"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1276
+msgid "Cândido Mendes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1277
+msgid "Cândido Mota"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1278
+msgid "Cândido Rodrigues"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1279
+msgid "Cândido Sales"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1274
+msgid "Cândido de Abreu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1481
+msgid "Céu Azul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1514
+msgid "Cícero Dantas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1650
+msgid "Córrego Danta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1653
+msgid "Córrego Fundo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1654
+msgid "Córrego Novo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1651
+msgid "Córrego do Bom Jesus"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1652
+msgid "Córrego do Ouro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1595
+msgid "Cônego Marinho"
+msgstr ""
+
+#. module: l10n_br
 #: model:l10n_latam.document.type,name:l10n_br.dt_18
 msgid "Daily Movement Summary"
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1757
+msgid "Damianópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1758
+msgid "Damião"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1759
+msgid "Damolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1760
+msgid "Darcinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1762
+msgid "Datas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1763
+msgid "David Canabarro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1764
+#: model:res.city,name:l10n_br.city_br_1765
+msgid "Davinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1766
+msgid "Delfim Moreira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1767
+msgid "Delfinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1768
+msgid "Delmiro Gouveia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1769
+msgid "Delta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1770
+msgid "Demerval Lobão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1771
+msgid "Denise"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1772
+msgid "Deodápolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1773
+msgid "Deputado Irapuan Pinheiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1774
+msgid "Derrubadas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1775
+msgid "Descalvado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1776
+msgid "Descanso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1777
+msgid "Descoberto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1778
+msgid "Desterro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1779
+msgid "Desterro de Entre Rios"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1780
+msgid "Desterro do Melo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1781
+msgid "Dezesseis de Novembro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_063
+msgid "Diadema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1782
+msgid "Diamante"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1783
+msgid "Diamante D'Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1784
+msgid "Diamante do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1785
+msgid "Diamante do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1786
+msgid "Diamantina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1787
+msgid "Diamantino"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1788
+msgid "Dianópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1789
+msgid "Dias d'Ávila"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1790
+msgid "Dilermando de Aguiar"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1791
+msgid "Diogo de Vasconcelos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1792
+msgid "Dionísio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1793
+msgid "Dionísio Cerqueira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1794
+msgid "Diorama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1795
+msgid "Dirce Reis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1796
+msgid "Dirceu Arcoverde"
+msgstr ""
+
+#. module: l10n_br
 #: model:ir.model.fields,field_description:l10n_br.field_account_tax__tax_discount
 msgid "Discount this Tax in Price"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1797
+msgid "Divina Pastora"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1799
+msgid "Divino"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1800
+msgid "Divino das Laranjeiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1801
+msgid "Divino de São Lourenço"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1802
+msgid "Divinolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1803
+msgid "Divinolândia de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1798
+msgid "Divinésia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_131
+msgid "Divinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1804
+msgid "Divinópolis de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1805
+msgid "Divinópolis do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1806
+msgid "Divisa Alegre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1807
+msgid "Divisa Nova"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1808
+msgid "Divisópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1809
+msgid "Dobrada"
+msgstr ""
+
+#. module: l10n_br
+#: model_terms:ir.ui.view,arch_db:l10n_br.view_partner_bank_form_inherit_account
+msgid "Documentation"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1810
+msgid "Dois Córregos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1811
+msgid "Dois Irmãos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1812
+msgid "Dois Irmãos das Missões"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1813
+msgid "Dois Irmãos do Buriti"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1814
+msgid "Dois Irmãos do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1815
+msgid "Dois Lajeados"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1816
+msgid "Dois Riachos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1817
+msgid "Dois Vizinhos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1818
+msgid "Dolcinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1819
+msgid "Dom Aquino"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1820
+msgid "Dom Basílio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1821
+msgid "Dom Bosco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1822
+msgid "Dom Cavati"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1823
+msgid "Dom Eliseu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1824
+msgid "Dom Expedito Lopes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1825
+msgid "Dom Feliciano"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1826
+msgid "Dom Inocêncio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1827
+msgid "Dom Joaquim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1828
+msgid "Dom Macedo Costa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1829
+msgid "Dom Pedrito"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1830
+msgid "Dom Pedro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1831
+msgid "Dom Pedro de Alcântara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1832
+msgid "Dom Silvério"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1833
+msgid "Dom Viçoso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1834
+msgid "Domingos Martins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1835
+msgid "Domingos Mourão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1836
+msgid "Dona Emma"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1837
+msgid "Dona Eusébia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1838
+msgid "Dona Francisca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1839
+msgid "Dona Inês"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1840
+msgid "Dores de Campos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1841
+msgid "Dores de Guanhães"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1842
+msgid "Dores do Indaiá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1843
+msgid "Dores do Rio Preto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1844
+msgid "Dores do Turvo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1845
+msgid "Doresópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1846
+msgid "Dormentes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1847
+#: model:res.city,name:l10n_br.city_br_1848
+msgid "Douradina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1849
+msgid "Dourado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1850
+msgid "Douradoquara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_120
+msgid "Dourados"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1851
+msgid "Doutor Camargo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1852
+msgid "Doutor Maurício Cardoso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1853
+msgid "Doutor Pedrinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1854
+msgid "Doutor Ricardo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1855
+msgid "Doutor Severiano"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1856
+msgid "Doutor Ulysses"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1857
+msgid "Doverlândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1858
+msgid "Dracena"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1859
+msgid "Duartina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1860
+msgid "Duas Barras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1861
+msgid "Duas Estradas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1862
+msgid "Dueré"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1863
+msgid "Dumont"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1864
+msgid "Duque Bacelar"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_022
+msgid "Duque de Caxias"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1865
+msgid "Durandé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1761
+msgid "Dário Meira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1866
+msgid "Echaporã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1867
+msgid "Ecoporanga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1868
+msgid "Edealina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1869
+msgid "Edéia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1870
+msgid "Eirunepé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1871
+#: model:res.city,name:l10n_br.city_br_1872
+msgid "Eldorado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1873
+msgid "Eldorado do Carajás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1874
+msgid "Eldorado do Sul"
 msgstr ""
 
 #. module: l10n_br
@@ -145,13 +7974,2082 @@ msgid "Electronic Tax Coupon (CF-e-SAT)"
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1875
+msgid "Elesbão Veloso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1876
+msgid "Elias Fausto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1877
+msgid "Eliseu Martins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1878
+msgid "Elisiário"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1879
+msgid "Elísio Medrado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1880
+msgid "Elói Mendes"
+msgstr ""
+
+#. module: l10n_br
+#: model:ir.model.fields.selection,name:l10n_br.selection__res_partner_bank__proxy_type__email
+msgid "Email Address"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1881
+msgid "Emas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1882
+msgid "Embaúba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_116
+msgid "Embu das Artes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1883
+msgid "Embu-Guaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1884
+msgid "Emilianópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1885
+msgid "Encantado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1886
+msgid "Encanto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1887
+msgid "Encruzilhada"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1888
+msgid "Encruzilhada do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1890
+msgid "Engenheiro Beltrão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1891
+msgid "Engenheiro Caldas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1892
+msgid "Engenheiro Coelho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1893
+msgid "Engenheiro Navarro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1894
+msgid "Engenheiro Paulo de Frontin"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1895
+msgid "Engenho Velho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1896
+msgid "Entre Folhas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1898
+#: model:res.city,name:l10n_br.city_br_1899
+msgid "Entre Rios"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1900
+msgid "Entre Rios de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1901
+msgid "Entre Rios do Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1902
+msgid "Entre Rios do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1897
+msgid "Entre-Ijuís"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1903
+msgid "Envira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1889
+msgid "Enéas Marques"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1904
+msgid "Epitaciolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1905
+msgid "Equador"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1906
+msgid "Erebango"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_295
+msgid "Erechim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1907
+msgid "Ererê"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1909
+msgid "Ermo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1910
+msgid "Ernestina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1911
+msgid "Erval Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1912
+msgid "Erval Seco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1913
+msgid "Erval Velho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1914
+msgid "Ervália"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1915
+msgid "Escada"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1916
+msgid "Esmeralda"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1917
+msgid "Esmeraldas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1918
+msgid "Espera Feliz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1922
+#: model:res.city,name:l10n_br.city_br_1923
+msgid "Esperantina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1924
+msgid "Esperantinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1919
+msgid "Esperança"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1921
+msgid "Esperança Nova"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1920
+msgid "Esperança do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1925
+msgid "Espigão Alto do Iguaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1926
+msgid "Espigão D'Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1927
+msgid "Espinosa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1932
+msgid "Esplanada"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1933
+msgid "Espumoso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1928
+msgid "Espírito Santo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1929
+msgid "Espírito Santo do Dourado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1930
+msgid "Espírito Santo do Pinhal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1931
+msgid "Espírito Santo do Turvo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1934
+msgid "Estação"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1937
+msgid "Esteio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1938
+msgid "Estiva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1939
+msgid "Estiva Gerbi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1940
+msgid "Estreito"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1941
+msgid "Estrela"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1943
+msgid "Estrela Dalva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1949
+msgid "Estrela Velha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1942
+msgid "Estrela d'Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1944
+msgid "Estrela de Alagoas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1945
+msgid "Estrela do Indaiá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1946
+#: model:res.city,name:l10n_br.city_br_1947
+msgid "Estrela do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1948
+msgid "Estrela do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1935
+msgid "Estância"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1936
+msgid "Estância Velha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1950
+msgid "Euclides da Cunha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1951
+msgid "Euclides da Cunha Paulista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1953
+msgid "Eugenópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1952
+msgid "Eugênio de Castro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_274
+msgid "Eunápolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1954
+msgid "Eusébio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1955
+msgid "Ewbank da Câmara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1956
+msgid "Extrema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1957
+msgid "Extremoz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1958
+msgid "Exu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1959
+msgid "Fagundes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1960
+msgid "Fagundes Varela"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1961
+msgid "Faina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1962
+msgid "Fama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1963
+msgid "Faria Lemos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1964
+msgid "Farias Brito"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1965
+msgid "Faro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1966
+msgid "Farol"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1967
+msgid "Farroupilha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1968
+msgid "Fartura"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1969
+msgid "Fartura do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1973
+msgid "Faxinal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1974
+msgid "Faxinal do Soturno"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1975
+msgid "Faxinal dos Guedes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1976
+msgid "Faxinalzinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1977
+msgid "Fazenda Nova"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_202
+msgid "Fazenda Rio Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1978
+msgid "Fazenda Vilanova"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1979
+msgid "Feijó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1981
+msgid "Feira Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1982
+#: model:res.city,name:l10n_br.city_br_1983
+msgid "Feira Nova"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1984
+msgid "Feira Nova do Maranhão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1980
+msgid "Feira da Mata"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_035
+msgid "Feira de Santana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1986
+msgid "Felipe Guerra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1987
+msgid "Felisburgo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1988
+msgid "Felixlândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1989
+msgid "Feliz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1990
+msgid "Feliz Deserto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1991
+msgid "Feliz Natal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1985
+msgid "Felício dos Santos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1993
+msgid "Fernandes Pinheiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1994
+msgid "Fernandes Tourinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1996
+msgid "Fernando Falcão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1997
+msgid "Fernando Pedroza"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1998
+msgid "Fernando Prestes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1995
+msgid "Fernando de Noronha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1999
+msgid "Fernandópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2000
+msgid "Fernão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_166
+msgid "Ferraz de Vasconcelos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2001
+msgid "Ferreira Gomes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2002
+msgid "Ferreiros"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2003
+msgid "Ferros"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2004
+msgid "Fervedouro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2005
+msgid "Figueira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2006
+msgid "Figueirão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2007
+msgid "Figueirópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2008
+msgid "Figueirópolis D'Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2009
+#: model:res.city,name:l10n_br.city_br_2010
+msgid "Filadélfia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2011
+msgid "Firmino Alves"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2012
+msgid "Firminópolis"
+msgstr ""
+
+#. module: l10n_br
 #: model:ir.model,name:l10n_br.model_account_fiscal_position
 msgid "Fiscal Position"
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2013
+msgid "Flexeiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2014
+msgid "Flor da Serra do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2015
+msgid "Flor do Sertão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2016
+msgid "Flora Rica"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2017
+msgid "Floraí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2019
+msgid "Floreal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2020
+msgid "Flores"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2021
+msgid "Flores da Cunha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2022
+msgid "Flores de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2023
+msgid "Flores do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2024
+#: model:res.city,name:l10n_br.city_br_2025
+msgid "Floresta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2026
+msgid "Floresta Azul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2027
+msgid "Floresta do Araguaia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2028
+msgid "Floresta do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2029
+msgid "Florestal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2030
+msgid "Florestópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2031
+msgid "Floriano"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2032
+msgid "Floriano Peixoto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_039
+msgid "Florianópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2018
+msgid "Florânia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2035
+msgid "Florínea"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2033
+msgid "Flórida"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2034
+msgid "Flórida Paulista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2036
+msgid "Fonte Boa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2037
+msgid "Fontoura Xavier"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2038
+msgid "Formiga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2039
+msgid "Formigueiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_268
+msgid "Formosa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2040
+msgid "Formosa da Serra Negra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2041
+msgid "Formosa do Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2042
+msgid "Formosa do Rio Preto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2043
+msgid "Formosa do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2044
+#: model:res.city,name:l10n_br.city_br_2045
+msgid "Formoso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2046
+msgid "Formoso do Araguaia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2047
+msgid "Forquetinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2048
+msgid "Forquilha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2049
+msgid "Forquilhinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_004
+msgid "Fortaleza"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2050
+msgid "Fortaleza de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2051
+msgid "Fortaleza do Tabocão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2052
+msgid "Fortaleza dos Nogueiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2053
+msgid "Fortaleza dos Valos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2054
+msgid "Fortim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2055
+msgid "Fortuna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2056
+msgid "Fortuna de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_097
+msgid "Foz do Iguaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2057
+msgid "Foz do Jordão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2058
+msgid "Fraiburgo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_075
+msgid "Franca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2059
+msgid "Francinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2060
+msgid "Francisco Alves"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2061
+msgid "Francisco Ayres"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2062
+msgid "Francisco Badaró"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2063
+msgid "Francisco Beltrão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2064
+msgid "Francisco Dantas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2065
+msgid "Francisco Dumont"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2066
+msgid "Francisco Macedo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_180
+msgid "Francisco Morato"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2068
+msgid "Francisco Santos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2067
+msgid "Francisco Sá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2069
+msgid "Franciscópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_209
+msgid "Franco da Rocha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2070
+msgid "Frecheirinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2071
+msgid "Frederico Westphalen"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2072
+msgid "Frei Gaspar"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2073
+msgid "Frei Inocêncio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2074
+msgid "Frei Lagonegro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2075
+msgid "Frei Martinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2076
+msgid "Frei Miguelinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2077
+msgid "Frei Paulo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2078
+msgid "Frei Rogério"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2079
+msgid "Fronteira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2080
+msgid "Fronteira dos Vales"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2081
+msgid "Fronteiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2082
+msgid "Fruta de Leite"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2083
+msgid "Frutal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2084
+msgid "Frutuoso Gomes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2085
+msgid "Fundão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2086
+msgid "Funilândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1970
+#: model:res.city,name:l10n_br.city_br_1971
+msgid "Fátima"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1972
+msgid "Fátima do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1992
+msgid "Fênix"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2087
+msgid "Gabriel Monteiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2088
+msgid "Gado Bravo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2090
+msgid "Galiléia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2091
+msgid "Galinhos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2092
+msgid "Galvão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2093
+msgid "Gameleira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2094
+msgid "Gameleira de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2095
+msgid "Gameleiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2096
+msgid "Gandu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_210
+msgid "Garanhuns"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2097
+msgid "Gararu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2099
+msgid "Garibaldi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2100
+msgid "Garopaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2101
+msgid "Garrafão do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2102
+msgid "Garruchos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2103
+msgid "Garuva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2098
+msgid "Garça"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2104
+msgid "Gaspar"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2105
+msgid "Gastão Vidigal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2107
+msgid "Gaurama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2108
+msgid "Gavião"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2109
+msgid "Gavião Peixoto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2106
+msgid "Gaúcha do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2110
+msgid "Geminiano"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2112
+#: model:res.city,name:l10n_br.city_br_2113
+msgid "General Carneiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2111
+msgid "General Câmara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2114
+msgid "General Maynard"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2115
+msgid "General Salgado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2116
+msgid "General Sampaio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2117
+msgid "Gentil"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2118
+msgid "Gentio do Ouro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2119
+msgid "Getulina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2120
+msgid "Getúlio Vargas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2121
+msgid "Gilbués"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2122
+msgid "Girau do Ponciano"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2123
+msgid "Giruá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2124
+msgid "Glaucilândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2125
+msgid "Glicério"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2130
+msgid "Glorinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2126
+msgid "Glória"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2127
+msgid "Glória D'Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2128
+msgid "Glória de Dourados"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2129
+msgid "Glória do Goitá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2131
+msgid "Godofredo Viana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2132
+msgid "Godoy Moreira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2133
+msgid "Goiabeira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2134
+msgid "Goiana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2137
+msgid "Goiandira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2140
+msgid "Goianinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2141
+msgid "Goianira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2142
+msgid "Goianorte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2135
+msgid "Goianá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2136
+msgid "Goianápolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2138
+msgid "Goianésia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2139
+msgid "Goianésia do Pará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2144
+msgid "Goiatins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2145
+msgid "Goiatuba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2146
+msgid "Goioerê"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2147
+msgid "Goioxim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2143
+msgid "Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_010
+msgid "Goiânia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2150
+msgid "Gongogi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2151
+msgid "Gonzaga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2148
+msgid "Gonçalves"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2149
+msgid "Gonçalves Dias"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2152
+msgid "Gouveia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2153
+msgid "Gouvelândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2154
+msgid "Governador Archer"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2155
+msgid "Governador Celso Ramos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2156
+msgid "Governador Dix-Sept Rosado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2157
+msgid "Governador Edison Lobão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2158
+msgid "Governador Eugênio Barros"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2159
+msgid "Governador Jorge Teixeira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2160
+msgid "Governador Lindenberg"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2161
+msgid "Governador Luiz Rocha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2162
+msgid "Governador Mangabeira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2163
+msgid "Governador Newton Bello"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2164
+msgid "Governador Nunes Freire"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_111
+msgid "Governador Valadares"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2167
+msgid "Gracho Cardoso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2168
+msgid "Grajaú"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2169
+msgid "Gramado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2171
+msgid "Gramado Xavier"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2170
+msgid "Gramado dos Loureiros"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2172
+msgid "Grandes Rios"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2173
+msgid "Granito"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2174
+msgid "Granja"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2175
+msgid "Granjeiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2179
+msgid "Gravatal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_107
+msgid "Gravataí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2178
+msgid "Gravatá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2165
+msgid "Graça"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2166
+msgid "Graça Aranha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2180
+msgid "Groaíras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2181
+msgid "Grossos"
+msgstr ""
+
+#. module: l10n_br
 #: model:l10n_latam.document.type,name:l10n_br.dt_08
 msgid "Ground Bill of Lading"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2182
+msgid "Grupiara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2176
+msgid "Grão Mogol"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2177
+msgid "Grão Pará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2183
+msgid "Guabiju"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2184
+msgid "Guabiruba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2186
+msgid "Guadalupe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2189
+msgid "Guaimbê"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2192
+msgid "Guairaçá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2188
+msgid "Guaiçara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2193
+msgid "Guaiúba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2194
+msgid "Guajará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2195
+msgid "Guajará-Mirim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2196
+msgid "Guajeru"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2197
+msgid "Guamaré"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2198
+msgid "Guamiranga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2199
+msgid "Guanambi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2200
+msgid "Guanhães"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2203
+msgid "Guapiara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2202
+msgid "Guapiaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2204
+msgid "Guapimirim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2205
+msgid "Guapirama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2208
+msgid "Guaporema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2207
+msgid "Guaporé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2201
+msgid "Guapé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2206
+msgid "Guapó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2210
+msgid "Guarabira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2212
+#: model:res.city,name:l10n_br.city_br_2213
+msgid "Guaraci"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2214
+#: model:res.city,name:l10n_br.city_br_2215
+msgid "Guaraciaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2216
+msgid "Guaraciaba do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2217
+msgid "Guaraciama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2220
+msgid "Guaramiranga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2221
+msgid "Guaramirim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2223
+msgid "Guarani"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2224
+msgid "Guarani d'Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2225
+msgid "Guarani das Missões"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2226
+msgid "Guarani de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2227
+msgid "Guaraniaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2228
+msgid "Guarantã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2229
+msgid "Guarantã do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2222
+msgid "Guaranésia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_243
+msgid "Guarapari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_165
+msgid "Guarapuava"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2230
+msgid "Guaraqueçaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2232
+msgid "Guararapes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2233
+msgid "Guararema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2231
+msgid "Guarará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2234
+msgid "Guaratinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_259
+msgid "Guaratinguetá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2235
+msgid "Guaratuba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2211
+msgid "Guaraçaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2218
+msgid "Guaraí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2219
+msgid "Guaraíta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2236
+msgid "Guarda-Mor"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2237
+msgid "Guareí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2238
+msgid "Guariba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2239
+msgid "Guaribas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2240
+msgid "Guarinos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_095
+msgid "Guarujá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2241
+msgid "Guarujá do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_013
+msgid "Guarulhos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2209
+msgid "Guará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2242
+msgid "Guatambú"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2243
+msgid "Guatapará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2244
+msgid "Guaxupé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2185
+msgid "Guaçuí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2187
+msgid "Guaíba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2190
+#: model:res.city,name:l10n_br.city_br_2191
+msgid "Guaíra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2245
+msgid "Guia Lopes da Laguna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2246
+msgid "Guidoval"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2248
+msgid "Guimarânia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2247
+msgid "Guimarães"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2249
+msgid "Guiratinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2250
+msgid "Guiricema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2251
+msgid "Gurinhatã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2252
+msgid "Gurinhém"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2253
+msgid "Gurjão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2255
+msgid "Gurupi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2254
+msgid "Gurupá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2256
+msgid "Guzolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2089
+msgid "Gália"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2257
+msgid "Harmonia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2258
+msgid "Heitoraí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2259
+msgid "Heliodora"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2260
+msgid "Heliópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2261
+msgid "Herculândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2262
+msgid "Herval"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2263
+msgid "Herval d'Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2264
+msgid "Herveiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2267
+msgid "Hidrolina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2265
+#: model:res.city,name:l10n_br.city_br_2266
+msgid "Hidrolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2268
+msgid "Holambra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2269
+msgid "Honório Serpa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2270
+msgid "Horizonte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2271
+msgid "Horizontina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_125
+msgid "Hortolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2272
+msgid "Hugo Napoleão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2273
+msgid "Hulha Negra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2274
+#: model:res.city,name:l10n_br.city_br_2275
+msgid "Humaitá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2276
+msgid "Humberto de Campos"
 msgstr ""
 
 #. module: l10n_br
@@ -289,8 +10187,692 @@ msgid "ISSQN tax"
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2277
+msgid "Iacanga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2278
+msgid "Iaciara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2279
+msgid "Iacri"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2281
+msgid "Iapu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2282
+msgid "Iaras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2283
+msgid "Iati"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2280
+msgid "Iaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2284
+msgid "Ibaiti"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2285
+msgid "Ibarama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2286
+msgid "Ibaretama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2288
+msgid "Ibateguara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2289
+msgid "Ibatiba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2287
+msgid "Ibaté"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2290
+msgid "Ibema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2291
+msgid "Ibertioga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2295
+msgid "Ibiam"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2296
+msgid "Ibiapina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2297
+msgid "Ibiara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2298
+msgid "Ibiassucê"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2293
+msgid "Ibiaçá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2294
+msgid "Ibiaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2299
+msgid "Ibicaraí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2300
+msgid "Ibicaré"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2301
+msgid "Ibicoara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2303
+msgid "Ibicuitinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2302
+msgid "Ibicuí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2304
+msgid "Ibimirim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2305
+msgid "Ibipeba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2306
+msgid "Ibipitanga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2307
+msgid "Ibiporã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2308
+msgid "Ibiquera"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2310
+msgid "Ibiracatu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2311
+msgid "Ibiraci"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2313
+msgid "Ibiraiaras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2314
+msgid "Ibirajuba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2315
+msgid "Ibirama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2316
+msgid "Ibirapitanga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2318
+msgid "Ibirapuitã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2317
+msgid "Ibirapuã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2319
+msgid "Ibirarema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2320
+msgid "Ibirataia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2312
+msgid "Ibiraçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_171
+msgid "Ibirité"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2321
+msgid "Ibirubá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2309
+msgid "Ibirá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2322
+msgid "Ibitiara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2323
+msgid "Ibitinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2324
+msgid "Ibitirama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2325
+msgid "Ibititá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2326
+msgid "Ibitiúra de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2327
+msgid "Ibituruna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2292
+msgid "Ibiá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2328
+msgid "Ibiúna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2329
+msgid "Ibotirama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2330
+msgid "Icapuí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2332
+msgid "Icaraí de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2333
+msgid "Icaraíma"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2334
+msgid "Icatu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2336
+msgid "Ichu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2338
+msgid "Iconha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2335
+msgid "Icém"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2337
+msgid "Icó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2339
+msgid "Ielmo Marinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2340
+msgid "Iepê"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2341
+msgid "Igaci"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2342
+msgid "Igaporã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2344
+msgid "Igaracy"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2345
+msgid "Igarapava"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2346
+msgid "Igarapé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2349
+msgid "Igarapé Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2348
+msgid "Igarapé do Meio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2347
+msgid "Igarapé-Açu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2350
+msgid "Igarapé-Miri"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_270
+msgid "Igarassu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2352
+msgid "Igaratinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2351
+msgid "Igaratá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2343
+msgid "Igaraçu do Tietê"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2353
+msgid "Igrapiúna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2354
+msgid "Igreja Nova"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2355
+msgid "Igrejinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2356
+msgid "Iguaba Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2358
+msgid "Iguape"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2360
+msgid "Iguaracy"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2359
+msgid "Iguaraçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2361
+msgid "Iguatama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2362
+msgid "Iguatemi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2363
+#: model:res.city,name:l10n_br.city_br_2364
+msgid "Iguatu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2357
+msgid "Iguaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2365
+msgid "Ijaci"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2366
+msgid "Ijuí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2367
+msgid "Ilha Comprida"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2370
+msgid "Ilha Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2371
+msgid "Ilha Solteira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2368
+msgid "Ilha das Flores"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2369
+msgid "Ilha de Itamaracá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2372
+msgid "Ilhabela"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2373
+msgid "Ilhota"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_167
+msgid "Ilhéus"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2374
+msgid "Ilicínea"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2375
+msgid "Ilópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2376
+msgid "Imaculada"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2377
+msgid "Imaruí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2378
+msgid "Imbaú"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2381
+msgid "Imbituba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2382
+msgid "Imbituva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2383
+msgid "Imbuia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2379
+msgid "Imbé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2380
+msgid "Imbé de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2384
+msgid "Imigrante"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_102
+msgid "Imperatriz"
+msgstr ""
+
+#. module: l10n_br
 #: model:l10n_latam.document.type,name:l10n_br.dt_02
 msgid "In-Consumer Sales Invoice"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2386
+msgid "Inaciolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2387
+#: model:res.city,name:l10n_br.city_br_2388
+msgid "Inajá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2389
+msgid "Inconfidentes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2390
+msgid "Indaiabira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2391
+msgid "Indaial"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_112
+msgid "Indaiatuba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2392
+#: model:res.city,name:l10n_br.city_br_2393
+msgid "Independência"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2394
+msgid "Indiana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2395
+#: model:res.city,name:l10n_br.city_br_2396
+msgid "Indianópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2397
+msgid "Indiaporã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2398
+msgid "Indiara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2399
+msgid "Indiaroba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2400
+msgid "Indiavaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2403
+msgid "Ingazeira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2402
+msgid "Ingaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2401
+msgid "Ingá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2404
+msgid "Inhacorá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2405
+msgid "Inhambupe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2406
+msgid "Inhangapi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2407
+msgid "Inhapi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2408
+msgid "Inhapim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2409
+msgid "Inhaúma"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2410
+msgid "Inhuma"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2411
+msgid "Inhumas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2412
+msgid "Inimutaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2413
+msgid "Inocência"
 msgstr ""
 
 #. module: l10n_br
@@ -344,6 +10926,1893 @@ msgid "Invoice from Producer"
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2385
+msgid "Inácio Martins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2414
+msgid "Inúbia Paulista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2415
+msgid "Iomerê"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2416
+msgid "Ipaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2417
+msgid "Ipameri"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2418
+msgid "Ipanema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2419
+msgid "Ipanguaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2420
+msgid "Ipaporanga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_134
+msgid "Ipatinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2421
+msgid "Ipaumirim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2422
+msgid "Ipaussu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2424
+msgid "Ipecaetá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2425
+msgid "Iperó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2426
+msgid "Ipeúna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2427
+msgid "Ipiaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2428
+msgid "Ipiaú"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2429
+msgid "Ipiguá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2430
+msgid "Ipira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2432
+msgid "Ipiranga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2433
+msgid "Ipiranga de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2434
+msgid "Ipiranga do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2435
+msgid "Ipiranga do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2436
+msgid "Ipiranga do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2431
+msgid "Ipirá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2437
+msgid "Ipixuna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2438
+msgid "Ipixuna do Pará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2439
+msgid "Ipojuca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2443
+msgid "Iporanga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2440
+msgid "Iporá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2441
+msgid "Iporã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2442
+msgid "Iporã do Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2444
+msgid "Ipu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2446
+msgid "Ipuaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2447
+msgid "Ipubi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2448
+msgid "Ipueira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2449
+#: model:res.city,name:l10n_br.city_br_2450
+msgid "Ipueiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2451
+msgid "Ipuiúna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2452
+msgid "Ipumirim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2453
+msgid "Ipupiara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2445
+msgid "Ipuã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2423
+msgid "Ipê"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2454
+#: model:res.city,name:l10n_br.city_br_2455
+msgid "Iracema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2456
+msgid "Iracema do Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2458
+msgid "Iraceminha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2457
+msgid "Iracemápolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2461
+msgid "Irajuba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2462
+msgid "Iramaia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2463
+msgid "Iranduba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2464
+msgid "Irani"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2466
+msgid "Irapuru"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2465
+msgid "Irapuã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2467
+msgid "Iraquara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2468
+msgid "Irará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2469
+#: model:res.city,name:l10n_br.city_br_2470
+msgid "Irati"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2471
+msgid "Irauçuba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2459
+msgid "Iraí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2460
+msgid "Iraí de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2472
+msgid "Irecê"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2473
+msgid "Iretama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2474
+msgid "Irineópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2475
+msgid "Irituia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2476
+msgid "Irupi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2477
+msgid "Isaías Coelho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2478
+msgid "Israelândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2480
+msgid "Itaara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2481
+#: model:res.city,name:l10n_br.city_br_309
+msgid "Itabaiana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2482
+msgid "Itabaianinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2483
+msgid "Itabela"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2485
+msgid "Itaberaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2486
+msgid "Itaberaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2484
+msgid "Itaberá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2487
+msgid "Itabi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_275
+msgid "Itabira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2488
+msgid "Itabirinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2489
+msgid "Itabirito"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_139
+msgid "Itaboraí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_161
+msgid "Itabuna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2490
+msgid "Itacajá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2491
+msgid "Itacambira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2492
+msgid "Itacarambi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2493
+msgid "Itacaré"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_308
+msgid "Itacoatiara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2494
+msgid "Itacuruba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2495
+msgid "Itacurubi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2496
+msgid "Itaeté"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2497
+msgid "Itagi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2498
+msgid "Itagibá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2499
+msgid "Itagimirim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2502
+msgid "Itaguajé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2503
+msgid "Itaguara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2504
+msgid "Itaguari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2505
+msgid "Itaguaru"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2506
+msgid "Itaguatins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2500
+msgid "Itaguaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2501
+msgid "Itaguaçu da Bahia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_264
+msgid "Itaguaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2510
+msgid "Itainópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2512
+msgid "Itaipava do Grajaú"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2514
+msgid "Itaipulândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2513
+msgid "Itaipé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2515
+msgid "Itaitinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_247
+msgid "Itaituba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2509
+msgid "Itaiçaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2511
+msgid "Itaiópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_109
+msgid "Itajaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2518
+msgid "Itajobi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2519
+msgid "Itaju"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2520
+msgid "Itaju do Colônia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2521
+msgid "Itajubá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2522
+msgid "Itajuípe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2516
+#: model:res.city,name:l10n_br.city_br_2517
+msgid "Itajá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2523
+msgid "Italva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2524
+msgid "Itamaraju"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2525
+msgid "Itamarandiba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2526
+msgid "Itamarati"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2527
+msgid "Itamarati de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2528
+msgid "Itamari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2529
+msgid "Itambacuri"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2530
+msgid "Itambaracá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2531
+#: model:res.city,name:l10n_br.city_br_2532
+#: model:res.city,name:l10n_br.city_br_2533
+msgid "Itambé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2534
+msgid "Itambé do Mato Dentro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2535
+msgid "Itamogi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2536
+msgid "Itamonte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2537
+msgid "Itanagra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2538
+msgid "Itanhandu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2539
+msgid "Itanhangá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_277
+msgid "Itanhaém"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2541
+msgid "Itanhomi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2540
+msgid "Itanhém"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2542
+msgid "Itaobim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2544
+msgid "Itaocara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2545
+msgid "Itapaci"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2546
+msgid "Itapagipe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2547
+msgid "Itapajé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2548
+msgid "Itaparica"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2550
+msgid "Itapebi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2551
+msgid "Itapecerica"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_189
+msgid "Itapecerica da Serra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2552
+msgid "Itapecuru Mirim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2553
+msgid "Itapejara d'Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2554
+msgid "Itapema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2555
+msgid "Itapemirim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_319
+msgid "Itaperuna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2556
+msgid "Itaperuçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2557
+msgid "Itapetim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2558
+msgid "Itapetinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_191
+msgid "Itapetininga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2559
+#: model:res.city,name:l10n_br.city_br_2560
+msgid "Itapeva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_129
+msgid "Itapevi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2561
+msgid "Itapicuru"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_228
+msgid "Itapipoca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2562
+msgid "Itapira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2563
+#: model:res.city,name:l10n_br.city_br_2564
+msgid "Itapiranga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2565
+msgid "Itapirapuã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2566
+msgid "Itapirapuã Paulista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2567
+msgid "Itapiratins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2568
+msgid "Itapissuma"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2569
+msgid "Itapitanga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2570
+msgid "Itapiúna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2575
+#: model:res.city,name:l10n_br.city_br_2576
+msgid "Itaporanga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2577
+msgid "Itaporanga d'Ajuda"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2578
+msgid "Itapororoca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2573
+msgid "Itaporã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2574
+msgid "Itaporã do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2571
+msgid "Itapoá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2580
+msgid "Itapuca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2582
+msgid "Itapura"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2583
+msgid "Itapuranga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2579
+msgid "Itapuã do Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2581
+msgid "Itapuí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2549
+msgid "Itapé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_069
+msgid "Itaquaquecetuba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2584
+msgid "Itaquara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2585
+msgid "Itaqui"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2586
+msgid "Itaquiraí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2587
+msgid "Itaquitinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2588
+msgid "Itarana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2589
+msgid "Itarantim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2590
+msgid "Itararé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2591
+msgid "Itarema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2592
+msgid "Itariri"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2593
+msgid "Itarumã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2594
+msgid "Itati"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2595
+msgid "Itatiaia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2596
+msgid "Itatiaiuçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_251
+msgid "Itatiba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2597
+msgid "Itatiba do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2598
+msgid "Itatim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2599
+msgid "Itatinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2600
+msgid "Itatira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2601
+msgid "Itatuba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2605
+msgid "Itaubal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2607
+msgid "Itaueira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2606
+msgid "Itauçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2610
+msgid "Itaverava"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2507
+msgid "Itaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2508
+msgid "Itaíba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2543
+msgid "Itaóca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2602
+msgid "Itaú"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2603
+msgid "Itaú de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2604
+msgid "Itaúba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2608
+msgid "Itaúna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2609
+msgid "Itaúna do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2611
+msgid "Itinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2612
+msgid "Itinga do Maranhão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2613
+msgid "Itiquira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2614
+msgid "Itirapina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2615
+msgid "Itirapuã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2616
+msgid "Itiruçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2617
+msgid "Itiúba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2618
+msgid "Itobi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2619
+msgid "Itororó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_173
+msgid "Itu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2620
+msgid "Ituaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2621
+msgid "Ituberá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2622
+msgid "Itueta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_314
+msgid "Ituiutaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_287
+msgid "Itumbiara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2623
+msgid "Itumirim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2624
+msgid "Itupeva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2625
+msgid "Itupiranga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2626
+msgid "Ituporanga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2627
+msgid "Iturama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2628
+msgid "Itutinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2629
+msgid "Ituverava"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2479
+msgid "Itá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2572
+msgid "Itápolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2630
+msgid "Iuiú"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2633
+msgid "Ivaiporã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2635
+msgid "Ivatuba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2634
+msgid "Ivaté"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2632
+msgid "Ivaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2636
+msgid "Ivinhema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2637
+msgid "Ivolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2638
+msgid "Ivorá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2639
+msgid "Ivoti"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2331
+msgid "Içara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2631
+msgid "Iúna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_032
+msgid "Jaboatão dos Guararapes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2641
+#: model:res.city,name:l10n_br.city_br_2642
+msgid "Jaborandi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2640
+msgid "Jaborá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2643
+msgid "Jaboti"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2644
+msgid "Jaboticaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2645
+msgid "Jaboticabal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2646
+msgid "Jaboticatubas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2648
+msgid "Jacaraci"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2649
+msgid "Jacaraú"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2651
+msgid "Jacareacanga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2652
+msgid "Jacarezinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_122
+msgid "Jacareí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2650
+msgid "Jacaré dos Homens"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2653
+msgid "Jaci"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2654
+msgid "Jaciara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2655
+msgid "Jacinto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2656
+msgid "Jacinto Machado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2657
+msgid "Jacobina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2658
+msgid "Jacobina do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2661
+msgid "Jacuizinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2662
+msgid "Jacundá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2663
+msgid "Jacupiranga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2664
+#: model:res.city,name:l10n_br.city_br_2665
+msgid "Jacutinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2659
+msgid "Jacuí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2660
+msgid "Jacuípe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2666
+msgid "Jaguapitã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2667
+msgid "Jaguaquara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2670
+msgid "Jaguarari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2668
+msgid "Jaguaraçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2672
+msgid "Jaguaretama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2673
+msgid "Jaguari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2674
+msgid "Jaguariaíva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2675
+msgid "Jaguaribara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2676
+msgid "Jaguaribe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2677
+msgid "Jaguaripe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2678
+msgid "Jaguariúna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2679
+msgid "Jaguaruana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2680
+msgid "Jaguaruna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2669
+msgid "Jaguarão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2671
+msgid "Jaguaré"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2682
+msgid "Jaicós"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2683
+msgid "Jales"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2684
+msgid "Jambeiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2685
+msgid "Jampruca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2686
+msgid "Janaúba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2687
+msgid "Jandaia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2688
+msgid "Jandaia do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2689
+#: model:res.city,name:l10n_br.city_br_2690
+msgid "Jandaíra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_258
+msgid "Jandira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2691
+msgid "Janduís"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2692
+msgid "Jangada"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2693
+msgid "Janiópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2694
+msgid "Januária"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2696
+msgid "Japaratinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2697
+msgid "Japaratuba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2695
+msgid "Japaraíba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2698
+msgid "Japeri"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2699
+msgid "Japi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2700
+msgid "Japira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2701
+msgid "Japoatã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2702
+msgid "Japonvar"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2703
+msgid "Japorã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2704
+#: model:res.city,name:l10n_br.city_br_2705
+msgid "Japurá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2706
+msgid "Jaqueira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2707
+msgid "Jaquirana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2709
+msgid "Jaraguari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2708
+msgid "Jaraguá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_164
+msgid "Jaraguá do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2710
+msgid "Jaramataia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2711
+#: model:res.city,name:l10n_br.city_br_2712
+msgid "Jardim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2713
+msgid "Jardim Alegre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2718
+msgid "Jardim Olinda"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2714
+msgid "Jardim de Angicos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2715
+msgid "Jardim de Piranhas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2716
+msgid "Jardim do Mulato"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2717
+msgid "Jardim do Seridó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2719
+#: model:res.city,name:l10n_br.city_br_2720
+msgid "Jardinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2721
+msgid "Jari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2722
+msgid "Jarinu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2723
+msgid "Jaru"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2724
+msgid "Jataizinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_294
+msgid "Jataí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2725
+msgid "Jataúba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2726
+msgid "Jateí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2727
+msgid "Jati"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2728
+#: model:res.city,name:l10n_br.city_br_2729
+msgid "Jatobá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2730
+msgid "Jatobá do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2732
+msgid "Jaupaci"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2733
+msgid "Jauru"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2647
+msgid "Jaçanã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2681
+msgid "Jaíba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_223
+msgid "Jaú"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2731
+msgid "Jaú do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2734
+msgid "Jeceaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2735
+msgid "Jenipapo de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2736
+msgid "Jenipapo dos Vieiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2737
+msgid "Jequeri"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2739
+msgid "Jequitaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2740
+msgid "Jequitibá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2741
+msgid "Jequitinhonha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2738
+msgid "Jequiá da Praia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_187
+msgid "Jequié"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2742
+msgid "Jeremoabo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2743
+msgid "Jericó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2744
+msgid "Jeriquara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2746
+msgid "Jerumenha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2745
+msgid "Jerônimo Monteiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2747
+msgid "Jesuânia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2748
+msgid "Jesuítas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2749
+msgid "Jesúpolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_244
+msgid "Ji-Paraná"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2750
+msgid "Jijoca de Jericoacoara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2751
+msgid "Jiquiriçá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2752
+msgid "Jitaúna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2755
+msgid "Joanésia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2756
+msgid "Joanópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2767
+msgid "Joaquim Felício"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2768
+msgid "Joaquim Gomes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2769
+msgid "Joaquim Nabuco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2770
+msgid "Joaquim Pires"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2771
+msgid "Joaquim Távora"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2753
+msgid "Joaçaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2754
+msgid "Joaíma"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2772
+msgid "Joca Claudino"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2773
+msgid "Joca Marques"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_034
+msgid "Joinville"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2775
+msgid "Jordânia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2776
+msgid "Jordão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2783
+msgid "Joselândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2784
+msgid "Josenópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2777
+msgid "José Boiteux"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2778
+msgid "José Bonifácio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2781
+msgid "José Gonçalves de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2782
+msgid "José Raydan"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2779
+msgid "José da Penha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2780
+msgid "José de Freitas"
+msgstr ""
+
+#. module: l10n_br
 #: model:ir.model,name:l10n_br.model_account_journal
 msgid "Journal"
 msgstr ""
@@ -354,8 +12823,1081 @@ msgid "Journal Entry"
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2785
+msgid "Joviânia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2757
+msgid "João Alfredo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2759
+msgid "João Costa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2758
+msgid "João Câmara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2760
+msgid "João Dias"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2761
+msgid "João Dourado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2762
+msgid "João Lisboa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2763
+msgid "João Monlevade"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2764
+msgid "João Neiva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_020
+msgid "João Pessoa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2765
+msgid "João Pinheiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2766
+msgid "João Ramalho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2786
+msgid "Juara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2787
+msgid "Juarez Távora"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2788
+msgid "Juarina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2789
+msgid "Juatuba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2790
+msgid "Juazeirinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_126
+msgid "Juazeiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_096
+msgid "Juazeiro do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2791
+msgid "Juazeiro do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2793
+msgid "Jucati"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2795
+msgid "Jucurutu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2794
+msgid "Jucuruçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2792
+msgid "Jucás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_038
+msgid "Juiz de Fora"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2800
+msgid "Jumirim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2801
+msgid "Junco do Maranhão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2802
+msgid "Junco do Seridó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_051
+msgid "Jundiaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2805
+msgid "Jundiaí do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2803
+#: model:res.city,name:l10n_br.city_br_2804
+msgid "Jundiá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2806
+msgid "Junqueiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2807
+msgid "Junqueirópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2808
+msgid "Jupi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2809
+msgid "Jupiá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2811
+msgid "Juquitiba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2810
+msgid "Juquiá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2812
+msgid "Juramento"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2813
+msgid "Juranda"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2814
+#: model:res.city,name:l10n_br.city_br_2815
+msgid "Jurema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2816
+msgid "Juripiranga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2817
+msgid "Juru"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2819
+msgid "Juruaia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2820
+msgid "Juruena"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2821
+msgid "Juruti"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2818
+msgid "Juruá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2822
+msgid "Juscimeira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2823
+#: model:res.city,name:l10n_br.city_br_2824
+#: model:res.city,name:l10n_br.city_br_2825
+msgid "Jussara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2826
+msgid "Jussari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2827
+msgid "Jussiape"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2828
+msgid "Jutaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2829
+msgid "Juti"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2830
+msgid "Juvenília"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2796
+msgid "Juína"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2774
+msgid "Jóia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2797
+msgid "Júlio Borges"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2799
+msgid "Júlio Mesquita"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2798
+msgid "Júlio de Castilhos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2831
+msgid "Kaloré"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2833
+msgid "Lacerdópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2834
+msgid "Ladainha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2835
+msgid "Ladário"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2836
+msgid "Lafaiete Coutinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2837
+msgid "Lagamar"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_317
+msgid "Lagarto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_182
+msgid "Lages"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2841
+msgid "Lago Verde"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2838
+msgid "Lago da Pedra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2839
+msgid "Lago do Junco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2840
+msgid "Lago dos Rodrigues"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2842
+msgid "Lagoa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2843
+msgid "Lagoa Alegre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2844
+msgid "Lagoa Bonita do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2864
+msgid "Lagoa Dourada"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2865
+msgid "Lagoa Formosa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2866
+#: model:res.city,name:l10n_br.city_br_2867
+msgid "Lagoa Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2868
+msgid "Lagoa Grande do Maranhão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2869
+msgid "Lagoa Nova"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2870
+msgid "Lagoa Real"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2871
+msgid "Lagoa Salgada"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2872
+#: model:res.city,name:l10n_br.city_br_2873
+msgid "Lagoa Santa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2874
+msgid "Lagoa Seca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2875
+msgid "Lagoa Vermelha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2845
+msgid "Lagoa d'Anta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2846
+msgid "Lagoa da Canoa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2847
+msgid "Lagoa da Confusão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2848
+msgid "Lagoa da Prata"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2849
+msgid "Lagoa de Dentro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2850
+msgid "Lagoa de Itaenga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2851
+msgid "Lagoa de Pedras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2852
+msgid "Lagoa de São Francisco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2853
+msgid "Lagoa de Velhos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2854
+msgid "Lagoa do Barro do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2855
+msgid "Lagoa do Carro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2856
+msgid "Lagoa do Mato"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2857
+msgid "Lagoa do Ouro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2858
+msgid "Lagoa do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2859
+msgid "Lagoa do Sítio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2860
+msgid "Lagoa do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2861
+msgid "Lagoa dos Gatos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2862
+msgid "Lagoa dos Patos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2863
+msgid "Lagoa dos Três Cantos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2877
+msgid "Lagoinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2878
+msgid "Lagoinha do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2876
+msgid "Lagoão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2879
+msgid "Laguna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2880
+msgid "Laguna Carapã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2881
+msgid "Laje"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2882
+msgid "Laje do Muriaé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2883
+#: model:res.city,name:l10n_br.city_br_2884
+msgid "Lajeado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2886
+msgid "Lajeado Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2887
+msgid "Lajeado Novo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2885
+msgid "Lajeado do Bugre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2889
+msgid "Lajedinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2890
+msgid "Lajedo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2891
+msgid "Lajedo do Tabocal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2888
+msgid "Lajedão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2892
+msgid "Lajes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2893
+msgid "Lajes Pintadas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2894
+msgid "Lajinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2895
+msgid "Lamarão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2896
+msgid "Lambari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2897
+msgid "Lambari D'Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2898
+msgid "Lamim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2899
+msgid "Landri Sales"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2900
+msgid "Lapa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2901
+msgid "Lapão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2902
+msgid "Laranja da Terra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2903
+#: model:res.city,name:l10n_br.city_br_2904
+msgid "Laranjal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2906
+msgid "Laranjal Paulista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2905
+msgid "Laranjal do Jari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2907
+msgid "Laranjeiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2908
+msgid "Laranjeiras do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2909
+msgid "Lassance"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2910
+msgid "Lastro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2911
+msgid "Laurentino"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2912
+msgid "Lauro Müller"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_148
+msgid "Lauro de Freitas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2913
+msgid "Lavandeira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_300
+msgid "Lavras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2915
+msgid "Lavras da Mangabeira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2916
+msgid "Lavras do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2917
+msgid "Lavrinhas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2914
+msgid "Lavínia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2918
+msgid "Leandro Ferreira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2919
+msgid "Lebon Régis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2920
+msgid "Leme"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2921
+msgid "Leme do Prado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2922
+msgid "Lençóis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2923
+msgid "Lençóis Paulista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2924
+msgid "Leoberto Leal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2925
+msgid "Leopoldina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2926
+msgid "Leopoldo de Bulhões"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2927
+msgid "Leópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2928
+msgid "Liberato Salzano"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2929
+msgid "Liberdade"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2930
+msgid "Licínio de Almeida"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2931
+msgid "Lidianópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2932
+msgid "Lima Campos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2933
+msgid "Lima Duarte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_094
+msgid "Limeira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2934
+msgid "Limeira do Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2935
+msgid "Limoeiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2936
+msgid "Limoeiro de Anadia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2937
+msgid "Limoeiro do Ajuru"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2938
+msgid "Limoeiro do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2939
+msgid "Lindoeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2942
+msgid "Lindolfo Collor"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2940
+msgid "Lindóia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2941
+msgid "Lindóia do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2943
+msgid "Linha Nova"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_177
+msgid "Linhares"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2944
+msgid "Lins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2945
+msgid "Livramento"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2946
+msgid "Livramento de Nossa Senhora"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2947
+msgid "Lizarda"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2948
+msgid "Loanda"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2949
+msgid "Lobato"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2950
+msgid "Logradouro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_037
+msgid "Londrina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2951
+msgid "Lontra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2952
+msgid "Lontras"
+msgstr ""
+
+#. module: l10n_br
 #: model:l10n_latam.document.type,name:l10n_br.dt_8B
 msgid "Loose Ground Bill of Lading"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2953
+msgid "Lorena"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2954
+msgid "Loreto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2955
+msgid "Lourdes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2956
+msgid "Louveira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2957
+msgid "Lucas do Rio Verde"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2959
+msgid "Lucena"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2960
+msgid "Lucianópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2961
+msgid "Luciara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2962
+msgid "Lucrécia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2958
+msgid "Lucélia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2967
+msgid "Luisburgo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2968
+msgid "Luislândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2969
+msgid "Luiz Alves"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2970
+msgid "Luiziana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2971
+msgid "Luiziânia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2972
+msgid "Luminárias"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2973
+msgid "Lunardelli"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2975
+msgid "Lupionópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2974
+msgid "Lupércio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2976
+msgid "Lutécia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2977
+msgid "Luz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2978
+msgid "Luzerna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2979
+msgid "Luzilândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2980
+msgid "Luzinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_146
+msgid "Luziânia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2963
+msgid "Luís Antônio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2964
+msgid "Luís Correia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2965
+msgid "Luís Domingues"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_288
+msgid "Luís Eduardo Magalhães"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2966
+msgid "Luís Gomes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2832
+msgid "Lábrea"
 msgstr ""
 
 #. module: l10n_br
@@ -364,13 +13906,1909 @@ msgid "MVA Percent"
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2982
+msgid "Macajuba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2984
+msgid "Macambira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2985
+msgid "Macaparana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_052
+msgid "Macapá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2986
+msgid "Macarani"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2987
+msgid "Macatuba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2988
+msgid "Macau"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2989
+msgid "Macaubal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_117
+msgid "Macaé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2981
+msgid "Macaíba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2990
+msgid "Macaúbas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2991
+msgid "Macedônia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_016
+msgid "Maceió"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2992
+msgid "Machacalis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2993
+msgid "Machadinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2994
+msgid "Machadinho D'Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2995
+msgid "Machado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2996
+msgid "Machados"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2997
+msgid "Macieira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2998
+msgid "Macuco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2999
+msgid "Macururé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3000
+msgid "Madalena"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3001
+msgid "Madeiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3002
+msgid "Madre de Deus"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3003
+msgid "Madre de Deus de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3006
+msgid "Maetinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3007
+msgid "Mafra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3008
+msgid "Magalhães Barata"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3009
+msgid "Magalhães de Almeida"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3010
+msgid "Magda"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_132
+msgid "Magé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3011
+msgid "Maiquinique"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3012
+msgid "Mairi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3013
+msgid "Mairinque"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3014
+msgid "Mairiporã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3015
+msgid "Mairipotaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3016
+msgid "Major Gercino"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3017
+msgid "Major Isidoro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3018
+msgid "Major Sales"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3019
+msgid "Major Vieira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3020
+msgid "Malacacheta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3021
+msgid "Malhada"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3022
+msgid "Malhada de Pedras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3023
+msgid "Malhada dos Bois"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3024
+msgid "Malhador"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3025
+msgid "Mallet"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3026
+msgid "Malta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3027
+msgid "Mamanguape"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3028
+msgid "Mambaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3029
+msgid "Mamborê"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3030
+msgid "Mamonas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3031
+msgid "Mampituba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_315
+msgid "Manacapuru"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3033
+msgid "Manaquiri"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3034
+msgid "Manari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_007
+msgid "Manaus"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3032
+msgid "Manaíra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3037
+msgid "Mandaguari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3036
+msgid "Mandaguaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3038
+msgid "Mandirituba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3039
+msgid "Manduri"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3040
+msgid "Manfrinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3041
+msgid "Manga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3042
+msgid "Mangaratiba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3043
+msgid "Mangueirinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3044
+msgid "Manhuaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3045
+msgid "Manhumirim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3046
+msgid "Manicoré"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3047
+msgid "Manoel Emídio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3048
+msgid "Manoel Ribas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3049
+msgid "Manoel Urbano"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3050
+msgid "Manoel Viana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3051
+msgid "Manoel Vitorino"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3052
+msgid "Mansidão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3053
+msgid "Mantena"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3054
+msgid "Mantenópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3055
+msgid "Maquiné"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3057
+msgid "Mar Vermelho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3056
+msgid "Mar de Espanha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3058
+msgid "Mara Rosa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_105
+msgid "Marabá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3060
+msgid "Marabá Paulista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3064
+msgid "Maracaju"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3063
+msgid "Maracajá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_128
+msgid "Maracanaú"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3065
+msgid "Maracanã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3061
+msgid "Maracaçumé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3062
+msgid "Maracaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3066
+msgid "Maracás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3067
+msgid "Maragogi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3068
+msgid "Maragogipe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3069
+msgid "Maraial"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3070
+msgid "Marajá do Sena"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_298
+msgid "Maranguape"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3071
+msgid "Maranhãozinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3072
+msgid "Marapanim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3073
+msgid "Marapoama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3075
+msgid "Marataízes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3074
+msgid "Maratá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3076
+msgid "Marau"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3078
+#: model:res.city,name:l10n_br.city_br_3079
+msgid "Maravilha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3080
+msgid "Maravilhas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3059
+msgid "Maraã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3077
+msgid "Maraú"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3081
+msgid "Marcação"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3083
+msgid "Marcelino Ramos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3084
+msgid "Marcelino Vieira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3082
+msgid "Marcelândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3085
+msgid "Marcionílio Souza"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3086
+msgid "Marco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3087
+msgid "Marcolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3088
+msgid "Marcos Parente"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3089
+msgid "Marechal Cândido Rondon"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3090
+msgid "Marechal Deodoro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3091
+msgid "Marechal Floriano"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3092
+msgid "Marechal Thaumaturgo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3093
+msgid "Marema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3094
+msgid "Mari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3096
+msgid "Maria Helena"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3095
+msgid "Maria da Fé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3097
+msgid "Marialva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3098
+msgid "Mariana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3099
+msgid "Mariana Pimentel"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3100
+msgid "Mariano Moro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3101
+msgid "Marianópolis do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3103
+msgid "Maribondo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_154
+msgid "Maricá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3104
+msgid "Marilac"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3107
+msgid "Marilena"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3108
+msgid "Mariluz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3105
+msgid "Marilândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3106
+msgid "Marilândia do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_061
+msgid "Maringá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3109
+msgid "Marinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3112
+msgid "Maripá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3113
+msgid "Maripá de Minas"
+msgstr ""
+
+#. module: l10n_br
 #: model:l10n_latam.document.type,name:l10n_br.dt_09
 msgid "Maritime Bill of Lading"
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_285
+msgid "Marituba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3114
+msgid "Marizópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3102
+msgid "Mariápolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3111
+msgid "Mariópolis"
+msgstr ""
+
+#. module: l10n_br
 #: model:ir.model.fields,help:l10n_br.field_account_tax__tax_discount
 msgid "Mark it for (ICMS, PIS e etc.)."
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3115
+msgid "Marliéria"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3116
+msgid "Marmeleiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3117
+msgid "Marmelópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3118
+msgid "Marques de Souza"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3119
+msgid "Marquinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3120
+msgid "Martinho Campos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3123
+msgid "Martins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3124
+msgid "Martins Soares"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3121
+msgid "Martinópole"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3122
+msgid "Martinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3125
+msgid "Maruim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3126
+msgid "Marumbi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3127
+msgid "Marzagão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_123
+msgid "Marília"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3128
+msgid "Mascote"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3129
+msgid "Massapê"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3130
+msgid "Massapê do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3131
+#: model:res.city,name:l10n_br.city_br_3132
+msgid "Massaranduba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3133
+msgid "Mata"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3135
+msgid "Mata Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3136
+msgid "Mata Roma"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3137
+msgid "Mata Verde"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3134
+msgid "Mata de São João"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3139
+msgid "Mataraca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3140
+msgid "Mateiros"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3141
+msgid "Matelândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3142
+msgid "Materlândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3143
+msgid "Mateus Leme"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3144
+msgid "Mathias Lobato"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3145
+msgid "Matias Barbosa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3146
+msgid "Matias Cardoso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3147
+msgid "Matias Olímpio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3148
+msgid "Matina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3149
+msgid "Matinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3150
+msgid "Matinhas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3151
+msgid "Matinhos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3152
+msgid "Matipó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3153
+msgid "Mato Castelhano"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3154
+msgid "Mato Grosso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3155
+msgid "Mato Leitão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3156
+msgid "Mato Queimado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3157
+msgid "Mato Rico"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3158
+msgid "Mato Verde"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3161
+msgid "Matos Costa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3162
+msgid "Matozinhos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3163
+msgid "Matrinchã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3164
+msgid "Matriz de Camaragibe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3165
+msgid "Matupá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3166
+msgid "Maturéia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3167
+msgid "Matutina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3138
+msgid "Matão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3159
+msgid "Matões"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3160
+msgid "Matões do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3170
+msgid "Maurilândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3171
+msgid "Maurilândia do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3172
+msgid "Mauriti"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_057
+msgid "Mauá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3168
+msgid "Mauá da Serra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3169
+msgid "Maués"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3173
+msgid "Maxaranguape"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3174
+msgid "Maximiliano de Almeida"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3175
+msgid "Mazagão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2983
+msgid "Maçambará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3176
+msgid "Medeiros"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3177
+msgid "Medeiros Neto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3178
+msgid "Medianeira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3179
+msgid "Medicilândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3180
+msgid "Medina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3181
+msgid "Meleiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3182
+msgid "Melgaço"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3183
+msgid "Mendes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3184
+msgid "Mendes Pimentel"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3185
+msgid "Mendonça"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3186
+msgid "Mercedes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3187
+msgid "Mercês"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3188
+msgid "Meridiano"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3189
+msgid "Meruoca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_176
+#: model:res.city,name:l10n_br.city_br_3191
+msgid "Mesquita"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3192
+msgid "Messias"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3193
+msgid "Messias Targino"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3190
+msgid "Mesópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3194
+msgid "Miguel Alves"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3195
+msgid "Miguel Calmon"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3196
+msgid "Miguel Leão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3197
+msgid "Miguel Pereira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3198
+msgid "Miguelópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3199
+#: model:res.city,name:l10n_br.city_br_3200
+msgid "Milagres"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3201
+msgid "Milagres do Maranhão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3202
+msgid "Milhã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3203
+msgid "Milton Brandão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3204
+msgid "Mimoso de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3205
+msgid "Mimoso do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3207
+msgid "Minador do Negrão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3209
+msgid "Minas Novas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3208
+msgid "Minas do Leão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3206
+msgid "Minaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3210
+msgid "Minduri"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3211
+msgid "Mineiros"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3212
+msgid "Mineiros do Tietê"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3213
+msgid "Ministro Andreazza"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3214
+msgid "Mira Estrela"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3215
+msgid "Mirabela"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3216
+msgid "Miracatu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3217
+msgid "Miracema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3218
+msgid "Miracema do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3219
+#: model:res.city,name:l10n_br.city_br_3220
+msgid "Mirador"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3221
+msgid "Miradouro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3222
+msgid "Miraguaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3225
+msgid "Miranda"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3226
+msgid "Miranda do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3227
+msgid "Mirandiba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3228
+msgid "Mirandópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3229
+msgid "Mirangaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3230
+msgid "Miranorte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3231
+msgid "Mirante"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3232
+msgid "Mirante da Serra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3233
+msgid "Mirante do Paranapanema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3234
+msgid "Miraselva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3235
+msgid "Mirassol"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3236
+msgid "Mirassol d'Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3237
+msgid "Mirassolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3238
+msgid "Miravânia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3223
+msgid "Miraí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3224
+msgid "Miraíma"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3239
+msgid "Mirim Doce"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3240
+msgid "Mirinzal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3241
+msgid "Missal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3242
+msgid "Missão Velha"
+msgstr ""
+
+#. module: l10n_br
+#: model:ir.model.fields.selection,name:l10n_br.selection__res_partner_bank__proxy_type__mobile
+msgid "Mobile Number"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3243
+msgid "Mocajuba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3244
+msgid "Mococa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3245
+msgid "Modelo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3246
+msgid "Moeda"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3247
+msgid "Moema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3248
+msgid "Mogeiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_196
+msgid "Mogi Guaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3249
+msgid "Mogi Mirim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_050
+msgid "Mogi das Cruzes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3250
+msgid "Moiporá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3251
+msgid "Moita Bonita"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3252
+msgid "Moju"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3253
+msgid "Mojuí dos Campos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3254
+msgid "Mombaça"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3255
+msgid "Mombuca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3258
+msgid "Mondaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3259
+msgid "Mongaguá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3260
+msgid "Monjolos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3261
+msgid "Monsenhor Gil"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3262
+msgid "Monsenhor Hipólito"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3263
+msgid "Monsenhor Paulo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3264
+msgid "Monsenhor Tabosa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3265
+msgid "Montadas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3266
+msgid "Montalvânia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3267
+msgid "Montanha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3268
+msgid "Montanhas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3269
+msgid "Montauri"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3270
+#: model:res.city,name:l10n_br.city_br_3271
+msgid "Monte Alegre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3272
+msgid "Monte Alegre de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3273
+msgid "Monte Alegre de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3274
+msgid "Monte Alegre de Sergipe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3275
+msgid "Monte Alegre do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3276
+msgid "Monte Alegre do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3277
+msgid "Monte Alegre dos Campos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3278
+msgid "Monte Alto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3279
+msgid "Monte Aprazível"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3280
+msgid "Monte Azul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3281
+msgid "Monte Azul Paulista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3282
+msgid "Monte Belo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3283
+msgid "Monte Belo do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3284
+msgid "Monte Carlo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3285
+msgid "Monte Carmelo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3286
+#: model:res.city,name:l10n_br.city_br_3287
+msgid "Monte Castelo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3290
+msgid "Monte Formoso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3291
+msgid "Monte Horebe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3292
+msgid "Monte Mor"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3293
+msgid "Monte Negro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3294
+msgid "Monte Santo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3295
+msgid "Monte Santo de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3296
+msgid "Monte Santo do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3297
+msgid "Monte Sião"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3288
+msgid "Monte das Gameleiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3289
+msgid "Monte do Carmo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3298
+msgid "Monteiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3299
+msgid "Monteiro Lobato"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3300
+msgid "Monteirópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3301
+msgid "Montenegro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3302
+msgid "Montes Altos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_058
+msgid "Montes Claros"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3303
+msgid "Montes Claros de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3304
+msgid "Montezuma"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3305
+msgid "Montividiu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3306
+msgid "Montividiu do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3256
+msgid "Monção"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3257
+msgid "Monções"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3307
+msgid "Morada Nova"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3308
+msgid "Morada Nova de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3309
+msgid "Moraújo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3310
+msgid "Moreilândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3311
+msgid "Moreira Sales"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3312
+msgid "Moreno"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3313
+msgid "Mormaço"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3314
+msgid "Morpará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3315
+msgid "Morretes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3316
+#: model:res.city,name:l10n_br.city_br_3317
+msgid "Morrinhos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3318
+msgid "Morrinhos do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3319
+msgid "Morro Agudo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3320
+msgid "Morro Agudo de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3321
+msgid "Morro Cabeça no Tempo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3327
+msgid "Morro Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3328
+msgid "Morro Redondo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3329
+msgid "Morro Reuter"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3322
+msgid "Morro da Fumaça"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3323
+msgid "Morro da Garça"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3324
+msgid "Morro do Chapéu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3325
+msgid "Morro do Chapéu do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3326
+msgid "Morro do Pilar"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3330
+msgid "Morros"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3331
+msgid "Mortugaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3332
+msgid "Morungaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_108
+msgid "Mossoró"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3333
+msgid "Mossâmedes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3334
+msgid "Mostardas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3335
+msgid "Motuca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3336
+msgid "Mozarlândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3337
+msgid "Muaná"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3338
+msgid "Mucajaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3339
+msgid "Mucambo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3340
+msgid "Mucugê"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3342
+msgid "Mucuri"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3343
+msgid "Mucurici"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3344
+msgid "Muitos Capões"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3345
+msgid "Muliterno"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3346
+#: model:res.city,name:l10n_br.city_br_3347
+msgid "Mulungu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3348
+msgid "Mulungu do Morro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3349
+#: model:res.city,name:l10n_br.city_br_3350
+#: model:res.city,name:l10n_br.city_br_3351
+msgid "Mundo Novo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3352
+msgid "Munhoz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3353
+msgid "Munhoz de Melo"
 msgstr ""
 
 #. module: l10n_br
@@ -381,8 +15819,159 @@ msgid "Municipal Tax Identification Number"
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3354
+msgid "Muniz Ferreira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3355
+msgid "Muniz Freire"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3357
+msgid "Muqui"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3356
+msgid "Muquém de São Francisco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_302
+msgid "Muriaé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3358
+msgid "Muribeca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3359
+msgid "Murici"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3360
+msgid "Murici dos Portelas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3361
+msgid "Muricilândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3362
+msgid "Muritiba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3363
+msgid "Murutinga do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3365
+msgid "Mutum"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3366
+msgid "Mutunópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3364
+msgid "Mutuípe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3367
+msgid "Muzambinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3341
+msgid "Muçum"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3110
+msgid "Mário Campos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3035
+msgid "Mâncio Lima"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3004
+msgid "Mãe d'Água"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3005
+msgid "Mãe do Rio"
+msgstr ""
+
+#. module: l10n_br
 #: model:ir.model.fields,field_description:l10n_br.field_res_company__l10n_br_nire_code
 msgid "NIRE"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3368
+msgid "Nacip Raydan"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3369
+msgid "Nantes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3370
+msgid "Nanuque"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3372
+msgid "Naque"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3373
+msgid "Narandiba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_024
+msgid "Natal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3374
+msgid "Natalândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3376
+#: model:res.city,name:l10n_br.city_br_3377
+msgid "Natividade"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3378
+msgid "Natividade da Serra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3379
+msgid "Natuba"
 msgstr ""
 
 #. module: l10n_br
@@ -391,13 +15980,1203 @@ msgid "Natural Persons Register."
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3375
+msgid "Natércia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3380
+msgid "Navegantes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3381
+msgid "Naviraí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3387
+msgid "Nazareno"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3388
+msgid "Nazarezinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3382
+#: model:res.city,name:l10n_br.city_br_3383
+msgid "Nazaré"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3386
+msgid "Nazaré Paulista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3384
+msgid "Nazaré da Mata"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3385
+msgid "Nazaré do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3389
+msgid "Nazária"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3390
+msgid "Nazário"
+msgstr ""
+
+#. module: l10n_br
+#: model_terms:ir.ui.view,arch_db:l10n_br.br_partner_address_form
+msgid "Neighborhood"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3392
+msgid "Nepomuceno"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3393
+msgid "Nerópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3394
+msgid "Neves Paulista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3391
+msgid "Neópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3395
+msgid "Nhamundá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3396
+msgid "Nhandeara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3397
+msgid "Nicolau Vergueiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3398
+msgid "Nilo Peçanha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_204
+msgid "Nilópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3399
+msgid "Nina Rodrigues"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3400
+msgid "Ninheira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3401
+msgid "Nioaque"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3402
+msgid "Nipoã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3403
+msgid "Niquelândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_044
+msgid "Niterói"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3405
+msgid "Nobres"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3406
+msgid "Nonoai"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3407
+msgid "Nordestina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3408
+msgid "Normandia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3409
+msgid "Nortelândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3410
+msgid "Nossa Senhora Aparecida"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3411
+msgid "Nossa Senhora da Glória"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3412
+msgid "Nossa Senhora das Dores"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3413
+msgid "Nossa Senhora das Graças"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3414
+msgid "Nossa Senhora de Lourdes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3415
+msgid "Nossa Senhora de Nazaré"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3416
+msgid "Nossa Senhora do Livramento"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_156
+msgid "Nossa Senhora do Socorro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3417
+msgid "Nossa Senhora dos Remédios"
+msgstr ""
+
+#. module: l10n_br
 #: model:l10n_latam.document.type,name:l10n_br.dt_06
 msgid "Nota Fiscal / Electricity Bill"
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3418
+msgid "Nova Aliança"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3419
+msgid "Nova Aliança do Ivaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3420
+msgid "Nova Alvorada"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3421
+msgid "Nova Alvorada do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3422
+msgid "Nova América"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3423
+msgid "Nova América da Colina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3424
+msgid "Nova Andradina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3425
+msgid "Nova Araçá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3426
+#: model:res.city,name:l10n_br.city_br_3427
+msgid "Nova Aurora"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3428
+msgid "Nova Bandeirantes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3429
+msgid "Nova Bassano"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3430
+msgid "Nova Belém"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3431
+msgid "Nova Boa Vista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3432
+msgid "Nova Brasilândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3433
+msgid "Nova Brasilândia D'Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3434
+msgid "Nova Bréscia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3435
+msgid "Nova Campina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3436
+msgid "Nova Canaã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3438
+msgid "Nova Canaã Paulista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3437
+msgid "Nova Canaã do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3439
+msgid "Nova Candelária"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3440
+msgid "Nova Cantu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3441
+msgid "Nova Castilho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3442
+msgid "Nova Colinas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3443
+msgid "Nova Crixás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3444
+msgid "Nova Cruz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3445
+msgid "Nova Era"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3446
+msgid "Nova Erechim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3447
+msgid "Nova Esperança"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3448
+msgid "Nova Esperança do Piriá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3449
+msgid "Nova Esperança do Sudoeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3450
+msgid "Nova Esperança do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3451
+msgid "Nova Europa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3454
+msgid "Nova Floresta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_159
+msgid "Nova Friburgo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3452
+#: model:res.city,name:l10n_br.city_br_3453
+msgid "Nova Fátima"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3455
+msgid "Nova Glória"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3456
+msgid "Nova Granada"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3457
+msgid "Nova Guarita"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3458
+msgid "Nova Guataporanga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3459
+msgid "Nova Hartz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3460
+msgid "Nova Ibiá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_023
+msgid "Nova Iguaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3461
+msgid "Nova Iguaçu de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3462
+msgid "Nova Independência"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3463
+msgid "Nova Iorque"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3464
+msgid "Nova Ipixuna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3465
+msgid "Nova Itaberaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3466
+msgid "Nova Itarana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3467
+msgid "Nova Lacerda"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3468
+msgid "Nova Laranjeiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_280
+msgid "Nova Lima"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3469
+msgid "Nova Londrina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3470
+msgid "Nova Luzitânia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3471
+msgid "Nova Mamoré"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3472
+msgid "Nova Marilândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3473
+msgid "Nova Maringá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3475
+msgid "Nova Monte Verde"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3476
+msgid "Nova Mutum"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3474
+msgid "Nova Módica"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3477
+msgid "Nova Nazaré"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3478
+msgid "Nova Odessa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3481
+#: model:res.city,name:l10n_br.city_br_3482
+#: model:res.city,name:l10n_br.city_br_3483
+msgid "Nova Olinda"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3484
+msgid "Nova Olinda do Maranhão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3485
+msgid "Nova Olinda do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3479
+#: model:res.city,name:l10n_br.city_br_3480
+msgid "Nova Olímpia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3487
+msgid "Nova Palma"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3488
+msgid "Nova Palmeira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3489
+msgid "Nova Petrópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3490
+msgid "Nova Ponte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3491
+msgid "Nova Porteirinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3492
+msgid "Nova Prata"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3493
+msgid "Nova Prata do Iguaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3486
+msgid "Nova Pádua"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3494
+msgid "Nova Ramada"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3495
+msgid "Nova Redenção"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3496
+msgid "Nova Resende"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3497
+msgid "Nova Roma"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3498
+msgid "Nova Roma do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3499
+msgid "Nova Rosalândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3500
+msgid "Nova Russas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3501
+msgid "Nova Santa Bárbara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3502
+msgid "Nova Santa Helena"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3503
+#: model:res.city,name:l10n_br.city_br_3504
+msgid "Nova Santa Rita"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3505
+msgid "Nova Santa Rosa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_296
+msgid "Nova Serrana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3506
+msgid "Nova Soure"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3507
+msgid "Nova Tebas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3508
+msgid "Nova Timboteua"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3509
+msgid "Nova Trento"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3510
+msgid "Nova Ubiratã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3511
+#: model:res.city,name:l10n_br.city_br_3512
+msgid "Nova União"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3514
+#: model:res.city,name:l10n_br.city_br_3515
+msgid "Nova Veneza"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3513
+msgid "Nova Venécia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3516
+msgid "Nova Viçosa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3517
+msgid "Nova Xavantina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3518
+msgid "Novais"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3519
+msgid "Novo Acordo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3520
+msgid "Novo Airão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3521
+msgid "Novo Alegre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3522
+msgid "Novo Aripuanã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3523
+msgid "Novo Barreiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3524
+msgid "Novo Brasil"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3525
+msgid "Novo Cabrais"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3526
+msgid "Novo Cruzeiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_305
+msgid "Novo Gama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_133
+msgid "Novo Hamburgo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3527
+#: model:res.city,name:l10n_br.city_br_3528
+#: model:res.city,name:l10n_br.city_br_3529
+msgid "Novo Horizonte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3530
+msgid "Novo Horizonte do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3531
+msgid "Novo Horizonte do Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3532
+msgid "Novo Horizonte do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3533
+msgid "Novo Itacolomi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3534
+msgid "Novo Jardim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3535
+msgid "Novo Lino"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3536
+msgid "Novo Machado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3537
+msgid "Novo Mundo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3538
+msgid "Novo Oriente"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3539
+msgid "Novo Oriente de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3540
+msgid "Novo Oriente do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3541
+msgid "Novo Planalto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3542
+msgid "Novo Progresso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3543
+msgid "Novo Repartimento"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3544
+#: model:res.city,name:l10n_br.city_br_3545
+msgid "Novo Santo Antônio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3546
+msgid "Novo São Joaquim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3547
+msgid "Novo Tiradentes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3548
+msgid "Novo Triunfo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3549
+msgid "Novo Xingu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3550
+msgid "Novorizonte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3551
+msgid "Nuporanga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3371
+msgid "Não-Me-Toque"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3404
+msgid "Nísia Floresta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3553
+msgid "Ocara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3554
+msgid "Ocauçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3555
+msgid "Oeiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3556
+msgid "Oeiras do Pará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3557
+msgid "Oiapoque"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3558
+msgid "Olaria"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3565
+msgid "Olho D'Água do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3560
+msgid "Olho d'Água"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3566
+msgid "Olho d'Água Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3561
+msgid "Olho d'Água das Cunhãs"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3562
+msgid "Olho d'Água das Flores"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3564
+msgid "Olho d'Água do Casado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3563
+msgid "Olho-d'Água do Borges"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3567
+msgid "Olhos-d'Água"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_076
+msgid "Olinda"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3570
+msgid "Olinda Nova do Maranhão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3571
+msgid "Olindina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3572
+msgid "Olivedos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3573
+msgid "Oliveira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3576
+msgid "Oliveira Fortes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3574
+msgid "Oliveira de Fátima"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3575
+msgid "Oliveira dos Brejinhos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3577
+msgid "Olivença"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3568
+msgid "Olímpia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3569
+msgid "Olímpio Noronha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3579
+msgid "Onda Verde"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3578
+msgid "Onça de Pitangui"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3580
+msgid "Oratórios"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3581
+msgid "Oriente"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3582
+msgid "Orindiúva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3583
+msgid "Oriximiná"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3585
+msgid "Orizona"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3584
+msgid "Orizânia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3587
+msgid "Orleans"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3586
+msgid "Orlândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3588
+msgid "Orobó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3589
+msgid "Orocó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3591
+msgid "Ortigueira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3590
+msgid "Orós"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_026
+msgid "Osasco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3592
+msgid "Oscar Bressane"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3594
+msgid "Osvaldo Cruz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3593
+msgid "Osório"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3595
+msgid "Otacílio Costa"
+msgstr ""
+
+#. module: l10n_br
 #: model:ir.model.fields.selection,name:l10n_br.selection__account_fiscal_position__l10n_br_fp_type__interstate
 msgid "Other interstate"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3598
+msgid "Ouricuri"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3599
+msgid "Ourilândia do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_304
+msgid "Ourinhos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3600
+msgid "Ourizona"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3597
+msgid "Ouriçangas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3601
+msgid "Ouro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3602
+#: model:res.city,name:l10n_br.city_br_3603
+#: model:res.city,name:l10n_br.city_br_3604
+msgid "Ouro Branco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3605
+msgid "Ouro Fino"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3606
+msgid "Ouro Preto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3607
+msgid "Ouro Preto do Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3608
+msgid "Ouro Velho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3609
+#: model:res.city,name:l10n_br.city_br_3610
+msgid "Ouro Verde"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3611
+msgid "Ouro Verde de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3612
+msgid "Ouro Verde de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3613
+msgid "Ouro Verde do Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3614
+msgid "Ouroeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3615
+msgid "Ourolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3596
+msgid "Ourém"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3616
+msgid "Ouvidor"
 msgstr ""
 
 #. module: l10n_br
@@ -416,6 +17195,2662 @@ msgid "PIS tax"
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3617
+msgid "Pacaembu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3619
+msgid "Pacajus"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3618
+msgid "Pacajá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3620
+msgid "Pacaraima"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3621
+#: model:res.city,name:l10n_br.city_br_3622
+msgid "Pacatuba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3623
+msgid "Pacoti"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3624
+msgid "Pacujá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3625
+msgid "Padre Bernardo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3626
+msgid "Padre Carvalho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3627
+msgid "Padre Marcos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3628
+msgid "Padre Paraíso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3629
+msgid "Paes Landim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3630
+msgid "Pai Pedro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3631
+msgid "Paial"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3633
+msgid "Paim Filho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3634
+msgid "Paineiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3635
+msgid "Painel"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3636
+msgid "Pains"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3637
+msgid "Paiva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3632
+msgid "Paiçandu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3638
+msgid "Pajeú do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3639
+#: model:res.city,name:l10n_br.city_br_3640
+msgid "Palestina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3641
+msgid "Palestina de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3642
+msgid "Palestina do Pará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3643
+msgid "Palhano"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_141
+msgid "Palhoça"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3644
+msgid "Palma"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3645
+msgid "Palma Sola"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3647
+msgid "Palmares"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3649
+msgid "Palmares Paulista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3648
+msgid "Palmares do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_091
+#: model:res.city,name:l10n_br.city_br_3650
+msgid "Palmas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3651
+msgid "Palmas de Monte Alto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3652
+#: model:res.city,name:l10n_br.city_br_3653
+msgid "Palmeira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3654
+msgid "Palmeira d'Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3655
+msgid "Palmeira das Missões"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3656
+msgid "Palmeira do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3657
+msgid "Palmeira dos Índios"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3658
+msgid "Palmeirais"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3660
+msgid "Palmeirante"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3661
+msgid "Palmeiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3662
+msgid "Palmeiras de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3663
+msgid "Palmeiras do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3664
+msgid "Palmeirina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3659
+msgid "Palmeirândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3665
+msgid "Palmeirópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3666
+msgid "Palmelo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3667
+msgid "Palminópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3668
+#: model:res.city,name:l10n_br.city_br_3669
+msgid "Palmital"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3670
+msgid "Palmitinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3671
+msgid "Palmitos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3646
+msgid "Palmácia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3672
+msgid "Palmópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3673
+msgid "Palotina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3675
+msgid "Panambi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3674
+msgid "Panamá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3676
+msgid "Pancas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3677
+msgid "Panelas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3678
+msgid "Panorama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3679
+msgid "Pantano Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3681
+msgid "Papagaios"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3682
+msgid "Papanduva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3683
+msgid "Paquetá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3685
+msgid "Paracambi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3686
+msgid "Paracatu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3687
+msgid "Paracuru"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_297
+msgid "Paragominas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3688
+msgid "Paraguaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3689
+msgid "Paraguaçu Paulista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3692
+msgid "Paraibano"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3693
+msgid "Paraibuna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3694
+msgid "Paraipaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3701
+msgid "Paraisópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3702
+msgid "Parambu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3703
+msgid "Paramirim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3704
+msgid "Paramoti"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3707
+msgid "Paranacity"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_205
+msgid "Paranaguá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3709
+msgid "Paranaiguara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3711
+msgid "Paranapanema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3712
+msgid "Paranapoema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3713
+msgid "Paranapuã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3714
+msgid "Paranatama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3715
+msgid "Paranatinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3716
+msgid "Paranavaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3708
+msgid "Paranaíba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3710
+msgid "Paranaíta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3717
+msgid "Paranhos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3705
+msgid "Paraná"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3706
+msgid "Paranã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3718
+msgid "Paraopeba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3719
+msgid "Parapuã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3720
+msgid "Parari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3721
+msgid "Paratinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3722
+msgid "Paraty"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_106
+msgid "Parauapebas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3725
+msgid "Parazinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3690
+msgid "Paraí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3691
+msgid "Paraíba do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3695
+#: model:res.city,name:l10n_br.city_br_3696
+msgid "Paraíso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3697
+msgid "Paraíso das Águas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3698
+msgid "Paraíso do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3699
+msgid "Paraíso do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3700
+msgid "Paraíso do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3723
+msgid "Paraú"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3724
+msgid "Paraúna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3726
+msgid "Pardinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3727
+msgid "Pareci Novo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3728
+msgid "Parecis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3729
+msgid "Parelhas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3730
+msgid "Pariconha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3731
+msgid "Parintins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3732
+msgid "Paripiranga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3733
+msgid "Paripueira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3734
+msgid "Pariquera-Açu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3735
+msgid "Parisi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3736
+msgid "Parnaguá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_115
+#: model:res.city,name:l10n_br.city_br_3737
+msgid "Parnamirim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3738
+msgid "Parnarama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_184
+msgid "Parnaíba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3739
+msgid "Parobé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3684
+msgid "Pará de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3741
+msgid "Passa Quatro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3742
+msgid "Passa Sete"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3743
+msgid "Passa Tempo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3740
+msgid "Passa e Fica"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3744
+msgid "Passa-Vinte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3745
+msgid "Passabém"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3746
+#: model:res.city,name:l10n_br.city_br_3747
+msgid "Passagem"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3748
+msgid "Passagem Franca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3749
+msgid "Passagem Franca do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3750
+msgid "Passira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_147
+msgid "Passo Fundo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3751
+msgid "Passo de Camaragibe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3752
+msgid "Passo de Torres"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3753
+msgid "Passo do Sobrado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_279
+msgid "Passos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3754
+msgid "Passos Maia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3755
+msgid "Pastos Bons"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3756
+msgid "Patis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3757
+msgid "Pato Bragado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3758
+msgid "Pato Branco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_311
+msgid "Patos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_186
+msgid "Patos de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3759
+msgid "Patos do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3760
+msgid "Patrocínio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3762
+msgid "Patrocínio Paulista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3761
+msgid "Patrocínio do Muriaé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3763
+msgid "Patu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3764
+msgid "Paty do Alferes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3765
+msgid "Pau Brasil"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3766
+#: model:res.city,name:l10n_br.city_br_3767
+msgid "Pau D'Arco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3768
+msgid "Pau D'Arco do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3769
+msgid "Pau dos Ferros"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3770
+msgid "Paudalho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3771
+msgid "Pauini"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3772
+msgid "Paula Cândido"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3773
+msgid "Paula Freitas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3774
+msgid "Paulicéia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3775
+msgid "Paulino Neves"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_080
+#: model:res.city,name:l10n_br.city_br_3776
+msgid "Paulista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3777
+msgid "Paulistana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3779
+msgid "Paulistas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3778
+msgid "Paulistânia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_276
+msgid "Paulo Afonso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3780
+msgid "Paulo Bento"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3782
+msgid "Paulo Frontin"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3783
+msgid "Paulo Jacinto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3784
+msgid "Paulo Lopes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3785
+msgid "Paulo Ramos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3781
+msgid "Paulo de Faria"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_284
+msgid "Paulínia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3787
+msgid "Paverama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3788
+msgid "Pavussu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3786
+msgid "Pavão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_206
+msgid "Paço do Lumiar"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3790
+msgid "Peabiru"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3792
+msgid "Pederneiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3793
+msgid "Pedra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3794
+msgid "Pedra Azul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3795
+msgid "Pedra Bela"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3796
+msgid "Pedra Bonita"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3797
+#: model:res.city,name:l10n_br.city_br_3798
+msgid "Pedra Branca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3799
+msgid "Pedra Branca do Amapari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3802
+msgid "Pedra Dourada"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3803
+msgid "Pedra Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3804
+msgid "Pedra Lavrada"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3805
+msgid "Pedra Mole"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3806
+#: model:res.city,name:l10n_br.city_br_3807
+msgid "Pedra Preta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3800
+msgid "Pedra do Anta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3801
+msgid "Pedra do Indaiá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3808
+msgid "Pedralva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3809
+msgid "Pedranópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3811
+msgid "Pedras Altas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3814
+msgid "Pedras Grandes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3812
+msgid "Pedras de Fogo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3813
+msgid "Pedras de Maria da Cruz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3815
+msgid "Pedregulho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3816
+msgid "Pedreira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3817
+msgid "Pedreiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3818
+msgid "Pedrinhas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3819
+msgid "Pedrinhas Paulista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3820
+msgid "Pedrinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3821
+msgid "Pedro Afonso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3822
+msgid "Pedro Alexandre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3823
+msgid "Pedro Avelino"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3824
+msgid "Pedro Canário"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3827
+msgid "Pedro Gomes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3828
+msgid "Pedro II"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3829
+msgid "Pedro Laurentino"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3830
+msgid "Pedro Leopoldo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3831
+msgid "Pedro Osório"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3832
+msgid "Pedro Régis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3833
+msgid "Pedro Teixeira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3834
+msgid "Pedro Velho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3825
+msgid "Pedro de Toledo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3826
+msgid "Pedro do Rosário"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3810
+msgid "Pedrão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3835
+msgid "Peixe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3836
+msgid "Peixe-Boi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3837
+msgid "Peixoto de Azevedo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3838
+msgid "Pejuçara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_086
+msgid "Pelotas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3839
+msgid "Penaforte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3840
+msgid "Penalva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3842
+msgid "Pendências"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3843
+msgid "Penedo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3844
+msgid "Penha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3845
+msgid "Pentecoste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3841
+msgid "Penápolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3846
+msgid "Pequeri"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3847
+msgid "Pequi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3848
+msgid "Pequizeiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3849
+msgid "Perdigão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3850
+msgid "Perdizes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3851
+msgid "Perdões"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3852
+msgid "Pereira Barreto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3853
+msgid "Pereiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3854
+msgid "Pereiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3855
+msgid "Peri Mirim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3856
+msgid "Periquito"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3857
+msgid "Peritiba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3858
+msgid "Peritoró"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3859
+msgid "Perobal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3862
+msgid "Perolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3863
+msgid "Peruíbe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3864
+msgid "Pescador"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3865
+msgid "Pescaria Brava"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3866
+msgid "Pesqueira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_065
+msgid "Petrolina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3869
+msgid "Petrolina de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3867
+#: model:res.city,name:l10n_br.city_br_3868
+msgid "Petrolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_099
+msgid "Petrópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3791
+msgid "Peçanha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3871
+msgid "Piacatu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3872
+msgid "Piancó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3873
+msgid "Piatã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3874
+msgid "Piau"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3870
+msgid "Piaçabuçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3875
+msgid "Picada Café"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3877
+msgid "Picos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3878
+msgid "Picuí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3879
+msgid "Piedade"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3880
+msgid "Piedade de Caratinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3881
+msgid "Piedade de Ponte Nova"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3882
+msgid "Piedade do Rio Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3883
+msgid "Piedade dos Gerais"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3886
+#: model:res.city,name:l10n_br.city_br_3887
+msgid "Pilar"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3888
+msgid "Pilar de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3889
+msgid "Pilar do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3885
+msgid "Pilão Arcado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3890
+#: model:res.city,name:l10n_br.city_br_3891
+msgid "Pilões"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3892
+msgid "Pilõezinhos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3893
+msgid "Pimenta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3894
+msgid "Pimenta Bueno"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3895
+msgid "Pimenteiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3896
+msgid "Pimenteiras do Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_179
+msgid "Pindamonhangaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3898
+msgid "Pindaré-Mirim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3897
+msgid "Pindaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3899
+msgid "Pindoba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3900
+msgid "Pindobaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3901
+msgid "Pindorama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3902
+msgid "Pindorama do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3903
+msgid "Pindoretama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3904
+msgid "Pingo-d'Água"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_237
+msgid "Pinhais"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3905
+msgid "Pinhal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3908
+msgid "Pinhal Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3906
+msgid "Pinhal da Serra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3907
+msgid "Pinhal de São Bento"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3910
+#: model:res.city,name:l10n_br.city_br_3911
+msgid "Pinhalzinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3909
+msgid "Pinhalão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3914
+msgid "Pinheiral"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3915
+msgid "Pinheirinho do Vale"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3916
+msgid "Pinheiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3917
+msgid "Pinheiro Machado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3918
+msgid "Pinheiro Preto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3919
+msgid "Pinheiros"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3912
+#: model:res.city,name:l10n_br.city_br_3913
+msgid "Pinhão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3920
+msgid "Pintadas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3921
+msgid "Pinto Bandeira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3922
+msgid "Pintópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3923
+msgid "Pio IX"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3924
+msgid "Pio XII"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3925
+msgid "Piquerobi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3926
+msgid "Piquet Carneiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3927
+msgid "Piquete"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3928
+msgid "Piracaia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3929
+msgid "Piracanjuba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3930
+msgid "Piracema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_054
+msgid "Piracicaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3931
+msgid "Piracuruca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3935
+msgid "Piraju"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3936
+msgid "Pirajuba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3937
+msgid "Pirajuí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3938
+msgid "Pirambu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3939
+msgid "Piranga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3940
+msgid "Pirangi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3942
+msgid "Piranguinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3941
+msgid "Piranguçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3943
+#: model:res.city,name:l10n_br.city_br_3944
+msgid "Piranhas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3945
+msgid "Pirapemas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3946
+msgid "Pirapetinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3948
+msgid "Pirapora"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3949
+msgid "Pirapora do Bom Jesus"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3950
+msgid "Pirapozinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3947
+msgid "Pirapó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_256
+msgid "Piraquara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3951
+msgid "Piraquê"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3952
+msgid "Pirassununga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3953
+msgid "Piratini"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3954
+msgid "Piratininga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3955
+msgid "Piratuba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3932
+msgid "Piraí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3933
+msgid "Piraí do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3934
+msgid "Piraí do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3956
+msgid "Piraúba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3957
+msgid "Pirenópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3959
+msgid "Pires Ferreira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3958
+msgid "Pires do Rio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3961
+msgid "Piripiri"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3960
+msgid "Piripá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3962
+msgid "Piritiba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3963
+msgid "Pirpirituba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3964
+msgid "Pitanga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3965
+#: model:res.city,name:l10n_br.city_br_3966
+msgid "Pitangueiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3967
+msgid "Pitangui"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3968
+msgid "Pitimbu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3969
+msgid "Pium"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3971
+msgid "Piumhi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3876
+msgid "Piçarra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3884
+msgid "Piên"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3970
+msgid "Piúma"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3972
+msgid "Placas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_299
+msgid "Planaltina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3974
+msgid "Planaltina do Paraná"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3975
+msgid "Planaltino"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3976
+#: model:res.city,name:l10n_br.city_br_3977
+#: model:res.city,name:l10n_br.city_br_3978
+#: model:res.city,name:l10n_br.city_br_3979
+msgid "Planalto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3980
+msgid "Planalto Alegre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3981
+msgid "Planalto da Serra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3982
+msgid "Planura"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3983
+msgid "Platina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3973
+msgid "Plácido de Castro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3986
+msgid "Pocinhos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3996
+msgid "Poconé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3997
+msgid "Pocrane"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3998
+msgid "Pojuca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3999
+msgid "Poloni"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4000
+msgid "Pombal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4001
+msgid "Pombos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4002
+msgid "Pomerode"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4003
+msgid "Pompéia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4004
+msgid "Pompéu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4005
+msgid "Pongaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_072
+msgid "Ponta Grossa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4007
+msgid "Ponta Porã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4006
+msgid "Ponta de Pedras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4008
+msgid "Pontal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4009
+msgid "Pontal do Araguaia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4010
+msgid "Pontal do Paraná"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4011
+msgid "Pontalina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4012
+msgid "Pontalinda"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4014
+msgid "Ponte Alta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4015
+msgid "Ponte Alta do Bom Jesus"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4016
+msgid "Ponte Alta do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4017
+msgid "Ponte Alta do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4018
+msgid "Ponte Branca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4019
+msgid "Ponte Nova"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4020
+msgid "Ponte Preta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4021
+msgid "Ponte Serrada"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4023
+msgid "Pontes Gestal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4022
+msgid "Pontes e Lacerda"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4024
+msgid "Ponto Belo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4025
+msgid "Ponto Chique"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4027
+msgid "Ponto Novo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4026
+msgid "Ponto dos Volantes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4013
+msgid "Pontão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4028
+msgid "Populina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4029
+msgid "Poranga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4030
+msgid "Porangaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4031
+msgid "Porangatu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4032
+msgid "Porciúncula"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4033
+msgid "Porecatu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4034
+msgid "Portalegre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4037
+msgid "Porteiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4038
+msgid "Porteirinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4036
+msgid "Porteirão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4039
+msgid "Portel"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4040
+msgid "Portelândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4041
+msgid "Porto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4042
+msgid "Porto Acre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_011
+msgid "Porto Alegre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4043
+msgid "Porto Alegre do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4044
+msgid "Porto Alegre do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4045
+msgid "Porto Alegre do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4046
+msgid "Porto Amazonas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4047
+msgid "Porto Barreiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4048
+msgid "Porto Belo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4049
+msgid "Porto Calvo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4055
+msgid "Porto Esperidião"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4056
+msgid "Porto Estrela"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4057
+msgid "Porto Feliz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4058
+msgid "Porto Ferreira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4059
+msgid "Porto Firme"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4060
+msgid "Porto Franco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4061
+msgid "Porto Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4062
+msgid "Porto Lucena"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4063
+msgid "Porto Mauá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4064
+msgid "Porto Murtinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4065
+msgid "Porto Nacional"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4066
+msgid "Porto Real"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4067
+msgid "Porto Real do Colégio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4068
+msgid "Porto Rico"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4069
+msgid "Porto Rico do Maranhão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_174
+msgid "Porto Seguro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4070
+msgid "Porto União"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_049
+msgid "Porto Velho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4071
+msgid "Porto Vera Cruz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4072
+msgid "Porto Vitória"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4073
+msgid "Porto Walter"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4074
+msgid "Porto Xavier"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4050
+msgid "Porto da Folha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4051
+msgid "Porto de Moz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4052
+msgid "Porto de Pedras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4053
+msgid "Porto do Mangue"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4054
+msgid "Porto dos Gaúchos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4035
+msgid "Portão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4075
+msgid "Posse"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4077
+msgid "Potengi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4078
+msgid "Potim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4079
+msgid "Potiraguá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4080
+msgid "Potirendaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4081
+msgid "Potiretama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4076
+msgid "Poté"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_197
+msgid "Pouso Alegre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4082
+msgid "Pouso Alto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4083
+msgid "Pouso Novo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4084
+msgid "Pouso Redondo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4085
+msgid "Poxoréu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_306
+msgid "Poá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3987
+msgid "Poço Branco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3988
+msgid "Poço Dantas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3992
+msgid "Poço Fundo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3993
+msgid "Poço Redondo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3994
+msgid "Poço Verde"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3989
+msgid "Poço das Antas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3990
+msgid "Poço das Trincheiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3991
+msgid "Poço de José de Moura"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_183
+msgid "Poços de Caldas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3984
+msgid "Poção"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3985
+msgid "Poção de Pedras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3995
+msgid "Poções"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4086
+msgid "Pracinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4087
+msgid "Pracuúba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4088
+msgid "Prado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4089
+msgid "Prado Ferreira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4091
+msgid "Prados"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4090
+msgid "Pradópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_077
+#: model:res.city,name:l10n_br.city_br_4092
+msgid "Praia Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4093
+msgid "Praia Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4094
+msgid "Prainha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4095
+msgid "Pranchita"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4096
+#: model:res.city,name:l10n_br.city_br_4097
+msgid "Prata"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4098
+msgid "Prata do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4101
+msgid "Pratinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4100
+msgid "Pratápolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4099
+msgid "Pratânia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4102
+msgid "Presidente Alves"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4103
+#: model:res.city,name:l10n_br.city_br_4104
+msgid "Presidente Bernardes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4105
+msgid "Presidente Castello Branco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4106
+msgid "Presidente Castelo Branco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4107
+#: model:res.city,name:l10n_br.city_br_4108
+msgid "Presidente Dutra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4109
+msgid "Presidente Epitácio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4110
+msgid "Presidente Figueiredo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4111
+msgid "Presidente Getúlio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4113
+#: model:res.city,name:l10n_br.city_br_4114
+msgid "Presidente Juscelino"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4112
+msgid "Presidente Jânio Quadros"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4115
+#: model:res.city,name:l10n_br.city_br_4116
+msgid "Presidente Kennedy"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4117
+msgid "Presidente Kubitschek"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4118
+msgid "Presidente Lucena"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4119
+#: model:res.city,name:l10n_br.city_br_4120
+msgid "Presidente Médici"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4121
+msgid "Presidente Nereu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4122
+msgid "Presidente Olegário"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_138
+msgid "Presidente Prudente"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4123
+msgid "Presidente Sarney"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4124
+msgid "Presidente Tancredo Neves"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4125
+msgid "Presidente Vargas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4126
+msgid "Presidente Venceslau"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4127
+#: model:res.city,name:l10n_br.city_br_4128
+msgid "Primavera"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4129
+msgid "Primavera de Rondônia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4130
+msgid "Primavera do Leste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4131
+msgid "Primeira Cruz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4132
+msgid "Primeiro de Maio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4133
+msgid "Princesa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4134
+msgid "Princesa Isabel"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4135
+msgid "Professor Jamil"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4136
+msgid "Progresso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4137
+msgid "Promissão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4138
+msgid "Propriá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4139
+msgid "Protásio Alves"
+msgstr ""
+
+#. module: l10n_br
+#: model:ir.model.fields,field_description:l10n_br.field_account_setup_bank_manual_config__proxy_type
+#: model:ir.model.fields,field_description:l10n_br.field_res_partner_bank__proxy_type
+msgid "Proxy Type"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4140
+msgid "Prudente de Morais"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4141
+msgid "Prudentópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4142
+msgid "Pugmil"
+msgstr ""
+
+#. module: l10n_br
 #: model:account.report.line,name:l10n_br.tax_report_ipi_extrada_tributada
 msgid "Purchase taxed at a zero rate"
 msgstr ""
@@ -423,6 +19858,253 @@ msgstr ""
 #. module: l10n_br
 #: model:account.report.line,name:l10n_br.tax_report_ipi_extrada_com
 msgid "Purchase with Credit Recovery"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4143
+msgid "Pureza"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4144
+msgid "Putinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4145
+msgid "Puxinanã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3680
+msgid "Pão de Açúcar"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3789
+msgid "Pé de Serra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3860
+msgid "Pérola"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3861
+msgid "Pérola d'Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4146
+msgid "Quadra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4147
+msgid "Quaraí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4148
+msgid "Quartel Geral"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4149
+msgid "Quarto Centenário"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4151
+msgid "Quatiguá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4152
+msgid "Quatipuru"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4153
+msgid "Quatis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4154
+msgid "Quatro Barras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4155
+msgid "Quatro Irmãos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4156
+msgid "Quatro Pontes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4150
+msgid "Quatá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4157
+msgid "Quebrangulo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4158
+msgid "Quedas do Iguaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4159
+msgid "Queimada Nova"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4160
+#: model:res.city,name:l10n_br.city_br_4161
+msgid "Queimadas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_213
+msgid "Queimados"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4162
+msgid "Queiroz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4163
+msgid "Queluz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4164
+msgid "Queluzito"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4165
+msgid "Querência"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4166
+msgid "Querência do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4167
+msgid "Quevedos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4168
+msgid "Quijingue"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4169
+msgid "Quilombo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4170
+msgid "Quinta do Sol"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4171
+msgid "Quintana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4172
+msgid "Quinze de Novembro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4173
+msgid "Quipapá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4174
+msgid "Quirinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4175
+msgid "Quissamã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4176
+msgid "Quitandinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4177
+msgid "Quiterianópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4178
+#: model:res.city,name:l10n_br.city_br_4179
+msgid "Quixaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4180
+msgid "Quixabeira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4181
+msgid "Quixadá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4182
+msgid "Quixelô"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4183
+msgid "Quixeramobim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4184
+msgid "Quixeré"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4185
+msgid "Rafael Fernandes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4186
+msgid "Rafael Godeiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4187
+msgid "Rafael Jambeiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4188
+msgid "Rafard"
 msgstr ""
 
 #. module: l10n_br
@@ -436,13 +20118,957 @@ msgid "Railway Ticket"
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4189
+msgid "Ramilândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4190
+msgid "Rancharia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4191
+msgid "Rancho Alegre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4192
+msgid "Rancho Alegre D'Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4193
+msgid "Rancho Queimado"
+msgstr ""
+
+#. module: l10n_br
+#: model:ir.model.fields.selection,name:l10n_br.selection__res_partner_bank__proxy_type__br_random
+msgid "Random Key (BR)"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4194
+msgid "Raposa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4195
+msgid "Raposos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4196
+msgid "Raul Soares"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4197
+msgid "Realeza"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4198
+msgid "Rebouças"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_009
+msgid "Recife"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4199
+msgid "Recreio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4200
+msgid "Recursolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4205
+msgid "Redentora"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4201
+#: model:res.city,name:l10n_br.city_br_4202
+msgid "Redenção"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4203
+msgid "Redenção da Serra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4204
+msgid "Redenção do Gurguéia"
+msgstr ""
+
+#. module: l10n_br
 #: model:ir.model.fields,field_description:l10n_br.field_account_tax__base_reduction
 msgid "Redution"
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4206
+msgid "Reduto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4207
+msgid "Regeneração"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4208
+msgid "Regente Feijó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4209
+msgid "Reginópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4210
+msgid "Registro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4211
+msgid "Relvado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4212
+msgid "Remanso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4213
+msgid "Remígio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4214
+msgid "Renascença"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4215
+msgid "Reriutaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_233
+msgid "Resende"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4216
+msgid "Resende Costa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4217
+msgid "Reserva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4218
+msgid "Reserva do Cabaçal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4219
+msgid "Reserva do Iguaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4220
+msgid "Resplendor"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4221
+msgid "Ressaquinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4222
+msgid "Restinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4223
+msgid "Restinga Sêca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4224
+msgid "Retirolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4232
+#: model:res.city,name:l10n_br.city_br_4233
+msgid "Riachinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4241
+msgid "Riacho Frio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4234
+msgid "Riacho da Cruz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4235
+msgid "Riacho das Almas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4236
+#: model:res.city,name:l10n_br.city_br_4237
+msgid "Riacho de Santana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4238
+msgid "Riacho de Santo Antônio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4239
+msgid "Riacho dos Cavalos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4240
+msgid "Riacho dos Machados"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4242
+#: model:res.city,name:l10n_br.city_br_4243
+msgid "Riachuelo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4225
+#: model:res.city,name:l10n_br.city_br_4226
+msgid "Riachão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4227
+msgid "Riachão das Neves"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4228
+msgid "Riachão do Bacamarte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4229
+msgid "Riachão do Dantas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4230
+msgid "Riachão do Jacuípe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4231
+msgid "Riachão do Poço"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4244
+msgid "Rialma"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4245
+msgid "Rianápolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4246
+msgid "Ribamar Fiquene"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4247
+msgid "Ribas do Rio Pardo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4248
+msgid "Ribeira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4249
+msgid "Ribeira do Amparo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4250
+msgid "Ribeira do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4251
+msgid "Ribeira do Pombal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4265
+msgid "Ribeiro Gonçalves"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4252
+msgid "Ribeirão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4253
+msgid "Ribeirão Bonito"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4254
+msgid "Ribeirão Branco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4255
+msgid "Ribeirão Cascalheira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4256
+msgid "Ribeirão Claro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4257
+msgid "Ribeirão Corrente"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4262
+msgid "Ribeirão Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_269
+msgid "Ribeirão Pires"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_029
+msgid "Ribeirão Preto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4263
+msgid "Ribeirão Vermelho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_084
+msgid "Ribeirão das Neves"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4258
+msgid "Ribeirão do Largo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4259
+msgid "Ribeirão do Pinhal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4260
+msgid "Ribeirão do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4261
+msgid "Ribeirão dos Índios"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4264
+msgid "Ribeirãozinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4266
+msgid "Ribeirópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4267
+msgid "Rifaina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4268
+msgid "Rincão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4269
+msgid "Rinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4270
+msgid "Rio Acima"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4271
+msgid "Rio Azul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4272
+msgid "Rio Bananal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4273
+msgid "Rio Bom"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4274
+msgid "Rio Bonito"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4275
+msgid "Rio Bonito do Iguaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_070
+#: model:res.city,name:l10n_br.city_br_4276
+msgid "Rio Branco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4277
+msgid "Rio Branco do Ivaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4278
+msgid "Rio Branco do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4279
+msgid "Rio Brilhante"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4280
+msgid "Rio Casca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_151
+#: model:res.city,name:l10n_br.city_br_4281
+msgid "Rio Claro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4282
+msgid "Rio Crespo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4295
+msgid "Rio Doce"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4299
+msgid "Rio Espera"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4300
+msgid "Rio Formoso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4301
+msgid "Rio Fortuna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_158
+msgid "Rio Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4302
+msgid "Rio Grande da Serra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4303
+msgid "Rio Grande do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4304
+msgid "Rio Largo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4305
+msgid "Rio Manso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4306
+msgid "Rio Maria"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4307
+msgid "Rio Negrinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4308
+#: model:res.city,name:l10n_br.city_br_4309
+msgid "Rio Negro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4310
+msgid "Rio Novo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4311
+msgid "Rio Novo do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4312
+msgid "Rio Paranaíba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4313
+msgid "Rio Pardo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4314
+msgid "Rio Pardo de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4315
+msgid "Rio Piracicaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4316
+msgid "Rio Pomba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4317
+msgid "Rio Preto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4318
+msgid "Rio Preto da Eva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4319
+msgid "Rio Quente"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4320
+msgid "Rio Real"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4321
+msgid "Rio Rufino"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4322
+msgid "Rio Sono"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4323
+msgid "Rio Tinto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_136
+msgid "Rio Verde"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4324
+msgid "Rio Verde de Mato Grosso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4325
+msgid "Rio Vermelho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4283
+msgid "Rio da Conceição"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4284
+msgid "Rio das Antas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4285
+msgid "Rio das Flores"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_193
+msgid "Rio das Ostras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4286
+msgid "Rio das Pedras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4287
+msgid "Rio de Contas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_002
+msgid "Rio de Janeiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4288
+msgid "Rio do Antônio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4289
+msgid "Rio do Campo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4290
+msgid "Rio do Fogo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4291
+msgid "Rio do Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4292
+msgid "Rio do Pires"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4293
+msgid "Rio do Prado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4294
+msgid "Rio do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4296
+msgid "Rio dos Bois"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4297
+msgid "Rio dos Cedros"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4298
+msgid "Rio dos Índios"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4326
+msgid "Riolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4327
+msgid "Riozinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4328
+msgid "Riqueza"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4329
+msgid "Ritápolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4330
+msgid "Riversul"
+msgstr ""
+
+#. module: l10n_br
 #: model:l10n_latam.document.type,name:l10n_br.dt_13
 msgid "Road Ticket"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4331
+msgid "Roca Sales"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4332
+msgid "Rochedo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4333
+msgid "Rochedo de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4334
+msgid "Rodeio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4335
+msgid "Rodeio Bonito"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4336
+msgid "Rodeiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4337
+msgid "Rodelas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4338
+msgid "Rodolfo Fernandes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4339
+msgid "Rodrigues Alves"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4340
+msgid "Rolador"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4342
+msgid "Rolante"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4343
+msgid "Rolim de Moura"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4341
+msgid "Rolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4344
+msgid "Romaria"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4345
+msgid "Romelândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4346
+msgid "Roncador"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4347
+msgid "Ronda Alta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4348
+msgid "Rondinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4349
+msgid "Rondolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4350
+msgid "Rondon"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4351
+msgid "Rondon do Pará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_118
+msgid "Rondonópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4352
+msgid "Roque Gonzales"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4353
+msgid "Rorainópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4354
+msgid "Rosana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4361
+msgid "Roseira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4355
+msgid "Rosário"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4360
+msgid "Rosário Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4356
+msgid "Rosário da Limeira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4357
+msgid "Rosário do Catete"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4358
+msgid "Rosário do Ivaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4359
+msgid "Rosário do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4362
+msgid "Roteiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4363
+msgid "Rubelita"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4365
+msgid "Rubiataba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4366
+msgid "Rubim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4367
+msgid "Rubinéia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4364
+msgid "Rubiácea"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4368
+msgid "Rurópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4369
+msgid "Russas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4370
+#: model:res.city,name:l10n_br.city_br_4371
+msgid "Ruy Barbosa"
 msgstr ""
 
 #. module: l10n_br
@@ -458,8 +21084,1988 @@ msgid "SUFRAMA registration number."
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_234
+msgid "Sabará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4373
+msgid "Sabino"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4374
+msgid "Sabinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4375
+msgid "Saboeiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4372
+msgid "Sabáudia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4376
+msgid "Sacramento"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4377
+msgid "Sagrada Família"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4378
+msgid "Sagres"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4379
+msgid "Sairé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4380
+msgid "Saldanha Marinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4381
+msgid "Sales"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4382
+msgid "Sales Oliveira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4383
+msgid "Salesópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4384
+msgid "Salete"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4385
+#: model:res.city,name:l10n_br.city_br_4386
+msgid "Salgadinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4387
+msgid "Salgado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4389
+msgid "Salgado Filho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4388
+msgid "Salgado de São Félix"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4390
+msgid "Salgueiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4391
+msgid "Salinas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4392
+msgid "Salinas da Margarida"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4393
+msgid "Salinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4394
+msgid "Salitre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4395
+msgid "Salmourão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4396
+msgid "Saloá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4397
+#: model:res.city,name:l10n_br.city_br_4398
+msgid "Saltinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_220
+msgid "Salto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4405
+msgid "Salto Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4406
+msgid "Salto Veloso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4399
+msgid "Salto da Divisa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4400
+msgid "Salto de Pirapora"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4401
+msgid "Salto do Céu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4402
+msgid "Salto do Itararé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4403
+msgid "Salto do Jacuí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4404
+msgid "Salto do Lontra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_005
+msgid "Salvador"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4407
+msgid "Salvador das Missões"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4408
+msgid "Salvador do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4409
+msgid "Salvaterra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4410
+msgid "Sambaíba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4411
+msgid "Sampaio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4412
+msgid "Sananduva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4413
+msgid "Sanclerlândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4414
+msgid "Sandolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4415
+msgid "Sandovalina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4416
+msgid "Sangão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4417
+msgid "Sanharó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4418
+msgid "Sant'Ana do Livramento"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4419
+msgid "Santa Adélia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4420
+msgid "Santa Albertina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4421
+msgid "Santa Amélia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4430
+msgid "Santa Branca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4431
+msgid "Santa Brígida"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4422
+#: model:res.city,name:l10n_br.city_br_4423
+msgid "Santa Bárbara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_163
+msgid "Santa Bárbara d'Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4424
+msgid "Santa Bárbara de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4425
+msgid "Santa Bárbara do Leste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4426
+msgid "Santa Bárbara do Monte Verde"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4427
+msgid "Santa Bárbara do Pará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4428
+msgid "Santa Bárbara do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4429
+msgid "Santa Bárbara do Tugúrio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4432
+msgid "Santa Carmem"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4433
+#: model:res.city,name:l10n_br.city_br_4434
+msgid "Santa Cecília"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4435
+msgid "Santa Cecília do Pavão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4436
+msgid "Santa Cecília do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4437
+msgid "Santa Clara d'Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4438
+msgid "Santa Clara do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4439
+#: model:res.city,name:l10n_br.city_br_4440
+#: model:res.city,name:l10n_br.city_br_4441
+msgid "Santa Cruz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4442
+msgid "Santa Cruz Cabrália"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4443
+msgid "Santa Cruz da Baixa Verde"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4444
+msgid "Santa Cruz da Conceição"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4445
+msgid "Santa Cruz da Esperança"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4446
+msgid "Santa Cruz da Vitória"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4447
+msgid "Santa Cruz das Palmeiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4448
+msgid "Santa Cruz de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4449
+msgid "Santa Cruz de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4450
+msgid "Santa Cruz de Monte Castelo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4451
+msgid "Santa Cruz de Salinas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4452
+msgid "Santa Cruz do Arari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4453
+msgid "Santa Cruz do Capibaribe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4454
+msgid "Santa Cruz do Escalvado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4455
+msgid "Santa Cruz do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4456
+msgid "Santa Cruz do Rio Pardo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_224
+msgid "Santa Cruz do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4457
+msgid "Santa Cruz do Xingu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4458
+msgid "Santa Cruz dos Milagres"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4459
+msgid "Santa Efigênia de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4460
+msgid "Santa Ernestina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4466
+#: model:res.city,name:l10n_br.city_br_4467
+msgid "Santa Filomena"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4468
+msgid "Santa Filomena do Maranhão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4461
+msgid "Santa Fé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4462
+msgid "Santa Fé de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4463
+msgid "Santa Fé de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4464
+msgid "Santa Fé do Araguaia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4465
+msgid "Santa Fé do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4469
+msgid "Santa Gertrudes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4470
+#: model:res.city,name:l10n_br.city_br_4471
+#: model:res.city,name:l10n_br.city_br_4472
+#: model:res.city,name:l10n_br.city_br_4473
+msgid "Santa Helena"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4474
+msgid "Santa Helena de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4475
+msgid "Santa Helena de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4476
+#: model:res.city,name:l10n_br.city_br_4477
+#: model:res.city,name:l10n_br.city_br_4478
+#: model:res.city,name:l10n_br.city_br_4479
+msgid "Santa Inês"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4480
+#: model:res.city,name:l10n_br.city_br_4481
+msgid "Santa Isabel"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4482
+msgid "Santa Isabel do Ivaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4483
+msgid "Santa Isabel do Rio Negro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4484
+msgid "Santa Izabel do Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4485
+msgid "Santa Izabel do Pará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4486
+msgid "Santa Juliana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4487
+msgid "Santa Leopoldina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4490
+msgid "Santa Luz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_143
+#: model:res.city,name:l10n_br.city_br_4491
+#: model:res.city,name:l10n_br.city_br_4492
+#: model:res.city,name:l10n_br.city_br_4493
+msgid "Santa Luzia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4494
+msgid "Santa Luzia D'Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4495
+msgid "Santa Luzia do Itanhy"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4496
+msgid "Santa Luzia do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4498
+msgid "Santa Luzia do Paruá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4497
+msgid "Santa Luzia do Pará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4488
+#: model:res.city,name:l10n_br.city_br_4489
+msgid "Santa Lúcia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4499
+msgid "Santa Margarida"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4500
+msgid "Santa Margarida do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_103
+#: model:res.city,name:l10n_br.city_br_4501
+msgid "Santa Maria"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4515
+msgid "Santa Maria Madalena"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4502
+msgid "Santa Maria da Boa Vista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4503
+msgid "Santa Maria da Serra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4504
+msgid "Santa Maria da Vitória"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4505
+msgid "Santa Maria das Barreiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4506
+msgid "Santa Maria de Itabira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4507
+msgid "Santa Maria de Jetibá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4508
+msgid "Santa Maria do Cambucá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4509
+msgid "Santa Maria do Herval"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4510
+msgid "Santa Maria do Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4511
+msgid "Santa Maria do Pará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4512
+msgid "Santa Maria do Salto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4513
+msgid "Santa Maria do Suaçuí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4514
+msgid "Santa Maria do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4516
+msgid "Santa Mariana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4517
+msgid "Santa Mercedes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4518
+msgid "Santa Mônica"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4519
+msgid "Santa Quitéria"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4520
+msgid "Santa Quitéria do Maranhão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_201
+#: model:res.city,name:l10n_br.city_br_4521
+msgid "Santa Rita"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4522
+msgid "Santa Rita d'Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4523
+msgid "Santa Rita de Caldas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4524
+msgid "Santa Rita de Cássia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4525
+msgid "Santa Rita de Ibitipoca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4526
+msgid "Santa Rita de Jacutinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4527
+msgid "Santa Rita de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4528
+msgid "Santa Rita do Araguaia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4529
+msgid "Santa Rita do Itueto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4530
+msgid "Santa Rita do Novo Destino"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4531
+msgid "Santa Rita do Pardo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4532
+msgid "Santa Rita do Passa Quatro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4533
+msgid "Santa Rita do Sapucaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4534
+msgid "Santa Rita do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4535
+msgid "Santa Rita do Trivelato"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4536
+msgid "Santa Rosa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4537
+msgid "Santa Rosa da Serra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4538
+msgid "Santa Rosa de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4539
+#: model:res.city,name:l10n_br.city_br_4540
+msgid "Santa Rosa de Lima"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4541
+msgid "Santa Rosa de Viterbo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4542
+msgid "Santa Rosa do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4543
+msgid "Santa Rosa do Purus"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4544
+msgid "Santa Rosa do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4545
+msgid "Santa Rosa do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4546
+msgid "Santa Salete"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4547
+msgid "Santa Teresa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4548
+#: model:res.city,name:l10n_br.city_br_4549
+msgid "Santa Teresinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4550
+msgid "Santa Tereza"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4551
+msgid "Santa Tereza de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4552
+msgid "Santa Tereza do Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4553
+msgid "Santa Tereza do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4554
+#: model:res.city,name:l10n_br.city_br_4555
+#: model:res.city,name:l10n_br.city_br_4556
+msgid "Santa Terezinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4557
+msgid "Santa Terezinha de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4558
+msgid "Santa Terezinha de Itaipu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4559
+msgid "Santa Terezinha do Progresso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4560
+msgid "Santa Terezinha do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4561
+msgid "Santa Vitória"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4562
+msgid "Santa Vitória do Palmar"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4563
+msgid "Santaluz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_289
+#: model:res.city,name:l10n_br.city_br_4564
+msgid "Santana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4565
+msgid "Santana da Boa Vista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4566
+msgid "Santana da Ponte Pensa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4567
+msgid "Santana da Vargem"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4568
+msgid "Santana de Cataguases"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4569
+msgid "Santana de Mangueira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_195
+msgid "Santana de Parnaíba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4570
+msgid "Santana de Pirapama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4571
+msgid "Santana do Acaraú"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4572
+msgid "Santana do Araguaia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4573
+msgid "Santana do Cariri"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4574
+msgid "Santana do Deserto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4575
+msgid "Santana do Garambéu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4576
+msgid "Santana do Ipanema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4577
+msgid "Santana do Itararé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4578
+msgid "Santana do Jacaré"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4579
+msgid "Santana do Manhuaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4580
+msgid "Santana do Maranhão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4581
+msgid "Santana do Matos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4582
+msgid "Santana do Mundaú"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4583
+msgid "Santana do Paraíso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4584
+msgid "Santana do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4585
+msgid "Santana do Riacho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4587
+msgid "Santana do Seridó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4586
+msgid "Santana do São Francisco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4588
+msgid "Santana dos Garrotes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4589
+msgid "Santana dos Montes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4590
+msgid "Santanópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_082
+msgid "Santarém"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4591
+msgid "Santarém Novo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4592
+msgid "Santiago"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4593
+msgid "Santiago do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4594
+msgid "Santo Afonso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4595
+msgid "Santo Amaro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4596
+msgid "Santo Amaro da Imperatriz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4597
+msgid "Santo Amaro das Brotas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4598
+msgid "Santo Amaro do Maranhão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4599
+msgid "Santo Anastácio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_025
+#: model:res.city,name:l10n_br.city_br_4600
+msgid "Santo André"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4602
+msgid "Santo Antônio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4603
+msgid "Santo Antônio da Alegria"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4604
+msgid "Santo Antônio da Barra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4605
+msgid "Santo Antônio da Patrulha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4606
+msgid "Santo Antônio da Platina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4607
+msgid "Santo Antônio das Missões"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4608
+msgid "Santo Antônio de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_313
+msgid "Santo Antônio de Jesus"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4609
+msgid "Santo Antônio de Lisboa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4611
+msgid "Santo Antônio de Posse"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4610
+msgid "Santo Antônio de Pádua"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4612
+msgid "Santo Antônio do Amparo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4613
+msgid "Santo Antônio do Aracanguá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4614
+msgid "Santo Antônio do Aventureiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4615
+msgid "Santo Antônio do Caiuá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4616
+msgid "Santo Antônio do Descoberto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4617
+msgid "Santo Antônio do Grama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4619
+msgid "Santo Antônio do Itambé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4618
+msgid "Santo Antônio do Içá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4620
+msgid "Santo Antônio do Jacinto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4621
+msgid "Santo Antônio do Jardim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4622
+msgid "Santo Antônio do Leste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4623
+msgid "Santo Antônio do Leverger"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4624
+msgid "Santo Antônio do Monte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4625
+msgid "Santo Antônio do Palma"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4626
+msgid "Santo Antônio do Paraíso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4627
+msgid "Santo Antônio do Pinhal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4628
+msgid "Santo Antônio do Planalto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4629
+msgid "Santo Antônio do Retiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4630
+msgid "Santo Antônio do Rio Abaixo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4631
+msgid "Santo Antônio do Sudoeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4632
+msgid "Santo Antônio do Tauá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4633
+msgid "Santo Antônio dos Lopes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4634
+msgid "Santo Antônio dos Milagres"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4635
+msgid "Santo Augusto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4636
+msgid "Santo Cristo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4637
+msgid "Santo Estêvão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4638
+msgid "Santo Expedito"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4639
+msgid "Santo Expedito do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4640
+msgid "Santo Hipólito"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4641
+msgid "Santo Inácio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4642
+msgid "Santo Inácio do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4601
+msgid "Santo Ângelo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_056
+msgid "Santos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4644
+msgid "Santos Dumont"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4643
+msgid "Santópolis do Aguapeí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4972
+msgid "Sapeaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4973
+msgid "Sapezal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4974
+msgid "Sapiranga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4975
+msgid "Sapopema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4977
+#: model:res.city,name:l10n_br.city_br_4978
+msgid "Sapucaia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_226
+msgid "Sapucaia do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4976
+msgid "Sapucaí-Mirim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4971
+msgid "Sapé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4979
+msgid "Saquarema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_257
+#: model:res.city,name:l10n_br.city_br_4980
+msgid "Sarandi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4981
+msgid "Sarapuí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4982
+msgid "Sardoá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4983
+msgid "Sarutaiá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4984
+msgid "Sarzedo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4986
+msgid "Satuba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4987
+msgid "Satubinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4988
+msgid "Saubara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4989
+msgid "Saudade do Iguaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4990
+msgid "Saudades"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4991
+msgid "Saúde"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4992
+msgid "Schroeder"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4993
+msgid "Seabra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4994
+msgid "Seara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4995
+msgid "Sebastianópolis do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4996
+msgid "Sebastião Barros"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4997
+msgid "Sebastião Laranjeiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4998
+msgid "Sebastião Leal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4999
+msgid "Seberi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5000
+msgid "Sede Nova"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5001
+msgid "Segredo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5002
+msgid "Selbach"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5003
+msgid "Selvíria"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5004
+msgid "Sem-Peixe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5005
+msgid "Sena Madureira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5006
+msgid "Senador Alexandre Costa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5007
+msgid "Senador Amaral"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_194
+msgid "Senador Canedo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5008
+msgid "Senador Cortes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5009
+msgid "Senador Elói de Souza"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5010
+msgid "Senador Firmino"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5011
+msgid "Senador Georgino Avelino"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5012
+msgid "Senador Guiomard"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5013
+msgid "Senador José Bento"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5014
+msgid "Senador José Porfírio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5015
+msgid "Senador La Rocque"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5016
+msgid "Senador Modestino Gonçalves"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5017
+msgid "Senador Pompeu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5018
+msgid "Senador Rui Palmeira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5020
+msgid "Senador Salgado Filho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5019
+msgid "Senador Sá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5021
+msgid "Sengés"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5022
+msgid "Senhor do Bonfim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5023
+msgid "Senhora de Oliveira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5024
+msgid "Senhora do Porto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5025
+msgid "Senhora dos Remédios"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5026
+msgid "Sentinela do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5027
+msgid "Sento Sé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5028
+msgid "Serafina Corrêa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5029
+msgid "Sericita"
+msgstr ""
+
+#. module: l10n_br
 #: model:ir.model.fields,field_description:l10n_br.field_account_journal__l10n_br_invoice_serial
 msgid "Series"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5030
+msgid "Seringueiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5032
+msgid "Seritinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5033
+msgid "Seropédica"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_041
+msgid "Serra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5034
+msgid "Serra Alta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5035
+msgid "Serra Azul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5036
+msgid "Serra Azul de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5037
+msgid "Serra Branca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5038
+msgid "Serra Caiada"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5047
+msgid "Serra Dourada"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5048
+msgid "Serra Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5049
+msgid "Serra Negra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5050
+msgid "Serra Negra do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5051
+msgid "Serra Nova Dourada"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5052
+msgid "Serra Preta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5053
+msgid "Serra Redonda"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5054
+msgid "Serra Talhada"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5039
+msgid "Serra da Raiz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5040
+msgid "Serra da Saudade"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5041
+msgid "Serra de São Bento"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5042
+msgid "Serra do Mel"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5043
+msgid "Serra do Navio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5044
+msgid "Serra do Ramalho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5045
+msgid "Serra do Salitre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5046
+msgid "Serra dos Aimorés"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5055
+msgid "Serrana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5056
+msgid "Serrania"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5057
+msgid "Serrano do Maranhão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5061
+msgid "Serranos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5058
+msgid "Serranópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5059
+msgid "Serranópolis de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5060
+msgid "Serranópolis do Iguaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5062
+msgid "Serraria"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5063
+#: model:res.city,name:l10n_br.city_br_5064
+msgid "Serrinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5065
+msgid "Serrinha dos Pintos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5066
+msgid "Serrita"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5067
+msgid "Serro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5068
+msgid "Serrolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5069
+msgid "Sertaneja"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5071
+msgid "Sertanópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5070
+msgid "Sertânia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5072
+msgid "Sertão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5073
+msgid "Sertão Santana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_238
+#: model:res.city,name:l10n_br.city_br_5074
+msgid "Sertãozinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5075
+msgid "Sete Barras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_135
+msgid "Sete Lagoas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5077
+msgid "Sete Quedas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5076
+msgid "Sete de Setembro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5078
+msgid "Setubinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5080
+msgid "Severiano Melo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5079
+msgid "Severiano de Almeida"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5081
+msgid "Severínia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5082
+msgid "Siderópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5083
+msgid "Sidrolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5084
+msgid "Sigefredo Pacheco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5085
+msgid "Silva Jardim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5087
+msgid "Silvanópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5088
+msgid "Silveira Martins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5090
+msgid "Silveiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5089
+msgid "Silveirânia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5091
+msgid "Silves"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5092
+msgid "Silvianópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5086
+msgid "Silvânia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5096
+msgid "Simolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5097
+msgid "Simonésia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5098
+msgid "Simplício Mendes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5093
+msgid "Simão Dias"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5094
+msgid "Simão Pereira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5095
+msgid "Simões"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_271
+msgid "Simões Filho"
 msgstr ""
 
 #. module: l10n_br
@@ -468,8 +23074,140 @@ msgid "Single invoice"
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5099
+msgid "Sinimbu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_155
+msgid "Sinop"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5100
+msgid "Siqueira Campos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5101
+msgid "Sirinhaém"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5102
+msgid "Siriri"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5109
+#: model:res.city,name:l10n_br.city_br_5110
+msgid "Sobradinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5111
+msgid "Sobrado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_150
+msgid "Sobral"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5112
+msgid "Sobrália"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5113
+msgid "Socorro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5114
+msgid "Socorro do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5116
+#: model:res.city,name:l10n_br.city_br_5117
+msgid "Soledade"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5118
+msgid "Soledade de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5119
+msgid "Solidão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5120
+msgid "Solonópole"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5115
+msgid "Solânea"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5121
+msgid "Sombrio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5122
+msgid "Sonora"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5123
+msgid "Sooretama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_027
+msgid "Sorocaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_283
+msgid "Sorriso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5124
+msgid "Sossêgo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5125
+msgid "Soure"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5126
+msgid "Sousa"
+msgstr ""
+
+#. module: l10n_br
 #: model:ir.model.fields.selection,name:l10n_br.selection__account_fiscal_position__l10n_br_fp_type__ss_nnm
 msgid "South/Southeast selling to North/Northeast/Midwest"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5127
+msgid "Souto Soares"
+msgstr ""
+
+#. module: l10n_br
+#: model_terms:ir.ui.view,arch_db:l10n_br.br_partner_address_form
+msgid "State"
 msgstr ""
 
 #. module: l10n_br
@@ -482,6 +23220,2131 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_br.field_res_partner__l10n_br_ie_code
 #: model:ir.model.fields,help:l10n_br.field_res_users__l10n_br_ie_code
 msgid "State Tax Identification Number. Should contain 9-14 digits."
+msgstr ""
+
+#. module: l10n_br
+#: model_terms:ir.ui.view,arch_db:l10n_br.br_partner_address_form
+msgid "Street"
+msgstr ""
+
+#. module: l10n_br
+#: model_terms:ir.ui.view,arch_db:l10n_br.br_partner_address_form
+msgid "Street #"
+msgstr ""
+
+#. module: l10n_br
+#: model_terms:ir.ui.view,arch_db:l10n_br.br_partner_address_form
+msgid "Street..."
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5128
+msgid "Sucupira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5129
+msgid "Sucupira do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5130
+msgid "Sucupira do Riachão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5131
+msgid "Sud Mennucci"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5132
+msgid "Sul Brasil"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5133
+msgid "Sulina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_098
+msgid "Sumaré"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5135
+msgid "Sumidouro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5134
+msgid "Sumé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5136
+msgid "Surubim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5137
+msgid "Sussuapara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_090
+msgid "Suzano"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5138
+msgid "Suzanápolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4985
+msgid "Sátiro Dias"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4645
+msgid "São Benedito"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4646
+msgid "São Benedito do Rio Preto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4647
+msgid "São Benedito do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4648
+msgid "São Bentinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4649
+#: model:res.city,name:l10n_br.city_br_4650
+msgid "São Bento"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4651
+msgid "São Bento Abade"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4652
+msgid "São Bento do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4653
+msgid "São Bento do Sapucaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4654
+msgid "São Bento do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4655
+msgid "São Bento do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4656
+msgid "São Bento do Trairí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4657
+msgid "São Bento do Una"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4658
+msgid "São Bernardino"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4659
+msgid "São Bernardo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_021
+msgid "São Bernardo do Campo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4660
+msgid "São Bonifácio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4661
+msgid "São Borja"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4664
+msgid "São Braz do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4662
+msgid "São Brás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4663
+msgid "São Brás do Suaçuí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4665
+msgid "São Caetano de Odivelas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_178
+msgid "São Caetano do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4666
+msgid "São Caitano"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_113
+#: model:res.city,name:l10n_br.city_br_4667
+msgid "São Carlos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4668
+msgid "São Carlos do Ivaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4669
+msgid "São Cristóvão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4670
+msgid "São Cristóvão do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4671
+msgid "São Desidério"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4672
+#: model:res.city,name:l10n_br.city_br_4673
+#: model:res.city,name:l10n_br.city_br_4674
+#: model:res.city,name:l10n_br.city_br_4675
+#: model:res.city,name:l10n_br.city_br_4676
+msgid "São Domingos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4677
+msgid "São Domingos das Dores"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4678
+msgid "São Domingos do Araguaia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4679
+msgid "São Domingos do Azeitão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4680
+msgid "São Domingos do Capim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4681
+msgid "São Domingos do Cariri"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4682
+msgid "São Domingos do Maranhão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4683
+msgid "São Domingos do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4684
+msgid "São Domingos do Prata"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4685
+msgid "São Domingos do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4686
+msgid "São Felipe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4687
+msgid "São Felipe D'Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4696
+msgid "São Fernando"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4697
+msgid "São Fidélis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4698
+#: model:res.city,name:l10n_br.city_br_4699
+#: model:res.city,name:l10n_br.city_br_4700
+#: model:res.city,name:l10n_br.city_br_4701
+msgid "São Francisco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4702
+msgid "São Francisco de Assis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4703
+msgid "São Francisco de Assis do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4704
+msgid "São Francisco de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4705
+msgid "São Francisco de Itabapoana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4706
+#: model:res.city,name:l10n_br.city_br_4707
+msgid "São Francisco de Paula"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4708
+msgid "São Francisco de Sales"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4709
+msgid "São Francisco do Brejão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4710
+msgid "São Francisco do Conde"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4711
+msgid "São Francisco do Glória"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4712
+msgid "São Francisco do Guaporé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4713
+msgid "São Francisco do Maranhão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4714
+msgid "São Francisco do Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4715
+msgid "São Francisco do Pará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4716
+msgid "São Francisco do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4717
+msgid "São Francisco do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4688
+msgid "São Félix"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4689
+msgid "São Félix de Balsas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4690
+msgid "São Félix de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4691
+msgid "São Félix do Araguaia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4692
+msgid "São Félix do Coribe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4693
+msgid "São Félix do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4694
+msgid "São Félix do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4695
+msgid "São Félix do Xingu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4718
+#: model:res.city,name:l10n_br.city_br_4719
+msgid "São Gabriel"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4720
+msgid "São Gabriel da Cachoeira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4721
+msgid "São Gabriel da Palha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4722
+msgid "São Gabriel do Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4723
+msgid "São Geraldo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4724
+msgid "São Geraldo da Piedade"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4725
+msgid "São Geraldo do Araguaia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4726
+msgid "São Geraldo do Baixio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_018
+msgid "São Gonçalo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4727
+msgid "São Gonçalo do Abaeté"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_265
+#: model:res.city,name:l10n_br.city_br_4728
+msgid "São Gonçalo do Amarante"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4729
+msgid "São Gonçalo do Gurguéia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4730
+msgid "São Gonçalo do Pará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4731
+msgid "São Gonçalo do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4732
+msgid "São Gonçalo do Rio Abaixo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4733
+msgid "São Gonçalo do Rio Preto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4734
+msgid "São Gonçalo do Sapucaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4735
+msgid "São Gonçalo dos Campos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4736
+msgid "São Gotardo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4737
+msgid "São Jerônimo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4738
+msgid "São Jerônimo da Serra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4790
+msgid "São Joaquim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4791
+msgid "São Joaquim da Barra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4792
+msgid "São Joaquim de Bicas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4793
+msgid "São Joaquim do Monte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4794
+msgid "São Jorge"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4795
+msgid "São Jorge d'Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4796
+msgid "São Jorge do Ivaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4797
+msgid "São Jorge do Patrocínio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_104
+msgid "São José"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4798
+msgid "São José da Barra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4799
+msgid "São José da Bela Vista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4800
+msgid "São José da Boa Vista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4801
+msgid "São José da Coroa Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4802
+msgid "São José da Lagoa Tapada"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4803
+msgid "São José da Laje"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4804
+msgid "São José da Lapa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4805
+msgid "São José da Safira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4806
+msgid "São José da Tapera"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4807
+msgid "São José da Varginha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4808
+msgid "São José da Vitória"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4809
+msgid "São José das Missões"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4810
+msgid "São José das Palmeiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4811
+msgid "São José de Caiana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4812
+msgid "São José de Espinharas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4813
+msgid "São José de Mipibu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4814
+msgid "São José de Piranhas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4815
+msgid "São José de Princesa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_119
+msgid "São José de Ribamar"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4816
+msgid "São José de Ubá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4817
+msgid "São José do Alegre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4818
+msgid "São José do Barreiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4819
+msgid "São José do Belmonte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4820
+msgid "São José do Bonfim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4821
+msgid "São José do Brejo do Cruz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4822
+msgid "São José do Calçado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4823
+msgid "São José do Campestre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4824
+msgid "São José do Cedro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4825
+msgid "São José do Cerrito"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4826
+#: model:res.city,name:l10n_br.city_br_4827
+msgid "São José do Divino"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4828
+msgid "São José do Egito"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4829
+msgid "São José do Goiabal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4830
+msgid "São José do Herval"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4831
+msgid "São José do Hortêncio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4832
+msgid "São José do Inhacorá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4834
+msgid "São José do Jacuri"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4833
+msgid "São José do Jacuípe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4835
+msgid "São José do Mantimento"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4836
+msgid "São José do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4837
+msgid "São José do Ouro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4838
+msgid "São José do Peixe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4839
+msgid "São José do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4840
+msgid "São José do Povo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4841
+msgid "São José do Rio Claro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4842
+msgid "São José do Rio Pardo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_045
+msgid "São José do Rio Preto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4843
+msgid "São José do Sabugi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4844
+msgid "São José do Seridó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4845
+msgid "São José do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4846
+msgid "São José do Vale do Rio Preto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4847
+msgid "São José do Xingu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4848
+msgid "São José dos Ausentes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4849
+msgid "São José dos Basílios"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_030
+msgid "São José dos Campos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4850
+msgid "São José dos Cordeiros"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_085
+msgid "São José dos Pinhais"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4851
+msgid "São José dos Quatro Marcos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4852
+msgid "São José dos Ramos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4739
+#: model:res.city,name:l10n_br.city_br_4740
+msgid "São João"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4741
+#: model:res.city,name:l10n_br.city_br_4742
+msgid "São João Batista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4743
+msgid "São João Batista do Glória"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4788
+msgid "São João Evangelista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4789
+msgid "São João Nepomuceno"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4744
+msgid "São João d'Aliança"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4745
+msgid "São João da Baliza"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4746
+msgid "São João da Barra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4747
+msgid "São João da Boa Vista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4748
+msgid "São João da Canabrava"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4749
+msgid "São João da Fronteira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4750
+msgid "São João da Lagoa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4751
+msgid "São João da Mata"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4752
+msgid "São João da Paraúna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4753
+msgid "São João da Ponta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4754
+msgid "São João da Ponte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4755
+msgid "São João da Serra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4756
+msgid "São João da Urtiga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4757
+msgid "São João da Varjota"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4758
+msgid "São João das Duas Pontes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4759
+msgid "São João das Missões"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4760
+msgid "São João de Iracema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_053
+msgid "São João de Meriti"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4761
+msgid "São João de Pirabas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4762
+msgid "São João del Rei"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4763
+msgid "São João do Araguaia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4764
+msgid "São João do Arraial"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4765
+msgid "São João do Caiuá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4766
+msgid "São João do Cariri"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4767
+msgid "São João do Carú"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4768
+msgid "São João do Itaperiú"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4769
+msgid "São João do Ivaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4770
+msgid "São João do Jaguaribe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4771
+msgid "São João do Manhuaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4772
+msgid "São João do Manteninha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4773
+msgid "São João do Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4774
+msgid "São João do Oriente"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4775
+msgid "São João do Pacuí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4776
+#: model:res.city,name:l10n_br.city_br_4777
+msgid "São João do Paraíso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4778
+msgid "São João do Pau d'Alho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4779
+msgid "São João do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4780
+msgid "São João do Polêsine"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4781
+msgid "São João do Rio do Peixe"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4782
+msgid "São João do Sabugi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4783
+msgid "São João do Soter"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4784
+msgid "São João do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4785
+msgid "São João do Tigre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4786
+msgid "São João do Triunfo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4787
+msgid "São João dos Patos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4853
+msgid "São Julião"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_144
+msgid "São Leopoldo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4854
+msgid "São Lourenço"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_282
+msgid "São Lourenço da Mata"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4855
+msgid "São Lourenço da Serra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4856
+msgid "São Lourenço do Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4857
+msgid "São Lourenço do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4858
+msgid "São Lourenço do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4859
+msgid "São Ludgero"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4862
+msgid "São Luis do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4865
+msgid "São Luiz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4868
+msgid "São Luiz Gonzaga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4866
+msgid "São Luiz do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4867
+msgid "São Luiz do Paraitinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_015
+msgid "São Luís"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4864
+msgid "São Luís Gonzaga do Maranhão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4860
+msgid "São Luís de Montes Belos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4861
+msgid "São Luís do Curu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4863
+msgid "São Luís do Quitunde"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4869
+msgid "São Mamede"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4870
+msgid "São Manoel do Paraná"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4871
+msgid "São Manuel"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4872
+msgid "São Marcos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4873
+#: model:res.city,name:l10n_br.city_br_4874
+msgid "São Martinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4875
+msgid "São Martinho da Serra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_246
+msgid "São Mateus"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4876
+msgid "São Mateus do Maranhão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4877
+msgid "São Mateus do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4878
+msgid "São Miguel"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4879
+msgid "São Miguel Arcanjo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4880
+msgid "São Miguel da Baixa Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4881
+msgid "São Miguel da Boa Vista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4882
+msgid "São Miguel das Matas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4883
+msgid "São Miguel das Missões"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4884
+msgid "São Miguel de Taipu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4885
+msgid "São Miguel do Aleixo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4886
+msgid "São Miguel do Anta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4887
+msgid "São Miguel do Araguaia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4888
+msgid "São Miguel do Fidalgo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4889
+msgid "São Miguel do Gostoso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4890
+msgid "São Miguel do Guamá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4891
+msgid "São Miguel do Guaporé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4892
+msgid "São Miguel do Iguaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4893
+msgid "São Miguel do Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4894
+msgid "São Miguel do Passa Quatro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4895
+msgid "São Miguel do Tapuio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4896
+msgid "São Miguel do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4897
+msgid "São Miguel dos Campos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4898
+msgid "São Miguel dos Milagres"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4899
+msgid "São Nicolau"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4900
+msgid "São Patrício"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_001
+msgid "São Paulo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4901
+msgid "São Paulo das Missões"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4902
+msgid "São Paulo de Olivença"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4903
+msgid "São Paulo do Potengi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4904
+#: model:res.city,name:l10n_br.city_br_4905
+msgid "São Pedro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_303
+msgid "São Pedro da Aldeia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4907
+msgid "São Pedro da Cipa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4908
+msgid "São Pedro da Serra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4909
+msgid "São Pedro da União"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4906
+msgid "São Pedro da Água Branca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4910
+msgid "São Pedro das Missões"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4911
+msgid "São Pedro de Alcântara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4912
+msgid "São Pedro do Butiá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4913
+msgid "São Pedro do Iguaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4914
+msgid "São Pedro do Ivaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4915
+msgid "São Pedro do Paraná"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4916
+msgid "São Pedro do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4917
+msgid "São Pedro do Suaçuí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4918
+msgid "São Pedro do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4919
+msgid "São Pedro do Turvo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4920
+msgid "São Pedro dos Crentes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4921
+msgid "São Pedro dos Ferros"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4922
+msgid "São Rafael"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4925
+msgid "São Raimundo Nonato"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4923
+msgid "São Raimundo das Mangabeiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4924
+msgid "São Raimundo do Doca Bezerra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4926
+msgid "São Roberto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4927
+msgid "São Romão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4928
+msgid "São Roque"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4929
+msgid "São Roque de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4930
+msgid "São Roque do Canaã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4931
+msgid "São Salvador do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4932
+#: model:res.city,name:l10n_br.city_br_4933
+msgid "São Sebastião"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4934
+msgid "São Sebastião da Amoreira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4935
+msgid "São Sebastião da Bela Vista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4936
+msgid "São Sebastião da Boa Vista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4937
+msgid "São Sebastião da Grama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4938
+msgid "São Sebastião da Vargem Alegre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4939
+msgid "São Sebastião de Lagoa de Roça"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4940
+msgid "São Sebastião do Alto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4941
+msgid "São Sebastião do Anta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4942
+msgid "São Sebastião do Caí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4943
+msgid "São Sebastião do Maranhão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4944
+msgid "São Sebastião do Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4945
+msgid "São Sebastião do Paraíso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4946
+msgid "São Sebastião do Passé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4947
+msgid "São Sebastião do Rio Preto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4948
+msgid "São Sebastião do Rio Verde"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4949
+msgid "São Sebastião do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4950
+msgid "São Sebastião do Uatumã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4951
+msgid "São Sebastião do Umbuzeiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4952
+msgid "São Sepé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4953
+#: model:res.city,name:l10n_br.city_br_4954
+msgid "São Simão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4955
+msgid "São Thomé das Letras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4956
+msgid "São Tiago"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4957
+msgid "São Tomás de Aquino"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4958
+#: model:res.city,name:l10n_br.city_br_4959
+msgid "São Tomé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4960
+msgid "São Valentim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4961
+msgid "São Valentim do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4962
+msgid "São Valério"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4963
+msgid "São Valério do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4964
+msgid "São Vendelino"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_083
+#: model:res.city,name:l10n_br.city_br_4965
+msgid "São Vicente"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4969
+msgid "São Vicente Ferrer"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4970
+msgid "São Vicente Férrer"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4966
+msgid "São Vicente de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4967
+msgid "São Vicente do Seridó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4968
+msgid "São Vicente do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5031
+msgid "Sério"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5106
+#: model:res.city,name:l10n_br.city_br_5107
+msgid "Sítio Novo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5108
+msgid "Sítio Novo do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5103
+msgid "Sítio d'Abadia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5104
+msgid "Sítio do Mato"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5105
+msgid "Sítio do Quinto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5140
+msgid "Tabaporã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5141
+msgid "Tabapuã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5142
+#: model:res.city,name:l10n_br.city_br_5143
+msgid "Tabatinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5139
+msgid "Tabaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5144
+msgid "Tabira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5145
+msgid "Tabocas do Brejo Velho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5146
+msgid "Taboleiro Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_101
+msgid "Taboão da Serra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5147
+msgid "Tabuleiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5148
+msgid "Tabuleiro do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5149
+msgid "Tacaimbó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5150
+msgid "Tacaratu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5151
+msgid "Taciba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5152
+msgid "Tacima"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5153
+msgid "Tacuru"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5155
+msgid "Taguatinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5154
+msgid "Taguaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5156
+msgid "Taiaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5157
+msgid "Tailândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5159
+msgid "Taiobeiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5160
+msgid "Taipas do Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5161
+msgid "Taipu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5158
+msgid "Taió"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5162
+msgid "Taiúva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5163
+msgid "Talismã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5164
+msgid "Tamandaré"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5165
+msgid "Tamarana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5166
+msgid "Tambaú"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5167
+msgid "Tamboara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5168
+msgid "Tamboril"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5169
+msgid "Tamboril do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5170
+msgid "Tanabi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5171
+#: model:res.city,name:l10n_br.city_br_5172
+msgid "Tangará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_293
+msgid "Tangará da Serra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5173
+msgid "Tanguá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5174
+msgid "Tanhaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5177
+msgid "Tanque Novo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5175
+msgid "Tanque d'Arca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5176
+msgid "Tanque do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5178
+msgid "Tanquinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5179
+msgid "Taparuba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5180
+msgid "Tapauá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5181
+#: model:res.city,name:l10n_br.city_br_5182
+msgid "Tapejara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5183
+msgid "Tapera"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5184
+#: model:res.city,name:l10n_br.city_br_5185
+msgid "Taperoá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5186
+msgid "Tapes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5187
+#: model:res.city,name:l10n_br.city_br_5188
+msgid "Tapira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5191
+msgid "Tapiramutá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5192
+msgid "Tapiratiba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5189
+#: model:res.city,name:l10n_br.city_br_5190
+msgid "Tapiraí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5193
+msgid "Tapurah"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5194
+msgid "Taquara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5196
+msgid "Taquaral"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5197
+msgid "Taquaral de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5198
+msgid "Taquarana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5195
+msgid "Taquaraçu de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5199
+msgid "Taquari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5200
+msgid "Taquaritinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5201
+msgid "Taquaritinga do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5202
+msgid "Taquarituba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5203
+msgid "Taquarivaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5205
+msgid "Taquarussu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5204
+msgid "Taquaruçu do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5206
+msgid "Tarabai"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5207
+msgid "Tarauacá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5208
+msgid "Tarrafas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5209
+msgid "Tartarugalzinho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5211
+msgid "Tarumirim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5210
+msgid "Tarumã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5212
+msgid "Tasso Fragoso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_245
+msgid "Tatuí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_089
+msgid "Taubaté"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5213
+msgid "Tauá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5214
+#: model:res.city,name:l10n_br.city_br_5215
+msgid "Tavares"
 msgstr ""
 
 #. module: l10n_br
@@ -521,82 +25384,186 @@ msgid "Taxed in full"
 msgstr ""
 
 #. module: l10n_br
-#: model:ir.model.fields,help:l10n_br.field_account_tax__amount_mva
-#: model:ir.model.fields,help:l10n_br.field_account_tax__base_reduction
-msgid "Um percentual decimal em % entre 0-1."
+#: model:res.city,name:l10n_br.city_br_5216
+msgid "Tefé"
 msgstr ""
 
 #. module: l10n_br
-#: model:l10n_latam.document.type,name:l10n_br.dt_14
-msgid "Waterway Ticket"
+#: model:res.city,name:l10n_br.city_br_5217
+msgid "Teixeira"
 msgstr ""
 
 #. module: l10n_br
-#: model:l10n_latam.document.type,name:l10n_br.dt_15
-msgid "e-Baggage Ticket"
+#: model:res.city,name:l10n_br.city_br_5218
+msgid "Teixeira Soares"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_207
+msgid "Teixeira de Freitas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5219
+msgid "Teixeiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5220
+msgid "Teixeirópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5222
+msgid "Tejupá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5221
+msgid "Tejuçuoca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5224
+msgid "Telha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5223
+msgid "Telêmaco Borba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5225
+msgid "Tenente Ananias"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5226
+msgid "Tenente Laurentino Cruz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5227
+msgid "Tenente Portela"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5228
+msgid "Tenório"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5229
+#: model:res.city,name:l10n_br.city_br_5230
+msgid "Teodoro Sampaio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5231
+msgid "Teofilândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5232
+msgid "Teolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5233
+msgid "Teotônio Vilela"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5234
+msgid "Terenos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_019
+msgid "Teresina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5235
+msgid "Teresina de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_181
+msgid "Teresópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5236
+msgid "Terezinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5237
+msgid "Terezópolis de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5238
+msgid "Terra Alta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5239
+msgid "Terra Boa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5241
+#: model:res.city,name:l10n_br.city_br_5242
+msgid "Terra Nova"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5243
+msgid "Terra Nova do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5244
+msgid "Terra Rica"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5245
+#: model:res.city,name:l10n_br.city_br_5246
+msgid "Terra Roxa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5247
+msgid "Terra Santa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5240
+msgid "Terra de Areia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5248
+msgid "Tesouro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5249
+msgid "Teutônia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_215
+msgid "Teófilo Otoni"
 msgstr ""
 
 #. module: l10n_br
 #. odoo-python
 #: code:addons/l10n_br/models/res_partner_bank.py:0
-#, python-format
-msgid "%s is not a valid CPF or CNPJ (don't include periods or dashes)."
-msgstr ""
-
-#. module: l10n_br
-#. odoo-python
-#: code:addons/l10n_br/models/res_partner_bank.py:0
-#, python-format
-msgid "%s is not a valid email."
-msgstr ""
-
-#. module: l10n_br
-#: model:ir.model,name:l10n_br.model_res_partner_bank
-msgid "Bank Accounts"
-msgstr ""
-
-#. module: l10n_br
-#: model:ir.model.fields.selection,name:l10n_br.selection__res_partner_bank__proxy_type__br_cpf_cnpj
-msgid "CPF/CNPJ (BR)"
-msgstr ""
-
-#. module: l10n_br
-#. odoo-python
-#: code:addons/l10n_br/models/res_partner_bank.py:0
-#, python-format
-msgid "Can't generate a Pix QR code with a currency other than BRL."
-msgstr ""
-
-#. module: l10n_br
-#: model_terms:ir.ui.view,arch_db:l10n_br.view_partner_bank_form_inherit_account
-msgid "Documentation"
-msgstr ""
-
-#. module: l10n_br
-#: model:ir.model.fields.selection,name:l10n_br.selection__res_partner_bank__proxy_type__email
-msgid "Email Address"
-msgstr ""
-
-#. module: l10n_br
-#: model:ir.model.fields.selection,name:l10n_br.selection__res_partner_bank__proxy_type__mobile
-msgid "Mobile Number"
-msgstr ""
-
-#. module: l10n_br
-#: model:ir.model.fields,field_description:l10n_br.field_account_setup_bank_manual_config__proxy_type
-#: model:ir.model.fields,field_description:l10n_br.field_res_partner_bank__proxy_type
-msgid "Proxy Type"
-msgstr ""
-
-#. module: l10n_br
-#: model:ir.model.fields.selection,name:l10n_br.selection__res_partner_bank__proxy_type__br_random
-msgid "Random Key (BR)"
-msgstr ""
-
-#. module: l10n_br
-#. odoo-python
-#: code:addons/l10n_br/models/res_partner_bank.py:0
-#, python-format
 msgid ""
 "The mobile number %s is invalid. It must start with +55, contain a 2 digit "
 "territory or state code followed by a 9 digit number."
@@ -605,7 +25572,6 @@ msgstr ""
 #. module: l10n_br
 #. odoo-python
 #: code:addons/l10n_br/models/res_partner_bank.py:0
-#, python-format
 msgid ""
 "The proxy type must be Email Address, Mobile Number, CPF/CNPJ (BR) or Random"
 " Key (BR) for Pix code generation."
@@ -614,17 +25580,1857 @@ msgstr ""
 #. module: l10n_br
 #. odoo-python
 #: code:addons/l10n_br/models/res_partner_bank.py:0
-#, python-format
 msgid ""
 "The random key %s is invalid, the format looks like this: "
 "71d6c6e1-64ea-4a11-9560-a10870c40ca2"
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5250
+msgid "Theobroma"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5251
+msgid "Tianguá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5252
+msgid "Tibagi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5253
+msgid "Tibau"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5254
+msgid "Tibau do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5255
+msgid "Tietê"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5256
+msgid "Tigrinhos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5257
+msgid "Tijucas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5258
+msgid "Tijucas do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5259
+msgid "Timbaúba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5260
+msgid "Timbaúba dos Batistas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5262
+msgid "Timbiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5265
+msgid "Timburi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5261
+msgid "Timbé do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5263
+msgid "Timbó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5264
+msgid "Timbó Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_169
+msgid "Timon"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5266
+msgid "Timóteo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5267
+msgid "Tio Hugo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5268
+msgid "Tiradentes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5269
+msgid "Tiradentes do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5270
+msgid "Tiros"
+msgstr ""
+
+#. module: l10n_br
 #. odoo-python
 #: code:addons/l10n_br/models/res_partner_bank.py:0
-#, python-format
 msgid ""
 "To generate a Pix code the proxy type for %s must be Email Address, Mobile "
 "Number, CPF/CNPJ (BR) or Random Key (BR)."
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5271
+msgid "Tobias Barreto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5274
+msgid "Tocantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5273
+msgid "Tocantinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5272
+msgid "Tocantínia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5275
+msgid "Tocos do Moji"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_200
+#: model:res.city,name:l10n_br.city_br_5276
+msgid "Toledo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5277
+msgid "Tomar do Geru"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5278
+msgid "Tomazina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5279
+msgid "Tombos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5280
+msgid "Tomé-Açu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5281
+msgid "Tonantins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5282
+msgid "Toritama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5283
+msgid "Torixoréu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5284
+msgid "Toropi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5285
+msgid "Torre de Pedra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5286
+msgid "Torres"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5287
+msgid "Torrinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5288
+msgid "Touros"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5289
+msgid "Trabiju"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5290
+msgid "Tracuateua"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5291
+msgid "Tracunhaém"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5292
+msgid "Traipu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5294
+msgid "Trairi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5293
+msgid "Trairão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5295
+msgid "Trajano de Moraes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5296
+msgid "Tramandaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5297
+msgid "Travesseiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5298
+msgid "Tremedal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5299
+msgid "Tremembé"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5315
+msgid "Treviso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5317
+msgid "Treze Tílias"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5316
+msgid "Treze de Maio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_211
+#: model:res.city,name:l10n_br.city_br_5318
+msgid "Trindade"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5319
+msgid "Trindade do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5320
+#: model:res.city,name:l10n_br.city_br_5321
+#: model:res.city,name:l10n_br.city_br_5322
+msgid "Triunfo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5323
+msgid "Triunfo Potiguar"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5324
+msgid "Trizidela do Vale"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5325
+msgid "Trombas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5326
+msgid "Trombudo Central"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5300
+msgid "Três Arroios"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5301
+msgid "Três Barras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5302
+msgid "Três Barras do Paraná"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5303
+msgid "Três Cachoeiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5304
+msgid "Três Corações"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5305
+msgid "Três Coroas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5307
+msgid "Três Forquilhas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5308
+msgid "Três Fronteiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_225
+msgid "Três Lagoas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5309
+msgid "Três Marias"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5310
+msgid "Três Palmeiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5311
+msgid "Três Passos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5312
+msgid "Três Pontas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5313
+msgid "Três Ranchos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5314
+msgid "Três Rios"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5306
+msgid "Três de Maio"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_286
+msgid "Tubarão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5327
+msgid "Tucano"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5328
+msgid "Tucumã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5329
+msgid "Tucunduva"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5330
+msgid "Tucuruí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5331
+msgid "Tufilândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5332
+msgid "Tuiuti"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5333
+msgid "Tumiritinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5335
+msgid "Tunas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5336
+msgid "Tunas do Paraná"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5337
+msgid "Tuneiras do Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5338
+msgid "Tuntum"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5334
+msgid "Tunápolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5340
+msgid "Tupaciguara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5341
+msgid "Tupanatinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5342
+msgid "Tupanci do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5343
+msgid "Tupanciretã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5344
+msgid "Tupandi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5345
+msgid "Tuparendi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5346
+msgid "Tuparetama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5348
+msgid "Tupi Paulista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5349
+msgid "Tupirama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5350
+msgid "Tupiratins"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5339
+msgid "Tupã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5347
+msgid "Tupãssi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5351
+msgid "Turiaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5352
+msgid "Turilândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5353
+msgid "Turiúba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5354
+#: model:res.city,name:l10n_br.city_br_5355
+msgid "Turmalina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5357
+msgid "Tururu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5356
+msgid "Turuçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5359
+msgid "Turvelândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5360
+#: model:res.city,name:l10n_br.city_br_5361
+msgid "Turvo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5362
+msgid "Turvolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5358
+msgid "Turvânia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5363
+msgid "Tutóia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5364
+msgid "Uarini"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5365
+msgid "Uauá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5368
+msgid "Ubaitaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5369
+msgid "Ubajara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5370
+msgid "Ubaporanga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5371
+msgid "Ubarana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5373
+msgid "Ubatuba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5372
+msgid "Ubatã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5366
+msgid "Ubaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5367
+msgid "Ubaíra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_081
+msgid "Uberaba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_028
+msgid "Uberlândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5374
+msgid "Ubirajara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5375
+msgid "Ubiratã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5376
+msgid "Ubiretama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_310
+msgid "Ubá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5377
+msgid "Uchoa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5378
+msgid "Uibaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5379
+msgid "Uiramutã"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5380
+msgid "Uirapuru"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5381
+msgid "Uiraúna"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5382
+msgid "Ulianópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:ir.model.fields,help:l10n_br.field_account_tax__amount_mva
+#: model:ir.model.fields,help:l10n_br.field_account_tax__base_reduction
+msgid "Um percentual decimal em % entre 0-1."
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5383
+msgid "Umari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5384
+msgid "Umarizal"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5385
+msgid "Umbaúba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5386
+msgid "Umburanas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5387
+msgid "Umburatiba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5388
+msgid "Umbuzeiro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5389
+msgid "Umirim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_263
+msgid "Umuarama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5390
+msgid "Una"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5391
+msgid "Unaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5400
+msgid "Uniflor"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5401
+msgid "Unistalda"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5392
+msgid "União"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5399
+msgid "União Paulista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5393
+msgid "União da Serra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5394
+msgid "União da Vitória"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5395
+msgid "União de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5396
+msgid "União do Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5397
+msgid "União do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5398
+msgid "União dos Palmares"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5402
+msgid "Upanema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5404
+msgid "Urandi"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5403
+msgid "Uraí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5406
+msgid "Urbano Santos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5407
+msgid "Uru"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5409
+msgid "Uruana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5410
+msgid "Uruana de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5411
+msgid "Uruará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5408
+msgid "Uruaçu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5412
+msgid "Urubici"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5413
+msgid "Uruburetama"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5415
+msgid "Urucará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5418
+msgid "Urucuia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5419
+msgid "Urucurituba"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5414
+msgid "Urucânia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_262
+msgid "Uruguaiana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5420
+msgid "Uruoca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5422
+msgid "Urupema"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5421
+msgid "Urupá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5423
+msgid "Urupês"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5424
+msgid "Urussanga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5425
+msgid "Urutaí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5416
+msgid "Uruçuca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5417
+msgid "Uruçuí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5405
+msgid "Urânia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5426
+msgid "Utinga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5427
+msgid "Vacaria"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5432
+msgid "Vale Real"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5433
+msgid "Vale Verde"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5428
+msgid "Vale de São Domingos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5429
+msgid "Vale do Anari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5430
+msgid "Vale do Paraíso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5431
+msgid "Vale do Sol"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5437
+msgid "Valente"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5438
+msgid "Valentim Gentil"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5434
+#: model:res.city,name:l10n_br.city_br_5435
+msgid "Valença"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5436
+msgid "Valença do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_240
+msgid "Valinhos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5439
+msgid "Valparaíso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_153
+msgid "Valparaíso de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5440
+msgid "Vanini"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5442
+#: model:res.city,name:l10n_br.city_br_5443
+msgid "Vargem"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5444
+msgid "Vargem Alegre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5445
+msgid "Vargem Alta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5446
+#: model:res.city,name:l10n_br.city_br_5447
+msgid "Vargem Bonita"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5448
+msgid "Vargem Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5451
+msgid "Vargem Grande Paulista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5449
+msgid "Vargem Grande do Rio Pardo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5450
+msgid "Vargem Grande do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5441
+msgid "Vargeão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_216
+msgid "Varginha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5454
+msgid "Varjota"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5452
+msgid "Varjão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5453
+msgid "Varjão de Minas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5455
+msgid "Varre-Sai"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5465
+msgid "Varzedo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5466
+msgid "Varzelândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5467
+msgid "Vassouras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5468
+msgid "Vazante"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5470
+msgid "Venda Nova do Imigrante"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5471
+msgid "Venha-Ver"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5472
+msgid "Ventania"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5473
+msgid "Venturosa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5469
+msgid "Venâncio Aires"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5474
+msgid "Vera"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5475
+#: model:res.city,name:l10n_br.city_br_5476
+#: model:res.city,name:l10n_br.city_br_5477
+#: model:res.city,name:l10n_br.city_br_5478
+msgid "Vera Cruz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5479
+msgid "Vera Cruz do Oeste"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5480
+msgid "Vera Mendes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5481
+msgid "Veranópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5482
+msgid "Verdejante"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5483
+msgid "Verdelândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5485
+msgid "Vereda"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5486
+msgid "Veredinha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5488
+msgid "Vermelho Novo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5489
+msgid "Vertente do Lério"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5490
+msgid "Vertentes"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5484
+msgid "Verê"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5487
+msgid "Veríssimo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_235
+msgid "Vespasiano"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5491
+msgid "Vespasiano Corrêa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5492
+msgid "Viadutos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_140
+msgid "Viamão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5493
+#: model:res.city,name:l10n_br.city_br_5494
+msgid "Viana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5495
+msgid "Vianópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5497
+msgid "Vicente Dutra"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5498
+msgid "Vicentina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5499
+msgid "Vicentinópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5504
+msgid "Victor Graeff"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5496
+msgid "Vicência"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5505
+msgid "Vidal Ramos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5506
+msgid "Videira"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5507
+msgid "Vieiras"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5508
+msgid "Vieirópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5509
+msgid "Vigia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5510
+msgid "Vila Bela da Santíssima Trindade"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5511
+msgid "Vila Boa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5512
+msgid "Vila Flor"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5513
+msgid "Vila Flores"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5514
+msgid "Vila Lângaro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5515
+msgid "Vila Maria"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5516
+msgid "Vila Nova do Piauí"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5517
+msgid "Vila Nova do Sul"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5518
+msgid "Vila Nova dos Martírios"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5519
+msgid "Vila Pavão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5520
+msgid "Vila Propício"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5521
+msgid "Vila Rica"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5522
+msgid "Vila Valério"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_047
+msgid "Vila Velha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5523
+msgid "Vilhena"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5524
+msgid "Vinhedo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5525
+msgid "Viradouro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5526
+msgid "Virgem da Lapa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5528
+msgid "Virginópolis"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5529
+msgid "Virgolândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5527
+msgid "Virgínia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5530
+msgid "Virmond"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5531
+msgid "Visconde do Rio Branco"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5532
+msgid "Viseu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5533
+msgid "Vista Alegre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5534
+msgid "Vista Alegre do Alto"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5535
+msgid "Vista Alegre do Prata"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5536
+msgid "Vista Gaúcha"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5537
+msgid "Vista Serrana"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5538
+msgid "Vitor Meireles"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5544
+msgid "Vitorino"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5545
+msgid "Vitorino Freire"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_087
+msgid "Vitória"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5539
+msgid "Vitória Brasil"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_068
+msgid "Vitória da Conquista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5540
+msgid "Vitória das Missões"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_222
+msgid "Vitória de Santo Antão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5541
+msgid "Vitória do Jari"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5542
+msgid "Vitória do Mearim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5543
+msgid "Vitória do Xingu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5500
+#: model:res.city,name:l10n_br.city_br_5501
+#: model:res.city,name:l10n_br.city_br_5502
+msgid "Viçosa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5503
+msgid "Viçosa do Ceará"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5546
+msgid "Volta Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_110
+msgid "Volta Redonda"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_236
+msgid "Votorantim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5547
+msgid "Votuporanga"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5456
+#: model:res.city,name:l10n_br.city_br_5457
+msgid "Várzea"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5458
+msgid "Várzea Alegre"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5459
+msgid "Várzea Branca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_093
+#: model:res.city,name:l10n_br.city_br_5463
+msgid "Várzea Grande"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5464
+msgid "Várzea Nova"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_267
+msgid "Várzea Paulista"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5460
+msgid "Várzea da Palma"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5461
+msgid "Várzea da Roça"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5462
+msgid "Várzea do Poço"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5548
+msgid "Wagner"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5549
+msgid "Wall Ferraz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5551
+msgid "Wanderley"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5550
+msgid "Wanderlândia"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_14
+msgid "Waterway Ticket"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5552
+#: model:res.city,name:l10n_br.city_br_5553
+msgid "Wenceslau Braz"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5554
+msgid "Wenceslau Guimarães"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5555
+msgid "Westfália"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5556
+msgid "Witmarsum"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5557
+msgid "Xambioá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5558
+msgid "Xambrê"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5559
+msgid "Xangri-lá"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5560
+msgid "Xanxerê"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5561
+msgid "Xapuri"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5562
+msgid "Xavantina"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5563
+msgid "Xaxim"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5564
+msgid "Xexéu"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5565
+msgid "Xinguara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5566
+msgid "Xique-Xique"
+msgstr ""
+
+#. module: l10n_br
+#: model_terms:ir.ui.view,arch_db:l10n_br.br_partner_address_form
+msgid "ZIP"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5567
+msgid "Zabelê"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5568
+msgid "Zacarias"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5570
+msgid "Zortéa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5569
+msgid "Zé Doca"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_15
+msgid "e-Baggage Ticket"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_363
+msgid "Água Azul do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_364
+#: model:res.city,name:l10n_br.city_br_365
+msgid "Água Boa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_366
+#: model:res.city,name:l10n_br.city_br_367
+#: model:res.city,name:l10n_br.city_br_368
+msgid "Água Branca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_369
+msgid "Água Clara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_370
+msgid "Água Comprida"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_371
+msgid "Água Doce"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_372
+msgid "Água Doce do Maranhão"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_373
+msgid "Água Doce do Norte"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_374
+msgid "Água Fria"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_375
+msgid "Água Fria de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_376
+msgid "Água Limpa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_377
+msgid "Água Nova"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_378
+msgid "Água Preta"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_379
+msgid "Água Santa"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_382
+msgid "Águas Belas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_388
+msgid "Águas Formosas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_389
+msgid "Águas Frias"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_137
+msgid "Águas Lindas de Goiás"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_390
+msgid "Águas Mornas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_391
+msgid "Águas Vermelhas"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_383
+msgid "Águas da Prata"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_384
+msgid "Águas de Chapecó"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_385
+msgid "Águas de Lindóia"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_386
+msgid "Águas de Santa Bárbara"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_387
+msgid "Águas de São Pedro"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_395
+msgid "Águia Branca"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_486
+msgid "Álvares Florence"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_487
+msgid "Álvares Machado"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_488
+msgid "Álvaro de Carvalho"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_721
+msgid "Áurea"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_553
+msgid "Ângulo"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1908
+msgid "Érico Cardoso"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3552
+msgid "Óbidos"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3559
+msgid "Óleo"
 msgstr ""

--- a/addons/l10n_br/i18n/pt.po
+++ b/addons/l10n_br/i18n/pt.po
@@ -4,15 +4,144 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0\n"
+"Project-Id-Version: Odoo Server 17.5alpha1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 19:17+0000\n"
-"PO-Revision-Date: 2023-10-20 15:43-0300\n"
+"POT-Creation-Date: 2024-09-18 00:40+0000\n"
+"PO-Revision-Date: 2024-09-17 21:18+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: pt\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_br
+#. odoo-python
+#: code:addons/l10n_br/models/res_partner_bank.py:0
+msgid "%s is not a valid CPF or CNPJ (don't include periods or dashes)."
+msgstr "%s não é um CPF ou CNPJ válido (não inclua pontos ou travessões)."
+
+#. module: l10n_br
+#. odoo-python
+#: code:addons/l10n_br/models/res_partner_bank.py:0
+msgid "%s is not a valid email."
+msgstr "%s não é um e-mail válido"
+
+#. module: l10n_br
+#: model_terms:ir.ui.view,arch_db:l10n_br.br_partner_address_form
+msgid "<span> - </span>"
+msgstr "<span> - </span>"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_320
+msgid "Abadia de Goiás"
+msgstr "Abadia de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_321
+msgid "Abadia dos Dourados"
+msgstr "Abadia dos Dourados"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_322
+msgid "Abadiânia"
+msgstr "Abadiânia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_190
+msgid "Abaetetuba"
+msgstr "Abaetetuba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_323
+msgid "Abaeté"
+msgstr "Abaeté"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_324
+msgid "Abaiara"
+msgstr "Abaiara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_326
+msgid "Abaré"
+msgstr "Abaré"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_327
+msgid "Abatiá"
+msgstr "Abatiá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_325
+msgid "Abaíra"
+msgstr "Abaíra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_328
+msgid "Abdon Batista"
+msgstr "Abdon Batista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_329
+msgid "Abel Figueiredo"
+msgstr "Abel Figueiredo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_330
+msgid "Abelardo Luz"
+msgstr "Abelardo Luz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_331
+msgid "Abre Campo"
+msgstr "Abre Campo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_332
+msgid "Abreu e Lima"
+msgstr "Abreu e Lima"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_333
+msgid "Abreulândia"
+msgstr "Abreulândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_334
+msgid "Acaiaca"
+msgstr "Acaiaca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_335
+msgid "Acajutiba"
+msgstr "Acajutiba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_337
+msgid "Acarape"
+msgstr "Acarape"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_338
+msgid "Acaraú"
+msgstr "Acaraú"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_339
+msgid "Acari"
+msgstr "Acari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_336
+msgid "Acará"
+msgstr "Acará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_340
+msgid "Acauã"
+msgstr "Acauã"
 
 #. module: l10n_br
 #: model:ir.model,name:l10n_br.model_account_chart_template
@@ -22,12 +151,1971 @@ msgstr "Modelo de plano da contas"
 #. module: l10n_br
 #: model:ir.model,name:l10n_br.model_account_move_reversal
 msgid "Account Move Reversal"
-msgstr ""
+msgstr "Reversão de movimentação de conta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_341
+msgid "Aceguá"
+msgstr "Aceguá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_342
+msgid "Acopiara"
+msgstr "Acopiara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_343
+msgid "Acorizal"
+msgstr "Acorizal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_344
+msgid "Acrelândia"
+msgstr "Acrelândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_345
+msgid "Acreúna"
+msgstr "Acreúna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_348
+msgid "Adamantina"
+msgstr "Adamantina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_349
+msgid "Adelândia"
+msgstr "Adelândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_350
+msgid "Adolfo"
+msgstr "Adolfo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_351
+msgid "Adrianópolis"
+msgstr "Adrianópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_352
+msgid "Adustina"
+msgstr "Adustina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_353
+msgid "Afogados da Ingazeira"
+msgstr "Afogados da Ingazeira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_354
+msgid "Afonso Bezerra"
+msgstr "Afonso Bezerra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_355
+msgid "Afonso Cláudio"
+msgstr "Afonso Cláudio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_356
+msgid "Afonso Cunha"
+msgstr "Afonso Cunha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_357
+msgid "Afrânio"
+msgstr "Afrânio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_358
+msgid "Afuá"
+msgstr "Afuá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_359
+msgid "Agrestina"
+msgstr "Agrestina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_360
+msgid "Agricolândia"
+msgstr "Agricolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_361
+msgid "Agrolândia"
+msgstr "Agrolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_362
+msgid "Agronômica"
+msgstr "Agronômica"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_381
+msgid "Aguanil"
+msgstr "Aguanil"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_380
+msgid "Aguaí"
+msgstr "Aguaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_392
+msgid "Agudo"
+msgstr "Agudo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_393
+msgid "Agudos"
+msgstr "Agudos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_394
+msgid "Agudos do Sul"
+msgstr "Agudos do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_396
+msgid "Aguiar"
+msgstr "Aguiar"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_397
+msgid "Aguiarnópolis"
+msgstr "Aguiarnópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_398
+msgid "Aimorés"
+msgstr "Aimorés"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_399
+msgid "Aiquara"
+msgstr "Aiquara"
 
 #. module: l10n_br
 #: model:l10n_latam.document.type,name:l10n_br.dt_10
 msgid "Aircraft Knowledge"
-msgstr ""
+msgstr "Conhecimento de Aeronaves"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_400
+msgid "Aiuaba"
+msgstr "Aiuaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_401
+msgid "Aiuruoca"
+msgstr "Aiuruoca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_402
+msgid "Ajuricaba"
+msgstr "Ajuricaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_403
+msgid "Alagoa"
+msgstr "Alagoa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_404
+msgid "Alagoa Grande"
+msgstr "Alagoa Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_405
+msgid "Alagoa Nova"
+msgstr "Alagoa Nova"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_406
+#: model:res.city,name:l10n_br.city_br_407
+msgid "Alagoinha"
+msgstr "Alagoinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_408
+msgid "Alagoinha do Piauí"
+msgstr "Alagoinha do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_199
+msgid "Alagoinhas"
+msgstr "Alagoinhas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_409
+msgid "Alambari"
+msgstr "Alambari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_410
+msgid "Albertina"
+msgstr "Albertina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_413
+msgid "Alcantil"
+msgstr "Alcantil"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_414
+msgid "Alcinópolis"
+msgstr "Alcinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_415
+msgid "Alcobaça"
+msgstr "Alcobaça"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_411
+msgid "Alcântara"
+msgstr "Alcântara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_412
+msgid "Alcântaras"
+msgstr "Alcântaras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_416
+msgid "Aldeias Altas"
+msgstr "Aldeias Altas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_417
+msgid "Alecrim"
+msgstr "Alecrim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_418
+msgid "Alegre"
+msgstr "Alegre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_419
+msgid "Alegrete"
+msgstr "Alegrete"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_420
+msgid "Alegrete do Piauí"
+msgstr "Alegrete do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_421
+msgid "Alegria"
+msgstr "Alegria"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_423
+msgid "Alenquer"
+msgstr "Alenquer"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_424
+msgid "Alexandria"
+msgstr "Alexandria"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_425
+msgid "Alexânia"
+msgstr "Alexânia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_426
+msgid "Alfenas"
+msgstr "Alfenas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_427
+msgid "Alfredo Chaves"
+msgstr "Alfredo Chaves"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_428
+msgid "Alfredo Marcondes"
+msgstr "Alfredo Marcondes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_429
+msgid "Alfredo Vasconcelos"
+msgstr "Alfredo Vasconcelos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_430
+msgid "Alfredo Wagner"
+msgstr "Alfredo Wagner"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_431
+msgid "Algodão de Jandaíra"
+msgstr "Algodão de Jandaíra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_432
+msgid "Alhandra"
+msgstr "Alhandra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_433
+msgid "Aliança"
+msgstr "Aliança"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_434
+msgid "Aliança do Tocantins"
+msgstr "Aliança do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_435
+msgid "Almadina"
+msgstr "Almadina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_436
+msgid "Almas"
+msgstr "Almas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_437
+msgid "Almeirim"
+msgstr "Almeirim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_438
+msgid "Almenara"
+msgstr "Almenara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_439
+msgid "Almino Afonso"
+msgstr "Almino Afonso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_253
+msgid "Almirante Tamandaré"
+msgstr "Almirante Tamandaré"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_440
+msgid "Almirante Tamandaré do Sul"
+msgstr "Almirante Tamandaré do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_441
+msgid "Aloândia"
+msgstr "Aloândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_442
+msgid "Alpercata"
+msgstr "Alpercata"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_443
+msgid "Alpestre"
+msgstr "Alpestre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_444
+msgid "Alpinópolis"
+msgstr "Alpinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_445
+msgid "Alta Floresta"
+msgstr "Alta Floresta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_446
+msgid "Alta Floresta D'Oeste"
+msgstr "Alta Floresta D'Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_447
+msgid "Altair"
+msgstr "Altair"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_241
+msgid "Altamira"
+msgstr "Altamira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_448
+msgid "Altamira do Maranhão"
+msgstr "Altamira do Maranhão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_449
+msgid "Altamira do Paraná"
+msgstr "Altamira do Paraná"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_450
+msgid "Altaneira"
+msgstr "Altaneira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_451
+msgid "Alterosa"
+msgstr "Alterosa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_452
+msgid "Altinho"
+msgstr "Altinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_453
+msgid "Altinópolis"
+msgstr "Altinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_454
+#: model:res.city,name:l10n_br.city_br_455
+#: model:res.city,name:l10n_br.city_br_456
+msgid "Alto Alegre"
+msgstr "Alto Alegre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_457
+msgid "Alto Alegre do Maranhão"
+msgstr "Alto Alegre do Maranhão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_458
+msgid "Alto Alegre do Pindaré"
+msgstr "Alto Alegre do Pindaré"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_459
+msgid "Alto Alegre dos Parecis"
+msgstr "Alto Alegre dos Parecis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_460
+msgid "Alto Araguaia"
+msgstr "Alto Araguaia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_461
+msgid "Alto Bela Vista"
+msgstr "Alto Bela Vista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_462
+msgid "Alto Boa Vista"
+msgstr "Alto Boa Vista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_463
+msgid "Alto Caparaó"
+msgstr "Alto Caparaó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_465
+msgid "Alto Feliz"
+msgstr "Alto Feliz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_466
+msgid "Alto Garças"
+msgstr "Alto Garças"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_467
+msgid "Alto Horizonte"
+msgstr "Alto Horizonte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_468
+msgid "Alto Jequitibá"
+msgstr "Alto Jequitibá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_469
+msgid "Alto Longá"
+msgstr "Alto Longá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_470
+msgid "Alto Paraguai"
+msgstr "Alto Paraguai"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_474
+msgid "Alto Paraná"
+msgstr "Alto Paraná"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_471
+#: model:res.city,name:l10n_br.city_br_472
+msgid "Alto Paraíso"
+msgstr "Alto Paraíso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_473
+msgid "Alto Paraíso de Goiás"
+msgstr "Alto Paraíso de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_475
+msgid "Alto Parnaíba"
+msgstr "Alto Parnaíba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_476
+msgid "Alto Piquiri"
+msgstr "Alto Piquiri"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_477
+msgid "Alto Rio Doce"
+msgstr "Alto Rio Doce"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_478
+msgid "Alto Rio Novo"
+msgstr "Alto Rio Novo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_479
+msgid "Alto Santo"
+msgstr "Alto Santo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_480
+msgid "Alto Taquari"
+msgstr "Alto Taquari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_464
+msgid "Alto do Rodrigues"
+msgstr "Alto do Rodrigues"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_482
+msgid "Altos"
+msgstr "Altos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_481
+msgid "Altônia"
+msgstr "Altônia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_483
+msgid "Alumínio"
+msgstr "Alumínio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_485
+msgid "Alvarenga"
+msgstr "Alvarenga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_484
+msgid "Alvarães"
+msgstr "Alvarães"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_489
+msgid "Alvinlândia"
+msgstr "Alvinlândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_490
+msgid "Alvinópolis"
+msgstr "Alvinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_160
+#: model:res.city,name:l10n_br.city_br_491
+msgid "Alvorada"
+msgstr "Alvorada"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_492
+msgid "Alvorada D'Oeste"
+msgstr "Alvorada D'Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_493
+msgid "Alvorada de Minas"
+msgstr "Alvorada de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_494
+msgid "Alvorada do Gurguéia"
+msgstr "Alvorada do Gurguéia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_495
+msgid "Alvorada do Norte"
+msgstr "Alvorada do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_496
+msgid "Alvorada do Sul"
+msgstr "Alvorada do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_422
+msgid "Além Paraíba"
+msgstr "Além Paraíba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_497
+msgid "Amajari"
+msgstr "Amajari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_498
+msgid "Amambai"
+msgstr "Amambai"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_501
+msgid "Amaporã"
+msgstr "Amaporã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_499
+msgid "Amapá"
+msgstr "Amapá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_500
+msgid "Amapá do Maranhão"
+msgstr "Amapá do Maranhão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_502
+msgid "Amaraji"
+msgstr "Amaraji"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_503
+msgid "Amaral Ferrador"
+msgstr "Amaral Ferrador"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_504
+msgid "Amaralina"
+msgstr "Amaralina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_505
+msgid "Amarante"
+msgstr "Amarante"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_506
+msgid "Amarante do Maranhão"
+msgstr "Amarante do Maranhão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_507
+msgid "Amargosa"
+msgstr "Amargosa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_508
+msgid "Amaturá"
+msgstr "Amaturá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_124
+msgid "Americana"
+msgstr "Americana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_511
+msgid "Americano do Brasil"
+msgstr "Americano do Brasil"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_514
+msgid "Ametista do Sul"
+msgstr "Ametista do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_515
+msgid "Amontada"
+msgstr "Amontada"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_516
+msgid "Amorinópolis"
+msgstr "Amorinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_517
+#: model:res.city,name:l10n_br.city_br_518
+msgid "Amparo"
+msgstr "Amparo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_519
+msgid "Amparo de São Francisco"
+msgstr "Amparo de São Francisco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_520
+msgid "Amparo do Serra"
+msgstr "Amparo do Serra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_521
+msgid "Ampére"
+msgstr "Ampére"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_509
+msgid "Amélia Rodrigues"
+msgstr "Amélia Rodrigues"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_510
+msgid "América Dourada"
+msgstr "América Dourada"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_512
+msgid "Américo Brasiliense"
+msgstr "Américo Brasiliense"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_513
+msgid "Américo de Campos"
+msgstr "Américo de Campos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_522
+msgid "Anadia"
+msgstr "Anadia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_523
+msgid "Anagé"
+msgstr "Anagé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_524
+msgid "Anahy"
+msgstr "Anahy"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_526
+msgid "Anajatuba"
+msgstr "Anajatuba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_525
+msgid "Anajás"
+msgstr "Anajás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_527
+msgid "Analândia"
+msgstr "Analândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_528
+msgid "Anamã"
+msgstr "Anamã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_046
+msgid "Ananindeua"
+msgstr "Ananindeua"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_529
+msgid "Ananás"
+msgstr "Ananás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_530
+msgid "Anapu"
+msgstr "Anapu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_531
+msgid "Anapurus"
+msgstr "Anapurus"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_532
+msgid "Anastácio"
+msgstr "Anastácio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_533
+msgid "Anaurilândia"
+msgstr "Anaurilândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_534
+#: model:res.city,name:l10n_br.city_br_535
+msgid "Anchieta"
+msgstr "Anchieta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_536
+msgid "Andaraí"
+msgstr "Andaraí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_537
+msgid "Andirá"
+msgstr "Andirá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_538
+msgid "Andorinha"
+msgstr "Andorinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_539
+msgid "Andradas"
+msgstr "Andradas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_540
+msgid "Andradina"
+msgstr "Andradina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_542
+msgid "Andrelândia"
+msgstr "Andrelândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_541
+msgid "André da Rocha"
+msgstr "André da Rocha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_543
+msgid "Angatuba"
+msgstr "Angatuba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_546
+msgid "Angelim"
+msgstr "Angelim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_547
+msgid "Angelina"
+msgstr "Angelina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_544
+msgid "Angelândia"
+msgstr "Angelândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_548
+msgid "Angical"
+msgstr "Angical"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_549
+msgid "Angical do Piauí"
+msgstr "Angical do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_550
+msgid "Angico"
+msgstr "Angico"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_551
+msgid "Angicos"
+msgstr "Angicos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_175
+msgid "Angra dos Reis"
+msgstr "Angra dos Reis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_552
+msgid "Anguera"
+msgstr "Anguera"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_545
+msgid "Angélica"
+msgstr "Angélica"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_554
+msgid "Anhanguera"
+msgstr "Anhanguera"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_555
+msgid "Anhembi"
+msgstr "Anhembi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_556
+msgid "Anhumas"
+msgstr "Anhumas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_557
+msgid "Anicuns"
+msgstr "Anicuns"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_559
+msgid "Anita Garibaldi"
+msgstr "Anita Garibaldi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_560
+msgid "Anitápolis"
+msgstr "Anitápolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_561
+msgid "Anori"
+msgstr "Anori"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_562
+msgid "Anta Gorda"
+msgstr "Anta Gorda"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_563
+msgid "Antas"
+msgstr "Antas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_564
+msgid "Antonina"
+msgstr "Antonina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_565
+msgid "Antonina do Norte"
+msgstr "Antonina do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_566
+msgid "Antônio Almeida"
+msgstr "Antônio Almeida"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_567
+msgid "Antônio Cardoso"
+msgstr "Antônio Cardoso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_568
+#: model:res.city,name:l10n_br.city_br_569
+msgid "Antônio Carlos"
+msgstr "Antônio Carlos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_570
+msgid "Antônio Dias"
+msgstr "Antônio Dias"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_571
+msgid "Antônio Gonçalves"
+msgstr "Antônio Gonçalves"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_572
+msgid "Antônio João"
+msgstr "Antônio João"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_573
+msgid "Antônio Martins"
+msgstr "Antônio Martins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_574
+msgid "Antônio Olinto"
+msgstr "Antônio Olinto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_575
+msgid "Antônio Prado"
+msgstr "Antônio Prado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_576
+msgid "Antônio Prado de Minas"
+msgstr "Antônio Prado de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_062
+msgid "Anápolis"
+msgstr "Anápolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_558
+msgid "Anísio de Abreu"
+msgstr "Anísio de Abreu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_577
+#: model:res.city,name:l10n_br.city_br_578
+msgid "Aparecida"
+msgstr "Aparecida"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_579
+msgid "Aparecida d'Oeste"
+msgstr "Aparecida d'Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_040
+msgid "Aparecida de Goiânia"
+msgstr "Aparecida de Goiânia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_580
+msgid "Aparecida do Rio Doce"
+msgstr "Aparecida do Rio Doce"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_581
+msgid "Aparecida do Rio Negro"
+msgstr "Aparecida do Rio Negro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_582
+msgid "Aparecida do Taboado"
+msgstr "Aparecida do Taboado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_583
+msgid "Aperibé"
+msgstr "Aperibé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_584
+msgid "Apiacá"
+msgstr "Apiacá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_585
+msgid "Apiacás"
+msgstr "Apiacás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_586
+msgid "Apiaí"
+msgstr "Apiaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_587
+msgid "Apicum-Açu"
+msgstr "Apicum-Açu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_588
+msgid "Apiúna"
+msgstr "Apiúna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_589
+msgid "Apodi"
+msgstr "Apodi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_590
+msgid "Aporá"
+msgstr "Aporá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_591
+msgid "Aporé"
+msgstr "Aporé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_592
+msgid "Apuarema"
+msgstr "Apuarema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_231
+msgid "Apucarana"
+msgstr "Apucarana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_594
+msgid "Apuiarés"
+msgstr "Apuiarés"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_593
+msgid "Apuí"
+msgstr "Apuí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_595
+msgid "Aquidabã"
+msgstr "Aquidabã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_596
+msgid "Aquidauana"
+msgstr "Aquidauana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_597
+msgid "Aquiraz"
+msgstr "Aquiraz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_598
+msgid "Arabutã"
+msgstr "Arabutã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_036
+msgid "Aracaju"
+msgstr "Aracaju"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_603
+msgid "Aracati"
+msgstr "Aracati"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_604
+msgid "Aracatu"
+msgstr "Aracatu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_605
+msgid "Araci"
+msgstr "Araci"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_606
+msgid "Aracitaba"
+msgstr "Aracitaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_607
+msgid "Aracoiaba"
+msgstr "Aracoiaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_610
+msgid "Aracruz"
+msgstr "Aracruz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_613
+msgid "Aragarças"
+msgstr "Aragarças"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_614
+msgid "Aragoiânia"
+msgstr "Aragoiânia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_615
+msgid "Aragominas"
+msgstr "Aragominas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_616
+msgid "Araguacema"
+msgstr "Araguacema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_618
+msgid "Araguaiana"
+msgstr "Araguaiana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_619
+msgid "Araguainha"
+msgstr "Araguainha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_620
+#: model:res.city,name:l10n_br.city_br_621
+msgid "Araguanã"
+msgstr "Araguanã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_622
+msgid "Araguapaz"
+msgstr "Araguapaz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_261
+msgid "Araguari"
+msgstr "Araguari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_623
+msgid "Araguatins"
+msgstr "Araguatins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_617
+msgid "Araguaçu"
+msgstr "Araguaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_170
+msgid "Araguaína"
+msgstr "Araguaína"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_624
+msgid "Araioses"
+msgstr "Araioses"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_625
+msgid "Aral Moreira"
+msgstr "Aral Moreira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_626
+msgid "Aramari"
+msgstr "Aramari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_627
+msgid "Arambaré"
+msgstr "Arambaré"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_628
+msgid "Arame"
+msgstr "Arame"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_629
+msgid "Aramina"
+msgstr "Aramina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_630
+msgid "Arandu"
+msgstr "Arandu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_631
+msgid "Arantina"
+msgstr "Arantina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_632
+msgid "Arapeí"
+msgstr "Arapeí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_127
+msgid "Arapiraca"
+msgstr "Arapiraca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_633
+msgid "Arapoema"
+msgstr "Arapoema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_634
+msgid "Araponga"
+msgstr "Araponga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_254
+msgid "Arapongas"
+msgstr "Arapongas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_635
+msgid "Araporã"
+msgstr "Araporã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_636
+msgid "Arapoti"
+msgstr "Arapoti"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_639
+msgid "Araputanga"
+msgstr "Araputanga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_637
+msgid "Arapuá"
+msgstr "Arapuá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_638
+msgid "Arapuã"
+msgstr "Arapuã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_640
+msgid "Araquari"
+msgstr "Araquari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_641
+msgid "Arara"
+msgstr "Arara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_642
+msgid "Araranguá"
+msgstr "Araranguá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_121
+msgid "Araraquara"
+msgstr "Araraquara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_230
+msgid "Araras"
+msgstr "Araras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_643
+msgid "Ararendá"
+msgstr "Ararendá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_644
+msgid "Arari"
+msgstr "Arari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_645
+msgid "Araricá"
+msgstr "Araricá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_646
+msgid "Araripe"
+msgstr "Araripe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_647
+msgid "Araripina"
+msgstr "Araripina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_232
+msgid "Araruama"
+msgstr "Araruama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_648
+#: model:res.city,name:l10n_br.city_br_649
+msgid "Araruna"
+msgstr "Araruna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_650
+msgid "Arataca"
+msgstr "Arataca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_651
+msgid "Aratiba"
+msgstr "Aratiba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_652
+msgid "Aratuba"
+msgstr "Aratuba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_653
+msgid "Aratuípe"
+msgstr "Aratuípe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_198
+msgid "Araucária"
+msgstr "Araucária"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_654
+msgid "Arauá"
+msgstr "Arauá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_281
+msgid "Araxá"
+msgstr "Araxá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_599
+msgid "Araçagi"
+msgstr "Araçagi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_601
+msgid "Araçariguama"
+msgstr "Araçariguama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_152
+msgid "Araçatuba"
+msgstr "Araçatuba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_600
+msgid "Araçaí"
+msgstr "Araçaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_608
+msgid "Araçoiaba"
+msgstr "Araçoiaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_609
+msgid "Araçoiaba da Serra"
+msgstr "Araçoiaba da Serra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_611
+msgid "Araçu"
+msgstr "Araçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_612
+msgid "Araçuaí"
+msgstr "Araçuaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_602
+msgid "Araçás"
+msgstr "Araçás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_655
+msgid "Araújos"
+msgstr "Araújos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_656
+msgid "Arceburgo"
+msgstr "Arceburgo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_657
+msgid "Arco-Íris"
+msgstr "Arco-Íris"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_658
+msgid "Arcos"
+msgstr "Arcos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_659
+msgid "Arcoverde"
+msgstr "Arcoverde"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_660
+msgid "Areado"
+msgstr "Areado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_661
+msgid "Areal"
+msgstr "Areal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_662
+msgid "Arealva"
+msgstr "Arealva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_663
+msgid "Areia"
+msgstr "Areia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_664
+#: model:res.city,name:l10n_br.city_br_665
+msgid "Areia Branca"
+msgstr "Areia Branca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_666
+msgid "Areia de Baraúnas"
+msgstr "Areia de Baraúnas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_667
+msgid "Areial"
+msgstr "Areial"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_668
+msgid "Areias"
+msgstr "Areias"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_669
+msgid "Areiópolis"
+msgstr "Areiópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_670
+msgid "Arenápolis"
+msgstr "Arenápolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_671
+msgid "Arenópolis"
+msgstr "Arenópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_673
+msgid "Argirita"
+msgstr "Argirita"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_674
+msgid "Aricanduva"
+msgstr "Aricanduva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_675
+msgid "Arinos"
+msgstr "Arinos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_676
+msgid "Aripuanã"
+msgstr "Aripuanã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_677
+msgid "Ariquemes"
+msgstr "Ariquemes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_678
+msgid "Ariranha"
+msgstr "Ariranha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_679
+msgid "Ariranha do Ivaí"
+msgstr "Ariranha do Ivaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_681
+msgid "Armazém"
+msgstr "Armazém"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_680
+msgid "Armação dos Búzios"
+msgstr "Armação dos Búzios"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_682
+msgid "Arneiroz"
+msgstr "Arneiroz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_683
+msgid "Aroazes"
+msgstr "Aroazes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_684
+msgid "Aroeiras"
+msgstr "Aroeiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_685
+msgid "Aroeiras do Itaim"
+msgstr "Aroeiras do Itaim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_686
+msgid "Arraial"
+msgstr "Arraial"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_687
+msgid "Arraial do Cabo"
+msgstr "Arraial do Cabo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_688
+msgid "Arraias"
+msgstr "Arraias"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_694
+msgid "Arroio Grande"
+msgstr "Arroio Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_695
+msgid "Arroio Trinta"
+msgstr "Arroio Trinta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_689
+msgid "Arroio do Meio"
+msgstr "Arroio do Meio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_690
+msgid "Arroio do Padre"
+msgstr "Arroio do Padre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_691
+msgid "Arroio do Sal"
+msgstr "Arroio do Sal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_692
+msgid "Arroio do Tigre"
+msgstr "Arroio do Tigre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_693
+msgid "Arroio dos Ratos"
+msgstr "Arroio dos Ratos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_696
+msgid "Artur Nogueira"
+msgstr "Artur Nogueira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_697
+msgid "Aruanã"
+msgstr "Aruanã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_698
+msgid "Arujá"
+msgstr "Arujá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_699
+msgid "Arvoredo"
+msgstr "Arvoredo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_700
+msgid "Arvorezinha"
+msgstr "Arvorezinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_672
+msgid "Arês"
+msgstr "Arês"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_701
+msgid "Ascurra"
+msgstr "Ascurra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_702
+msgid "Aspásia"
+msgstr "Aspásia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_704
+msgid "Assaré"
+msgstr "Assaré"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_703
+msgid "Assaí"
+msgstr "Assaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_318
+msgid "Assis"
+msgstr "Assis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_705
+msgid "Assis Brasil"
+msgstr "Assis Brasil"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_706
+msgid "Assis Chateaubriand"
+msgstr "Assis Chateaubriand"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_707
+msgid "Assunção"
+msgstr "Assunção"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_708
+msgid "Assunção do Piauí"
+msgstr "Assunção do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_709
+msgid "Astolfo Dutra"
+msgstr "Astolfo Dutra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_710
+msgid "Astorga"
+msgstr "Astorga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_711
+#: model:res.city,name:l10n_br.city_br_712
+msgid "Atalaia"
+msgstr "Atalaia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_713
+msgid "Atalaia do Norte"
+msgstr "Atalaia do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_714
+msgid "Atalanta"
+msgstr "Atalanta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_715
+msgid "Ataléia"
+msgstr "Ataléia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_188
+msgid "Atibaia"
+msgstr "Atibaia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_716
+msgid "Atílio Vivacqua"
+msgstr "Atílio Vivacqua"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_717
+msgid "Augustinópolis"
+msgstr "Augustinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_718
+msgid "Augusto Corrêa"
+msgstr "Augusto Corrêa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_720
+msgid "Augusto Pestana"
+msgstr "Augusto Pestana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_719
+msgid "Augusto de Lima"
+msgstr "Augusto de Lima"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_722
+msgid "Aurelino Leal"
+msgstr "Aurelino Leal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_723
+msgid "Auriflama"
+msgstr "Auriflama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_724
+msgid "Aurilândia"
+msgstr "Aurilândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_725
+#: model:res.city,name:l10n_br.city_br_726
+msgid "Aurora"
+msgstr "Aurora"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_727
+msgid "Aurora do Pará"
+msgstr "Aurora do Pará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_728
+msgid "Aurora do Tocantins"
+msgstr "Aurora do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_729
+msgid "Autazes"
+msgstr "Autazes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_731
+msgid "Avanhandava"
+msgstr "Avanhandava"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_732
+msgid "Avaré"
+msgstr "Avaré"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_730
+msgid "Avaí"
+msgstr "Avaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_733
+msgid "Aveiro"
+msgstr "Aveiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_734
+msgid "Avelino Lopes"
+msgstr "Avelino Lopes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_735
+msgid "Avelinópolis"
+msgstr "Avelinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_736
+msgid "Axixá"
+msgstr "Axixá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_737
+msgid "Axixá do Tocantins"
+msgstr "Axixá do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_292
+msgid "Açailândia"
+msgstr "Açailândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_346
+msgid "Açu"
+msgstr "Açu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_347
+msgid "Açucena"
+msgstr "Açucena"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_738
+msgid "Babaçulândia"
+msgstr "Babaçulândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_307
+msgid "Bacabal"
+msgstr "Bacabal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_739
+msgid "Bacabeira"
+msgstr "Bacabeira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_740
+msgid "Bacuri"
+msgstr "Bacuri"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_741
+msgid "Bacurituba"
+msgstr "Bacurituba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_742
+msgid "Bady Bassitt"
+msgstr "Bady Bassitt"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_743
+msgid "Baependi"
+msgstr "Baependi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_744
+msgid "Bagre"
+msgstr "Bagre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_260
+msgid "Bagé"
+msgstr "Bagé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_747
+msgid "Baianópolis"
+msgstr "Baianópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_749
+msgid "Baixa Grande"
+msgstr "Baixa Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_750
+msgid "Baixa Grande do Ribeiro"
+msgstr "Baixa Grande do Ribeiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_751
+msgid "Baixio"
+msgstr "Baixio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_752
+msgid "Baixo Guandu"
+msgstr "Baixo Guandu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_748
+msgid "Baião"
+msgstr "Baião"
 
 #. module: l10n_br
 #: model:account.report.column,name:l10n_br.tax_report_balance
@@ -35,8 +2123,1386 @@ msgid "Balance"
 msgstr "Saldo"
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_753
+msgid "Balbinos"
+msgstr "Balbinos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_754
+msgid "Baldim"
+msgstr "Baldim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_755
+msgid "Baliza"
+msgstr "Baliza"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_756
+msgid "Balneário Arroio do Silva"
+msgstr "Balneário Arroio do Silva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_757
+msgid "Balneário Barra do Sul"
+msgstr "Balneário Barra do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_214
+msgid "Balneário Camboriú"
+msgstr "Balneário Camboriú"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_758
+msgid "Balneário Gaivota"
+msgstr "Balneário Gaivota"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_760
+msgid "Balneário Pinhal"
+msgstr "Balneário Pinhal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_759
+msgid "Balneário Piçarras"
+msgstr "Balneário Piçarras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_761
+msgid "Balneário Rincão"
+msgstr "Balneário Rincão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_762
+msgid "Balsa Nova"
+msgstr "Balsa Nova"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_316
+msgid "Balsas"
+msgstr "Balsas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_764
+msgid "Bambuí"
+msgstr "Bambuí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_765
+msgid "Banabuiú"
+msgstr "Banabuiú"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_766
+msgid "Bananal"
+msgstr "Bananal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_767
+msgid "Bananeiras"
+msgstr "Bananeiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_768
+msgid "Bandeira"
+msgstr "Bandeira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_769
+msgid "Bandeira do Sul"
+msgstr "Bandeira do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_770
+msgid "Bandeirante"
+msgstr "Bandeirante"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_771
+#: model:res.city,name:l10n_br.city_br_772
+msgid "Bandeirantes"
+msgstr "Bandeirantes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_773
+msgid "Bandeirantes do Tocantins"
+msgstr "Bandeirantes do Tocantins"
+
+#. module: l10n_br
+#: model:ir.model,name:l10n_br.model_res_partner_bank
+msgid "Bank Accounts"
+msgstr "Contas bancárias"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_774
+msgid "Bannach"
+msgstr "Bannach"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_775
+msgid "Banzaê"
+msgstr "Banzaê"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_784
+#: model:res.city,name:l10n_br.city_br_785
+msgid "Baraúna"
+msgstr "Baraúna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_242
+msgid "Barbacena"
+msgstr "Barbacena"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_786
+msgid "Barbalha"
+msgstr "Barbalha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_787
+msgid "Barbosa"
+msgstr "Barbosa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_788
+msgid "Barbosa Ferraz"
+msgstr "Barbosa Ferraz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_239
+msgid "Barcarena"
+msgstr "Barcarena"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_789
+msgid "Barcelona"
+msgstr "Barcelona"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_790
+msgid "Barcelos"
+msgstr "Barcelos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_791
+msgid "Bariri"
+msgstr "Bariri"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_792
+msgid "Barra"
+msgstr "Barra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_793
+#: model:res.city,name:l10n_br.city_br_794
+msgid "Barra Bonita"
+msgstr "Barra Bonita"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_795
+msgid "Barra D'Alcântara"
+msgstr "Barra D'Alcântara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_820
+msgid "Barra Funda"
+msgstr "Barra Funda"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_821
+msgid "Barra Longa"
+msgstr "Barra Longa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_172
+msgid "Barra Mansa"
+msgstr "Barra Mansa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_822
+msgid "Barra Velha"
+msgstr "Barra Velha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_796
+msgid "Barra da Estiva"
+msgstr "Barra da Estiva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_797
+msgid "Barra de Guabiraba"
+msgstr "Barra de Guabiraba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_798
+msgid "Barra de Santa Rosa"
+msgstr "Barra de Santa Rosa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_799
+msgid "Barra de Santana"
+msgstr "Barra de Santana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_800
+msgid "Barra de Santo Antônio"
+msgstr "Barra de Santo Antônio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_801
+msgid "Barra de São Francisco"
+msgstr "Barra de São Francisco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_802
+#: model:res.city,name:l10n_br.city_br_803
+msgid "Barra de São Miguel"
+msgstr "Barra de São Miguel"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_804
+msgid "Barra do Bugres"
+msgstr "Barra do Bugres"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_805
+msgid "Barra do Chapéu"
+msgstr "Barra do Chapéu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_806
+msgid "Barra do Choça"
+msgstr "Barra do Choça"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_807
+msgid "Barra do Corda"
+msgstr "Barra do Corda"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_808
+msgid "Barra do Garças"
+msgstr "Barra do Garças"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_809
+msgid "Barra do Guarita"
+msgstr "Barra do Guarita"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_810
+msgid "Barra do Jacaré"
+msgstr "Barra do Jacaré"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_811
+msgid "Barra do Mendes"
+msgstr "Barra do Mendes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_812
+msgid "Barra do Ouro"
+msgstr "Barra do Ouro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_813
+msgid "Barra do Piraí"
+msgstr "Barra do Piraí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_814
+msgid "Barra do Quaraí"
+msgstr "Barra do Quaraí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_815
+msgid "Barra do Ribeiro"
+msgstr "Barra do Ribeiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_816
+msgid "Barra do Rio Azul"
+msgstr "Barra do Rio Azul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_817
+msgid "Barra do Rocha"
+msgstr "Barra do Rocha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_818
+msgid "Barra do Turvo"
+msgstr "Barra do Turvo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_819
+msgid "Barra dos Coqueiros"
+msgstr "Barra dos Coqueiros"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_823
+#: model:res.city,name:l10n_br.city_br_824
+msgid "Barracão"
+msgstr "Barracão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_825
+msgid "Barras"
+msgstr "Barras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_826
+msgid "Barreira"
+msgstr "Barreira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_185
+msgid "Barreiras"
+msgstr "Barreiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_827
+msgid "Barreiras do Piauí"
+msgstr "Barreiras do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_828
+msgid "Barreirinha"
+msgstr "Barreirinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_829
+msgid "Barreirinhas"
+msgstr "Barreirinhas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_830
+msgid "Barreiros"
+msgstr "Barreiros"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_250
+msgid "Barretos"
+msgstr "Barretos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_831
+msgid "Barrinha"
+msgstr "Barrinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_832
+msgid "Barro"
+msgstr "Barro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_833
+#: model:res.city,name:l10n_br.city_br_834
+msgid "Barro Alto"
+msgstr "Barro Alto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_835
+msgid "Barro Duro"
+msgstr "Barro Duro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_836
+msgid "Barro Preto"
+msgstr "Barro Preto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_837
+msgid "Barrocas"
+msgstr "Barrocas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_838
+msgid "Barrolândia"
+msgstr "Barrolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_839
+msgid "Barroquinha"
+msgstr "Barroquinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_840
+msgid "Barros Cassal"
+msgstr "Barros Cassal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_841
+msgid "Barroso"
+msgstr "Barroso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_088
+msgid "Barueri"
+msgstr "Barueri"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_776
+msgid "Barão"
+msgstr "Barão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_777
+msgid "Barão de Antonina"
+msgstr "Barão de Antonina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_778
+msgid "Barão de Cocais"
+msgstr "Barão de Cocais"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_779
+msgid "Barão de Cotegipe"
+msgstr "Barão de Cotegipe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_780
+msgid "Barão de Grajaú"
+msgstr "Barão de Grajaú"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_781
+msgid "Barão de Melgaço"
+msgstr "Barão de Melgaço"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_782
+msgid "Barão de Monte Alto"
+msgstr "Barão de Monte Alto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_783
+msgid "Barão do Triunfo"
+msgstr "Barão do Triunfo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_842
+msgid "Bastos"
+msgstr "Bastos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_843
+msgid "Bataguassu"
+msgstr "Bataguassu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_844
+#: model:res.city,name:l10n_br.city_br_845
+msgid "Batalha"
+msgstr "Batalha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_846
+msgid "Batatais"
+msgstr "Batatais"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_847
+msgid "Batayporã"
+msgstr "Batayporã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_848
+msgid "Baturité"
+msgstr "Baturité"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_066
+msgid "Bauru"
+msgstr "Bauru"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_849
+msgid "Bayeux"
+msgstr "Bayeux"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_746
+msgid "Baía Formosa"
+msgstr "Baía Formosa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_745
+msgid "Baía da Traição"
+msgstr "Baía da Traição"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_850
+msgid "Bebedouro"
+msgstr "Bebedouro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_851
+msgid "Beberibe"
+msgstr "Beberibe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_852
+msgid "Bela Cruz"
+msgstr "Bela Cruz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_853
+msgid "Bela Vista"
+msgstr "Bela Vista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_854
+msgid "Bela Vista da Caroba"
+msgstr "Bela Vista da Caroba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_855
+msgid "Bela Vista de Goiás"
+msgstr "Bela Vista de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_856
+msgid "Bela Vista de Minas"
+msgstr "Bela Vista de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_857
+msgid "Bela Vista do Maranhão"
+msgstr "Bela Vista do Maranhão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_858
+msgid "Bela Vista do Paraíso"
+msgstr "Bela Vista do Paraíso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_859
+msgid "Bela Vista do Piauí"
+msgstr "Bela Vista do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_860
+msgid "Bela Vista do Toldo"
+msgstr "Bela Vista do Toldo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_043
+msgid "Belford Roxo"
+msgstr "Belford Roxo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_868
+msgid "Belmiro Braga"
+msgstr "Belmiro Braga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_869
+#: model:res.city,name:l10n_br.city_br_870
+msgid "Belmonte"
+msgstr "Belmonte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_871
+msgid "Belo Campo"
+msgstr "Belo Campo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_006
+msgid "Belo Horizonte"
+msgstr "Belo Horizonte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_872
+msgid "Belo Jardim"
+msgstr "Belo Jardim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_873
+msgid "Belo Monte"
+msgstr "Belo Monte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_874
+msgid "Belo Oriente"
+msgstr "Belo Oriente"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_875
+msgid "Belo Vale"
+msgstr "Belo Vale"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_876
+msgid "Belterra"
+msgstr "Belterra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_861
+msgid "Belágua"
+msgstr "Belágua"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_012
+#: model:res.city,name:l10n_br.city_br_862
+#: model:res.city,name:l10n_br.city_br_863
+msgid "Belém"
+msgstr "Belém"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_864
+msgid "Belém de Maria"
+msgstr "Belém de Maria"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_865
+msgid "Belém do Brejo do Cruz"
+msgstr "Belém do Brejo do Cruz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_866
+msgid "Belém do Piauí"
+msgstr "Belém do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_867
+msgid "Belém do São Francisco"
+msgstr "Belém do São Francisco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_877
+msgid "Beneditinos"
+msgstr "Beneditinos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_878
+msgid "Benedito Leite"
+msgstr "Benedito Leite"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_879
+msgid "Benedito Novo"
+msgstr "Benedito Novo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_880
+msgid "Benevides"
+msgstr "Benevides"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_881
+msgid "Benjamin Constant"
+msgstr "Benjamin Constant"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_882
+msgid "Benjamin Constant do Sul"
+msgstr "Benjamin Constant do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_884
+msgid "Bento Fernandes"
+msgstr "Bento Fernandes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_248
+msgid "Bento Gonçalves"
+msgstr "Bento Gonçalves"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_883
+msgid "Bento de Abreu"
+msgstr "Bento de Abreu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_885
+msgid "Bequimão"
+msgstr "Bequimão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_886
+msgid "Berilo"
+msgstr "Berilo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_887
+msgid "Berizal"
+msgstr "Berizal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_888
+msgid "Bernardino Batista"
+msgstr "Bernardino Batista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_889
+msgid "Bernardino de Campos"
+msgstr "Bernardino de Campos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_891
+msgid "Bernardo Sayão"
+msgstr "Bernardo Sayão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_890
+msgid "Bernardo do Mearim"
+msgstr "Bernardo do Mearim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_892
+msgid "Bertioga"
+msgstr "Bertioga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_893
+msgid "Bertolínia"
+msgstr "Bertolínia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_894
+msgid "Bertópolis"
+msgstr "Bertópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_895
+msgid "Beruri"
+msgstr "Beruri"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_060
+msgid "Betim"
+msgstr "Betim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_896
+msgid "Betânia"
+msgstr "Betânia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_897
+msgid "Betânia do Piauí"
+msgstr "Betânia do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_898
+msgid "Bezerros"
+msgstr "Bezerros"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_899
+msgid "Bias Fortes"
+msgstr "Bias Fortes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_900
+msgid "Bicas"
+msgstr "Bicas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_901
+msgid "Biguaçu"
+msgstr "Biguaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_902
+msgid "Bilac"
+msgstr "Bilac"
+
+#. module: l10n_br
 #: model:l10n_latam.document.type,name:l10n_br.dt_26
 msgid "Bill of Lading Multimodal Transport"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_903
+msgid "Biquinhas"
+msgstr "Biquinhas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_255
+msgid "Birigui"
+msgstr "Birigui"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_904
+msgid "Biritiba-Mirim"
+msgstr "Biritiba-Mirim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_905
+msgid "Biritinga"
+msgstr "Biritinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_906
+msgid "Bituruna"
+msgstr "Bituruna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_071
+msgid "Blumenau"
+msgstr "Blumenau"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_907
+#: model:res.city,name:l10n_br.city_br_908
+#: model:res.city,name:l10n_br.city_br_909
+msgid "Boa Esperança"
+msgstr "Boa Esperança"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_910
+msgid "Boa Esperança do Iguaçu"
+msgstr "Boa Esperança do Iguaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_911
+msgid "Boa Esperança do Sul"
+msgstr "Boa Esperança do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_912
+msgid "Boa Hora"
+msgstr "Boa Hora"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_913
+msgid "Boa Nova"
+msgstr "Boa Nova"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_914
+msgid "Boa Saúde"
+msgstr "Boa Saúde"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_915
+msgid "Boa Ventura"
+msgstr "Boa Ventura"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_916
+msgid "Boa Ventura de São Roque"
+msgstr "Boa Ventura de São Roque"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_917
+msgid "Boa Viagem"
+msgstr "Boa Viagem"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_059
+#: model:res.city,name:l10n_br.city_br_918
+msgid "Boa Vista"
+msgstr "Boa Vista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_919
+msgid "Boa Vista da Aparecida"
+msgstr "Boa Vista da Aparecida"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_920
+msgid "Boa Vista das Missões"
+msgstr "Boa Vista das Missões"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_921
+msgid "Boa Vista do Buricá"
+msgstr "Boa Vista do Buricá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_922
+msgid "Boa Vista do Cadeado"
+msgstr "Boa Vista do Cadeado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_923
+msgid "Boa Vista do Gurupi"
+msgstr "Boa Vista do Gurupi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_924
+msgid "Boa Vista do Incra"
+msgstr "Boa Vista do Incra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_925
+msgid "Boa Vista do Ramos"
+msgstr "Boa Vista do Ramos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_926
+msgid "Boa Vista do Sul"
+msgstr "Boa Vista do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_927
+msgid "Boa Vista do Tupim"
+msgstr "Boa Vista do Tupim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_928
+msgid "Boca da Mata"
+msgstr "Boca da Mata"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_929
+msgid "Boca do Acre"
+msgstr "Boca do Acre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_930
+#: model:res.city,name:l10n_br.city_br_931
+msgid "Bocaina"
+msgstr "Bocaina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_932
+msgid "Bocaina de Minas"
+msgstr "Bocaina de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_933
+msgid "Bocaina do Sul"
+msgstr "Bocaina do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_934
+msgid "Bocaiúva"
+msgstr "Bocaiúva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_935
+msgid "Bocaiúva do Sul"
+msgstr "Bocaiúva do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_937
+msgid "Bodocó"
+msgstr "Bodocó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_938
+msgid "Bodoquena"
+msgstr "Bodoquena"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_936
+msgid "Bodó"
+msgstr "Bodó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_939
+msgid "Bofete"
+msgstr "Bofete"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_940
+msgid "Boituva"
+msgstr "Boituva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_941
+msgid "Bom Conselho"
+msgstr "Bom Conselho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_942
+msgid "Bom Despacho"
+msgstr "Bom Despacho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_943
+#: model:res.city,name:l10n_br.city_br_944
+#: model:res.city,name:l10n_br.city_br_945
+msgid "Bom Jardim"
+msgstr "Bom Jardim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_946
+msgid "Bom Jardim da Serra"
+msgstr "Bom Jardim da Serra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_947
+msgid "Bom Jardim de Goiás"
+msgstr "Bom Jardim de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_948
+msgid "Bom Jardim de Minas"
+msgstr "Bom Jardim de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_949
+#: model:res.city,name:l10n_br.city_br_950
+#: model:res.city,name:l10n_br.city_br_951
+#: model:res.city,name:l10n_br.city_br_952
+#: model:res.city,name:l10n_br.city_br_953
+msgid "Bom Jesus"
+msgstr "Bom Jesus"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_954
+msgid "Bom Jesus da Lapa"
+msgstr "Bom Jesus da Lapa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_955
+msgid "Bom Jesus da Penha"
+msgstr "Bom Jesus da Penha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_956
+msgid "Bom Jesus da Serra"
+msgstr "Bom Jesus da Serra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_957
+msgid "Bom Jesus das Selvas"
+msgstr "Bom Jesus das Selvas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_958
+msgid "Bom Jesus de Goiás"
+msgstr "Bom Jesus de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_959
+msgid "Bom Jesus do Amparo"
+msgstr "Bom Jesus do Amparo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_960
+msgid "Bom Jesus do Araguaia"
+msgstr "Bom Jesus do Araguaia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_961
+msgid "Bom Jesus do Galho"
+msgstr "Bom Jesus do Galho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_962
+msgid "Bom Jesus do Itabapoana"
+msgstr "Bom Jesus do Itabapoana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_963
+msgid "Bom Jesus do Norte"
+msgstr "Bom Jesus do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_964
+msgid "Bom Jesus do Oeste"
+msgstr "Bom Jesus do Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_965
+msgid "Bom Jesus do Sul"
+msgstr "Bom Jesus do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_966
+#: model:res.city,name:l10n_br.city_br_967
+msgid "Bom Jesus do Tocantins"
+msgstr "Bom Jesus do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_968
+msgid "Bom Jesus dos Perdões"
+msgstr "Bom Jesus dos Perdões"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_969
+msgid "Bom Lugar"
+msgstr "Bom Lugar"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_970
+msgid "Bom Princípio"
+msgstr "Bom Princípio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_971
+msgid "Bom Princípio do Piauí"
+msgstr "Bom Princípio do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_972
+msgid "Bom Progresso"
+msgstr "Bom Progresso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_973
+msgid "Bom Repouso"
+msgstr "Bom Repouso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_974
+msgid "Bom Retiro"
+msgstr "Bom Retiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_975
+msgid "Bom Retiro do Sul"
+msgstr "Bom Retiro do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_976
+#: model:res.city,name:l10n_br.city_br_977
+#: model:res.city,name:l10n_br.city_br_978
+msgid "Bom Sucesso"
+msgstr "Bom Sucesso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_979
+msgid "Bom Sucesso de Itararé"
+msgstr "Bom Sucesso de Itararé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_980
+msgid "Bom Sucesso do Sul"
+msgstr "Bom Sucesso do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_981
+msgid "Bombinhas"
+msgstr "Bombinhas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_982
+#: model:res.city,name:l10n_br.city_br_983
+msgid "Bonfim"
+msgstr "Bonfim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_984
+msgid "Bonfim do Piauí"
+msgstr "Bonfim do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_985
+msgid "Bonfinópolis"
+msgstr "Bonfinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_986
+msgid "Bonfinópolis de Minas"
+msgstr "Bonfinópolis de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_987
+msgid "Boninal"
+msgstr "Boninal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_988
+#: model:res.city,name:l10n_br.city_br_989
+#: model:res.city,name:l10n_br.city_br_990
+#: model:res.city,name:l10n_br.city_br_991
+msgid "Bonito"
+msgstr "Bonito"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_992
+msgid "Bonito de Minas"
+msgstr "Bonito de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_993
+msgid "Bonito de Santa Fé"
+msgstr "Bonito de Santa Fé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_994
+msgid "Bonópolis"
+msgstr "Bonópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_995
+msgid "Boqueirão"
+msgstr "Boqueirão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_996
+msgid "Boqueirão do Leão"
+msgstr "Boqueirão do Leão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_997
+msgid "Boqueirão do Piauí"
+msgstr "Boqueirão do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_998
+msgid "Boquim"
+msgstr "Boquim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_999
+msgid "Boquira"
+msgstr "Boquira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1001
+msgid "Boracéia"
+msgstr "Boracéia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1002
+msgid "Borba"
+msgstr "Borba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1003
+#: model:res.city,name:l10n_br.city_br_1004
+msgid "Borborema"
+msgstr "Borborema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1005
+msgid "Borda da Mata"
+msgstr "Borda da Mata"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1006
+msgid "Borebi"
+msgstr "Borebi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1007
+msgid "Borrazópolis"
+msgstr "Borrazópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1000
+msgid "Borá"
+msgstr "Borá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1008
+msgid "Bossoroca"
+msgstr "Bossoroca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1009
+msgid "Botelhos"
+msgstr "Botelhos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_208
+msgid "Botucatu"
+msgstr "Botucatu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1010
+msgid "Botumirim"
+msgstr "Botumirim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1011
+msgid "Botuporã"
+msgstr "Botuporã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1012
+msgid "Botuverá"
+msgstr "Botuverá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1013
+msgid "Bozano"
+msgstr "Bozano"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1016
+msgid "Braga"
+msgstr "Braga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1017
+msgid "Braganey"
+msgstr "Braganey"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_249
+msgid "Bragança"
+msgstr "Bragança"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_168
+msgid "Bragança Paulista"
+msgstr "Bragança Paulista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1018
+msgid "Branquinha"
+msgstr "Branquinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1020
+msgid "Brasil Novo"
+msgstr "Brasil Novo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1026
+msgid "Brasileira"
+msgstr "Brasileira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1021
+msgid "Brasilândia"
+msgstr "Brasilândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1022
+msgid "Brasilândia de Minas"
+msgstr "Brasilândia de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1023
+msgid "Brasilândia do Sul"
+msgstr "Brasilândia do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1024
+msgid "Brasilândia do Tocantins"
+msgstr "Brasilândia do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1025
+msgid "Brasiléia"
+msgstr "Brasiléia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1028
+msgid "Brasnorte"
+msgstr "Brasnorte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_003
+msgid "Brasília"
+msgstr "Brasília"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1027
+msgid "Brasília de Minas"
+msgstr "Brasília de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1031
+msgid "Brazabrantes"
+msgstr "Brazabrantes"
+
+#. module: l10n_br
+#: model:ir.ui.menu,name:l10n_br.brazilian_accounting_menu
+msgid "Brazil"
 msgstr ""
 
 #. module: l10n_br
@@ -48,9 +3514,306 @@ msgid ""
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1032
+msgid "Brazópolis"
+msgstr "Brazópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1014
+msgid "Braço do Norte"
+msgstr "Braço do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1015
+msgid "Braço do Trombudo"
+msgstr "Braço do Trombudo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1029
+msgid "Braúna"
+msgstr "Braúna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1030
+msgid "Braúnas"
+msgstr "Braúnas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1034
+msgid "Brejetuba"
+msgstr "Brejetuba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1035
+#: model:res.city,name:l10n_br.city_br_1036
+msgid "Brejinho"
+msgstr "Brejinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1037
+msgid "Brejinho de Nazaré"
+msgstr "Brejinho de Nazaré"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1038
+msgid "Brejo"
+msgstr "Brejo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1039
+msgid "Brejo Alegre"
+msgstr "Brejo Alegre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1045
+msgid "Brejo Grande"
+msgstr "Brejo Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1046
+msgid "Brejo Grande do Araguaia"
+msgstr "Brejo Grande do Araguaia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1047
+msgid "Brejo Santo"
+msgstr "Brejo Santo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1040
+msgid "Brejo da Madre de Deus"
+msgstr "Brejo da Madre de Deus"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1041
+msgid "Brejo de Areia"
+msgstr "Brejo de Areia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1042
+msgid "Brejo do Cruz"
+msgstr "Brejo do Cruz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1043
+msgid "Brejo do Piauí"
+msgstr "Brejo do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1044
+msgid "Brejo dos Santos"
+msgstr "Brejo dos Santos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1049
+msgid "Brejolândia"
+msgstr "Brejolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1033
+msgid "Brejão"
+msgstr "Brejão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1048
+msgid "Brejões"
+msgstr "Brejões"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1050
+msgid "Breu Branco"
+msgstr "Breu Branco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_291
+msgid "Breves"
+msgstr "Breves"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1051
+msgid "Britânia"
+msgstr "Britânia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1052
+msgid "Brochier"
+msgstr "Brochier"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1053
+msgid "Brodowski"
+msgstr "Brodowski"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1054
+msgid "Brotas"
+msgstr "Brotas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1055
+msgid "Brotas de Macaúbas"
+msgstr "Brotas de Macaúbas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1056
+msgid "Brumadinho"
+msgstr "Brumadinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1057
+msgid "Brumado"
+msgstr "Brumado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1058
+msgid "Brunópolis"
+msgstr "Brunópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_212
+msgid "Brusque"
+msgstr "Brusque"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1019
+msgid "Brás Pires"
+msgstr "Brás Pires"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1059
+msgid "Bueno Brandão"
+msgstr "Bueno Brandão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1061
+msgid "Buenos Aires"
+msgstr "Buenos Aires"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1060
+msgid "Buenópolis"
+msgstr "Buenópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1062
+msgid "Buerarema"
+msgstr "Buerarema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1063
+msgid "Bugre"
+msgstr "Bugre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1065
+msgid "Bujari"
+msgstr "Bujari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1066
+msgid "Bujaru"
+msgstr "Bujaru"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1067
+msgid "Buri"
+msgstr "Buri"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1068
+msgid "Buritama"
+msgstr "Buritama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1069
+msgid "Buriti"
+msgstr "Buriti"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1070
+msgid "Buriti Alegre"
+msgstr "Buriti Alegre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1071
+msgid "Buriti Bravo"
+msgstr "Buriti Bravo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1072
+msgid "Buriti de Goiás"
+msgstr "Buriti de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1073
+msgid "Buriti do Tocantins"
+msgstr "Buriti do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1074
+msgid "Buriti dos Lopes"
+msgstr "Buriti dos Lopes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1075
+msgid "Buriti dos Montes"
+msgstr "Buriti dos Montes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1076
+msgid "Buriticupu"
+msgstr "Buriticupu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1077
+msgid "Buritinópolis"
+msgstr "Buritinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1078
+msgid "Buritirama"
+msgstr "Buritirama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1079
+msgid "Buritirana"
+msgstr "Buritirana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1080
+#: model:res.city,name:l10n_br.city_br_1081
+msgid "Buritis"
+msgstr "Buritis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1082
+msgid "Buritizal"
+msgstr "Buritizal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1083
+msgid "Buritizeiro"
+msgstr "Buritizeiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1084
+msgid "Butiá"
+msgstr "Butiá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1064
+msgid "Buíque"
+msgstr "Buíque"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_763
+msgid "Bálsamo"
+msgstr "Bálsamo"
+
+#. module: l10n_br
 #: model:l10n_latam.identification.type,name:l10n_br.cnpj
 msgid "CNPJ"
-msgstr ""
+msgstr "CNPJ"
 
 #. module: l10n_br
 #: model:account.report.line,name:l10n_br.tax_report_cofins
@@ -74,6 +3837,11 @@ msgid "CPF"
 msgstr "CPF"
 
 #. module: l10n_br
+#: model:ir.model.fields.selection,name:l10n_br.selection__res_partner_bank__proxy_type__br_cpf_cnpj
+msgid "CPF/CNPJ (BR)"
+msgstr "CPF/CNPJ"
+
+#. module: l10n_br
 #: model:account.report.line,name:l10n_br.tax_report_csll
 msgid "CSLL"
 msgstr "CSLL"
@@ -89,9 +3857,2632 @@ msgid "CSLL tax"
 msgstr "Imposto CSLL"
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1085
+msgid "Caapiranga"
+msgstr "Caapiranga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1086
+msgid "Caaporã"
+msgstr "Caaporã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1087
+msgid "Caarapó"
+msgstr "Caarapó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1088
+msgid "Caatiba"
+msgstr "Caatiba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1089
+msgid "Cabaceiras"
+msgstr "Cabaceiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1090
+msgid "Cabaceiras do Paraguaçu"
+msgstr "Cabaceiras do Paraguaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1091
+msgid "Cabeceira Grande"
+msgstr "Cabeceira Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1092
+msgid "Cabeceiras"
+msgstr "Cabeceiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1093
+msgid "Cabeceiras do Piauí"
+msgstr "Cabeceiras do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1094
+msgid "Cabedelo"
+msgstr "Cabedelo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1095
+msgid "Cabixi"
+msgstr "Cabixi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_142
+msgid "Cabo Frio"
+msgstr "Cabo Frio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1096
+msgid "Cabo Verde"
+msgstr "Cabo Verde"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_149
+msgid "Cabo de Santo Agostinho"
+msgstr "Cabo de Santo Agostinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1098
+msgid "Cabreúva"
+msgstr "Cabreúva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1099
+msgid "Cabrobó"
+msgstr "Cabrobó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1097
+msgid "Cabrália Paulista"
+msgstr "Cabrália Paulista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1103
+msgid "Cacaulândia"
+msgstr "Cacaulândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1104
+msgid "Cacequi"
+msgstr "Cacequi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1106
+msgid "Cachoeira"
+msgstr "Cachoeira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1107
+msgid "Cachoeira Alta"
+msgstr "Cachoeira Alta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1116
+#: model:res.city,name:l10n_br.city_br_1117
+msgid "Cachoeira Dourada"
+msgstr "Cachoeira Dourada"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1118
+msgid "Cachoeira Grande"
+msgstr "Cachoeira Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1119
+msgid "Cachoeira Paulista"
+msgstr "Cachoeira Paulista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1108
+msgid "Cachoeira da Prata"
+msgstr "Cachoeira da Prata"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1109
+msgid "Cachoeira de Goiás"
+msgstr "Cachoeira de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1110
+msgid "Cachoeira de Minas"
+msgstr "Cachoeira de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1111
+msgid "Cachoeira de Pajeú"
+msgstr "Cachoeira de Pajeú"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1112
+msgid "Cachoeira do Arari"
+msgstr "Cachoeira do Arari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1113
+msgid "Cachoeira do Piriá"
+msgstr "Cachoeira do Piriá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1114
+msgid "Cachoeira do Sul"
+msgstr "Cachoeira do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1115
+msgid "Cachoeira dos Índios"
+msgstr "Cachoeira dos Índios"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1120
+msgid "Cachoeiras de Macacu"
+msgstr "Cachoeiras de Macacu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1121
+#: model:res.city,name:l10n_br.city_br_1122
+#: model:res.city,name:l10n_br.city_br_218
+msgid "Cachoeirinha"
+msgstr "Cachoeirinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_162
+msgid "Cachoeiro de Itapemirim"
+msgstr "Cachoeiro de Itapemirim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1123
+msgid "Cacimba de Areia"
+msgstr "Cacimba de Areia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1124
+msgid "Cacimba de Dentro"
+msgstr "Cacimba de Dentro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1125
+msgid "Cacimbas"
+msgstr "Cacimbas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1126
+msgid "Cacimbinhas"
+msgstr "Cacimbinhas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1127
+msgid "Cacique Doble"
+msgstr "Cacique Doble"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1128
+msgid "Cacoal"
+msgstr "Cacoal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1129
+msgid "Caconde"
+msgstr "Caconde"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1131
+msgid "Caculé"
+msgstr "Caculé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1134
+msgid "Caetanos"
+msgstr "Caetanos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1133
+msgid "Caetanópolis"
+msgstr "Caetanópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1137
+msgid "Caetité"
+msgstr "Caetité"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1135
+msgid "Caeté"
+msgstr "Caeté"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1136
+msgid "Caetés"
+msgstr "Caetés"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1138
+msgid "Cafarnaum"
+msgstr "Cafarnaum"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1139
+msgid "Cafeara"
+msgstr "Cafeara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1140
+#: model:res.city,name:l10n_br.city_br_1141
+msgid "Cafelândia"
+msgstr "Cafelândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1142
+msgid "Cafezal do Sul"
+msgstr "Cafezal do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1143
+msgid "Caiabu"
+msgstr "Caiabu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1144
+msgid "Caiana"
+msgstr "Caiana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1145
+msgid "Caiapônia"
+msgstr "Caiapônia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1146
+msgid "Caibaté"
+msgstr "Caibaté"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1147
+msgid "Caibi"
+msgstr "Caibi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1152
+msgid "Caicó"
+msgstr "Caicó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1153
+msgid "Caieiras"
+msgstr "Caieiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1154
+msgid "Cairu"
+msgstr "Cairu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1155
+msgid "Caiuá"
+msgstr "Caiuá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1148
+#: model:res.city,name:l10n_br.city_br_1149
+msgid "Caiçara"
+msgstr "Caiçara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1150
+msgid "Caiçara do Norte"
+msgstr "Caiçara do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1151
+msgid "Caiçara do Rio do Vento"
+msgstr "Caiçara do Rio do Vento"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1156
+msgid "Cajamar"
+msgstr "Cajamar"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1157
+msgid "Cajapió"
+msgstr "Cajapió"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1158
+msgid "Cajari"
+msgstr "Cajari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1159
+msgid "Cajati"
+msgstr "Cajati"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1160
+msgid "Cajazeiras"
+msgstr "Cajazeiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1161
+msgid "Cajazeiras do Piauí"
+msgstr "Cajazeiras do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1162
+msgid "Cajazeirinhas"
+msgstr "Cajazeirinhas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1163
+msgid "Cajobi"
+msgstr "Cajobi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1164
+msgid "Cajueiro"
+msgstr "Cajueiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1165
+msgid "Cajueiro da Praia"
+msgstr "Cajueiro da Praia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1166
+msgid "Cajuri"
+msgstr "Cajuri"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1167
+msgid "Cajuru"
+msgstr "Cajuru"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1170
+msgid "Caldas"
+msgstr "Caldas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1171
+msgid "Caldas Brandão"
+msgstr "Caldas Brandão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1172
+msgid "Caldas Novas"
+msgstr "Caldas Novas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1173
+msgid "Caldazinha"
+msgstr "Caldazinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1174
+msgid "Caldeirão Grande"
+msgstr "Caldeirão Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1175
+msgid "Caldeirão Grande do Piauí"
+msgstr "Caldeirão Grande do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1176
+msgid "Califórnia"
+msgstr "Califórnia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1177
+msgid "Calmon"
+msgstr "Calmon"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1178
+msgid "Calumbi"
+msgstr "Calumbi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1168
+msgid "Calçado"
+msgstr "Calçado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1169
+msgid "Calçoene"
+msgstr "Calçoene"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1179
+msgid "Camacan"
+msgstr "Camacan"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1180
+msgid "Camacho"
+msgstr "Camacho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1181
+msgid "Camalaú"
+msgstr "Camalaú"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1182
+msgid "Camamu"
+msgstr "Camamu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1183
+msgid "Camanducaia"
+msgstr "Camanducaia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1184
+msgid "Camapuã"
+msgstr "Camapuã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1185
+msgid "Camaquã"
+msgstr "Camaquã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_203
+msgid "Camaragibe"
+msgstr "Camaragibe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1186
+msgid "Camargo"
+msgstr "Camargo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_092
+msgid "Camaçari"
+msgstr "Camaçari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1187
+msgid "Cambará"
+msgstr "Cambará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1188
+msgid "Cambará do Sul"
+msgstr "Cambará do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1189
+msgid "Cambira"
+msgstr "Cambira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_312
+msgid "Camboriú"
+msgstr "Camboriú"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1190
+msgid "Cambuci"
+msgstr "Cambuci"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1192
+msgid "Cambuquira"
+msgstr "Cambuquira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1191
+msgid "Cambuí"
+msgstr "Cambuí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_290
+msgid "Cambé"
+msgstr "Cambé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_221
+msgid "Cametá"
+msgstr "Cametá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1193
+msgid "Camocim"
+msgstr "Camocim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1194
+msgid "Camocim de São Félix"
+msgstr "Camocim de São Félix"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1196
+msgid "Campanha"
+msgstr "Campanha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1195
+msgid "Campanário"
+msgstr "Campanário"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1197
+#: model:res.city,name:l10n_br.city_br_1198
+msgid "Campestre"
+msgstr "Campestre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1199
+msgid "Campestre da Serra"
+msgstr "Campestre da Serra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1200
+msgid "Campestre de Goiás"
+msgstr "Campestre de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1201
+msgid "Campestre do Maranhão"
+msgstr "Campestre do Maranhão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_055
+msgid "Campina Grande"
+msgstr "Campina Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1206
+msgid "Campina Grande do Sul"
+msgstr "Campina Grande do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1207
+msgid "Campina Verde"
+msgstr "Campina Verde"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1202
+msgid "Campina da Lagoa"
+msgstr "Campina da Lagoa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1203
+msgid "Campina das Missões"
+msgstr "Campina das Missões"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1204
+msgid "Campina do Monte Alegre"
+msgstr "Campina do Monte Alegre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1205
+msgid "Campina do Simão"
+msgstr "Campina do Simão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_014
+msgid "Campinas"
+msgstr "Campinas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1210
+msgid "Campinas do Piauí"
+msgstr "Campinas do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1211
+msgid "Campinas do Sul"
+msgstr "Campinas do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1208
+msgid "Campinaçu"
+msgstr "Campinaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1212
+msgid "Campinorte"
+msgstr "Campinorte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1209
+msgid "Campinápolis"
+msgstr "Campinápolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1213
+#: model:res.city,name:l10n_br.city_br_1214
+msgid "Campo Alegre"
+msgstr "Campo Alegre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1215
+msgid "Campo Alegre de Goiás"
+msgstr "Campo Alegre de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1216
+msgid "Campo Alegre de Lourdes"
+msgstr "Campo Alegre de Lourdes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1217
+msgid "Campo Alegre do Fidalgo"
+msgstr "Campo Alegre do Fidalgo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1218
+msgid "Campo Azul"
+msgstr "Campo Azul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1219
+msgid "Campo Belo"
+msgstr "Campo Belo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1220
+msgid "Campo Belo do Sul"
+msgstr "Campo Belo do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1221
+msgid "Campo Bom"
+msgstr "Campo Bom"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1222
+msgid "Campo Bonito"
+msgstr "Campo Bonito"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1226
+msgid "Campo Erê"
+msgstr "Campo Erê"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1227
+msgid "Campo Florido"
+msgstr "Campo Florido"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1228
+msgid "Campo Formoso"
+msgstr "Campo Formoso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_017
+#: model:res.city,name:l10n_br.city_br_1229
+#: model:res.city,name:l10n_br.city_br_1230
+msgid "Campo Grande"
+msgstr "Campo Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1231
+msgid "Campo Grande do Piauí"
+msgstr "Campo Grande do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_217
+msgid "Campo Largo"
+msgstr "Campo Largo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1232
+msgid "Campo Largo do Piauí"
+msgstr "Campo Largo do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1234
+msgid "Campo Limpo Paulista"
+msgstr "Campo Limpo Paulista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1233
+msgid "Campo Limpo de Goiás"
+msgstr "Campo Limpo de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1235
+msgid "Campo Magro"
+msgstr "Campo Magro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1236
+msgid "Campo Maior"
+msgstr "Campo Maior"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1237
+msgid "Campo Mourão"
+msgstr "Campo Mourão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1238
+msgid "Campo Novo"
+msgstr "Campo Novo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1239
+msgid "Campo Novo de Rondônia"
+msgstr "Campo Novo de Rondônia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1240
+msgid "Campo Novo do Parecis"
+msgstr "Campo Novo do Parecis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1241
+msgid "Campo Redondo"
+msgstr "Campo Redondo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1242
+msgid "Campo Verde"
+msgstr "Campo Verde"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1223
+msgid "Campo do Brito"
+msgstr "Campo do Brito"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1224
+msgid "Campo do Meio"
+msgstr "Campo do Meio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1225
+msgid "Campo do Tenente"
+msgstr "Campo do Tenente"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1243
+msgid "Campos Altos"
+msgstr "Campos Altos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1244
+msgid "Campos Belos"
+msgstr "Campos Belos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1245
+msgid "Campos Borges"
+msgstr "Campos Borges"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1248
+msgid "Campos Gerais"
+msgstr "Campos Gerais"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1249
+msgid "Campos Lindos"
+msgstr "Campos Lindos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1250
+msgid "Campos Novos"
+msgstr "Campos Novos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1251
+msgid "Campos Novos Paulista"
+msgstr "Campos Novos Paulista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1252
+msgid "Campos Sales"
+msgstr "Campos Sales"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1253
+msgid "Campos Verdes"
+msgstr "Campos Verdes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1246
+msgid "Campos de Júlio"
+msgstr "Campos de Júlio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1247
+msgid "Campos do Jordão"
+msgstr "Campos do Jordão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_042
+msgid "Campos dos Goytacazes"
+msgstr "Campos dos Goytacazes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1254
+msgid "Camutanga"
+msgstr "Camutanga"
+
+#. module: l10n_br
+#. odoo-python
+#: code:addons/l10n_br/models/res_partner_bank.py:0
+msgid "Can't generate a Pix QR code with a currency other than BRL."
+msgstr "Não é possível gerar o código QR de Pix com moedas diferentes do BRL"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1255
+msgid "Cana Verde"
+msgstr "Cana Verde"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1258
+msgid "Canabrava do Norte"
+msgstr "Canabrava do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1259
+msgid "Cananéia"
+msgstr "Cananéia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1260
+msgid "Canapi"
+msgstr "Canapi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1263
+#: model:res.city,name:l10n_br.city_br_1264
+msgid "Canarana"
+msgstr "Canarana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1265
+msgid "Canas"
+msgstr "Canas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1266
+msgid "Canavieira"
+msgstr "Canavieira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1267
+msgid "Canavieiras"
+msgstr "Canavieiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1256
+msgid "Canaã"
+msgstr "Canaã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1257
+msgid "Canaã dos Carajás"
+msgstr "Canaã dos Carajás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1268
+msgid "Candeal"
+msgstr "Candeal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1269
+#: model:res.city,name:l10n_br.city_br_1270
+msgid "Candeias"
+msgstr "Candeias"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1271
+msgid "Candeias do Jamari"
+msgstr "Candeias do Jamari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1272
+msgid "Candelária"
+msgstr "Candelária"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1273
+msgid "Candiba"
+msgstr "Candiba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1280
+msgid "Candiota"
+msgstr "Candiota"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1281
+msgid "Candói"
+msgstr "Candói"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1282
+msgid "Canela"
+msgstr "Canela"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1283
+msgid "Canelinha"
+msgstr "Canelinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1284
+msgid "Canguaretama"
+msgstr "Canguaretama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1285
+msgid "Canguçu"
+msgstr "Canguçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1286
+msgid "Canhoba"
+msgstr "Canhoba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1287
+msgid "Canhotinho"
+msgstr "Canhotinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1288
+msgid "Canindé"
+msgstr "Canindé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1289
+msgid "Canindé de São Francisco"
+msgstr "Canindé de São Francisco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1290
+msgid "Canitar"
+msgstr "Canitar"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_079
+msgid "Canoas"
+msgstr "Canoas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1291
+msgid "Canoinhas"
+msgstr "Canoinhas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1292
+msgid "Cansanção"
+msgstr "Cansanção"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1294
+#: model:res.city,name:l10n_br.city_br_1295
+#: model:res.city,name:l10n_br.city_br_1296
+msgid "Cantagalo"
+msgstr "Cantagalo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1297
+msgid "Cantanhede"
+msgstr "Cantanhede"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1298
+msgid "Canto do Buriti"
+msgstr "Canto do Buriti"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1293
+msgid "Cantá"
+msgstr "Cantá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1299
+msgid "Canudos"
+msgstr "Canudos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1300
+msgid "Canudos do Vale"
+msgstr "Canudos do Vale"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1301
+msgid "Canutama"
+msgstr "Canutama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1261
+#: model:res.city,name:l10n_br.city_br_1262
+msgid "Canápolis"
+msgstr "Canápolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1302
+#: model:res.city,name:l10n_br.city_br_1303
+msgid "Capanema"
+msgstr "Capanema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1310
+msgid "Caparaó"
+msgstr "Caparaó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1311
+#: model:res.city,name:l10n_br.city_br_1312
+msgid "Capela"
+msgstr "Capela"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1316
+msgid "Capela Nova"
+msgstr "Capela Nova"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1313
+msgid "Capela de Santana"
+msgstr "Capela de Santana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1314
+msgid "Capela do Alto"
+msgstr "Capela do Alto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1315
+msgid "Capela do Alto Alegre"
+msgstr "Capela do Alto Alegre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1317
+msgid "Capelinha"
+msgstr "Capelinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1318
+msgid "Capetinga"
+msgstr "Capetinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1319
+msgid "Capim"
+msgstr "Capim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1320
+msgid "Capim Branco"
+msgstr "Capim Branco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1321
+msgid "Capim Grosso"
+msgstr "Capim Grosso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1323
+msgid "Capinzal"
+msgstr "Capinzal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1324
+msgid "Capinzal do Norte"
+msgstr "Capinzal do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1322
+msgid "Capinópolis"
+msgstr "Capinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1325
+msgid "Capistrano"
+msgstr "Capistrano"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1326
+msgid "Capitão"
+msgstr "Capitão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1327
+msgid "Capitão Andrade"
+msgstr "Capitão Andrade"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1329
+msgid "Capitão Enéas"
+msgstr "Capitão Enéas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1330
+msgid "Capitão Gervásio Oliveira"
+msgstr "Capitão Gervásio Oliveira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1331
+msgid "Capitão Leônidas Marques"
+msgstr "Capitão Leônidas Marques"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1332
+msgid "Capitão Poço"
+msgstr "Capitão Poço"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1328
+msgid "Capitão de Campos"
+msgstr "Capitão de Campos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1333
+msgid "Capitólio"
+msgstr "Capitólio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1334
+msgid "Capivari"
+msgstr "Capivari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1335
+msgid "Capivari de Baixo"
+msgstr "Capivari de Baixo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1336
+msgid "Capivari do Sul"
+msgstr "Capivari do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1337
+msgid "Capixaba"
+msgstr "Capixaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1338
+msgid "Capoeiras"
+msgstr "Capoeiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1339
+msgid "Caputira"
+msgstr "Caputira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1304
+msgid "Capão Alto"
+msgstr "Capão Alto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1305
+msgid "Capão Bonito"
+msgstr "Capão Bonito"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1306
+msgid "Capão Bonito do Sul"
+msgstr "Capão Bonito do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1307
+msgid "Capão da Canoa"
+msgstr "Capão da Canoa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1308
+msgid "Capão do Cipó"
+msgstr "Capão do Cipó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1309
+msgid "Capão do Leão"
+msgstr "Capão do Leão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1341
+msgid "Caracaraí"
+msgstr "Caracaraí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1342
+#: model:res.city,name:l10n_br.city_br_1343
+msgid "Caracol"
+msgstr "Caracol"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_219
+msgid "Caraguatatuba"
+msgstr "Caraguatatuba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1346
+msgid "Carambeí"
+msgstr "Carambeí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1347
+msgid "Caranaíba"
+msgstr "Caranaíba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1348
+msgid "Carandaí"
+msgstr "Carandaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1349
+msgid "Carangola"
+msgstr "Carangola"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1350
+msgid "Carapebus"
+msgstr "Carapebus"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_064
+msgid "Carapicuíba"
+msgstr "Carapicuíba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1351
+msgid "Caratinga"
+msgstr "Caratinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1352
+msgid "Carauari"
+msgstr "Carauari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1356
+msgid "Caravelas"
+msgstr "Caravelas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1357
+msgid "Carazinho"
+msgstr "Carazinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1340
+msgid "Caraá"
+msgstr "Caraá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1344
+msgid "Caraí"
+msgstr "Caraí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1345
+msgid "Caraíbas"
+msgstr "Caraíbas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1353
+#: model:res.city,name:l10n_br.city_br_1354
+msgid "Caraúbas"
+msgstr "Caraúbas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1355
+msgid "Caraúbas do Piauí"
+msgstr "Caraúbas do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1358
+msgid "Carbonita"
+msgstr "Carbonita"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1359
+msgid "Cardeal da Silva"
+msgstr "Cardeal da Silva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1360
+msgid "Cardoso"
+msgstr "Cardoso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1361
+msgid "Cardoso Moreira"
+msgstr "Cardoso Moreira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1362
+msgid "Careaçu"
+msgstr "Careaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1363
+msgid "Careiro"
+msgstr "Careiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1364
+msgid "Careiro da Várzea"
+msgstr "Careiro da Várzea"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_074
+msgid "Cariacica"
+msgstr "Cariacica"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1365
+msgid "Caridade"
+msgstr "Caridade"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1366
+msgid "Caridade do Piauí"
+msgstr "Caridade do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1367
+msgid "Carinhanha"
+msgstr "Carinhanha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1368
+msgid "Carira"
+msgstr "Carira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1370
+msgid "Cariri do Tocantins"
+msgstr "Cariri do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1371
+msgid "Caririaçu"
+msgstr "Caririaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1369
+msgid "Cariré"
+msgstr "Cariré"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1372
+msgid "Cariús"
+msgstr "Cariús"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1373
+msgid "Carlinda"
+msgstr "Carlinda"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1375
+msgid "Carlos Barbosa"
+msgstr "Carlos Barbosa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1376
+msgid "Carlos Chagas"
+msgstr "Carlos Chagas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1377
+msgid "Carlos Gomes"
+msgstr "Carlos Gomes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1374
+msgid "Carlópolis"
+msgstr "Carlópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1379
+msgid "Carmo"
+msgstr "Carmo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1380
+msgid "Carmo da Cachoeira"
+msgstr "Carmo da Cachoeira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1381
+msgid "Carmo da Mata"
+msgstr "Carmo da Mata"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1382
+msgid "Carmo de Minas"
+msgstr "Carmo de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1383
+msgid "Carmo do Cajuru"
+msgstr "Carmo do Cajuru"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1384
+msgid "Carmo do Paranaíba"
+msgstr "Carmo do Paranaíba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1385
+msgid "Carmo do Rio Claro"
+msgstr "Carmo do Rio Claro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1386
+msgid "Carmo do Rio Verde"
+msgstr "Carmo do Rio Verde"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1387
+msgid "Carmolândia"
+msgstr "Carmolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1378
+msgid "Carmésia"
+msgstr "Carmésia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1388
+msgid "Carmópolis"
+msgstr "Carmópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1389
+msgid "Carmópolis de Minas"
+msgstr "Carmópolis de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1392
+msgid "Carnaubais"
+msgstr "Carnaubais"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1393
+msgid "Carnaubal"
+msgstr "Carnaubal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1394
+msgid "Carnaubeira da Penha"
+msgstr "Carnaubeira da Penha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1390
+msgid "Carnaíba"
+msgstr "Carnaíba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1391
+msgid "Carnaúba dos Dantas"
+msgstr "Carnaúba dos Dantas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1395
+msgid "Carneirinho"
+msgstr "Carneirinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1396
+msgid "Carneiros"
+msgstr "Carneiros"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1397
+msgid "Caroebe"
+msgstr "Caroebe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1398
+msgid "Carolina"
+msgstr "Carolina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1399
+msgid "Carpina"
+msgstr "Carpina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1400
+msgid "Carrancas"
+msgstr "Carrancas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1401
+msgid "Carrapateira"
+msgstr "Carrapateira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1402
+msgid "Carrasco Bonito"
+msgstr "Carrasco Bonito"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_067
+msgid "Caruaru"
+msgstr "Caruaru"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1403
+msgid "Carutapera"
+msgstr "Carutapera"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1405
+msgid "Carvalhos"
+msgstr "Carvalhos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1404
+msgid "Carvalhópolis"
+msgstr "Carvalhópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1406
+msgid "Casa Branca"
+msgstr "Casa Branca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1407
+msgid "Casa Grande"
+msgstr "Casa Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1408
+msgid "Casa Nova"
+msgstr "Casa Nova"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1409
+msgid "Casca"
+msgstr "Casca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1410
+msgid "Cascalho Rico"
+msgstr "Cascalho Rico"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_078
+#: model:res.city,name:l10n_br.city_br_1411
+msgid "Cascavel"
+msgstr "Cascavel"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1412
+msgid "Caseara"
+msgstr "Caseara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1413
+msgid "Caseiros"
+msgstr "Caseiros"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1414
+msgid "Casimiro de Abreu"
+msgstr "Casimiro de Abreu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1415
+msgid "Casinhas"
+msgstr "Casinhas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1416
+msgid "Casserengue"
+msgstr "Casserengue"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1419
+msgid "Cassilândia"
+msgstr "Cassilândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_157
+msgid "Castanhal"
+msgstr "Castanhal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1420
+msgid "Castanheira"
+msgstr "Castanheira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1421
+msgid "Castanheiras"
+msgstr "Castanheiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1423
+msgid "Castelo"
+msgstr "Castelo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1424
+msgid "Castelo do Piauí"
+msgstr "Castelo do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1422
+msgid "Castelândia"
+msgstr "Castelândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1425
+msgid "Castilho"
+msgstr "Castilho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1426
+msgid "Castro"
+msgstr "Castro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1427
+msgid "Castro Alves"
+msgstr "Castro Alves"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1428
+msgid "Cataguases"
+msgstr "Cataguases"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_272
+msgid "Catalão"
+msgstr "Catalão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_266
+msgid "Catanduva"
+msgstr "Catanduva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1429
+#: model:res.city,name:l10n_br.city_br_1430
+msgid "Catanduvas"
+msgstr "Catanduvas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1431
+msgid "Catarina"
+msgstr "Catarina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1432
+msgid "Catas Altas"
+msgstr "Catas Altas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1433
+msgid "Catas Altas da Noruega"
+msgstr "Catas Altas da Noruega"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1434
+msgid "Catende"
+msgstr "Catende"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1435
+msgid "Catiguá"
+msgstr "Catiguá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1436
+msgid "Catingueira"
+msgstr "Catingueira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1437
+msgid "Catolândia"
+msgstr "Catolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1438
+msgid "Catolé do Rocha"
+msgstr "Catolé do Rocha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1439
+msgid "Catu"
+msgstr "Catu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1441
+msgid "Catuji"
+msgstr "Catuji"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1442
+msgid "Catunda"
+msgstr "Catunda"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1444
+msgid "Caturama"
+msgstr "Caturama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1443
+msgid "Caturaí"
+msgstr "Caturaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1445
+msgid "Caturité"
+msgstr "Caturité"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1446
+msgid "Catuti"
+msgstr "Catuti"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1440
+msgid "Catuípe"
+msgstr "Catuípe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_073
+msgid "Caucaia"
+msgstr "Caucaia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1447
+msgid "Cavalcante"
+msgstr "Cavalcante"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1448
+msgid "Caxambu"
+msgstr "Caxambu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1449
+msgid "Caxambu do Sul"
+msgstr "Caxambu do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_192
+msgid "Caxias"
+msgstr "Caxias"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_048
+msgid "Caxias do Sul"
+msgstr "Caxias do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1450
+msgid "Caxingó"
+msgstr "Caxingó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1100
+msgid "Caçador"
+msgstr "Caçador"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1101
+msgid "Caçapava"
+msgstr "Caçapava"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1102
+msgid "Caçapava do Sul"
+msgstr "Caçapava do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1130
+msgid "Caçu"
+msgstr "Caçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1132
+msgid "Caém"
+msgstr "Caém"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1451
+msgid "Ceará-Mirim"
+msgstr "Ceará-Mirim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1452
+#: model:res.city,name:l10n_br.city_br_1453
+msgid "Cedral"
+msgstr "Cedral"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1454
+#: model:res.city,name:l10n_br.city_br_1455
+msgid "Cedro"
+msgstr "Cedro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1456
+msgid "Cedro de São João"
+msgstr "Cedro de São João"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1457
+msgid "Cedro do Abaeté"
+msgstr "Cedro do Abaeté"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1458
+msgid "Celso Ramos"
+msgstr "Celso Ramos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1459
+#: model:res.city,name:l10n_br.city_br_1460
+msgid "Centenário"
+msgstr "Centenário"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1461
+msgid "Centenário do Sul"
+msgstr "Centenário do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1462
+msgid "Central"
+msgstr "Central"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1463
+msgid "Central de Minas"
+msgstr "Central de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1464
+msgid "Central do Maranhão"
+msgstr "Central do Maranhão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1465
+msgid "Centralina"
+msgstr "Centralina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1467
+msgid "Centro Novo do Maranhão"
+msgstr "Centro Novo do Maranhão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1466
+msgid "Centro do Guilherme"
+msgstr "Centro do Guilherme"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1468
+msgid "Cerejeiras"
+msgstr "Cerejeiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1469
+msgid "Ceres"
+msgstr "Ceres"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1470
+msgid "Cerqueira César"
+msgstr "Cerqueira César"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1471
+msgid "Cerquilho"
+msgstr "Cerquilho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1472
+msgid "Cerrito"
+msgstr "Cerrito"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1473
+msgid "Cerro Azul"
+msgstr "Cerro Azul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1474
+msgid "Cerro Branco"
+msgstr "Cerro Branco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1475
+msgid "Cerro Corá"
+msgstr "Cerro Corá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1476
+msgid "Cerro Grande"
+msgstr "Cerro Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1477
+msgid "Cerro Grande do Sul"
+msgstr "Cerro Grande do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1478
+msgid "Cerro Largo"
+msgstr "Cerro Largo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1479
+msgid "Cerro Negro"
+msgstr "Cerro Negro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1480
+msgid "Cesário Lange"
+msgstr "Cesário Lange"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1482
+msgid "Cezarina"
+msgstr "Cezarina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1487
+msgid "Chalé"
+msgstr "Chalé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1488
+msgid "Chapada"
+msgstr "Chapada"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1493
+msgid "Chapada Gaúcha"
+msgstr "Chapada Gaúcha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1489
+msgid "Chapada da Natividade"
+msgstr "Chapada da Natividade"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1490
+msgid "Chapada de Areia"
+msgstr "Chapada de Areia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1491
+msgid "Chapada do Norte"
+msgstr "Chapada do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1492
+msgid "Chapada dos Guimarães"
+msgstr "Chapada dos Guimarães"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1497
+msgid "Chapadinha"
+msgstr "Chapadinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1494
+msgid "Chapadão do Céu"
+msgstr "Chapadão do Céu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1495
+msgid "Chapadão do Lageado"
+msgstr "Chapadão do Lageado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1496
+msgid "Chapadão do Sul"
+msgstr "Chapadão do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_114
+msgid "Chapecó"
+msgstr "Chapecó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1498
+msgid "Charqueada"
+msgstr "Charqueada"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1499
+msgid "Charqueadas"
+msgstr "Charqueadas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1500
+msgid "Charrua"
+msgstr "Charrua"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1501
+msgid "Chaval"
+msgstr "Chaval"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1502
+msgid "Chavantes"
+msgstr "Chavantes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1503
+msgid "Chaves"
+msgstr "Chaves"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1504
+msgid "Chiador"
+msgstr "Chiador"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1505
+msgid "Chiapetta"
+msgstr "Chiapetta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1506
+msgid "Chopinzinho"
+msgstr "Chopinzinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1508
+msgid "Chorozinho"
+msgstr "Chorozinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1509
+msgid "Chorrochó"
+msgstr "Chorrochó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1507
+msgid "Choró"
+msgstr "Choró"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1511
+msgid "Chupinguaia"
+msgstr "Chupinguaia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1512
+msgid "Chuvisca"
+msgstr "Chuvisca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1510
+msgid "Chuí"
+msgstr "Chuí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1486
+msgid "Chácara"
+msgstr "Chácara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1484
+msgid "Chã Grande"
+msgstr "Chã Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1485
+msgid "Chã Preta"
+msgstr "Chã Preta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1483
+msgid "Chã de Alegria"
+msgstr "Chã de Alegria"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1513
+msgid "Cianorte"
+msgstr "Cianorte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1515
+msgid "Cidade Gaúcha"
+msgstr "Cidade Gaúcha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1516
+msgid "Cidade Ocidental"
+msgstr "Cidade Ocidental"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1517
+msgid "Cidelândia"
+msgstr "Cidelândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1518
+msgid "Cidreira"
+msgstr "Cidreira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1520
+msgid "Cipotânea"
+msgstr "Cipotânea"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1519
+msgid "Cipó"
+msgstr "Cipó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1521
+msgid "Ciríaco"
+msgstr "Ciríaco"
+
+#. module: l10n_br
+#: model_terms:ir.ui.view,arch_db:l10n_br.br_partner_address_form
+msgid "City"
+msgstr "Cidade"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1522
+msgid "Claraval"
+msgstr "Claraval"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1523
+msgid "Claro dos Poções"
+msgstr "Claro dos Poções"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1526
+msgid "Clementina"
+msgstr "Clementina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1527
+msgid "Clevelândia"
+msgstr "Clevelândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1524
+msgid "Cláudia"
+msgstr "Cláudia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1525
+msgid "Cláudio"
+msgstr "Cláudio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1528
+msgid "Coaraci"
+msgstr "Coaraci"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1529
+msgid "Coari"
+msgstr "Coari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1530
+msgid "Cocal"
+msgstr "Cocal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1531
+msgid "Cocal de Telha"
+msgstr "Cocal de Telha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1532
+msgid "Cocal do Sul"
+msgstr "Cocal do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1533
+msgid "Cocal dos Alves"
+msgstr "Cocal dos Alves"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1534
+msgid "Cocalinho"
+msgstr "Cocalinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1535
+msgid "Cocalzinho de Goiás"
+msgstr "Cocalzinho de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1536
+msgid "Cocos"
+msgstr "Cocos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1537
+msgid "Codajás"
+msgstr "Codajás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_273
+msgid "Codó"
+msgstr "Codó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1538
+msgid "Coelho Neto"
+msgstr "Coelho Neto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1539
+msgid "Coimbra"
+msgstr "Coimbra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1540
+msgid "Coité do Nóia"
+msgstr "Coité do Nóia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1541
+msgid "Coivaras"
+msgstr "Coivaras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1542
+msgid "Colares"
+msgstr "Colares"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_252
+msgid "Colatina"
+msgstr "Colatina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1544
+msgid "Colina"
+msgstr "Colina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1545
+#: model:res.city,name:l10n_br.city_br_1546
+msgid "Colinas"
+msgstr "Colinas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1547
+msgid "Colinas do Sul"
+msgstr "Colinas do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1548
+msgid "Colinas do Tocantins"
+msgstr "Colinas do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1549
+msgid "Colméia"
+msgstr "Colméia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1550
+msgid "Colniza"
+msgstr "Colniza"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_130
+msgid "Colombo"
+msgstr "Colombo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1555
+#: model:res.city,name:l10n_br.city_br_1556
+msgid "Colorado"
+msgstr "Colorado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1557
+msgid "Colorado do Oeste"
+msgstr "Colorado do Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1558
+msgid "Coluna"
+msgstr "Coluna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1543
+msgid "Colíder"
+msgstr "Colíder"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1551
+msgid "Colômbia"
+msgstr "Colômbia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1554
+msgid "Colônia Leopoldina"
+msgstr "Colônia Leopoldina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1552
+msgid "Colônia do Gurguéia"
+msgstr "Colônia do Gurguéia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1553
+msgid "Colônia do Piauí"
+msgstr "Colônia do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1559
+msgid "Combinado"
+msgstr "Combinado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1560
+msgid "Comendador Gomes"
+msgstr "Comendador Gomes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1561
+msgid "Comendador Levy Gasparian"
+msgstr "Comendador Levy Gasparian"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1562
+msgid "Comercinho"
+msgstr "Comercinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1563
+msgid "Comodoro"
+msgstr "Comodoro"
+
+#. module: l10n_br
 #: model:ir.model,name:l10n_br.model_res_company
 msgid "Companies"
 msgstr "Empresas"
+
+#. module: l10n_br
+#: model_terms:ir.ui.view,arch_db:l10n_br.br_partner_address_form
+msgid "Complement"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1564
+msgid "Conceição"
+msgstr "Conceição"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1565
+msgid "Conceição da Aparecida"
+msgstr "Conceição da Aparecida"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1566
+msgid "Conceição da Barra"
+msgstr "Conceição da Barra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1567
+msgid "Conceição da Barra de Minas"
+msgstr "Conceição da Barra de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1568
+msgid "Conceição da Feira"
+msgstr "Conceição da Feira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1569
+msgid "Conceição das Alagoas"
+msgstr "Conceição das Alagoas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1570
+msgid "Conceição das Pedras"
+msgstr "Conceição das Pedras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1571
+msgid "Conceição de Ipanema"
+msgstr "Conceição de Ipanema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1572
+msgid "Conceição de Macabu"
+msgstr "Conceição de Macabu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1573
+msgid "Conceição do Almeida"
+msgstr "Conceição do Almeida"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1574
+msgid "Conceição do Araguaia"
+msgstr "Conceição do Araguaia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1575
+msgid "Conceição do Canindé"
+msgstr "Conceição do Canindé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1576
+msgid "Conceição do Castelo"
+msgstr "Conceição do Castelo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1577
+msgid "Conceição do Coité"
+msgstr "Conceição do Coité"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1578
+msgid "Conceição do Jacuípe"
+msgstr "Conceição do Jacuípe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1579
+msgid "Conceição do Lago-Açu"
+msgstr "Conceição do Lago-Açu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1580
+msgid "Conceição do Mato Dentro"
+msgstr "Conceição do Mato Dentro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1581
+msgid "Conceição do Pará"
+msgstr "Conceição do Pará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1582
+msgid "Conceição do Rio Verde"
+msgstr "Conceição do Rio Verde"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1583
+msgid "Conceição do Tocantins"
+msgstr "Conceição do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1584
+msgid "Conceição dos Ouros"
+msgstr "Conceição dos Ouros"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1585
+msgid "Conchal"
+msgstr "Conchal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1586
+msgid "Conchas"
+msgstr "Conchas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1587
+msgid "Concórdia"
+msgstr "Concórdia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1588
+msgid "Concórdia do Pará"
+msgstr "Concórdia do Pará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1589
+#: model:res.city,name:l10n_br.city_br_1590
+msgid "Condado"
+msgstr "Condado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1591
+#: model:res.city,name:l10n_br.city_br_1592
+msgid "Conde"
+msgstr "Conde"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1593
+msgid "Condeúba"
+msgstr "Condeúba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1594
+msgid "Condor"
+msgstr "Condor"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1596
+msgid "Confins"
+msgstr "Confins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1597
+msgid "Confresa"
+msgstr "Confresa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1598
+msgid "Congo"
+msgstr "Congo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1599
+msgid "Congonhal"
+msgstr "Congonhal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1600
+msgid "Congonhas"
+msgstr "Congonhas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1601
+msgid "Congonhas do Norte"
+msgstr "Congonhas do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1602
+msgid "Congonhinhas"
+msgstr "Congonhinhas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1603
+msgid "Conquista"
+msgstr "Conquista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1604
+msgid "Conquista D'Oeste"
+msgstr "Conquista D'Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_227
+msgid "Conselheiro Lafaiete"
+msgstr "Conselheiro Lafaiete"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1605
+msgid "Conselheiro Mairinck"
+msgstr "Conselheiro Mairinck"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1606
+msgid "Conselheiro Pena"
+msgstr "Conselheiro Pena"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1607
+msgid "Consolação"
+msgstr "Consolação"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1608
+msgid "Constantina"
+msgstr "Constantina"
 
 #. module: l10n_br
 #: model:ir.model,name:l10n_br.model_res_partner
@@ -99,14 +6490,1454 @@ msgid "Contact"
 msgstr "Contato"
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_033
+msgid "Contagem"
+msgstr "Contagem"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1609
+msgid "Contenda"
+msgstr "Contenda"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1610
+msgid "Contendas do Sincorá"
+msgstr "Contendas do Sincorá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1611
+msgid "Coqueiral"
+msgstr "Coqueiral"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1612
+msgid "Coqueiro Baixo"
+msgstr "Coqueiro Baixo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1613
+msgid "Coqueiro Seco"
+msgstr "Coqueiro Seco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1614
+msgid "Coqueiros do Sul"
+msgstr "Coqueiros do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1615
+msgid "Coração de Jesus"
+msgstr "Coração de Jesus"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1616
+msgid "Coração de Maria"
+msgstr "Coração de Maria"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1617
+msgid "Corbélia"
+msgstr "Corbélia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1618
+msgid "Cordeiro"
+msgstr "Cordeiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1620
+msgid "Cordeiros"
+msgstr "Cordeiros"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1619
+msgid "Cordeirópolis"
+msgstr "Cordeirópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1621
+msgid "Cordilheira Alta"
+msgstr "Cordilheira Alta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1622
+msgid "Cordisburgo"
+msgstr "Cordisburgo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1623
+msgid "Cordislândia"
+msgstr "Cordislândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1624
+msgid "Coreaú"
+msgstr "Coreaú"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1625
+msgid "Coremas"
+msgstr "Coremas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1626
+msgid "Corguinho"
+msgstr "Corguinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1627
+msgid "Coribe"
+msgstr "Coribe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1628
+msgid "Corinto"
+msgstr "Corinto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1629
+msgid "Cornélio Procópio"
+msgstr "Cornélio Procópio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1630
+msgid "Coroaci"
+msgstr "Coroaci"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1631
+msgid "Coroados"
+msgstr "Coroados"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1632
+msgid "Coroatá"
+msgstr "Coroatá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1633
+msgid "Coromandel"
+msgstr "Coromandel"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1634
+msgid "Coronel Barros"
+msgstr "Coronel Barros"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1635
+msgid "Coronel Bicaco"
+msgstr "Coronel Bicaco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1636
+msgid "Coronel Domingos Soares"
+msgstr "Coronel Domingos Soares"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1637
+msgid "Coronel Ezequiel"
+msgstr "Coronel Ezequiel"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_301
+msgid "Coronel Fabriciano"
+msgstr "Coronel Fabriciano"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1638
+msgid "Coronel Freitas"
+msgstr "Coronel Freitas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1641
+msgid "Coronel José Dias"
+msgstr "Coronel José Dias"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1639
+msgid "Coronel João Pessoa"
+msgstr "Coronel João Pessoa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1640
+msgid "Coronel João Sá"
+msgstr "Coronel João Sá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1642
+msgid "Coronel Macedo"
+msgstr "Coronel Macedo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1643
+msgid "Coronel Martins"
+msgstr "Coronel Martins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1644
+msgid "Coronel Murta"
+msgstr "Coronel Murta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1645
+msgid "Coronel Pacheco"
+msgstr "Coronel Pacheco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1646
+msgid "Coronel Pilar"
+msgstr "Coronel Pilar"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1647
+msgid "Coronel Sapucaia"
+msgstr "Coronel Sapucaia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1648
+msgid "Coronel Vivida"
+msgstr "Coronel Vivida"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1649
+msgid "Coronel Xavier Chaves"
+msgstr "Coronel Xavier Chaves"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1655
+msgid "Correia Pinto"
+msgstr "Correia Pinto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1656
+msgid "Corrente"
+msgstr "Corrente"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1657
+msgid "Correntes"
+msgstr "Correntes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1658
+msgid "Correntina"
+msgstr "Correntina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1659
+msgid "Cortês"
+msgstr "Cortês"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1663
+msgid "Corumbataí"
+msgstr "Corumbataí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1664
+msgid "Corumbataí do Sul"
+msgstr "Corumbataí do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1662
+msgid "Corumbaíba"
+msgstr "Corumbaíba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1665
+msgid "Corumbiara"
+msgstr "Corumbiara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1660
+msgid "Corumbá"
+msgstr "Corumbá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1661
+msgid "Corumbá de Goiás"
+msgstr "Corumbá de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1666
+msgid "Corupá"
+msgstr "Corupá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1667
+msgid "Coruripe"
+msgstr "Coruripe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1669
+msgid "Cosmorama"
+msgstr "Cosmorama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1668
+msgid "Cosmópolis"
+msgstr "Cosmópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1670
+msgid "Costa Marques"
+msgstr "Costa Marques"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1671
+msgid "Costa Rica"
+msgstr "Costa Rica"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1672
+msgid "Cotegipe"
+msgstr "Cotegipe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_100
+msgid "Cotia"
+msgstr "Cotia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1673
+msgid "Cotiporã"
+msgstr "Cotiporã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1674
+msgid "Cotriguaçu"
+msgstr "Cotriguaçu"
+
+#. module: l10n_br
+#: model_terms:ir.ui.view,arch_db:l10n_br.br_partner_address_form
+msgid "Country"
+msgstr "País"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1676
+msgid "Couto Magalhães"
+msgstr "Couto Magalhães"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1675
+msgid "Couto de Magalhães de Minas"
+msgstr "Couto de Magalhães de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1677
+msgid "Coxilha"
+msgstr "Coxilha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1678
+msgid "Coxim"
+msgstr "Coxim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1679
+msgid "Coxixola"
+msgstr "Coxixola"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1681
+msgid "Crateús"
+msgstr "Crateús"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_229
+msgid "Crato"
+msgstr "Crato"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1682
+msgid "Cravinhos"
+msgstr "Cravinhos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1683
+msgid "Cravolândia"
+msgstr "Cravolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1680
+msgid "Craíbas"
+msgstr "Craíbas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_145
+msgid "Criciúma"
+msgstr "Criciúma"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1686
+msgid "Crissiumal"
+msgstr "Crissiumal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1687
+msgid "Cristais"
+msgstr "Cristais"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1688
+msgid "Cristais Paulista"
+msgstr "Cristais Paulista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1689
+msgid "Cristal"
+msgstr "Cristal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1690
+msgid "Cristal do Sul"
+msgstr "Cristal do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1694
+msgid "Cristalina"
+msgstr "Cristalina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1691
+msgid "Cristalândia"
+msgstr "Cristalândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1692
+msgid "Cristalândia do Piauí"
+msgstr "Cristalândia do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1695
+msgid "Cristiano Otoni"
+msgstr "Cristiano Otoni"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1696
+msgid "Cristianópolis"
+msgstr "Cristianópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1697
+msgid "Cristina"
+msgstr "Cristina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1699
+msgid "Cristino Castro"
+msgstr "Cristino Castro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1698
+msgid "Cristinápolis"
+msgstr "Cristinápolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1693
+msgid "Cristália"
+msgstr "Cristália"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1700
+msgid "Cristópolis"
+msgstr "Cristópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1684
+msgid "Crisólita"
+msgstr "Crisólita"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1685
+msgid "Crisópolis"
+msgstr "Crisópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1701
+msgid "Crixás"
+msgstr "Crixás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1702
+msgid "Crixás do Tocantins"
+msgstr "Crixás do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1703
+msgid "Croatá"
+msgstr "Croatá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1704
+msgid "Cromínia"
+msgstr "Cromínia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1705
+msgid "Crucilândia"
+msgstr "Crucilândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1706
+msgid "Cruz"
+msgstr "Cruz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1707
+msgid "Cruz Alta"
+msgstr "Cruz Alta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1710
+msgid "Cruz Machado"
+msgstr "Cruz Machado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1708
+msgid "Cruz das Almas"
+msgstr "Cruz das Almas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1709
+msgid "Cruz do Espírito Santo"
+msgstr "Cruz do Espírito Santo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1712
+msgid "Cruzaltense"
+msgstr "Cruzaltense"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1713
+msgid "Cruzeiro"
+msgstr "Cruzeiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1714
+msgid "Cruzeiro da Fortaleza"
+msgstr "Cruzeiro da Fortaleza"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1715
+msgid "Cruzeiro do Iguaçu"
+msgstr "Cruzeiro do Iguaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1716
+msgid "Cruzeiro do Oeste"
+msgstr "Cruzeiro do Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1717
+#: model:res.city,name:l10n_br.city_br_1718
+#: model:res.city,name:l10n_br.city_br_1719
+msgid "Cruzeiro do Sul"
+msgstr "Cruzeiro do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1720
+msgid "Cruzeta"
+msgstr "Cruzeta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1722
+msgid "Cruzmaltina"
+msgstr "Cruzmaltina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1711
+msgid "Cruzália"
+msgstr "Cruzália"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1721
+msgid "Cruzília"
+msgstr "Cruzília"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1723
+msgid "Cubati"
+msgstr "Cubati"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_278
+msgid "Cubatão"
+msgstr "Cubatão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_031
+msgid "Cuiabá"
+msgstr "Cuiabá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1726
+msgid "Cuitegi"
+msgstr "Cuitegi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1724
+msgid "Cuité"
+msgstr "Cuité"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1725
+msgid "Cuité de Mamanguape"
+msgstr "Cuité de Mamanguape"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1727
+msgid "Cujubim"
+msgstr "Cujubim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1728
+msgid "Cumari"
+msgstr "Cumari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1729
+msgid "Cumaru"
+msgstr "Cumaru"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1730
+msgid "Cumaru do Norte"
+msgstr "Cumaru do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1731
+msgid "Cumbe"
+msgstr "Cumbe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1732
+msgid "Cunha"
+msgstr "Cunha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1733
+msgid "Cunha Porã"
+msgstr "Cunha Porã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1734
+msgid "Cunhataí"
+msgstr "Cunhataí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1735
+msgid "Cuparaque"
+msgstr "Cuparaque"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1736
+msgid "Cupira"
+msgstr "Cupira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1737
+msgid "Curaçá"
+msgstr "Curaçá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1738
+msgid "Curimatá"
+msgstr "Curimatá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1739
+msgid "Curionópolis"
+msgstr "Curionópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_008
+msgid "Curitiba"
+msgstr "Curitiba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1740
+msgid "Curitibanos"
+msgstr "Curitibanos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1741
+msgid "Curiúva"
+msgstr "Curiúva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1742
+msgid "Currais"
+msgstr "Currais"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1743
+msgid "Currais Novos"
+msgstr "Currais Novos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1746
+msgid "Curral Novo do Piauí"
+msgstr "Curral Novo do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1747
+msgid "Curral Velho"
+msgstr "Curral Velho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1744
+msgid "Curral de Cima"
+msgstr "Curral de Cima"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1745
+msgid "Curral de Dentro"
+msgstr "Curral de Dentro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1748
+msgid "Curralinho"
+msgstr "Curralinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1749
+msgid "Curralinhos"
+msgstr "Curralinhos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1752
+msgid "Cururupu"
+msgstr "Cururupu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1750
+msgid "Curuá"
+msgstr "Curuá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1751
+msgid "Curuçá"
+msgstr "Curuçá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1754
+msgid "Curvelo"
+msgstr "Curvelo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1753
+msgid "Curvelândia"
+msgstr "Curvelândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1755
+msgid "Custódia"
+msgstr "Custódia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1756
+msgid "Cutias"
+msgstr "Cutias"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1105
+msgid "Cáceres"
+msgstr "Cáceres"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1417
+msgid "Cássia"
+msgstr "Cássia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1418
+msgid "Cássia dos Coqueiros"
+msgstr "Cássia dos Coqueiros"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1275
+msgid "Cândido Godói"
+msgstr "Cândido Godói"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1276
+msgid "Cândido Mendes"
+msgstr "Cândido Mendes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1277
+msgid "Cândido Mota"
+msgstr "Cândido Mota"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1278
+msgid "Cândido Rodrigues"
+msgstr "Cândido Rodrigues"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1279
+msgid "Cândido Sales"
+msgstr "Cândido Sales"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1274
+msgid "Cândido de Abreu"
+msgstr "Cândido de Abreu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1481
+msgid "Céu Azul"
+msgstr "Céu Azul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1514
+msgid "Cícero Dantas"
+msgstr "Cícero Dantas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1650
+msgid "Córrego Danta"
+msgstr "Córrego Danta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1653
+msgid "Córrego Fundo"
+msgstr "Córrego Fundo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1654
+msgid "Córrego Novo"
+msgstr "Córrego Novo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1651
+msgid "Córrego do Bom Jesus"
+msgstr "Córrego do Bom Jesus"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1652
+msgid "Córrego do Ouro"
+msgstr "Córrego do Ouro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1595
+msgid "Cônego Marinho"
+msgstr "Cônego Marinho"
+
+#. module: l10n_br
 #: model:l10n_latam.document.type,name:l10n_br.dt_18
 msgid "Daily Movement Summary"
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1757
+msgid "Damianópolis"
+msgstr "Damianópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1758
+msgid "Damião"
+msgstr "Damião"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1759
+msgid "Damolândia"
+msgstr "Damolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1760
+msgid "Darcinópolis"
+msgstr "Darcinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1762
+msgid "Datas"
+msgstr "Datas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1763
+msgid "David Canabarro"
+msgstr "David Canabarro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1764
+#: model:res.city,name:l10n_br.city_br_1765
+msgid "Davinópolis"
+msgstr "Davinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1766
+msgid "Delfim Moreira"
+msgstr "Delfim Moreira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1767
+msgid "Delfinópolis"
+msgstr "Delfinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1768
+msgid "Delmiro Gouveia"
+msgstr "Delmiro Gouveia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1769
+msgid "Delta"
+msgstr "Delta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1770
+msgid "Demerval Lobão"
+msgstr "Demerval Lobão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1771
+msgid "Denise"
+msgstr "Denise"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1772
+msgid "Deodápolis"
+msgstr "Deodápolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1773
+msgid "Deputado Irapuan Pinheiro"
+msgstr "Deputado Irapuan Pinheiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1774
+msgid "Derrubadas"
+msgstr "Derrubadas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1775
+msgid "Descalvado"
+msgstr "Descalvado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1776
+msgid "Descanso"
+msgstr "Descanso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1777
+msgid "Descoberto"
+msgstr "Descoberto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1778
+msgid "Desterro"
+msgstr "Desterro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1779
+msgid "Desterro de Entre Rios"
+msgstr "Desterro de Entre Rios"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1780
+msgid "Desterro do Melo"
+msgstr "Desterro do Melo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1781
+msgid "Dezesseis de Novembro"
+msgstr "Dezesseis de Novembro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_063
+msgid "Diadema"
+msgstr "Diadema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1782
+msgid "Diamante"
+msgstr "Diamante"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1783
+msgid "Diamante D'Oeste"
+msgstr "Diamante D'Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1784
+msgid "Diamante do Norte"
+msgstr "Diamante do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1785
+msgid "Diamante do Sul"
+msgstr "Diamante do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1786
+msgid "Diamantina"
+msgstr "Diamantina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1787
+msgid "Diamantino"
+msgstr "Diamantino"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1788
+msgid "Dianópolis"
+msgstr "Dianópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1789
+msgid "Dias d'Ávila"
+msgstr "Dias d'Ávila"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1790
+msgid "Dilermando de Aguiar"
+msgstr "Dilermando de Aguiar"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1791
+msgid "Diogo de Vasconcelos"
+msgstr "Diogo de Vasconcelos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1792
+msgid "Dionísio"
+msgstr "Dionísio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1793
+msgid "Dionísio Cerqueira"
+msgstr "Dionísio Cerqueira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1794
+msgid "Diorama"
+msgstr "Diorama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1795
+msgid "Dirce Reis"
+msgstr "Dirce Reis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1796
+msgid "Dirceu Arcoverde"
+msgstr "Dirceu Arcoverde"
+
+#. module: l10n_br
 #: model:ir.model.fields,field_description:l10n_br.field_account_tax__tax_discount
 msgid "Discount this Tax in Price"
 msgstr "Descontar esse imposto no preço"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1797
+msgid "Divina Pastora"
+msgstr "Divina Pastora"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1799
+msgid "Divino"
+msgstr "Divino"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1800
+msgid "Divino das Laranjeiras"
+msgstr "Divino das Laranjeiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1801
+msgid "Divino de São Lourenço"
+msgstr "Divino de São Lourenço"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1802
+msgid "Divinolândia"
+msgstr "Divinolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1803
+msgid "Divinolândia de Minas"
+msgstr "Divinolândia de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1798
+msgid "Divinésia"
+msgstr "Divinésia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_131
+msgid "Divinópolis"
+msgstr "Divinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1804
+msgid "Divinópolis de Goiás"
+msgstr "Divinópolis de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1805
+msgid "Divinópolis do Tocantins"
+msgstr "Divinópolis do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1806
+msgid "Divisa Alegre"
+msgstr "Divisa Alegre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1807
+msgid "Divisa Nova"
+msgstr "Divisa Nova"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1808
+msgid "Divisópolis"
+msgstr "Divisópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1809
+msgid "Dobrada"
+msgstr "Dobrada"
+
+#. module: l10n_br
+#: model_terms:ir.ui.view,arch_db:l10n_br.view_partner_bank_form_inherit_account
+msgid "Documentation"
+msgstr "Documentação"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1810
+msgid "Dois Córregos"
+msgstr "Dois Córregos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1811
+msgid "Dois Irmãos"
+msgstr "Dois Irmãos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1812
+msgid "Dois Irmãos das Missões"
+msgstr "Dois Irmãos das Missões"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1813
+msgid "Dois Irmãos do Buriti"
+msgstr "Dois Irmãos do Buriti"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1814
+msgid "Dois Irmãos do Tocantins"
+msgstr "Dois Irmãos do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1815
+msgid "Dois Lajeados"
+msgstr "Dois Lajeados"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1816
+msgid "Dois Riachos"
+msgstr "Dois Riachos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1817
+msgid "Dois Vizinhos"
+msgstr "Dois Vizinhos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1818
+msgid "Dolcinópolis"
+msgstr "Dolcinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1819
+msgid "Dom Aquino"
+msgstr "Dom Aquino"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1820
+msgid "Dom Basílio"
+msgstr "Dom Basílio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1821
+msgid "Dom Bosco"
+msgstr "Dom Bosco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1822
+msgid "Dom Cavati"
+msgstr "Dom Cavati"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1823
+msgid "Dom Eliseu"
+msgstr "Dom Eliseu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1824
+msgid "Dom Expedito Lopes"
+msgstr "Dom Expedito Lopes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1825
+msgid "Dom Feliciano"
+msgstr "Dom Feliciano"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1826
+msgid "Dom Inocêncio"
+msgstr "Dom Inocêncio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1827
+msgid "Dom Joaquim"
+msgstr "Dom Joaquim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1828
+msgid "Dom Macedo Costa"
+msgstr "Dom Macedo Costa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1829
+msgid "Dom Pedrito"
+msgstr "Dom Pedrito"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1830
+msgid "Dom Pedro"
+msgstr "Dom Pedro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1831
+msgid "Dom Pedro de Alcântara"
+msgstr "Dom Pedro de Alcântara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1832
+msgid "Dom Silvério"
+msgstr "Dom Silvério"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1833
+msgid "Dom Viçoso"
+msgstr "Dom Viçoso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1834
+msgid "Domingos Martins"
+msgstr "Domingos Martins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1835
+msgid "Domingos Mourão"
+msgstr "Domingos Mourão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1836
+msgid "Dona Emma"
+msgstr "Dona Emma"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1837
+msgid "Dona Eusébia"
+msgstr "Dona Eusébia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1838
+msgid "Dona Francisca"
+msgstr "Dona Francisca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1839
+msgid "Dona Inês"
+msgstr "Dona Inês"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1840
+msgid "Dores de Campos"
+msgstr "Dores de Campos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1841
+msgid "Dores de Guanhães"
+msgstr "Dores de Guanhães"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1842
+msgid "Dores do Indaiá"
+msgstr "Dores do Indaiá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1843
+msgid "Dores do Rio Preto"
+msgstr "Dores do Rio Preto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1844
+msgid "Dores do Turvo"
+msgstr "Dores do Turvo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1845
+msgid "Doresópolis"
+msgstr "Doresópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1846
+msgid "Dormentes"
+msgstr "Dormentes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1847
+#: model:res.city,name:l10n_br.city_br_1848
+msgid "Douradina"
+msgstr "Douradina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1849
+msgid "Dourado"
+msgstr "Dourado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1850
+msgid "Douradoquara"
+msgstr "Douradoquara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_120
+msgid "Dourados"
+msgstr "Dourados"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1851
+msgid "Doutor Camargo"
+msgstr "Doutor Camargo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1852
+msgid "Doutor Maurício Cardoso"
+msgstr "Doutor Maurício Cardoso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1853
+msgid "Doutor Pedrinho"
+msgstr "Doutor Pedrinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1854
+msgid "Doutor Ricardo"
+msgstr "Doutor Ricardo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1855
+msgid "Doutor Severiano"
+msgstr "Doutor Severiano"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1856
+msgid "Doutor Ulysses"
+msgstr "Doutor Ulysses"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1857
+msgid "Doverlândia"
+msgstr "Doverlândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1858
+msgid "Dracena"
+msgstr "Dracena"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1859
+msgid "Duartina"
+msgstr "Duartina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1860
+msgid "Duas Barras"
+msgstr "Duas Barras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1861
+msgid "Duas Estradas"
+msgstr "Duas Estradas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1862
+msgid "Dueré"
+msgstr "Dueré"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1863
+msgid "Dumont"
+msgstr "Dumont"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1864
+msgid "Duque Bacelar"
+msgstr "Duque Bacelar"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_022
+msgid "Duque de Caxias"
+msgstr "Duque de Caxias"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1865
+msgid "Durandé"
+msgstr "Durandé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1761
+msgid "Dário Meira"
+msgstr "Dário Meira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1866
+msgid "Echaporã"
+msgstr "Echaporã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1867
+msgid "Ecoporanga"
+msgstr "Ecoporanga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1868
+msgid "Edealina"
+msgstr "Edealina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1869
+msgid "Edéia"
+msgstr "Edéia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1870
+msgid "Eirunepé"
+msgstr "Eirunepé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1871
+#: model:res.city,name:l10n_br.city_br_1872
+msgid "Eldorado"
+msgstr "Eldorado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1873
+msgid "Eldorado do Carajás"
+msgstr "Eldorado do Carajás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1874
+msgid "Eldorado do Sul"
+msgstr "Eldorado do Sul"
 
 #. module: l10n_br
 #: model:l10n_latam.document.type,name:l10n_br.dt_57
@@ -144,14 +7975,2083 @@ msgid "Electronic Tax Coupon (CF-e-SAT)"
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1875
+msgid "Elesbão Veloso"
+msgstr "Elesbão Veloso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1876
+msgid "Elias Fausto"
+msgstr "Elias Fausto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1877
+msgid "Eliseu Martins"
+msgstr "Eliseu Martins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1878
+msgid "Elisiário"
+msgstr "Elisiário"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1879
+msgid "Elísio Medrado"
+msgstr "Elísio Medrado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1880
+msgid "Elói Mendes"
+msgstr "Elói Mendes"
+
+#. module: l10n_br
+#: model:ir.model.fields.selection,name:l10n_br.selection__res_partner_bank__proxy_type__email
+msgid "Email Address"
+msgstr "Endereço de e-mail"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1881
+msgid "Emas"
+msgstr "Emas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1882
+msgid "Embaúba"
+msgstr "Embaúba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_116
+msgid "Embu das Artes"
+msgstr "Embu das Artes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1883
+msgid "Embu-Guaçu"
+msgstr "Embu-Guaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1884
+msgid "Emilianópolis"
+msgstr "Emilianópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1885
+msgid "Encantado"
+msgstr "Encantado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1886
+msgid "Encanto"
+msgstr "Encanto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1887
+msgid "Encruzilhada"
+msgstr "Encruzilhada"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1888
+msgid "Encruzilhada do Sul"
+msgstr "Encruzilhada do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1890
+msgid "Engenheiro Beltrão"
+msgstr "Engenheiro Beltrão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1891
+msgid "Engenheiro Caldas"
+msgstr "Engenheiro Caldas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1892
+msgid "Engenheiro Coelho"
+msgstr "Engenheiro Coelho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1893
+msgid "Engenheiro Navarro"
+msgstr "Engenheiro Navarro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1894
+msgid "Engenheiro Paulo de Frontin"
+msgstr "Engenheiro Paulo de Frontin"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1895
+msgid "Engenho Velho"
+msgstr "Engenho Velho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1896
+msgid "Entre Folhas"
+msgstr "Entre Folhas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1898
+#: model:res.city,name:l10n_br.city_br_1899
+msgid "Entre Rios"
+msgstr "Entre Rios"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1900
+msgid "Entre Rios de Minas"
+msgstr "Entre Rios de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1901
+msgid "Entre Rios do Oeste"
+msgstr "Entre Rios do Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1902
+msgid "Entre Rios do Sul"
+msgstr "Entre Rios do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1897
+msgid "Entre-Ijuís"
+msgstr "Entre-Ijuís"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1903
+msgid "Envira"
+msgstr "Envira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1889
+msgid "Enéas Marques"
+msgstr "Enéas Marques"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1904
+msgid "Epitaciolândia"
+msgstr "Epitaciolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1905
+msgid "Equador"
+msgstr "Equador"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1906
+msgid "Erebango"
+msgstr "Erebango"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_295
+msgid "Erechim"
+msgstr "Erechim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1907
+msgid "Ererê"
+msgstr "Ererê"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1909
+msgid "Ermo"
+msgstr "Ermo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1910
+msgid "Ernestina"
+msgstr "Ernestina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1911
+msgid "Erval Grande"
+msgstr "Erval Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1912
+msgid "Erval Seco"
+msgstr "Erval Seco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1913
+msgid "Erval Velho"
+msgstr "Erval Velho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1914
+msgid "Ervália"
+msgstr "Ervália"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1915
+msgid "Escada"
+msgstr "Escada"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1916
+msgid "Esmeralda"
+msgstr "Esmeralda"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1917
+msgid "Esmeraldas"
+msgstr "Esmeraldas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1918
+msgid "Espera Feliz"
+msgstr "Espera Feliz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1922
+#: model:res.city,name:l10n_br.city_br_1923
+msgid "Esperantina"
+msgstr "Esperantina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1924
+msgid "Esperantinópolis"
+msgstr "Esperantinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1919
+msgid "Esperança"
+msgstr "Esperança"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1921
+msgid "Esperança Nova"
+msgstr "Esperança Nova"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1920
+msgid "Esperança do Sul"
+msgstr "Esperança do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1925
+msgid "Espigão Alto do Iguaçu"
+msgstr "Espigão Alto do Iguaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1926
+msgid "Espigão D'Oeste"
+msgstr "Espigão D'Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1927
+msgid "Espinosa"
+msgstr "Espinosa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1932
+msgid "Esplanada"
+msgstr "Esplanada"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1933
+msgid "Espumoso"
+msgstr "Espumoso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1928
+msgid "Espírito Santo"
+msgstr "Espírito Santo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1929
+msgid "Espírito Santo do Dourado"
+msgstr "Espírito Santo do Dourado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1930
+msgid "Espírito Santo do Pinhal"
+msgstr "Espírito Santo do Pinhal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1931
+msgid "Espírito Santo do Turvo"
+msgstr "Espírito Santo do Turvo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1934
+msgid "Estação"
+msgstr "Estação"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1937
+msgid "Esteio"
+msgstr "Esteio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1938
+msgid "Estiva"
+msgstr "Estiva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1939
+msgid "Estiva Gerbi"
+msgstr "Estiva Gerbi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1940
+msgid "Estreito"
+msgstr "Estreito"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1941
+msgid "Estrela"
+msgstr "Estrela"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1943
+msgid "Estrela Dalva"
+msgstr "Estrela Dalva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1949
+msgid "Estrela Velha"
+msgstr "Estrela Velha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1942
+msgid "Estrela d'Oeste"
+msgstr "Estrela d'Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1944
+msgid "Estrela de Alagoas"
+msgstr "Estrela de Alagoas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1945
+msgid "Estrela do Indaiá"
+msgstr "Estrela do Indaiá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1946
+#: model:res.city,name:l10n_br.city_br_1947
+msgid "Estrela do Norte"
+msgstr "Estrela do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1948
+msgid "Estrela do Sul"
+msgstr "Estrela do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1935
+msgid "Estância"
+msgstr "Estância"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1936
+msgid "Estância Velha"
+msgstr "Estância Velha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1950
+msgid "Euclides da Cunha"
+msgstr "Euclides da Cunha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1951
+msgid "Euclides da Cunha Paulista"
+msgstr "Euclides da Cunha Paulista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1953
+msgid "Eugenópolis"
+msgstr "Eugenópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1952
+msgid "Eugênio de Castro"
+msgstr "Eugênio de Castro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_274
+msgid "Eunápolis"
+msgstr "Eunápolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1954
+msgid "Eusébio"
+msgstr "Eusébio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1955
+msgid "Ewbank da Câmara"
+msgstr "Ewbank da Câmara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1956
+msgid "Extrema"
+msgstr "Extrema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1957
+msgid "Extremoz"
+msgstr "Extremoz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1958
+msgid "Exu"
+msgstr "Exu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1959
+msgid "Fagundes"
+msgstr "Fagundes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1960
+msgid "Fagundes Varela"
+msgstr "Fagundes Varela"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1961
+msgid "Faina"
+msgstr "Faina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1962
+msgid "Fama"
+msgstr "Fama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1963
+msgid "Faria Lemos"
+msgstr "Faria Lemos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1964
+msgid "Farias Brito"
+msgstr "Farias Brito"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1965
+msgid "Faro"
+msgstr "Faro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1966
+msgid "Farol"
+msgstr "Farol"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1967
+msgid "Farroupilha"
+msgstr "Farroupilha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1968
+msgid "Fartura"
+msgstr "Fartura"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1969
+msgid "Fartura do Piauí"
+msgstr "Fartura do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1973
+msgid "Faxinal"
+msgstr "Faxinal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1974
+msgid "Faxinal do Soturno"
+msgstr "Faxinal do Soturno"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1975
+msgid "Faxinal dos Guedes"
+msgstr "Faxinal dos Guedes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1976
+msgid "Faxinalzinho"
+msgstr "Faxinalzinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1977
+msgid "Fazenda Nova"
+msgstr "Fazenda Nova"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_202
+msgid "Fazenda Rio Grande"
+msgstr "Fazenda Rio Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1978
+msgid "Fazenda Vilanova"
+msgstr "Fazenda Vilanova"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1979
+msgid "Feijó"
+msgstr "Feijó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1981
+msgid "Feira Grande"
+msgstr "Feira Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1982
+#: model:res.city,name:l10n_br.city_br_1983
+msgid "Feira Nova"
+msgstr "Feira Nova"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1984
+msgid "Feira Nova do Maranhão"
+msgstr "Feira Nova do Maranhão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1980
+msgid "Feira da Mata"
+msgstr "Feira da Mata"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_035
+msgid "Feira de Santana"
+msgstr "Feira de Santana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1986
+msgid "Felipe Guerra"
+msgstr "Felipe Guerra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1987
+msgid "Felisburgo"
+msgstr "Felisburgo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1988
+msgid "Felixlândia"
+msgstr "Felixlândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1989
+msgid "Feliz"
+msgstr "Feliz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1990
+msgid "Feliz Deserto"
+msgstr "Feliz Deserto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1991
+msgid "Feliz Natal"
+msgstr "Feliz Natal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1985
+msgid "Felício dos Santos"
+msgstr "Felício dos Santos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1993
+msgid "Fernandes Pinheiro"
+msgstr "Fernandes Pinheiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1994
+msgid "Fernandes Tourinho"
+msgstr "Fernandes Tourinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1996
+msgid "Fernando Falcão"
+msgstr "Fernando Falcão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1997
+msgid "Fernando Pedroza"
+msgstr "Fernando Pedroza"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1998
+msgid "Fernando Prestes"
+msgstr "Fernando Prestes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1995
+msgid "Fernando de Noronha"
+msgstr "Fernando de Noronha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1999
+msgid "Fernandópolis"
+msgstr "Fernandópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2000
+msgid "Fernão"
+msgstr "Fernão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_166
+msgid "Ferraz de Vasconcelos"
+msgstr "Ferraz de Vasconcelos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2001
+msgid "Ferreira Gomes"
+msgstr "Ferreira Gomes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2002
+msgid "Ferreiros"
+msgstr "Ferreiros"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2003
+msgid "Ferros"
+msgstr "Ferros"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2004
+msgid "Fervedouro"
+msgstr "Fervedouro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2005
+msgid "Figueira"
+msgstr "Figueira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2006
+msgid "Figueirão"
+msgstr "Figueirão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2007
+msgid "Figueirópolis"
+msgstr "Figueirópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2008
+msgid "Figueirópolis D'Oeste"
+msgstr "Figueirópolis D'Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2009
+#: model:res.city,name:l10n_br.city_br_2010
+msgid "Filadélfia"
+msgstr "Filadélfia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2011
+msgid "Firmino Alves"
+msgstr "Firmino Alves"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2012
+msgid "Firminópolis"
+msgstr "Firminópolis"
+
+#. module: l10n_br
 #: model:ir.model,name:l10n_br.model_account_fiscal_position
 msgid "Fiscal Position"
 msgstr "Posição fiscal"
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2013
+msgid "Flexeiras"
+msgstr "Flexeiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2014
+msgid "Flor da Serra do Sul"
+msgstr "Flor da Serra do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2015
+msgid "Flor do Sertão"
+msgstr "Flor do Sertão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2016
+msgid "Flora Rica"
+msgstr "Flora Rica"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2017
+msgid "Floraí"
+msgstr "Floraí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2019
+msgid "Floreal"
+msgstr "Floreal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2020
+msgid "Flores"
+msgstr "Flores"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2021
+msgid "Flores da Cunha"
+msgstr "Flores da Cunha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2022
+msgid "Flores de Goiás"
+msgstr "Flores de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2023
+msgid "Flores do Piauí"
+msgstr "Flores do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2024
+#: model:res.city,name:l10n_br.city_br_2025
+msgid "Floresta"
+msgstr "Floresta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2026
+msgid "Floresta Azul"
+msgstr "Floresta Azul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2027
+msgid "Floresta do Araguaia"
+msgstr "Floresta do Araguaia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2028
+msgid "Floresta do Piauí"
+msgstr "Floresta do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2029
+msgid "Florestal"
+msgstr "Florestal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2030
+msgid "Florestópolis"
+msgstr "Florestópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2031
+msgid "Floriano"
+msgstr "Floriano"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2032
+msgid "Floriano Peixoto"
+msgstr "Floriano Peixoto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_039
+msgid "Florianópolis"
+msgstr "Florianópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2018
+msgid "Florânia"
+msgstr "Florânia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2035
+msgid "Florínea"
+msgstr "Florínea"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2033
+msgid "Flórida"
+msgstr "Flórida"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2034
+msgid "Flórida Paulista"
+msgstr "Flórida Paulista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2036
+msgid "Fonte Boa"
+msgstr "Fonte Boa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2037
+msgid "Fontoura Xavier"
+msgstr "Fontoura Xavier"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2038
+msgid "Formiga"
+msgstr "Formiga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2039
+msgid "Formigueiro"
+msgstr "Formigueiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_268
+msgid "Formosa"
+msgstr "Formosa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2040
+msgid "Formosa da Serra Negra"
+msgstr "Formosa da Serra Negra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2041
+msgid "Formosa do Oeste"
+msgstr "Formosa do Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2042
+msgid "Formosa do Rio Preto"
+msgstr "Formosa do Rio Preto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2043
+msgid "Formosa do Sul"
+msgstr "Formosa do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2044
+#: model:res.city,name:l10n_br.city_br_2045
+msgid "Formoso"
+msgstr "Formoso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2046
+msgid "Formoso do Araguaia"
+msgstr "Formoso do Araguaia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2047
+msgid "Forquetinha"
+msgstr "Forquetinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2048
+msgid "Forquilha"
+msgstr "Forquilha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2049
+msgid "Forquilhinha"
+msgstr "Forquilhinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_004
+msgid "Fortaleza"
+msgstr "Fortaleza"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2050
+msgid "Fortaleza de Minas"
+msgstr "Fortaleza de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2051
+msgid "Fortaleza do Tabocão"
+msgstr "Fortaleza do Tabocão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2052
+msgid "Fortaleza dos Nogueiras"
+msgstr "Fortaleza dos Nogueiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2053
+msgid "Fortaleza dos Valos"
+msgstr "Fortaleza dos Valos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2054
+msgid "Fortim"
+msgstr "Fortim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2055
+msgid "Fortuna"
+msgstr "Fortuna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2056
+msgid "Fortuna de Minas"
+msgstr "Fortuna de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_097
+msgid "Foz do Iguaçu"
+msgstr "Foz do Iguaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2057
+msgid "Foz do Jordão"
+msgstr "Foz do Jordão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2058
+msgid "Fraiburgo"
+msgstr "Fraiburgo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_075
+msgid "Franca"
+msgstr "Franca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2059
+msgid "Francinópolis"
+msgstr "Francinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2060
+msgid "Francisco Alves"
+msgstr "Francisco Alves"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2061
+msgid "Francisco Ayres"
+msgstr "Francisco Ayres"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2062
+msgid "Francisco Badaró"
+msgstr "Francisco Badaró"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2063
+msgid "Francisco Beltrão"
+msgstr "Francisco Beltrão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2064
+msgid "Francisco Dantas"
+msgstr "Francisco Dantas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2065
+msgid "Francisco Dumont"
+msgstr "Francisco Dumont"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2066
+msgid "Francisco Macedo"
+msgstr "Francisco Macedo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_180
+msgid "Francisco Morato"
+msgstr "Francisco Morato"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2068
+msgid "Francisco Santos"
+msgstr "Francisco Santos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2067
+msgid "Francisco Sá"
+msgstr "Francisco Sá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2069
+msgid "Franciscópolis"
+msgstr "Franciscópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_209
+msgid "Franco da Rocha"
+msgstr "Franco da Rocha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2070
+msgid "Frecheirinha"
+msgstr "Frecheirinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2071
+msgid "Frederico Westphalen"
+msgstr "Frederico Westphalen"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2072
+msgid "Frei Gaspar"
+msgstr "Frei Gaspar"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2073
+msgid "Frei Inocêncio"
+msgstr "Frei Inocêncio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2074
+msgid "Frei Lagonegro"
+msgstr "Frei Lagonegro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2075
+msgid "Frei Martinho"
+msgstr "Frei Martinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2076
+msgid "Frei Miguelinho"
+msgstr "Frei Miguelinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2077
+msgid "Frei Paulo"
+msgstr "Frei Paulo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2078
+msgid "Frei Rogério"
+msgstr "Frei Rogério"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2079
+msgid "Fronteira"
+msgstr "Fronteira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2080
+msgid "Fronteira dos Vales"
+msgstr "Fronteira dos Vales"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2081
+msgid "Fronteiras"
+msgstr "Fronteiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2082
+msgid "Fruta de Leite"
+msgstr "Fruta de Leite"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2083
+msgid "Frutal"
+msgstr "Frutal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2084
+msgid "Frutuoso Gomes"
+msgstr "Frutuoso Gomes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2085
+msgid "Fundão"
+msgstr "Fundão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2086
+msgid "Funilândia"
+msgstr "Funilândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1970
+#: model:res.city,name:l10n_br.city_br_1971
+msgid "Fátima"
+msgstr "Fátima"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1972
+msgid "Fátima do Sul"
+msgstr "Fátima do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1992
+msgid "Fênix"
+msgstr "Fênix"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2087
+msgid "Gabriel Monteiro"
+msgstr "Gabriel Monteiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2088
+msgid "Gado Bravo"
+msgstr "Gado Bravo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2090
+msgid "Galiléia"
+msgstr "Galiléia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2091
+msgid "Galinhos"
+msgstr "Galinhos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2092
+msgid "Galvão"
+msgstr "Galvão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2093
+msgid "Gameleira"
+msgstr "Gameleira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2094
+msgid "Gameleira de Goiás"
+msgstr "Gameleira de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2095
+msgid "Gameleiras"
+msgstr "Gameleiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2096
+msgid "Gandu"
+msgstr "Gandu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_210
+msgid "Garanhuns"
+msgstr "Garanhuns"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2097
+msgid "Gararu"
+msgstr "Gararu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2099
+msgid "Garibaldi"
+msgstr "Garibaldi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2100
+msgid "Garopaba"
+msgstr "Garopaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2101
+msgid "Garrafão do Norte"
+msgstr "Garrafão do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2102
+msgid "Garruchos"
+msgstr "Garruchos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2103
+msgid "Garuva"
+msgstr "Garuva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2098
+msgid "Garça"
+msgstr "Garça"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2104
+msgid "Gaspar"
+msgstr "Gaspar"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2105
+msgid "Gastão Vidigal"
+msgstr "Gastão Vidigal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2107
+msgid "Gaurama"
+msgstr "Gaurama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2108
+msgid "Gavião"
+msgstr "Gavião"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2109
+msgid "Gavião Peixoto"
+msgstr "Gavião Peixoto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2106
+msgid "Gaúcha do Norte"
+msgstr "Gaúcha do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2110
+msgid "Geminiano"
+msgstr "Geminiano"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2112
+#: model:res.city,name:l10n_br.city_br_2113
+msgid "General Carneiro"
+msgstr "General Carneiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2111
+msgid "General Câmara"
+msgstr "General Câmara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2114
+msgid "General Maynard"
+msgstr "General Maynard"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2115
+msgid "General Salgado"
+msgstr "General Salgado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2116
+msgid "General Sampaio"
+msgstr "General Sampaio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2117
+msgid "Gentil"
+msgstr "Gentil"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2118
+msgid "Gentio do Ouro"
+msgstr "Gentio do Ouro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2119
+msgid "Getulina"
+msgstr "Getulina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2120
+msgid "Getúlio Vargas"
+msgstr "Getúlio Vargas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2121
+msgid "Gilbués"
+msgstr "Gilbués"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2122
+msgid "Girau do Ponciano"
+msgstr "Girau do Ponciano"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2123
+msgid "Giruá"
+msgstr "Giruá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2124
+msgid "Glaucilândia"
+msgstr "Glaucilândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2125
+msgid "Glicério"
+msgstr "Glicério"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2130
+msgid "Glorinha"
+msgstr "Glorinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2126
+msgid "Glória"
+msgstr "Glória"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2127
+msgid "Glória D'Oeste"
+msgstr "Glória D'Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2128
+msgid "Glória de Dourados"
+msgstr "Glória de Dourados"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2129
+msgid "Glória do Goitá"
+msgstr "Glória do Goitá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2131
+msgid "Godofredo Viana"
+msgstr "Godofredo Viana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2132
+msgid "Godoy Moreira"
+msgstr "Godoy Moreira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2133
+msgid "Goiabeira"
+msgstr "Goiabeira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2134
+msgid "Goiana"
+msgstr "Goiana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2137
+msgid "Goiandira"
+msgstr "Goiandira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2140
+msgid "Goianinha"
+msgstr "Goianinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2141
+msgid "Goianira"
+msgstr "Goianira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2142
+msgid "Goianorte"
+msgstr "Goianorte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2135
+msgid "Goianá"
+msgstr "Goianá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2136
+msgid "Goianápolis"
+msgstr "Goianápolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2138
+msgid "Goianésia"
+msgstr "Goianésia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2139
+msgid "Goianésia do Pará"
+msgstr "Goianésia do Pará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2144
+msgid "Goiatins"
+msgstr "Goiatins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2145
+msgid "Goiatuba"
+msgstr "Goiatuba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2146
+msgid "Goioerê"
+msgstr "Goioerê"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2147
+msgid "Goioxim"
+msgstr "Goioxim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2143
+msgid "Goiás"
+msgstr "Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_010
+msgid "Goiânia"
+msgstr "Goiânia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2150
+msgid "Gongogi"
+msgstr "Gongogi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2151
+msgid "Gonzaga"
+msgstr "Gonzaga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2148
+msgid "Gonçalves"
+msgstr "Gonçalves"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2149
+msgid "Gonçalves Dias"
+msgstr "Gonçalves Dias"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2152
+msgid "Gouveia"
+msgstr "Gouveia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2153
+msgid "Gouvelândia"
+msgstr "Gouvelândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2154
+msgid "Governador Archer"
+msgstr "Governador Archer"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2155
+msgid "Governador Celso Ramos"
+msgstr "Governador Celso Ramos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2156
+msgid "Governador Dix-Sept Rosado"
+msgstr "Governador Dix-Sept Rosado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2157
+msgid "Governador Edison Lobão"
+msgstr "Governador Edison Lobão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2158
+msgid "Governador Eugênio Barros"
+msgstr "Governador Eugênio Barros"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2159
+msgid "Governador Jorge Teixeira"
+msgstr "Governador Jorge Teixeira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2160
+msgid "Governador Lindenberg"
+msgstr "Governador Lindenberg"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2161
+msgid "Governador Luiz Rocha"
+msgstr "Governador Luiz Rocha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2162
+msgid "Governador Mangabeira"
+msgstr "Governador Mangabeira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2163
+msgid "Governador Newton Bello"
+msgstr "Governador Newton Bello"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2164
+msgid "Governador Nunes Freire"
+msgstr "Governador Nunes Freire"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_111
+msgid "Governador Valadares"
+msgstr "Governador Valadares"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2167
+msgid "Gracho Cardoso"
+msgstr "Gracho Cardoso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2168
+msgid "Grajaú"
+msgstr "Grajaú"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2169
+msgid "Gramado"
+msgstr "Gramado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2171
+msgid "Gramado Xavier"
+msgstr "Gramado Xavier"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2170
+msgid "Gramado dos Loureiros"
+msgstr "Gramado dos Loureiros"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2172
+msgid "Grandes Rios"
+msgstr "Grandes Rios"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2173
+msgid "Granito"
+msgstr "Granito"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2174
+msgid "Granja"
+msgstr "Granja"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2175
+msgid "Granjeiro"
+msgstr "Granjeiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2179
+msgid "Gravatal"
+msgstr "Gravatal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_107
+msgid "Gravataí"
+msgstr "Gravataí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2178
+msgid "Gravatá"
+msgstr "Gravatá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2165
+msgid "Graça"
+msgstr "Graça"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2166
+msgid "Graça Aranha"
+msgstr "Graça Aranha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2180
+msgid "Groaíras"
+msgstr "Groaíras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2181
+msgid "Grossos"
+msgstr "Grossos"
+
+#. module: l10n_br
 #: model:l10n_latam.document.type,name:l10n_br.dt_08
 msgid "Ground Bill of Lading"
 msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2182
+msgid "Grupiara"
+msgstr "Grupiara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2176
+msgid "Grão Mogol"
+msgstr "Grão Mogol"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2177
+msgid "Grão Pará"
+msgstr "Grão Pará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2183
+msgid "Guabiju"
+msgstr "Guabiju"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2184
+msgid "Guabiruba"
+msgstr "Guabiruba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2186
+msgid "Guadalupe"
+msgstr "Guadalupe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2189
+msgid "Guaimbê"
+msgstr "Guaimbê"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2192
+msgid "Guairaçá"
+msgstr "Guairaçá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2188
+msgid "Guaiçara"
+msgstr "Guaiçara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2193
+msgid "Guaiúba"
+msgstr "Guaiúba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2194
+msgid "Guajará"
+msgstr "Guajará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2195
+msgid "Guajará-Mirim"
+msgstr "Guajará-Mirim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2196
+msgid "Guajeru"
+msgstr "Guajeru"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2197
+msgid "Guamaré"
+msgstr "Guamaré"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2198
+msgid "Guamiranga"
+msgstr "Guamiranga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2199
+msgid "Guanambi"
+msgstr "Guanambi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2200
+msgid "Guanhães"
+msgstr "Guanhães"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2203
+msgid "Guapiara"
+msgstr "Guapiara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2202
+msgid "Guapiaçu"
+msgstr "Guapiaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2204
+msgid "Guapimirim"
+msgstr "Guapimirim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2205
+msgid "Guapirama"
+msgstr "Guapirama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2208
+msgid "Guaporema"
+msgstr "Guaporema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2207
+msgid "Guaporé"
+msgstr "Guaporé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2201
+msgid "Guapé"
+msgstr "Guapé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2206
+msgid "Guapó"
+msgstr "Guapó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2210
+msgid "Guarabira"
+msgstr "Guarabira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2212
+#: model:res.city,name:l10n_br.city_br_2213
+msgid "Guaraci"
+msgstr "Guaraci"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2214
+#: model:res.city,name:l10n_br.city_br_2215
+msgid "Guaraciaba"
+msgstr "Guaraciaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2216
+msgid "Guaraciaba do Norte"
+msgstr "Guaraciaba do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2217
+msgid "Guaraciama"
+msgstr "Guaraciama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2220
+msgid "Guaramiranga"
+msgstr "Guaramiranga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2221
+msgid "Guaramirim"
+msgstr "Guaramirim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2223
+msgid "Guarani"
+msgstr "Guarani"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2224
+msgid "Guarani d'Oeste"
+msgstr "Guarani d'Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2225
+msgid "Guarani das Missões"
+msgstr "Guarani das Missões"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2226
+msgid "Guarani de Goiás"
+msgstr "Guarani de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2227
+msgid "Guaraniaçu"
+msgstr "Guaraniaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2228
+msgid "Guarantã"
+msgstr "Guarantã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2229
+msgid "Guarantã do Norte"
+msgstr "Guarantã do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2222
+msgid "Guaranésia"
+msgstr "Guaranésia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_243
+msgid "Guarapari"
+msgstr "Guarapari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_165
+msgid "Guarapuava"
+msgstr "Guarapuava"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2230
+msgid "Guaraqueçaba"
+msgstr "Guaraqueçaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2232
+msgid "Guararapes"
+msgstr "Guararapes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2233
+msgid "Guararema"
+msgstr "Guararema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2231
+msgid "Guarará"
+msgstr "Guarará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2234
+msgid "Guaratinga"
+msgstr "Guaratinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_259
+msgid "Guaratinguetá"
+msgstr "Guaratinguetá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2235
+msgid "Guaratuba"
+msgstr "Guaratuba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2211
+msgid "Guaraçaí"
+msgstr "Guaraçaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2218
+msgid "Guaraí"
+msgstr "Guaraí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2219
+msgid "Guaraíta"
+msgstr "Guaraíta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2236
+msgid "Guarda-Mor"
+msgstr "Guarda-Mor"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2237
+msgid "Guareí"
+msgstr "Guareí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2238
+msgid "Guariba"
+msgstr "Guariba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2239
+msgid "Guaribas"
+msgstr "Guaribas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2240
+msgid "Guarinos"
+msgstr "Guarinos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_095
+msgid "Guarujá"
+msgstr "Guarujá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2241
+msgid "Guarujá do Sul"
+msgstr "Guarujá do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_013
+msgid "Guarulhos"
+msgstr "Guarulhos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2209
+msgid "Guará"
+msgstr "Guará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2242
+msgid "Guatambú"
+msgstr "Guatambú"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2243
+msgid "Guatapará"
+msgstr "Guatapará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2244
+msgid "Guaxupé"
+msgstr "Guaxupé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2185
+msgid "Guaçuí"
+msgstr "Guaçuí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2187
+msgid "Guaíba"
+msgstr "Guaíba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2190
+#: model:res.city,name:l10n_br.city_br_2191
+msgid "Guaíra"
+msgstr "Guaíra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2245
+msgid "Guia Lopes da Laguna"
+msgstr "Guia Lopes da Laguna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2246
+msgid "Guidoval"
+msgstr "Guidoval"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2248
+msgid "Guimarânia"
+msgstr "Guimarânia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2247
+msgid "Guimarães"
+msgstr "Guimarães"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2249
+msgid "Guiratinga"
+msgstr "Guiratinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2250
+msgid "Guiricema"
+msgstr "Guiricema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2251
+msgid "Gurinhatã"
+msgstr "Gurinhatã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2252
+msgid "Gurinhém"
+msgstr "Gurinhém"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2253
+msgid "Gurjão"
+msgstr "Gurjão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2255
+msgid "Gurupi"
+msgstr "Gurupi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2254
+msgid "Gurupá"
+msgstr "Gurupá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2256
+msgid "Guzolândia"
+msgstr "Guzolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2089
+msgid "Gália"
+msgstr "Gália"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2257
+msgid "Harmonia"
+msgstr "Harmonia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2258
+msgid "Heitoraí"
+msgstr "Heitoraí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2259
+msgid "Heliodora"
+msgstr "Heliodora"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2260
+msgid "Heliópolis"
+msgstr "Heliópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2261
+msgid "Herculândia"
+msgstr "Herculândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2262
+msgid "Herval"
+msgstr "Herval"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2263
+msgid "Herval d'Oeste"
+msgstr "Herval d'Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2264
+msgid "Herveiras"
+msgstr "Herveiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2267
+msgid "Hidrolina"
+msgstr "Hidrolina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2265
+#: model:res.city,name:l10n_br.city_br_2266
+msgid "Hidrolândia"
+msgstr "Hidrolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2268
+msgid "Holambra"
+msgstr "Holambra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2269
+msgid "Honório Serpa"
+msgstr "Honório Serpa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2270
+msgid "Horizonte"
+msgstr "Horizonte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2271
+msgid "Horizontina"
+msgstr "Horizontina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_125
+msgid "Hortolândia"
+msgstr "Hortolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2272
+msgid "Hugo Napoleão"
+msgstr "Hugo Napoleão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2273
+msgid "Hulha Negra"
+msgstr "Hulha Negra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2274
+#: model:res.city,name:l10n_br.city_br_2275
+msgid "Humaitá"
+msgstr "Humaitá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2276
+msgid "Humberto de Campos"
+msgstr "Humberto de Campos"
 
 #. module: l10n_br
 #: model:account.report.line,name:l10n_br.tax_report_icms
@@ -288,9 +10188,693 @@ msgid "ISSQN tax"
 msgstr "Imposto ISSQN"
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2277
+msgid "Iacanga"
+msgstr "Iacanga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2278
+msgid "Iaciara"
+msgstr "Iaciara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2279
+msgid "Iacri"
+msgstr "Iacri"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2281
+msgid "Iapu"
+msgstr "Iapu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2282
+msgid "Iaras"
+msgstr "Iaras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2283
+msgid "Iati"
+msgstr "Iati"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2280
+msgid "Iaçu"
+msgstr "Iaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2284
+msgid "Ibaiti"
+msgstr "Ibaiti"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2285
+msgid "Ibarama"
+msgstr "Ibarama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2286
+msgid "Ibaretama"
+msgstr "Ibaretama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2288
+msgid "Ibateguara"
+msgstr "Ibateguara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2289
+msgid "Ibatiba"
+msgstr "Ibatiba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2287
+msgid "Ibaté"
+msgstr "Ibaté"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2290
+msgid "Ibema"
+msgstr "Ibema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2291
+msgid "Ibertioga"
+msgstr "Ibertioga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2295
+msgid "Ibiam"
+msgstr "Ibiam"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2296
+msgid "Ibiapina"
+msgstr "Ibiapina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2297
+msgid "Ibiara"
+msgstr "Ibiara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2298
+msgid "Ibiassucê"
+msgstr "Ibiassucê"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2293
+msgid "Ibiaçá"
+msgstr "Ibiaçá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2294
+msgid "Ibiaí"
+msgstr "Ibiaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2299
+msgid "Ibicaraí"
+msgstr "Ibicaraí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2300
+msgid "Ibicaré"
+msgstr "Ibicaré"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2301
+msgid "Ibicoara"
+msgstr "Ibicoara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2303
+msgid "Ibicuitinga"
+msgstr "Ibicuitinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2302
+msgid "Ibicuí"
+msgstr "Ibicuí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2304
+msgid "Ibimirim"
+msgstr "Ibimirim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2305
+msgid "Ibipeba"
+msgstr "Ibipeba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2306
+msgid "Ibipitanga"
+msgstr "Ibipitanga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2307
+msgid "Ibiporã"
+msgstr "Ibiporã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2308
+msgid "Ibiquera"
+msgstr "Ibiquera"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2310
+msgid "Ibiracatu"
+msgstr "Ibiracatu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2311
+msgid "Ibiraci"
+msgstr "Ibiraci"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2313
+msgid "Ibiraiaras"
+msgstr "Ibiraiaras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2314
+msgid "Ibirajuba"
+msgstr "Ibirajuba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2315
+msgid "Ibirama"
+msgstr "Ibirama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2316
+msgid "Ibirapitanga"
+msgstr "Ibirapitanga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2318
+msgid "Ibirapuitã"
+msgstr "Ibirapuitã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2317
+msgid "Ibirapuã"
+msgstr "Ibirapuã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2319
+msgid "Ibirarema"
+msgstr "Ibirarema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2320
+msgid "Ibirataia"
+msgstr "Ibirataia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2312
+msgid "Ibiraçu"
+msgstr "Ibiraçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_171
+msgid "Ibirité"
+msgstr "Ibirité"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2321
+msgid "Ibirubá"
+msgstr "Ibirubá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2309
+msgid "Ibirá"
+msgstr "Ibirá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2322
+msgid "Ibitiara"
+msgstr "Ibitiara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2323
+msgid "Ibitinga"
+msgstr "Ibitinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2324
+msgid "Ibitirama"
+msgstr "Ibitirama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2325
+msgid "Ibititá"
+msgstr "Ibititá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2326
+msgid "Ibitiúra de Minas"
+msgstr "Ibitiúra de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2327
+msgid "Ibituruna"
+msgstr "Ibituruna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2292
+msgid "Ibiá"
+msgstr "Ibiá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2328
+msgid "Ibiúna"
+msgstr "Ibiúna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2329
+msgid "Ibotirama"
+msgstr "Ibotirama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2330
+msgid "Icapuí"
+msgstr "Icapuí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2332
+msgid "Icaraí de Minas"
+msgstr "Icaraí de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2333
+msgid "Icaraíma"
+msgstr "Icaraíma"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2334
+msgid "Icatu"
+msgstr "Icatu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2336
+msgid "Ichu"
+msgstr "Ichu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2338
+msgid "Iconha"
+msgstr "Iconha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2335
+msgid "Icém"
+msgstr "Icém"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2337
+msgid "Icó"
+msgstr "Icó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2339
+msgid "Ielmo Marinho"
+msgstr "Ielmo Marinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2340
+msgid "Iepê"
+msgstr "Iepê"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2341
+msgid "Igaci"
+msgstr "Igaci"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2342
+msgid "Igaporã"
+msgstr "Igaporã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2344
+msgid "Igaracy"
+msgstr "Igaracy"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2345
+msgid "Igarapava"
+msgstr "Igarapava"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2346
+msgid "Igarapé"
+msgstr "Igarapé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2349
+msgid "Igarapé Grande"
+msgstr "Igarapé Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2348
+msgid "Igarapé do Meio"
+msgstr "Igarapé do Meio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2347
+msgid "Igarapé-Açu"
+msgstr "Igarapé-Açu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2350
+msgid "Igarapé-Miri"
+msgstr "Igarapé-Miri"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_270
+msgid "Igarassu"
+msgstr "Igarassu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2352
+msgid "Igaratinga"
+msgstr "Igaratinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2351
+msgid "Igaratá"
+msgstr "Igaratá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2343
+msgid "Igaraçu do Tietê"
+msgstr "Igaraçu do Tietê"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2353
+msgid "Igrapiúna"
+msgstr "Igrapiúna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2354
+msgid "Igreja Nova"
+msgstr "Igreja Nova"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2355
+msgid "Igrejinha"
+msgstr "Igrejinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2356
+msgid "Iguaba Grande"
+msgstr "Iguaba Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2358
+msgid "Iguape"
+msgstr "Iguape"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2360
+msgid "Iguaracy"
+msgstr "Iguaracy"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2359
+msgid "Iguaraçu"
+msgstr "Iguaraçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2361
+msgid "Iguatama"
+msgstr "Iguatama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2362
+msgid "Iguatemi"
+msgstr "Iguatemi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2363
+#: model:res.city,name:l10n_br.city_br_2364
+msgid "Iguatu"
+msgstr "Iguatu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2357
+msgid "Iguaí"
+msgstr "Iguaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2365
+msgid "Ijaci"
+msgstr "Ijaci"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2366
+msgid "Ijuí"
+msgstr "Ijuí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2367
+msgid "Ilha Comprida"
+msgstr "Ilha Comprida"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2370
+msgid "Ilha Grande"
+msgstr "Ilha Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2371
+msgid "Ilha Solteira"
+msgstr "Ilha Solteira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2368
+msgid "Ilha das Flores"
+msgstr "Ilha das Flores"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2369
+msgid "Ilha de Itamaracá"
+msgstr "Ilha de Itamaracá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2372
+msgid "Ilhabela"
+msgstr "Ilhabela"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2373
+msgid "Ilhota"
+msgstr "Ilhota"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_167
+msgid "Ilhéus"
+msgstr "Ilhéus"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2374
+msgid "Ilicínea"
+msgstr "Ilicínea"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2375
+msgid "Ilópolis"
+msgstr "Ilópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2376
+msgid "Imaculada"
+msgstr "Imaculada"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2377
+msgid "Imaruí"
+msgstr "Imaruí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2378
+msgid "Imbaú"
+msgstr "Imbaú"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2381
+msgid "Imbituba"
+msgstr "Imbituba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2382
+msgid "Imbituva"
+msgstr "Imbituva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2383
+msgid "Imbuia"
+msgstr "Imbuia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2379
+msgid "Imbé"
+msgstr "Imbé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2380
+msgid "Imbé de Minas"
+msgstr "Imbé de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2384
+msgid "Imigrante"
+msgstr "Imigrante"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_102
+msgid "Imperatriz"
+msgstr "Imperatriz"
+
+#. module: l10n_br
 #: model:l10n_latam.document.type,name:l10n_br.dt_02
 msgid "In-Consumer Sales Invoice"
 msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2386
+msgid "Inaciolândia"
+msgstr "Inaciolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2387
+#: model:res.city,name:l10n_br.city_br_2388
+msgid "Inajá"
+msgstr "Inajá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2389
+msgid "Inconfidentes"
+msgstr "Inconfidentes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2390
+msgid "Indaiabira"
+msgstr "Indaiabira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2391
+msgid "Indaial"
+msgstr "Indaial"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_112
+msgid "Indaiatuba"
+msgstr "Indaiatuba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2392
+#: model:res.city,name:l10n_br.city_br_2393
+msgid "Independência"
+msgstr "Independência"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2394
+msgid "Indiana"
+msgstr "Indiana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2395
+#: model:res.city,name:l10n_br.city_br_2396
+msgid "Indianópolis"
+msgstr "Indianópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2397
+msgid "Indiaporã"
+msgstr "Indiaporã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2398
+msgid "Indiara"
+msgstr "Indiara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2399
+msgid "Indiaroba"
+msgstr "Indiaroba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2400
+msgid "Indiavaí"
+msgstr "Indiavaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2403
+msgid "Ingazeira"
+msgstr "Ingazeira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2402
+msgid "Ingaí"
+msgstr "Ingaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2401
+msgid "Ingá"
+msgstr "Ingá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2404
+msgid "Inhacorá"
+msgstr "Inhacorá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2405
+msgid "Inhambupe"
+msgstr "Inhambupe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2406
+msgid "Inhangapi"
+msgstr "Inhangapi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2407
+msgid "Inhapi"
+msgstr "Inhapi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2408
+msgid "Inhapim"
+msgstr "Inhapim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2409
+msgid "Inhaúma"
+msgstr "Inhaúma"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2410
+msgid "Inhuma"
+msgstr "Inhuma"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2411
+msgid "Inhumas"
+msgstr "Inhumas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2412
+msgid "Inimutaba"
+msgstr "Inimutaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2413
+msgid "Inocência"
+msgstr "Inocência"
 
 #. module: l10n_br
 #: model:ir.model.fields.selection,name:l10n_br.selection__account_fiscal_position__l10n_br_fp_type__internal
@@ -343,6 +10927,1893 @@ msgid "Invoice from Producer"
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2385
+msgid "Inácio Martins"
+msgstr "Inácio Martins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2414
+msgid "Inúbia Paulista"
+msgstr "Inúbia Paulista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2415
+msgid "Iomerê"
+msgstr "Iomerê"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2416
+msgid "Ipaba"
+msgstr "Ipaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2417
+msgid "Ipameri"
+msgstr "Ipameri"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2418
+msgid "Ipanema"
+msgstr "Ipanema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2419
+msgid "Ipanguaçu"
+msgstr "Ipanguaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2420
+msgid "Ipaporanga"
+msgstr "Ipaporanga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_134
+msgid "Ipatinga"
+msgstr "Ipatinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2421
+msgid "Ipaumirim"
+msgstr "Ipaumirim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2422
+msgid "Ipaussu"
+msgstr "Ipaussu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2424
+msgid "Ipecaetá"
+msgstr "Ipecaetá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2425
+msgid "Iperó"
+msgstr "Iperó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2426
+msgid "Ipeúna"
+msgstr "Ipeúna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2427
+msgid "Ipiaçu"
+msgstr "Ipiaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2428
+msgid "Ipiaú"
+msgstr "Ipiaú"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2429
+msgid "Ipiguá"
+msgstr "Ipiguá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2430
+msgid "Ipira"
+msgstr "Ipira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2432
+msgid "Ipiranga"
+msgstr "Ipiranga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2433
+msgid "Ipiranga de Goiás"
+msgstr "Ipiranga de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2434
+msgid "Ipiranga do Norte"
+msgstr "Ipiranga do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2435
+msgid "Ipiranga do Piauí"
+msgstr "Ipiranga do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2436
+msgid "Ipiranga do Sul"
+msgstr "Ipiranga do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2431
+msgid "Ipirá"
+msgstr "Ipirá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2437
+msgid "Ipixuna"
+msgstr "Ipixuna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2438
+msgid "Ipixuna do Pará"
+msgstr "Ipixuna do Pará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2439
+msgid "Ipojuca"
+msgstr "Ipojuca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2443
+msgid "Iporanga"
+msgstr "Iporanga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2440
+msgid "Iporá"
+msgstr "Iporá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2441
+msgid "Iporã"
+msgstr "Iporã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2442
+msgid "Iporã do Oeste"
+msgstr "Iporã do Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2444
+msgid "Ipu"
+msgstr "Ipu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2446
+msgid "Ipuaçu"
+msgstr "Ipuaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2447
+msgid "Ipubi"
+msgstr "Ipubi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2448
+msgid "Ipueira"
+msgstr "Ipueira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2449
+#: model:res.city,name:l10n_br.city_br_2450
+msgid "Ipueiras"
+msgstr "Ipueiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2451
+msgid "Ipuiúna"
+msgstr "Ipuiúna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2452
+msgid "Ipumirim"
+msgstr "Ipumirim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2453
+msgid "Ipupiara"
+msgstr "Ipupiara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2445
+msgid "Ipuã"
+msgstr "Ipuã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2423
+msgid "Ipê"
+msgstr "Ipê"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2454
+#: model:res.city,name:l10n_br.city_br_2455
+msgid "Iracema"
+msgstr "Iracema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2456
+msgid "Iracema do Oeste"
+msgstr "Iracema do Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2458
+msgid "Iraceminha"
+msgstr "Iraceminha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2457
+msgid "Iracemápolis"
+msgstr "Iracemápolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2461
+msgid "Irajuba"
+msgstr "Irajuba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2462
+msgid "Iramaia"
+msgstr "Iramaia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2463
+msgid "Iranduba"
+msgstr "Iranduba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2464
+msgid "Irani"
+msgstr "Irani"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2466
+msgid "Irapuru"
+msgstr "Irapuru"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2465
+msgid "Irapuã"
+msgstr "Irapuã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2467
+msgid "Iraquara"
+msgstr "Iraquara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2468
+msgid "Irará"
+msgstr "Irará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2469
+#: model:res.city,name:l10n_br.city_br_2470
+msgid "Irati"
+msgstr "Irati"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2471
+msgid "Irauçuba"
+msgstr "Irauçuba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2459
+msgid "Iraí"
+msgstr "Iraí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2460
+msgid "Iraí de Minas"
+msgstr "Iraí de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2472
+msgid "Irecê"
+msgstr "Irecê"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2473
+msgid "Iretama"
+msgstr "Iretama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2474
+msgid "Irineópolis"
+msgstr "Irineópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2475
+msgid "Irituia"
+msgstr "Irituia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2476
+msgid "Irupi"
+msgstr "Irupi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2477
+msgid "Isaías Coelho"
+msgstr "Isaías Coelho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2478
+msgid "Israelândia"
+msgstr "Israelândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2480
+msgid "Itaara"
+msgstr "Itaara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2481
+#: model:res.city,name:l10n_br.city_br_309
+msgid "Itabaiana"
+msgstr "Itabaiana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2482
+msgid "Itabaianinha"
+msgstr "Itabaianinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2483
+msgid "Itabela"
+msgstr "Itabela"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2485
+msgid "Itaberaba"
+msgstr "Itaberaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2486
+msgid "Itaberaí"
+msgstr "Itaberaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2484
+msgid "Itaberá"
+msgstr "Itaberá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2487
+msgid "Itabi"
+msgstr "Itabi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_275
+msgid "Itabira"
+msgstr "Itabira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2488
+msgid "Itabirinha"
+msgstr "Itabirinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2489
+msgid "Itabirito"
+msgstr "Itabirito"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_139
+msgid "Itaboraí"
+msgstr "Itaboraí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_161
+msgid "Itabuna"
+msgstr "Itabuna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2490
+msgid "Itacajá"
+msgstr "Itacajá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2491
+msgid "Itacambira"
+msgstr "Itacambira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2492
+msgid "Itacarambi"
+msgstr "Itacarambi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2493
+msgid "Itacaré"
+msgstr "Itacaré"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_308
+msgid "Itacoatiara"
+msgstr "Itacoatiara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2494
+msgid "Itacuruba"
+msgstr "Itacuruba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2495
+msgid "Itacurubi"
+msgstr "Itacurubi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2496
+msgid "Itaeté"
+msgstr "Itaeté"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2497
+msgid "Itagi"
+msgstr "Itagi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2498
+msgid "Itagibá"
+msgstr "Itagibá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2499
+msgid "Itagimirim"
+msgstr "Itagimirim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2502
+msgid "Itaguajé"
+msgstr "Itaguajé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2503
+msgid "Itaguara"
+msgstr "Itaguara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2504
+msgid "Itaguari"
+msgstr "Itaguari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2505
+msgid "Itaguaru"
+msgstr "Itaguaru"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2506
+msgid "Itaguatins"
+msgstr "Itaguatins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2500
+msgid "Itaguaçu"
+msgstr "Itaguaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2501
+msgid "Itaguaçu da Bahia"
+msgstr "Itaguaçu da Bahia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_264
+msgid "Itaguaí"
+msgstr "Itaguaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2510
+msgid "Itainópolis"
+msgstr "Itainópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2512
+msgid "Itaipava do Grajaú"
+msgstr "Itaipava do Grajaú"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2514
+msgid "Itaipulândia"
+msgstr "Itaipulândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2513
+msgid "Itaipé"
+msgstr "Itaipé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2515
+msgid "Itaitinga"
+msgstr "Itaitinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_247
+msgid "Itaituba"
+msgstr "Itaituba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2509
+msgid "Itaiçaba"
+msgstr "Itaiçaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2511
+msgid "Itaiópolis"
+msgstr "Itaiópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_109
+msgid "Itajaí"
+msgstr "Itajaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2518
+msgid "Itajobi"
+msgstr "Itajobi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2519
+msgid "Itaju"
+msgstr "Itaju"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2520
+msgid "Itaju do Colônia"
+msgstr "Itaju do Colônia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2521
+msgid "Itajubá"
+msgstr "Itajubá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2522
+msgid "Itajuípe"
+msgstr "Itajuípe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2516
+#: model:res.city,name:l10n_br.city_br_2517
+msgid "Itajá"
+msgstr "Itajá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2523
+msgid "Italva"
+msgstr "Italva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2524
+msgid "Itamaraju"
+msgstr "Itamaraju"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2525
+msgid "Itamarandiba"
+msgstr "Itamarandiba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2526
+msgid "Itamarati"
+msgstr "Itamarati"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2527
+msgid "Itamarati de Minas"
+msgstr "Itamarati de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2528
+msgid "Itamari"
+msgstr "Itamari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2529
+msgid "Itambacuri"
+msgstr "Itambacuri"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2530
+msgid "Itambaracá"
+msgstr "Itambaracá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2531
+#: model:res.city,name:l10n_br.city_br_2532
+#: model:res.city,name:l10n_br.city_br_2533
+msgid "Itambé"
+msgstr "Itambé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2534
+msgid "Itambé do Mato Dentro"
+msgstr "Itambé do Mato Dentro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2535
+msgid "Itamogi"
+msgstr "Itamogi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2536
+msgid "Itamonte"
+msgstr "Itamonte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2537
+msgid "Itanagra"
+msgstr "Itanagra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2538
+msgid "Itanhandu"
+msgstr "Itanhandu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2539
+msgid "Itanhangá"
+msgstr "Itanhangá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_277
+msgid "Itanhaém"
+msgstr "Itanhaém"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2541
+msgid "Itanhomi"
+msgstr "Itanhomi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2540
+msgid "Itanhém"
+msgstr "Itanhém"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2542
+msgid "Itaobim"
+msgstr "Itaobim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2544
+msgid "Itaocara"
+msgstr "Itaocara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2545
+msgid "Itapaci"
+msgstr "Itapaci"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2546
+msgid "Itapagipe"
+msgstr "Itapagipe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2547
+msgid "Itapajé"
+msgstr "Itapajé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2548
+msgid "Itaparica"
+msgstr "Itaparica"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2550
+msgid "Itapebi"
+msgstr "Itapebi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2551
+msgid "Itapecerica"
+msgstr "Itapecerica"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_189
+msgid "Itapecerica da Serra"
+msgstr "Itapecerica da Serra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2552
+msgid "Itapecuru Mirim"
+msgstr "Itapecuru Mirim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2553
+msgid "Itapejara d'Oeste"
+msgstr "Itapejara d'Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2554
+msgid "Itapema"
+msgstr "Itapema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2555
+msgid "Itapemirim"
+msgstr "Itapemirim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_319
+msgid "Itaperuna"
+msgstr "Itaperuna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2556
+msgid "Itaperuçu"
+msgstr "Itaperuçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2557
+msgid "Itapetim"
+msgstr "Itapetim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2558
+msgid "Itapetinga"
+msgstr "Itapetinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_191
+msgid "Itapetininga"
+msgstr "Itapetininga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2559
+#: model:res.city,name:l10n_br.city_br_2560
+msgid "Itapeva"
+msgstr "Itapeva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_129
+msgid "Itapevi"
+msgstr "Itapevi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2561
+msgid "Itapicuru"
+msgstr "Itapicuru"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_228
+msgid "Itapipoca"
+msgstr "Itapipoca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2562
+msgid "Itapira"
+msgstr "Itapira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2563
+#: model:res.city,name:l10n_br.city_br_2564
+msgid "Itapiranga"
+msgstr "Itapiranga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2565
+msgid "Itapirapuã"
+msgstr "Itapirapuã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2566
+msgid "Itapirapuã Paulista"
+msgstr "Itapirapuã Paulista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2567
+msgid "Itapiratins"
+msgstr "Itapiratins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2568
+msgid "Itapissuma"
+msgstr "Itapissuma"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2569
+msgid "Itapitanga"
+msgstr "Itapitanga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2570
+msgid "Itapiúna"
+msgstr "Itapiúna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2575
+#: model:res.city,name:l10n_br.city_br_2576
+msgid "Itaporanga"
+msgstr "Itaporanga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2577
+msgid "Itaporanga d'Ajuda"
+msgstr "Itaporanga d'Ajuda"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2578
+msgid "Itapororoca"
+msgstr "Itapororoca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2573
+msgid "Itaporã"
+msgstr "Itaporã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2574
+msgid "Itaporã do Tocantins"
+msgstr "Itaporã do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2571
+msgid "Itapoá"
+msgstr "Itapoá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2580
+msgid "Itapuca"
+msgstr "Itapuca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2582
+msgid "Itapura"
+msgstr "Itapura"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2583
+msgid "Itapuranga"
+msgstr "Itapuranga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2579
+msgid "Itapuã do Oeste"
+msgstr "Itapuã do Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2581
+msgid "Itapuí"
+msgstr "Itapuí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2549
+msgid "Itapé"
+msgstr "Itapé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_069
+msgid "Itaquaquecetuba"
+msgstr "Itaquaquecetuba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2584
+msgid "Itaquara"
+msgstr "Itaquara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2585
+msgid "Itaqui"
+msgstr "Itaqui"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2586
+msgid "Itaquiraí"
+msgstr "Itaquiraí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2587
+msgid "Itaquitinga"
+msgstr "Itaquitinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2588
+msgid "Itarana"
+msgstr "Itarana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2589
+msgid "Itarantim"
+msgstr "Itarantim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2590
+msgid "Itararé"
+msgstr "Itararé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2591
+msgid "Itarema"
+msgstr "Itarema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2592
+msgid "Itariri"
+msgstr "Itariri"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2593
+msgid "Itarumã"
+msgstr "Itarumã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2594
+msgid "Itati"
+msgstr "Itati"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2595
+msgid "Itatiaia"
+msgstr "Itatiaia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2596
+msgid "Itatiaiuçu"
+msgstr "Itatiaiuçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_251
+msgid "Itatiba"
+msgstr "Itatiba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2597
+msgid "Itatiba do Sul"
+msgstr "Itatiba do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2598
+msgid "Itatim"
+msgstr "Itatim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2599
+msgid "Itatinga"
+msgstr "Itatinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2600
+msgid "Itatira"
+msgstr "Itatira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2601
+msgid "Itatuba"
+msgstr "Itatuba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2605
+msgid "Itaubal"
+msgstr "Itaubal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2607
+msgid "Itaueira"
+msgstr "Itaueira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2606
+msgid "Itauçu"
+msgstr "Itauçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2610
+msgid "Itaverava"
+msgstr "Itaverava"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2507
+msgid "Itaí"
+msgstr "Itaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2508
+msgid "Itaíba"
+msgstr "Itaíba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2543
+msgid "Itaóca"
+msgstr "Itaóca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2602
+msgid "Itaú"
+msgstr "Itaú"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2603
+msgid "Itaú de Minas"
+msgstr "Itaú de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2604
+msgid "Itaúba"
+msgstr "Itaúba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2608
+msgid "Itaúna"
+msgstr "Itaúna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2609
+msgid "Itaúna do Sul"
+msgstr "Itaúna do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2611
+msgid "Itinga"
+msgstr "Itinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2612
+msgid "Itinga do Maranhão"
+msgstr "Itinga do Maranhão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2613
+msgid "Itiquira"
+msgstr "Itiquira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2614
+msgid "Itirapina"
+msgstr "Itirapina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2615
+msgid "Itirapuã"
+msgstr "Itirapuã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2616
+msgid "Itiruçu"
+msgstr "Itiruçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2617
+msgid "Itiúba"
+msgstr "Itiúba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2618
+msgid "Itobi"
+msgstr "Itobi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2619
+msgid "Itororó"
+msgstr "Itororó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_173
+msgid "Itu"
+msgstr "Itu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2620
+msgid "Ituaçu"
+msgstr "Ituaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2621
+msgid "Ituberá"
+msgstr "Ituberá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2622
+msgid "Itueta"
+msgstr "Itueta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_314
+msgid "Ituiutaba"
+msgstr "Ituiutaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_287
+msgid "Itumbiara"
+msgstr "Itumbiara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2623
+msgid "Itumirim"
+msgstr "Itumirim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2624
+msgid "Itupeva"
+msgstr "Itupeva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2625
+msgid "Itupiranga"
+msgstr "Itupiranga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2626
+msgid "Ituporanga"
+msgstr "Ituporanga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2627
+msgid "Iturama"
+msgstr "Iturama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2628
+msgid "Itutinga"
+msgstr "Itutinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2629
+msgid "Ituverava"
+msgstr "Ituverava"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2479
+msgid "Itá"
+msgstr "Itá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2572
+msgid "Itápolis"
+msgstr "Itápolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2630
+msgid "Iuiú"
+msgstr "Iuiú"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2633
+msgid "Ivaiporã"
+msgstr "Ivaiporã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2635
+msgid "Ivatuba"
+msgstr "Ivatuba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2634
+msgid "Ivaté"
+msgstr "Ivaté"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2632
+msgid "Ivaí"
+msgstr "Ivaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2636
+msgid "Ivinhema"
+msgstr "Ivinhema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2637
+msgid "Ivolândia"
+msgstr "Ivolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2638
+msgid "Ivorá"
+msgstr "Ivorá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2639
+msgid "Ivoti"
+msgstr "Ivoti"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2331
+msgid "Içara"
+msgstr "Içara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2631
+msgid "Iúna"
+msgstr "Iúna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_032
+msgid "Jaboatão dos Guararapes"
+msgstr "Jaboatão dos Guararapes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2641
+#: model:res.city,name:l10n_br.city_br_2642
+msgid "Jaborandi"
+msgstr "Jaborandi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2640
+msgid "Jaborá"
+msgstr "Jaborá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2643
+msgid "Jaboti"
+msgstr "Jaboti"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2644
+msgid "Jaboticaba"
+msgstr "Jaboticaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2645
+msgid "Jaboticabal"
+msgstr "Jaboticabal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2646
+msgid "Jaboticatubas"
+msgstr "Jaboticatubas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2648
+msgid "Jacaraci"
+msgstr "Jacaraci"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2649
+msgid "Jacaraú"
+msgstr "Jacaraú"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2651
+msgid "Jacareacanga"
+msgstr "Jacareacanga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2652
+msgid "Jacarezinho"
+msgstr "Jacarezinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_122
+msgid "Jacareí"
+msgstr "Jacareí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2650
+msgid "Jacaré dos Homens"
+msgstr "Jacaré dos Homens"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2653
+msgid "Jaci"
+msgstr "Jaci"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2654
+msgid "Jaciara"
+msgstr "Jaciara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2655
+msgid "Jacinto"
+msgstr "Jacinto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2656
+msgid "Jacinto Machado"
+msgstr "Jacinto Machado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2657
+msgid "Jacobina"
+msgstr "Jacobina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2658
+msgid "Jacobina do Piauí"
+msgstr "Jacobina do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2661
+msgid "Jacuizinho"
+msgstr "Jacuizinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2662
+msgid "Jacundá"
+msgstr "Jacundá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2663
+msgid "Jacupiranga"
+msgstr "Jacupiranga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2664
+#: model:res.city,name:l10n_br.city_br_2665
+msgid "Jacutinga"
+msgstr "Jacutinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2659
+msgid "Jacuí"
+msgstr "Jacuí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2660
+msgid "Jacuípe"
+msgstr "Jacuípe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2666
+msgid "Jaguapitã"
+msgstr "Jaguapitã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2667
+msgid "Jaguaquara"
+msgstr "Jaguaquara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2670
+msgid "Jaguarari"
+msgstr "Jaguarari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2668
+msgid "Jaguaraçu"
+msgstr "Jaguaraçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2672
+msgid "Jaguaretama"
+msgstr "Jaguaretama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2673
+msgid "Jaguari"
+msgstr "Jaguari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2674
+msgid "Jaguariaíva"
+msgstr "Jaguariaíva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2675
+msgid "Jaguaribara"
+msgstr "Jaguaribara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2676
+msgid "Jaguaribe"
+msgstr "Jaguaribe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2677
+msgid "Jaguaripe"
+msgstr "Jaguaripe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2678
+msgid "Jaguariúna"
+msgstr "Jaguariúna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2679
+msgid "Jaguaruana"
+msgstr "Jaguaruana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2680
+msgid "Jaguaruna"
+msgstr "Jaguaruna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2669
+msgid "Jaguarão"
+msgstr "Jaguarão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2671
+msgid "Jaguaré"
+msgstr "Jaguaré"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2682
+msgid "Jaicós"
+msgstr "Jaicós"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2683
+msgid "Jales"
+msgstr "Jales"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2684
+msgid "Jambeiro"
+msgstr "Jambeiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2685
+msgid "Jampruca"
+msgstr "Jampruca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2686
+msgid "Janaúba"
+msgstr "Janaúba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2687
+msgid "Jandaia"
+msgstr "Jandaia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2688
+msgid "Jandaia do Sul"
+msgstr "Jandaia do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2689
+#: model:res.city,name:l10n_br.city_br_2690
+msgid "Jandaíra"
+msgstr "Jandaíra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_258
+msgid "Jandira"
+msgstr "Jandira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2691
+msgid "Janduís"
+msgstr "Janduís"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2692
+msgid "Jangada"
+msgstr "Jangada"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2693
+msgid "Janiópolis"
+msgstr "Janiópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2694
+msgid "Januária"
+msgstr "Januária"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2696
+msgid "Japaratinga"
+msgstr "Japaratinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2697
+msgid "Japaratuba"
+msgstr "Japaratuba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2695
+msgid "Japaraíba"
+msgstr "Japaraíba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2698
+msgid "Japeri"
+msgstr "Japeri"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2699
+msgid "Japi"
+msgstr "Japi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2700
+msgid "Japira"
+msgstr "Japira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2701
+msgid "Japoatã"
+msgstr "Japoatã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2702
+msgid "Japonvar"
+msgstr "Japonvar"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2703
+msgid "Japorã"
+msgstr "Japorã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2704
+#: model:res.city,name:l10n_br.city_br_2705
+msgid "Japurá"
+msgstr "Japurá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2706
+msgid "Jaqueira"
+msgstr "Jaqueira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2707
+msgid "Jaquirana"
+msgstr "Jaquirana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2709
+msgid "Jaraguari"
+msgstr "Jaraguari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2708
+msgid "Jaraguá"
+msgstr "Jaraguá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_164
+msgid "Jaraguá do Sul"
+msgstr "Jaraguá do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2710
+msgid "Jaramataia"
+msgstr "Jaramataia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2711
+#: model:res.city,name:l10n_br.city_br_2712
+msgid "Jardim"
+msgstr "Jardim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2713
+msgid "Jardim Alegre"
+msgstr "Jardim Alegre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2718
+msgid "Jardim Olinda"
+msgstr "Jardim Olinda"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2714
+msgid "Jardim de Angicos"
+msgstr "Jardim de Angicos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2715
+msgid "Jardim de Piranhas"
+msgstr "Jardim de Piranhas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2716
+msgid "Jardim do Mulato"
+msgstr "Jardim do Mulato"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2717
+msgid "Jardim do Seridó"
+msgstr "Jardim do Seridó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2719
+#: model:res.city,name:l10n_br.city_br_2720
+msgid "Jardinópolis"
+msgstr "Jardinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2721
+msgid "Jari"
+msgstr "Jari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2722
+msgid "Jarinu"
+msgstr "Jarinu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2723
+msgid "Jaru"
+msgstr "Jaru"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2724
+msgid "Jataizinho"
+msgstr "Jataizinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_294
+msgid "Jataí"
+msgstr "Jataí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2725
+msgid "Jataúba"
+msgstr "Jataúba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2726
+msgid "Jateí"
+msgstr "Jateí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2727
+msgid "Jati"
+msgstr "Jati"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2728
+#: model:res.city,name:l10n_br.city_br_2729
+msgid "Jatobá"
+msgstr "Jatobá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2730
+msgid "Jatobá do Piauí"
+msgstr "Jatobá do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2732
+msgid "Jaupaci"
+msgstr "Jaupaci"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2733
+msgid "Jauru"
+msgstr "Jauru"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2647
+msgid "Jaçanã"
+msgstr "Jaçanã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2681
+msgid "Jaíba"
+msgstr "Jaíba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_223
+msgid "Jaú"
+msgstr "Jaú"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2731
+msgid "Jaú do Tocantins"
+msgstr "Jaú do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2734
+msgid "Jeceaba"
+msgstr "Jeceaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2735
+msgid "Jenipapo de Minas"
+msgstr "Jenipapo de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2736
+msgid "Jenipapo dos Vieiras"
+msgstr "Jenipapo dos Vieiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2737
+msgid "Jequeri"
+msgstr "Jequeri"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2739
+msgid "Jequitaí"
+msgstr "Jequitaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2740
+msgid "Jequitibá"
+msgstr "Jequitibá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2741
+msgid "Jequitinhonha"
+msgstr "Jequitinhonha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2738
+msgid "Jequiá da Praia"
+msgstr "Jequiá da Praia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_187
+msgid "Jequié"
+msgstr "Jequié"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2742
+msgid "Jeremoabo"
+msgstr "Jeremoabo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2743
+msgid "Jericó"
+msgstr "Jericó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2744
+msgid "Jeriquara"
+msgstr "Jeriquara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2746
+msgid "Jerumenha"
+msgstr "Jerumenha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2745
+msgid "Jerônimo Monteiro"
+msgstr "Jerônimo Monteiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2747
+msgid "Jesuânia"
+msgstr "Jesuânia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2748
+msgid "Jesuítas"
+msgstr "Jesuítas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2749
+msgid "Jesúpolis"
+msgstr "Jesúpolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_244
+msgid "Ji-Paraná"
+msgstr "Ji-Paraná"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2750
+msgid "Jijoca de Jericoacoara"
+msgstr "Jijoca de Jericoacoara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2751
+msgid "Jiquiriçá"
+msgstr "Jiquiriçá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2752
+msgid "Jitaúna"
+msgstr "Jitaúna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2755
+msgid "Joanésia"
+msgstr "Joanésia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2756
+msgid "Joanópolis"
+msgstr "Joanópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2767
+msgid "Joaquim Felício"
+msgstr "Joaquim Felício"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2768
+msgid "Joaquim Gomes"
+msgstr "Joaquim Gomes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2769
+msgid "Joaquim Nabuco"
+msgstr "Joaquim Nabuco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2770
+msgid "Joaquim Pires"
+msgstr "Joaquim Pires"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2771
+msgid "Joaquim Távora"
+msgstr "Joaquim Távora"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2753
+msgid "Joaçaba"
+msgstr "Joaçaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2754
+msgid "Joaíma"
+msgstr "Joaíma"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2772
+msgid "Joca Claudino"
+msgstr "Joca Claudino"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2773
+msgid "Joca Marques"
+msgstr "Joca Marques"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_034
+msgid "Joinville"
+msgstr "Joinville"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2775
+msgid "Jordânia"
+msgstr "Jordânia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2776
+msgid "Jordão"
+msgstr "Jordão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2783
+msgid "Joselândia"
+msgstr "Joselândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2784
+msgid "Josenópolis"
+msgstr "Josenópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2777
+msgid "José Boiteux"
+msgstr "José Boiteux"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2778
+msgid "José Bonifácio"
+msgstr "José Bonifácio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2781
+msgid "José Gonçalves de Minas"
+msgstr "José Gonçalves de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2782
+msgid "José Raydan"
+msgstr "José Raydan"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2779
+msgid "José da Penha"
+msgstr "José da Penha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2780
+msgid "José de Freitas"
+msgstr "José de Freitas"
+
+#. module: l10n_br
 #: model:ir.model,name:l10n_br.model_account_journal
 msgid "Journal"
 msgstr ""
@@ -353,9 +12824,1082 @@ msgid "Journal Entry"
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2785
+msgid "Joviânia"
+msgstr "Joviânia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2757
+msgid "João Alfredo"
+msgstr "João Alfredo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2759
+msgid "João Costa"
+msgstr "João Costa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2758
+msgid "João Câmara"
+msgstr "João Câmara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2760
+msgid "João Dias"
+msgstr "João Dias"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2761
+msgid "João Dourado"
+msgstr "João Dourado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2762
+msgid "João Lisboa"
+msgstr "João Lisboa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2763
+msgid "João Monlevade"
+msgstr "João Monlevade"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2764
+msgid "João Neiva"
+msgstr "João Neiva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_020
+msgid "João Pessoa"
+msgstr "João Pessoa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2765
+msgid "João Pinheiro"
+msgstr "João Pinheiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2766
+msgid "João Ramalho"
+msgstr "João Ramalho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2786
+msgid "Juara"
+msgstr "Juara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2787
+msgid "Juarez Távora"
+msgstr "Juarez Távora"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2788
+msgid "Juarina"
+msgstr "Juarina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2789
+msgid "Juatuba"
+msgstr "Juatuba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2790
+msgid "Juazeirinho"
+msgstr "Juazeirinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_126
+msgid "Juazeiro"
+msgstr "Juazeiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_096
+msgid "Juazeiro do Norte"
+msgstr "Juazeiro do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2791
+msgid "Juazeiro do Piauí"
+msgstr "Juazeiro do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2793
+msgid "Jucati"
+msgstr "Jucati"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2795
+msgid "Jucurutu"
+msgstr "Jucurutu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2794
+msgid "Jucuruçu"
+msgstr "Jucuruçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2792
+msgid "Jucás"
+msgstr "Jucás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_038
+msgid "Juiz de Fora"
+msgstr "Juiz de Fora"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2800
+msgid "Jumirim"
+msgstr "Jumirim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2801
+msgid "Junco do Maranhão"
+msgstr "Junco do Maranhão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2802
+msgid "Junco do Seridó"
+msgstr "Junco do Seridó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_051
+msgid "Jundiaí"
+msgstr "Jundiaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2805
+msgid "Jundiaí do Sul"
+msgstr "Jundiaí do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2803
+#: model:res.city,name:l10n_br.city_br_2804
+msgid "Jundiá"
+msgstr "Jundiá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2806
+msgid "Junqueiro"
+msgstr "Junqueiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2807
+msgid "Junqueirópolis"
+msgstr "Junqueirópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2808
+msgid "Jupi"
+msgstr "Jupi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2809
+msgid "Jupiá"
+msgstr "Jupiá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2811
+msgid "Juquitiba"
+msgstr "Juquitiba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2810
+msgid "Juquiá"
+msgstr "Juquiá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2812
+msgid "Juramento"
+msgstr "Juramento"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2813
+msgid "Juranda"
+msgstr "Juranda"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2814
+#: model:res.city,name:l10n_br.city_br_2815
+msgid "Jurema"
+msgstr "Jurema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2816
+msgid "Juripiranga"
+msgstr "Juripiranga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2817
+msgid "Juru"
+msgstr "Juru"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2819
+msgid "Juruaia"
+msgstr "Juruaia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2820
+msgid "Juruena"
+msgstr "Juruena"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2821
+msgid "Juruti"
+msgstr "Juruti"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2818
+msgid "Juruá"
+msgstr "Juruá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2822
+msgid "Juscimeira"
+msgstr "Juscimeira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2823
+#: model:res.city,name:l10n_br.city_br_2824
+#: model:res.city,name:l10n_br.city_br_2825
+msgid "Jussara"
+msgstr "Jussara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2826
+msgid "Jussari"
+msgstr "Jussari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2827
+msgid "Jussiape"
+msgstr "Jussiape"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2828
+msgid "Jutaí"
+msgstr "Jutaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2829
+msgid "Juti"
+msgstr "Juti"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2830
+msgid "Juvenília"
+msgstr "Juvenília"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2796
+msgid "Juína"
+msgstr "Juína"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2774
+msgid "Jóia"
+msgstr "Jóia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2797
+msgid "Júlio Borges"
+msgstr "Júlio Borges"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2799
+msgid "Júlio Mesquita"
+msgstr "Júlio Mesquita"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2798
+msgid "Júlio de Castilhos"
+msgstr "Júlio de Castilhos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2831
+msgid "Kaloré"
+msgstr "Kaloré"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2833
+msgid "Lacerdópolis"
+msgstr "Lacerdópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2834
+msgid "Ladainha"
+msgstr "Ladainha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2835
+msgid "Ladário"
+msgstr "Ladário"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2836
+msgid "Lafaiete Coutinho"
+msgstr "Lafaiete Coutinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2837
+msgid "Lagamar"
+msgstr "Lagamar"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_317
+msgid "Lagarto"
+msgstr "Lagarto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_182
+msgid "Lages"
+msgstr "Lages"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2841
+msgid "Lago Verde"
+msgstr "Lago Verde"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2838
+msgid "Lago da Pedra"
+msgstr "Lago da Pedra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2839
+msgid "Lago do Junco"
+msgstr "Lago do Junco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2840
+msgid "Lago dos Rodrigues"
+msgstr "Lago dos Rodrigues"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2842
+msgid "Lagoa"
+msgstr "Lagoa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2843
+msgid "Lagoa Alegre"
+msgstr "Lagoa Alegre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2844
+msgid "Lagoa Bonita do Sul"
+msgstr "Lagoa Bonita do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2864
+msgid "Lagoa Dourada"
+msgstr "Lagoa Dourada"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2865
+msgid "Lagoa Formosa"
+msgstr "Lagoa Formosa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2866
+#: model:res.city,name:l10n_br.city_br_2867
+msgid "Lagoa Grande"
+msgstr "Lagoa Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2868
+msgid "Lagoa Grande do Maranhão"
+msgstr "Lagoa Grande do Maranhão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2869
+msgid "Lagoa Nova"
+msgstr "Lagoa Nova"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2870
+msgid "Lagoa Real"
+msgstr "Lagoa Real"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2871
+msgid "Lagoa Salgada"
+msgstr "Lagoa Salgada"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2872
+#: model:res.city,name:l10n_br.city_br_2873
+msgid "Lagoa Santa"
+msgstr "Lagoa Santa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2874
+msgid "Lagoa Seca"
+msgstr "Lagoa Seca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2875
+msgid "Lagoa Vermelha"
+msgstr "Lagoa Vermelha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2845
+msgid "Lagoa d'Anta"
+msgstr "Lagoa d'Anta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2846
+msgid "Lagoa da Canoa"
+msgstr "Lagoa da Canoa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2847
+msgid "Lagoa da Confusão"
+msgstr "Lagoa da Confusão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2848
+msgid "Lagoa da Prata"
+msgstr "Lagoa da Prata"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2849
+msgid "Lagoa de Dentro"
+msgstr "Lagoa de Dentro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2850
+msgid "Lagoa de Itaenga"
+msgstr "Lagoa de Itaenga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2851
+msgid "Lagoa de Pedras"
+msgstr "Lagoa de Pedras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2852
+msgid "Lagoa de São Francisco"
+msgstr "Lagoa de São Francisco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2853
+msgid "Lagoa de Velhos"
+msgstr "Lagoa de Velhos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2854
+msgid "Lagoa do Barro do Piauí"
+msgstr "Lagoa do Barro do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2855
+msgid "Lagoa do Carro"
+msgstr "Lagoa do Carro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2856
+msgid "Lagoa do Mato"
+msgstr "Lagoa do Mato"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2857
+msgid "Lagoa do Ouro"
+msgstr "Lagoa do Ouro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2858
+msgid "Lagoa do Piauí"
+msgstr "Lagoa do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2859
+msgid "Lagoa do Sítio"
+msgstr "Lagoa do Sítio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2860
+msgid "Lagoa do Tocantins"
+msgstr "Lagoa do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2861
+msgid "Lagoa dos Gatos"
+msgstr "Lagoa dos Gatos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2862
+msgid "Lagoa dos Patos"
+msgstr "Lagoa dos Patos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2863
+msgid "Lagoa dos Três Cantos"
+msgstr "Lagoa dos Três Cantos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2877
+msgid "Lagoinha"
+msgstr "Lagoinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2878
+msgid "Lagoinha do Piauí"
+msgstr "Lagoinha do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2876
+msgid "Lagoão"
+msgstr "Lagoão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2879
+msgid "Laguna"
+msgstr "Laguna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2880
+msgid "Laguna Carapã"
+msgstr "Laguna Carapã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2881
+msgid "Laje"
+msgstr "Laje"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2882
+msgid "Laje do Muriaé"
+msgstr "Laje do Muriaé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2883
+#: model:res.city,name:l10n_br.city_br_2884
+msgid "Lajeado"
+msgstr "Lajeado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2886
+msgid "Lajeado Grande"
+msgstr "Lajeado Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2887
+msgid "Lajeado Novo"
+msgstr "Lajeado Novo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2885
+msgid "Lajeado do Bugre"
+msgstr "Lajeado do Bugre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2889
+msgid "Lajedinho"
+msgstr "Lajedinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2890
+msgid "Lajedo"
+msgstr "Lajedo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2891
+msgid "Lajedo do Tabocal"
+msgstr "Lajedo do Tabocal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2888
+msgid "Lajedão"
+msgstr "Lajedão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2892
+msgid "Lajes"
+msgstr "Lajes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2893
+msgid "Lajes Pintadas"
+msgstr "Lajes Pintadas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2894
+msgid "Lajinha"
+msgstr "Lajinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2895
+msgid "Lamarão"
+msgstr "Lamarão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2896
+msgid "Lambari"
+msgstr "Lambari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2897
+msgid "Lambari D'Oeste"
+msgstr "Lambari D'Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2898
+msgid "Lamim"
+msgstr "Lamim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2899
+msgid "Landri Sales"
+msgstr "Landri Sales"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2900
+msgid "Lapa"
+msgstr "Lapa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2901
+msgid "Lapão"
+msgstr "Lapão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2902
+msgid "Laranja da Terra"
+msgstr "Laranja da Terra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2903
+#: model:res.city,name:l10n_br.city_br_2904
+msgid "Laranjal"
+msgstr "Laranjal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2906
+msgid "Laranjal Paulista"
+msgstr "Laranjal Paulista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2905
+msgid "Laranjal do Jari"
+msgstr "Laranjal do Jari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2907
+msgid "Laranjeiras"
+msgstr "Laranjeiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2908
+msgid "Laranjeiras do Sul"
+msgstr "Laranjeiras do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2909
+msgid "Lassance"
+msgstr "Lassance"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2910
+msgid "Lastro"
+msgstr "Lastro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2911
+msgid "Laurentino"
+msgstr "Laurentino"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2912
+msgid "Lauro Müller"
+msgstr "Lauro Müller"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_148
+msgid "Lauro de Freitas"
+msgstr "Lauro de Freitas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2913
+msgid "Lavandeira"
+msgstr "Lavandeira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_300
+msgid "Lavras"
+msgstr "Lavras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2915
+msgid "Lavras da Mangabeira"
+msgstr "Lavras da Mangabeira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2916
+msgid "Lavras do Sul"
+msgstr "Lavras do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2917
+msgid "Lavrinhas"
+msgstr "Lavrinhas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2914
+msgid "Lavínia"
+msgstr "Lavínia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2918
+msgid "Leandro Ferreira"
+msgstr "Leandro Ferreira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2919
+msgid "Lebon Régis"
+msgstr "Lebon Régis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2920
+msgid "Leme"
+msgstr "Leme"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2921
+msgid "Leme do Prado"
+msgstr "Leme do Prado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2922
+msgid "Lençóis"
+msgstr "Lençóis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2923
+msgid "Lençóis Paulista"
+msgstr "Lençóis Paulista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2924
+msgid "Leoberto Leal"
+msgstr "Leoberto Leal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2925
+msgid "Leopoldina"
+msgstr "Leopoldina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2926
+msgid "Leopoldo de Bulhões"
+msgstr "Leopoldo de Bulhões"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2927
+msgid "Leópolis"
+msgstr "Leópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2928
+msgid "Liberato Salzano"
+msgstr "Liberato Salzano"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2929
+msgid "Liberdade"
+msgstr "Liberdade"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2930
+msgid "Licínio de Almeida"
+msgstr "Licínio de Almeida"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2931
+msgid "Lidianópolis"
+msgstr "Lidianópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2932
+msgid "Lima Campos"
+msgstr "Lima Campos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2933
+msgid "Lima Duarte"
+msgstr "Lima Duarte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_094
+msgid "Limeira"
+msgstr "Limeira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2934
+msgid "Limeira do Oeste"
+msgstr "Limeira do Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2935
+msgid "Limoeiro"
+msgstr "Limoeiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2936
+msgid "Limoeiro de Anadia"
+msgstr "Limoeiro de Anadia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2937
+msgid "Limoeiro do Ajuru"
+msgstr "Limoeiro do Ajuru"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2938
+msgid "Limoeiro do Norte"
+msgstr "Limoeiro do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2939
+msgid "Lindoeste"
+msgstr "Lindoeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2942
+msgid "Lindolfo Collor"
+msgstr "Lindolfo Collor"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2940
+msgid "Lindóia"
+msgstr "Lindóia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2941
+msgid "Lindóia do Sul"
+msgstr "Lindóia do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2943
+msgid "Linha Nova"
+msgstr "Linha Nova"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_177
+msgid "Linhares"
+msgstr "Linhares"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2944
+msgid "Lins"
+msgstr "Lins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2945
+msgid "Livramento"
+msgstr "Livramento"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2946
+msgid "Livramento de Nossa Senhora"
+msgstr "Livramento de Nossa Senhora"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2947
+msgid "Lizarda"
+msgstr "Lizarda"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2948
+msgid "Loanda"
+msgstr "Loanda"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2949
+msgid "Lobato"
+msgstr "Lobato"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2950
+msgid "Logradouro"
+msgstr "Logradouro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_037
+msgid "Londrina"
+msgstr "Londrina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2951
+msgid "Lontra"
+msgstr "Lontra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2952
+msgid "Lontras"
+msgstr "Lontras"
+
+#. module: l10n_br
 #: model:l10n_latam.document.type,name:l10n_br.dt_8B
 msgid "Loose Ground Bill of Lading"
 msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2953
+msgid "Lorena"
+msgstr "Lorena"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2954
+msgid "Loreto"
+msgstr "Loreto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2955
+msgid "Lourdes"
+msgstr "Lourdes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2956
+msgid "Louveira"
+msgstr "Louveira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2957
+msgid "Lucas do Rio Verde"
+msgstr "Lucas do Rio Verde"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2959
+msgid "Lucena"
+msgstr "Lucena"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2960
+msgid "Lucianópolis"
+msgstr "Lucianópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2961
+msgid "Luciara"
+msgstr "Luciara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2962
+msgid "Lucrécia"
+msgstr "Lucrécia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2958
+msgid "Lucélia"
+msgstr "Lucélia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2967
+msgid "Luisburgo"
+msgstr "Luisburgo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2968
+msgid "Luislândia"
+msgstr "Luislândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2969
+msgid "Luiz Alves"
+msgstr "Luiz Alves"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2970
+msgid "Luiziana"
+msgstr "Luiziana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2971
+msgid "Luiziânia"
+msgstr "Luiziânia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2972
+msgid "Luminárias"
+msgstr "Luminárias"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2973
+msgid "Lunardelli"
+msgstr "Lunardelli"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2975
+msgid "Lupionópolis"
+msgstr "Lupionópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2974
+msgid "Lupércio"
+msgstr "Lupércio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2976
+msgid "Lutécia"
+msgstr "Lutécia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2977
+msgid "Luz"
+msgstr "Luz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2978
+msgid "Luzerna"
+msgstr "Luzerna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2979
+msgid "Luzilândia"
+msgstr "Luzilândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2980
+msgid "Luzinópolis"
+msgstr "Luzinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_146
+msgid "Luziânia"
+msgstr "Luziânia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2963
+msgid "Luís Antônio"
+msgstr "Luís Antônio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2964
+msgid "Luís Correia"
+msgstr "Luís Correia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2965
+msgid "Luís Domingues"
+msgstr "Luís Domingues"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_288
+msgid "Luís Eduardo Magalhães"
+msgstr "Luís Eduardo Magalhães"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2966
+msgid "Luís Gomes"
+msgstr "Luís Gomes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2832
+msgid "Lábrea"
+msgstr "Lábrea"
 
 #. module: l10n_br
 #: model:ir.model.fields,field_description:l10n_br.field_account_tax__amount_mva
@@ -363,14 +13907,1910 @@ msgid "MVA Percent"
 msgstr "Porcentagem de MVA"
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2982
+msgid "Macajuba"
+msgstr "Macajuba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2984
+msgid "Macambira"
+msgstr "Macambira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2985
+msgid "Macaparana"
+msgstr "Macaparana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_052
+msgid "Macapá"
+msgstr "Macapá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2986
+msgid "Macarani"
+msgstr "Macarani"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2987
+msgid "Macatuba"
+msgstr "Macatuba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2988
+msgid "Macau"
+msgstr "Macau"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2989
+msgid "Macaubal"
+msgstr "Macaubal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_117
+msgid "Macaé"
+msgstr "Macaé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2981
+msgid "Macaíba"
+msgstr "Macaíba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2990
+msgid "Macaúbas"
+msgstr "Macaúbas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2991
+msgid "Macedônia"
+msgstr "Macedônia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_016
+msgid "Maceió"
+msgstr "Maceió"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2992
+msgid "Machacalis"
+msgstr "Machacalis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2993
+msgid "Machadinho"
+msgstr "Machadinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2994
+msgid "Machadinho D'Oeste"
+msgstr "Machadinho D'Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2995
+msgid "Machado"
+msgstr "Machado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2996
+msgid "Machados"
+msgstr "Machados"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2997
+msgid "Macieira"
+msgstr "Macieira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2998
+msgid "Macuco"
+msgstr "Macuco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2999
+msgid "Macururé"
+msgstr "Macururé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3000
+msgid "Madalena"
+msgstr "Madalena"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3001
+msgid "Madeiro"
+msgstr "Madeiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3002
+msgid "Madre de Deus"
+msgstr "Madre de Deus"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3003
+msgid "Madre de Deus de Minas"
+msgstr "Madre de Deus de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3006
+msgid "Maetinga"
+msgstr "Maetinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3007
+msgid "Mafra"
+msgstr "Mafra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3008
+msgid "Magalhães Barata"
+msgstr "Magalhães Barata"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3009
+msgid "Magalhães de Almeida"
+msgstr "Magalhães de Almeida"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3010
+msgid "Magda"
+msgstr "Magda"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_132
+msgid "Magé"
+msgstr "Magé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3011
+msgid "Maiquinique"
+msgstr "Maiquinique"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3012
+msgid "Mairi"
+msgstr "Mairi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3013
+msgid "Mairinque"
+msgstr "Mairinque"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3014
+msgid "Mairiporã"
+msgstr "Mairiporã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3015
+msgid "Mairipotaba"
+msgstr "Mairipotaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3016
+msgid "Major Gercino"
+msgstr "Major Gercino"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3017
+msgid "Major Isidoro"
+msgstr "Major Isidoro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3018
+msgid "Major Sales"
+msgstr "Major Sales"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3019
+msgid "Major Vieira"
+msgstr "Major Vieira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3020
+msgid "Malacacheta"
+msgstr "Malacacheta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3021
+msgid "Malhada"
+msgstr "Malhada"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3022
+msgid "Malhada de Pedras"
+msgstr "Malhada de Pedras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3023
+msgid "Malhada dos Bois"
+msgstr "Malhada dos Bois"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3024
+msgid "Malhador"
+msgstr "Malhador"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3025
+msgid "Mallet"
+msgstr "Mallet"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3026
+msgid "Malta"
+msgstr "Malta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3027
+msgid "Mamanguape"
+msgstr "Mamanguape"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3028
+msgid "Mambaí"
+msgstr "Mambaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3029
+msgid "Mamborê"
+msgstr "Mamborê"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3030
+msgid "Mamonas"
+msgstr "Mamonas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3031
+msgid "Mampituba"
+msgstr "Mampituba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_315
+msgid "Manacapuru"
+msgstr "Manacapuru"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3033
+msgid "Manaquiri"
+msgstr "Manaquiri"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3034
+msgid "Manari"
+msgstr "Manari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_007
+msgid "Manaus"
+msgstr "Manaus"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3032
+msgid "Manaíra"
+msgstr "Manaíra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3037
+msgid "Mandaguari"
+msgstr "Mandaguari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3036
+msgid "Mandaguaçu"
+msgstr "Mandaguaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3038
+msgid "Mandirituba"
+msgstr "Mandirituba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3039
+msgid "Manduri"
+msgstr "Manduri"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3040
+msgid "Manfrinópolis"
+msgstr "Manfrinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3041
+msgid "Manga"
+msgstr "Manga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3042
+msgid "Mangaratiba"
+msgstr "Mangaratiba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3043
+msgid "Mangueirinha"
+msgstr "Mangueirinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3044
+msgid "Manhuaçu"
+msgstr "Manhuaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3045
+msgid "Manhumirim"
+msgstr "Manhumirim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3046
+msgid "Manicoré"
+msgstr "Manicoré"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3047
+msgid "Manoel Emídio"
+msgstr "Manoel Emídio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3048
+msgid "Manoel Ribas"
+msgstr "Manoel Ribas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3049
+msgid "Manoel Urbano"
+msgstr "Manoel Urbano"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3050
+msgid "Manoel Viana"
+msgstr "Manoel Viana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3051
+msgid "Manoel Vitorino"
+msgstr "Manoel Vitorino"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3052
+msgid "Mansidão"
+msgstr "Mansidão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3053
+msgid "Mantena"
+msgstr "Mantena"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3054
+msgid "Mantenópolis"
+msgstr "Mantenópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3055
+msgid "Maquiné"
+msgstr "Maquiné"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3057
+msgid "Mar Vermelho"
+msgstr "Mar Vermelho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3056
+msgid "Mar de Espanha"
+msgstr "Mar de Espanha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3058
+msgid "Mara Rosa"
+msgstr "Mara Rosa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_105
+msgid "Marabá"
+msgstr "Marabá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3060
+msgid "Marabá Paulista"
+msgstr "Marabá Paulista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3064
+msgid "Maracaju"
+msgstr "Maracaju"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3063
+msgid "Maracajá"
+msgstr "Maracajá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_128
+msgid "Maracanaú"
+msgstr "Maracanaú"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3065
+msgid "Maracanã"
+msgstr "Maracanã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3061
+msgid "Maracaçumé"
+msgstr "Maracaçumé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3062
+msgid "Maracaí"
+msgstr "Maracaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3066
+msgid "Maracás"
+msgstr "Maracás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3067
+msgid "Maragogi"
+msgstr "Maragogi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3068
+msgid "Maragogipe"
+msgstr "Maragogipe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3069
+msgid "Maraial"
+msgstr "Maraial"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3070
+msgid "Marajá do Sena"
+msgstr "Marajá do Sena"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_298
+msgid "Maranguape"
+msgstr "Maranguape"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3071
+msgid "Maranhãozinho"
+msgstr "Maranhãozinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3072
+msgid "Marapanim"
+msgstr "Marapanim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3073
+msgid "Marapoama"
+msgstr "Marapoama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3075
+msgid "Marataízes"
+msgstr "Marataízes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3074
+msgid "Maratá"
+msgstr "Maratá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3076
+msgid "Marau"
+msgstr "Marau"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3078
+#: model:res.city,name:l10n_br.city_br_3079
+msgid "Maravilha"
+msgstr "Maravilha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3080
+msgid "Maravilhas"
+msgstr "Maravilhas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3059
+msgid "Maraã"
+msgstr "Maraã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3077
+msgid "Maraú"
+msgstr "Maraú"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3081
+msgid "Marcação"
+msgstr "Marcação"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3083
+msgid "Marcelino Ramos"
+msgstr "Marcelino Ramos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3084
+msgid "Marcelino Vieira"
+msgstr "Marcelino Vieira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3082
+msgid "Marcelândia"
+msgstr "Marcelândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3085
+msgid "Marcionílio Souza"
+msgstr "Marcionílio Souza"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3086
+msgid "Marco"
+msgstr "Marco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3087
+msgid "Marcolândia"
+msgstr "Marcolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3088
+msgid "Marcos Parente"
+msgstr "Marcos Parente"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3089
+msgid "Marechal Cândido Rondon"
+msgstr "Marechal Cândido Rondon"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3090
+msgid "Marechal Deodoro"
+msgstr "Marechal Deodoro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3091
+msgid "Marechal Floriano"
+msgstr "Marechal Floriano"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3092
+msgid "Marechal Thaumaturgo"
+msgstr "Marechal Thaumaturgo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3093
+msgid "Marema"
+msgstr "Marema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3094
+msgid "Mari"
+msgstr "Mari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3096
+msgid "Maria Helena"
+msgstr "Maria Helena"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3095
+msgid "Maria da Fé"
+msgstr "Maria da Fé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3097
+msgid "Marialva"
+msgstr "Marialva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3098
+msgid "Mariana"
+msgstr "Mariana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3099
+msgid "Mariana Pimentel"
+msgstr "Mariana Pimentel"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3100
+msgid "Mariano Moro"
+msgstr "Mariano Moro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3101
+msgid "Marianópolis do Tocantins"
+msgstr "Marianópolis do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3103
+msgid "Maribondo"
+msgstr "Maribondo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_154
+msgid "Maricá"
+msgstr "Maricá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3104
+msgid "Marilac"
+msgstr "Marilac"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3107
+msgid "Marilena"
+msgstr "Marilena"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3108
+msgid "Mariluz"
+msgstr "Mariluz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3105
+msgid "Marilândia"
+msgstr "Marilândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3106
+msgid "Marilândia do Sul"
+msgstr "Marilândia do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_061
+msgid "Maringá"
+msgstr "Maringá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3109
+msgid "Marinópolis"
+msgstr "Marinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3112
+msgid "Maripá"
+msgstr "Maripá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3113
+msgid "Maripá de Minas"
+msgstr "Maripá de Minas"
+
+#. module: l10n_br
 #: model:l10n_latam.document.type,name:l10n_br.dt_09
 msgid "Maritime Bill of Lading"
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_285
+msgid "Marituba"
+msgstr "Marituba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3114
+msgid "Marizópolis"
+msgstr "Marizópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3102
+msgid "Mariápolis"
+msgstr "Mariápolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3111
+msgid "Mariópolis"
+msgstr "Mariópolis"
+
+#. module: l10n_br
 #: model:ir.model.fields,help:l10n_br.field_account_tax__tax_discount
 msgid "Mark it for (ICMS, PIS e etc.)."
 msgstr "Marque para (ICMS, PIS etc.)."
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3115
+msgid "Marliéria"
+msgstr "Marliéria"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3116
+msgid "Marmeleiro"
+msgstr "Marmeleiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3117
+msgid "Marmelópolis"
+msgstr "Marmelópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3118
+msgid "Marques de Souza"
+msgstr "Marques de Souza"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3119
+msgid "Marquinho"
+msgstr "Marquinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3120
+msgid "Martinho Campos"
+msgstr "Martinho Campos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3123
+msgid "Martins"
+msgstr "Martins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3124
+msgid "Martins Soares"
+msgstr "Martins Soares"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3121
+msgid "Martinópole"
+msgstr "Martinópole"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3122
+msgid "Martinópolis"
+msgstr "Martinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3125
+msgid "Maruim"
+msgstr "Maruim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3126
+msgid "Marumbi"
+msgstr "Marumbi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3127
+msgid "Marzagão"
+msgstr "Marzagão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_123
+msgid "Marília"
+msgstr "Marília"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3128
+msgid "Mascote"
+msgstr "Mascote"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3129
+msgid "Massapê"
+msgstr "Massapê"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3130
+msgid "Massapê do Piauí"
+msgstr "Massapê do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3131
+#: model:res.city,name:l10n_br.city_br_3132
+msgid "Massaranduba"
+msgstr "Massaranduba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3133
+msgid "Mata"
+msgstr "Mata"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3135
+msgid "Mata Grande"
+msgstr "Mata Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3136
+msgid "Mata Roma"
+msgstr "Mata Roma"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3137
+msgid "Mata Verde"
+msgstr "Mata Verde"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3134
+msgid "Mata de São João"
+msgstr "Mata de São João"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3139
+msgid "Mataraca"
+msgstr "Mataraca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3140
+msgid "Mateiros"
+msgstr "Mateiros"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3141
+msgid "Matelândia"
+msgstr "Matelândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3142
+msgid "Materlândia"
+msgstr "Materlândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3143
+msgid "Mateus Leme"
+msgstr "Mateus Leme"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3144
+msgid "Mathias Lobato"
+msgstr "Mathias Lobato"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3145
+msgid "Matias Barbosa"
+msgstr "Matias Barbosa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3146
+msgid "Matias Cardoso"
+msgstr "Matias Cardoso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3147
+msgid "Matias Olímpio"
+msgstr "Matias Olímpio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3148
+msgid "Matina"
+msgstr "Matina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3149
+msgid "Matinha"
+msgstr "Matinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3150
+msgid "Matinhas"
+msgstr "Matinhas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3151
+msgid "Matinhos"
+msgstr "Matinhos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3152
+msgid "Matipó"
+msgstr "Matipó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3153
+msgid "Mato Castelhano"
+msgstr "Mato Castelhano"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3154
+msgid "Mato Grosso"
+msgstr "Mato Grosso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3155
+msgid "Mato Leitão"
+msgstr "Mato Leitão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3156
+msgid "Mato Queimado"
+msgstr "Mato Queimado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3157
+msgid "Mato Rico"
+msgstr "Mato Rico"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3158
+msgid "Mato Verde"
+msgstr "Mato Verde"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3161
+msgid "Matos Costa"
+msgstr "Matos Costa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3162
+msgid "Matozinhos"
+msgstr "Matozinhos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3163
+msgid "Matrinchã"
+msgstr "Matrinchã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3164
+msgid "Matriz de Camaragibe"
+msgstr "Matriz de Camaragibe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3165
+msgid "Matupá"
+msgstr "Matupá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3166
+msgid "Maturéia"
+msgstr "Maturéia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3167
+msgid "Matutina"
+msgstr "Matutina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3138
+msgid "Matão"
+msgstr "Matão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3159
+msgid "Matões"
+msgstr "Matões"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3160
+msgid "Matões do Norte"
+msgstr "Matões do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3170
+msgid "Maurilândia"
+msgstr "Maurilândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3171
+msgid "Maurilândia do Tocantins"
+msgstr "Maurilândia do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3172
+msgid "Mauriti"
+msgstr "Mauriti"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_057
+msgid "Mauá"
+msgstr "Mauá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3168
+msgid "Mauá da Serra"
+msgstr "Mauá da Serra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3169
+msgid "Maués"
+msgstr "Maués"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3173
+msgid "Maxaranguape"
+msgstr "Maxaranguape"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3174
+msgid "Maximiliano de Almeida"
+msgstr "Maximiliano de Almeida"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3175
+msgid "Mazagão"
+msgstr "Mazagão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_2983
+msgid "Maçambará"
+msgstr "Maçambará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3176
+msgid "Medeiros"
+msgstr "Medeiros"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3177
+msgid "Medeiros Neto"
+msgstr "Medeiros Neto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3178
+msgid "Medianeira"
+msgstr "Medianeira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3179
+msgid "Medicilândia"
+msgstr "Medicilândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3180
+msgid "Medina"
+msgstr "Medina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3181
+msgid "Meleiro"
+msgstr "Meleiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3182
+msgid "Melgaço"
+msgstr "Melgaço"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3183
+msgid "Mendes"
+msgstr "Mendes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3184
+msgid "Mendes Pimentel"
+msgstr "Mendes Pimentel"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3185
+msgid "Mendonça"
+msgstr "Mendonça"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3186
+msgid "Mercedes"
+msgstr "Mercedes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3187
+msgid "Mercês"
+msgstr "Mercês"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3188
+msgid "Meridiano"
+msgstr "Meridiano"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3189
+msgid "Meruoca"
+msgstr "Meruoca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_176
+#: model:res.city,name:l10n_br.city_br_3191
+msgid "Mesquita"
+msgstr "Mesquita"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3192
+msgid "Messias"
+msgstr "Messias"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3193
+msgid "Messias Targino"
+msgstr "Messias Targino"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3190
+msgid "Mesópolis"
+msgstr "Mesópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3194
+msgid "Miguel Alves"
+msgstr "Miguel Alves"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3195
+msgid "Miguel Calmon"
+msgstr "Miguel Calmon"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3196
+msgid "Miguel Leão"
+msgstr "Miguel Leão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3197
+msgid "Miguel Pereira"
+msgstr "Miguel Pereira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3198
+msgid "Miguelópolis"
+msgstr "Miguelópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3199
+#: model:res.city,name:l10n_br.city_br_3200
+msgid "Milagres"
+msgstr "Milagres"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3201
+msgid "Milagres do Maranhão"
+msgstr "Milagres do Maranhão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3202
+msgid "Milhã"
+msgstr "Milhã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3203
+msgid "Milton Brandão"
+msgstr "Milton Brandão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3204
+msgid "Mimoso de Goiás"
+msgstr "Mimoso de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3205
+msgid "Mimoso do Sul"
+msgstr "Mimoso do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3207
+msgid "Minador do Negrão"
+msgstr "Minador do Negrão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3209
+msgid "Minas Novas"
+msgstr "Minas Novas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3208
+msgid "Minas do Leão"
+msgstr "Minas do Leão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3206
+msgid "Minaçu"
+msgstr "Minaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3210
+msgid "Minduri"
+msgstr "Minduri"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3211
+msgid "Mineiros"
+msgstr "Mineiros"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3212
+msgid "Mineiros do Tietê"
+msgstr "Mineiros do Tietê"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3213
+msgid "Ministro Andreazza"
+msgstr "Ministro Andreazza"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3214
+msgid "Mira Estrela"
+msgstr "Mira Estrela"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3215
+msgid "Mirabela"
+msgstr "Mirabela"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3216
+msgid "Miracatu"
+msgstr "Miracatu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3217
+msgid "Miracema"
+msgstr "Miracema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3218
+msgid "Miracema do Tocantins"
+msgstr "Miracema do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3219
+#: model:res.city,name:l10n_br.city_br_3220
+msgid "Mirador"
+msgstr "Mirador"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3221
+msgid "Miradouro"
+msgstr "Miradouro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3222
+msgid "Miraguaí"
+msgstr "Miraguaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3225
+msgid "Miranda"
+msgstr "Miranda"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3226
+msgid "Miranda do Norte"
+msgstr "Miranda do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3227
+msgid "Mirandiba"
+msgstr "Mirandiba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3228
+msgid "Mirandópolis"
+msgstr "Mirandópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3229
+msgid "Mirangaba"
+msgstr "Mirangaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3230
+msgid "Miranorte"
+msgstr "Miranorte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3231
+msgid "Mirante"
+msgstr "Mirante"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3232
+msgid "Mirante da Serra"
+msgstr "Mirante da Serra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3233
+msgid "Mirante do Paranapanema"
+msgstr "Mirante do Paranapanema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3234
+msgid "Miraselva"
+msgstr "Miraselva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3235
+msgid "Mirassol"
+msgstr "Mirassol"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3236
+msgid "Mirassol d'Oeste"
+msgstr "Mirassol d'Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3237
+msgid "Mirassolândia"
+msgstr "Mirassolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3238
+msgid "Miravânia"
+msgstr "Miravânia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3223
+msgid "Miraí"
+msgstr "Miraí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3224
+msgid "Miraíma"
+msgstr "Miraíma"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3239
+msgid "Mirim Doce"
+msgstr "Mirim Doce"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3240
+msgid "Mirinzal"
+msgstr "Mirinzal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3241
+msgid "Missal"
+msgstr "Missal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3242
+msgid "Missão Velha"
+msgstr "Missão Velha"
+
+#. module: l10n_br
+#: model:ir.model.fields.selection,name:l10n_br.selection__res_partner_bank__proxy_type__mobile
+msgid "Mobile Number"
+msgstr "Número de celular"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3243
+msgid "Mocajuba"
+msgstr "Mocajuba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3244
+msgid "Mococa"
+msgstr "Mococa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3245
+msgid "Modelo"
+msgstr "Modelo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3246
+msgid "Moeda"
+msgstr "Moeda"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3247
+msgid "Moema"
+msgstr "Moema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3248
+msgid "Mogeiro"
+msgstr "Mogeiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_196
+msgid "Mogi Guaçu"
+msgstr "Mogi Guaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3249
+msgid "Mogi Mirim"
+msgstr "Mogi Mirim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_050
+msgid "Mogi das Cruzes"
+msgstr "Mogi das Cruzes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3250
+msgid "Moiporá"
+msgstr "Moiporá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3251
+msgid "Moita Bonita"
+msgstr "Moita Bonita"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3252
+msgid "Moju"
+msgstr "Moju"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3253
+msgid "Mojuí dos Campos"
+msgstr "Mojuí dos Campos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3254
+msgid "Mombaça"
+msgstr "Mombaça"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3255
+msgid "Mombuca"
+msgstr "Mombuca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3258
+msgid "Mondaí"
+msgstr "Mondaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3259
+msgid "Mongaguá"
+msgstr "Mongaguá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3260
+msgid "Monjolos"
+msgstr "Monjolos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3261
+msgid "Monsenhor Gil"
+msgstr "Monsenhor Gil"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3262
+msgid "Monsenhor Hipólito"
+msgstr "Monsenhor Hipólito"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3263
+msgid "Monsenhor Paulo"
+msgstr "Monsenhor Paulo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3264
+msgid "Monsenhor Tabosa"
+msgstr "Monsenhor Tabosa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3265
+msgid "Montadas"
+msgstr "Montadas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3266
+msgid "Montalvânia"
+msgstr "Montalvânia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3267
+msgid "Montanha"
+msgstr "Montanha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3268
+msgid "Montanhas"
+msgstr "Montanhas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3269
+msgid "Montauri"
+msgstr "Montauri"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3270
+#: model:res.city,name:l10n_br.city_br_3271
+msgid "Monte Alegre"
+msgstr "Monte Alegre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3272
+msgid "Monte Alegre de Goiás"
+msgstr "Monte Alegre de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3273
+msgid "Monte Alegre de Minas"
+msgstr "Monte Alegre de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3274
+msgid "Monte Alegre de Sergipe"
+msgstr "Monte Alegre de Sergipe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3275
+msgid "Monte Alegre do Piauí"
+msgstr "Monte Alegre do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3276
+msgid "Monte Alegre do Sul"
+msgstr "Monte Alegre do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3277
+msgid "Monte Alegre dos Campos"
+msgstr "Monte Alegre dos Campos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3278
+msgid "Monte Alto"
+msgstr "Monte Alto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3279
+msgid "Monte Aprazível"
+msgstr "Monte Aprazível"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3280
+msgid "Monte Azul"
+msgstr "Monte Azul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3281
+msgid "Monte Azul Paulista"
+msgstr "Monte Azul Paulista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3282
+msgid "Monte Belo"
+msgstr "Monte Belo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3283
+msgid "Monte Belo do Sul"
+msgstr "Monte Belo do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3284
+msgid "Monte Carlo"
+msgstr "Monte Carlo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3285
+msgid "Monte Carmelo"
+msgstr "Monte Carmelo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3286
+#: model:res.city,name:l10n_br.city_br_3287
+msgid "Monte Castelo"
+msgstr "Monte Castelo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3290
+msgid "Monte Formoso"
+msgstr "Monte Formoso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3291
+msgid "Monte Horebe"
+msgstr "Monte Horebe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3292
+msgid "Monte Mor"
+msgstr "Monte Mor"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3293
+msgid "Monte Negro"
+msgstr "Monte Negro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3294
+msgid "Monte Santo"
+msgstr "Monte Santo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3295
+msgid "Monte Santo de Minas"
+msgstr "Monte Santo de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3296
+msgid "Monte Santo do Tocantins"
+msgstr "Monte Santo do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3297
+msgid "Monte Sião"
+msgstr "Monte Sião"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3288
+msgid "Monte das Gameleiras"
+msgstr "Monte das Gameleiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3289
+msgid "Monte do Carmo"
+msgstr "Monte do Carmo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3298
+msgid "Monteiro"
+msgstr "Monteiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3299
+msgid "Monteiro Lobato"
+msgstr "Monteiro Lobato"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3300
+msgid "Monteirópolis"
+msgstr "Monteirópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3301
+msgid "Montenegro"
+msgstr "Montenegro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3302
+msgid "Montes Altos"
+msgstr "Montes Altos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_058
+msgid "Montes Claros"
+msgstr "Montes Claros"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3303
+msgid "Montes Claros de Goiás"
+msgstr "Montes Claros de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3304
+msgid "Montezuma"
+msgstr "Montezuma"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3305
+msgid "Montividiu"
+msgstr "Montividiu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3306
+msgid "Montividiu do Norte"
+msgstr "Montividiu do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3256
+msgid "Monção"
+msgstr "Monção"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3257
+msgid "Monções"
+msgstr "Monções"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3307
+msgid "Morada Nova"
+msgstr "Morada Nova"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3308
+msgid "Morada Nova de Minas"
+msgstr "Morada Nova de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3309
+msgid "Moraújo"
+msgstr "Moraújo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3310
+msgid "Moreilândia"
+msgstr "Moreilândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3311
+msgid "Moreira Sales"
+msgstr "Moreira Sales"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3312
+msgid "Moreno"
+msgstr "Moreno"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3313
+msgid "Mormaço"
+msgstr "Mormaço"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3314
+msgid "Morpará"
+msgstr "Morpará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3315
+msgid "Morretes"
+msgstr "Morretes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3316
+#: model:res.city,name:l10n_br.city_br_3317
+msgid "Morrinhos"
+msgstr "Morrinhos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3318
+msgid "Morrinhos do Sul"
+msgstr "Morrinhos do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3319
+msgid "Morro Agudo"
+msgstr "Morro Agudo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3320
+msgid "Morro Agudo de Goiás"
+msgstr "Morro Agudo de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3321
+msgid "Morro Cabeça no Tempo"
+msgstr "Morro Cabeça no Tempo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3327
+msgid "Morro Grande"
+msgstr "Morro Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3328
+msgid "Morro Redondo"
+msgstr "Morro Redondo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3329
+msgid "Morro Reuter"
+msgstr "Morro Reuter"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3322
+msgid "Morro da Fumaça"
+msgstr "Morro da Fumaça"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3323
+msgid "Morro da Garça"
+msgstr "Morro da Garça"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3324
+msgid "Morro do Chapéu"
+msgstr "Morro do Chapéu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3325
+msgid "Morro do Chapéu do Piauí"
+msgstr "Morro do Chapéu do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3326
+msgid "Morro do Pilar"
+msgstr "Morro do Pilar"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3330
+msgid "Morros"
+msgstr "Morros"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3331
+msgid "Mortugaba"
+msgstr "Mortugaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3332
+msgid "Morungaba"
+msgstr "Morungaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_108
+msgid "Mossoró"
+msgstr "Mossoró"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3333
+msgid "Mossâmedes"
+msgstr "Mossâmedes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3334
+msgid "Mostardas"
+msgstr "Mostardas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3335
+msgid "Motuca"
+msgstr "Motuca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3336
+msgid "Mozarlândia"
+msgstr "Mozarlândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3337
+msgid "Muaná"
+msgstr "Muaná"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3338
+msgid "Mucajaí"
+msgstr "Mucajaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3339
+msgid "Mucambo"
+msgstr "Mucambo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3340
+msgid "Mucugê"
+msgstr "Mucugê"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3342
+msgid "Mucuri"
+msgstr "Mucuri"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3343
+msgid "Mucurici"
+msgstr "Mucurici"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3344
+msgid "Muitos Capões"
+msgstr "Muitos Capões"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3345
+msgid "Muliterno"
+msgstr "Muliterno"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3346
+#: model:res.city,name:l10n_br.city_br_3347
+msgid "Mulungu"
+msgstr "Mulungu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3348
+msgid "Mulungu do Morro"
+msgstr "Mulungu do Morro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3349
+#: model:res.city,name:l10n_br.city_br_3350
+#: model:res.city,name:l10n_br.city_br_3351
+msgid "Mundo Novo"
+msgstr "Mundo Novo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3352
+msgid "Munhoz"
+msgstr "Munhoz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3353
+msgid "Munhoz de Melo"
+msgstr "Munhoz de Melo"
 
 #. module: l10n_br
 #: model:ir.model.fields,help:l10n_br.field_res_company__l10n_br_im_code
@@ -380,9 +15820,160 @@ msgid "Municipal Tax Identification Number"
 msgstr "Inscrição municipal"
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3354
+msgid "Muniz Ferreira"
+msgstr "Muniz Ferreira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3355
+msgid "Muniz Freire"
+msgstr "Muniz Freire"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3357
+msgid "Muqui"
+msgstr "Muqui"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3356
+msgid "Muquém de São Francisco"
+msgstr "Muquém de São Francisco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_302
+msgid "Muriaé"
+msgstr "Muriaé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3358
+msgid "Muribeca"
+msgstr "Muribeca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3359
+msgid "Murici"
+msgstr "Murici"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3360
+msgid "Murici dos Portelas"
+msgstr "Murici dos Portelas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3361
+msgid "Muricilândia"
+msgstr "Muricilândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3362
+msgid "Muritiba"
+msgstr "Muritiba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3363
+msgid "Murutinga do Sul"
+msgstr "Murutinga do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3365
+msgid "Mutum"
+msgstr "Mutum"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3366
+msgid "Mutunópolis"
+msgstr "Mutunópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3364
+msgid "Mutuípe"
+msgstr "Mutuípe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3367
+msgid "Muzambinho"
+msgstr "Muzambinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3341
+msgid "Muçum"
+msgstr "Muçum"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3110
+msgid "Mário Campos"
+msgstr "Mário Campos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3035
+msgid "Mâncio Lima"
+msgstr "Mâncio Lima"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3004
+msgid "Mãe d'Água"
+msgstr "Mãe d'Água"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3005
+msgid "Mãe do Rio"
+msgstr "Mãe do Rio"
+
+#. module: l10n_br
 #: model:ir.model.fields,field_description:l10n_br.field_res_company__l10n_br_nire_code
 msgid "NIRE"
 msgstr "NIRE"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3368
+msgid "Nacip Raydan"
+msgstr "Nacip Raydan"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3369
+msgid "Nantes"
+msgstr "Nantes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3370
+msgid "Nanuque"
+msgstr "Nanuque"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3372
+msgid "Naque"
+msgstr "Naque"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3373
+msgid "Narandiba"
+msgstr "Narandiba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_024
+msgid "Natal"
+msgstr "Natal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3374
+msgid "Natalândia"
+msgstr "Natalândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3376
+#: model:res.city,name:l10n_br.city_br_3377
+msgid "Natividade"
+msgstr "Natividade"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3378
+msgid "Natividade da Serra"
+msgstr "Natividade da Serra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3379
+msgid "Natuba"
+msgstr "Natuba"
 
 #. module: l10n_br
 #: model:ir.model.fields,help:l10n_br.field_res_company__l10n_br_cpf_code
@@ -390,14 +15981,1204 @@ msgid "Natural Persons Register."
 msgstr "Registro Civil das Pessoas Naturais."
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3375
+msgid "Natércia"
+msgstr "Natércia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3380
+msgid "Navegantes"
+msgstr "Navegantes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3381
+msgid "Naviraí"
+msgstr "Naviraí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3387
+msgid "Nazareno"
+msgstr "Nazareno"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3388
+msgid "Nazarezinho"
+msgstr "Nazarezinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3382
+#: model:res.city,name:l10n_br.city_br_3383
+msgid "Nazaré"
+msgstr "Nazaré"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3386
+msgid "Nazaré Paulista"
+msgstr "Nazaré Paulista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3384
+msgid "Nazaré da Mata"
+msgstr "Nazaré da Mata"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3385
+msgid "Nazaré do Piauí"
+msgstr "Nazaré do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3389
+msgid "Nazária"
+msgstr "Nazária"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3390
+msgid "Nazário"
+msgstr "Nazário"
+
+#. module: l10n_br
+#: model_terms:ir.ui.view,arch_db:l10n_br.br_partner_address_form
+msgid "Neighborhood"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3392
+msgid "Nepomuceno"
+msgstr "Nepomuceno"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3393
+msgid "Nerópolis"
+msgstr "Nerópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3394
+msgid "Neves Paulista"
+msgstr "Neves Paulista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3391
+msgid "Neópolis"
+msgstr "Neópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3395
+msgid "Nhamundá"
+msgstr "Nhamundá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3396
+msgid "Nhandeara"
+msgstr "Nhandeara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3397
+msgid "Nicolau Vergueiro"
+msgstr "Nicolau Vergueiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3398
+msgid "Nilo Peçanha"
+msgstr "Nilo Peçanha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_204
+msgid "Nilópolis"
+msgstr "Nilópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3399
+msgid "Nina Rodrigues"
+msgstr "Nina Rodrigues"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3400
+msgid "Ninheira"
+msgstr "Ninheira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3401
+msgid "Nioaque"
+msgstr "Nioaque"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3402
+msgid "Nipoã"
+msgstr "Nipoã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3403
+msgid "Niquelândia"
+msgstr "Niquelândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_044
+msgid "Niterói"
+msgstr "Niterói"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3405
+msgid "Nobres"
+msgstr "Nobres"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3406
+msgid "Nonoai"
+msgstr "Nonoai"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3407
+msgid "Nordestina"
+msgstr "Nordestina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3408
+msgid "Normandia"
+msgstr "Normandia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3409
+msgid "Nortelândia"
+msgstr "Nortelândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3410
+msgid "Nossa Senhora Aparecida"
+msgstr "Nossa Senhora Aparecida"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3411
+msgid "Nossa Senhora da Glória"
+msgstr "Nossa Senhora da Glória"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3412
+msgid "Nossa Senhora das Dores"
+msgstr "Nossa Senhora das Dores"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3413
+msgid "Nossa Senhora das Graças"
+msgstr "Nossa Senhora das Graças"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3414
+msgid "Nossa Senhora de Lourdes"
+msgstr "Nossa Senhora de Lourdes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3415
+msgid "Nossa Senhora de Nazaré"
+msgstr "Nossa Senhora de Nazaré"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3416
+msgid "Nossa Senhora do Livramento"
+msgstr "Nossa Senhora do Livramento"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_156
+msgid "Nossa Senhora do Socorro"
+msgstr "Nossa Senhora do Socorro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3417
+msgid "Nossa Senhora dos Remédios"
+msgstr "Nossa Senhora dos Remédios"
+
+#. module: l10n_br
 #: model:l10n_latam.document.type,name:l10n_br.dt_06
 msgid "Nota Fiscal / Electricity Bill"
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3418
+msgid "Nova Aliança"
+msgstr "Nova Aliança"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3419
+msgid "Nova Aliança do Ivaí"
+msgstr "Nova Aliança do Ivaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3420
+msgid "Nova Alvorada"
+msgstr "Nova Alvorada"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3421
+msgid "Nova Alvorada do Sul"
+msgstr "Nova Alvorada do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3422
+msgid "Nova América"
+msgstr "Nova América"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3423
+msgid "Nova América da Colina"
+msgstr "Nova América da Colina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3424
+msgid "Nova Andradina"
+msgstr "Nova Andradina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3425
+msgid "Nova Araçá"
+msgstr "Nova Araçá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3426
+#: model:res.city,name:l10n_br.city_br_3427
+msgid "Nova Aurora"
+msgstr "Nova Aurora"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3428
+msgid "Nova Bandeirantes"
+msgstr "Nova Bandeirantes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3429
+msgid "Nova Bassano"
+msgstr "Nova Bassano"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3430
+msgid "Nova Belém"
+msgstr "Nova Belém"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3431
+msgid "Nova Boa Vista"
+msgstr "Nova Boa Vista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3432
+msgid "Nova Brasilândia"
+msgstr "Nova Brasilândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3433
+msgid "Nova Brasilândia D'Oeste"
+msgstr "Nova Brasilândia D'Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3434
+msgid "Nova Bréscia"
+msgstr "Nova Bréscia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3435
+msgid "Nova Campina"
+msgstr "Nova Campina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3436
+msgid "Nova Canaã"
+msgstr "Nova Canaã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3438
+msgid "Nova Canaã Paulista"
+msgstr "Nova Canaã Paulista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3437
+msgid "Nova Canaã do Norte"
+msgstr "Nova Canaã do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3439
+msgid "Nova Candelária"
+msgstr "Nova Candelária"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3440
+msgid "Nova Cantu"
+msgstr "Nova Cantu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3441
+msgid "Nova Castilho"
+msgstr "Nova Castilho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3442
+msgid "Nova Colinas"
+msgstr "Nova Colinas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3443
+msgid "Nova Crixás"
+msgstr "Nova Crixás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3444
+msgid "Nova Cruz"
+msgstr "Nova Cruz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3445
+msgid "Nova Era"
+msgstr "Nova Era"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3446
+msgid "Nova Erechim"
+msgstr "Nova Erechim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3447
+msgid "Nova Esperança"
+msgstr "Nova Esperança"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3448
+msgid "Nova Esperança do Piriá"
+msgstr "Nova Esperança do Piriá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3449
+msgid "Nova Esperança do Sudoeste"
+msgstr "Nova Esperança do Sudoeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3450
+msgid "Nova Esperança do Sul"
+msgstr "Nova Esperança do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3451
+msgid "Nova Europa"
+msgstr "Nova Europa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3454
+msgid "Nova Floresta"
+msgstr "Nova Floresta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_159
+msgid "Nova Friburgo"
+msgstr "Nova Friburgo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3452
+#: model:res.city,name:l10n_br.city_br_3453
+msgid "Nova Fátima"
+msgstr "Nova Fátima"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3455
+msgid "Nova Glória"
+msgstr "Nova Glória"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3456
+msgid "Nova Granada"
+msgstr "Nova Granada"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3457
+msgid "Nova Guarita"
+msgstr "Nova Guarita"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3458
+msgid "Nova Guataporanga"
+msgstr "Nova Guataporanga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3459
+msgid "Nova Hartz"
+msgstr "Nova Hartz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3460
+msgid "Nova Ibiá"
+msgstr "Nova Ibiá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_023
+msgid "Nova Iguaçu"
+msgstr "Nova Iguaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3461
+msgid "Nova Iguaçu de Goiás"
+msgstr "Nova Iguaçu de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3462
+msgid "Nova Independência"
+msgstr "Nova Independência"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3463
+msgid "Nova Iorque"
+msgstr "Nova Iorque"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3464
+msgid "Nova Ipixuna"
+msgstr "Nova Ipixuna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3465
+msgid "Nova Itaberaba"
+msgstr "Nova Itaberaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3466
+msgid "Nova Itarana"
+msgstr "Nova Itarana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3467
+msgid "Nova Lacerda"
+msgstr "Nova Lacerda"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3468
+msgid "Nova Laranjeiras"
+msgstr "Nova Laranjeiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_280
+msgid "Nova Lima"
+msgstr "Nova Lima"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3469
+msgid "Nova Londrina"
+msgstr "Nova Londrina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3470
+msgid "Nova Luzitânia"
+msgstr "Nova Luzitânia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3471
+msgid "Nova Mamoré"
+msgstr "Nova Mamoré"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3472
+msgid "Nova Marilândia"
+msgstr "Nova Marilândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3473
+msgid "Nova Maringá"
+msgstr "Nova Maringá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3475
+msgid "Nova Monte Verde"
+msgstr "Nova Monte Verde"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3476
+msgid "Nova Mutum"
+msgstr "Nova Mutum"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3474
+msgid "Nova Módica"
+msgstr "Nova Módica"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3477
+msgid "Nova Nazaré"
+msgstr "Nova Nazaré"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3478
+msgid "Nova Odessa"
+msgstr "Nova Odessa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3481
+#: model:res.city,name:l10n_br.city_br_3482
+#: model:res.city,name:l10n_br.city_br_3483
+msgid "Nova Olinda"
+msgstr "Nova Olinda"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3484
+msgid "Nova Olinda do Maranhão"
+msgstr "Nova Olinda do Maranhão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3485
+msgid "Nova Olinda do Norte"
+msgstr "Nova Olinda do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3479
+#: model:res.city,name:l10n_br.city_br_3480
+msgid "Nova Olímpia"
+msgstr "Nova Olímpia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3487
+msgid "Nova Palma"
+msgstr "Nova Palma"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3488
+msgid "Nova Palmeira"
+msgstr "Nova Palmeira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3489
+msgid "Nova Petrópolis"
+msgstr "Nova Petrópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3490
+msgid "Nova Ponte"
+msgstr "Nova Ponte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3491
+msgid "Nova Porteirinha"
+msgstr "Nova Porteirinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3492
+msgid "Nova Prata"
+msgstr "Nova Prata"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3493
+msgid "Nova Prata do Iguaçu"
+msgstr "Nova Prata do Iguaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3486
+msgid "Nova Pádua"
+msgstr "Nova Pádua"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3494
+msgid "Nova Ramada"
+msgstr "Nova Ramada"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3495
+msgid "Nova Redenção"
+msgstr "Nova Redenção"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3496
+msgid "Nova Resende"
+msgstr "Nova Resende"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3497
+msgid "Nova Roma"
+msgstr "Nova Roma"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3498
+msgid "Nova Roma do Sul"
+msgstr "Nova Roma do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3499
+msgid "Nova Rosalândia"
+msgstr "Nova Rosalândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3500
+msgid "Nova Russas"
+msgstr "Nova Russas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3501
+msgid "Nova Santa Bárbara"
+msgstr "Nova Santa Bárbara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3502
+msgid "Nova Santa Helena"
+msgstr "Nova Santa Helena"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3503
+#: model:res.city,name:l10n_br.city_br_3504
+msgid "Nova Santa Rita"
+msgstr "Nova Santa Rita"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3505
+msgid "Nova Santa Rosa"
+msgstr "Nova Santa Rosa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_296
+msgid "Nova Serrana"
+msgstr "Nova Serrana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3506
+msgid "Nova Soure"
+msgstr "Nova Soure"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3507
+msgid "Nova Tebas"
+msgstr "Nova Tebas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3508
+msgid "Nova Timboteua"
+msgstr "Nova Timboteua"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3509
+msgid "Nova Trento"
+msgstr "Nova Trento"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3510
+msgid "Nova Ubiratã"
+msgstr "Nova Ubiratã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3511
+#: model:res.city,name:l10n_br.city_br_3512
+msgid "Nova União"
+msgstr "Nova União"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3514
+#: model:res.city,name:l10n_br.city_br_3515
+msgid "Nova Veneza"
+msgstr "Nova Veneza"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3513
+msgid "Nova Venécia"
+msgstr "Nova Venécia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3516
+msgid "Nova Viçosa"
+msgstr "Nova Viçosa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3517
+msgid "Nova Xavantina"
+msgstr "Nova Xavantina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3518
+msgid "Novais"
+msgstr "Novais"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3519
+msgid "Novo Acordo"
+msgstr "Novo Acordo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3520
+msgid "Novo Airão"
+msgstr "Novo Airão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3521
+msgid "Novo Alegre"
+msgstr "Novo Alegre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3522
+msgid "Novo Aripuanã"
+msgstr "Novo Aripuanã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3523
+msgid "Novo Barreiro"
+msgstr "Novo Barreiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3524
+msgid "Novo Brasil"
+msgstr "Novo Brasil"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3525
+msgid "Novo Cabrais"
+msgstr "Novo Cabrais"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3526
+msgid "Novo Cruzeiro"
+msgstr "Novo Cruzeiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_305
+msgid "Novo Gama"
+msgstr "Novo Gama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_133
+msgid "Novo Hamburgo"
+msgstr "Novo Hamburgo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3527
+#: model:res.city,name:l10n_br.city_br_3528
+#: model:res.city,name:l10n_br.city_br_3529
+msgid "Novo Horizonte"
+msgstr "Novo Horizonte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3530
+msgid "Novo Horizonte do Norte"
+msgstr "Novo Horizonte do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3531
+msgid "Novo Horizonte do Oeste"
+msgstr "Novo Horizonte do Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3532
+msgid "Novo Horizonte do Sul"
+msgstr "Novo Horizonte do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3533
+msgid "Novo Itacolomi"
+msgstr "Novo Itacolomi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3534
+msgid "Novo Jardim"
+msgstr "Novo Jardim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3535
+msgid "Novo Lino"
+msgstr "Novo Lino"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3536
+msgid "Novo Machado"
+msgstr "Novo Machado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3537
+msgid "Novo Mundo"
+msgstr "Novo Mundo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3538
+msgid "Novo Oriente"
+msgstr "Novo Oriente"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3539
+msgid "Novo Oriente de Minas"
+msgstr "Novo Oriente de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3540
+msgid "Novo Oriente do Piauí"
+msgstr "Novo Oriente do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3541
+msgid "Novo Planalto"
+msgstr "Novo Planalto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3542
+msgid "Novo Progresso"
+msgstr "Novo Progresso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3543
+msgid "Novo Repartimento"
+msgstr "Novo Repartimento"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3544
+#: model:res.city,name:l10n_br.city_br_3545
+msgid "Novo Santo Antônio"
+msgstr "Novo Santo Antônio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3546
+msgid "Novo São Joaquim"
+msgstr "Novo São Joaquim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3547
+msgid "Novo Tiradentes"
+msgstr "Novo Tiradentes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3548
+msgid "Novo Triunfo"
+msgstr "Novo Triunfo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3549
+msgid "Novo Xingu"
+msgstr "Novo Xingu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3550
+msgid "Novorizonte"
+msgstr "Novorizonte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3551
+msgid "Nuporanga"
+msgstr "Nuporanga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3371
+msgid "Não-Me-Toque"
+msgstr "Não-Me-Toque"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3404
+msgid "Nísia Floresta"
+msgstr "Nísia Floresta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3553
+msgid "Ocara"
+msgstr "Ocara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3554
+msgid "Ocauçu"
+msgstr "Ocauçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3555
+msgid "Oeiras"
+msgstr "Oeiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3556
+msgid "Oeiras do Pará"
+msgstr "Oeiras do Pará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3557
+msgid "Oiapoque"
+msgstr "Oiapoque"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3558
+msgid "Olaria"
+msgstr "Olaria"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3565
+msgid "Olho D'Água do Piauí"
+msgstr "Olho D'Água do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3560
+msgid "Olho d'Água"
+msgstr "Olho d'Água"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3566
+msgid "Olho d'Água Grande"
+msgstr "Olho d'Água Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3561
+msgid "Olho d'Água das Cunhãs"
+msgstr "Olho d'Água das Cunhãs"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3562
+msgid "Olho d'Água das Flores"
+msgstr "Olho d'Água das Flores"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3564
+msgid "Olho d'Água do Casado"
+msgstr "Olho d'Água do Casado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3563
+msgid "Olho-d'Água do Borges"
+msgstr "Olho-d'Água do Borges"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3567
+msgid "Olhos-d'Água"
+msgstr "Olhos-d'Água"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_076
+msgid "Olinda"
+msgstr "Olinda"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3570
+msgid "Olinda Nova do Maranhão"
+msgstr "Olinda Nova do Maranhão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3571
+msgid "Olindina"
+msgstr "Olindina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3572
+msgid "Olivedos"
+msgstr "Olivedos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3573
+msgid "Oliveira"
+msgstr "Oliveira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3576
+msgid "Oliveira Fortes"
+msgstr "Oliveira Fortes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3574
+msgid "Oliveira de Fátima"
+msgstr "Oliveira de Fátima"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3575
+msgid "Oliveira dos Brejinhos"
+msgstr "Oliveira dos Brejinhos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3577
+msgid "Olivença"
+msgstr "Olivença"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3568
+msgid "Olímpia"
+msgstr "Olímpia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3569
+msgid "Olímpio Noronha"
+msgstr "Olímpio Noronha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3579
+msgid "Onda Verde"
+msgstr "Onda Verde"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3578
+msgid "Onça de Pitangui"
+msgstr "Onça de Pitangui"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3580
+msgid "Oratórios"
+msgstr "Oratórios"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3581
+msgid "Oriente"
+msgstr "Oriente"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3582
+msgid "Orindiúva"
+msgstr "Orindiúva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3583
+msgid "Oriximiná"
+msgstr "Oriximiná"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3585
+msgid "Orizona"
+msgstr "Orizona"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3584
+msgid "Orizânia"
+msgstr "Orizânia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3587
+msgid "Orleans"
+msgstr "Orleans"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3586
+msgid "Orlândia"
+msgstr "Orlândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3588
+msgid "Orobó"
+msgstr "Orobó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3589
+msgid "Orocó"
+msgstr "Orocó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3591
+msgid "Ortigueira"
+msgstr "Ortigueira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3590
+msgid "Orós"
+msgstr "Orós"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_026
+msgid "Osasco"
+msgstr "Osasco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3592
+msgid "Oscar Bressane"
+msgstr "Oscar Bressane"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3594
+msgid "Osvaldo Cruz"
+msgstr "Osvaldo Cruz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3593
+msgid "Osório"
+msgstr "Osório"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3595
+msgid "Otacílio Costa"
+msgstr "Otacílio Costa"
+
+#. module: l10n_br
 #: model:ir.model.fields.selection,name:l10n_br.selection__account_fiscal_position__l10n_br_fp_type__interstate
 msgid "Other interstate"
 msgstr "Outro interestadual"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3598
+msgid "Ouricuri"
+msgstr "Ouricuri"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3599
+msgid "Ourilândia do Norte"
+msgstr "Ourilândia do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_304
+msgid "Ourinhos"
+msgstr "Ourinhos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3600
+msgid "Ourizona"
+msgstr "Ourizona"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3597
+msgid "Ouriçangas"
+msgstr "Ouriçangas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3601
+msgid "Ouro"
+msgstr "Ouro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3602
+#: model:res.city,name:l10n_br.city_br_3603
+#: model:res.city,name:l10n_br.city_br_3604
+msgid "Ouro Branco"
+msgstr "Ouro Branco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3605
+msgid "Ouro Fino"
+msgstr "Ouro Fino"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3606
+msgid "Ouro Preto"
+msgstr "Ouro Preto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3607
+msgid "Ouro Preto do Oeste"
+msgstr "Ouro Preto do Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3608
+msgid "Ouro Velho"
+msgstr "Ouro Velho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3609
+#: model:res.city,name:l10n_br.city_br_3610
+msgid "Ouro Verde"
+msgstr "Ouro Verde"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3611
+msgid "Ouro Verde de Goiás"
+msgstr "Ouro Verde de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3612
+msgid "Ouro Verde de Minas"
+msgstr "Ouro Verde de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3613
+msgid "Ouro Verde do Oeste"
+msgstr "Ouro Verde do Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3614
+msgid "Ouroeste"
+msgstr "Ouroeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3615
+msgid "Ourolândia"
+msgstr "Ourolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3596
+msgid "Ourém"
+msgstr "Ourém"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3616
+msgid "Ouvidor"
+msgstr "Ouvidor"
 
 #. module: l10n_br
 #: model:account.report.line,name:l10n_br.tax_report_pis
@@ -415,6 +17196,2662 @@ msgid "PIS tax"
 msgstr "Imposto PIS"
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3617
+msgid "Pacaembu"
+msgstr "Pacaembu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3619
+msgid "Pacajus"
+msgstr "Pacajus"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3618
+msgid "Pacajá"
+msgstr "Pacajá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3620
+msgid "Pacaraima"
+msgstr "Pacaraima"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3621
+#: model:res.city,name:l10n_br.city_br_3622
+msgid "Pacatuba"
+msgstr "Pacatuba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3623
+msgid "Pacoti"
+msgstr "Pacoti"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3624
+msgid "Pacujá"
+msgstr "Pacujá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3625
+msgid "Padre Bernardo"
+msgstr "Padre Bernardo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3626
+msgid "Padre Carvalho"
+msgstr "Padre Carvalho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3627
+msgid "Padre Marcos"
+msgstr "Padre Marcos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3628
+msgid "Padre Paraíso"
+msgstr "Padre Paraíso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3629
+msgid "Paes Landim"
+msgstr "Paes Landim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3630
+msgid "Pai Pedro"
+msgstr "Pai Pedro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3631
+msgid "Paial"
+msgstr "Paial"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3633
+msgid "Paim Filho"
+msgstr "Paim Filho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3634
+msgid "Paineiras"
+msgstr "Paineiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3635
+msgid "Painel"
+msgstr "Painel"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3636
+msgid "Pains"
+msgstr "Pains"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3637
+msgid "Paiva"
+msgstr "Paiva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3632
+msgid "Paiçandu"
+msgstr "Paiçandu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3638
+msgid "Pajeú do Piauí"
+msgstr "Pajeú do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3639
+#: model:res.city,name:l10n_br.city_br_3640
+msgid "Palestina"
+msgstr "Palestina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3641
+msgid "Palestina de Goiás"
+msgstr "Palestina de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3642
+msgid "Palestina do Pará"
+msgstr "Palestina do Pará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3643
+msgid "Palhano"
+msgstr "Palhano"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_141
+msgid "Palhoça"
+msgstr "Palhoça"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3644
+msgid "Palma"
+msgstr "Palma"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3645
+msgid "Palma Sola"
+msgstr "Palma Sola"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3647
+msgid "Palmares"
+msgstr "Palmares"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3649
+msgid "Palmares Paulista"
+msgstr "Palmares Paulista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3648
+msgid "Palmares do Sul"
+msgstr "Palmares do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_091
+#: model:res.city,name:l10n_br.city_br_3650
+msgid "Palmas"
+msgstr "Palmas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3651
+msgid "Palmas de Monte Alto"
+msgstr "Palmas de Monte Alto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3652
+#: model:res.city,name:l10n_br.city_br_3653
+msgid "Palmeira"
+msgstr "Palmeira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3654
+msgid "Palmeira d'Oeste"
+msgstr "Palmeira d'Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3655
+msgid "Palmeira das Missões"
+msgstr "Palmeira das Missões"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3656
+msgid "Palmeira do Piauí"
+msgstr "Palmeira do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3657
+msgid "Palmeira dos Índios"
+msgstr "Palmeira dos Índios"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3658
+msgid "Palmeirais"
+msgstr "Palmeirais"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3660
+msgid "Palmeirante"
+msgstr "Palmeirante"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3661
+msgid "Palmeiras"
+msgstr "Palmeiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3662
+msgid "Palmeiras de Goiás"
+msgstr "Palmeiras de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3663
+msgid "Palmeiras do Tocantins"
+msgstr "Palmeiras do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3664
+msgid "Palmeirina"
+msgstr "Palmeirina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3659
+msgid "Palmeirândia"
+msgstr "Palmeirândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3665
+msgid "Palmeirópolis"
+msgstr "Palmeirópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3666
+msgid "Palmelo"
+msgstr "Palmelo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3667
+msgid "Palminópolis"
+msgstr "Palminópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3668
+#: model:res.city,name:l10n_br.city_br_3669
+msgid "Palmital"
+msgstr "Palmital"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3670
+msgid "Palmitinho"
+msgstr "Palmitinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3671
+msgid "Palmitos"
+msgstr "Palmitos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3646
+msgid "Palmácia"
+msgstr "Palmácia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3672
+msgid "Palmópolis"
+msgstr "Palmópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3673
+msgid "Palotina"
+msgstr "Palotina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3675
+msgid "Panambi"
+msgstr "Panambi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3674
+msgid "Panamá"
+msgstr "Panamá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3676
+msgid "Pancas"
+msgstr "Pancas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3677
+msgid "Panelas"
+msgstr "Panelas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3678
+msgid "Panorama"
+msgstr "Panorama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3679
+msgid "Pantano Grande"
+msgstr "Pantano Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3681
+msgid "Papagaios"
+msgstr "Papagaios"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3682
+msgid "Papanduva"
+msgstr "Papanduva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3683
+msgid "Paquetá"
+msgstr "Paquetá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3685
+msgid "Paracambi"
+msgstr "Paracambi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3686
+msgid "Paracatu"
+msgstr "Paracatu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3687
+msgid "Paracuru"
+msgstr "Paracuru"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_297
+msgid "Paragominas"
+msgstr "Paragominas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3688
+msgid "Paraguaçu"
+msgstr "Paraguaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3689
+msgid "Paraguaçu Paulista"
+msgstr "Paraguaçu Paulista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3692
+msgid "Paraibano"
+msgstr "Paraibano"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3693
+msgid "Paraibuna"
+msgstr "Paraibuna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3694
+msgid "Paraipaba"
+msgstr "Paraipaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3701
+msgid "Paraisópolis"
+msgstr "Paraisópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3702
+msgid "Parambu"
+msgstr "Parambu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3703
+msgid "Paramirim"
+msgstr "Paramirim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3704
+msgid "Paramoti"
+msgstr "Paramoti"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3707
+msgid "Paranacity"
+msgstr "Paranacity"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_205
+msgid "Paranaguá"
+msgstr "Paranaguá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3709
+msgid "Paranaiguara"
+msgstr "Paranaiguara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3711
+msgid "Paranapanema"
+msgstr "Paranapanema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3712
+msgid "Paranapoema"
+msgstr "Paranapoema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3713
+msgid "Paranapuã"
+msgstr "Paranapuã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3714
+msgid "Paranatama"
+msgstr "Paranatama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3715
+msgid "Paranatinga"
+msgstr "Paranatinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3716
+msgid "Paranavaí"
+msgstr "Paranavaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3708
+msgid "Paranaíba"
+msgstr "Paranaíba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3710
+msgid "Paranaíta"
+msgstr "Paranaíta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3717
+msgid "Paranhos"
+msgstr "Paranhos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3705
+msgid "Paraná"
+msgstr "Paraná"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3706
+msgid "Paranã"
+msgstr "Paranã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3718
+msgid "Paraopeba"
+msgstr "Paraopeba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3719
+msgid "Parapuã"
+msgstr "Parapuã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3720
+msgid "Parari"
+msgstr "Parari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3721
+msgid "Paratinga"
+msgstr "Paratinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3722
+msgid "Paraty"
+msgstr "Paraty"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_106
+msgid "Parauapebas"
+msgstr "Parauapebas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3725
+msgid "Parazinho"
+msgstr "Parazinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3690
+msgid "Paraí"
+msgstr "Paraí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3691
+msgid "Paraíba do Sul"
+msgstr "Paraíba do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3695
+#: model:res.city,name:l10n_br.city_br_3696
+msgid "Paraíso"
+msgstr "Paraíso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3697
+msgid "Paraíso das Águas"
+msgstr "Paraíso das Águas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3698
+msgid "Paraíso do Norte"
+msgstr "Paraíso do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3699
+msgid "Paraíso do Sul"
+msgstr "Paraíso do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3700
+msgid "Paraíso do Tocantins"
+msgstr "Paraíso do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3723
+msgid "Paraú"
+msgstr "Paraú"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3724
+msgid "Paraúna"
+msgstr "Paraúna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3726
+msgid "Pardinho"
+msgstr "Pardinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3727
+msgid "Pareci Novo"
+msgstr "Pareci Novo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3728
+msgid "Parecis"
+msgstr "Parecis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3729
+msgid "Parelhas"
+msgstr "Parelhas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3730
+msgid "Pariconha"
+msgstr "Pariconha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3731
+msgid "Parintins"
+msgstr "Parintins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3732
+msgid "Paripiranga"
+msgstr "Paripiranga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3733
+msgid "Paripueira"
+msgstr "Paripueira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3734
+msgid "Pariquera-Açu"
+msgstr "Pariquera-Açu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3735
+msgid "Parisi"
+msgstr "Parisi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3736
+msgid "Parnaguá"
+msgstr "Parnaguá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_115
+#: model:res.city,name:l10n_br.city_br_3737
+msgid "Parnamirim"
+msgstr "Parnamirim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3738
+msgid "Parnarama"
+msgstr "Parnarama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_184
+msgid "Parnaíba"
+msgstr "Parnaíba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3739
+msgid "Parobé"
+msgstr "Parobé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3684
+msgid "Pará de Minas"
+msgstr "Pará de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3741
+msgid "Passa Quatro"
+msgstr "Passa Quatro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3742
+msgid "Passa Sete"
+msgstr "Passa Sete"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3743
+msgid "Passa Tempo"
+msgstr "Passa Tempo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3740
+msgid "Passa e Fica"
+msgstr "Passa e Fica"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3744
+msgid "Passa-Vinte"
+msgstr "Passa-Vinte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3745
+msgid "Passabém"
+msgstr "Passabém"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3746
+#: model:res.city,name:l10n_br.city_br_3747
+msgid "Passagem"
+msgstr "Passagem"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3748
+msgid "Passagem Franca"
+msgstr "Passagem Franca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3749
+msgid "Passagem Franca do Piauí"
+msgstr "Passagem Franca do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3750
+msgid "Passira"
+msgstr "Passira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_147
+msgid "Passo Fundo"
+msgstr "Passo Fundo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3751
+msgid "Passo de Camaragibe"
+msgstr "Passo de Camaragibe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3752
+msgid "Passo de Torres"
+msgstr "Passo de Torres"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3753
+msgid "Passo do Sobrado"
+msgstr "Passo do Sobrado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_279
+msgid "Passos"
+msgstr "Passos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3754
+msgid "Passos Maia"
+msgstr "Passos Maia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3755
+msgid "Pastos Bons"
+msgstr "Pastos Bons"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3756
+msgid "Patis"
+msgstr "Patis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3757
+msgid "Pato Bragado"
+msgstr "Pato Bragado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3758
+msgid "Pato Branco"
+msgstr "Pato Branco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_311
+msgid "Patos"
+msgstr "Patos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_186
+msgid "Patos de Minas"
+msgstr "Patos de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3759
+msgid "Patos do Piauí"
+msgstr "Patos do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3760
+msgid "Patrocínio"
+msgstr "Patrocínio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3762
+msgid "Patrocínio Paulista"
+msgstr "Patrocínio Paulista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3761
+msgid "Patrocínio do Muriaé"
+msgstr "Patrocínio do Muriaé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3763
+msgid "Patu"
+msgstr "Patu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3764
+msgid "Paty do Alferes"
+msgstr "Paty do Alferes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3765
+msgid "Pau Brasil"
+msgstr "Pau Brasil"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3766
+#: model:res.city,name:l10n_br.city_br_3767
+msgid "Pau D'Arco"
+msgstr "Pau D'Arco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3768
+msgid "Pau D'Arco do Piauí"
+msgstr "Pau D'Arco do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3769
+msgid "Pau dos Ferros"
+msgstr "Pau dos Ferros"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3770
+msgid "Paudalho"
+msgstr "Paudalho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3771
+msgid "Pauini"
+msgstr "Pauini"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3772
+msgid "Paula Cândido"
+msgstr "Paula Cândido"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3773
+msgid "Paula Freitas"
+msgstr "Paula Freitas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3774
+msgid "Paulicéia"
+msgstr "Paulicéia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3775
+msgid "Paulino Neves"
+msgstr "Paulino Neves"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_080
+#: model:res.city,name:l10n_br.city_br_3776
+msgid "Paulista"
+msgstr "Paulista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3777
+msgid "Paulistana"
+msgstr "Paulistana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3779
+msgid "Paulistas"
+msgstr "Paulistas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3778
+msgid "Paulistânia"
+msgstr "Paulistânia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_276
+msgid "Paulo Afonso"
+msgstr "Paulo Afonso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3780
+msgid "Paulo Bento"
+msgstr "Paulo Bento"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3782
+msgid "Paulo Frontin"
+msgstr "Paulo Frontin"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3783
+msgid "Paulo Jacinto"
+msgstr "Paulo Jacinto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3784
+msgid "Paulo Lopes"
+msgstr "Paulo Lopes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3785
+msgid "Paulo Ramos"
+msgstr "Paulo Ramos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3781
+msgid "Paulo de Faria"
+msgstr "Paulo de Faria"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_284
+msgid "Paulínia"
+msgstr "Paulínia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3787
+msgid "Paverama"
+msgstr "Paverama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3788
+msgid "Pavussu"
+msgstr "Pavussu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3786
+msgid "Pavão"
+msgstr "Pavão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_206
+msgid "Paço do Lumiar"
+msgstr "Paço do Lumiar"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3790
+msgid "Peabiru"
+msgstr "Peabiru"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3792
+msgid "Pederneiras"
+msgstr "Pederneiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3793
+msgid "Pedra"
+msgstr "Pedra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3794
+msgid "Pedra Azul"
+msgstr "Pedra Azul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3795
+msgid "Pedra Bela"
+msgstr "Pedra Bela"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3796
+msgid "Pedra Bonita"
+msgstr "Pedra Bonita"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3797
+#: model:res.city,name:l10n_br.city_br_3798
+msgid "Pedra Branca"
+msgstr "Pedra Branca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3799
+msgid "Pedra Branca do Amapari"
+msgstr "Pedra Branca do Amapari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3802
+msgid "Pedra Dourada"
+msgstr "Pedra Dourada"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3803
+msgid "Pedra Grande"
+msgstr "Pedra Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3804
+msgid "Pedra Lavrada"
+msgstr "Pedra Lavrada"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3805
+msgid "Pedra Mole"
+msgstr "Pedra Mole"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3806
+#: model:res.city,name:l10n_br.city_br_3807
+msgid "Pedra Preta"
+msgstr "Pedra Preta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3800
+msgid "Pedra do Anta"
+msgstr "Pedra do Anta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3801
+msgid "Pedra do Indaiá"
+msgstr "Pedra do Indaiá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3808
+msgid "Pedralva"
+msgstr "Pedralva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3809
+msgid "Pedranópolis"
+msgstr "Pedranópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3811
+msgid "Pedras Altas"
+msgstr "Pedras Altas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3814
+msgid "Pedras Grandes"
+msgstr "Pedras Grandes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3812
+msgid "Pedras de Fogo"
+msgstr "Pedras de Fogo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3813
+msgid "Pedras de Maria da Cruz"
+msgstr "Pedras de Maria da Cruz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3815
+msgid "Pedregulho"
+msgstr "Pedregulho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3816
+msgid "Pedreira"
+msgstr "Pedreira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3817
+msgid "Pedreiras"
+msgstr "Pedreiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3818
+msgid "Pedrinhas"
+msgstr "Pedrinhas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3819
+msgid "Pedrinhas Paulista"
+msgstr "Pedrinhas Paulista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3820
+msgid "Pedrinópolis"
+msgstr "Pedrinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3821
+msgid "Pedro Afonso"
+msgstr "Pedro Afonso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3822
+msgid "Pedro Alexandre"
+msgstr "Pedro Alexandre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3823
+msgid "Pedro Avelino"
+msgstr "Pedro Avelino"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3824
+msgid "Pedro Canário"
+msgstr "Pedro Canário"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3827
+msgid "Pedro Gomes"
+msgstr "Pedro Gomes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3828
+msgid "Pedro II"
+msgstr "Pedro II"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3829
+msgid "Pedro Laurentino"
+msgstr "Pedro Laurentino"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3830
+msgid "Pedro Leopoldo"
+msgstr "Pedro Leopoldo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3831
+msgid "Pedro Osório"
+msgstr "Pedro Osório"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3832
+msgid "Pedro Régis"
+msgstr "Pedro Régis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3833
+msgid "Pedro Teixeira"
+msgstr "Pedro Teixeira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3834
+msgid "Pedro Velho"
+msgstr "Pedro Velho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3825
+msgid "Pedro de Toledo"
+msgstr "Pedro de Toledo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3826
+msgid "Pedro do Rosário"
+msgstr "Pedro do Rosário"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3810
+msgid "Pedrão"
+msgstr "Pedrão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3835
+msgid "Peixe"
+msgstr "Peixe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3836
+msgid "Peixe-Boi"
+msgstr "Peixe-Boi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3837
+msgid "Peixoto de Azevedo"
+msgstr "Peixoto de Azevedo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3838
+msgid "Pejuçara"
+msgstr "Pejuçara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_086
+msgid "Pelotas"
+msgstr "Pelotas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3839
+msgid "Penaforte"
+msgstr "Penaforte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3840
+msgid "Penalva"
+msgstr "Penalva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3842
+msgid "Pendências"
+msgstr "Pendências"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3843
+msgid "Penedo"
+msgstr "Penedo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3844
+msgid "Penha"
+msgstr "Penha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3845
+msgid "Pentecoste"
+msgstr "Pentecoste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3841
+msgid "Penápolis"
+msgstr "Penápolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3846
+msgid "Pequeri"
+msgstr "Pequeri"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3847
+msgid "Pequi"
+msgstr "Pequi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3848
+msgid "Pequizeiro"
+msgstr "Pequizeiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3849
+msgid "Perdigão"
+msgstr "Perdigão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3850
+msgid "Perdizes"
+msgstr "Perdizes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3851
+msgid "Perdões"
+msgstr "Perdões"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3852
+msgid "Pereira Barreto"
+msgstr "Pereira Barreto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3853
+msgid "Pereiras"
+msgstr "Pereiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3854
+msgid "Pereiro"
+msgstr "Pereiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3855
+msgid "Peri Mirim"
+msgstr "Peri Mirim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3856
+msgid "Periquito"
+msgstr "Periquito"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3857
+msgid "Peritiba"
+msgstr "Peritiba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3858
+msgid "Peritoró"
+msgstr "Peritoró"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3859
+msgid "Perobal"
+msgstr "Perobal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3862
+msgid "Perolândia"
+msgstr "Perolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3863
+msgid "Peruíbe"
+msgstr "Peruíbe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3864
+msgid "Pescador"
+msgstr "Pescador"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3865
+msgid "Pescaria Brava"
+msgstr "Pescaria Brava"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3866
+msgid "Pesqueira"
+msgstr "Pesqueira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_065
+msgid "Petrolina"
+msgstr "Petrolina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3869
+msgid "Petrolina de Goiás"
+msgstr "Petrolina de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3867
+#: model:res.city,name:l10n_br.city_br_3868
+msgid "Petrolândia"
+msgstr "Petrolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_099
+msgid "Petrópolis"
+msgstr "Petrópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3791
+msgid "Peçanha"
+msgstr "Peçanha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3871
+msgid "Piacatu"
+msgstr "Piacatu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3872
+msgid "Piancó"
+msgstr "Piancó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3873
+msgid "Piatã"
+msgstr "Piatã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3874
+msgid "Piau"
+msgstr "Piau"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3870
+msgid "Piaçabuçu"
+msgstr "Piaçabuçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3875
+msgid "Picada Café"
+msgstr "Picada Café"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3877
+msgid "Picos"
+msgstr "Picos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3878
+msgid "Picuí"
+msgstr "Picuí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3879
+msgid "Piedade"
+msgstr "Piedade"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3880
+msgid "Piedade de Caratinga"
+msgstr "Piedade de Caratinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3881
+msgid "Piedade de Ponte Nova"
+msgstr "Piedade de Ponte Nova"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3882
+msgid "Piedade do Rio Grande"
+msgstr "Piedade do Rio Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3883
+msgid "Piedade dos Gerais"
+msgstr "Piedade dos Gerais"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3886
+#: model:res.city,name:l10n_br.city_br_3887
+msgid "Pilar"
+msgstr "Pilar"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3888
+msgid "Pilar de Goiás"
+msgstr "Pilar de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3889
+msgid "Pilar do Sul"
+msgstr "Pilar do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3885
+msgid "Pilão Arcado"
+msgstr "Pilão Arcado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3890
+#: model:res.city,name:l10n_br.city_br_3891
+msgid "Pilões"
+msgstr "Pilões"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3892
+msgid "Pilõezinhos"
+msgstr "Pilõezinhos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3893
+msgid "Pimenta"
+msgstr "Pimenta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3894
+msgid "Pimenta Bueno"
+msgstr "Pimenta Bueno"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3895
+msgid "Pimenteiras"
+msgstr "Pimenteiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3896
+msgid "Pimenteiras do Oeste"
+msgstr "Pimenteiras do Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_179
+msgid "Pindamonhangaba"
+msgstr "Pindamonhangaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3898
+msgid "Pindaré-Mirim"
+msgstr "Pindaré-Mirim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3897
+msgid "Pindaí"
+msgstr "Pindaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3899
+msgid "Pindoba"
+msgstr "Pindoba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3900
+msgid "Pindobaçu"
+msgstr "Pindobaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3901
+msgid "Pindorama"
+msgstr "Pindorama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3902
+msgid "Pindorama do Tocantins"
+msgstr "Pindorama do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3903
+msgid "Pindoretama"
+msgstr "Pindoretama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3904
+msgid "Pingo-d'Água"
+msgstr "Pingo-d'Água"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_237
+msgid "Pinhais"
+msgstr "Pinhais"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3905
+msgid "Pinhal"
+msgstr "Pinhal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3908
+msgid "Pinhal Grande"
+msgstr "Pinhal Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3906
+msgid "Pinhal da Serra"
+msgstr "Pinhal da Serra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3907
+msgid "Pinhal de São Bento"
+msgstr "Pinhal de São Bento"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3910
+#: model:res.city,name:l10n_br.city_br_3911
+msgid "Pinhalzinho"
+msgstr "Pinhalzinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3909
+msgid "Pinhalão"
+msgstr "Pinhalão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3914
+msgid "Pinheiral"
+msgstr "Pinheiral"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3915
+msgid "Pinheirinho do Vale"
+msgstr "Pinheirinho do Vale"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3916
+msgid "Pinheiro"
+msgstr "Pinheiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3917
+msgid "Pinheiro Machado"
+msgstr "Pinheiro Machado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3918
+msgid "Pinheiro Preto"
+msgstr "Pinheiro Preto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3919
+msgid "Pinheiros"
+msgstr "Pinheiros"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3912
+#: model:res.city,name:l10n_br.city_br_3913
+msgid "Pinhão"
+msgstr "Pinhão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3920
+msgid "Pintadas"
+msgstr "Pintadas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3921
+msgid "Pinto Bandeira"
+msgstr "Pinto Bandeira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3922
+msgid "Pintópolis"
+msgstr "Pintópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3923
+msgid "Pio IX"
+msgstr "Pio IX"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3924
+msgid "Pio XII"
+msgstr "Pio XII"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3925
+msgid "Piquerobi"
+msgstr "Piquerobi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3926
+msgid "Piquet Carneiro"
+msgstr "Piquet Carneiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3927
+msgid "Piquete"
+msgstr "Piquete"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3928
+msgid "Piracaia"
+msgstr "Piracaia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3929
+msgid "Piracanjuba"
+msgstr "Piracanjuba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3930
+msgid "Piracema"
+msgstr "Piracema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_054
+msgid "Piracicaba"
+msgstr "Piracicaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3931
+msgid "Piracuruca"
+msgstr "Piracuruca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3935
+msgid "Piraju"
+msgstr "Piraju"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3936
+msgid "Pirajuba"
+msgstr "Pirajuba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3937
+msgid "Pirajuí"
+msgstr "Pirajuí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3938
+msgid "Pirambu"
+msgstr "Pirambu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3939
+msgid "Piranga"
+msgstr "Piranga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3940
+msgid "Pirangi"
+msgstr "Pirangi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3942
+msgid "Piranguinho"
+msgstr "Piranguinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3941
+msgid "Piranguçu"
+msgstr "Piranguçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3943
+#: model:res.city,name:l10n_br.city_br_3944
+msgid "Piranhas"
+msgstr "Piranhas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3945
+msgid "Pirapemas"
+msgstr "Pirapemas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3946
+msgid "Pirapetinga"
+msgstr "Pirapetinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3948
+msgid "Pirapora"
+msgstr "Pirapora"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3949
+msgid "Pirapora do Bom Jesus"
+msgstr "Pirapora do Bom Jesus"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3950
+msgid "Pirapozinho"
+msgstr "Pirapozinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3947
+msgid "Pirapó"
+msgstr "Pirapó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_256
+msgid "Piraquara"
+msgstr "Piraquara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3951
+msgid "Piraquê"
+msgstr "Piraquê"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3952
+msgid "Pirassununga"
+msgstr "Pirassununga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3953
+msgid "Piratini"
+msgstr "Piratini"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3954
+msgid "Piratininga"
+msgstr "Piratininga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3955
+msgid "Piratuba"
+msgstr "Piratuba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3932
+msgid "Piraí"
+msgstr "Piraí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3933
+msgid "Piraí do Norte"
+msgstr "Piraí do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3934
+msgid "Piraí do Sul"
+msgstr "Piraí do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3956
+msgid "Piraúba"
+msgstr "Piraúba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3957
+msgid "Pirenópolis"
+msgstr "Pirenópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3959
+msgid "Pires Ferreira"
+msgstr "Pires Ferreira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3958
+msgid "Pires do Rio"
+msgstr "Pires do Rio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3961
+msgid "Piripiri"
+msgstr "Piripiri"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3960
+msgid "Piripá"
+msgstr "Piripá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3962
+msgid "Piritiba"
+msgstr "Piritiba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3963
+msgid "Pirpirituba"
+msgstr "Pirpirituba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3964
+msgid "Pitanga"
+msgstr "Pitanga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3965
+#: model:res.city,name:l10n_br.city_br_3966
+msgid "Pitangueiras"
+msgstr "Pitangueiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3967
+msgid "Pitangui"
+msgstr "Pitangui"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3968
+msgid "Pitimbu"
+msgstr "Pitimbu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3969
+msgid "Pium"
+msgstr "Pium"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3971
+msgid "Piumhi"
+msgstr "Piumhi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3876
+msgid "Piçarra"
+msgstr "Piçarra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3884
+msgid "Piên"
+msgstr "Piên"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3970
+msgid "Piúma"
+msgstr "Piúma"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3972
+msgid "Placas"
+msgstr "Placas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_299
+msgid "Planaltina"
+msgstr "Planaltina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3974
+msgid "Planaltina do Paraná"
+msgstr "Planaltina do Paraná"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3975
+msgid "Planaltino"
+msgstr "Planaltino"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3976
+#: model:res.city,name:l10n_br.city_br_3977
+#: model:res.city,name:l10n_br.city_br_3978
+#: model:res.city,name:l10n_br.city_br_3979
+msgid "Planalto"
+msgstr "Planalto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3980
+msgid "Planalto Alegre"
+msgstr "Planalto Alegre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3981
+msgid "Planalto da Serra"
+msgstr "Planalto da Serra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3982
+msgid "Planura"
+msgstr "Planura"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3983
+msgid "Platina"
+msgstr "Platina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3973
+msgid "Plácido de Castro"
+msgstr "Plácido de Castro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3986
+msgid "Pocinhos"
+msgstr "Pocinhos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3996
+msgid "Poconé"
+msgstr "Poconé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3997
+msgid "Pocrane"
+msgstr "Pocrane"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3998
+msgid "Pojuca"
+msgstr "Pojuca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3999
+msgid "Poloni"
+msgstr "Poloni"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4000
+msgid "Pombal"
+msgstr "Pombal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4001
+msgid "Pombos"
+msgstr "Pombos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4002
+msgid "Pomerode"
+msgstr "Pomerode"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4003
+msgid "Pompéia"
+msgstr "Pompéia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4004
+msgid "Pompéu"
+msgstr "Pompéu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4005
+msgid "Pongaí"
+msgstr "Pongaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_072
+msgid "Ponta Grossa"
+msgstr "Ponta Grossa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4007
+msgid "Ponta Porã"
+msgstr "Ponta Porã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4006
+msgid "Ponta de Pedras"
+msgstr "Ponta de Pedras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4008
+msgid "Pontal"
+msgstr "Pontal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4009
+msgid "Pontal do Araguaia"
+msgstr "Pontal do Araguaia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4010
+msgid "Pontal do Paraná"
+msgstr "Pontal do Paraná"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4011
+msgid "Pontalina"
+msgstr "Pontalina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4012
+msgid "Pontalinda"
+msgstr "Pontalinda"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4014
+msgid "Ponte Alta"
+msgstr "Ponte Alta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4015
+msgid "Ponte Alta do Bom Jesus"
+msgstr "Ponte Alta do Bom Jesus"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4016
+msgid "Ponte Alta do Norte"
+msgstr "Ponte Alta do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4017
+msgid "Ponte Alta do Tocantins"
+msgstr "Ponte Alta do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4018
+msgid "Ponte Branca"
+msgstr "Ponte Branca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4019
+msgid "Ponte Nova"
+msgstr "Ponte Nova"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4020
+msgid "Ponte Preta"
+msgstr "Ponte Preta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4021
+msgid "Ponte Serrada"
+msgstr "Ponte Serrada"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4023
+msgid "Pontes Gestal"
+msgstr "Pontes Gestal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4022
+msgid "Pontes e Lacerda"
+msgstr "Pontes e Lacerda"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4024
+msgid "Ponto Belo"
+msgstr "Ponto Belo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4025
+msgid "Ponto Chique"
+msgstr "Ponto Chique"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4027
+msgid "Ponto Novo"
+msgstr "Ponto Novo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4026
+msgid "Ponto dos Volantes"
+msgstr "Ponto dos Volantes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4013
+msgid "Pontão"
+msgstr "Pontão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4028
+msgid "Populina"
+msgstr "Populina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4029
+msgid "Poranga"
+msgstr "Poranga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4030
+msgid "Porangaba"
+msgstr "Porangaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4031
+msgid "Porangatu"
+msgstr "Porangatu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4032
+msgid "Porciúncula"
+msgstr "Porciúncula"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4033
+msgid "Porecatu"
+msgstr "Porecatu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4034
+msgid "Portalegre"
+msgstr "Portalegre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4037
+msgid "Porteiras"
+msgstr "Porteiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4038
+msgid "Porteirinha"
+msgstr "Porteirinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4036
+msgid "Porteirão"
+msgstr "Porteirão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4039
+msgid "Portel"
+msgstr "Portel"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4040
+msgid "Portelândia"
+msgstr "Portelândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4041
+msgid "Porto"
+msgstr "Porto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4042
+msgid "Porto Acre"
+msgstr "Porto Acre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_011
+msgid "Porto Alegre"
+msgstr "Porto Alegre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4043
+msgid "Porto Alegre do Norte"
+msgstr "Porto Alegre do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4044
+msgid "Porto Alegre do Piauí"
+msgstr "Porto Alegre do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4045
+msgid "Porto Alegre do Tocantins"
+msgstr "Porto Alegre do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4046
+msgid "Porto Amazonas"
+msgstr "Porto Amazonas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4047
+msgid "Porto Barreiro"
+msgstr "Porto Barreiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4048
+msgid "Porto Belo"
+msgstr "Porto Belo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4049
+msgid "Porto Calvo"
+msgstr "Porto Calvo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4055
+msgid "Porto Esperidião"
+msgstr "Porto Esperidião"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4056
+msgid "Porto Estrela"
+msgstr "Porto Estrela"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4057
+msgid "Porto Feliz"
+msgstr "Porto Feliz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4058
+msgid "Porto Ferreira"
+msgstr "Porto Ferreira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4059
+msgid "Porto Firme"
+msgstr "Porto Firme"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4060
+msgid "Porto Franco"
+msgstr "Porto Franco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4061
+msgid "Porto Grande"
+msgstr "Porto Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4062
+msgid "Porto Lucena"
+msgstr "Porto Lucena"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4063
+msgid "Porto Mauá"
+msgstr "Porto Mauá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4064
+msgid "Porto Murtinho"
+msgstr "Porto Murtinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4065
+msgid "Porto Nacional"
+msgstr "Porto Nacional"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4066
+msgid "Porto Real"
+msgstr "Porto Real"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4067
+msgid "Porto Real do Colégio"
+msgstr "Porto Real do Colégio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4068
+msgid "Porto Rico"
+msgstr "Porto Rico"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4069
+msgid "Porto Rico do Maranhão"
+msgstr "Porto Rico do Maranhão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_174
+msgid "Porto Seguro"
+msgstr "Porto Seguro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4070
+msgid "Porto União"
+msgstr "Porto União"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_049
+msgid "Porto Velho"
+msgstr "Porto Velho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4071
+msgid "Porto Vera Cruz"
+msgstr "Porto Vera Cruz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4072
+msgid "Porto Vitória"
+msgstr "Porto Vitória"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4073
+msgid "Porto Walter"
+msgstr "Porto Walter"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4074
+msgid "Porto Xavier"
+msgstr "Porto Xavier"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4050
+msgid "Porto da Folha"
+msgstr "Porto da Folha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4051
+msgid "Porto de Moz"
+msgstr "Porto de Moz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4052
+msgid "Porto de Pedras"
+msgstr "Porto de Pedras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4053
+msgid "Porto do Mangue"
+msgstr "Porto do Mangue"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4054
+msgid "Porto dos Gaúchos"
+msgstr "Porto dos Gaúchos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4035
+msgid "Portão"
+msgstr "Portão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4075
+msgid "Posse"
+msgstr "Posse"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4077
+msgid "Potengi"
+msgstr "Potengi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4078
+msgid "Potim"
+msgstr "Potim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4079
+msgid "Potiraguá"
+msgstr "Potiraguá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4080
+msgid "Potirendaba"
+msgstr "Potirendaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4081
+msgid "Potiretama"
+msgstr "Potiretama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4076
+msgid "Poté"
+msgstr "Poté"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_197
+msgid "Pouso Alegre"
+msgstr "Pouso Alegre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4082
+msgid "Pouso Alto"
+msgstr "Pouso Alto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4083
+msgid "Pouso Novo"
+msgstr "Pouso Novo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4084
+msgid "Pouso Redondo"
+msgstr "Pouso Redondo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4085
+msgid "Poxoréu"
+msgstr "Poxoréu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_306
+msgid "Poá"
+msgstr "Poá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3987
+msgid "Poço Branco"
+msgstr "Poço Branco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3988
+msgid "Poço Dantas"
+msgstr "Poço Dantas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3992
+msgid "Poço Fundo"
+msgstr "Poço Fundo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3993
+msgid "Poço Redondo"
+msgstr "Poço Redondo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3994
+msgid "Poço Verde"
+msgstr "Poço Verde"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3989
+msgid "Poço das Antas"
+msgstr "Poço das Antas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3990
+msgid "Poço das Trincheiras"
+msgstr "Poço das Trincheiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3991
+msgid "Poço de José de Moura"
+msgstr "Poço de José de Moura"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_183
+msgid "Poços de Caldas"
+msgstr "Poços de Caldas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3984
+msgid "Poção"
+msgstr "Poção"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3985
+msgid "Poção de Pedras"
+msgstr "Poção de Pedras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3995
+msgid "Poções"
+msgstr "Poções"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4086
+msgid "Pracinha"
+msgstr "Pracinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4087
+msgid "Pracuúba"
+msgstr "Pracuúba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4088
+msgid "Prado"
+msgstr "Prado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4089
+msgid "Prado Ferreira"
+msgstr "Prado Ferreira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4091
+msgid "Prados"
+msgstr "Prados"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4090
+msgid "Pradópolis"
+msgstr "Pradópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_077
+#: model:res.city,name:l10n_br.city_br_4092
+msgid "Praia Grande"
+msgstr "Praia Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4093
+msgid "Praia Norte"
+msgstr "Praia Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4094
+msgid "Prainha"
+msgstr "Prainha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4095
+msgid "Pranchita"
+msgstr "Pranchita"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4096
+#: model:res.city,name:l10n_br.city_br_4097
+msgid "Prata"
+msgstr "Prata"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4098
+msgid "Prata do Piauí"
+msgstr "Prata do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4101
+msgid "Pratinha"
+msgstr "Pratinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4100
+msgid "Pratápolis"
+msgstr "Pratápolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4099
+msgid "Pratânia"
+msgstr "Pratânia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4102
+msgid "Presidente Alves"
+msgstr "Presidente Alves"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4103
+#: model:res.city,name:l10n_br.city_br_4104
+msgid "Presidente Bernardes"
+msgstr "Presidente Bernardes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4105
+msgid "Presidente Castello Branco"
+msgstr "Presidente Castello Branco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4106
+msgid "Presidente Castelo Branco"
+msgstr "Presidente Castelo Branco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4107
+#: model:res.city,name:l10n_br.city_br_4108
+msgid "Presidente Dutra"
+msgstr "Presidente Dutra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4109
+msgid "Presidente Epitácio"
+msgstr "Presidente Epitácio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4110
+msgid "Presidente Figueiredo"
+msgstr "Presidente Figueiredo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4111
+msgid "Presidente Getúlio"
+msgstr "Presidente Getúlio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4113
+#: model:res.city,name:l10n_br.city_br_4114
+msgid "Presidente Juscelino"
+msgstr "Presidente Juscelino"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4112
+msgid "Presidente Jânio Quadros"
+msgstr "Presidente Jânio Quadros"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4115
+#: model:res.city,name:l10n_br.city_br_4116
+msgid "Presidente Kennedy"
+msgstr "Presidente Kennedy"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4117
+msgid "Presidente Kubitschek"
+msgstr "Presidente Kubitschek"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4118
+msgid "Presidente Lucena"
+msgstr "Presidente Lucena"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4119
+#: model:res.city,name:l10n_br.city_br_4120
+msgid "Presidente Médici"
+msgstr "Presidente Médici"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4121
+msgid "Presidente Nereu"
+msgstr "Presidente Nereu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4122
+msgid "Presidente Olegário"
+msgstr "Presidente Olegário"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_138
+msgid "Presidente Prudente"
+msgstr "Presidente Prudente"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4123
+msgid "Presidente Sarney"
+msgstr "Presidente Sarney"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4124
+msgid "Presidente Tancredo Neves"
+msgstr "Presidente Tancredo Neves"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4125
+msgid "Presidente Vargas"
+msgstr "Presidente Vargas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4126
+msgid "Presidente Venceslau"
+msgstr "Presidente Venceslau"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4127
+#: model:res.city,name:l10n_br.city_br_4128
+msgid "Primavera"
+msgstr "Primavera"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4129
+msgid "Primavera de Rondônia"
+msgstr "Primavera de Rondônia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4130
+msgid "Primavera do Leste"
+msgstr "Primavera do Leste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4131
+msgid "Primeira Cruz"
+msgstr "Primeira Cruz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4132
+msgid "Primeiro de Maio"
+msgstr "Primeiro de Maio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4133
+msgid "Princesa"
+msgstr "Princesa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4134
+msgid "Princesa Isabel"
+msgstr "Princesa Isabel"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4135
+msgid "Professor Jamil"
+msgstr "Professor Jamil"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4136
+msgid "Progresso"
+msgstr "Progresso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4137
+msgid "Promissão"
+msgstr "Promissão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4138
+msgid "Propriá"
+msgstr "Propriá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4139
+msgid "Protásio Alves"
+msgstr "Protásio Alves"
+
+#. module: l10n_br
+#: model:ir.model.fields,field_description:l10n_br.field_account_setup_bank_manual_config__proxy_type
+#: model:ir.model.fields,field_description:l10n_br.field_res_partner_bank__proxy_type
+msgid "Proxy Type"
+msgstr "Tipo de proxy"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4140
+msgid "Prudente de Morais"
+msgstr "Prudente de Morais"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4141
+msgid "Prudentópolis"
+msgstr "Prudentópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4142
+msgid "Pugmil"
+msgstr "Pugmil"
+
+#. module: l10n_br
 #: model:account.report.line,name:l10n_br.tax_report_ipi_extrada_tributada
 msgid "Purchase taxed at a zero rate"
 msgstr "Entrada tributada com alíquota zero"
@@ -423,6 +19860,253 @@ msgstr "Entrada tributada com alíquota zero"
 #: model:account.report.line,name:l10n_br.tax_report_ipi_extrada_com
 msgid "Purchase with Credit Recovery"
 msgstr "Entrada com recuperação de crédito"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4143
+msgid "Pureza"
+msgstr "Pureza"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4144
+msgid "Putinga"
+msgstr "Putinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4145
+msgid "Puxinanã"
+msgstr "Puxinanã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3680
+msgid "Pão de Açúcar"
+msgstr "Pão de Açúcar"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3789
+msgid "Pé de Serra"
+msgstr "Pé de Serra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3860
+msgid "Pérola"
+msgstr "Pérola"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3861
+msgid "Pérola d'Oeste"
+msgstr "Pérola d'Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4146
+msgid "Quadra"
+msgstr "Quadra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4147
+msgid "Quaraí"
+msgstr "Quaraí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4148
+msgid "Quartel Geral"
+msgstr "Quartel Geral"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4149
+msgid "Quarto Centenário"
+msgstr "Quarto Centenário"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4151
+msgid "Quatiguá"
+msgstr "Quatiguá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4152
+msgid "Quatipuru"
+msgstr "Quatipuru"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4153
+msgid "Quatis"
+msgstr "Quatis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4154
+msgid "Quatro Barras"
+msgstr "Quatro Barras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4155
+msgid "Quatro Irmãos"
+msgstr "Quatro Irmãos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4156
+msgid "Quatro Pontes"
+msgstr "Quatro Pontes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4150
+msgid "Quatá"
+msgstr "Quatá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4157
+msgid "Quebrangulo"
+msgstr "Quebrangulo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4158
+msgid "Quedas do Iguaçu"
+msgstr "Quedas do Iguaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4159
+msgid "Queimada Nova"
+msgstr "Queimada Nova"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4160
+#: model:res.city,name:l10n_br.city_br_4161
+msgid "Queimadas"
+msgstr "Queimadas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_213
+msgid "Queimados"
+msgstr "Queimados"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4162
+msgid "Queiroz"
+msgstr "Queiroz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4163
+msgid "Queluz"
+msgstr "Queluz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4164
+msgid "Queluzito"
+msgstr "Queluzito"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4165
+msgid "Querência"
+msgstr "Querência"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4166
+msgid "Querência do Norte"
+msgstr "Querência do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4167
+msgid "Quevedos"
+msgstr "Quevedos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4168
+msgid "Quijingue"
+msgstr "Quijingue"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4169
+msgid "Quilombo"
+msgstr "Quilombo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4170
+msgid "Quinta do Sol"
+msgstr "Quinta do Sol"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4171
+msgid "Quintana"
+msgstr "Quintana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4172
+msgid "Quinze de Novembro"
+msgstr "Quinze de Novembro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4173
+msgid "Quipapá"
+msgstr "Quipapá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4174
+msgid "Quirinópolis"
+msgstr "Quirinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4175
+msgid "Quissamã"
+msgstr "Quissamã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4176
+msgid "Quitandinha"
+msgstr "Quitandinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4177
+msgid "Quiterianópolis"
+msgstr "Quiterianópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4178
+#: model:res.city,name:l10n_br.city_br_4179
+msgid "Quixaba"
+msgstr "Quixaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4180
+msgid "Quixabeira"
+msgstr "Quixabeira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4181
+msgid "Quixadá"
+msgstr "Quixadá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4182
+msgid "Quixelô"
+msgstr "Quixelô"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4183
+msgid "Quixeramobim"
+msgstr "Quixeramobim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4184
+msgid "Quixeré"
+msgstr "Quixeré"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4185
+msgid "Rafael Fernandes"
+msgstr "Rafael Fernandes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4186
+msgid "Rafael Godeiro"
+msgstr "Rafael Godeiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4187
+msgid "Rafael Jambeiro"
+msgstr "Rafael Jambeiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4188
+msgid "Rafard"
+msgstr "Rafard"
 
 #. module: l10n_br
 #: model:l10n_latam.document.type,name:l10n_br.dt_11
@@ -435,14 +20119,958 @@ msgid "Railway Ticket"
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4189
+msgid "Ramilândia"
+msgstr "Ramilândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4190
+msgid "Rancharia"
+msgstr "Rancharia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4191
+msgid "Rancho Alegre"
+msgstr "Rancho Alegre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4192
+msgid "Rancho Alegre D'Oeste"
+msgstr "Rancho Alegre D'Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4193
+msgid "Rancho Queimado"
+msgstr "Rancho Queimado"
+
+#. module: l10n_br
+#: model:ir.model.fields.selection,name:l10n_br.selection__res_partner_bank__proxy_type__br_random
+msgid "Random Key (BR)"
+msgstr "Chave aleatória"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4194
+msgid "Raposa"
+msgstr "Raposa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4195
+msgid "Raposos"
+msgstr "Raposos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4196
+msgid "Raul Soares"
+msgstr "Raul Soares"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4197
+msgid "Realeza"
+msgstr "Realeza"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4198
+msgid "Rebouças"
+msgstr "Rebouças"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_009
+msgid "Recife"
+msgstr "Recife"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4199
+msgid "Recreio"
+msgstr "Recreio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4200
+msgid "Recursolândia"
+msgstr "Recursolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4205
+msgid "Redentora"
+msgstr "Redentora"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4201
+#: model:res.city,name:l10n_br.city_br_4202
+msgid "Redenção"
+msgstr "Redenção"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4203
+msgid "Redenção da Serra"
+msgstr "Redenção da Serra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4204
+msgid "Redenção do Gurguéia"
+msgstr "Redenção do Gurguéia"
+
+#. module: l10n_br
 #: model:ir.model.fields,field_description:l10n_br.field_account_tax__base_reduction
 msgid "Redution"
 msgstr "Redução"
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4206
+msgid "Reduto"
+msgstr "Reduto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4207
+msgid "Regeneração"
+msgstr "Regeneração"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4208
+msgid "Regente Feijó"
+msgstr "Regente Feijó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4209
+msgid "Reginópolis"
+msgstr "Reginópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4210
+msgid "Registro"
+msgstr "Registro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4211
+msgid "Relvado"
+msgstr "Relvado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4212
+msgid "Remanso"
+msgstr "Remanso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4213
+msgid "Remígio"
+msgstr "Remígio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4214
+msgid "Renascença"
+msgstr "Renascença"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4215
+msgid "Reriutaba"
+msgstr "Reriutaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_233
+msgid "Resende"
+msgstr "Resende"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4216
+msgid "Resende Costa"
+msgstr "Resende Costa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4217
+msgid "Reserva"
+msgstr "Reserva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4218
+msgid "Reserva do Cabaçal"
+msgstr "Reserva do Cabaçal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4219
+msgid "Reserva do Iguaçu"
+msgstr "Reserva do Iguaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4220
+msgid "Resplendor"
+msgstr "Resplendor"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4221
+msgid "Ressaquinha"
+msgstr "Ressaquinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4222
+msgid "Restinga"
+msgstr "Restinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4223
+msgid "Restinga Sêca"
+msgstr "Restinga Sêca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4224
+msgid "Retirolândia"
+msgstr "Retirolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4232
+#: model:res.city,name:l10n_br.city_br_4233
+msgid "Riachinho"
+msgstr "Riachinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4241
+msgid "Riacho Frio"
+msgstr "Riacho Frio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4234
+msgid "Riacho da Cruz"
+msgstr "Riacho da Cruz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4235
+msgid "Riacho das Almas"
+msgstr "Riacho das Almas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4236
+#: model:res.city,name:l10n_br.city_br_4237
+msgid "Riacho de Santana"
+msgstr "Riacho de Santana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4238
+msgid "Riacho de Santo Antônio"
+msgstr "Riacho de Santo Antônio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4239
+msgid "Riacho dos Cavalos"
+msgstr "Riacho dos Cavalos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4240
+msgid "Riacho dos Machados"
+msgstr "Riacho dos Machados"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4242
+#: model:res.city,name:l10n_br.city_br_4243
+msgid "Riachuelo"
+msgstr "Riachuelo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4225
+#: model:res.city,name:l10n_br.city_br_4226
+msgid "Riachão"
+msgstr "Riachão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4227
+msgid "Riachão das Neves"
+msgstr "Riachão das Neves"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4228
+msgid "Riachão do Bacamarte"
+msgstr "Riachão do Bacamarte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4229
+msgid "Riachão do Dantas"
+msgstr "Riachão do Dantas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4230
+msgid "Riachão do Jacuípe"
+msgstr "Riachão do Jacuípe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4231
+msgid "Riachão do Poço"
+msgstr "Riachão do Poço"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4244
+msgid "Rialma"
+msgstr "Rialma"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4245
+msgid "Rianápolis"
+msgstr "Rianápolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4246
+msgid "Ribamar Fiquene"
+msgstr "Ribamar Fiquene"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4247
+msgid "Ribas do Rio Pardo"
+msgstr "Ribas do Rio Pardo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4248
+msgid "Ribeira"
+msgstr "Ribeira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4249
+msgid "Ribeira do Amparo"
+msgstr "Ribeira do Amparo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4250
+msgid "Ribeira do Piauí"
+msgstr "Ribeira do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4251
+msgid "Ribeira do Pombal"
+msgstr "Ribeira do Pombal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4265
+msgid "Ribeiro Gonçalves"
+msgstr "Ribeiro Gonçalves"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4252
+msgid "Ribeirão"
+msgstr "Ribeirão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4253
+msgid "Ribeirão Bonito"
+msgstr "Ribeirão Bonito"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4254
+msgid "Ribeirão Branco"
+msgstr "Ribeirão Branco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4255
+msgid "Ribeirão Cascalheira"
+msgstr "Ribeirão Cascalheira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4256
+msgid "Ribeirão Claro"
+msgstr "Ribeirão Claro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4257
+msgid "Ribeirão Corrente"
+msgstr "Ribeirão Corrente"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4262
+msgid "Ribeirão Grande"
+msgstr "Ribeirão Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_269
+msgid "Ribeirão Pires"
+msgstr "Ribeirão Pires"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_029
+msgid "Ribeirão Preto"
+msgstr "Ribeirão Preto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4263
+msgid "Ribeirão Vermelho"
+msgstr "Ribeirão Vermelho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_084
+msgid "Ribeirão das Neves"
+msgstr "Ribeirão das Neves"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4258
+msgid "Ribeirão do Largo"
+msgstr "Ribeirão do Largo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4259
+msgid "Ribeirão do Pinhal"
+msgstr "Ribeirão do Pinhal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4260
+msgid "Ribeirão do Sul"
+msgstr "Ribeirão do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4261
+msgid "Ribeirão dos Índios"
+msgstr "Ribeirão dos Índios"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4264
+msgid "Ribeirãozinho"
+msgstr "Ribeirãozinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4266
+msgid "Ribeirópolis"
+msgstr "Ribeirópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4267
+msgid "Rifaina"
+msgstr "Rifaina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4268
+msgid "Rincão"
+msgstr "Rincão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4269
+msgid "Rinópolis"
+msgstr "Rinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4270
+msgid "Rio Acima"
+msgstr "Rio Acima"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4271
+msgid "Rio Azul"
+msgstr "Rio Azul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4272
+msgid "Rio Bananal"
+msgstr "Rio Bananal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4273
+msgid "Rio Bom"
+msgstr "Rio Bom"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4274
+msgid "Rio Bonito"
+msgstr "Rio Bonito"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4275
+msgid "Rio Bonito do Iguaçu"
+msgstr "Rio Bonito do Iguaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_070
+#: model:res.city,name:l10n_br.city_br_4276
+msgid "Rio Branco"
+msgstr "Rio Branco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4277
+msgid "Rio Branco do Ivaí"
+msgstr "Rio Branco do Ivaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4278
+msgid "Rio Branco do Sul"
+msgstr "Rio Branco do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4279
+msgid "Rio Brilhante"
+msgstr "Rio Brilhante"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4280
+msgid "Rio Casca"
+msgstr "Rio Casca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_151
+#: model:res.city,name:l10n_br.city_br_4281
+msgid "Rio Claro"
+msgstr "Rio Claro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4282
+msgid "Rio Crespo"
+msgstr "Rio Crespo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4295
+msgid "Rio Doce"
+msgstr "Rio Doce"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4299
+msgid "Rio Espera"
+msgstr "Rio Espera"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4300
+msgid "Rio Formoso"
+msgstr "Rio Formoso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4301
+msgid "Rio Fortuna"
+msgstr "Rio Fortuna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_158
+msgid "Rio Grande"
+msgstr "Rio Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4302
+msgid "Rio Grande da Serra"
+msgstr "Rio Grande da Serra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4303
+msgid "Rio Grande do Piauí"
+msgstr "Rio Grande do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4304
+msgid "Rio Largo"
+msgstr "Rio Largo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4305
+msgid "Rio Manso"
+msgstr "Rio Manso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4306
+msgid "Rio Maria"
+msgstr "Rio Maria"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4307
+msgid "Rio Negrinho"
+msgstr "Rio Negrinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4308
+#: model:res.city,name:l10n_br.city_br_4309
+msgid "Rio Negro"
+msgstr "Rio Negro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4310
+msgid "Rio Novo"
+msgstr "Rio Novo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4311
+msgid "Rio Novo do Sul"
+msgstr "Rio Novo do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4312
+msgid "Rio Paranaíba"
+msgstr "Rio Paranaíba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4313
+msgid "Rio Pardo"
+msgstr "Rio Pardo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4314
+msgid "Rio Pardo de Minas"
+msgstr "Rio Pardo de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4315
+msgid "Rio Piracicaba"
+msgstr "Rio Piracicaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4316
+msgid "Rio Pomba"
+msgstr "Rio Pomba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4317
+msgid "Rio Preto"
+msgstr "Rio Preto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4318
+msgid "Rio Preto da Eva"
+msgstr "Rio Preto da Eva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4319
+msgid "Rio Quente"
+msgstr "Rio Quente"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4320
+msgid "Rio Real"
+msgstr "Rio Real"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4321
+msgid "Rio Rufino"
+msgstr "Rio Rufino"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4322
+msgid "Rio Sono"
+msgstr "Rio Sono"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4323
+msgid "Rio Tinto"
+msgstr "Rio Tinto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_136
+msgid "Rio Verde"
+msgstr "Rio Verde"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4324
+msgid "Rio Verde de Mato Grosso"
+msgstr "Rio Verde de Mato Grosso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4325
+msgid "Rio Vermelho"
+msgstr "Rio Vermelho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4283
+msgid "Rio da Conceição"
+msgstr "Rio da Conceição"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4284
+msgid "Rio das Antas"
+msgstr "Rio das Antas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4285
+msgid "Rio das Flores"
+msgstr "Rio das Flores"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_193
+msgid "Rio das Ostras"
+msgstr "Rio das Ostras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4286
+msgid "Rio das Pedras"
+msgstr "Rio das Pedras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4287
+msgid "Rio de Contas"
+msgstr "Rio de Contas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_002
+msgid "Rio de Janeiro"
+msgstr "Rio de Janeiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4288
+msgid "Rio do Antônio"
+msgstr "Rio do Antônio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4289
+msgid "Rio do Campo"
+msgstr "Rio do Campo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4290
+msgid "Rio do Fogo"
+msgstr "Rio do Fogo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4291
+msgid "Rio do Oeste"
+msgstr "Rio do Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4292
+msgid "Rio do Pires"
+msgstr "Rio do Pires"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4293
+msgid "Rio do Prado"
+msgstr "Rio do Prado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4294
+msgid "Rio do Sul"
+msgstr "Rio do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4296
+msgid "Rio dos Bois"
+msgstr "Rio dos Bois"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4297
+msgid "Rio dos Cedros"
+msgstr "Rio dos Cedros"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4298
+msgid "Rio dos Índios"
+msgstr "Rio dos Índios"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4326
+msgid "Riolândia"
+msgstr "Riolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4327
+msgid "Riozinho"
+msgstr "Riozinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4328
+msgid "Riqueza"
+msgstr "Riqueza"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4329
+msgid "Ritápolis"
+msgstr "Ritápolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4330
+msgid "Riversul"
+msgstr "Riversul"
+
+#. module: l10n_br
 #: model:l10n_latam.document.type,name:l10n_br.dt_13
 msgid "Road Ticket"
 msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4331
+msgid "Roca Sales"
+msgstr "Roca Sales"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4332
+msgid "Rochedo"
+msgstr "Rochedo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4333
+msgid "Rochedo de Minas"
+msgstr "Rochedo de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4334
+msgid "Rodeio"
+msgstr "Rodeio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4335
+msgid "Rodeio Bonito"
+msgstr "Rodeio Bonito"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4336
+msgid "Rodeiro"
+msgstr "Rodeiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4337
+msgid "Rodelas"
+msgstr "Rodelas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4338
+msgid "Rodolfo Fernandes"
+msgstr "Rodolfo Fernandes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4339
+msgid "Rodrigues Alves"
+msgstr "Rodrigues Alves"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4340
+msgid "Rolador"
+msgstr "Rolador"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4342
+msgid "Rolante"
+msgstr "Rolante"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4343
+msgid "Rolim de Moura"
+msgstr "Rolim de Moura"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4341
+msgid "Rolândia"
+msgstr "Rolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4344
+msgid "Romaria"
+msgstr "Romaria"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4345
+msgid "Romelândia"
+msgstr "Romelândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4346
+msgid "Roncador"
+msgstr "Roncador"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4347
+msgid "Ronda Alta"
+msgstr "Ronda Alta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4348
+msgid "Rondinha"
+msgstr "Rondinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4349
+msgid "Rondolândia"
+msgstr "Rondolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4350
+msgid "Rondon"
+msgstr "Rondon"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4351
+msgid "Rondon do Pará"
+msgstr "Rondon do Pará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_118
+msgid "Rondonópolis"
+msgstr "Rondonópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4352
+msgid "Roque Gonzales"
+msgstr "Roque Gonzales"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4353
+msgid "Rorainópolis"
+msgstr "Rorainópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4354
+msgid "Rosana"
+msgstr "Rosana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4361
+msgid "Roseira"
+msgstr "Roseira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4355
+msgid "Rosário"
+msgstr "Rosário"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4360
+msgid "Rosário Oeste"
+msgstr "Rosário Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4356
+msgid "Rosário da Limeira"
+msgstr "Rosário da Limeira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4357
+msgid "Rosário do Catete"
+msgstr "Rosário do Catete"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4358
+msgid "Rosário do Ivaí"
+msgstr "Rosário do Ivaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4359
+msgid "Rosário do Sul"
+msgstr "Rosário do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4362
+msgid "Roteiro"
+msgstr "Roteiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4363
+msgid "Rubelita"
+msgstr "Rubelita"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4365
+msgid "Rubiataba"
+msgstr "Rubiataba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4366
+msgid "Rubim"
+msgstr "Rubim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4367
+msgid "Rubinéia"
+msgstr "Rubinéia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4364
+msgid "Rubiácea"
+msgstr "Rubiácea"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4368
+msgid "Rurópolis"
+msgstr "Rurópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4369
+msgid "Russas"
+msgstr "Russas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4370
+#: model:res.city,name:l10n_br.city_br_4371
+msgid "Ruy Barbosa"
+msgstr "Ruy Barbosa"
 
 #. module: l10n_br
 #: model:ir.model.fields,field_description:l10n_br.field_res_partner__l10n_br_isuf_code
@@ -457,9 +21085,1989 @@ msgid "SUFRAMA registration number."
 msgstr "Número de registro da SUFRAMA."
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_234
+msgid "Sabará"
+msgstr "Sabará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4373
+msgid "Sabino"
+msgstr "Sabino"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4374
+msgid "Sabinópolis"
+msgstr "Sabinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4375
+msgid "Saboeiro"
+msgstr "Saboeiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4372
+msgid "Sabáudia"
+msgstr "Sabáudia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4376
+msgid "Sacramento"
+msgstr "Sacramento"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4377
+msgid "Sagrada Família"
+msgstr "Sagrada Família"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4378
+msgid "Sagres"
+msgstr "Sagres"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4379
+msgid "Sairé"
+msgstr "Sairé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4380
+msgid "Saldanha Marinho"
+msgstr "Saldanha Marinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4381
+msgid "Sales"
+msgstr "Sales"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4382
+msgid "Sales Oliveira"
+msgstr "Sales Oliveira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4383
+msgid "Salesópolis"
+msgstr "Salesópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4384
+msgid "Salete"
+msgstr "Salete"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4385
+#: model:res.city,name:l10n_br.city_br_4386
+msgid "Salgadinho"
+msgstr "Salgadinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4387
+msgid "Salgado"
+msgstr "Salgado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4389
+msgid "Salgado Filho"
+msgstr "Salgado Filho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4388
+msgid "Salgado de São Félix"
+msgstr "Salgado de São Félix"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4390
+msgid "Salgueiro"
+msgstr "Salgueiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4391
+msgid "Salinas"
+msgstr "Salinas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4392
+msgid "Salinas da Margarida"
+msgstr "Salinas da Margarida"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4393
+msgid "Salinópolis"
+msgstr "Salinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4394
+msgid "Salitre"
+msgstr "Salitre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4395
+msgid "Salmourão"
+msgstr "Salmourão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4396
+msgid "Saloá"
+msgstr "Saloá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4397
+#: model:res.city,name:l10n_br.city_br_4398
+msgid "Saltinho"
+msgstr "Saltinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_220
+msgid "Salto"
+msgstr "Salto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4405
+msgid "Salto Grande"
+msgstr "Salto Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4406
+msgid "Salto Veloso"
+msgstr "Salto Veloso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4399
+msgid "Salto da Divisa"
+msgstr "Salto da Divisa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4400
+msgid "Salto de Pirapora"
+msgstr "Salto de Pirapora"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4401
+msgid "Salto do Céu"
+msgstr "Salto do Céu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4402
+msgid "Salto do Itararé"
+msgstr "Salto do Itararé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4403
+msgid "Salto do Jacuí"
+msgstr "Salto do Jacuí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4404
+msgid "Salto do Lontra"
+msgstr "Salto do Lontra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_005
+msgid "Salvador"
+msgstr "Salvador"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4407
+msgid "Salvador das Missões"
+msgstr "Salvador das Missões"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4408
+msgid "Salvador do Sul"
+msgstr "Salvador do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4409
+msgid "Salvaterra"
+msgstr "Salvaterra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4410
+msgid "Sambaíba"
+msgstr "Sambaíba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4411
+msgid "Sampaio"
+msgstr "Sampaio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4412
+msgid "Sananduva"
+msgstr "Sananduva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4413
+msgid "Sanclerlândia"
+msgstr "Sanclerlândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4414
+msgid "Sandolândia"
+msgstr "Sandolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4415
+msgid "Sandovalina"
+msgstr "Sandovalina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4416
+msgid "Sangão"
+msgstr "Sangão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4417
+msgid "Sanharó"
+msgstr "Sanharó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4418
+msgid "Sant'Ana do Livramento"
+msgstr "Sant'Ana do Livramento"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4419
+msgid "Santa Adélia"
+msgstr "Santa Adélia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4420
+msgid "Santa Albertina"
+msgstr "Santa Albertina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4421
+msgid "Santa Amélia"
+msgstr "Santa Amélia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4430
+msgid "Santa Branca"
+msgstr "Santa Branca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4431
+msgid "Santa Brígida"
+msgstr "Santa Brígida"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4422
+#: model:res.city,name:l10n_br.city_br_4423
+msgid "Santa Bárbara"
+msgstr "Santa Bárbara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_163
+msgid "Santa Bárbara d'Oeste"
+msgstr "Santa Bárbara d'Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4424
+msgid "Santa Bárbara de Goiás"
+msgstr "Santa Bárbara de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4425
+msgid "Santa Bárbara do Leste"
+msgstr "Santa Bárbara do Leste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4426
+msgid "Santa Bárbara do Monte Verde"
+msgstr "Santa Bárbara do Monte Verde"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4427
+msgid "Santa Bárbara do Pará"
+msgstr "Santa Bárbara do Pará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4428
+msgid "Santa Bárbara do Sul"
+msgstr "Santa Bárbara do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4429
+msgid "Santa Bárbara do Tugúrio"
+msgstr "Santa Bárbara do Tugúrio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4432
+msgid "Santa Carmem"
+msgstr "Santa Carmem"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4433
+#: model:res.city,name:l10n_br.city_br_4434
+msgid "Santa Cecília"
+msgstr "Santa Cecília"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4435
+msgid "Santa Cecília do Pavão"
+msgstr "Santa Cecília do Pavão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4436
+msgid "Santa Cecília do Sul"
+msgstr "Santa Cecília do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4437
+msgid "Santa Clara d'Oeste"
+msgstr "Santa Clara d'Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4438
+msgid "Santa Clara do Sul"
+msgstr "Santa Clara do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4439
+#: model:res.city,name:l10n_br.city_br_4440
+#: model:res.city,name:l10n_br.city_br_4441
+msgid "Santa Cruz"
+msgstr "Santa Cruz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4442
+msgid "Santa Cruz Cabrália"
+msgstr "Santa Cruz Cabrália"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4443
+msgid "Santa Cruz da Baixa Verde"
+msgstr "Santa Cruz da Baixa Verde"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4444
+msgid "Santa Cruz da Conceição"
+msgstr "Santa Cruz da Conceição"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4445
+msgid "Santa Cruz da Esperança"
+msgstr "Santa Cruz da Esperança"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4446
+msgid "Santa Cruz da Vitória"
+msgstr "Santa Cruz da Vitória"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4447
+msgid "Santa Cruz das Palmeiras"
+msgstr "Santa Cruz das Palmeiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4448
+msgid "Santa Cruz de Goiás"
+msgstr "Santa Cruz de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4449
+msgid "Santa Cruz de Minas"
+msgstr "Santa Cruz de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4450
+msgid "Santa Cruz de Monte Castelo"
+msgstr "Santa Cruz de Monte Castelo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4451
+msgid "Santa Cruz de Salinas"
+msgstr "Santa Cruz de Salinas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4452
+msgid "Santa Cruz do Arari"
+msgstr "Santa Cruz do Arari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4453
+msgid "Santa Cruz do Capibaribe"
+msgstr "Santa Cruz do Capibaribe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4454
+msgid "Santa Cruz do Escalvado"
+msgstr "Santa Cruz do Escalvado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4455
+msgid "Santa Cruz do Piauí"
+msgstr "Santa Cruz do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4456
+msgid "Santa Cruz do Rio Pardo"
+msgstr "Santa Cruz do Rio Pardo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_224
+msgid "Santa Cruz do Sul"
+msgstr "Santa Cruz do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4457
+msgid "Santa Cruz do Xingu"
+msgstr "Santa Cruz do Xingu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4458
+msgid "Santa Cruz dos Milagres"
+msgstr "Santa Cruz dos Milagres"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4459
+msgid "Santa Efigênia de Minas"
+msgstr "Santa Efigênia de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4460
+msgid "Santa Ernestina"
+msgstr "Santa Ernestina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4466
+#: model:res.city,name:l10n_br.city_br_4467
+msgid "Santa Filomena"
+msgstr "Santa Filomena"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4468
+msgid "Santa Filomena do Maranhão"
+msgstr "Santa Filomena do Maranhão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4461
+msgid "Santa Fé"
+msgstr "Santa Fé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4462
+msgid "Santa Fé de Goiás"
+msgstr "Santa Fé de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4463
+msgid "Santa Fé de Minas"
+msgstr "Santa Fé de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4464
+msgid "Santa Fé do Araguaia"
+msgstr "Santa Fé do Araguaia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4465
+msgid "Santa Fé do Sul"
+msgstr "Santa Fé do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4469
+msgid "Santa Gertrudes"
+msgstr "Santa Gertrudes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4470
+#: model:res.city,name:l10n_br.city_br_4471
+#: model:res.city,name:l10n_br.city_br_4472
+#: model:res.city,name:l10n_br.city_br_4473
+msgid "Santa Helena"
+msgstr "Santa Helena"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4474
+msgid "Santa Helena de Goiás"
+msgstr "Santa Helena de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4475
+msgid "Santa Helena de Minas"
+msgstr "Santa Helena de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4476
+#: model:res.city,name:l10n_br.city_br_4477
+#: model:res.city,name:l10n_br.city_br_4478
+#: model:res.city,name:l10n_br.city_br_4479
+msgid "Santa Inês"
+msgstr "Santa Inês"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4480
+#: model:res.city,name:l10n_br.city_br_4481
+msgid "Santa Isabel"
+msgstr "Santa Isabel"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4482
+msgid "Santa Isabel do Ivaí"
+msgstr "Santa Isabel do Ivaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4483
+msgid "Santa Isabel do Rio Negro"
+msgstr "Santa Isabel do Rio Negro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4484
+msgid "Santa Izabel do Oeste"
+msgstr "Santa Izabel do Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4485
+msgid "Santa Izabel do Pará"
+msgstr "Santa Izabel do Pará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4486
+msgid "Santa Juliana"
+msgstr "Santa Juliana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4487
+msgid "Santa Leopoldina"
+msgstr "Santa Leopoldina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4490
+msgid "Santa Luz"
+msgstr "Santa Luz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_143
+#: model:res.city,name:l10n_br.city_br_4491
+#: model:res.city,name:l10n_br.city_br_4492
+#: model:res.city,name:l10n_br.city_br_4493
+msgid "Santa Luzia"
+msgstr "Santa Luzia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4494
+msgid "Santa Luzia D'Oeste"
+msgstr "Santa Luzia D'Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4495
+msgid "Santa Luzia do Itanhy"
+msgstr "Santa Luzia do Itanhy"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4496
+msgid "Santa Luzia do Norte"
+msgstr "Santa Luzia do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4498
+msgid "Santa Luzia do Paruá"
+msgstr "Santa Luzia do Paruá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4497
+msgid "Santa Luzia do Pará"
+msgstr "Santa Luzia do Pará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4488
+#: model:res.city,name:l10n_br.city_br_4489
+msgid "Santa Lúcia"
+msgstr "Santa Lúcia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4499
+msgid "Santa Margarida"
+msgstr "Santa Margarida"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4500
+msgid "Santa Margarida do Sul"
+msgstr "Santa Margarida do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_103
+#: model:res.city,name:l10n_br.city_br_4501
+msgid "Santa Maria"
+msgstr "Santa Maria"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4515
+msgid "Santa Maria Madalena"
+msgstr "Santa Maria Madalena"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4502
+msgid "Santa Maria da Boa Vista"
+msgstr "Santa Maria da Boa Vista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4503
+msgid "Santa Maria da Serra"
+msgstr "Santa Maria da Serra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4504
+msgid "Santa Maria da Vitória"
+msgstr "Santa Maria da Vitória"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4505
+msgid "Santa Maria das Barreiras"
+msgstr "Santa Maria das Barreiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4506
+msgid "Santa Maria de Itabira"
+msgstr "Santa Maria de Itabira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4507
+msgid "Santa Maria de Jetibá"
+msgstr "Santa Maria de Jetibá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4508
+msgid "Santa Maria do Cambucá"
+msgstr "Santa Maria do Cambucá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4509
+msgid "Santa Maria do Herval"
+msgstr "Santa Maria do Herval"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4510
+msgid "Santa Maria do Oeste"
+msgstr "Santa Maria do Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4511
+msgid "Santa Maria do Pará"
+msgstr "Santa Maria do Pará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4512
+msgid "Santa Maria do Salto"
+msgstr "Santa Maria do Salto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4513
+msgid "Santa Maria do Suaçuí"
+msgstr "Santa Maria do Suaçuí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4514
+msgid "Santa Maria do Tocantins"
+msgstr "Santa Maria do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4516
+msgid "Santa Mariana"
+msgstr "Santa Mariana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4517
+msgid "Santa Mercedes"
+msgstr "Santa Mercedes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4518
+msgid "Santa Mônica"
+msgstr "Santa Mônica"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4519
+msgid "Santa Quitéria"
+msgstr "Santa Quitéria"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4520
+msgid "Santa Quitéria do Maranhão"
+msgstr "Santa Quitéria do Maranhão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_201
+#: model:res.city,name:l10n_br.city_br_4521
+msgid "Santa Rita"
+msgstr "Santa Rita"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4522
+msgid "Santa Rita d'Oeste"
+msgstr "Santa Rita d'Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4523
+msgid "Santa Rita de Caldas"
+msgstr "Santa Rita de Caldas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4524
+msgid "Santa Rita de Cássia"
+msgstr "Santa Rita de Cássia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4525
+msgid "Santa Rita de Ibitipoca"
+msgstr "Santa Rita de Ibitipoca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4526
+msgid "Santa Rita de Jacutinga"
+msgstr "Santa Rita de Jacutinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4527
+msgid "Santa Rita de Minas"
+msgstr "Santa Rita de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4528
+msgid "Santa Rita do Araguaia"
+msgstr "Santa Rita do Araguaia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4529
+msgid "Santa Rita do Itueto"
+msgstr "Santa Rita do Itueto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4530
+msgid "Santa Rita do Novo Destino"
+msgstr "Santa Rita do Novo Destino"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4531
+msgid "Santa Rita do Pardo"
+msgstr "Santa Rita do Pardo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4532
+msgid "Santa Rita do Passa Quatro"
+msgstr "Santa Rita do Passa Quatro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4533
+msgid "Santa Rita do Sapucaí"
+msgstr "Santa Rita do Sapucaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4534
+msgid "Santa Rita do Tocantins"
+msgstr "Santa Rita do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4535
+msgid "Santa Rita do Trivelato"
+msgstr "Santa Rita do Trivelato"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4536
+msgid "Santa Rosa"
+msgstr "Santa Rosa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4537
+msgid "Santa Rosa da Serra"
+msgstr "Santa Rosa da Serra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4538
+msgid "Santa Rosa de Goiás"
+msgstr "Santa Rosa de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4539
+#: model:res.city,name:l10n_br.city_br_4540
+msgid "Santa Rosa de Lima"
+msgstr "Santa Rosa de Lima"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4541
+msgid "Santa Rosa de Viterbo"
+msgstr "Santa Rosa de Viterbo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4542
+msgid "Santa Rosa do Piauí"
+msgstr "Santa Rosa do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4543
+msgid "Santa Rosa do Purus"
+msgstr "Santa Rosa do Purus"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4544
+msgid "Santa Rosa do Sul"
+msgstr "Santa Rosa do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4545
+msgid "Santa Rosa do Tocantins"
+msgstr "Santa Rosa do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4546
+msgid "Santa Salete"
+msgstr "Santa Salete"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4547
+msgid "Santa Teresa"
+msgstr "Santa Teresa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4548
+#: model:res.city,name:l10n_br.city_br_4549
+msgid "Santa Teresinha"
+msgstr "Santa Teresinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4550
+msgid "Santa Tereza"
+msgstr "Santa Tereza"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4551
+msgid "Santa Tereza de Goiás"
+msgstr "Santa Tereza de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4552
+msgid "Santa Tereza do Oeste"
+msgstr "Santa Tereza do Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4553
+msgid "Santa Tereza do Tocantins"
+msgstr "Santa Tereza do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4554
+#: model:res.city,name:l10n_br.city_br_4555
+#: model:res.city,name:l10n_br.city_br_4556
+msgid "Santa Terezinha"
+msgstr "Santa Terezinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4557
+msgid "Santa Terezinha de Goiás"
+msgstr "Santa Terezinha de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4558
+msgid "Santa Terezinha de Itaipu"
+msgstr "Santa Terezinha de Itaipu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4559
+msgid "Santa Terezinha do Progresso"
+msgstr "Santa Terezinha do Progresso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4560
+msgid "Santa Terezinha do Tocantins"
+msgstr "Santa Terezinha do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4561
+msgid "Santa Vitória"
+msgstr "Santa Vitória"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4562
+msgid "Santa Vitória do Palmar"
+msgstr "Santa Vitória do Palmar"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4563
+msgid "Santaluz"
+msgstr "Santaluz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_289
+#: model:res.city,name:l10n_br.city_br_4564
+msgid "Santana"
+msgstr "Santana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4565
+msgid "Santana da Boa Vista"
+msgstr "Santana da Boa Vista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4566
+msgid "Santana da Ponte Pensa"
+msgstr "Santana da Ponte Pensa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4567
+msgid "Santana da Vargem"
+msgstr "Santana da Vargem"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4568
+msgid "Santana de Cataguases"
+msgstr "Santana de Cataguases"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4569
+msgid "Santana de Mangueira"
+msgstr "Santana de Mangueira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_195
+msgid "Santana de Parnaíba"
+msgstr "Santana de Parnaíba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4570
+msgid "Santana de Pirapama"
+msgstr "Santana de Pirapama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4571
+msgid "Santana do Acaraú"
+msgstr "Santana do Acaraú"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4572
+msgid "Santana do Araguaia"
+msgstr "Santana do Araguaia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4573
+msgid "Santana do Cariri"
+msgstr "Santana do Cariri"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4574
+msgid "Santana do Deserto"
+msgstr "Santana do Deserto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4575
+msgid "Santana do Garambéu"
+msgstr "Santana do Garambéu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4576
+msgid "Santana do Ipanema"
+msgstr "Santana do Ipanema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4577
+msgid "Santana do Itararé"
+msgstr "Santana do Itararé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4578
+msgid "Santana do Jacaré"
+msgstr "Santana do Jacaré"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4579
+msgid "Santana do Manhuaçu"
+msgstr "Santana do Manhuaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4580
+msgid "Santana do Maranhão"
+msgstr "Santana do Maranhão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4581
+msgid "Santana do Matos"
+msgstr "Santana do Matos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4582
+msgid "Santana do Mundaú"
+msgstr "Santana do Mundaú"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4583
+msgid "Santana do Paraíso"
+msgstr "Santana do Paraíso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4584
+msgid "Santana do Piauí"
+msgstr "Santana do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4585
+msgid "Santana do Riacho"
+msgstr "Santana do Riacho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4587
+msgid "Santana do Seridó"
+msgstr "Santana do Seridó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4586
+msgid "Santana do São Francisco"
+msgstr "Santana do São Francisco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4588
+msgid "Santana dos Garrotes"
+msgstr "Santana dos Garrotes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4589
+msgid "Santana dos Montes"
+msgstr "Santana dos Montes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4590
+msgid "Santanópolis"
+msgstr "Santanópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_082
+msgid "Santarém"
+msgstr "Santarém"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4591
+msgid "Santarém Novo"
+msgstr "Santarém Novo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4592
+msgid "Santiago"
+msgstr "Santiago"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4593
+msgid "Santiago do Sul"
+msgstr "Santiago do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4594
+msgid "Santo Afonso"
+msgstr "Santo Afonso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4595
+msgid "Santo Amaro"
+msgstr "Santo Amaro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4596
+msgid "Santo Amaro da Imperatriz"
+msgstr "Santo Amaro da Imperatriz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4597
+msgid "Santo Amaro das Brotas"
+msgstr "Santo Amaro das Brotas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4598
+msgid "Santo Amaro do Maranhão"
+msgstr "Santo Amaro do Maranhão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4599
+msgid "Santo Anastácio"
+msgstr "Santo Anastácio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_025
+#: model:res.city,name:l10n_br.city_br_4600
+msgid "Santo André"
+msgstr "Santo André"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4602
+msgid "Santo Antônio"
+msgstr "Santo Antônio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4603
+msgid "Santo Antônio da Alegria"
+msgstr "Santo Antônio da Alegria"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4604
+msgid "Santo Antônio da Barra"
+msgstr "Santo Antônio da Barra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4605
+msgid "Santo Antônio da Patrulha"
+msgstr "Santo Antônio da Patrulha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4606
+msgid "Santo Antônio da Platina"
+msgstr "Santo Antônio da Platina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4607
+msgid "Santo Antônio das Missões"
+msgstr "Santo Antônio das Missões"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4608
+msgid "Santo Antônio de Goiás"
+msgstr "Santo Antônio de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_313
+msgid "Santo Antônio de Jesus"
+msgstr "Santo Antônio de Jesus"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4609
+msgid "Santo Antônio de Lisboa"
+msgstr "Santo Antônio de Lisboa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4611
+msgid "Santo Antônio de Posse"
+msgstr "Santo Antônio de Posse"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4610
+msgid "Santo Antônio de Pádua"
+msgstr "Santo Antônio de Pádua"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4612
+msgid "Santo Antônio do Amparo"
+msgstr "Santo Antônio do Amparo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4613
+msgid "Santo Antônio do Aracanguá"
+msgstr "Santo Antônio do Aracanguá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4614
+msgid "Santo Antônio do Aventureiro"
+msgstr "Santo Antônio do Aventureiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4615
+msgid "Santo Antônio do Caiuá"
+msgstr "Santo Antônio do Caiuá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4616
+msgid "Santo Antônio do Descoberto"
+msgstr "Santo Antônio do Descoberto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4617
+msgid "Santo Antônio do Grama"
+msgstr "Santo Antônio do Grama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4619
+msgid "Santo Antônio do Itambé"
+msgstr "Santo Antônio do Itambé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4618
+msgid "Santo Antônio do Içá"
+msgstr "Santo Antônio do Içá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4620
+msgid "Santo Antônio do Jacinto"
+msgstr "Santo Antônio do Jacinto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4621
+msgid "Santo Antônio do Jardim"
+msgstr "Santo Antônio do Jardim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4622
+msgid "Santo Antônio do Leste"
+msgstr "Santo Antônio do Leste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4623
+msgid "Santo Antônio do Leverger"
+msgstr "Santo Antônio do Leverger"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4624
+msgid "Santo Antônio do Monte"
+msgstr "Santo Antônio do Monte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4625
+msgid "Santo Antônio do Palma"
+msgstr "Santo Antônio do Palma"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4626
+msgid "Santo Antônio do Paraíso"
+msgstr "Santo Antônio do Paraíso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4627
+msgid "Santo Antônio do Pinhal"
+msgstr "Santo Antônio do Pinhal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4628
+msgid "Santo Antônio do Planalto"
+msgstr "Santo Antônio do Planalto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4629
+msgid "Santo Antônio do Retiro"
+msgstr "Santo Antônio do Retiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4630
+msgid "Santo Antônio do Rio Abaixo"
+msgstr "Santo Antônio do Rio Abaixo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4631
+msgid "Santo Antônio do Sudoeste"
+msgstr "Santo Antônio do Sudoeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4632
+msgid "Santo Antônio do Tauá"
+msgstr "Santo Antônio do Tauá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4633
+msgid "Santo Antônio dos Lopes"
+msgstr "Santo Antônio dos Lopes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4634
+msgid "Santo Antônio dos Milagres"
+msgstr "Santo Antônio dos Milagres"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4635
+msgid "Santo Augusto"
+msgstr "Santo Augusto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4636
+msgid "Santo Cristo"
+msgstr "Santo Cristo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4637
+msgid "Santo Estêvão"
+msgstr "Santo Estêvão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4638
+msgid "Santo Expedito"
+msgstr "Santo Expedito"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4639
+msgid "Santo Expedito do Sul"
+msgstr "Santo Expedito do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4640
+msgid "Santo Hipólito"
+msgstr "Santo Hipólito"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4641
+msgid "Santo Inácio"
+msgstr "Santo Inácio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4642
+msgid "Santo Inácio do Piauí"
+msgstr "Santo Inácio do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4601
+msgid "Santo Ângelo"
+msgstr "Santo Ângelo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_056
+msgid "Santos"
+msgstr "Santos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4644
+msgid "Santos Dumont"
+msgstr "Santos Dumont"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4643
+msgid "Santópolis do Aguapeí"
+msgstr "Santópolis do Aguapeí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4972
+msgid "Sapeaçu"
+msgstr "Sapeaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4973
+msgid "Sapezal"
+msgstr "Sapezal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4974
+msgid "Sapiranga"
+msgstr "Sapiranga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4975
+msgid "Sapopema"
+msgstr "Sapopema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4977
+#: model:res.city,name:l10n_br.city_br_4978
+msgid "Sapucaia"
+msgstr "Sapucaia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_226
+msgid "Sapucaia do Sul"
+msgstr "Sapucaia do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4976
+msgid "Sapucaí-Mirim"
+msgstr "Sapucaí-Mirim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4971
+msgid "Sapé"
+msgstr "Sapé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4979
+msgid "Saquarema"
+msgstr "Saquarema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_257
+#: model:res.city,name:l10n_br.city_br_4980
+msgid "Sarandi"
+msgstr "Sarandi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4981
+msgid "Sarapuí"
+msgstr "Sarapuí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4982
+msgid "Sardoá"
+msgstr "Sardoá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4983
+msgid "Sarutaiá"
+msgstr "Sarutaiá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4984
+msgid "Sarzedo"
+msgstr "Sarzedo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4986
+msgid "Satuba"
+msgstr "Satuba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4987
+msgid "Satubinha"
+msgstr "Satubinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4988
+msgid "Saubara"
+msgstr "Saubara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4989
+msgid "Saudade do Iguaçu"
+msgstr "Saudade do Iguaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4990
+msgid "Saudades"
+msgstr "Saudades"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4991
+msgid "Saúde"
+msgstr "Saúde"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4992
+msgid "Schroeder"
+msgstr "Schroeder"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4993
+msgid "Seabra"
+msgstr "Seabra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4994
+msgid "Seara"
+msgstr "Seara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4995
+msgid "Sebastianópolis do Sul"
+msgstr "Sebastianópolis do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4996
+msgid "Sebastião Barros"
+msgstr "Sebastião Barros"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4997
+msgid "Sebastião Laranjeiras"
+msgstr "Sebastião Laranjeiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4998
+msgid "Sebastião Leal"
+msgstr "Sebastião Leal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4999
+msgid "Seberi"
+msgstr "Seberi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5000
+msgid "Sede Nova"
+msgstr "Sede Nova"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5001
+msgid "Segredo"
+msgstr "Segredo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5002
+msgid "Selbach"
+msgstr "Selbach"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5003
+msgid "Selvíria"
+msgstr "Selvíria"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5004
+msgid "Sem-Peixe"
+msgstr "Sem-Peixe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5005
+msgid "Sena Madureira"
+msgstr "Sena Madureira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5006
+msgid "Senador Alexandre Costa"
+msgstr "Senador Alexandre Costa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5007
+msgid "Senador Amaral"
+msgstr "Senador Amaral"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_194
+msgid "Senador Canedo"
+msgstr "Senador Canedo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5008
+msgid "Senador Cortes"
+msgstr "Senador Cortes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5009
+msgid "Senador Elói de Souza"
+msgstr "Senador Elói de Souza"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5010
+msgid "Senador Firmino"
+msgstr "Senador Firmino"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5011
+msgid "Senador Georgino Avelino"
+msgstr "Senador Georgino Avelino"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5012
+msgid "Senador Guiomard"
+msgstr "Senador Guiomard"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5013
+msgid "Senador José Bento"
+msgstr "Senador José Bento"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5014
+msgid "Senador José Porfírio"
+msgstr "Senador José Porfírio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5015
+msgid "Senador La Rocque"
+msgstr "Senador La Rocque"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5016
+msgid "Senador Modestino Gonçalves"
+msgstr "Senador Modestino Gonçalves"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5017
+msgid "Senador Pompeu"
+msgstr "Senador Pompeu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5018
+msgid "Senador Rui Palmeira"
+msgstr "Senador Rui Palmeira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5020
+msgid "Senador Salgado Filho"
+msgstr "Senador Salgado Filho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5019
+msgid "Senador Sá"
+msgstr "Senador Sá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5021
+msgid "Sengés"
+msgstr "Sengés"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5022
+msgid "Senhor do Bonfim"
+msgstr "Senhor do Bonfim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5023
+msgid "Senhora de Oliveira"
+msgstr "Senhora de Oliveira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5024
+msgid "Senhora do Porto"
+msgstr "Senhora do Porto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5025
+msgid "Senhora dos Remédios"
+msgstr "Senhora dos Remédios"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5026
+msgid "Sentinela do Sul"
+msgstr "Sentinela do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5027
+msgid "Sento Sé"
+msgstr "Sento Sé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5028
+msgid "Serafina Corrêa"
+msgstr "Serafina Corrêa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5029
+msgid "Sericita"
+msgstr "Sericita"
+
+#. module: l10n_br
 #: model:ir.model.fields,field_description:l10n_br.field_account_journal__l10n_br_invoice_serial
 msgid "Series"
 msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5030
+msgid "Seringueiras"
+msgstr "Seringueiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5032
+msgid "Seritinga"
+msgstr "Seritinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5033
+msgid "Seropédica"
+msgstr "Seropédica"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_041
+msgid "Serra"
+msgstr "Serra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5034
+msgid "Serra Alta"
+msgstr "Serra Alta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5035
+msgid "Serra Azul"
+msgstr "Serra Azul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5036
+msgid "Serra Azul de Minas"
+msgstr "Serra Azul de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5037
+msgid "Serra Branca"
+msgstr "Serra Branca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5038
+msgid "Serra Caiada"
+msgstr "Serra Caiada"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5047
+msgid "Serra Dourada"
+msgstr "Serra Dourada"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5048
+msgid "Serra Grande"
+msgstr "Serra Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5049
+msgid "Serra Negra"
+msgstr "Serra Negra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5050
+msgid "Serra Negra do Norte"
+msgstr "Serra Negra do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5051
+msgid "Serra Nova Dourada"
+msgstr "Serra Nova Dourada"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5052
+msgid "Serra Preta"
+msgstr "Serra Preta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5053
+msgid "Serra Redonda"
+msgstr "Serra Redonda"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5054
+msgid "Serra Talhada"
+msgstr "Serra Talhada"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5039
+msgid "Serra da Raiz"
+msgstr "Serra da Raiz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5040
+msgid "Serra da Saudade"
+msgstr "Serra da Saudade"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5041
+msgid "Serra de São Bento"
+msgstr "Serra de São Bento"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5042
+msgid "Serra do Mel"
+msgstr "Serra do Mel"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5043
+msgid "Serra do Navio"
+msgstr "Serra do Navio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5044
+msgid "Serra do Ramalho"
+msgstr "Serra do Ramalho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5045
+msgid "Serra do Salitre"
+msgstr "Serra do Salitre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5046
+msgid "Serra dos Aimorés"
+msgstr "Serra dos Aimorés"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5055
+msgid "Serrana"
+msgstr "Serrana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5056
+msgid "Serrania"
+msgstr "Serrania"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5057
+msgid "Serrano do Maranhão"
+msgstr "Serrano do Maranhão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5061
+msgid "Serranos"
+msgstr "Serranos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5058
+msgid "Serranópolis"
+msgstr "Serranópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5059
+msgid "Serranópolis de Minas"
+msgstr "Serranópolis de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5060
+msgid "Serranópolis do Iguaçu"
+msgstr "Serranópolis do Iguaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5062
+msgid "Serraria"
+msgstr "Serraria"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5063
+#: model:res.city,name:l10n_br.city_br_5064
+msgid "Serrinha"
+msgstr "Serrinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5065
+msgid "Serrinha dos Pintos"
+msgstr "Serrinha dos Pintos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5066
+msgid "Serrita"
+msgstr "Serrita"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5067
+msgid "Serro"
+msgstr "Serro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5068
+msgid "Serrolândia"
+msgstr "Serrolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5069
+msgid "Sertaneja"
+msgstr "Sertaneja"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5071
+msgid "Sertanópolis"
+msgstr "Sertanópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5070
+msgid "Sertânia"
+msgstr "Sertânia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5072
+msgid "Sertão"
+msgstr "Sertão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5073
+msgid "Sertão Santana"
+msgstr "Sertão Santana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_238
+#: model:res.city,name:l10n_br.city_br_5074
+msgid "Sertãozinho"
+msgstr "Sertãozinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5075
+msgid "Sete Barras"
+msgstr "Sete Barras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_135
+msgid "Sete Lagoas"
+msgstr "Sete Lagoas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5077
+msgid "Sete Quedas"
+msgstr "Sete Quedas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5076
+msgid "Sete de Setembro"
+msgstr "Sete de Setembro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5078
+msgid "Setubinha"
+msgstr "Setubinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5080
+msgid "Severiano Melo"
+msgstr "Severiano Melo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5079
+msgid "Severiano de Almeida"
+msgstr "Severiano de Almeida"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5081
+msgid "Severínia"
+msgstr "Severínia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5082
+msgid "Siderópolis"
+msgstr "Siderópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5083
+msgid "Sidrolândia"
+msgstr "Sidrolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5084
+msgid "Sigefredo Pacheco"
+msgstr "Sigefredo Pacheco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5085
+msgid "Silva Jardim"
+msgstr "Silva Jardim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5087
+msgid "Silvanópolis"
+msgstr "Silvanópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5088
+msgid "Silveira Martins"
+msgstr "Silveira Martins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5090
+msgid "Silveiras"
+msgstr "Silveiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5089
+msgid "Silveirânia"
+msgstr "Silveirânia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5091
+msgid "Silves"
+msgstr "Silves"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5092
+msgid "Silvianópolis"
+msgstr "Silvianópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5086
+msgid "Silvânia"
+msgstr "Silvânia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5096
+msgid "Simolândia"
+msgstr "Simolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5097
+msgid "Simonésia"
+msgstr "Simonésia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5098
+msgid "Simplício Mendes"
+msgstr "Simplício Mendes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5093
+msgid "Simão Dias"
+msgstr "Simão Dias"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5094
+msgid "Simão Pereira"
+msgstr "Simão Pereira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5095
+msgid "Simões"
+msgstr "Simões"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_271
+msgid "Simões Filho"
+msgstr "Simões Filho"
 
 #. module: l10n_br
 #: model:l10n_latam.document.type,name:l10n_br.dt_1B
@@ -467,9 +23075,141 @@ msgid "Single invoice"
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5099
+msgid "Sinimbu"
+msgstr "Sinimbu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_155
+msgid "Sinop"
+msgstr "Sinop"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5100
+msgid "Siqueira Campos"
+msgstr "Siqueira Campos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5101
+msgid "Sirinhaém"
+msgstr "Sirinhaém"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5102
+msgid "Siriri"
+msgstr "Siriri"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5109
+#: model:res.city,name:l10n_br.city_br_5110
+msgid "Sobradinho"
+msgstr "Sobradinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5111
+msgid "Sobrado"
+msgstr "Sobrado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_150
+msgid "Sobral"
+msgstr "Sobral"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5112
+msgid "Sobrália"
+msgstr "Sobrália"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5113
+msgid "Socorro"
+msgstr "Socorro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5114
+msgid "Socorro do Piauí"
+msgstr "Socorro do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5116
+#: model:res.city,name:l10n_br.city_br_5117
+msgid "Soledade"
+msgstr "Soledade"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5118
+msgid "Soledade de Minas"
+msgstr "Soledade de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5119
+msgid "Solidão"
+msgstr "Solidão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5120
+msgid "Solonópole"
+msgstr "Solonópole"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5115
+msgid "Solânea"
+msgstr "Solânea"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5121
+msgid "Sombrio"
+msgstr "Sombrio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5122
+msgid "Sonora"
+msgstr "Sonora"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5123
+msgid "Sooretama"
+msgstr "Sooretama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_027
+msgid "Sorocaba"
+msgstr "Sorocaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_283
+msgid "Sorriso"
+msgstr "Sorriso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5124
+msgid "Sossêgo"
+msgstr "Sossêgo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5125
+msgid "Soure"
+msgstr "Soure"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5126
+msgid "Sousa"
+msgstr "Sousa"
+
+#. module: l10n_br
 #: model:ir.model.fields.selection,name:l10n_br.selection__account_fiscal_position__l10n_br_fp_type__ss_nnm
 msgid "South/Southeast selling to North/Northeast/Midwest"
 msgstr "Sul/Sudeste vendendo para Norte/Nordeste/Centro-Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5127
+msgid "Souto Soares"
+msgstr "Souto Soares"
+
+#. module: l10n_br
+#: model_terms:ir.ui.view,arch_db:l10n_br.br_partner_address_form
+msgid "State"
+msgstr ""
 
 #. module: l10n_br
 #: model:ir.model.fields,help:l10n_br.field_res_company__l10n_br_nire_code
@@ -482,8 +23222,2131 @@ msgstr "Número de Identificação do Registro de Empresas. Deve ter 11 dígitos
 #: model:ir.model.fields,help:l10n_br.field_res_users__l10n_br_ie_code
 msgid "State Tax Identification Number. Should contain 9-14 digits."
 msgstr ""
-"Inscrição municipal: identificação estadual para tributação. Deve contar "
-"9-14 dígitos."
+
+#. module: l10n_br
+#: model_terms:ir.ui.view,arch_db:l10n_br.br_partner_address_form
+msgid "Street"
+msgstr ""
+
+#. module: l10n_br
+#: model_terms:ir.ui.view,arch_db:l10n_br.br_partner_address_form
+msgid "Street #"
+msgstr ""
+
+#. module: l10n_br
+#: model_terms:ir.ui.view,arch_db:l10n_br.br_partner_address_form
+msgid "Street..."
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5128
+msgid "Sucupira"
+msgstr "Sucupira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5129
+msgid "Sucupira do Norte"
+msgstr "Sucupira do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5130
+msgid "Sucupira do Riachão"
+msgstr "Sucupira do Riachão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5131
+msgid "Sud Mennucci"
+msgstr "Sud Mennucci"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5132
+msgid "Sul Brasil"
+msgstr "Sul Brasil"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5133
+msgid "Sulina"
+msgstr "Sulina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_098
+msgid "Sumaré"
+msgstr "Sumaré"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5135
+msgid "Sumidouro"
+msgstr "Sumidouro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5134
+msgid "Sumé"
+msgstr "Sumé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5136
+msgid "Surubim"
+msgstr "Surubim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5137
+msgid "Sussuapara"
+msgstr "Sussuapara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_090
+msgid "Suzano"
+msgstr "Suzano"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5138
+msgid "Suzanápolis"
+msgstr "Suzanápolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4985
+msgid "Sátiro Dias"
+msgstr "Sátiro Dias"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4645
+msgid "São Benedito"
+msgstr "São Benedito"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4646
+msgid "São Benedito do Rio Preto"
+msgstr "São Benedito do Rio Preto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4647
+msgid "São Benedito do Sul"
+msgstr "São Benedito do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4648
+msgid "São Bentinho"
+msgstr "São Bentinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4649
+#: model:res.city,name:l10n_br.city_br_4650
+msgid "São Bento"
+msgstr "São Bento"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4651
+msgid "São Bento Abade"
+msgstr "São Bento Abade"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4652
+msgid "São Bento do Norte"
+msgstr "São Bento do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4653
+msgid "São Bento do Sapucaí"
+msgstr "São Bento do Sapucaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4654
+msgid "São Bento do Sul"
+msgstr "São Bento do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4655
+msgid "São Bento do Tocantins"
+msgstr "São Bento do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4656
+msgid "São Bento do Trairí"
+msgstr "São Bento do Trairí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4657
+msgid "São Bento do Una"
+msgstr "São Bento do Una"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4658
+msgid "São Bernardino"
+msgstr "São Bernardino"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4659
+msgid "São Bernardo"
+msgstr "São Bernardo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_021
+msgid "São Bernardo do Campo"
+msgstr "São Bernardo do Campo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4660
+msgid "São Bonifácio"
+msgstr "São Bonifácio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4661
+msgid "São Borja"
+msgstr "São Borja"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4664
+msgid "São Braz do Piauí"
+msgstr "São Braz do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4662
+msgid "São Brás"
+msgstr "São Brás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4663
+msgid "São Brás do Suaçuí"
+msgstr "São Brás do Suaçuí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4665
+msgid "São Caetano de Odivelas"
+msgstr "São Caetano de Odivelas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_178
+msgid "São Caetano do Sul"
+msgstr "São Caetano do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4666
+msgid "São Caitano"
+msgstr "São Caitano"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_113
+#: model:res.city,name:l10n_br.city_br_4667
+msgid "São Carlos"
+msgstr "São Carlos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4668
+msgid "São Carlos do Ivaí"
+msgstr "São Carlos do Ivaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4669
+msgid "São Cristóvão"
+msgstr "São Cristóvão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4670
+msgid "São Cristóvão do Sul"
+msgstr "São Cristóvão do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4671
+msgid "São Desidério"
+msgstr "São Desidério"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4672
+#: model:res.city,name:l10n_br.city_br_4673
+#: model:res.city,name:l10n_br.city_br_4674
+#: model:res.city,name:l10n_br.city_br_4675
+#: model:res.city,name:l10n_br.city_br_4676
+msgid "São Domingos"
+msgstr "São Domingos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4677
+msgid "São Domingos das Dores"
+msgstr "São Domingos das Dores"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4678
+msgid "São Domingos do Araguaia"
+msgstr "São Domingos do Araguaia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4679
+msgid "São Domingos do Azeitão"
+msgstr "São Domingos do Azeitão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4680
+msgid "São Domingos do Capim"
+msgstr "São Domingos do Capim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4681
+msgid "São Domingos do Cariri"
+msgstr "São Domingos do Cariri"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4682
+msgid "São Domingos do Maranhão"
+msgstr "São Domingos do Maranhão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4683
+msgid "São Domingos do Norte"
+msgstr "São Domingos do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4684
+msgid "São Domingos do Prata"
+msgstr "São Domingos do Prata"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4685
+msgid "São Domingos do Sul"
+msgstr "São Domingos do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4686
+msgid "São Felipe"
+msgstr "São Felipe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4687
+msgid "São Felipe D'Oeste"
+msgstr "São Felipe D'Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4696
+msgid "São Fernando"
+msgstr "São Fernando"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4697
+msgid "São Fidélis"
+msgstr "São Fidélis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4698
+#: model:res.city,name:l10n_br.city_br_4699
+#: model:res.city,name:l10n_br.city_br_4700
+#: model:res.city,name:l10n_br.city_br_4701
+msgid "São Francisco"
+msgstr "São Francisco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4702
+msgid "São Francisco de Assis"
+msgstr "São Francisco de Assis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4703
+msgid "São Francisco de Assis do Piauí"
+msgstr "São Francisco de Assis do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4704
+msgid "São Francisco de Goiás"
+msgstr "São Francisco de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4705
+msgid "São Francisco de Itabapoana"
+msgstr "São Francisco de Itabapoana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4706
+#: model:res.city,name:l10n_br.city_br_4707
+msgid "São Francisco de Paula"
+msgstr "São Francisco de Paula"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4708
+msgid "São Francisco de Sales"
+msgstr "São Francisco de Sales"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4709
+msgid "São Francisco do Brejão"
+msgstr "São Francisco do Brejão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4710
+msgid "São Francisco do Conde"
+msgstr "São Francisco do Conde"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4711
+msgid "São Francisco do Glória"
+msgstr "São Francisco do Glória"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4712
+msgid "São Francisco do Guaporé"
+msgstr "São Francisco do Guaporé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4713
+msgid "São Francisco do Maranhão"
+msgstr "São Francisco do Maranhão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4714
+msgid "São Francisco do Oeste"
+msgstr "São Francisco do Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4715
+msgid "São Francisco do Pará"
+msgstr "São Francisco do Pará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4716
+msgid "São Francisco do Piauí"
+msgstr "São Francisco do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4717
+msgid "São Francisco do Sul"
+msgstr "São Francisco do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4688
+msgid "São Félix"
+msgstr "São Félix"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4689
+msgid "São Félix de Balsas"
+msgstr "São Félix de Balsas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4690
+msgid "São Félix de Minas"
+msgstr "São Félix de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4691
+msgid "São Félix do Araguaia"
+msgstr "São Félix do Araguaia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4692
+msgid "São Félix do Coribe"
+msgstr "São Félix do Coribe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4693
+msgid "São Félix do Piauí"
+msgstr "São Félix do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4694
+msgid "São Félix do Tocantins"
+msgstr "São Félix do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4695
+msgid "São Félix do Xingu"
+msgstr "São Félix do Xingu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4718
+#: model:res.city,name:l10n_br.city_br_4719
+msgid "São Gabriel"
+msgstr "São Gabriel"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4720
+msgid "São Gabriel da Cachoeira"
+msgstr "São Gabriel da Cachoeira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4721
+msgid "São Gabriel da Palha"
+msgstr "São Gabriel da Palha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4722
+msgid "São Gabriel do Oeste"
+msgstr "São Gabriel do Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4723
+msgid "São Geraldo"
+msgstr "São Geraldo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4724
+msgid "São Geraldo da Piedade"
+msgstr "São Geraldo da Piedade"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4725
+msgid "São Geraldo do Araguaia"
+msgstr "São Geraldo do Araguaia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4726
+msgid "São Geraldo do Baixio"
+msgstr "São Geraldo do Baixio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_018
+msgid "São Gonçalo"
+msgstr "São Gonçalo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4727
+msgid "São Gonçalo do Abaeté"
+msgstr "São Gonçalo do Abaeté"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_265
+#: model:res.city,name:l10n_br.city_br_4728
+msgid "São Gonçalo do Amarante"
+msgstr "São Gonçalo do Amarante"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4729
+msgid "São Gonçalo do Gurguéia"
+msgstr "São Gonçalo do Gurguéia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4730
+msgid "São Gonçalo do Pará"
+msgstr "São Gonçalo do Pará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4731
+msgid "São Gonçalo do Piauí"
+msgstr "São Gonçalo do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4732
+msgid "São Gonçalo do Rio Abaixo"
+msgstr "São Gonçalo do Rio Abaixo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4733
+msgid "São Gonçalo do Rio Preto"
+msgstr "São Gonçalo do Rio Preto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4734
+msgid "São Gonçalo do Sapucaí"
+msgstr "São Gonçalo do Sapucaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4735
+msgid "São Gonçalo dos Campos"
+msgstr "São Gonçalo dos Campos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4736
+msgid "São Gotardo"
+msgstr "São Gotardo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4737
+msgid "São Jerônimo"
+msgstr "São Jerônimo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4738
+msgid "São Jerônimo da Serra"
+msgstr "São Jerônimo da Serra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4790
+msgid "São Joaquim"
+msgstr "São Joaquim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4791
+msgid "São Joaquim da Barra"
+msgstr "São Joaquim da Barra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4792
+msgid "São Joaquim de Bicas"
+msgstr "São Joaquim de Bicas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4793
+msgid "São Joaquim do Monte"
+msgstr "São Joaquim do Monte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4794
+msgid "São Jorge"
+msgstr "São Jorge"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4795
+msgid "São Jorge d'Oeste"
+msgstr "São Jorge d'Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4796
+msgid "São Jorge do Ivaí"
+msgstr "São Jorge do Ivaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4797
+msgid "São Jorge do Patrocínio"
+msgstr "São Jorge do Patrocínio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_104
+msgid "São José"
+msgstr "São José"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4798
+msgid "São José da Barra"
+msgstr "São José da Barra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4799
+msgid "São José da Bela Vista"
+msgstr "São José da Bela Vista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4800
+msgid "São José da Boa Vista"
+msgstr "São José da Boa Vista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4801
+msgid "São José da Coroa Grande"
+msgstr "São José da Coroa Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4802
+msgid "São José da Lagoa Tapada"
+msgstr "São José da Lagoa Tapada"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4803
+msgid "São José da Laje"
+msgstr "São José da Laje"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4804
+msgid "São José da Lapa"
+msgstr "São José da Lapa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4805
+msgid "São José da Safira"
+msgstr "São José da Safira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4806
+msgid "São José da Tapera"
+msgstr "São José da Tapera"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4807
+msgid "São José da Varginha"
+msgstr "São José da Varginha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4808
+msgid "São José da Vitória"
+msgstr "São José da Vitória"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4809
+msgid "São José das Missões"
+msgstr "São José das Missões"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4810
+msgid "São José das Palmeiras"
+msgstr "São José das Palmeiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4811
+msgid "São José de Caiana"
+msgstr "São José de Caiana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4812
+msgid "São José de Espinharas"
+msgstr "São José de Espinharas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4813
+msgid "São José de Mipibu"
+msgstr "São José de Mipibu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4814
+msgid "São José de Piranhas"
+msgstr "São José de Piranhas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4815
+msgid "São José de Princesa"
+msgstr "São José de Princesa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_119
+msgid "São José de Ribamar"
+msgstr "São José de Ribamar"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4816
+msgid "São José de Ubá"
+msgstr "São José de Ubá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4817
+msgid "São José do Alegre"
+msgstr "São José do Alegre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4818
+msgid "São José do Barreiro"
+msgstr "São José do Barreiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4819
+msgid "São José do Belmonte"
+msgstr "São José do Belmonte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4820
+msgid "São José do Bonfim"
+msgstr "São José do Bonfim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4821
+msgid "São José do Brejo do Cruz"
+msgstr "São José do Brejo do Cruz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4822
+msgid "São José do Calçado"
+msgstr "São José do Calçado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4823
+msgid "São José do Campestre"
+msgstr "São José do Campestre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4824
+msgid "São José do Cedro"
+msgstr "São José do Cedro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4825
+msgid "São José do Cerrito"
+msgstr "São José do Cerrito"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4826
+#: model:res.city,name:l10n_br.city_br_4827
+msgid "São José do Divino"
+msgstr "São José do Divino"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4828
+msgid "São José do Egito"
+msgstr "São José do Egito"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4829
+msgid "São José do Goiabal"
+msgstr "São José do Goiabal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4830
+msgid "São José do Herval"
+msgstr "São José do Herval"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4831
+msgid "São José do Hortêncio"
+msgstr "São José do Hortêncio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4832
+msgid "São José do Inhacorá"
+msgstr "São José do Inhacorá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4834
+msgid "São José do Jacuri"
+msgstr "São José do Jacuri"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4833
+msgid "São José do Jacuípe"
+msgstr "São José do Jacuípe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4835
+msgid "São José do Mantimento"
+msgstr "São José do Mantimento"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4836
+msgid "São José do Norte"
+msgstr "São José do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4837
+msgid "São José do Ouro"
+msgstr "São José do Ouro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4838
+msgid "São José do Peixe"
+msgstr "São José do Peixe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4839
+msgid "São José do Piauí"
+msgstr "São José do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4840
+msgid "São José do Povo"
+msgstr "São José do Povo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4841
+msgid "São José do Rio Claro"
+msgstr "São José do Rio Claro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4842
+msgid "São José do Rio Pardo"
+msgstr "São José do Rio Pardo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_045
+msgid "São José do Rio Preto"
+msgstr "São José do Rio Preto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4843
+msgid "São José do Sabugi"
+msgstr "São José do Sabugi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4844
+msgid "São José do Seridó"
+msgstr "São José do Seridó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4845
+msgid "São José do Sul"
+msgstr "São José do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4846
+msgid "São José do Vale do Rio Preto"
+msgstr "São José do Vale do Rio Preto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4847
+msgid "São José do Xingu"
+msgstr "São José do Xingu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4848
+msgid "São José dos Ausentes"
+msgstr "São José dos Ausentes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4849
+msgid "São José dos Basílios"
+msgstr "São José dos Basílios"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_030
+msgid "São José dos Campos"
+msgstr "São José dos Campos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4850
+msgid "São José dos Cordeiros"
+msgstr "São José dos Cordeiros"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_085
+msgid "São José dos Pinhais"
+msgstr "São José dos Pinhais"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4851
+msgid "São José dos Quatro Marcos"
+msgstr "São José dos Quatro Marcos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4852
+msgid "São José dos Ramos"
+msgstr "São José dos Ramos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4739
+#: model:res.city,name:l10n_br.city_br_4740
+msgid "São João"
+msgstr "São João"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4741
+#: model:res.city,name:l10n_br.city_br_4742
+msgid "São João Batista"
+msgstr "São João Batista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4743
+msgid "São João Batista do Glória"
+msgstr "São João Batista do Glória"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4788
+msgid "São João Evangelista"
+msgstr "São João Evangelista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4789
+msgid "São João Nepomuceno"
+msgstr "São João Nepomuceno"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4744
+msgid "São João d'Aliança"
+msgstr "São João d'Aliança"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4745
+msgid "São João da Baliza"
+msgstr "São João da Baliza"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4746
+msgid "São João da Barra"
+msgstr "São João da Barra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4747
+msgid "São João da Boa Vista"
+msgstr "São João da Boa Vista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4748
+msgid "São João da Canabrava"
+msgstr "São João da Canabrava"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4749
+msgid "São João da Fronteira"
+msgstr "São João da Fronteira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4750
+msgid "São João da Lagoa"
+msgstr "São João da Lagoa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4751
+msgid "São João da Mata"
+msgstr "São João da Mata"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4752
+msgid "São João da Paraúna"
+msgstr "São João da Paraúna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4753
+msgid "São João da Ponta"
+msgstr "São João da Ponta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4754
+msgid "São João da Ponte"
+msgstr "São João da Ponte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4755
+msgid "São João da Serra"
+msgstr "São João da Serra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4756
+msgid "São João da Urtiga"
+msgstr "São João da Urtiga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4757
+msgid "São João da Varjota"
+msgstr "São João da Varjota"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4758
+msgid "São João das Duas Pontes"
+msgstr "São João das Duas Pontes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4759
+msgid "São João das Missões"
+msgstr "São João das Missões"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4760
+msgid "São João de Iracema"
+msgstr "São João de Iracema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_053
+msgid "São João de Meriti"
+msgstr "São João de Meriti"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4761
+msgid "São João de Pirabas"
+msgstr "São João de Pirabas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4762
+msgid "São João del Rei"
+msgstr "São João del Rei"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4763
+msgid "São João do Araguaia"
+msgstr "São João do Araguaia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4764
+msgid "São João do Arraial"
+msgstr "São João do Arraial"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4765
+msgid "São João do Caiuá"
+msgstr "São João do Caiuá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4766
+msgid "São João do Cariri"
+msgstr "São João do Cariri"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4767
+msgid "São João do Carú"
+msgstr "São João do Carú"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4768
+msgid "São João do Itaperiú"
+msgstr "São João do Itaperiú"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4769
+msgid "São João do Ivaí"
+msgstr "São João do Ivaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4770
+msgid "São João do Jaguaribe"
+msgstr "São João do Jaguaribe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4771
+msgid "São João do Manhuaçu"
+msgstr "São João do Manhuaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4772
+msgid "São João do Manteninha"
+msgstr "São João do Manteninha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4773
+msgid "São João do Oeste"
+msgstr "São João do Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4774
+msgid "São João do Oriente"
+msgstr "São João do Oriente"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4775
+msgid "São João do Pacuí"
+msgstr "São João do Pacuí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4776
+#: model:res.city,name:l10n_br.city_br_4777
+msgid "São João do Paraíso"
+msgstr "São João do Paraíso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4778
+msgid "São João do Pau d'Alho"
+msgstr "São João do Pau d'Alho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4779
+msgid "São João do Piauí"
+msgstr "São João do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4780
+msgid "São João do Polêsine"
+msgstr "São João do Polêsine"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4781
+msgid "São João do Rio do Peixe"
+msgstr "São João do Rio do Peixe"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4782
+msgid "São João do Sabugi"
+msgstr "São João do Sabugi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4783
+msgid "São João do Soter"
+msgstr "São João do Soter"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4784
+msgid "São João do Sul"
+msgstr "São João do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4785
+msgid "São João do Tigre"
+msgstr "São João do Tigre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4786
+msgid "São João do Triunfo"
+msgstr "São João do Triunfo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4787
+msgid "São João dos Patos"
+msgstr "São João dos Patos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4853
+msgid "São Julião"
+msgstr "São Julião"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_144
+msgid "São Leopoldo"
+msgstr "São Leopoldo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4854
+msgid "São Lourenço"
+msgstr "São Lourenço"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_282
+msgid "São Lourenço da Mata"
+msgstr "São Lourenço da Mata"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4855
+msgid "São Lourenço da Serra"
+msgstr "São Lourenço da Serra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4856
+msgid "São Lourenço do Oeste"
+msgstr "São Lourenço do Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4857
+msgid "São Lourenço do Piauí"
+msgstr "São Lourenço do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4858
+msgid "São Lourenço do Sul"
+msgstr "São Lourenço do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4859
+msgid "São Ludgero"
+msgstr "São Ludgero"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4862
+msgid "São Luis do Piauí"
+msgstr "São Luis do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4865
+msgid "São Luiz"
+msgstr "São Luiz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4868
+msgid "São Luiz Gonzaga"
+msgstr "São Luiz Gonzaga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4866
+msgid "São Luiz do Norte"
+msgstr "São Luiz do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4867
+msgid "São Luiz do Paraitinga"
+msgstr "São Luiz do Paraitinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_015
+msgid "São Luís"
+msgstr "São Luís"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4864
+msgid "São Luís Gonzaga do Maranhão"
+msgstr "São Luís Gonzaga do Maranhão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4860
+msgid "São Luís de Montes Belos"
+msgstr "São Luís de Montes Belos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4861
+msgid "São Luís do Curu"
+msgstr "São Luís do Curu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4863
+msgid "São Luís do Quitunde"
+msgstr "São Luís do Quitunde"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4869
+msgid "São Mamede"
+msgstr "São Mamede"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4870
+msgid "São Manoel do Paraná"
+msgstr "São Manoel do Paraná"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4871
+msgid "São Manuel"
+msgstr "São Manuel"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4872
+msgid "São Marcos"
+msgstr "São Marcos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4873
+#: model:res.city,name:l10n_br.city_br_4874
+msgid "São Martinho"
+msgstr "São Martinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4875
+msgid "São Martinho da Serra"
+msgstr "São Martinho da Serra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_246
+msgid "São Mateus"
+msgstr "São Mateus"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4876
+msgid "São Mateus do Maranhão"
+msgstr "São Mateus do Maranhão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4877
+msgid "São Mateus do Sul"
+msgstr "São Mateus do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4878
+msgid "São Miguel"
+msgstr "São Miguel"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4879
+msgid "São Miguel Arcanjo"
+msgstr "São Miguel Arcanjo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4880
+msgid "São Miguel da Baixa Grande"
+msgstr "São Miguel da Baixa Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4881
+msgid "São Miguel da Boa Vista"
+msgstr "São Miguel da Boa Vista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4882
+msgid "São Miguel das Matas"
+msgstr "São Miguel das Matas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4883
+msgid "São Miguel das Missões"
+msgstr "São Miguel das Missões"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4884
+msgid "São Miguel de Taipu"
+msgstr "São Miguel de Taipu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4885
+msgid "São Miguel do Aleixo"
+msgstr "São Miguel do Aleixo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4886
+msgid "São Miguel do Anta"
+msgstr "São Miguel do Anta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4887
+msgid "São Miguel do Araguaia"
+msgstr "São Miguel do Araguaia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4888
+msgid "São Miguel do Fidalgo"
+msgstr "São Miguel do Fidalgo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4889
+msgid "São Miguel do Gostoso"
+msgstr "São Miguel do Gostoso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4890
+msgid "São Miguel do Guamá"
+msgstr "São Miguel do Guamá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4891
+msgid "São Miguel do Guaporé"
+msgstr "São Miguel do Guaporé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4892
+msgid "São Miguel do Iguaçu"
+msgstr "São Miguel do Iguaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4893
+msgid "São Miguel do Oeste"
+msgstr "São Miguel do Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4894
+msgid "São Miguel do Passa Quatro"
+msgstr "São Miguel do Passa Quatro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4895
+msgid "São Miguel do Tapuio"
+msgstr "São Miguel do Tapuio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4896
+msgid "São Miguel do Tocantins"
+msgstr "São Miguel do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4897
+msgid "São Miguel dos Campos"
+msgstr "São Miguel dos Campos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4898
+msgid "São Miguel dos Milagres"
+msgstr "São Miguel dos Milagres"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4899
+msgid "São Nicolau"
+msgstr "São Nicolau"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4900
+msgid "São Patrício"
+msgstr "São Patrício"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_001
+msgid "São Paulo"
+msgstr "São Paulo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4901
+msgid "São Paulo das Missões"
+msgstr "São Paulo das Missões"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4902
+msgid "São Paulo de Olivença"
+msgstr "São Paulo de Olivença"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4903
+msgid "São Paulo do Potengi"
+msgstr "São Paulo do Potengi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4904
+#: model:res.city,name:l10n_br.city_br_4905
+msgid "São Pedro"
+msgstr "São Pedro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_303
+msgid "São Pedro da Aldeia"
+msgstr "São Pedro da Aldeia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4907
+msgid "São Pedro da Cipa"
+msgstr "São Pedro da Cipa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4908
+msgid "São Pedro da Serra"
+msgstr "São Pedro da Serra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4909
+msgid "São Pedro da União"
+msgstr "São Pedro da União"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4906
+msgid "São Pedro da Água Branca"
+msgstr "São Pedro da Água Branca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4910
+msgid "São Pedro das Missões"
+msgstr "São Pedro das Missões"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4911
+msgid "São Pedro de Alcântara"
+msgstr "São Pedro de Alcântara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4912
+msgid "São Pedro do Butiá"
+msgstr "São Pedro do Butiá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4913
+msgid "São Pedro do Iguaçu"
+msgstr "São Pedro do Iguaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4914
+msgid "São Pedro do Ivaí"
+msgstr "São Pedro do Ivaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4915
+msgid "São Pedro do Paraná"
+msgstr "São Pedro do Paraná"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4916
+msgid "São Pedro do Piauí"
+msgstr "São Pedro do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4917
+msgid "São Pedro do Suaçuí"
+msgstr "São Pedro do Suaçuí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4918
+msgid "São Pedro do Sul"
+msgstr "São Pedro do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4919
+msgid "São Pedro do Turvo"
+msgstr "São Pedro do Turvo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4920
+msgid "São Pedro dos Crentes"
+msgstr "São Pedro dos Crentes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4921
+msgid "São Pedro dos Ferros"
+msgstr "São Pedro dos Ferros"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4922
+msgid "São Rafael"
+msgstr "São Rafael"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4925
+msgid "São Raimundo Nonato"
+msgstr "São Raimundo Nonato"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4923
+msgid "São Raimundo das Mangabeiras"
+msgstr "São Raimundo das Mangabeiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4924
+msgid "São Raimundo do Doca Bezerra"
+msgstr "São Raimundo do Doca Bezerra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4926
+msgid "São Roberto"
+msgstr "São Roberto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4927
+msgid "São Romão"
+msgstr "São Romão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4928
+msgid "São Roque"
+msgstr "São Roque"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4929
+msgid "São Roque de Minas"
+msgstr "São Roque de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4930
+msgid "São Roque do Canaã"
+msgstr "São Roque do Canaã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4931
+msgid "São Salvador do Tocantins"
+msgstr "São Salvador do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4932
+#: model:res.city,name:l10n_br.city_br_4933
+msgid "São Sebastião"
+msgstr "São Sebastião"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4934
+msgid "São Sebastião da Amoreira"
+msgstr "São Sebastião da Amoreira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4935
+msgid "São Sebastião da Bela Vista"
+msgstr "São Sebastião da Bela Vista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4936
+msgid "São Sebastião da Boa Vista"
+msgstr "São Sebastião da Boa Vista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4937
+msgid "São Sebastião da Grama"
+msgstr "São Sebastião da Grama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4938
+msgid "São Sebastião da Vargem Alegre"
+msgstr "São Sebastião da Vargem Alegre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4939
+msgid "São Sebastião de Lagoa de Roça"
+msgstr "São Sebastião de Lagoa de Roça"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4940
+msgid "São Sebastião do Alto"
+msgstr "São Sebastião do Alto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4941
+msgid "São Sebastião do Anta"
+msgstr "São Sebastião do Anta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4942
+msgid "São Sebastião do Caí"
+msgstr "São Sebastião do Caí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4943
+msgid "São Sebastião do Maranhão"
+msgstr "São Sebastião do Maranhão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4944
+msgid "São Sebastião do Oeste"
+msgstr "São Sebastião do Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4945
+msgid "São Sebastião do Paraíso"
+msgstr "São Sebastião do Paraíso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4946
+msgid "São Sebastião do Passé"
+msgstr "São Sebastião do Passé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4947
+msgid "São Sebastião do Rio Preto"
+msgstr "São Sebastião do Rio Preto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4948
+msgid "São Sebastião do Rio Verde"
+msgstr "São Sebastião do Rio Verde"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4949
+msgid "São Sebastião do Tocantins"
+msgstr "São Sebastião do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4950
+msgid "São Sebastião do Uatumã"
+msgstr "São Sebastião do Uatumã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4951
+msgid "São Sebastião do Umbuzeiro"
+msgstr "São Sebastião do Umbuzeiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4952
+msgid "São Sepé"
+msgstr "São Sepé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4953
+#: model:res.city,name:l10n_br.city_br_4954
+msgid "São Simão"
+msgstr "São Simão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4955
+msgid "São Thomé das Letras"
+msgstr "São Thomé das Letras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4956
+msgid "São Tiago"
+msgstr "São Tiago"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4957
+msgid "São Tomás de Aquino"
+msgstr "São Tomás de Aquino"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4958
+#: model:res.city,name:l10n_br.city_br_4959
+msgid "São Tomé"
+msgstr "São Tomé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4960
+msgid "São Valentim"
+msgstr "São Valentim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4961
+msgid "São Valentim do Sul"
+msgstr "São Valentim do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4962
+msgid "São Valério"
+msgstr "São Valério"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4963
+msgid "São Valério do Sul"
+msgstr "São Valério do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4964
+msgid "São Vendelino"
+msgstr "São Vendelino"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_083
+#: model:res.city,name:l10n_br.city_br_4965
+msgid "São Vicente"
+msgstr "São Vicente"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4969
+msgid "São Vicente Ferrer"
+msgstr "São Vicente Ferrer"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4970
+msgid "São Vicente Férrer"
+msgstr "São Vicente Férrer"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4966
+msgid "São Vicente de Minas"
+msgstr "São Vicente de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4967
+msgid "São Vicente do Seridó"
+msgstr "São Vicente do Seridó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_4968
+msgid "São Vicente do Sul"
+msgstr "São Vicente do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5031
+msgid "Sério"
+msgstr "Sério"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5106
+#: model:res.city,name:l10n_br.city_br_5107
+msgid "Sítio Novo"
+msgstr "Sítio Novo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5108
+msgid "Sítio Novo do Tocantins"
+msgstr "Sítio Novo do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5103
+msgid "Sítio d'Abadia"
+msgstr "Sítio d'Abadia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5104
+msgid "Sítio do Mato"
+msgstr "Sítio do Mato"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5105
+msgid "Sítio do Quinto"
+msgstr "Sítio do Quinto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5140
+msgid "Tabaporã"
+msgstr "Tabaporã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5141
+msgid "Tabapuã"
+msgstr "Tabapuã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5142
+#: model:res.city,name:l10n_br.city_br_5143
+msgid "Tabatinga"
+msgstr "Tabatinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5139
+msgid "Tabaí"
+msgstr "Tabaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5144
+msgid "Tabira"
+msgstr "Tabira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5145
+msgid "Tabocas do Brejo Velho"
+msgstr "Tabocas do Brejo Velho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5146
+msgid "Taboleiro Grande"
+msgstr "Taboleiro Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_101
+msgid "Taboão da Serra"
+msgstr "Taboão da Serra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5147
+msgid "Tabuleiro"
+msgstr "Tabuleiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5148
+msgid "Tabuleiro do Norte"
+msgstr "Tabuleiro do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5149
+msgid "Tacaimbó"
+msgstr "Tacaimbó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5150
+msgid "Tacaratu"
+msgstr "Tacaratu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5151
+msgid "Taciba"
+msgstr "Taciba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5152
+msgid "Tacima"
+msgstr "Tacima"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5153
+msgid "Tacuru"
+msgstr "Tacuru"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5155
+msgid "Taguatinga"
+msgstr "Taguatinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5154
+msgid "Taguaí"
+msgstr "Taguaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5156
+msgid "Taiaçu"
+msgstr "Taiaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5157
+msgid "Tailândia"
+msgstr "Tailândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5159
+msgid "Taiobeiras"
+msgstr "Taiobeiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5160
+msgid "Taipas do Tocantins"
+msgstr "Taipas do Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5161
+msgid "Taipu"
+msgstr "Taipu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5158
+msgid "Taió"
+msgstr "Taió"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5162
+msgid "Taiúva"
+msgstr "Taiúva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5163
+msgid "Talismã"
+msgstr "Talismã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5164
+msgid "Tamandaré"
+msgstr "Tamandaré"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5165
+msgid "Tamarana"
+msgstr "Tamarana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5166
+msgid "Tambaú"
+msgstr "Tambaú"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5167
+msgid "Tamboara"
+msgstr "Tamboara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5168
+msgid "Tamboril"
+msgstr "Tamboril"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5169
+msgid "Tamboril do Piauí"
+msgstr "Tamboril do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5170
+msgid "Tanabi"
+msgstr "Tanabi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5171
+#: model:res.city,name:l10n_br.city_br_5172
+msgid "Tangará"
+msgstr "Tangará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_293
+msgid "Tangará da Serra"
+msgstr "Tangará da Serra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5173
+msgid "Tanguá"
+msgstr "Tanguá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5174
+msgid "Tanhaçu"
+msgstr "Tanhaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5177
+msgid "Tanque Novo"
+msgstr "Tanque Novo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5175
+msgid "Tanque d'Arca"
+msgstr "Tanque d'Arca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5176
+msgid "Tanque do Piauí"
+msgstr "Tanque do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5178
+msgid "Tanquinho"
+msgstr "Tanquinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5179
+msgid "Taparuba"
+msgstr "Taparuba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5180
+msgid "Tapauá"
+msgstr "Tapauá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5181
+#: model:res.city,name:l10n_br.city_br_5182
+msgid "Tapejara"
+msgstr "Tapejara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5183
+msgid "Tapera"
+msgstr "Tapera"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5184
+#: model:res.city,name:l10n_br.city_br_5185
+msgid "Taperoá"
+msgstr "Taperoá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5186
+msgid "Tapes"
+msgstr "Tapes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5187
+#: model:res.city,name:l10n_br.city_br_5188
+msgid "Tapira"
+msgstr "Tapira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5191
+msgid "Tapiramutá"
+msgstr "Tapiramutá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5192
+msgid "Tapiratiba"
+msgstr "Tapiratiba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5189
+#: model:res.city,name:l10n_br.city_br_5190
+msgid "Tapiraí"
+msgstr "Tapiraí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5193
+msgid "Tapurah"
+msgstr "Tapurah"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5194
+msgid "Taquara"
+msgstr "Taquara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5196
+msgid "Taquaral"
+msgstr "Taquaral"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5197
+msgid "Taquaral de Goiás"
+msgstr "Taquaral de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5198
+msgid "Taquarana"
+msgstr "Taquarana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5195
+msgid "Taquaraçu de Minas"
+msgstr "Taquaraçu de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5199
+msgid "Taquari"
+msgstr "Taquari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5200
+msgid "Taquaritinga"
+msgstr "Taquaritinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5201
+msgid "Taquaritinga do Norte"
+msgstr "Taquaritinga do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5202
+msgid "Taquarituba"
+msgstr "Taquarituba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5203
+msgid "Taquarivaí"
+msgstr "Taquarivaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5205
+msgid "Taquarussu"
+msgstr "Taquarussu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5204
+msgid "Taquaruçu do Sul"
+msgstr "Taquaruçu do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5206
+msgid "Tarabai"
+msgstr "Tarabai"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5207
+msgid "Tarauacá"
+msgstr "Tarauacá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5208
+msgid "Tarrafas"
+msgstr "Tarrafas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5209
+msgid "Tartarugalzinho"
+msgstr "Tartarugalzinho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5211
+msgid "Tarumirim"
+msgstr "Tarumirim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5210
+msgid "Tarumã"
+msgstr "Tarumã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5212
+msgid "Tasso Fragoso"
+msgstr "Tasso Fragoso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_245
+msgid "Tatuí"
+msgstr "Tatuí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_089
+msgid "Taubaté"
+msgstr "Taubaté"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5213
+msgid "Tauá"
+msgstr "Tauá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5214
+#: model:res.city,name:l10n_br.city_br_5215
+msgid "Tavares"
+msgstr "Tavares"
 
 #. module: l10n_br
 #: model:ir.model,name:l10n_br.model_account_tax
@@ -522,10 +25385,1785 @@ msgid "Taxed in full"
 msgstr "Tributado integralmente"
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5216
+msgid "Tefé"
+msgstr "Tefé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5217
+msgid "Teixeira"
+msgstr "Teixeira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5218
+msgid "Teixeira Soares"
+msgstr "Teixeira Soares"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_207
+msgid "Teixeira de Freitas"
+msgstr "Teixeira de Freitas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5219
+msgid "Teixeiras"
+msgstr "Teixeiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5220
+msgid "Teixeirópolis"
+msgstr "Teixeirópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5222
+msgid "Tejupá"
+msgstr "Tejupá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5221
+msgid "Tejuçuoca"
+msgstr "Tejuçuoca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5224
+msgid "Telha"
+msgstr "Telha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5223
+msgid "Telêmaco Borba"
+msgstr "Telêmaco Borba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5225
+msgid "Tenente Ananias"
+msgstr "Tenente Ananias"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5226
+msgid "Tenente Laurentino Cruz"
+msgstr "Tenente Laurentino Cruz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5227
+msgid "Tenente Portela"
+msgstr "Tenente Portela"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5228
+msgid "Tenório"
+msgstr "Tenório"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5229
+#: model:res.city,name:l10n_br.city_br_5230
+msgid "Teodoro Sampaio"
+msgstr "Teodoro Sampaio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5231
+msgid "Teofilândia"
+msgstr "Teofilândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5232
+msgid "Teolândia"
+msgstr "Teolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5233
+msgid "Teotônio Vilela"
+msgstr "Teotônio Vilela"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5234
+msgid "Terenos"
+msgstr "Terenos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_019
+msgid "Teresina"
+msgstr "Teresina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5235
+msgid "Teresina de Goiás"
+msgstr "Teresina de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_181
+msgid "Teresópolis"
+msgstr "Teresópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5236
+msgid "Terezinha"
+msgstr "Terezinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5237
+msgid "Terezópolis de Goiás"
+msgstr "Terezópolis de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5238
+msgid "Terra Alta"
+msgstr "Terra Alta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5239
+msgid "Terra Boa"
+msgstr "Terra Boa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5241
+#: model:res.city,name:l10n_br.city_br_5242
+msgid "Terra Nova"
+msgstr "Terra Nova"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5243
+msgid "Terra Nova do Norte"
+msgstr "Terra Nova do Norte"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5244
+msgid "Terra Rica"
+msgstr "Terra Rica"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5245
+#: model:res.city,name:l10n_br.city_br_5246
+msgid "Terra Roxa"
+msgstr "Terra Roxa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5247
+msgid "Terra Santa"
+msgstr "Terra Santa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5240
+msgid "Terra de Areia"
+msgstr "Terra de Areia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5248
+msgid "Tesouro"
+msgstr "Tesouro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5249
+msgid "Teutônia"
+msgstr "Teutônia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_215
+msgid "Teófilo Otoni"
+msgstr "Teófilo Otoni"
+
+#. module: l10n_br
+#. odoo-python
+#: code:addons/l10n_br/models/res_partner_bank.py:0
+msgid ""
+"The mobile number %s is invalid. It must start with +55, contain a 2 digit "
+"territory or state code followed by a 9 digit number."
+msgstr ""
+"O número de celular %s é inválido. Ele deve começar com +55, conter o DDD de "
+"2 dígitos e o número de 9 dígitos."
+
+#. module: l10n_br
+#. odoo-python
+#: code:addons/l10n_br/models/res_partner_bank.py:0
+msgid ""
+"The proxy type must be Email Address, Mobile Number, CPF/CNPJ (BR) or Random "
+"Key (BR) for Pix code generation."
+msgstr ""
+"O tipo de proxy para geração do código Pix deve ser endereço de e-mail, "
+"número de celular, CPF/CNPF ou chave aleatória."
+
+#. module: l10n_br
+#. odoo-python
+#: code:addons/l10n_br/models/res_partner_bank.py:0
+msgid ""
+"The random key %s is invalid, the format looks like this: "
+"71d6c6e1-64ea-4a11-9560-a10870c40ca2"
+msgstr ""
+"A chave aleatória %s é inválida. O formato deve se assemelhar a: "
+"71d6c6e1-64ea-4a11-9560-a10870c40ca2"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5250
+msgid "Theobroma"
+msgstr "Theobroma"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5251
+msgid "Tianguá"
+msgstr "Tianguá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5252
+msgid "Tibagi"
+msgstr "Tibagi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5253
+msgid "Tibau"
+msgstr "Tibau"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5254
+msgid "Tibau do Sul"
+msgstr "Tibau do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5255
+msgid "Tietê"
+msgstr "Tietê"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5256
+msgid "Tigrinhos"
+msgstr "Tigrinhos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5257
+msgid "Tijucas"
+msgstr "Tijucas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5258
+msgid "Tijucas do Sul"
+msgstr "Tijucas do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5259
+msgid "Timbaúba"
+msgstr "Timbaúba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5260
+msgid "Timbaúba dos Batistas"
+msgstr "Timbaúba dos Batistas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5262
+msgid "Timbiras"
+msgstr "Timbiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5265
+msgid "Timburi"
+msgstr "Timburi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5261
+msgid "Timbé do Sul"
+msgstr "Timbé do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5263
+msgid "Timbó"
+msgstr "Timbó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5264
+msgid "Timbó Grande"
+msgstr "Timbó Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_169
+msgid "Timon"
+msgstr "Timon"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5266
+msgid "Timóteo"
+msgstr "Timóteo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5267
+msgid "Tio Hugo"
+msgstr "Tio Hugo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5268
+msgid "Tiradentes"
+msgstr "Tiradentes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5269
+msgid "Tiradentes do Sul"
+msgstr "Tiradentes do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5270
+msgid "Tiros"
+msgstr "Tiros"
+
+#. module: l10n_br
+#. odoo-python
+#: code:addons/l10n_br/models/res_partner_bank.py:0
+msgid ""
+"To generate a Pix code the proxy type for %s must be Email Address, Mobile "
+"Number, CPF/CNPJ (BR) or Random Key (BR)."
+msgstr ""
+"Para gerar um código Pix, o tipo de proxy de %s deve ser endereço de e-mail, "
+"número de celular, CPF/CNPJ ou chave aleatória."
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5271
+msgid "Tobias Barreto"
+msgstr "Tobias Barreto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5274
+msgid "Tocantins"
+msgstr "Tocantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5273
+msgid "Tocantinópolis"
+msgstr "Tocantinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5272
+msgid "Tocantínia"
+msgstr "Tocantínia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5275
+msgid "Tocos do Moji"
+msgstr "Tocos do Moji"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_200
+#: model:res.city,name:l10n_br.city_br_5276
+msgid "Toledo"
+msgstr "Toledo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5277
+msgid "Tomar do Geru"
+msgstr "Tomar do Geru"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5278
+msgid "Tomazina"
+msgstr "Tomazina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5279
+msgid "Tombos"
+msgstr "Tombos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5280
+msgid "Tomé-Açu"
+msgstr "Tomé-Açu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5281
+msgid "Tonantins"
+msgstr "Tonantins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5282
+msgid "Toritama"
+msgstr "Toritama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5283
+msgid "Torixoréu"
+msgstr "Torixoréu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5284
+msgid "Toropi"
+msgstr "Toropi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5285
+msgid "Torre de Pedra"
+msgstr "Torre de Pedra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5286
+msgid "Torres"
+msgstr "Torres"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5287
+msgid "Torrinha"
+msgstr "Torrinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5288
+msgid "Touros"
+msgstr "Touros"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5289
+msgid "Trabiju"
+msgstr "Trabiju"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5290
+msgid "Tracuateua"
+msgstr "Tracuateua"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5291
+msgid "Tracunhaém"
+msgstr "Tracunhaém"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5292
+msgid "Traipu"
+msgstr "Traipu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5294
+msgid "Trairi"
+msgstr "Trairi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5293
+msgid "Trairão"
+msgstr "Trairão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5295
+msgid "Trajano de Moraes"
+msgstr "Trajano de Moraes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5296
+msgid "Tramandaí"
+msgstr "Tramandaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5297
+msgid "Travesseiro"
+msgstr "Travesseiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5298
+msgid "Tremedal"
+msgstr "Tremedal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5299
+msgid "Tremembé"
+msgstr "Tremembé"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5315
+msgid "Treviso"
+msgstr "Treviso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5317
+msgid "Treze Tílias"
+msgstr "Treze Tílias"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5316
+msgid "Treze de Maio"
+msgstr "Treze de Maio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_211
+#: model:res.city,name:l10n_br.city_br_5318
+msgid "Trindade"
+msgstr "Trindade"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5319
+msgid "Trindade do Sul"
+msgstr "Trindade do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5320
+#: model:res.city,name:l10n_br.city_br_5321
+#: model:res.city,name:l10n_br.city_br_5322
+msgid "Triunfo"
+msgstr "Triunfo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5323
+msgid "Triunfo Potiguar"
+msgstr "Triunfo Potiguar"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5324
+msgid "Trizidela do Vale"
+msgstr "Trizidela do Vale"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5325
+msgid "Trombas"
+msgstr "Trombas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5326
+msgid "Trombudo Central"
+msgstr "Trombudo Central"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5300
+msgid "Três Arroios"
+msgstr "Três Arroios"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5301
+msgid "Três Barras"
+msgstr "Três Barras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5302
+msgid "Três Barras do Paraná"
+msgstr "Três Barras do Paraná"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5303
+msgid "Três Cachoeiras"
+msgstr "Três Cachoeiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5304
+msgid "Três Corações"
+msgstr "Três Corações"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5305
+msgid "Três Coroas"
+msgstr "Três Coroas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5307
+msgid "Três Forquilhas"
+msgstr "Três Forquilhas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5308
+msgid "Três Fronteiras"
+msgstr "Três Fronteiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_225
+msgid "Três Lagoas"
+msgstr "Três Lagoas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5309
+msgid "Três Marias"
+msgstr "Três Marias"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5310
+msgid "Três Palmeiras"
+msgstr "Três Palmeiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5311
+msgid "Três Passos"
+msgstr "Três Passos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5312
+msgid "Três Pontas"
+msgstr "Três Pontas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5313
+msgid "Três Ranchos"
+msgstr "Três Ranchos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5314
+msgid "Três Rios"
+msgstr "Três Rios"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5306
+msgid "Três de Maio"
+msgstr "Três de Maio"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_286
+msgid "Tubarão"
+msgstr "Tubarão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5327
+msgid "Tucano"
+msgstr "Tucano"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5328
+msgid "Tucumã"
+msgstr "Tucumã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5329
+msgid "Tucunduva"
+msgstr "Tucunduva"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5330
+msgid "Tucuruí"
+msgstr "Tucuruí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5331
+msgid "Tufilândia"
+msgstr "Tufilândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5332
+msgid "Tuiuti"
+msgstr "Tuiuti"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5333
+msgid "Tumiritinga"
+msgstr "Tumiritinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5335
+msgid "Tunas"
+msgstr "Tunas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5336
+msgid "Tunas do Paraná"
+msgstr "Tunas do Paraná"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5337
+msgid "Tuneiras do Oeste"
+msgstr "Tuneiras do Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5338
+msgid "Tuntum"
+msgstr "Tuntum"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5334
+msgid "Tunápolis"
+msgstr "Tunápolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5340
+msgid "Tupaciguara"
+msgstr "Tupaciguara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5341
+msgid "Tupanatinga"
+msgstr "Tupanatinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5342
+msgid "Tupanci do Sul"
+msgstr "Tupanci do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5343
+msgid "Tupanciretã"
+msgstr "Tupanciretã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5344
+msgid "Tupandi"
+msgstr "Tupandi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5345
+msgid "Tuparendi"
+msgstr "Tuparendi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5346
+msgid "Tuparetama"
+msgstr "Tuparetama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5348
+msgid "Tupi Paulista"
+msgstr "Tupi Paulista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5349
+msgid "Tupirama"
+msgstr "Tupirama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5350
+msgid "Tupiratins"
+msgstr "Tupiratins"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5339
+msgid "Tupã"
+msgstr "Tupã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5347
+msgid "Tupãssi"
+msgstr "Tupãssi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5351
+msgid "Turiaçu"
+msgstr "Turiaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5352
+msgid "Turilândia"
+msgstr "Turilândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5353
+msgid "Turiúba"
+msgstr "Turiúba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5354
+#: model:res.city,name:l10n_br.city_br_5355
+msgid "Turmalina"
+msgstr "Turmalina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5357
+msgid "Tururu"
+msgstr "Tururu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5356
+msgid "Turuçu"
+msgstr "Turuçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5359
+msgid "Turvelândia"
+msgstr "Turvelândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5360
+#: model:res.city,name:l10n_br.city_br_5361
+msgid "Turvo"
+msgstr "Turvo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5362
+msgid "Turvolândia"
+msgstr "Turvolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5358
+msgid "Turvânia"
+msgstr "Turvânia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5363
+msgid "Tutóia"
+msgstr "Tutóia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5364
+msgid "Uarini"
+msgstr "Uarini"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5365
+msgid "Uauá"
+msgstr "Uauá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5368
+msgid "Ubaitaba"
+msgstr "Ubaitaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5369
+msgid "Ubajara"
+msgstr "Ubajara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5370
+msgid "Ubaporanga"
+msgstr "Ubaporanga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5371
+msgid "Ubarana"
+msgstr "Ubarana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5373
+msgid "Ubatuba"
+msgstr "Ubatuba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5372
+msgid "Ubatã"
+msgstr "Ubatã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5366
+msgid "Ubaí"
+msgstr "Ubaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5367
+msgid "Ubaíra"
+msgstr "Ubaíra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_081
+msgid "Uberaba"
+msgstr "Uberaba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_028
+msgid "Uberlândia"
+msgstr "Uberlândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5374
+msgid "Ubirajara"
+msgstr "Ubirajara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5375
+msgid "Ubiratã"
+msgstr "Ubiratã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5376
+msgid "Ubiretama"
+msgstr "Ubiretama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_310
+msgid "Ubá"
+msgstr "Ubá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5377
+msgid "Uchoa"
+msgstr "Uchoa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5378
+msgid "Uibaí"
+msgstr "Uibaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5379
+msgid "Uiramutã"
+msgstr "Uiramutã"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5380
+msgid "Uirapuru"
+msgstr "Uirapuru"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5381
+msgid "Uiraúna"
+msgstr "Uiraúna"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5382
+msgid "Ulianópolis"
+msgstr "Ulianópolis"
+
+#. module: l10n_br
 #: model:ir.model.fields,help:l10n_br.field_account_tax__amount_mva
 #: model:ir.model.fields,help:l10n_br.field_account_tax__base_reduction
 msgid "Um percentual decimal em % entre 0-1."
 msgstr "Um percentual decimal em % entre 0 e 1."
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5383
+msgid "Umari"
+msgstr "Umari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5384
+msgid "Umarizal"
+msgstr "Umarizal"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5385
+msgid "Umbaúba"
+msgstr "Umbaúba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5386
+msgid "Umburanas"
+msgstr "Umburanas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5387
+msgid "Umburatiba"
+msgstr "Umburatiba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5388
+msgid "Umbuzeiro"
+msgstr "Umbuzeiro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5389
+msgid "Umirim"
+msgstr "Umirim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_263
+msgid "Umuarama"
+msgstr "Umuarama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5390
+msgid "Una"
+msgstr "Una"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5391
+msgid "Unaí"
+msgstr "Unaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5400
+msgid "Uniflor"
+msgstr "Uniflor"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5401
+msgid "Unistalda"
+msgstr "Unistalda"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5392
+msgid "União"
+msgstr "União"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5399
+msgid "União Paulista"
+msgstr "União Paulista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5393
+msgid "União da Serra"
+msgstr "União da Serra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5394
+msgid "União da Vitória"
+msgstr "União da Vitória"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5395
+msgid "União de Minas"
+msgstr "União de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5396
+msgid "União do Oeste"
+msgstr "União do Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5397
+msgid "União do Sul"
+msgstr "União do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5398
+msgid "União dos Palmares"
+msgstr "União dos Palmares"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5402
+msgid "Upanema"
+msgstr "Upanema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5404
+msgid "Urandi"
+msgstr "Urandi"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5403
+msgid "Uraí"
+msgstr "Uraí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5406
+msgid "Urbano Santos"
+msgstr "Urbano Santos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5407
+msgid "Uru"
+msgstr "Uru"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5409
+msgid "Uruana"
+msgstr "Uruana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5410
+msgid "Uruana de Minas"
+msgstr "Uruana de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5411
+msgid "Uruará"
+msgstr "Uruará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5408
+msgid "Uruaçu"
+msgstr "Uruaçu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5412
+msgid "Urubici"
+msgstr "Urubici"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5413
+msgid "Uruburetama"
+msgstr "Uruburetama"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5415
+msgid "Urucará"
+msgstr "Urucará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5418
+msgid "Urucuia"
+msgstr "Urucuia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5419
+msgid "Urucurituba"
+msgstr "Urucurituba"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5414
+msgid "Urucânia"
+msgstr "Urucânia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_262
+msgid "Uruguaiana"
+msgstr "Uruguaiana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5420
+msgid "Uruoca"
+msgstr "Uruoca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5422
+msgid "Urupema"
+msgstr "Urupema"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5421
+msgid "Urupá"
+msgstr "Urupá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5423
+msgid "Urupês"
+msgstr "Urupês"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5424
+msgid "Urussanga"
+msgstr "Urussanga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5425
+msgid "Urutaí"
+msgstr "Urutaí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5416
+msgid "Uruçuca"
+msgstr "Uruçuca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5417
+msgid "Uruçuí"
+msgstr "Uruçuí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5405
+msgid "Urânia"
+msgstr "Urânia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5426
+msgid "Utinga"
+msgstr "Utinga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5427
+msgid "Vacaria"
+msgstr "Vacaria"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5432
+msgid "Vale Real"
+msgstr "Vale Real"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5433
+msgid "Vale Verde"
+msgstr "Vale Verde"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5428
+msgid "Vale de São Domingos"
+msgstr "Vale de São Domingos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5429
+msgid "Vale do Anari"
+msgstr "Vale do Anari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5430
+msgid "Vale do Paraíso"
+msgstr "Vale do Paraíso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5431
+msgid "Vale do Sol"
+msgstr "Vale do Sol"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5437
+msgid "Valente"
+msgstr "Valente"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5438
+msgid "Valentim Gentil"
+msgstr "Valentim Gentil"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5434
+#: model:res.city,name:l10n_br.city_br_5435
+msgid "Valença"
+msgstr "Valença"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5436
+msgid "Valença do Piauí"
+msgstr "Valença do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_240
+msgid "Valinhos"
+msgstr "Valinhos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5439
+msgid "Valparaíso"
+msgstr "Valparaíso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_153
+msgid "Valparaíso de Goiás"
+msgstr "Valparaíso de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5440
+msgid "Vanini"
+msgstr "Vanini"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5442
+#: model:res.city,name:l10n_br.city_br_5443
+msgid "Vargem"
+msgstr "Vargem"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5444
+msgid "Vargem Alegre"
+msgstr "Vargem Alegre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5445
+msgid "Vargem Alta"
+msgstr "Vargem Alta"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5446
+#: model:res.city,name:l10n_br.city_br_5447
+msgid "Vargem Bonita"
+msgstr "Vargem Bonita"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5448
+msgid "Vargem Grande"
+msgstr "Vargem Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5451
+msgid "Vargem Grande Paulista"
+msgstr "Vargem Grande Paulista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5449
+msgid "Vargem Grande do Rio Pardo"
+msgstr "Vargem Grande do Rio Pardo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5450
+msgid "Vargem Grande do Sul"
+msgstr "Vargem Grande do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5441
+msgid "Vargeão"
+msgstr "Vargeão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_216
+msgid "Varginha"
+msgstr "Varginha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5454
+msgid "Varjota"
+msgstr "Varjota"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5452
+msgid "Varjão"
+msgstr "Varjão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5453
+msgid "Varjão de Minas"
+msgstr "Varjão de Minas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5455
+msgid "Varre-Sai"
+msgstr "Varre-Sai"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5465
+msgid "Varzedo"
+msgstr "Varzedo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5466
+msgid "Varzelândia"
+msgstr "Varzelândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5467
+msgid "Vassouras"
+msgstr "Vassouras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5468
+msgid "Vazante"
+msgstr "Vazante"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5470
+msgid "Venda Nova do Imigrante"
+msgstr "Venda Nova do Imigrante"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5471
+msgid "Venha-Ver"
+msgstr "Venha-Ver"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5472
+msgid "Ventania"
+msgstr "Ventania"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5473
+msgid "Venturosa"
+msgstr "Venturosa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5469
+msgid "Venâncio Aires"
+msgstr "Venâncio Aires"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5474
+msgid "Vera"
+msgstr "Vera"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5475
+#: model:res.city,name:l10n_br.city_br_5476
+#: model:res.city,name:l10n_br.city_br_5477
+#: model:res.city,name:l10n_br.city_br_5478
+msgid "Vera Cruz"
+msgstr "Vera Cruz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5479
+msgid "Vera Cruz do Oeste"
+msgstr "Vera Cruz do Oeste"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5480
+msgid "Vera Mendes"
+msgstr "Vera Mendes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5481
+msgid "Veranópolis"
+msgstr "Veranópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5482
+msgid "Verdejante"
+msgstr "Verdejante"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5483
+msgid "Verdelândia"
+msgstr "Verdelândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5485
+msgid "Vereda"
+msgstr "Vereda"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5486
+msgid "Veredinha"
+msgstr "Veredinha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5488
+msgid "Vermelho Novo"
+msgstr "Vermelho Novo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5489
+msgid "Vertente do Lério"
+msgstr "Vertente do Lério"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5490
+msgid "Vertentes"
+msgstr "Vertentes"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5484
+msgid "Verê"
+msgstr "Verê"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5487
+msgid "Veríssimo"
+msgstr "Veríssimo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_235
+msgid "Vespasiano"
+msgstr "Vespasiano"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5491
+msgid "Vespasiano Corrêa"
+msgstr "Vespasiano Corrêa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5492
+msgid "Viadutos"
+msgstr "Viadutos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_140
+msgid "Viamão"
+msgstr "Viamão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5493
+#: model:res.city,name:l10n_br.city_br_5494
+msgid "Viana"
+msgstr "Viana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5495
+msgid "Vianópolis"
+msgstr "Vianópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5497
+msgid "Vicente Dutra"
+msgstr "Vicente Dutra"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5498
+msgid "Vicentina"
+msgstr "Vicentina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5499
+msgid "Vicentinópolis"
+msgstr "Vicentinópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5504
+msgid "Victor Graeff"
+msgstr "Victor Graeff"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5496
+msgid "Vicência"
+msgstr "Vicência"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5505
+msgid "Vidal Ramos"
+msgstr "Vidal Ramos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5506
+msgid "Videira"
+msgstr "Videira"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5507
+msgid "Vieiras"
+msgstr "Vieiras"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5508
+msgid "Vieirópolis"
+msgstr "Vieirópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5509
+msgid "Vigia"
+msgstr "Vigia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5510
+msgid "Vila Bela da Santíssima Trindade"
+msgstr "Vila Bela da Santíssima Trindade"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5511
+msgid "Vila Boa"
+msgstr "Vila Boa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5512
+msgid "Vila Flor"
+msgstr "Vila Flor"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5513
+msgid "Vila Flores"
+msgstr "Vila Flores"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5514
+msgid "Vila Lângaro"
+msgstr "Vila Lângaro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5515
+msgid "Vila Maria"
+msgstr "Vila Maria"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5516
+msgid "Vila Nova do Piauí"
+msgstr "Vila Nova do Piauí"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5517
+msgid "Vila Nova do Sul"
+msgstr "Vila Nova do Sul"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5518
+msgid "Vila Nova dos Martírios"
+msgstr "Vila Nova dos Martírios"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5519
+msgid "Vila Pavão"
+msgstr "Vila Pavão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5520
+msgid "Vila Propício"
+msgstr "Vila Propício"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5521
+msgid "Vila Rica"
+msgstr "Vila Rica"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5522
+msgid "Vila Valério"
+msgstr "Vila Valério"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_047
+msgid "Vila Velha"
+msgstr "Vila Velha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5523
+msgid "Vilhena"
+msgstr "Vilhena"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5524
+msgid "Vinhedo"
+msgstr "Vinhedo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5525
+msgid "Viradouro"
+msgstr "Viradouro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5526
+msgid "Virgem da Lapa"
+msgstr "Virgem da Lapa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5528
+msgid "Virginópolis"
+msgstr "Virginópolis"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5529
+msgid "Virgolândia"
+msgstr "Virgolândia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5527
+msgid "Virgínia"
+msgstr "Virgínia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5530
+msgid "Virmond"
+msgstr "Virmond"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5531
+msgid "Visconde do Rio Branco"
+msgstr "Visconde do Rio Branco"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5532
+msgid "Viseu"
+msgstr "Viseu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5533
+msgid "Vista Alegre"
+msgstr "Vista Alegre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5534
+msgid "Vista Alegre do Alto"
+msgstr "Vista Alegre do Alto"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5535
+msgid "Vista Alegre do Prata"
+msgstr "Vista Alegre do Prata"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5536
+msgid "Vista Gaúcha"
+msgstr "Vista Gaúcha"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5537
+msgid "Vista Serrana"
+msgstr "Vista Serrana"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5538
+msgid "Vitor Meireles"
+msgstr "Vitor Meireles"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5544
+msgid "Vitorino"
+msgstr "Vitorino"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5545
+msgid "Vitorino Freire"
+msgstr "Vitorino Freire"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_087
+msgid "Vitória"
+msgstr "Vitória"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5539
+msgid "Vitória Brasil"
+msgstr "Vitória Brasil"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_068
+msgid "Vitória da Conquista"
+msgstr "Vitória da Conquista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5540
+msgid "Vitória das Missões"
+msgstr "Vitória das Missões"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_222
+msgid "Vitória de Santo Antão"
+msgstr "Vitória de Santo Antão"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5541
+msgid "Vitória do Jari"
+msgstr "Vitória do Jari"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5542
+msgid "Vitória do Mearim"
+msgstr "Vitória do Mearim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5543
+msgid "Vitória do Xingu"
+msgstr "Vitória do Xingu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5500
+#: model:res.city,name:l10n_br.city_br_5501
+#: model:res.city,name:l10n_br.city_br_5502
+msgid "Viçosa"
+msgstr "Viçosa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5503
+msgid "Viçosa do Ceará"
+msgstr "Viçosa do Ceará"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5546
+msgid "Volta Grande"
+msgstr "Volta Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_110
+msgid "Volta Redonda"
+msgstr "Volta Redonda"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_236
+msgid "Votorantim"
+msgstr "Votorantim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5547
+msgid "Votuporanga"
+msgstr "Votuporanga"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5456
+#: model:res.city,name:l10n_br.city_br_5457
+msgid "Várzea"
+msgstr "Várzea"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5458
+msgid "Várzea Alegre"
+msgstr "Várzea Alegre"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5459
+msgid "Várzea Branca"
+msgstr "Várzea Branca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_093
+#: model:res.city,name:l10n_br.city_br_5463
+msgid "Várzea Grande"
+msgstr "Várzea Grande"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5464
+msgid "Várzea Nova"
+msgstr "Várzea Nova"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_267
+msgid "Várzea Paulista"
+msgstr "Várzea Paulista"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5460
+msgid "Várzea da Palma"
+msgstr "Várzea da Palma"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5461
+msgid "Várzea da Roça"
+msgstr "Várzea da Roça"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5462
+msgid "Várzea do Poço"
+msgstr "Várzea do Poço"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5548
+msgid "Wagner"
+msgstr "Wagner"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5549
+msgid "Wall Ferraz"
+msgstr "Wall Ferraz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5551
+msgid "Wanderley"
+msgstr "Wanderley"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5550
+msgid "Wanderlândia"
+msgstr "Wanderlândia"
 
 #. module: l10n_br
 #: model:l10n_latam.document.type,name:l10n_br.dt_14
@@ -533,99 +27171,275 @@ msgid "Waterway Ticket"
 msgstr ""
 
 #. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5552
+#: model:res.city,name:l10n_br.city_br_5553
+msgid "Wenceslau Braz"
+msgstr "Wenceslau Braz"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5554
+msgid "Wenceslau Guimarães"
+msgstr "Wenceslau Guimarães"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5555
+msgid "Westfália"
+msgstr "Westfália"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5556
+msgid "Witmarsum"
+msgstr "Witmarsum"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5557
+msgid "Xambioá"
+msgstr "Xambioá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5558
+msgid "Xambrê"
+msgstr "Xambrê"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5559
+msgid "Xangri-lá"
+msgstr "Xangri-lá"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5560
+msgid "Xanxerê"
+msgstr "Xanxerê"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5561
+msgid "Xapuri"
+msgstr "Xapuri"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5562
+msgid "Xavantina"
+msgstr "Xavantina"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5563
+msgid "Xaxim"
+msgstr "Xaxim"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5564
+msgid "Xexéu"
+msgstr "Xexéu"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5565
+msgid "Xinguara"
+msgstr "Xinguara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5566
+msgid "Xique-Xique"
+msgstr "Xique-Xique"
+
+#. module: l10n_br
+#: model_terms:ir.ui.view,arch_db:l10n_br.br_partner_address_form
+msgid "ZIP"
+msgstr ""
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5567
+msgid "Zabelê"
+msgstr "Zabelê"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5568
+msgid "Zacarias"
+msgstr "Zacarias"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5570
+msgid "Zortéa"
+msgstr "Zortéa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_5569
+msgid "Zé Doca"
+msgstr "Zé Doca"
+
+#. module: l10n_br
 #: model:l10n_latam.document.type,name:l10n_br.dt_15
 msgid "e-Baggage Ticket"
 msgstr ""
 
 #. module: l10n_br
-#. odoo-python
-#: code:addons/l10n_br/models/res_partner_bank.py:0
-#, python-format
-msgid "%s is not a valid CPF or CNPJ (don't include periods or dashes)."
-msgstr "%s não é um CPF ou CNPJ válido (não inclua pontos ou travessões)."
+#: model:res.city,name:l10n_br.city_br_363
+msgid "Água Azul do Norte"
+msgstr "Água Azul do Norte"
 
 #. module: l10n_br
-#. odoo-python
-#: code:addons/l10n_br/models/res_partner_bank.py:0
-#, python-format
-msgid "%s is not a valid email."
-msgstr "%s não é um e-mail válido"
+#: model:res.city,name:l10n_br.city_br_364
+#: model:res.city,name:l10n_br.city_br_365
+msgid "Água Boa"
+msgstr "Água Boa"
 
 #. module: l10n_br
-#: model:ir.model,name:l10n_br.model_res_partner_bank
-msgid "Bank Accounts"
-msgstr "Contas bancárias"
+#: model:res.city,name:l10n_br.city_br_366
+#: model:res.city,name:l10n_br.city_br_367
+#: model:res.city,name:l10n_br.city_br_368
+msgid "Água Branca"
+msgstr "Água Branca"
 
 #. module: l10n_br
-#: model:ir.model.fields.selection,name:l10n_br.selection__res_partner_bank__proxy_type__br_cpf_cnpj
-msgid "CPF/CNPJ (BR)"
-msgstr "CPF/CNPJ"
+#: model:res.city,name:l10n_br.city_br_369
+msgid "Água Clara"
+msgstr "Água Clara"
 
 #. module: l10n_br
-#. odoo-python
-#: code:addons/l10n_br/models/res_partner_bank.py:0
-#, python-format
-msgid "Can't generate a Pix QR code with a currency other than BRL."
-msgstr "Não é possível gerar o código QR de Pix com moedas diferentes do BRL"
+#: model:res.city,name:l10n_br.city_br_370
+msgid "Água Comprida"
+msgstr "Água Comprida"
 
 #. module: l10n_br
-#: model_terms:ir.ui.view,arch_db:l10n_br.view_partner_bank_form_inherit_account
-msgid "Documentation"
-msgstr "Documentação"
+#: model:res.city,name:l10n_br.city_br_371
+msgid "Água Doce"
+msgstr "Água Doce"
 
 #. module: l10n_br
-#: model:ir.model.fields.selection,name:l10n_br.selection__res_partner_bank__proxy_type__email
-msgid "Email Address"
-msgstr "Endereço de e-mail"
+#: model:res.city,name:l10n_br.city_br_372
+msgid "Água Doce do Maranhão"
+msgstr "Água Doce do Maranhão"
 
 #. module: l10n_br
-#: model:ir.model.fields.selection,name:l10n_br.selection__res_partner_bank__proxy_type__mobile
-msgid "Mobile Number"
-msgstr "Número de celular"
+#: model:res.city,name:l10n_br.city_br_373
+msgid "Água Doce do Norte"
+msgstr "Água Doce do Norte"
 
 #. module: l10n_br
-#: model:ir.model.fields,field_description:l10n_br.field_account_setup_bank_manual_config__proxy_type
-#: model:ir.model.fields,field_description:l10n_br.field_res_partner_bank__proxy_type
-msgid "Proxy Type"
-msgstr "Tipo de proxy"
+#: model:res.city,name:l10n_br.city_br_374
+msgid "Água Fria"
+msgstr "Água Fria"
 
 #. module: l10n_br
-#: model:ir.model.fields.selection,name:l10n_br.selection__res_partner_bank__proxy_type__br_random
-msgid "Random Key (BR)"
-msgstr "Chave aleatória"
+#: model:res.city,name:l10n_br.city_br_375
+msgid "Água Fria de Goiás"
+msgstr "Água Fria de Goiás"
 
 #. module: l10n_br
-#. odoo-python
-#: code:addons/l10n_br/models/res_partner_bank.py:0
-#, python-format
-msgid ""
-"The mobile number %s is invalid. It must start with +55, contain a 2 digit "
-"territory or state code followed by a 9 digit number."
-msgstr "O número de celular %s é inválido. Ele deve começar com +55, conter o DDD de 2 dígitos e o número de 9 dígitos."
+#: model:res.city,name:l10n_br.city_br_376
+msgid "Água Limpa"
+msgstr "Água Limpa"
 
 #. module: l10n_br
-#. odoo-python
-#: code:addons/l10n_br/models/res_partner_bank.py:0
-#, python-format
-msgid ""
-"The proxy type must be Email Address, Mobile Number, CPF/CNPJ (BR) or Random"
-" Key (BR) for Pix code generation."
-msgstr "O tipo de proxy para geração do código Pix deve ser endereço de e-mail, número de celular, CPF/CNPF ou chave aleatória."
+#: model:res.city,name:l10n_br.city_br_377
+msgid "Água Nova"
+msgstr "Água Nova"
 
 #. module: l10n_br
-#. odoo-python
-#: code:addons/l10n_br/models/res_partner_bank.py:0
-#, python-format
-msgid ""
-"The random key %s is invalid, the format looks like this: "
-"71d6c6e1-64ea-4a11-9560-a10870c40ca2"
-msgstr "A chave aleatória %s é inválida. O formato deve se assemelhar a: 71d6c6e1-64ea-4a11-9560-a10870c40ca2"
+#: model:res.city,name:l10n_br.city_br_378
+msgid "Água Preta"
+msgstr "Água Preta"
 
 #. module: l10n_br
-#. odoo-python
-#: code:addons/l10n_br/models/res_partner_bank.py:0
-#, python-format
-msgid ""
-"To generate a Pix code the proxy type for %s must be Email Address, Mobile "
-"Number, CPF/CNPJ (BR) or Random Key (BR)."
-msgstr "Para gerar um código Pix, o tipo de proxy de %s deve ser endereço de e-mail, número de celular, CPF/CNPJ ou chave aleatória."
+#: model:res.city,name:l10n_br.city_br_379
+msgid "Água Santa"
+msgstr "Água Santa"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_382
+msgid "Águas Belas"
+msgstr "Águas Belas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_388
+msgid "Águas Formosas"
+msgstr "Águas Formosas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_389
+msgid "Águas Frias"
+msgstr "Águas Frias"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_137
+msgid "Águas Lindas de Goiás"
+msgstr "Águas Lindas de Goiás"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_390
+msgid "Águas Mornas"
+msgstr "Águas Mornas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_391
+msgid "Águas Vermelhas"
+msgstr "Águas Vermelhas"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_383
+msgid "Águas da Prata"
+msgstr "Águas da Prata"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_384
+msgid "Águas de Chapecó"
+msgstr "Águas de Chapecó"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_385
+msgid "Águas de Lindóia"
+msgstr "Águas de Lindóia"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_386
+msgid "Águas de Santa Bárbara"
+msgstr "Águas de Santa Bárbara"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_387
+msgid "Águas de São Pedro"
+msgstr "Águas de São Pedro"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_395
+msgid "Águia Branca"
+msgstr "Águia Branca"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_486
+msgid "Álvares Florence"
+msgstr "Álvares Florence"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_487
+msgid "Álvares Machado"
+msgstr "Álvares Machado"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_488
+msgid "Álvaro de Carvalho"
+msgstr "Álvaro de Carvalho"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_721
+msgid "Áurea"
+msgstr "Áurea"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_553
+msgid "Ângulo"
+msgstr "Ângulo"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_1908
+msgid "Érico Cardoso"
+msgstr "Érico Cardoso"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3552
+msgid "Óbidos"
+msgstr "Óbidos"
+
+#. module: l10n_br
+#: model:res.city,name:l10n_br.city_br_3559
+msgid "Óleo"
+msgstr "Óleo"

--- a/addons/l10n_br_website_sale/__manifest__.py
+++ b/addons/l10n_br_website_sale/__manifest__.py
@@ -14,6 +14,14 @@
         'views/portal.xml',
         'views/templates.xml',
     ],
+    'assets': {
+        'web.assets_frontend': [
+            'l10n_br_website_sale/static/src/**/*',
+        ],
+        'web.assets_tests': [
+            'l10n_br_website_sale/static/tests/**/*',
+        ]
+    },
     'installable': True,
     'auto_install': True,
     'post_init_hook': '_l10n_br_website_sale_post_init_hook',

--- a/addons/l10n_br_website_sale/controllers/main.py
+++ b/addons/l10n_br_website_sale/controllers/main.py
@@ -1,5 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
+from odoo import _lt
 from odoo.http import request
 
 from odoo.addons.website_sale.controllers.main import WebsiteSale
@@ -7,23 +7,39 @@ from odoo.addons.website_sale.controllers.main import WebsiteSale
 
 class L10nBRWebsiteSale(WebsiteSale):
 
+    def _get_mandatory_delivery_address_fields(self, country_sudo):
+        mandatory_fields = super()._get_mandatory_delivery_address_fields(country_sudo)
+        if (
+            country_sudo.code == 'BR'
+            and request.website.sudo().company_id.account_fiscal_country_id.code == 'BR'
+        ):
+            mandatory_fields |= {
+                'vat', 'l10n_latam_identification_type_id', 'street_name', 'street2', 'street_number', 'zip', 'city_id', 'state_id', 'country_id'
+            }
+            mandatory_fields -= {'street', 'city'}  # Brazil uses the base_extended_address fields added above
+
+        return mandatory_fields
+
     def _get_mandatory_billing_address_fields(self, country_sudo):
         """Extend mandatory fields to add the vat in case the website and the customer are from brazil"""
         mandatory_fields = super()._get_mandatory_billing_address_fields(country_sudo)
 
         if (
             country_sudo.code == 'BR'
-            and request.website.sudo().company_id.country_id.code == 'BR'
+            and request.website.sudo().company_id.account_fiscal_country_id.code == 'BR'
         ):
-            mandatory_fields.add('vat')
+            mandatory_fields |= {
+                'vat', 'l10n_latam_identification_type_id', 'street_name', 'street2', 'street_number', 'zip', 'city_id', 'state_id', 'country_id'
+            }
+            mandatory_fields -= {'street', 'city'}  # Brazil uses the base_extended_address fields added above
 
         return mandatory_fields
 
-    def _prepare_address_form_values(self, *args, address_type, **kwargs):
+    def _prepare_address_form_values(self, order_sudo, partner_sudo, *args, address_type, **kwargs):
         rendering_values = super()._prepare_address_form_values(
-            *args, address_type=address_type, **kwargs
+            order_sudo, partner_sudo, *args, address_type=address_type, **kwargs
         )
-        if address_type == 'billing' and request.website.sudo().company_id.country_id.code == 'BR':
+        if address_type == 'billing' and request.website.sudo().company_id.account_fiscal_country_id.code == 'BR':
             can_edit_vat = rendering_values['can_edit_vat']
             LatamIdentificationType = request.env['l10n_latam.identification.type'].sudo()
             rendering_values.update({
@@ -31,4 +47,7 @@ class L10nBRWebsiteSale(WebsiteSale):
                     '|', ('country_id', '=', False), ('country_id.code', '=', 'BR'),
                 ]) if can_edit_vat else LatamIdentificationType,
             })
+            rendering_values['city_sudo'] = partner_sudo.city_id
+            rendering_values['cities_sudo'] = request.env['res.city'].sudo().search([('country_id.code', '=', 'BR')])
+            rendering_values['vat_label'] = _lt('Number')
         return rendering_values

--- a/addons/l10n_br_website_sale/data/ir_model_fields.xml
+++ b/addons/l10n_br_website_sale/data/ir_model_fields.xml
@@ -4,7 +4,7 @@
     <function model="ir.model.fields" name="formbuilder_whitelist">
         <value>res.partner</value>
         <value eval="[
-            'l10n_latam_identification_type_id',
+            'l10n_latam_identification_type_id', 'city_id', 'street_name', 'street_number', 'street_number2',
         ]"/>
     </function>
 

--- a/addons/l10n_br_website_sale/i18n/l10n_br_website_sale.pot
+++ b/addons/l10n_br_website_sale/i18n/l10n_br_website_sale.pot
@@ -7,13 +7,19 @@ msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-12-07 08:25+0000\n"
-"PO-Revision-Date: 2023-12-07 08:25+0000\n"
+"PO-Revision-Date: 2024-08-26 21:38+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: l10n_br_website_sale
+#: model_terms:ir.ui.view,arch_db:l10n_br_website_sale.address
+msgid "<option value=\"\">City...</option>"
+msgstr ""
 
 #. module: l10n_br_website_sale
 #: model_terms:ir.ui.view,arch_db:l10n_br_website_sale.address
@@ -31,6 +37,37 @@ msgstr ""
 
 #. module: l10n_br_website_sale
 #: model_terms:ir.ui.view,arch_db:l10n_br_website_sale.address
+msgid "Complement"
+msgstr ""
+
+#. module: l10n_br_website_sale
+#: model_terms:ir.ui.view,arch_db:l10n_br_website_sale.address
 #: model_terms:ir.ui.view,arch_db:l10n_br_website_sale.portal_my_details_fields
 msgid "Identification Type"
+msgstr ""
+
+#. module: l10n_br_website_sale
+#: model_terms:ir.ui.view,arch_db:l10n_br_website_sale.address
+msgid "Neighborhood"
+msgstr ""
+
+#. module: l10n_br_website_sale
+#. odoo-python
+#: code:addons/l10n_br_website_sale/controllers/main.py:0
+msgid "Number"
+msgstr ""
+
+#. module: l10n_br_website_sale
+#: model_terms:ir.ui.view,arch_db:l10n_br_website_sale.address
+msgid "Street"
+msgstr ""
+
+#. module: l10n_br_website_sale
+#: model_terms:ir.ui.view,arch_db:l10n_br_website_sale.address
+msgid "Street Number"
+msgstr ""
+
+#. module: l10n_br_website_sale
+#: model:ir.model,name:l10n_br_website_sale.model_website
+msgid "Website"
 msgstr ""

--- a/addons/l10n_br_website_sale/i18n/pt_BR.po
+++ b/addons/l10n_br_website_sale/i18n/pt_BR.po
@@ -7,13 +7,20 @@ msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-12-07 08:25+0000\n"
-"PO-Revision-Date: 2023-12-07 08:25+0000\n"
+"PO-Revision-Date: 2024-08-26 21:38+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
+"X-Generator: Poedit 3.0.1\n"
+
+#. module: l10n_br_website_sale
+#: model_terms:ir.ui.view,arch_db:l10n_br_website_sale.address
+msgid "<option value=\"\">City...</option>"
+msgstr "<option value=\"\">Cidade...</option>"
 
 #. module: l10n_br_website_sale
 #: model_terms:ir.ui.view,arch_db:l10n_br_website_sale.address
@@ -27,10 +34,44 @@ msgstr "<option value=\"\">Tipo de identificação...</option>"
 msgid ""
 "Changing Identification type is not allowed once document(s) have been "
 "issued for your account. Please contact us directly for this operation."
-msgstr "Não é permitido alterar o tipo de identificação depois que o(s) documento(s) tiver(em) sido emitido(s) para sua conta. Entre em contato conosco diretamente para essa operação."
+msgstr ""
+"Não é permitido alterar o tipo de identificação depois que o(s) documento(s) "
+"tiver(em) sido emitido(s) para sua conta. Entre em contato conosco "
+"diretamente para essa operação."
+
+#. module: l10n_br_website_sale
+#: model_terms:ir.ui.view,arch_db:l10n_br_website_sale.address
+msgid "Complement"
+msgstr "Complemento"
 
 #. module: l10n_br_website_sale
 #: model_terms:ir.ui.view,arch_db:l10n_br_website_sale.address
 #: model_terms:ir.ui.view,arch_db:l10n_br_website_sale.portal_my_details_fields
 msgid "Identification Type"
 msgstr "Tipo de identificação"
+
+#. module: l10n_br_website_sale
+#: model_terms:ir.ui.view,arch_db:l10n_br_website_sale.address
+msgid "Neighborhood"
+msgstr "Bairro"
+
+#. module: l10n_br_website_sale
+#. odoo-python
+#: code:addons/l10n_br_website_sale/controllers/main.py:0
+msgid "Number"
+msgstr "Número"
+
+#. module: l10n_br_website_sale
+#: model_terms:ir.ui.view,arch_db:l10n_br_website_sale.address
+msgid "Street"
+msgstr "Rua"
+
+#. module: l10n_br_website_sale
+#: model_terms:ir.ui.view,arch_db:l10n_br_website_sale.address
+msgid "Street Number"
+msgstr "Número"
+
+#. module: l10n_br_website_sale
+#: model:ir.model,name:l10n_br_website_sale.model_website
+msgid "Website"
+msgstr "Site"

--- a/addons/l10n_br_website_sale/static/src/js/address.js
+++ b/addons/l10n_br_website_sale/static/src/js/address.js
@@ -1,0 +1,98 @@
+/** @odoo-module **/
+import websiteSaleAddress from "@website_sale/js/address";
+import { Component, useState } from "@odoo/owl";
+import { SelectMenu } from "@web/core/select_menu/select_menu";
+import { attachComponent } from "@web_editor/js/core/owl_utils";
+
+class SelectMenuWrapper extends Component {
+    static template = "l10n_br_website_sale.SelectMenuWrapper";
+    static components = { SelectMenu };
+    static props = {
+        el: { optional: true, type: Object },
+    };
+
+    setup() {
+        this.state = useState({
+            choices: [],
+            value: this.props.el.value,
+        });
+        this.state.choices = [...this.props.el.querySelectorAll("option")].filter((x) => x.value);
+        this.props.el.classList.add("d-none");
+    }
+
+    onSelect(value) {
+        this.state.value = value;
+        this.props.el.value = value;
+        // Manually trigger the change event
+        const event = new Event("change", { bubbles: true });
+        this.props.el.dispatchEvent(event);
+    }
+}
+
+websiteSaleAddress.include({
+    events: Object.assign(
+        {},
+        websiteSaleAddress.prototype.events,
+        {
+            'change .o_select_city': '_onChangeBrazilianCity',
+        }
+    ),
+
+    start: async function () {
+        this._super.apply(this, arguments);
+
+        if (this.countryCode === "BR") {
+            const selectEl = this.el.querySelector("select[name='city_id']");
+            await attachComponent(this, selectEl.parentElement, SelectMenuWrapper, {
+                el: selectEl,
+            });
+            this._changeCountry();
+        }
+    },
+
+    _selectState: function(id) {
+        this.addressForm.querySelector(`select[name="state_id"] > option[value="${id}"]`).selected = 'selected';
+    },
+
+    _setVisibility(selector, should_show) {
+        this.addressForm.querySelectorAll(selector).forEach(el => {
+            if (should_show) {
+                el.classList.remove('d-none');
+            } else {
+                el.classList.add('d-none');
+            }
+
+            // Disable hidden inputs to avoid sending back e.g. an empty street when street_name and street_number is
+            // filled. It causes street_name and street_number to be lost.
+            if (el.tagName === 'INPUT') {
+                el.disabled = !should_show;
+            }
+
+            el.querySelectorAll('input').forEach(input => input.disabled = !should_show);
+        })
+    },
+
+    async _changeCountry(ev) {
+        const res = await this._super(...arguments);
+        if (this.countryCode === 'BR') {
+            const countryOption = this.addressForm.country_id;
+            const selectedCountryCode = countryOption.value ? countryOption.selectedOptions[0].getAttribute('code') : '';
+
+            if (selectedCountryCode === 'BR') {
+                this._setVisibility('.o_standard_address', false); // hide
+                this._setVisibility('.o_extended_address', true); // show
+            } else {
+                this._setVisibility('.o_standard_address', true); // show
+                this._setVisibility('.o_extended_address', false); // hide
+            }
+        }
+
+        return res;
+    },
+
+    _onChangeBrazilianCity() {
+        if (this.addressForm.city_id.value) {
+            this._selectState(this.addressForm.city_id.querySelector(`option[value='${this.addressForm.city_id.value}']`).getAttribute('state-id'));
+        }
+    },
+});

--- a/addons/l10n_br_website_sale/static/src/xml/select_menu_wrapper_template.xml
+++ b/addons/l10n_br_website_sale/static/src/xml/select_menu_wrapper_template.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+
+<t t-name="l10n_br_website_sale.SelectMenuWrapper">
+    <SelectMenu value="state.value" choices="state.choices" class="'o_extended_address'" onSelect.bind="onSelect"/>
+</t>
+
+</templates>

--- a/addons/l10n_br_website_sale/static/tests/tours/brazilian_address.js
+++ b/addons/l10n_br_website_sale/static/tests/tours/brazilian_address.js
@@ -1,0 +1,60 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import * as tourUtils from "@website_sale/js/tours/tour_utils";
+
+function assertState(expectedState) {
+    // :checked doesn't seem to work in the trigger, so let's check manually.
+    const select_value = document.querySelector('select[name="state_id"]').value;
+    const option = document.querySelector(`select[name="state_id"] option[value="${select_value}"]`);
+    if (!option.innerText.includes(expectedState)) {
+        throw new Error("The right state was not auto-selected.");
+    }
+}
+
+registry.category("web_tour.tours").add("test_brazilian_address", {
+    test: true,
+    url: '/shop?search=Brazilian test product',
+    steps: () => [
+        ...tourUtils.addToCart({productName: "Brazilian test product", search: false}),
+        tourUtils.goToCart({quantity: 1}),
+        tourUtils.goToCheckout(),
+        {
+            content: 'base_address_extended should not be shown',
+            trigger: 'select[name="city_id"]:not(:visible)',
+        },
+        {
+            content: 'Set Brazil first',
+            trigger: 'select[name="country_id"]',
+            run: 'selectByLabel Brazil',
+        },
+        {
+            content: 'base_address_extended fields should be shown',
+            trigger: 'input[id="o_street_number"]',
+        },
+        {
+            content: 'Click to select a city',
+            trigger: '.o_select_menu_toggler',
+            run: 'click',
+        },
+        {
+            content: 'Select Abadia de Goiás',
+            trigger: '.o_select_menu_menu > span:first',
+            run: 'click',
+        },
+        {
+            content: 'Check that Abadia de Goiás is selected',
+            trigger: '.o_select_city:contains("Abadia de Goiás")',
+        },
+        {
+            content: 'Check that Goiás state is automatically selected based on the city.',
+            trigger: 'select[name="country_id"]',
+            run: () => assertState('Goiás'),
+        },
+        {
+            content: 'Discard',
+            trigger: 'a[href^="/shop/cart"]',
+            run: 'click',
+        },
+    ],
+});

--- a/addons/l10n_br_website_sale/tests/__init__.py
+++ b/addons/l10n_br_website_sale/tests/__init__.py
@@ -1,0 +1,2 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import test_address

--- a/addons/l10n_br_website_sale/tests/test_address.py
+++ b/addons/l10n_br_website_sale/tests/test_address.py
@@ -1,0 +1,18 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.tests import tagged, HttpCase
+
+
+@tagged("post_install_l10n", "post_install", "-at_install")
+class TestBrazilianAddress(HttpCase):
+    def test_brazilian_address_frontend(self):
+        """Test the visibility of fields and autocompletion of Brazilian state and city based on zip."""
+        website = self.env["website"].get_current_website()
+        website.company_id.account_fiscal_country_id = website.company_id.country_id = self.env.ref("base.br")
+        self.env["product.product"].create(
+            {
+                "name": "Brazilian test product",
+                "list_price": 12.50,
+                "is_published": True,
+            }
+        )
+        self.start_tour("/", "test_brazilian_address")

--- a/addons/l10n_br_website_sale/views/templates.xml
+++ b/addons/l10n_br_website_sale/views/templates.xml
@@ -33,6 +33,50 @@
                 </div>
             </t>
         </div>
+        <!-- o_city must remain in DOM, otherwise the standard website_sale js breaks. -->
+        <input id="o_city" position="attributes">
+            <attribute name="class" separator=" " add="o_standard_address"/>
+        </input>
+        <input id="o_city" position="after">
+            <div t-if="res_company.account_fiscal_country_id.code == 'BR'" class="o_select_city">
+                <!-- will be replaced with SelectMenuWrapper -->
+                <select id="o_city_id" name="city_id" class="form-select">
+                    <option value="">City...</option>
+                    <t t-foreach="cities_sudo" t-as="c">
+                        <option t-att-value="c.id" t-att-selected="c.id == city_sudo.id" t-att-code="c.id" t-att-state-id="c.state_id.id">
+                            <t t-esc="c.name" />
+                        </option>
+                    </t>
+                </select>
+            </div>
+        </input>
+        <!-- put base_address_extended fields separately to be more user-friendly -->
+        <div id="div_street" position="attributes">
+            <attribute name="class" separator=" " add="o_standard_address"/>
+        </div>
+        <div id="div_street" position="after">
+            <div id="div_street_name" t-attf-class="col-lg-8 mb-2 o_extended_address">
+                <label class="col-form-label" for="o_street_name">Street</label>
+                <input id="o_street_name" type="text" name="street_name" class="form-control" t-att-value="partner_sudo.street_name"/>
+            </div>
+            <div id="div_street_number" t-attf-class="col-lg-4 mb-2 o_extended_address">
+                <label class="col-form-label" for="o_street_number">Street Number</label>
+                <input id="o_street_number" type="text" name="street_number" class="form-control" t-att-value="partner_sudo.street_number"/>
+            </div>
+            <div class="w-100"/>
+            <div id="div_street_number2" t-attf-class="col-lg-6 mb-2 o_extended_address">
+                <label class="col-form-label" for="o_street_number2">Complement</label>
+                <input id="o_street_number2" type="text" name="street_number2" class="form-control" t-att-value="partner_sudo.street_number2"/>
+            </div>
+            <div id="div_street2" position="move"/>
+        </div>
+        <!-- street2 is used for neighborhood in Brazil, change the default label -->
+        <label for="o_street2" position="attributes">
+            <attribute name="t-attf-class" separator=" " add="col-form-label label-optional o_standard_address"/>
+        </label>
+        <label for="o_street2" position="after">
+            <label t-attf-class="col-form-label label-optional o_extended_address" for="o_street2">Neighborhood</label>
+        </label>
     </template>
 
     <template id="total" inherit_id="website_sale.total">


### PR DESCRIPTION
This improves the eCommerce address page for Brazil by replacing the regular address fields with base_address_extended fields. l10n_br depends on base_address_extended.

A downside is that the user has to select the city_id out of a large list of cities. To make this easier, we use the new SelectMenu widget [1].

task-4061540

Alternative to https://github.com/odoo/odoo/pull/177124.
