### PR TITLE
[FIX] pos_sale: adjust order domain in PoS to handle different curren…

### DIFF
--- a/addons/pos_sale/static/src/app/order_management_screen/sale_order_fetcher/sale_order_fetcher.js
+++ b/addons/pos_sale/static/src/app/order_management_screen/sale_order_fetcher/sale_order_fetcher.js
@@ -61,9 +61,7 @@ class SaleOrderFetcher extends EventBus {
         return sale_orders;
     }
     async _getOrderIdsForCurrentPage(limit, offset) {
-        const domain = [["currency_id", "=", this.pos.currency.id]].concat(
-            this.searchDomain || []
-        );
+        const domain = this.searchDomain || [];
 
         this.pos.set_synch("connecting");
         const saleOrders = await this.orm.searchRead(


### PR DESCRIPTION
…cies (as in `saas-17.4`)

Problem:
When creating a sale order under a company with a currency different from the one currently selected, the sale order doesn't appear in the orders list. This issue was addressed in `saas-17.4`, and the same fix is now applied for `saas-17.0` to `saas-17.2`.

Steps to reproduce:
- Select a company with a different currency (e.g., CL company).
- Create a sale order (USD pricelist).
- Go to PoS and attempt to list the orders.
- The sale order you created will not be displayed, but in `saas-17.4`, it shows correctly.

opw-4178592

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
