### PR TITLE
[IMP] account, web, partner_autocomplete: placeholder

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -11,6 +11,7 @@ from odoo.tools import format_list, SQL
 from odoo.tools.mail import is_html_empty
 from odoo.tools.misc import format_date
 from odoo.addons.account.models.account_move import MAX_HASH_VERSION
+from odoo.addons.base_vat.models.res_partner import _ref_vat
 
 
 MONTH_SELECTION = [
@@ -253,6 +254,7 @@ class ResCompany(models.Model):
         required=True,
         help="Default on whether the sales price used on the product and invoices with this Company includes its taxes."
     )
+    company_vat_placeholder = fields.Char(compute='_compute_company_vat_placeholder')
 
     def get_next_batch_payment_communication(self):
         '''
@@ -1002,3 +1004,16 @@ class ResCompany(models.Model):
 
         return {'date_from': datetime(year=current_date.year, month=1, day=1).date(),
                 'date_to': datetime(year=current_date.year, month=12, day=31).date()}
+
+    @api.depends('country_id', 'account_fiscal_country_id')
+    def _compute_company_vat_placeholder(self):
+        for company in self:
+            placeholder = _("/ if not applicable")
+            if company.country_id or company.account_fiscal_country_id:
+                expected_vat = _ref_vat.get(
+                    company.country_id.code.lower() or company.account_fiscal_country_id.code.lower()
+                )
+                if expected_vat:
+                    placeholder = _("%s, or / if not applicable", expected_vat)
+
+            company.company_vat_placeholder = placeholder

--- a/addons/account/static/src/components/char_with_placeholder_field/char_with_placeholder_field.js
+++ b/addons/account/static/src/components/char_with_placeholder_field/char_with_placeholder_field.js
@@ -1,6 +1,5 @@
 /** @odoo-module **/
 
-import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { CharField, charField } from "@web/views/fields/char/char_field";
 
@@ -10,37 +9,16 @@ import "@mail/js/onchange_on_keydown";
 
 export class CharWithPlaceholderField extends CharField {
     static template = "account.CharWithPlaceholderField";
-    static props = {
-        ...CharField.props,
-        placeholderField: { type: String },
-    };
 
     /** Override **/
     get formattedValue() {
         return super.formattedValue || this.placeholder;
-    }
-
-    get placeholder() {
-        return this.props.record.data[this.props.placeholderField] || this.props.placeholder;
     }
 }
 
 export const charWithPlaceholderField = {
     ...charField,
     component: CharWithPlaceholderField,
-    supportedOptions: [
-        ...charField.supportedOptions,
-        {
-            label: _t("Placeholder field"),
-            name: "placeholder_field",
-            type: "field",
-            availableTypes: ["char"],
-        },
-    ],
-    extractProps: ({ attrs, options }) => ({
-        ...charField.extractProps({ attrs, options }),
-        placeholderField: options.placeholder_field,
-    }),
 };
 
 registry.category("fields").add("char_with_placeholder_field", charWithPlaceholderField);

--- a/addons/account/static/src/components/char_with_placeholder_field/char_with_placeholder_field.xml
+++ b/addons/account/static/src/components/char_with_placeholder_field/char_with_placeholder_field.xml
@@ -5,9 +5,6 @@
         <xpath expr="//span" position="attributes">
             <attribute name="t-att-class">{'text-muted': !this.props.record.data[props.name]}</attribute>
         </xpath>
-        <xpath expr="//input" position="attributes">
-            <attribute name="t-att-placeholder">placeholder</attribute>
-        </xpath>
     </t>
 
 </templates>

--- a/addons/account/static/tests/char_with_placeholder_field.test.js
+++ b/addons/account/static/tests/char_with_placeholder_field.test.js
@@ -28,16 +28,6 @@ class Account extends models.Model {
     ];
 
     _views = {
-        form: /* xml */ `
-            <form>
-                <sheet>
-                    <group>
-                        <field name="placeholder_code" invisible="1" />
-                        <field name="code" widget="char_with_placeholder_field" options="{'placeholder_field': 'placeholder_code'}" />
-                    </group>
-                </sheet>
-            </form>
-        `,
         list: /* xml */ `
             <list editable="top" create="1" delete="1">
                 <field name="placeholder_code" column_invisible="1" />
@@ -49,18 +39,6 @@ class Account extends models.Model {
 
 defineAccountModels();
 defineModels([Account]);
-
-test("Form: placeholder_field shows as placeholder", async () => {
-    await mountView({ type: "form", resModel: "account.account", resId: 1 });
-
-    expect("input").toHaveValue("", {
-        message: "should have no value in input",
-    });
-    expect("input").toHaveAttribute("placeholder", "Placeholder Code", {
-        message: "placeholder_field should be the placeholder",
-    });
-});
-
 test.tags("desktop")("List: placeholder_field shows as text/placeholder", async () => {
     await mountView({
         type: "list",

--- a/addons/account/views/account_account_views.xml
+++ b/addons/account/views/account_account_views.xml
@@ -40,7 +40,7 @@
                                         <div>
                                             <field name="placeholder_code" invisible="1"/>
                                             <field name="code" placeholder="e.g. 101000" class="oe_inline"
-                                                   widget="char_with_placeholder_field" options="{'placeholder_field': 'placeholder_code'}"/>
+                                                   options="{'placeholder_field': 'placeholder_code'}"/>
                                         </div>
                                     </div>
                                 </div>

--- a/addons/account/views/account_analytic_distribution_model_views.xml
+++ b/addons/account/views/account_analytic_distribution_model_views.xml
@@ -27,7 +27,7 @@
                 <data>
                     <xpath expr="//field[@name='partner_category_id']" position="after">
                         <field name="prefix_placeholder" invisible="1"/> <!-- Needed for the char_with_placeholder_field widget -->
-                        <field name="account_prefix" string="Accounts Prefixes" widget="char_with_placeholder_field" options="{'placeholder_field': 'prefix_placeholder'}"/>
+                        <field name="account_prefix" string="Accounts Prefixes" options="{'placeholder_field': 'prefix_placeholder'}"/>
                     </xpath>
                     <xpath expr="//field[@name='company_id']" position="before">
                             <field name="product_id"/>

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -158,6 +158,13 @@
                         </group>
                     </group>
                 </page>
+
+                <field name="vat" position="before">
+                    <field name="partner_vat_placeholder" invisible="1"/> <!-- Needed for the placeholder widget -->
+                </field>
+                <field name="vat" position="attributes">
+                    <attribute name="options">{'placeholder_field': 'partner_vat_placeholder'}</attribute>
+                </field>
             </field>
         </record>
 

--- a/addons/account/views/res_company_views.xml
+++ b/addons/account/views/res_company_views.xml
@@ -11,6 +11,12 @@
             <xpath expr="//sheet" position="after">
                 <chatter/>
             </xpath>
+            <field name="vat" position="before">
+                <field name="company_vat_placeholder" invisible="1"/> <!-- Needed for the placeholder widget -->
+            </field>
+            <field name="vat" position="attributes">
+                <attribute name="options">{'placeholder_field': 'company_vat_placeholder'}</attribute>
+            </field>
         </field>
     </record>
 

--- a/addons/partner_autocomplete/static/src/xml/partner_autocomplete.xml
+++ b/addons/partner_autocomplete/static/src/xml/partner_autocomplete.xml
@@ -8,7 +8,7 @@
                     sources="sources"
                     onSelect.bind="onSelect"
                     input="inputRef"
-                    placeholder="props.placeholder || ''"
+                    placeholder="placeholder || ''"
                 />
             </t>
         </xpath>

--- a/addons/web/static/src/views/fields/char/char_field.js
+++ b/addons/web/static/src/views/fields/char/char_field.js
@@ -21,6 +21,7 @@ export class CharField extends Component {
         placeholder: { type: String, optional: true },
         dynamicPlaceholder: { type: Boolean, optional: true },
         dynamicPlaceholderModelReferenceField: { type: String, optional: true },
+        placeholderField: { type: String, optional: true },
     };
     static defaultProps = { dynamicPlaceholder: false };
 
@@ -59,6 +60,10 @@ export class CharField extends Component {
     }
     get hasDynamicPlaceholder() {
         return this.props.dynamicPlaceholder && !this.props.readonly;
+    }
+
+    get placeholder() {
+        return this.props.record.data[this.props.placeholderField] || this.props.placeholder;
     }
 
     parse(value) {
@@ -115,6 +120,12 @@ export const charField = {
             type: "field",
             availableTypes: ["char"],
         },
+        {
+            label: _t("Placeholder field"),
+            name: "placeholder_field",
+            type: "field",
+            availableTypes: ["char"],
+        },
     ],
     extractProps: ({ attrs, options }) => ({
         isPassword: exprToBoolean(attrs.password),
@@ -123,6 +134,7 @@ export const charField = {
             options.dynamic_placeholder_model_reference_field || "",
         autocomplete: attrs.autocomplete,
         placeholder: attrs.placeholder,
+        placeholderField: options.placeholder_field,
     }),
 };
 

--- a/addons/web/static/src/views/fields/char/char_field.xml
+++ b/addons/web/static/src/views/fields/char/char_field.xml
@@ -16,7 +16,7 @@
                 t-att-type="props.isPassword ? 'password' : 'text'"
                 t-att-autocomplete="props.autocomplete or (props.isPassword ? 'new-password' : 'off')"
                 t-att-maxlength="maxLength > 0 and maxLength"
-                t-att-placeholder="props.placeholder"
+                t-att-placeholder="placeholder"
                 t-on-blur="onBlur"
                 t-ref="input"
             />

--- a/addons/web/static/tests/views/fields/char_field.test.js
+++ b/addons/web/static/tests/views/fields/char_field.test.js
@@ -50,6 +50,8 @@ class Partner extends models.Model {
     });
     product_id = fields.Many2one({ relation: "product" });
 
+    placeholder_name = fields.Char();
+
     _records = [
         {
             id: 1,
@@ -57,6 +59,7 @@ class Partner extends models.Model {
             name: "yop",
             int_field: 10,
             partner_ids: [],
+            placeholder_name: "Placeholder Name",
         },
         {
             id: 2,
@@ -833,6 +836,30 @@ test("char field with placeholder", async () => {
     });
     expect(".o_field_widget[name='name'] input").toHaveAttribute("placeholder", "Placeholder", {
         message: "placeholder attribute should be set",
+    });
+});
+
+test("Form: placeholder_field shows as placeholder", async () => {
+    Partner._records[0].name = false;
+    await mountView({
+        type: "form",
+        resModel: "res.partner",
+        resId: 1,
+        arch: `
+        <form>
+            <sheet>
+                <group>
+                    <field name="placeholder_name" invisible="1" />
+                    <field name="name" options="{'placeholder_field': 'placeholder_name'}" />
+                </group>
+            </sheet>
+        </form>`,
+    });
+    expect("input").toHaveValue("", {
+        message: "should have no value in input",
+    });
+    expect("input").toHaveAttribute("placeholder", "Placeholder Name", {
+        message: "placeholder_field should be the placeholder",
     });
 });
 


### PR DESCRIPTION
This PR will do two things:
- In this commit: https://github.com/odoo/odoo/pull/178588/commits/a0f734aeb4771610e00d2d242c4a9cf481b4156b we added a new widget to add a dynamic placeholder on the field. But we had a problem when the field already has a widget. By moving the widget in the generic charField the problem is solved.

- We will put a placeholder field on the vat field on res_partner and
res_company. Since partner autocomplete overwrite the template of the charFields, we change
the placeholder="props.placeholder" by the new function placeholder. 

task: 4191835

enterprise pr: https://github.com/odoo/enterprise/pull/70314

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
