### PR TITLE
[FIX] loyalty,sale: fix combo item deletion and disallow combos as free products

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -805,18 +805,6 @@ class SaleOrder(models.Model):
 
     @api.onchange('order_line')
     def _onchange_order_line(self):
-        virtual_ids = self.order_line.mapped('virtual_id')
-        lines_to_delete = self.order_line.filtered(
-            lambda sol: bool(
-                # Lines which aren't saved in DB yet.
-                virtual_ids and sol.linked_virtual_id and sol.linked_virtual_id not in virtual_ids
-            ) or bool(
-                # Lines which are saved in DB.
-                sol.linked_line_id and sol.linked_line_id not in self.order_line
-            )
-        )
-        if lines_to_delete:
-            self.order_line = [Command.delete(line.id) for line in lines_to_delete]
         for index, line in enumerate(self.order_line):
             if line.product_type == 'combo' and line.selected_combo_items:
                 linked_lines = line._get_linked_lines()

--- a/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.js
+++ b/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.js
@@ -74,6 +74,13 @@ export class SaleOrderLineListRenderer extends ProductLabelSectionAndNoteListRen
         );
     }
 
+    async onDeleteRecord(record) {
+        if (this.isCombo(record)) {
+            await record.update({ selected_combo_items: JSON.stringify([]) });
+        }
+        await super.onDeleteRecord(record);
+    }
+
     isCombo(record) {
         return record.data.product_type === 'combo';
     }


### PR DESCRIPTION
Combo items were sometimes erroneously deleted. This was because we compared "real" records (saved in DB) with "virtual" records (not saved in DB). In some situations, the "virtual" records were simply wrappers around the "real" record, in which case they should be considered equal, but they weren't.

Combos need to be configured, so we can't allow them to be awarded as free products.