### PR TITLE
[I18N] l10n_fr_account: add missing translations

### DIFF
--- a/addons/l10n_fr_account/i18n/fr.po
+++ b/addons/l10n_fr_account/i18n/fr.po
@@ -334,17 +334,17 @@ msgstr "Balance"
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
 msgid "Cancel"
-msgstr ""
+msgstr "Annuler"
 
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
 msgid "Column"
-msgstr ""
+msgstr "Colonne"
 
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
 msgid "Comment"
-msgstr ""
+msgstr "Commentaire"
 
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
@@ -374,12 +374,12 @@ msgstr ""
 #. module: l10n_fr_account
 #: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__create_uid
 msgid "Created by"
-msgstr ""
+msgstr "Créé par"
 
 #. module: l10n_fr_account
 #: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__create_date
 msgid "Created on"
-msgstr ""
+msgstr "Créé le"
 
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_credit
@@ -395,7 +395,7 @@ msgstr "Crédit imputé"
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.report_invoice_document
 msgid "Customer Address:"
-msgstr ""
+msgstr "Adresse du client\u00a0:"
 
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
@@ -420,7 +420,7 @@ msgstr "Détermination du montant à payer et/ou des crédits de TVA et/ou de TI
 #. module: l10n_fr_account
 #: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__display_name
 msgid "Display Name"
-msgstr ""
+msgstr "Nom d'affichage"
 
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_E1
@@ -483,22 +483,22 @@ msgstr ""
 #. module: l10n_fr_account
 #: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__date_to
 msgid "End Date"
-msgstr ""
+msgstr "Date de fin"
 
 #. module: l10n_fr_account
 #: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__exclude_zero
 msgid "Exclude lines at 0"
-msgstr ""
+msgstr "Exclure les lignes à 0"
 
 #. module: l10n_fr_account
 #: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__excluded_journal_ids
 msgid "Excluded Journals"
-msgstr ""
+msgstr "Journaux exclus"
 
 #. module: l10n_fr_account
 #: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__export_type
 msgid "Export Type"
-msgstr ""
+msgstr "Type d'exportation"
 
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_F1
@@ -557,7 +557,7 @@ msgstr "F9 - Opérations internes réalisées entre membres d'un assujetti uniqu
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
 msgid "FEC File Generation"
-msgstr ""
+msgstr "Génération de fichiers FEC"
 
 #. module: l10n_fr_account
 #: model:ir.model,name:l10n_fr_account.model_l10n_fr_fec_export_wizard
@@ -567,7 +567,7 @@ msgstr ""
 #. module: l10n_fr_account
 #: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__filename
 msgid "Filename"
-msgstr ""
+msgstr "Nom de fichier"
 
 #. module: l10n_fr_account
 #: model:ir.ui.menu,name:l10n_fr_account.account_reports_fr_statements_menu
@@ -577,12 +577,12 @@ msgstr "France"
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
 msgid "Generate"
-msgstr ""
+msgstr "Générer"
 
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.report_invoice_document
 msgid "Goods Delivery"
-msgstr ""
+msgstr "Livraison de biens"
 
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_tva_brute
@@ -667,7 +667,7 @@ msgstr "Importations"
 #. module: l10n_fr_account
 #: model:ir.model,name:l10n_fr_account.model_account_move
 msgid "Journal Entry"
-msgstr ""
+msgstr "Pièce comptable"
 
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
@@ -699,17 +699,17 @@ msgstr ""
 #. module: l10n_fr_account
 #: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__write_uid
 msgid "Last Updated by"
-msgstr ""
+msgstr "Mis à jour par"
 
 #. module: l10n_fr_account
 #: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__write_date
 msgid "Last Updated on"
-msgstr ""
+msgstr "Mis à jour le"
 
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.report_invoice_document
 msgid "Mixed Operation"
-msgstr ""
+msgstr "Opération mixte"
 
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
@@ -719,12 +719,12 @@ msgstr ""
 #. module: l10n_fr_account
 #: model:ir.model.fields.selection,name:l10n_fr_account.selection__l10n_fr_fec_export_wizard__export_type__nonofficial
 msgid "Non-official FEC report (posted and unposted entries)"
