### PR TITLE
[FIX] web: domain field: within descriptions in facets

### DIFF
--- a/addons/web/static/src/views/fields/domain/domain_field.js
+++ b/addons/web/static/src/views/fields/domain/domain_field.js
@@ -9,7 +9,7 @@ import { registry } from "@web/core/registry";
 import { SelectCreateDialog } from "@web/views/view_dialogs/select_create_dialog";
 import { standardFieldProps } from "../standard_field_props";
 import { useBus, useService, useOwnedDialogs } from "@web/core/utils/hooks";
-import { useGetTreeDescription } from "@web/core/tree_editor/utils";
+import { useGetTreeDescription, useMakeGetFieldDef } from "@web/core/tree_editor/utils";
 import { useGetDefaultLeafDomain } from "@web/core/domain_selector/utils";
 import { treeFromDomain } from "@web/core/tree_editor/condition_tree";
 import { useRecordObserver } from "@web/model/relational_model/utils";
@@ -34,6 +34,7 @@ export class DomainField extends Component {
     setup() {
         this.orm = useService("orm");
         this.getDomainTreeDescription = useGetTreeDescription();
+        this.makeGetFieldDef = useMakeGetFieldDef();
         this.getDefaultLeafDomain = useGetDefaultLeafDomain();
         this.addDialog = useOwnedDialogs();
 
@@ -139,7 +140,8 @@ export class DomainField extends Component {
         let promises = [];
         const domain = this.getDomain(props);
         try {
-            const tree = treeFromDomain(domain, { distributeNot: !this.env.debug });
+            const getFieldDef = await this.makeGetFieldDef(resModel, treeFromDomain(domain));
+            const tree = treeFromDomain(domain, { distributeNot: !this.env.debug, getFieldDef });
             const trees = !tree.negate && tree.value === "&" ? tree.children : [tree];
             promises = trees.map((tree) => this.getDomainTreeDescription(resModel, tree));
         } catch (error) {

--- a/addons/web/static/tests/core/domain_field.test.js
+++ b/addons/web/static/tests/core/domain_field.test.js
@@ -1000,3 +1000,26 @@ test("folded domain field with any operator", async function () {
     });
     expect(`.o_field_domain .o_facet_values`).toHaveText("Company matches ( Id = 1 )");
 });
+
+test("folded domain field with withinh operator", async function () {
+    Partner._fields.company_id = fields.Many2one({ relation: "partner" });
+    Partner._records[0].foo = `[
+        "&",
+        ("datetime", ">=", datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")),
+        ("datetime", "<=", datetime.datetime.combine(context_today() + relativedelta(months = 2), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S"))
+    ]`;
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: `
+            <form>
+                <sheet>
+                    <group>
+                        <field name="foo" widget="domain" options="{'model': 'partner', 'foldable': true}" />
+                    </group>
+                </sheet>
+            </form>`,
+    });
+    expect(`.o_field_domain .o_facet_values`).toHaveText("Datetime is within 2 months");
+});


### PR DESCRIPTION
In a folded domain field, a facet associated with the virtual operator within (introduced in https://github.com/odoo/odoo/pull/169940) would reveal the technical content of the associated domain conditions instead of a user friendly text like "date is within 2 months". We fix that.

Task ID: 4196898