### PR TITLE
[IMP] website_sale: hide delivery price in the cart summary

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2891,7 +2891,10 @@
     <template id="total">
         <div id="cart_total" t-if="website_sale_order and website_sale_order.website_order_line" t-att-class="_cart_total_classes">
             <table class="table mb-0">
-                <tr t-if="website_sale_order._has_deliverable_products()" id="order_delivery">
+                <tr
+                    t-if="website_sale_order._has_deliverable_products() and website_sale_order.carrier_id"
+                    id="order_delivery"
+                >
                     <td
                         class="ps-0 pt-0 pb-2 border-0 text-muted"
                         colspan="2"


### PR DESCRIPTION
Before this commit:
The delivery price was displayed as 0 in the /cart when the user had yet to choose a delivery method. This could be misleading, as it might seem like the delivery was free.

After this commit:
The delivery price is now hidden on the /cart page when user has yet to select a delivery method.

task-4193868