### PR TITLE
[FIX] mail: avoid creating multiple chat with first connecting user

### DIFF
--- a/addons/mail/static/src/discuss/core/web/discuss_core_web_service.js
+++ b/addons/mail/static/src/discuss/core/web/discuss_core_web_service.js
@@ -16,6 +16,7 @@ export class DiscussCoreWeb {
         this.ui = services.ui;
         this.discussCoreCommonService = services["discuss.core.common"];
         this.store = services["mail.store"];
+        this.multiTab = services.multi_tab;
         try {
             this.sidebarCategoriesBroadcast = new browser.BroadcastChannel(
                 "discuss_core_web.sidebar_categories"
@@ -52,6 +53,9 @@ export class DiscussCoreWeb {
                 { user: username }
             );
             this.notificationService.add(notification, { type: "info" });
+            if (!this.multiTab.isOnMainTab()) {
+                return;
+            }
             const chat = await this.store.getChat({ partnerId });
             if (chat && !this.ui.isSmall) {
                 this.store.chatHub.opened.add({ thread: chat });
@@ -88,7 +92,7 @@ export class DiscussCoreWeb {
 }
 
 export const discussCoreWeb = {
-    dependencies: ["bus_service", "discuss.core.common", "mail.store", "notification", "ui"],
+    dependencies: ["bus_service", "discuss.core.common", "mail.store", "notification", "ui", "multi_tab"],
     /**
      * @param {import("@web/env").OdooEnv} env
      * @param {Partial<import("services").Services>} services


### PR DESCRIPTION
Before this PR, if Odoo was open in multiple tabs, the res.users/connection notification whould open one chat by tab. This is because the RPC whould fire once by tab.

This PR check that only the main tab send the RPC.

opw-4133175