### PR TITLE
[FIX] project: hide subtasks on project stage deletion

### DIFF
--- a/addons/project/wizard/project_task_type_delete.py
+++ b/addons/project/wizard/project_task_type_delete.py
@@ -59,7 +59,7 @@ class ProjectTaskTypeDelete(models.TransientModel):
 
         if project_id:
             action = self.env["ir.actions.actions"]._for_xml_id("project.action_view_task")
-            action['domain'] = [('project_id', '=', project_id)]
+            action['domain'] = [('display_project_id', '=', project_id)]
             action['context'] = str({
                 'pivot_row_groupby': ['user_ids'],
                 'default_project_id': project_id,


### PR DESCRIPTION
Steps to reproduce:
- (16.0 only) Project > Configuration > Settings > Enable 'Sub-tasks'
- Project > New > Add 2 Stages and a Task
- Click the task > Sub-tasks tab > Create a subtask
- Go back to the project's task view
- Delete the 2nd stage

The sub-tasks are now visbile when they should not be. This is because we reload the view after stage deletion, with an action that does not contain display_project_id (16.0) / display_in_project (>= 17.0) in its domain.

opw-4191732

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
