### PR TITLE
[IMP] stock, *:  simplify kanban archs

### DIFF
--- a/addons/mrp/views/stock_picking_views.xml
+++ b/addons/mrp/views/stock_picking_views.xml
@@ -5,18 +5,10 @@
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="stock.stock_picking_type_kanban"/>
         <field name="arch" type="xml">
-            <field name="code" position="after">
-                <field name="count_mo_todo"/>
-                <field name="count_mo_waiting"/>
-                <field name="count_mo_late"/>
-                <field name="count_mo_in_progress"/>
-                <field name="count_mo_to_close"/>
-            </field>
-
             <xpath expr="//t[@t-name='kanban-menu']" position="inside">
                 <div class="container" t-if="record.code.raw_value == 'mrp_operation'">
                     <div class="row">
-                        <div class="col-6 o_kanban_card_manage_section o_kanban_manage_view" name="picking_left_manage_pane">
+                        <div class="col-6" name="picking_left_manage_pane">
                             <h5 role="menuitem" class="o_kanban_card_manage_title">
                                 <span>Orders</span>
                             </h5>
@@ -30,7 +22,7 @@
                                 <a name="%(mrp_production_action_picking_deshboard)d" type="action" context="{'search_default_planned': 1}">Planned</a>
                             </div>
                         </div>
-                        <div class="col-6 o_kanban_card_manage_section o_kanban_manage_new">
+                        <div name="kanban_menu_section" class="col-6">
                             <h5 role="menuitem" class="o_kanban_card_manage_title">
                                 <span>New</span>
                             </h5>
@@ -45,7 +37,7 @@
 
                     <div t-if="widget.editable" class="o_kanban_card_manage_settings row">
                         <div role="menuitem" aria-haspopup="true" class="col-8">
-                            <ul role="menu" class="oe_kanban_colorpicker" data-field="color"/>
+                            <field name="color" widget="kanban_color_picker"/>
                         </div>
                     </div>
 
@@ -58,67 +50,57 @@
                 </div>
             </xpath>
             <xpath expr='//div[@name="stock_picking"]' position="after">
-                <div t-if="record.code.raw_value == 'mrp_operation'" t-attf-class="#{!selection_mode ? kanban_color(record.color.raw_value) : ''}">
-                    <div t-attf-class="o_kanban_card_header">
-                        <div class="o_kanban_card_header_title">
-                            <div class="o_primary" t-if="!selection_mode">
-                                <a type="object" name="get_mrp_stock_picking_action_picking_type">
-                                    <field name="name"/>
+                <div t-if="record.code.raw_value == 'mrp_operation'" class="px-2">
+                    <a t-if="!selection_mode" type="object" name="get_mrp_stock_picking_action_picking_type">
+                        <field name="name" class="fw-bold fs-4"/>
+                    </a>
+                    <field t-if="selection_mode" name="name" class="fw-bold fs-4"/>
+                    <field name="warehouse_id" class="d-block" groups="stock.group_stock_multi_warehouses"/>
+                    <div t-if="!selection_mode" class="row mt-3">
+                        <div class="col-6">
+                            <button class="btn btn-primary" name="%(mrp_production_action_picking_deshboard)d" type="action" context="{'search_default_filter_confirmed': 1, 'default_picking_type_id': id}">
+                                <span t-if="record.count_mo_todo.raw_value > 0">
+                                    <field name="count_mo_todo"/> To Manufacture
+                                </span>
+                                <span t-else="">Open</span>
+                            </button>
+                        </div>
+                        <div class="col-6 stock-overview-links">
+                            <div t-if="record.count_mo_waiting.raw_value > 0" class="row">
+                                <a class="col-8 offset-4 text-truncate" name="%(mrp_production_action_picking_deshboard)d" type="action" context="{'search_default_waiting': 1}">
+                                    <div class="row">
+                                        <span class="col-6">Waiting</span>
+                                        <field class="col-2 text-end" name="count_mo_waiting"/>
+                                    </div>
                                 </a>
                             </div>
