### PR TITLE
[FIX] pos*: pre-oxp tracebacks fix

### DIFF
--- a/addons/l10n_in_pos/static/src/overrides/models/pos_order_line.js
+++ b/addons/l10n_in_pos/static/src/overrides/models/pos_order_line.js
@@ -22,7 +22,7 @@ patch(Orderline, {
             ...Orderline.props.line,
             shape: {
                 ...Orderline.props.line.shape,
-                l10n_in_hsn_code: { type: String, optional: true },
+                l10n_in_hsn_code: { type: [String, { value: false }], optional: true },
             },
         },
     },

--- a/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.js
+++ b/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.js
@@ -77,4 +77,7 @@ export class OrderTabs extends Component {
             }
         });
     }
+    showOderTabs() {
+        return !this.ui.isSmall || this.env.inDialog;
+    }
 }

--- a/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.xml
+++ b/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.OrderTabs">
-        <ListContainer items="orders"
+        <ListContainer
+            items="orders"
             onClickPlus="() => this.newFloatingOrder()"
             t-slot-scope="scope"
             class="props.class"
-            forceSmall="ui.isSmall and !env.inDialog"
+            show="showOderTabs()"
         >
             <t t-set="order" t-value="scope.item" />
             <button t-esc="order.getName()"

--- a/addons/point_of_sale/static/src/app/generic_components/list_container/list_container.js
+++ b/addons/point_of_sale/static/src/app/generic_components/list_container/list_container.js
@@ -28,12 +28,14 @@ export class ListContainer extends Component {
         slots: { type: Object },
         class: { type: String, optional: true },
         forceSmall: { type: Boolean, optional: true },
+        show: { type: Boolean, optional: true },
     };
     static defaultProps = {
         class: "",
+        show: true,
     };
     static template = xml`
-        <div class="overflow-hidden d-flex flex-grow-1" t-attf-class="{{props.class}}">
+        <div t-if="props.show" class="overflow-hidden d-flex flex-grow-1" t-attf-class="{{props.class}}">
             <button t-if="props.onClickPlus" class="list-plus-btn btn btn-secondary btn-lg me-1" t-on-click="props.onClickPlus">
                 <i class="fa fa-fw fa-plus-circle" aria-hidden="true"/>
             </button>

--- a/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
+++ b/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
@@ -131,7 +131,7 @@ export class SplitBillScreen extends Component {
             newOrder.updateLastOrderChange();
         }
 
-        originalOrder.customerCount -= 1;
+        originalOrder.customer_count -= 1;
         originalOrder.set_screen_data({ name: "ProductScreen" });
         this.pos.selectedOrderUuid = null;
         this.pos.set_order(newOrder);

--- a/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.xml
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.xml
@@ -29,11 +29,18 @@
                     </button>
                 </div>
                 <div t-if="!ui.isSmall" class="ms-1 me-2 my-2 border-start border"/>
-                <div class="d-flex align-items-center" t-if="pos.orderToTransferUuid">
+                <div class="d-flex align-items-center" t-if="pos.orderToTransferUuid and !ui.isSmall">
                     <strong class="mx-2 text-warning">
                         Select table to transfer order
                     </strong>
                 </div>
+            </div>
+        </xpath>
+        <xpath expr="//div[hasclass('pos-rightheader')]//div[hasclass('status-buttons')]" position="before">
+            <div class="d-flex align-items-center" t-if="pos.orderToTransferUuid and ui.isSmall">
+                <strong class="mx-2 text-warning">
+                    Transferring
+                </strong>
             </div>
         </xpath>
     </t>

--- a/addons/pos_restaurant/static/src/overrides/components/order_tabs/order_tabs.js
+++ b/addons/pos_restaurant/static/src/overrides/components/order_tabs/order_tabs.js
@@ -9,4 +9,7 @@ patch(OrderTabs.prototype, {
             order.setBooked(true);
         }
     },
+    showOderTabs() {
+        return super.showOderTabs() && !this.pos.orderToTransferUuid;
+    },
 });

--- a/addons/pos_restaurant/static/src/overrides/models/pos_order.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_order.js
@@ -5,19 +5,19 @@ patch(PosOrder.prototype, {
     setup(_defaultObj, options) {
         super.setup(...arguments);
         if (this.config.module_pos_restaurant) {
-            this.customerCount = this.customerCount || 1;
+            this.customer_count = this.customer_count || 1;
         }
     },
     getCustomerCount() {
-        return this.customerCount;
+        return this.customer_count;
     },
     setCustomerCount(count) {
-        this.customerCount = Math.max(count, 0);
+        this.customer_count = Math.max(count, 0);
     },
     getTable() {
         return this.table_id;
     },
-    amountPerGuest(numCustomers = this.customerCount) {
+    amountPerGuest(numCustomers = this.customer_count) {
         if (numCustomers === 0) {
             return 0;
         }


### PR DESCRIPTION
pos*: l10n_in_pos, point_of_sale, pos_restaurant

This commit solves multiple tracebacks and bugs in the POS.

1.
    Fix traceback when deleting demo records in POS.
        When deleting some demo orders in the POS, a traceback was
        raised because the lines of the orders did not had an order
        linked to it. This was because they did not have an uuid.
        We now have default uuid values for orders, order lines and
        pos payments.

2.
    Fix customer count not update.
        When changing the customer count on an order in the POS, the
        customer count was not updated in the backend. This was because
        the customer count was not correctly updated in the frontend
        leading to a customer count of 0 in the backend.

3.
    Fix "Select table to transfer order" not visible on mobile.
        When transfering an order in mobile, the text "Select table to
        transfer order" was not visible because the text was too big.
        We now display "Transferring" when in mobile. We also stop
        showing the floating orders tab when transferring an order as it
        makes no sense to show it.

Enterprise PR: https://github.com/odoo/enterprise/pull/70357

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
