### PR TITLE
[FIX] tools/mail: adapt getaddresses

### DIFF
--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -9,7 +9,8 @@ import re
 import socket
 import threading
 import time
-from email.utils import getaddresses
+import email.utils
+from email.utils import getaddresses as orig_getaddresses
 from urllib.parse import urlparse
 
 import idna
@@ -23,6 +24,17 @@ from odoo.loglevels import ustr
 from odoo.tools import misc
 
 _logger = logging.getLogger(__name__)
+
+
+# disable strict mode when present: we rely on original non-strict
+# parsing, and we know that it isn't reliable, that ok.
+# cfr python/cpython@4a153a1d3b18803a684cd1bcc2cdf3ede3dbae19
+if hasattr(email.utils, 'supports_strict_parsing'):
+    def getaddresses(fieldvalues):
+        return orig_getaddresses(fieldvalues, strict=False)
+else:
+    getaddresses = orig_getaddresses
+
 
 #----------------------------------------------------------
 # HTML Sanitizer


### PR DESCRIPTION
A patch was backported in python 3.12.3-1ubuntu0.2 on ubuntu noble breaking the address parsing. Odoo relies on the non strict behavior but the strict was introduced as the default one.

This commit conditionally checks if the patch is present and reverts it to the previous behavior.

test_email_split unittest was used for testing in both version ( 3.12.3-1ubuntu0.1 and 3.12.3-1ubuntu0.2)3.10.3-ubuntu0.1

References:
https://launchpad.net/ubuntu/+source/python3.12/3.12.3-1ubuntu0.2 

Backported patch:
python/cpython@4a153a1d3b18803a684cd1bcc2cdf3ede3dbae19
