### PR TITLE
[IMP] mail: better resolution of image previews in discuss

### DIFF
--- a/addons/mail/static/src/core/common/attachment_list.js
+++ b/addons/mail/static/src/core/common/attachment_list.js
@@ -36,8 +36,8 @@ export class AttachmentList extends Component {
         }
         return url(attachment.urlRoute, {
             ...attachment.urlQueryParams,
-            width: this.imagesWidth,
-            height: this.props.imagesHeight,
+            width: this.imagesWidth * 2,
+            height: this.props.imagesHeight * 2,
         });
     }
 

--- a/addons/mail/static/tests/thread/attachment_list.test.js
+++ b/addons/mail/static/tests/thread/attachment_list.test.js
@@ -329,6 +329,6 @@ test("img file has proper src in discuss.channel", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(
-        `.o-mail-AttachmentImage[title='test.png'] img[data-src='${getOrigin()}/discuss/channel/${channelId}/image/${attachmentId}?filename=test.png&width=1920&height=300']`
+        `.o-mail-AttachmentImage[title='test.png'] img[data-src*='${getOrigin()}/discuss/channel/${channelId}/image/${attachmentId}?filename=test.png']`
     );
 });


### PR DESCRIPTION
Before / After

<img width="187" alt="Screenshot 2024-09-19 at 14 06 36" src="https://github.com/user-attachments/assets/7f2e9943-36f9-4f42-87af-de3c1a916c9e"> <img width="256" alt="Screenshot 2024-09-19 at 14 07 06" src="https://github.com/user-attachments/assets/6809e18b-67cd-4039-99fb-6a30fa3adf5c">
