### PR TITLE
[FIX] account_edi_ubl_cii_tax_extension: requires_exemption_reason field

### DIFF
--- a/addons/account_edi_ubl_cii_tax_extension/models/account_tax.py
+++ b/addons/account_edi_ubl_cii_tax_extension/models/account_tax.py
@@ -85,13 +85,15 @@ class AccountTax(models.Model):
             ('VATEX_FR-CNWVAT', 'VATEX-FR-CNWVAT - France domestic Credit Notes without VAT, due to supplier forfeit of VAT for discount'),
         ]
     )
+    ubl_cii_requires_exemption_reason = fields.Boolean(compute='_compute_ubl_cii_requires_exemption_reason')
 
-    def _requires_exemption_reason(self):
-        self.ensure_one()
-        return self.ubl_cii_tax_category_code in ['AE', 'E', 'G', 'O', 'K']
+    @api.depends('ubl_cii_tax_category_code')
+    def _compute_ubl_cii_requires_exemption_reason(self):
+        for tax in self:
+            tax.ubl_cii_requires_exemption_reason = tax.ubl_cii_tax_category_code in ['AE', 'E', 'G', 'O', 'K']
 
-    @api.onchange("ubl_cii_tax_category_code")
+    @api.onchange('ubl_cii_requires_exemption_reason')
     def _onchange_ubl_cii_tax_category_code(self):
         for tax in self:
-            if not tax._requires_exemption_reason():
+            if not tax.ubl_cii_requires_exemption_reason:
                 tax.ubl_cii_tax_exemption_reason_code = False

--- a/addons/account_edi_ubl_cii_tax_extension/views/account_tax_views.xml
+++ b/addons/account_edi_ubl_cii_tax_extension/views/account_tax_views.xml
@@ -8,8 +8,8 @@
             <xpath expr="//field[@name='country_id']" position="after">
                 <field name="ubl_cii_tax_category_code"/>
                 <field name="ubl_cii_tax_exemption_reason_code"
-                       invisible="ubl_cii_tax_category_code not in ('AE', 'E', 'G', 'O', 'K')"
-                       required="ubl_cii_tax_category_code in ('AE', 'E', 'G', 'O', 'K')"
+                       invisible="not ubl_cii_requires_exemption_reason"
+                       required="ubl_cii_requires_exemption_reason"
                        />
             </xpath>
         </field>


### PR DESCRIPTION
Add a computed field `ubl_cii_requires_exemption_reason`, such that its
compute function can be modified/extended without having to touch the
view.

Indeed, new formats are expected to add new `ubl_cii_tax_category_code`
and `ubl_cii_tax_exemption_reason_code` and thus to modify the condition
on the `required` for the field `ubl_cii_tax_exemption_reason_code`.

We want to avoid forcing these new formats to extend the view. In
addition, it is hard to add multiple category codes coming from
different modules by inheriting the view.

no task