-                            <span class="o_primary" t-if="selection_mode"><field name="name"/></span>
-                            <div class="o_secondary"><field class="o_secondary" name="warehouse_id" readonly="1" groups="stock.group_stock_multi_warehouses"/></div>
-                        </div>
-                    </div>
-                    <div class="container o_kanban_card_content" t-if="!selection_mode">
-                        <div class="row">
-                            <div class="col-6 o_kanban_primary_left">
-                                <button class="btn btn-primary" name="%(mrp_production_action_picking_deshboard)d" type="action" context="{'search_default_filter_confirmed': 1, 'default_picking_type_id': id}">
-                                    <span t-if="record.count_mo_todo.raw_value > 0">
-                                        <t t-esc="record.count_mo_todo.value"/> To Manufacture
-                                    </span>
-                                    <span t-else="">Open</span>
-                                </button>
+                            <div t-if="record.count_mo_late.raw_value > 0" class="row">
+                                <a class="col-8 offset-4 text-truncate" name="%(mrp_production_action_picking_deshboard)d" type="action" context="{'search_default_filter_late_mo': 1, 'default_picking_type_id': id}">
+                                    <div class="row">
+                                        <span class="col-6">Late</span>
+                                        <field class="col-2 text-end" name="count_mo_late"/>
+                                    </div>
+                                </a>
                             </div>
-                            <div class="col-6 o_kanban_primary_right stock-overview-links">
-                                <div t-if="record.count_mo_waiting.raw_value > 0" class="row">
-                                    <a class="col-8 offset-4" name="%(mrp_production_action_picking_deshboard)d" type="action" context="{'search_default_waiting': 1}">
-                                        <div class="row">
-                                            <span class="col-6">Waiting</span>
-                                            <field class="col-2 text-end" name="count_mo_waiting"/>
-                                        </div>
-                                    </a>
-                                </div>
-                                <div t-if="record.count_mo_late.raw_value > 0" class="row">
-                                    <a class="col-8 offset-4 oe_kanban_stock_picking_type_list" name="%(mrp_production_action_picking_deshboard)d" type="action" context="{'search_default_filter_late_mo': 1, 'default_picking_type_id': id}">
-                                        <div class="row">
-                                            <span class="col-6">Late</span>
-                                            <field class="col-2 text-end" name="count_mo_late"/>
-                                        </div>
-                                    </a>
-                                </div>
-                                <div t-if="record.count_mo_in_progress.raw_value > 0" class="row">
-                                    <a class="col-8 offset-4 oe_kanban_stock_picking_type_list" name="%(mrp_production_action_picking_deshboard)d" type="action" context="{'search_default_filter_in_progress': 1, 'default_picking_type_id': id}">
-                                        <div class="row">
-                                            <span class="col-6">In Progress</span>
-                                            <field class="col-2 text-end" name="count_mo_in_progress"/>
-                                        </div>
-                                    </a>
-                                </div>
-                                <div t-if="record.count_mo_to_close.raw_value > 0" class="row">
-                                    <a class="col-8 offset-4 oe_kanban_stock_picking_type_list" name="%(mrp_production_action_picking_deshboard)d" type="action" context="{'search_default_filter_to_close': 1, 'default_picking_type_id': id}">
-                                        <div class="row">
-                                            <span class="col-6">To Close</span>
-                                            <field class="col-2 text-end" name="count_mo_to_close"/>
-                                        </div>
-                                    </a>
-                                </div>
+                            <div t-if="record.count_mo_in_progress.raw_value > 0" class="row">
+                                <a class="col-8 offset-4 text-truncate" name="%(mrp_production_action_picking_deshboard)d" type="action" context="{'search_default_filter_in_progress': 1, 'default_picking_type_id': id}">
+                                    <div class="row">
+                                        <span class="col-6">In Progress</span>
+                                        <field class="col-2 text-end" name="count_mo_in_progress"/>
+                                    </div>
+                                </a>
+                            </div>
+                            <div t-if="record.count_mo_to_close.raw_value > 0" class="row">
+                                <a class="col-8 offset-4 text-truncate" name="%(mrp_production_action_picking_deshboard)d" type="action" context="{'search_default_filter_to_close': 1, 'default_picking_type_id': id}">
+                                    <div class="row">
+                                        <span class="col-6">To Close</span>
+                                        <field class="col-2 text-end" name="count_mo_to_close"/>
+                                    </div>
+                                </a>
                             </div>
                         </div>
