### PR TITLE
[IMP] base: remove hack that makes 'group_no_one' independent

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1056,7 +1056,7 @@ actual arch.
         return tree
 
     def _postprocess_features_to_cache(self, tree):
-        group_features = {'base.group_no_one'}
+        group_features = {'base.group_no_one', 'base.group_multi_company'}
         remove = {f'!{group}' for group in group_features}
         group_features |= remove
         for node in tree.xpath("//*[@groups]"):
@@ -1068,9 +1068,12 @@ actual arch.
 
     def _postprocess_features(self, tree):
         debug = request and request.session.debug
+        multi = len(self.env.user.company_ids) > 1
         group_features = {
             'base.group_no_one': debug,
             '!base.group_no_one': not debug,
+            'base.group_multi_company': multi,
+            '!base.group_multi_company': not multi,
         }
         for node in tree.xpath('//*[@__features__]'):
             features = node.attrib.pop('__features__')

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -998,10 +998,6 @@ actual arch.
         group_definitions = self.env['res.groups']._get_group_definitions()
 
         user_group_ids = self.env.user._get_group_ids()
-        # The 'base.group_no_one' is not actually involved by any other group because it is session dependent.
-        group_no_one_id = group_definitions.get_id('base.group_no_one')
-        if group_no_one_id in user_group_ids and not (request and request.session.debug):
-            user_group_ids = [g for g in user_group_ids if g != group_no_one_id]
 
         # check the read/visibility access
         @functools.cache
@@ -1059,6 +1055,30 @@ actual arch.
 
         return tree
 
+    def _postprocess_features_to_cache(self, tree):
+        group_features = {'base.group_no_one'}
+        remove = {f'!{group}' for group in group_features}
+        group_features |= remove
+        for node in tree.xpath("//*[@groups]"):
+            groups = set(node.attrib.get('groups', '').split(','))
+            features = group_features & groups
+            if features:
+                node.attrib['__features__'] = ','.join(features)
+                node.attrib['groups'] = ','.join(groups - remove)
+
+    def _postprocess_features(self, tree):
+        debug = request and request.session.debug
+        group_features = {
+            'base.group_no_one': debug,
+            '!base.group_no_one': not debug,
+        }
+        for node in tree.xpath('//*[@__features__]'):
+            features = node.attrib.pop('__features__')
+            for feature, value in group_features.items():
+                if value == (feature not in features):
+                    node.attrib['invisible'] = '1'
+        return tree
+
     def _postprocess_view(self, node, model_name, editable=True, node_info=None, **options):
         """ Process the given architecture, modifying it in-place to add and
         remove stuff.
@@ -1097,6 +1117,8 @@ actual arch.
         }
 
         is_compute_warning_info = options.get('is_compute_warning_info')
+
+        self._postprocess_features_to_cache(root)
 
         # use a stack to recursively traverse the tree
         stack = [(root, view_groups, editable)]
@@ -2758,6 +2780,7 @@ class Model(models.AbstractModel):
 
         node = etree.fromstring(result['arch'])
         node = self.env['ir.ui.view']._postprocess_access_rights(node)
+        node = self.env['ir.ui.view']._postprocess_features(node)
         result['arch'] = etree.tostring(node, encoding="unicode").replace('\t', '')
 
         return result

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1528,18 +1528,13 @@ class GroupsImplied(models.Model):
         """ Return the definition of all the groups as a :class:`~odoo.tools.SetDefinitions`. """
         groups = self.sudo().search([], order='id')
         id_to_ref = groups.get_external_id()
-
-        # The 'base.group_no_one' is not actually involved by any other group because it is session dependent.
-        group_no_one_id = {gid for gid, ref in id_to_ref.items() if ref == 'base.group_no_one'}
-
         data = {
             group.id: {
                 'ref': id_to_ref[group.id] or str(group.id),
-                'supersets': set(group.implied_ids.ids) - group_no_one_id,
+                'supersets': group.implied_ids.ids,
             }
             for group in groups
         }
-
         # determine exclusive groups (will be disjoint for the set expression)
         user_types_category_id = self.env['ir.model.data']._xmlid_to_res_id('base.module_category_user_type', raise_if_not_found=False)
         if user_types_category_id:

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1183,6 +1183,8 @@ class Users(models.Model):
         result = self._has_group(group_ext_id)
         if group_ext_id == 'base.group_no_one':
             result = result and bool(request and request.session.debug)
+        elif group_ext_id == 'base.group_multi_company':
+            result = result and len(self.company_ids) > 1
         return result
 
     def _has_group(self, group_ext_id: str) -> bool:
@@ -1856,44 +1858,18 @@ class UsersView(models.Model):
         new_vals_list = []
         for values in vals_list:
             new_vals_list.append(self._remove_reified_groups(values))
-        users = super(UsersView, self).create(new_vals_list)
-        group_multi_company_id = self.env['ir.model.data']._xmlid_to_res_id(
-            'base.group_multi_company', raise_if_not_found=False)
-        if group_multi_company_id:
-            for user in users:
-                if len(user.company_ids) <= 1 and group_multi_company_id in user.groups_id.ids:
-                    user.write({'groups_id': [Command.unlink(group_multi_company_id)]})
-                elif len(user.company_ids) > 1 and group_multi_company_id not in user.groups_id.ids:
-                    user.write({'groups_id': [Command.link(group_multi_company_id)]})
-        return users
+        return super().create(new_vals_list)
 
     def write(self, values):
         values = self._remove_reified_groups(values)
-        res = super(UsersView, self).write(values)
-        if 'company_ids' not in values:
-            return res
-        group_multi_company = self.env.ref('base.group_multi_company', False)
-        if group_multi_company:
-            for user in self:
-                if len(user.company_ids) <= 1 and user.id in group_multi_company.users.ids:
-                    user.write({'groups_id': [Command.unlink(group_multi_company.id)]})
-                elif len(user.company_ids) > 1 and user.id not in group_multi_company.users.ids:
-                    user.write({'groups_id': [Command.link(group_multi_company.id)]})
-        return res
+        return super().write(values)
 
     @api.model
     def new(self, values=None, origin=None, ref=None):
         if values is None:
             values = {}
         values = self._remove_reified_groups(values)
-        user = super().new(values=values, origin=origin, ref=ref)
-        group_multi_company = self.env.ref('base.group_multi_company', False)
-        if group_multi_company and 'company_ids' in values:
-            if len(user.company_ids) <= 1 and user.id in group_multi_company.users.ids:
-                user.update({'groups_id': [Command.unlink(group_multi_company.id)]})
-            elif len(user.company_ids) > 1 and user.id not in group_multi_company.users.ids:
-                user.update({'groups_id': [Command.link(group_multi_company.id)]})
-        return user
+        return super().new(values=values, origin=origin, ref=ref)
 
     def _prepare_warning_for_group_inheritance(self, user):
         """ Check (updated) groups configuration for user. If implieds groups


### PR DESCRIPTION
[IMP] base: remove hack that makes 'group_no_one' independent

Uses a dummy element in the theory set to indicate whether the user
is in debug mode. This allows the implications of the groups in the
data to not be changed. The 'debug-mode' element is not used as data
(neither in views nor in xmlids).