### PR TITLE
[FIX] sale_project: prevent stopIteration exception on SO projet access

### DIFF
--- a/addons/sale_project/i18n/sale_project.pot
+++ b/addons/sale_project/i18n/sale_project.pot
@@ -775,6 +775,13 @@ msgstr ""
 #. odoo-python
 #: code:addons/sale_project/models/sale_order.py:0
 #, python-format
+msgid "The product configuration has been modified, please refresh the page."
+msgstr ""
+
+#. module: sale_project
+#. odoo-python
+#: code:addons/sale_project/models/sale_order.py:0
+#, python-format
 msgid "This Sales Order must contain at least one product of type \"Service\"."
 msgstr ""
 

--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -201,7 +201,14 @@ class SaleOrder(models.Model):
             return {'type': 'ir.actions.act_window_close'}
 
         sorted_line = self.order_line.sorted('sequence')
-        default_sale_line = next(sol for sol in sorted_line if sol.product_id.detailed_type == 'service')
+        default_sale_line = next((
+            sol for sol in sorted_line
+            if sol.product_id.detailed_type == 'service' and not sol.is_downpayment
+        ), self.env['sale.order.line'])
+
+        if not default_sale_line:
+            raise UserError(_("The product configuration has been modified, please refresh the page."))
+
         action = {
             'type': 'ir.actions.act_window',
             'name': _('Projects'),

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import Command
-from odoo.exceptions import AccessError
+from odoo.exceptions import AccessError, UserError
 from odoo.tests import Form, new_test_user, tagged
 
 from .common import TestSaleProjectCommon
@@ -817,3 +817,19 @@ class TestSaleProject(TestSaleProjectCommon):
             'sale_line_id': sale_order.order_line.id,
         })
         self.assertEqual(task3.sale_order_id, sale_order, "Task matches SO's partner_id")
+
+    def test_revoke_project_access_after_product_type_update(self):
+        order = self.env['sale.order'].create({
+            'name': 'Project Order',
+            'partner_id': self.partner.id
+        })
+
+        self.env['sale.order.line'].create({
+            'product_id': self.product_order_service4.id,
+            'order_id': order.id,
+        })
+
+        order.action_confirm()
+        self.product_order_service4.type = 'consu'
+        with self.assertRaises(UserError):
+            order.action_view_project_ids()


### PR DESCRIPTION
Steps to reproduce:
- Create a service product with 'Create on Order' set to 'Project'
- Duplicate your browser tab (Right click the tab)
- (New tab)Sales > Quotations > New > Add your product > Confirm
- (Old tab) Edit your product to be a consumable
- (Old tab) A warning will pop up but it can be dismissed > Save
- (New tab) Try to access the project with the link button

Despite the warning claiming "You cannot change the product's type because it is already used in sales orders.", the product template's type can be changed at will. This causes issues when accessing the project view because we iterate under the assumption that a service product will be found (Only services can generate projects).

The project button disappears after reloading the page but if someone did click it raises an unhandled exception, which is not great even if the user really has to go out of their way to get it.

opw-4189248

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
