### PR TITLE
[FIX] pos_self_order: retrieve display_type from the correct attribute

### DIFF
--- a/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.js
+++ b/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.js
@@ -113,7 +113,7 @@ export class AttributeSelection extends Component {
             this.selectedValues[attr.id] = {};
 
             for (const value of attr.attribute_id.template_value_ids) {
-                if (attr.display_type === "multi") {
+                if (attr.attribute_id.display_type === "multi") {
                     this.selectedValues[attr.id][value.id] = initValue(value);
                 } else if (typeof this.selectedValues[attr.id] !== "number") {
                     this.selectedValues[attr.id] = initValue(value);
@@ -127,7 +127,7 @@ export class AttributeSelection extends Component {
     }
 
     isChecked(attribute, value) {
-        return attribute.display_type === "multi"
+        return attribute.attribute_id.display_type === "multi"
             ? this.selectedValues[attribute.id][value.id]
             : parseInt(this.selectedValues[attribute.id]) === value.id;
     }

--- a/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
+++ b/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
@@ -24,7 +24,7 @@
                                     <input
                                         type="radio"
                                         class="d-none"
-                                        t-if="attribute.display_type !== 'multi'"
+                                        t-if="attribute.attribute_id.display_type !== 'multi'"
                                         t-att-value="value.id"
                                         t-attf-id="{{ attribute.id }}_{{ value.id }}"
                                         t-model="this.selectedValues[attribute.id]" />

--- a/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
@@ -38,3 +38,19 @@ registry.category("web_tour.tours").add("self_attribute_selector", {
         Utils.checkIsNoBtn("Order Now"),
     ],
 });
+
+registry.category("web_tour.tours").add("self_multi_attribute_selector", {
+    test: true,
+    steps: () => [
+        Utils.clickBtn("Order Now"),
+        ProductPage.clickProduct("Multi Check Attribute Product"),
+        ...ProductPage.setupAttribute(
+            [
+                { name: "Attribute 1", value: "Attribute Val 1" },
+                { name: "Attribute 1", value: "Attribute Val 2" },
+            ],
+            false
+        ),
+        ProductPage.verifyIsCheckedAttribute("Attribute 1", ["Attribute Val 1", "Attribute Val 2"]),
+    ],
+});

--- a/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
@@ -57,6 +57,35 @@ export function setupAttribute(attributes, addToCart = true) {
     return steps;
 }
 
+export function verifyIsCheckedAttribute(attribute, values = []) {
+    return {
+        content: `Select value for attribute ${attribute}`,
+        trigger: `div.attribute-row h2:contains("${attribute}")`,
+        run: () => {
+            const attributesValues = Array.from(
+                document.querySelectorAll("div.attribute-row h2")
+            ).find((el) => el.textContent.includes(attribute));
+            if (!attributesValues) {
+                throw Error(`${attribute} not found.`);
+            }
+            const rowDiv = attributesValues.nextElementSibling;
+            if (!rowDiv || !rowDiv.matches("div.row")) {
+                throw Error("Sibling div.row not found or is incorrect.");
+            }
+            const colDiv = rowDiv.querySelector("div.col");
+            const labelElement = colDiv ? colDiv.querySelector("label") : null;
+            const inputElement = colDiv ? colDiv.querySelector("input") : null;
+            if (!labelElement || !inputElement) {
+                throw Error(`Missing ${attribute} values`);
+            }
+            const attributeValue = labelElement.querySelector("div > span").textContent.trim();
+            if (values.includes(attributeValue) && !inputElement.checked) {
+                throw Error(`Attribute ${attributeValue} not checked`);
+            }
+        },
+    };
+}
+
 export function setupCombo(products, addToCart = true) {
     const steps = [];
 

--- a/addons/pos_self_order/tests/test_self_order_attribute.py
+++ b/addons/pos_self_order/tests/test_self_order_attribute.py
@@ -28,3 +28,47 @@ class TestSelfOrderAttribute(SelfOrderCommonTest):
         order = self.pos_config.current_session_id.order_ids[0]
         self.assertEqual(order.lines[0].price_extra, 1.0)
         self.assertEqual(order.lines[1].price_extra, 2.0)
+
+    def test_self_order_multi_check_attribute(self):
+        self.pos_config.write({
+            'self_ordering_default_user_id': self.pos_admin.id,
+            'self_ordering_takeaway': False,
+            'self_ordering_mode': 'mobile',
+            'self_ordering_pay_after': 'each',
+            'self_ordering_service_mode': 'counter',
+        })
+
+        pos_categ_misc = self.env['pos.category'].create({
+            'name': 'Miscellaneous',
+        })
+
+        product = self.env['product.product'].create({
+            'name': 'Multi Check Attribute Product',
+            'available_in_pos': True,
+            'list_price': 1,
+            'pos_categ_ids': [(4, pos_categ_misc.id)],
+        })
+        attribute = self.env['product.attribute'].create({
+            'name': 'Attribute 1',
+            'display_type': 'multi',
+            'create_variant': 'no_variant',
+        })
+        attribute_val_1 = self.env['product.attribute.value'].create({
+            'name': 'Attribute Val 1',
+            'attribute_id': attribute.id,
+        })
+        attribute_val_2 = self.env['product.attribute.value'].create({
+            'name': 'Attribute Val 2',
+            'attribute_id': attribute.id,
+        })
+
+        self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': product.product_tmpl_id.id,
+            'attribute_id': attribute.id,
+            'value_ids': [(6, 0, [attribute_val_1.id, attribute_val_2.id])]
+        })
+
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self_route = self.pos_config._get_self_order_route()
+
+        self.start_tour(self_route, "self_multi_attribute_selector")


### PR DESCRIPTION
Problem:
The `display_type` attribute was being retrieved from the wrong field, causing issues when selecting multiple product attributes in Self-Ordering.

Steps to reproduce:
- Create a product available for Self-Ordering.
- Add a "Multi-checkbox" type attribute to the product.
- Go to the Self-Ordering interface.
- Attempt to order the product.
- You can only select one attribute option, even though multiple should be selectable.

opw-4192992


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
