### PR TITLE
[REF] html_editor: use editing mode flag for link popover

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -211,6 +211,8 @@ export class LinkPlugin extends Plugin {
 
         this.getExternalMetaData = memoize(fetchExternalMetaData);
         this.getInternalMetaData = memoize(fetchInternalMetaData);
+
+        this.LinkPopoverState = { editing: false };
     }
 
     destroy() {
@@ -333,6 +335,7 @@ export class LinkPlugin extends Plugin {
             },
             getInternalMetaData: this.getInternalMetaData,
             getExternalMetaData: this.getExternalMetaData,
+            LinkPopoverState: this.LinkPopoverState,
         };
         if (!selectionData.documentSelectionIsInEditable) {
             // note that data-prevent-closing-overlay also used in color picker but link popover
@@ -360,6 +363,7 @@ export class LinkPlugin extends Plugin {
                         this.linkElement.href = url;
                         this.shared.setCursorEnd(this.linkElement);
                         this.removeCurrentLinkIfEmtpy();
+                        this.LinkPopoverState.editing = false;
                         this.dispatch("ADD_STEP");
                     },
                 };
@@ -414,6 +418,7 @@ export class LinkPlugin extends Plugin {
                         this.linkElement.removeAttribute("class");
                     }
                     this.removeCurrentLinkIfEmtpy();
+                    this.LinkPopoverState.editing = false;
                     this.dispatch("ADD_STEP");
                 },
             };
@@ -456,6 +461,7 @@ export class LinkPlugin extends Plugin {
             return linkElement;
         } else {
             // create a new link element
+            this.LinkPopoverState.editing = true;
             const selectedNodes = this.shared.getSelectedNodes();
             const imageNode = selectedNodes.find((node) => node.tagName === "IMG");
 

--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -15,6 +15,7 @@ export class LinkPopover extends Component {
         getInternalMetaData: Function,
         getExternalMetaData: Function,
         isImage: Boolean,
+        LinkPopoverState: Object,
     };
     colorsData = [
         { type: "", label: _t("Link"), btnPreview: "link" },
@@ -46,7 +47,7 @@ export class LinkPopover extends Component {
         this.http = useService("http");
 
         this.state = useState({
-            editing: this.props.linkEl.href ? false : true,
+            editing: this.props.LinkPopoverState.editing,
             url: this.props.linkEl.href || "",
             label: cleanZWChars(this.props.linkEl.textContent),
             previewIcon: false,

--- a/addons/html_editor/static/tests/link/isolated.test.js
+++ b/addons/html_editor/static/tests/link/isolated.test.js
@@ -235,6 +235,6 @@ test("should zwnbps-pad links with .btn class", async () => {
 test("should not add visual indication to a button", async () => {
     await testEditor({
         contentBefore: '<p><a class="btn">[]content</a></p>',
-        contentBeforeEdit: '<p>\ufeff<a class="btn">\ufeffcontent\ufeff</a>\ufeff</p>',
+        contentBeforeEdit: '<p>\ufeff<a class="btn">\ufeff[]content\ufeff</a>\ufeff</p>',
     });
 });

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -36,13 +36,6 @@ describe("should open a popover", () => {
         await waitUntil(() => !queryFirst(".o-we-linkpopover"));
         expect(".o-we-linkpopover").toHaveCount(0);
     });
-    test("link popover should have input field for href when the link doesn't have href", async () => {
-        await setupEditor("<p>this is a <a>li[]nk</a></p>");
-        await waitFor(".o-we-linkpopover");
-        expect(".o-we-linkpopover").toHaveCount(1);
-        expect(".o_we_label_link").toHaveValue("link");
-        expect(".o_we_href_input_link").toHaveValue("");
-    });
     test("link popover should have buttons for link operation when the link has href", async () => {
         await setupEditor('<p>this is a <a href="test.com">li[]nk</a></p>');
         await waitFor(".o-we-linkpopover");
@@ -53,6 +46,7 @@ describe("should open a popover", () => {
     });
     test("link popover should not repositioned when clicking in the input field", async () => {
         await setupEditor("<p>this is a <a>li[]nk</a></p>");
+        await contains(".o-we-linkpopover .o_we_edit_link").click();
         await waitFor(".o_we_href_input_link");
         const style = queryOne(".o-we-linkpopover").parentElement.style.cssText;
         queryOne(".o_we_href_input_link").focus();
@@ -99,7 +93,7 @@ describe("popover should switch UI depending on editing state", () => {
     });
     test("after clicking on apply button, the popover should be with the non editing mode, e.g. with three buttons", async () => {
         await setupEditor("<p>this is a <a>li[]nk</a></p>");
-        await waitFor(".o-we-linkpopover");
+        await contains(".o-we-linkpopover .o_we_edit_link").click();
         click(".o_we_href_input_link");
         click(".o_we_apply_link");
         await waitFor(".o_we_edit_link");
@@ -113,7 +107,7 @@ describe("popover should switch UI depending on editing state", () => {
 describe("popover should edit,copy,remove the link", () => {
     test("after apply url on a link without href, the link element should be updated", async () => {
         const { el } = await setupEditor("<p>this is a <a>li[]nk</a></p>");
-
+        await contains(".o-we-linkpopover .o_we_edit_link").click();
         await contains(".o-we-linkpopover input.o_we_href_input_link").edit("http://test.com/");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
             '<p>this is a <a href="http://test.com/">li[]nk</a></p>'
@@ -185,6 +179,7 @@ describe("Incorrect URL should be corrected", () => {
     test("when a link's URL is an email, the link's URL should start with mailto:", async () => {
         const { el } = await setupEditor("<p>this is a <a>li[]nk</a></p>");
 
+        await contains(".o-we-linkpopover .o_we_edit_link").click();
         await contains(".o-we-linkpopover input.o_we_href_input_link").edit("test@test.com");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
             '<p>this is a <a href="mailto:test@test.com">li[]nk</a></p>'
@@ -193,6 +188,7 @@ describe("Incorrect URL should be corrected", () => {
     test("when a link's URL is an phonenumber, the link's URL should start with tel://:", async () => {
         const { el } = await setupEditor("<p>this is a <a>li[]nk</a></p>");
 
+        await contains(".o-we-linkpopover .o_we_edit_link").click();
         await contains(".o-we-linkpopover input.o_we_href_input_link").edit("+1234567890");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
             '<p>this is a <a href="tel://+1234567890">li[]nk</a></p>'
@@ -611,6 +607,7 @@ describe("shortcut", () => {
     test("Press enter to apply when create a link", async () => {
         const { el } = await setupEditor(`<p><a>li[]nk</a></p>`);
 
+        await contains(".o-we-linkpopover .o_we_edit_link").click();
         await contains(".o-we-linkpopover input.o_we_href_input_link").fill("test.com");
         press("Enter");
         expect(cleanLinkArtifacts(getContent(el))).toBe(


### PR DESCRIPTION
Before this commit: The popover's editing mode was determined by whether the link had an href attribute.

After this commit: A dedicated editing flag is used to control the popover mode when it is opened.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
