### PR TITLE
[FIX] event{_sms}: filters event templates

### DIFF
--- a/addons/event/models/mail_template.py
+++ b/addons/event/models/mail_template.py
@@ -9,17 +9,17 @@ class MailTemplate(models.Model):
     _inherit = 'mail.template'
 
     @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
+    def _search(self, domain, *args, **kwargs):
         """Context-based hack to filter reference field in a m2o search box to emulate a domain the ORM currently does not support.
 
         As we can not specify a domain on a reference field, we added a context
         key `filter_template_on_event` on the template reference field. If this
-        key is set, we add our domain in the `domain` in the `_name_search`
+        key is set, we add our domain in the `domain` in the `_search`
         method to filtrate the mail templates.
         """
         if self.env.context.get('filter_template_on_event'):
             domain = expression.AND([[('model', '=', 'event.registration')], domain])
-        return super()._name_search(name, domain, operator, limit, order)
+        return super()._search(domain, *args, **kwargs)
 
     def unlink(self):
         res = super().unlink()

--- a/addons/event/tests/test_event_internals.py
+++ b/addons/event/tests/test_event_internals.py
@@ -395,6 +395,8 @@ class TestEventData(TestEventInternalsCommon):
         self.env['mail.template'].create({'model_id': self.env['ir.model']._get('res.partner').id, 'name': 'test template'})
         templates = self.env['mail.template'].with_context(filter_template_on_event=True).name_search('test template')
         self.assertEqual(len(templates), 1, 'Should return only mail templates related to the event registration model')
+        templates = self.env['mail.template'].with_context(filter_template_on_event=True).search([('name', '=', 'test template')])
+        self.assertEqual(len(templates), 1, 'Should also return only mail templates related to the event registration model using search')
 
     @freeze_time('2020-1-31 10:00:00')
     @users('user_eventmanager')

--- a/addons/event_sms/models/sms_template.py
+++ b/addons/event_sms/models/sms_template.py
@@ -9,17 +9,17 @@ class SmsTemplate(models.Model):
     _inherit = 'sms.template'
 
     @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
+    def _search(self, domain, *args, **kwargs):
         """Context-based hack to filter reference field in a m2o search box to emulate a domain the ORM currently does not support.
 
         As we can not specify a domain on a reference field, we added a context
         key `filter_template_on_event` on the template reference field. If this
-        key is set, we add our domain in the `domain` in the `_name_search`
+        key is set, we add our domain in the `domain` in the `_search`
         method to filtrate the SMS templates.
         """
         if self.env.context.get('filter_template_on_event'):
             domain = expression.AND([[('model', '=', 'event.registration')], domain])
-        return super()._name_search(name, domain, operator, limit, order)
+        return super()._search(domain, *args, **kwargs)
 
     def unlink(self):
         res = super().unlink()


### PR DESCRIPTION
Current behaviour:
---
When setting mail templates in the communication tab of an event, you initially only see event templates, 
unless you click on "Search more ..." which allows you to set non-event templates.

Expected behaviour:
---
Only seeing/and being able to set event templates

Steps to reproduce:
---
1. Install event_sale
2. Go to Events, pick an event
3. In the communication tab, remove all templates
4. By clicking on "Search more ..." add a sale template
5. Set as Immediately and After each registration
6. Click on the smart button "Attendees"
7. Create a new attendee with an email then save
8. You may need to create multiple attendees
9. Failed to render inline_template template

Cause of the issue:
---
When selecting a sale template, the render model is `sale.order` So when passing the registration id to get rendered, 
it tries to read this id on a `sale.order`, causing an error if a `sale.order` with this id doesn't exist.
Caused by: https://github.com/odoo/odoo/commit/6abd149259e9caf815fe1804f1322f623f8fcb50 
`_name_search` was overriden, but the "Search more ..." option doesn't used `_name_search` but `web_search_read`

Fix:
---
Overrode `_search` as well

opw-4106237

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
