### PR TITLE
[FIX] pos_restaurant: traceback when merging tables

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -325,6 +325,7 @@ patch(PosStore.prototype, {
         if (!this.tableHasOrders(destinationTable)) {
             order.update({ table_id: destinationTable });
             this.set_order(order);
+            this.addPendingOrder([order.id]);
         } else {
             const destinationOrder = this.getActiveOrdersOnTable(destinationTable)[0];
             for (const orphanLine of order.lines) {
@@ -338,9 +339,9 @@ patch(PosStore.prototype, {
                 }
             }
             this.set_order(destinationOrder);
+            this.addPendingOrder([destinationOrder.id]);
             await this.deleteOrders([order]);
         }
-        this.addPendingOrder([order.id]);
         await this.setTable(destinationTable);
     },
     updateTables(...tables) {

--- a/addons/pos_restaurant/static/tests/tours/control_buttons_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/control_buttons_tour.js
@@ -20,27 +20,21 @@ registry.category("web_tour.tours").add("ControlButtonsTour", {
     test: true,
     steps: () =>
         [
-            // Test TransferOrderButton
+            // Test merging table, transfer is already tested in pos_restaurant_sync_second_login.
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
             FloorScreen.clickTable("2"),
             activeTableIs("2"),
             ProductScreen.addOrderline("Water", "5", "2", "10.0"),
-            ProductScreen.clickControlButton("Transfer"),
+            Chrome.clickPlanButton(),
             FloorScreen.clickTable("4"),
             activeTableIs("4"),
-            Order.hasLine({ productName: "Water", withClass: ".selected" }),
-            Chrome.clickPlanButton(),
+            ProductScreen.addOrderline("Minute Maid", "3", "2", "6.0"),
+            ProductScreen.clickControlButton("Transfer"),
             FloorScreen.clickTable("2"),
             activeTableIs("2"),
-            ProductScreen.orderIsEmpty(),
-            Chrome.clickPlanButton(),
-            FloorScreen.isShown(),
-            FloorScreen.clickTable("4"),
-            Order.hasLine({
-                productName: "Water",
-                quantity: "5",
-            }),
+            Order.hasLine({ productName: "Water", quantity: "5" }),
+            Order.hasLine({ productName: "Minute Maid", quantity: "3" }),
 
             // Test SplitBillButton
             ProductScreen.clickControlButton("Split"),
@@ -58,7 +52,7 @@ registry.category("web_tour.tours").add("ControlButtonsTour", {
             }),
             // Check that note is imported if come back to the table
             Chrome.clickPlanButton(),
-            FloorScreen.clickTable("4"),
+            FloorScreen.clickTable("2"),
             Order.hasLine({
                 productName: "Water",
                 quantity: "5",


### PR DESCRIPTION
Steps to reproduce:

1. make 2 orders on 2 tables
3. use transfer merge in the control buttons to merge the 2 orders
3. observe traceback

Appeared after this: 9511bacc89cc23ce162f93af4682a4806c45dfda

Fix:

We are adding the wrong order in the pending order to sync when merging. We should add as pending order the `destination` because it's the one that remains. Also, the `source` order is already removed from the call to `deleteOrders`, thus, there is no point on adding it in the pending orders to sync.
