### PR TITLE
[FIX] mrp: shop floor detail operation quantity

### DIFF
--- a/addons/mrp/views/stock_move_views.xml
+++ b/addons/mrp/views/stock_move_views.xml
@@ -17,6 +17,9 @@
                 <xpath expr="//label[@for='product_uom_qty']" position="attributes">
 		            <attribute name="string">Total To Consume</attribute>
                 </xpath>
+                <xpath expr="//field[@name='show_lots_m2o']" position="after">
+                    <field name="quantity" invisible="1"/>
+               </xpath>
             </field>
         </record>
 


### PR DESCRIPTION
Issue Before This Commit:
============================
When clicking on the generate button in the Generate Serials/Lots in that result in TypeError: unsupported operand type(s) for //: 'NoneType' and 'int'

Steps to Produce:
====================
1. Open the detailed operation for a component with lot tracking in the shop floor.
2. Click on Generate Serials/Lots.
3. Enter the lot number then click on the generate button.

With this commit:
====================
The error is resolved, and the functionality now works as intended without any errors and allows for lot number generation.