-                        <div class="row">
-                            <field name="kanban_dashboard_graph" graph_type="bar" widget="picking_type_dashboard_graph"/>
-                        </div>
                     </div>
+                    <field t-if="!selection_mode" name="kanban_dashboard_graph" class="mt-auto" graph_type="bar" widget="picking_type_dashboard_graph"/>
                 </div>
             </xpath>
         </field>

--- a/addons/repair/views/stock_picking_views.xml
+++ b/addons/repair/views/stock_picking_views.xml
@@ -46,13 +46,10 @@
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="stock.stock_picking_type_kanban"/>
         <field name="arch" type="xml">
-            <field name="code" position="after">
-                <field name="count_repair_ready"/>
-            </field>
             <xpath expr="//t[@t-name='kanban-menu']" position="inside">
                 <div class="container" t-if="record.code.raw_value == 'repair_operation'">
                         <div class="row">
-                            <div class="col-6 o_kanban_card_manage_section o_kanban_manage_view" name="picking_left_manage_pane">
+                            <div class="col-6" name="picking_left_manage_pane">
                                 <h5 role="menuitem" class="o_kanban_card_manage_title">
                                     <span>Orders</span>
                                 </h5>
@@ -63,7 +60,7 @@
                                     <a name="get_repair_stock_picking_action_picking_type" context="{'search_default_ready': 1}" type="object">Ready</a>
                                 </div>
                             </div>
-                            <div class="col-6 o_kanban_card_manage_section o_kanban_manage_new">
+                            <div name="kanban_menu_section" class="col-6">
                                 <h5 role="menuitem" class="o_kanban_card_manage_title">
                                     <a name="%(action_repair_order_form)d" type="action" context="{'default_picking_type_id': id}">New</a>
                                 </h5>
@@ -75,7 +72,7 @@
 
                         <div t-if="widget.editable" class="o_kanban_card_manage_settings row">
                             <div role="menuitem" aria-haspopup="true" class="col-8">
-                                <ul role="menu" class="oe_kanban_colorpicker" data-field="color"/>
+                                <field name="color" widget="kanban_color_picker"/>
                             </div>
                         </div>
 
@@ -88,65 +85,49 @@
                     </div>
             </xpath>
             <xpath expr='//div[@name="stock_picking"]' position="after">
-                <div t-if="record.code.raw_value == 'repair_operation'" t-attf-class="#{!selection_mode ? kanban_color(record.color.raw_value) : ''}">
-                    <div t-attf-class="o_kanban_card_header">
-                        <div class="o_kanban_card_header_title">
-                            <div class="o_primary" t-if="!selection_mode">
-                                <a type="object" name="get_repair_stock_picking_action_picking_type">
-                                    <field name="name"/>
+                <div t-if="record.code.raw_value == 'repair_operation'" class="px-2">
+                    <a t-if="!selection_mode" type="object" name="get_repair_stock_picking_action_picking_type">
+                        <field name="name" class="fw-bold fs-4"/>
+                    </a>
+                    <field t-if="selection_mode" name="name" class="fw-bold fs-4"/>
+                    <field class="d-block"  name="warehouse_id"  groups="stock.group_stock_multi_warehouses"/>
+                    <div t-if="!selection_mode" class="row mt-3">
+                        <div class="col-6">
+                            <button class="btn btn-primary" name="get_repair_stock_picking_action_picking_type" context="{'search_default_ready': 1}" type="object">
+                                <span t-if="record.count_repair_ready.raw_value > 0">
+                                    <field name="count_repair_ready"/> To Repair
+                                </span>
+                                <span t-else="">Open</span>
+                            </button>
+                        </div>
+                        <div class="col-6 stock-overview-links">
+                            <div t-if="record.count_repair_late.raw_value > 0" class="row">
+                                <a class="col-8 offset-4 text-truncate" name="get_repair_stock_picking_action_picking_type" context="{'search_default_filter_late': 1}" type="object">
+                                    <div class="row">
+                                        <span class="col-6">Late</span>
+                                        <field class="col-2 text-end" name="count_repair_late"/>
+                                    </div>
                                 </a>
                             </div>