-msgstr ""
+msgstr "Rapport FEC non officiel (pièces comptabilisées et non comptabilisées)"
 
 #. module: l10n_fr_account
 #: model:ir.model.fields.selection,name:l10n_fr_account.selection__l10n_fr_fec_export_wizard__export_type__official
 msgid "Official FEC report (posted entries only)"
-msgstr ""
+msgstr "Rapport FEC officiel (pièces comptabilisées uniquement)"
 
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_tva_brute_petrolier
@@ -734,7 +734,7 @@ msgstr "Produits pétroliers"
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.report_invoice_document
 msgid "Operation Type:"
-msgstr ""
+msgstr "Type d'opération\u00a0:"
 
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_tva_brute_metropo
@@ -749,12 +749,12 @@ msgstr "Opérations réalisées dans les DOM"
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.report_invoice_document
 msgid "Option to pay tax on debits"
-msgstr ""
+msgstr "Option pour le paiement de la taxe d'après les débits"
 
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
 msgid "Options"
-msgstr ""
+msgstr "Options"
 
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_reliquat
@@ -804,7 +804,7 @@ msgstr "Régularisation des taxes intérieures de consommation (TIC)"
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.report_invoice_document
 msgid "SIRET:"
-msgstr ""
+msgstr "SIRET\u00a0:"
 
 #. module: l10n_fr_account
 #: model:account.account.tag,name:l10n_fr_account.account_fr_tag_salaires
@@ -814,7 +814,7 @@ msgstr "Salaires"
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.report_invoice_document
 msgid "Service Delivery"
-msgstr ""
+msgstr "Prestation de services"
 
 #. module: l10n_fr_account
 #: model:account.account.tag,name:l10n_fr_account.account_fr_tag_charges_sociales
@@ -824,7 +824,7 @@ msgstr "Charges sociales"
 #. module: l10n_fr_account
 #: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__date_from
 msgid "Start Date"
-msgstr ""
+msgstr "Date de début"
 
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_T1_base
@@ -937,17 +937,17 @@ msgstr "TD - TVA Due"
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_TICC
 msgid "TICC"
-msgstr ""
+msgstr "TICC"
 
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_TICFE
 msgid "TICFE"
-msgstr ""
+msgstr "TICFE"
 
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_TICGN
 msgid "TICGN"
-msgstr ""
+msgstr "TICGN"
 
 #. module: l10n_fr_account
 #: model:account.report,name:l10n_fr_account.tax_report
@@ -967,17 +967,17 @@ msgstr "Opérations imposables (H.T.)"
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
 msgid "Technical Info"
-msgstr ""
+msgstr "Informations techniques"
 
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
 msgid "Technical Name"
-msgstr ""
+msgstr "Nom technique"
 
 #. module: l10n_fr_account
 #: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__test_file
 msgid "Test File"
-msgstr ""
+msgstr "Fichier de test"
 
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
@@ -985,11 +985,13 @@ msgid ""
 "The encoding of this text file is UTF-8. The structure of file is CSV "
 "separated by pipe '|'."
 msgstr ""
+"L'encodage de ce fichier texte est UTF-8. La structure du fichier est CSV, "
+"séparée par un caractère pipe « | »."
 
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_TIC_total
 msgid "Total"
-msgstr ""
+msgstr "Total"
 
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_tva_brute_autre
@@ -1009,7 +1011,7 @@ msgstr ""
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
 msgid "We use partner.id"
-msgstr ""
+msgstr "Nous utilisons partner.id"
 
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
@@ -1018,6 +1020,10 @@ msgid ""
 "                If you want to test the FEC file generation, please tick the "
 "test file checkbox."
 msgstr ""
+"Lorsque vous téléchargez un fichier FEC, la date de verrouillage est définie "
+"sur la date de fin.\n"
+"Si vous souhaitez tester la génération du fichier FEC, veuillez cocher la "
+"case du fichier de test."
 
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_X1
@@ -1083,6 +1089,8 @@ msgstr ""
 msgid ""
 "You are in test mode. The FEC file generation will not set the lock date."
 msgstr ""
+"Vous êtes en mode test. La génération du fichier FEC ne définira pas la date "
+"de verrouillage."
 
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_Z1


### PR DESCRIPTION
After [this commit] the translation file for `l10n_fr_account` was updated. Some translations were lost in the process.

This commit restores the lost translations and adds other missing ones.

[this commit]: https://github.com/odoo/odoo/commit/00e3fcf757432b7de3c7557da034077ad91dbea8