### PR TITLE
[FIX] pos_hr: print session report by employee getting connection lost

### DIFF
--- a/addons/pos_hr/static/src/app/print_report_button/print_report_button.js
+++ b/addons/pos_hr/static/src/app/print_report_button/print_report_button.js
@@ -14,13 +14,16 @@ class PrintReportButton extends Component {
 
     setup() {
         this.action = useService("action");
-        this.orm = useService("orm");
+        // Why not `this.orm = useService("orm");` ?
+        // Because in the `onClick` method, the first action call will potentially open the `new layout action wizard`
+        // closing the current dialog. Once closed, the succeeding actions will be terminated because of the protection
+        // made by calling `useService`. We want to continue with the full logic of the `onClick` method even if the
+        // dialog is closed.
+        this.orm = this.env.services.orm;
     }
 
     async onClick() {
         const context = makeContext([this.props.record.evalContext || {}]);
-
-        const promises = [];
 
         const single_report_action = await this.orm.call(
             "pos.daily.sales.reports.wizard",
@@ -30,7 +33,10 @@ class PrintReportButton extends Component {
                 pos_session_id: context.pos_session_id,
             }
         );
-        promises.push(this.action.doAction(single_report_action));
+        await this.action.doAction({
+            ...single_report_action,
+            close_on_report_download: !context.add_report_per_employee,
+        });
 
         if (context.add_report_per_employee) {
             const multi_report_action = await this.orm.call(
@@ -42,10 +48,8 @@ class PrintReportButton extends Component {
                     employee_ids: context.employee_ids,
                 }
             );
-            promises.push(this.action.doAction(multi_report_action));
+            await this.action.doAction({ ...multi_report_action, close_on_report_download: true });
         }
-
-        await Promise.all(promises);
     }
 }
 


### PR DESCRIPTION
Steps:
- Activate 'login with employees'  in settings
- Open PoS
- Make sales and switch between different employees 
- Close session 
- Go to reporting, click on Session Report 
- Check the box "add a report per each employee" 
- Click on print, if the report layout wizard comes up, print the report.
- Again try to print the report.

Issue:
Stuck on loading then the connection gets lost

Cause:
Try to process two async requests parallelly to download reports "session report" and "session report per employee" causing them to get stuck on loading then the connection lost

FIX:
Instead of trying to process two async requests parallel, we will wait for first one to complete then execute the second one.

task - 4191502
