### PR TITLE
[FIX] account: reverse sequence in fpos ranking

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -231,7 +231,7 @@ class AccountFiscalPosition(models.Model):
                 not fpos.country_group_id
                 or (partner.country_id in fpos.country_group_id.country_ids and 2)
             )),
-            ('sequence', lambda fpos: fpos.sequence or 0.1),  # do not filter out sequence=0
+            ('sequence', lambda fpos: -(fpos.sequence or 0.1)),  # do not filter out sequence=0, priority to lowest sequence in `max` method
         ]
 
     @api.model

--- a/addons/account/tests/test_fiscal_position.py
+++ b/addons/account/tests/test_fiscal_position.py
@@ -307,3 +307,11 @@ class TestFiscalPosition(common.TransactionCase):
             'zip_from': '123',
             'zip_to': '456',
         }])
+
+    def test_get_first_fiscal_position(self):
+        fiscal_positions = self.fp.create([{
+            'name': f'fiscal_position_{sequence}',
+            'auto_apply': True,
+            'sequence': sequence
+        } for sequence in range(1, 3)])
+        self.assertEqual(self.fp._get_fiscal_position(self.env.company.partner_id), fiscal_positions[0])


### PR DESCRIPTION
### Steps to reproduce the issue:

1. Install French Localization and use the FR company
2. Add a Contact located in France with a VAT number
3. Create an Invoice and select the Contact as Customer
4. The Fiscal Position under the Other Info tab is "Intra-EU B2B" instead of "Domestic - France"

### Explanation:

In `_get_fiscal_position`, the rankings are done to give priority to the highest sequence due to the `max` method when fiscal positions are equal in every other ranking. https://github.com/odoo/odoo/blob/c7e90ff39b7e47312d475d8c2dd26263cb6d1b4a/addons/account/models/partner.py#L269-L280

### Fix reasoning:

Returning their opposite to give priority to the lowest sequence without adapting every other condition for the use of `min`.

opw-4150262 opw-4154081 opw-4182825 opw-4186137