-                            <span class="o_primary" t-if="selection_mode">
-                                <field name="name"/>
-                            </span>
-                            <div class="o_secondary">
-                                <field class="o_secondary"  name="warehouse_id" readonly="1" groups="stock.group_stock_multi_warehouses"/>
+                            <div t-if="record.count_repair_confirmed.raw_value > 0" class="row">
+                                <a class="col-8 offset-4 text-truncate" name="get_repair_stock_picking_action_picking_type" context="{'search_default_filter_confirmed': 1}" type="object">
+                                    <div class="row">
+                                        <span class="col-6">Confirmed</span>
+                                        <field class="col-2 text-end" name="count_repair_confirmed"/>
+                                    </div>
+                                </a>
+                            </div>
+                            <div t-if="record.count_repair_under_repair.raw_value > 0" class="row">
+                                <a class="col-8 offset-4 text-truncate" name="get_repair_stock_picking_action_picking_type" context="{'search_default_filter_under_repair': 1}" type="object">
+                                    <div class="row">
+                                        <span class="col-6">Under Repair</span>
+                                        <field class="col-2 text-end" name="count_repair_under_repair"/>
+                                    </div>
+                                </a>
                             </div>
                         </div>
                     </div>
-                    <div class="container o_kanban_card_content" t-if="!selection_mode">
-                        <div class="row">
-                            <div class="col-6 o_kanban_primary_left">
-                                <button class="btn btn-primary" name="get_repair_stock_picking_action_picking_type" context="{'search_default_ready': 1}" type="object">
-                                    <span>
-                                        <span t-if="record.count_repair_ready.raw_value > 0">
-                                            <t t-esc="record.count_repair_ready.value"/> To Repair
-                                        </span>
-                                        <span t-else="">Open</span>
-                                    </span>
-                                </button>
-                            </div>
-                            <div class="col-6 o_kanban_primary_right stock-overview-links">
-                                <div t-if="record.count_repair_late.raw_value > 0" class="row">
-                                    <a class="col-8 offset-4" name="get_repair_stock_picking_action_picking_type" context="{'search_default_filter_late': 1}" type="object">
-                                        <div class="row">
-                                            <span class="col-6">Late</span>
-                                            <field class="col-2 text-end" name="count_repair_late"/>
-                                        </div>
-                                    </a>
-                                </div>
-                                <div t-if="record.count_repair_confirmed.raw_value > 0" class="row">
-                                    <a class="col-8 offset-4" name="get_repair_stock_picking_action_picking_type" context="{'search_default_filter_confirmed': 1}" type="object">
-                                        <div class="row">
-                                            <span class="col-6">Confirmed</span>
-                                            <field class="col-2 text-end" name="count_repair_confirmed"/>
-                                        </div>
-                                    </a>
-                                </div>
-                                <div t-if="record.count_repair_under_repair.raw_value > 0" class="row">
-                                    <a class="col-8 offset-4" name="get_repair_stock_picking_action_picking_type" context="{'search_default_filter_under_repair': 1}" type="object">
-                                        <div class="row">
-                                            <span class="col-6">Under Repair</span>
-                                            <field class="col-2 text-end" name="count_repair_under_repair"/>
-                                        </div>
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="row">
-                            <field name="kanban_dashboard_graph" graph_type="bar" widget="picking_type_dashboard_graph"/>
-                        </div>
-                    </div>
+                    <field t-if="!selection_mode" class="mt-auto" name="kanban_dashboard_graph" graph_type="bar" widget="picking_type_dashboard_graph"/>
                 </div>
             </xpath>
         </field>

