### PR TITLE
[FIX] account: flush precommit hook

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -648,6 +648,8 @@ class AccountAccount(models.Model):
         for company, company_accounts in accounts_per_company.items():
             company._update_opening_move({account: data[account.id] for account in company_accounts})
 
+        self.env.flush_all()
+
     def _toggle_reconcile_to_true(self):
         '''Toggle the `reconcile´ boolean from False -> True
 


### PR DESCRIPTION
**Current behavior:**
Attempting to test the import of a new CoA on a fresh DB will
result in a query actually getting executed and an error
propagated up to the UI, however if you were to instead actually
do the import, it would work and everything would be correct.

**Expected behavior:**
If the actual import would work, the 'Test' button should
indicate the same.

**Steps to reproduce:**
*From a fresh DB with account_accountant*
1. Go to the Chart of Accounts view

2. Import a new CoA

3. Download the template offerred, upload it

4. Click 'Test' -> see the FKEY error

**Cause of the issue:**
The precommit hook for updating a company's opening move is
expected to flush its changes, which is currently not happening.

**Fix:**
Flush the changes made in the precommit hook at the end of the
method.

opw-4103686