### PR TITLE
[IMP] l10n_au: Add new account for deductions

### DIFF
--- a/addons/l10n_au/data/template/account.account-au.csv
+++ b/addons/l10n_au/data/template/account.account-au.csv
@@ -43,6 +43,7 @@
 "au_21600","21600","Customer Deposits","liability_current","False"
 "au_21700","21700","Other Current Liabilities","liability_current","False"
 "au_21760","21760","Unearned Income from System","liability_current","False"
+"au_21800","21800","Deductions","liability_current","True"
 "au_22100","22100","Mortgages Payable","liability_non_current","False"
 "au_22200","22200","Notes Payable","liability_non_current","False"
 "au_22300","22300","Other Long Term Liabilities","liability_non_current","False"


### PR DESCRIPTION
This commit adds a new account for deductions
in the Australian chart of accounts.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
