### PR TITLE
[FIX] point_of_sale: display product price and quantity instead of variant's in info popup

### DIFF
--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -177,7 +177,7 @@ class ProductProduct(models.Model):
         config = self.env['pos.config'].browse(pos_config_id)
 
         # Tax related
-        taxes = self.taxes_id.compute_all(price, config.currency_id, quantity, self)
+        taxes = self.taxes_id.compute_all(self.product_tmpl_id.list_price, config.currency_id, quantity, self)
         grouped_taxes = {}
         for tax in taxes['taxes']:
             if tax['id'] in grouped_taxes:
@@ -241,7 +241,8 @@ class ProductProduct(models.Model):
             'pricelists': pricelist_list,
             'warehouses': warehouse_list,
             'suppliers': supplier_list,
-            'variants': variant_list
+            'variants': variant_list,
+            'total_qty_available': self.product_tmpl_id.qty_available
         }
 
 

--- a/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.js
+++ b/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.js
@@ -39,8 +39,7 @@ export class ProductInfoBanner extends Component {
 
                     if (result) {
                         const productInfo = result.productInfo;
-                        this.state.available_quantity =
-                            productInfo.warehouses[0]?.available_quantity;
+                        this.state.available_quantity = productInfo.total_qty_available;
                         this.state.price_with_tax = productInfo.all_prices.price_with_tax;
                         this.state.price_without_tax = productInfo.all_prices.price_without_tax;
                         this.state.tax_name = productInfo.all_prices.tax_details[0]?.name || "";

--- a/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.xml
+++ b/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.xml
@@ -7,13 +7,13 @@
                 <span class="h4" t-esc="props.product.name"/>
                 <span t-if="this.props.product.is_storable" class="h4">
                     <span>On hand: </span>
-                    <span t-if="this.fetchStock.status === 'success' || this.props.info"><t t-esc="this.state.available_quantity"/> Units</span>
+                    <span class="section-product-info-title-quantity" t-if="this.fetchStock.status === 'success' || this.props.info"><t t-esc="this.state.available_quantity"/> Units</span>
                     <span t-elif="this.fetchStock.status === 'error'">N/A</span>
                     <i t-else="" class="fa fa-fw fa-spin fa-circle-o-notch" aria-hidden="true" />
                 </span>
             </div>
             <div t-att-class="{ 'align-items-end': !this.ui.isSmall }" class="d-flex flex-column">
-                <span class="h4"><t t-esc="this.env.utils.formatCurrency(state.price_with_tax)"/></span>
+                <span class="h4 section-product-info-title-price"><t t-esc="this.env.utils.formatCurrency(state.price_with_tax)"/></span>
                 <span class="h4">VAT: <t t-esc="state.tax_name || 0" /> (= <t t-esc="this.env.utils.formatCurrency(state.tax_amount)" />)</span>
             </div>
         </div>

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -328,3 +328,23 @@ registry.category("web_tour.tours").add("PosCustomerAllFieldsDisplayed", {
             PartnerList.searchCustomerValue("john@doe.com"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("PosPopupPriceAndQuantity", {
+    test: true,
+    url: "/pos/ui",
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            ProductScreen.clickInfoProduct("Test Product with Sizes"),
+            {
+                content: `Check Product Quantity`,
+                trigger: '.section-product-info-title-quantity:contains("20 Units")',
+                run: () => {},
+            },
+            {
+                content: `Check Product Price`,
+                trigger: '.section-product-info-title-price:contains("$ 5.75")',
+                run: () => {},
+            },
+        ].flat(),
+});


### PR DESCRIPTION
Problem:
In the product information popup in PoS, the price and quantity displayed are for the first variant, rather than the base product, leading to inaccurate information being shown.

Steps to reproduce:
- Create a product with two variants, each having a different extra price and quantity.
- Open PoS.
- Open the info popup for the created product.
- The price and quantity shown correspond to the first variant instead of the base product.

opw-4191949

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
