### PR TITLE
[FIX] web: fix timeout in test

### DIFF
--- a/addons/web/static/tests/views/fields/daterange_field.test.js
+++ b/addons/web/static/tests/views/fields/daterange_field.test.js
@@ -357,6 +357,9 @@ test("Render with initial empty value and optional start date", async () => {
     });
 
     await contains("input[data-field=datetime_end]").click();
+    // wait for the popover to be rendered.
+    // It sometimes happens that the element is not present yet.
+    await animationFrame();
     expect(".o_datetime_picker").toHaveCount(1);
     expect(".o_add_date").toHaveCount(0);
 


### PR DESCRIPTION
This commit fixes a test which sometimes timeout.
To quickly explain, the test tries to open the date picker popover and it succeeds almost everytime but it happens that the popover takes more time than the usual.