### PR TITLE
[FIX] sale: disable unavailable `<option>` elements in FireFox/iOS/macOS

### DIFF
--- a/addons/sale/static/src/js/variant_mixin.js
+++ b/addons/sale/static/src/js/variant_mixin.js
@@ -7,6 +7,7 @@ var utils = require('web.utils');
 var ajax = require('web.ajax');
 var session = require('web.session');
 var _t = core._t;
+const { isBrowserFirefox, isIOS, isMacOS } = require('@web/core/browser/feature_detection');
 
 var VariantMixin = {
     events: {
@@ -388,7 +389,8 @@ var VariantMixin = {
         }
         $parent
             .find('option, input, label, .o_variant_pills')
-            .removeClass('css_not_available')
+            .removeClass('css_not_available disabled')
+            .prop('disabled', false)
             .attr('title', function () { return $(this).data('value_name') || ''; })
             .data('excluded-by', '');
 
@@ -524,6 +526,11 @@ var VariantMixin = {
 
             $target.attr('title', _.str.sprintf(_t('Not available with %s'), excludedByData.join(', ')));
             $target.data('excluded-by', JSON.stringify(excludedByData));
+        }
+        // only Chromium-based browsers on a non-Apple OS support CSS styling of `<option>`
+        // so elsewhere, use the `disabled` prop to indicate unavailability
+        if ($input.is('option') && (isBrowserFirefox() || isIOS() || isMacOS())) {
+            $input.addClass('disabled').prop('disabled', true);
         }
     },
     /**


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Use FireFox and/or an Apple OS;
2. create a product with several variants;
3. set Display Type of one or more attributes to Select;
4. delete or archive part of the variants w/ Select type attributes;
5. go to product page in eCommerce.

Issue
-----
Unavailable attributes aren't distinguishable in the select menu.

Cause
-----
The CSS styling of `<option>` elements introduced by 43977deb713e is highly limited[^1].

Apple enforces its system theme on dropdowns, while FireFox doesn't apply the `color: #ccc` rule for the `css_not_available` class (even though the MDN docs claim the opposite: that Chrome doesn't support it while FireFox does).

Solution
--------
While styling options are limited, the `disabled` attribute is part of the `<option>` standard[^2]. When this property is set, the option also gets grayed out. However, it does also prevents the user from selecting it.

In the product's `VariantMixin`, when adding the `css_not_available` class to unavailable `<option>` elements, check whether the current browser is FireFox, or the current OS is macOS or iOS. If so, enable the `disabled` property, and add the `disabled` class.

When removing the `css_not_available` class, also remove the `disabled` class and disable the `disabled` property.

> [!Caution]
> Handling `<option>` this way could lead to rare cases where the user isn't able to switch between variants.
> e.g. a "Table" with material & color attributes selected via dropdown, and only `Steel/Black` & `Aluminium/White` variants, won't allow switching between the two as they don't share any common attributes.

[^1]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option#styling_with_css
[^2]: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled

opw-4058572