--- a/addons/stock/static/src/scss/stock_overview.scss
+++ b/addons/stock/static/src/scss/stock_overview.scss
@@ -1,4 +1,4 @@
-.o_kanban_dashboard.o_stock_kanban .o_kanban_renderer {
+.o_stock_kanban .o_kanban_renderer {
     --KanbanRecord-width: 480px;
 
     @include media-only(screen) {

--- a/addons/stock/views/stock_picking_type_views.xml
+++ b/addons/stock/views/stock_picking_type_views.xml
@@ -175,21 +175,16 @@
         <field name="name">stock.picking.type.kanban</field>
         <field name="model">stock.picking.type</field>
         <field name="arch" type="xml">
-            <kanban class="o_kanban_dashboard o_stock_kanban o_emphasize_colors" js_class="stock_dashboard_kanban" create="0" group_create="false" can_open="0">
+            <kanban highlight_color="color" class="o_stock_kanban" js_class="stock_dashboard_kanban" create="0" group_create="false" can_open="0">
                 <field name="color"/>
                 <field name="code" readonly="1"/>
-                <field name="count_picking_ready"/>
-                <field name="count_picking_draft"/>
-                <field name="count_picking_waiting"/>
-                <field name="count_picking_late"/>
-                <field name="count_picking_backorders"/>
                 <field name="count_move_ready"/>
                 <field name="show_picking_type" invisible="1"/>
                 <templates>
                     <t t-name="kanban-menu" t-if="!selection_mode">
                         <div class="container" t-if="record.show_picking_type.raw_value">
                             <div class="row">
-                                <div class="col-6 o_kanban_card_manage_section o_kanban_manage_view">
+                                <div class="col-6">
                                     <h5 role="menuitem" class="o_kanban_card_manage_title">
                                         <span t-if="record.code.raw_value == 'internal'">Transfers</span>
                                         <span t-else="">View</span>
@@ -204,7 +199,7 @@
                                         <a name="get_action_picking_tree_waiting" type="object">Waiting</a>
                                     </div>
                                 </div>
-                                <div class="col-6 o_kanban_card_manage_section o_kanban_manage_new">
+                                <div name="kanban_menu_section" class="col-6">
                                     <h5 role="menuitem" class="o_kanban_card_manage_title">
                                         <a name="%(action_picking_form)d" type="action">New</a>
                                     </h5>
@@ -216,7 +211,7 @@
 
                             <div t-if="widget.editable" class="o_kanban_card_manage_settings row">
                                 <div class="col-8" role="menuitem" aria-haspopup="true">
-                                    <ul class="oe_kanban_colorpicker" data-field="color" role="menu"/>
+                                    <field name="color" widget="kanban_color_picker"/>
                                 </div>
                             </div>
 
@@ -228,76 +223,64 @@
                             </div>
                         </div>
                     </t>
-                    <t t-name="kanban-box">
-                        <div t-if="record.show_picking_type.raw_value" t-attf-class="#{!selection_mode ? kanban_color(record.color.raw_value) : ''}" name="stock_picking">
-                            <div t-attf-class="o_kanban_card_header">
-                                <div class="o_kanban_card_header_title">
-                                    <div class="o_primary" t-if="!selection_mode">
-                                        <a type="object" name="get_stock_picking_action_picking_type">
-                                            <field name="name"/>
+                    <t t-name="kanban-card">
+                        <div t-if="record.show_picking_type.raw_value" name="stock_picking" class="px-2">
+                            <a t-if="!selection_mode" type="object" name="get_stock_picking_action_picking_type">
+                                <field class="fw-bold fs-4" name="name"/>
+                            </a>
+                            <field t-if="selection_mode" class="fw-bold fs-4" name="name"/>
+                            <field name="warehouse_id" class="d-block" groups="stock.group_stock_multi_warehouses"/>
+                            <div t-if="!selection_mode" class="row mt-3">
+                                <div class="col-6">
+                                    <button class="btn btn-primary" name="get_action_picking_tree_ready" type="object">
+                                        <span t-if="record.count_picking_ready.raw_value > 0">
+                                            <field name="count_picking_ready"/>
+                                            <t t-if="record.code.raw_value === 'incoming'"> To Receive</t>
+                                            <t t-elif="record.code.raw_value === 'outgoing'" name="outgoing_label"> To Deliver</t>
+                                            <t t-else=""> To Process</t>
+                                        </span>
+                                        <span t-else="">Open</span>
+                                    </button>
+                                </div>
+                                <div class="col-6 stock-overview-links">
+                                    <div t-if="record.count_picking_waiting.raw_value > 0" class="row">
+                                        <a class="col-8 offset-4 text-truncate" name="get_action_picking_tree_waiting" type="object">
+                                            <div class="row">
+                                                <span class="col-6">Waiting</span>
+                                                <field class="col-2 text-end" name="count_picking_waiting"/>
+                                            </div>
                                         </a>
                                     </div>
-                                    <div class="o_primary" t-if="selection_mode">
-                                        <field name="name"/>
+
+                                    <div t-if="record.count_picking_late.raw_value > 0" class="row">
+                                        <a class="col-8 offset-4 text-truncate" name="get_action_picking_tree_late" type="object">
+                                            <div class="row">
+                                                <span class="col-6">Late</span>
+                                                <field class="col-2 text-end" name="count_picking_late"/>
+                                            </div>
+                                        </a>
                                     </div>
-                                    <div class="o_secondary"><field class="o_secondary" name="warehouse_id" readonly="1" groups="stock.group_stock_multi_warehouses"/></div>
+
+                                    <div t-if="record.count_picking_backorders.raw_value > 0" class="row" name="picking_type_backorder_count">
+                                        <a class="col-8 offset-4 text-truncate" name="get_action_picking_tree_backorder" type="object">
+                                            <div class="row">
+                                                <span class="col-6">Back Orders</span>
+                                                <field class="col-2 text-end" name="count_picking_backorders"/>
+                                            </div>
+                                        </a>
+                                    </div>
+
+                                    <div t-if="record.count_move_ready.raw_value > 0" class="row">
+                                        <a class="col-8 offset-4 text-truncate" name="get_action_picking_type_ready_moves" type="object">
+                                            <div class="row">
+                                                <span class="col-6">Operations</span>
+                                                <field class="col-2 text-end" name="count_move_ready"/>
+                                            </div>
+                                        </a>
+                                    </div>
                                 </div>
                             </div>
-                            <div class="container o_kanban_card_content" t-if="!selection_mode">
-                                <div class="row">
-                                    <div class="col-6 o_kanban_primary_left">
-                                        <button class="btn btn-primary" name="get_action_picking_tree_ready" type="object">
-                                            <span t-if="record.count_picking_ready.raw_value > 0">
-                                                <t t-esc="record.count_picking_ready.value"/>
-                                                <t t-if="record.code.raw_value === 'incoming'"> To Receive</t>
-                                                <t t-elif="record.code.raw_value === 'outgoing'" name="outgoing_label"> To Deliver</t>
-                                                <t t-else=""> To Process</t>
-                                            </span>
-                                            <span t-else="">Open</span>
-                                        </button>
-                                    </div>
-                                    <div class="col-6 o_kanban_primary_right stock-overview-links">
-                                        <div t-if="record.count_picking_waiting.raw_value > 0" class="row">
-                                            <a class="col-8 offset-4" name="get_action_picking_tree_waiting" type="object">
-                                                <div class="row">
-                                                    <span class="col-6">Waiting</span>
-                                                    <field class="col-2 text-end" name="count_picking_waiting"/>
-                                                </div>
-                                            </a>
-                                        </div>
-
-                                        <div t-if="record.count_picking_late.raw_value > 0" class="row">
-                                            <a class="col-8 offset-4 oe_kanban_stock_picking_type_list" name="get_action_picking_tree_late" type="object">
-                                                <div class="row">
-                                                    <span class="col-6">Late</span>
-                                                    <field class="col-2 text-end" name="count_picking_late"/>
-                                                </div>
-                                            </a>
-                                        </div>
-
-                                        <div t-if="record.count_picking_backorders.raw_value > 0" class="row" name="picking_type_backorder_count">
-                                            <a class="col-8 offset-4 oe_kanban_stock_picking_type_list" name="get_action_picking_tree_backorder" type="object">
-                                                <div class="row">
-                                                    <span class="col-6">Back Orders</span>
-                                                    <field class="col-2 text-end" name="count_picking_backorders"/>
-                                                </div>
-                                            </a>
-                                        </div>
-
-                                        <div t-if="record.count_move_ready.raw_value > 0" class="row">
-                                            <a class="col-8 offset-4" name="get_action_picking_type_ready_moves" type="object">
-                                                <div class="row">
-                                                    <span class="col-6">Operations</span>
-                                                    <field class="col-2 text-end" name="count_move_ready"/>
-                                                </div>
-                                            </a>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="row mt-auto">
-                                    <field name="kanban_dashboard_graph" graph_type="bar" widget="picking_type_dashboard_graph"/>
-                                </div>
-                            </div>
+                            <field t-if="!selection_mode" name="kanban_dashboard_graph" class="mt-auto" graph_type="bar" widget="picking_type_dashboard_graph"/>
                         </div>
                     </t>
                 </templates>

--- a/addons/stock_fleet/views/stock_picking_type.xml
+++ b/addons/stock_fleet/views/stock_picking_type.xml
@@ -7,9 +7,9 @@
             <field name="inherit_id" ref="stock.stock_picking_type_kanban"/>
             <field name="arch" type="xml">
                 <data>
-                    <xpath expr="//div[hasclass('col-6') and hasclass('o_kanban_card_manage_section') and hasclass('o_kanban_manage_new')]" position="after">
+                    <xpath expr="//div[@name='kanban_menu_section']" position="after">
                         <t t-if="record.code.raw_value == 'incoming' or record.code.raw_value == 'outgoing'">
-                            <div class="col-6 o_kanban_card_manage_section o_kanban_manage_new">
+                            <div class="col-6">
                                 <h5 role="menuitem" class="o_kanban_card_manage_title" style="white-space: nowrap;">
                                     <a>Transport Management</a>
                                 </h5>

--- a/addons/stock_picking_batch/views/stock_picking_wave_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_wave_views.xml
@@ -92,7 +92,7 @@
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="stock.stock_picking_type_kanban"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[hasclass('col-6') and hasclass('o_kanban_card_manage_section') and hasclass('o_kanban_manage_new')]" position="inside">
+            <xpath expr="//div[@name='kanban_menu_section']" position="inside">
                 <div role="menuitem">
                     <a name="action_batch" type="object" context="{'view_mode':'form'}">
                         Prepare Batch
@@ -105,7 +105,7 @@
                 </div>
             </xpath>
             <xpath expr="//button[@name='get_action_picking_tree_ready']" position="before">
-                <button t-if="record.count_picking_batch.raw_value > 0" class="btn btn-primary mr8 mb4 align-top" name="action_batch" type="object">
+                <button t-if="record.count_picking_batch.raw_value > 0" class="btn btn-primary me-2" name="action_batch" type="object">
                     <field name="count_picking_batch"/> Batches
                 </button>
             </xpath>
@@ -113,18 +113,18 @@
                 <attribute
                     name="t-attf-class"
                     remove="btn-primary"
-                    add="{{ record.count_picking_batch.raw_value > 0 ? 'btn-secondary' : 'btn-primary'}} align-top"
+                    add="{{ record.count_picking_batch.raw_value > 0 ? 'btn-secondary' : 'btn-primary'}}"
                     separator=" "
                 />
             </xpath>
-            <xpath expr="//div[@name='picking_type_backorder_count']" position="after">
-                <div t-if="record.count_picking_wave.raw_value > 0" class="row">
-                    <div class="col-12">
-                        <a class="oe_kanban_stock_picking_type_list" name="%(stock_picking_batch.action_picking_tree_wave)d" type="action">
-                            <field name="count_picking_wave"/>
-                            Waves
-                        </a>
-                    </div>
+            <xpath expr="//div[@name='picking_type_backorder_count']" class="row" position="after">
+                <div class="row">
+                    <a class="col-8 offset-4 text-truncate" name="%(stock_picking_batch.action_picking_tree_wave)d" type="action">
+                        <div t-if="record.count_picking_wave.raw_value > 0"  class="row">
+                            <span class="col-6">Waves</span>
+                            <field name="count_picking_wave" class="col-2 text-end"/>
+                        </div>
+                    </a>
                 </div>
             </xpath>
         </field>


### PR DESCRIPTION
\* = [stock_picking_batch, stock_fleet, mrp, repair]

In this commit we have simplified the kanban arch for the stock and it's related module dashboard. The goal is to simplify them, make them easier to read and use bootstrap utility classnames.

- Previously, we used kanban-box, but now we are using kanban-card instead.
- Deprecated oe_kanban_global_click and oe_kanban_global_click_edit.
- More use of <field/> tags
- Removed the oe_kanban_colorpicker class and replaced it with the kanban_color_picker widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- kanban_image from rendering context, is deprecated so we use <field name=... widget=image/> instead
- kanban_color, kanban_getcolor and kanban_getcolorname are deprecated use new attribute highlight_color=color_field_name on root node

Task-3992107
