### PR TITLE
[FIX] pos_self_order: retrieve `display_type` from the correct attribute

### DIFF
--- a/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.js
+++ b/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.js
@@ -113,7 +113,7 @@ export class AttributeSelection extends Component {
             this.selectedValues[attr.id] = {};
 
             for (const value of attr.values) {
-                if (attr.display_type === "multi") {
+                if (attr.attribute_id.display_type === "multi") {
                     this.selectedValues[attr.id][value.id] = initValue(value);
                 } else if (typeof this.selectedValues[attr.id] !== "number") {
                     this.selectedValues[attr.id] = initValue(value);
@@ -127,7 +127,7 @@ export class AttributeSelection extends Component {
     }
 
     isChecked(attribute, value) {
-        return attribute.display_type === "multi"
+        return attribute.attribute_id.display_type === "multi"
             ? this.selectedValues[attribute.id][value.id]
             : parseInt(this.selectedValues[attribute.id]) === value.id;
     }

--- a/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
+++ b/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
@@ -24,7 +24,7 @@
                                     <input
                                         type="radio" 
                                         class="d-none"
-                                        t-if="attribute.display_type !== 'multi'"
+                                        t-if="attribute.attribute_id.display_type !== 'multi'"
                                         t-att-value="value.id"
                                         t-attf-id="{{ attribute.id }}_{{ value.id }}"
                                         t-model="this.selectedValues[attribute.id]" />


### PR DESCRIPTION
Problem:
The `display_type` attribute was being retrieved from the wrong field, causing issues when selecting multiple product attributes in Self-Ordering.

Steps to reproduce:
- Create a product available for Self-Ordering.
- Add a "Multi-checkbox" type attribute to the product.
- Go to the Self-Ordering interface.
- Attempt to order the product.
- You can only select one attribute option, even though multiple should be selectable.

opw-4192992

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
