### PR TITLE
[FIX] website_sale_collect,*: fix flow when warehouse is set on website

### DIFF
--- a/addons/delivery/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.js
+++ b/addons/delivery/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.js
@@ -107,6 +107,15 @@ export class LocationSelectorDialog extends Component {
     }
 
     /**
+     * Find the selected location based on its id.
+     *
+     * @return {Object} The selected location.
+     */
+    get selectedLocation() {
+        return this.state.locations.find(l => String(l.id) === this.state.selectedLocationId);
+    }
+
+    /**
      * Set the selectedLocationId in the state.
      *
      * @param {String} locationId

--- a/addons/sale/static/src/js/quantity_buttons/quantity_buttons.xml
+++ b/addons/sale/static/src/js/quantity_buttons/quantity_buttons.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-name="sale.QuantityButtons">
-        <div class="input-group justify-content-center">
+        <div name="quantity_buttons_wrapper" class="input-group justify-content-center">
             <button
                 class="btn btn-secondary d-none d-md-inline-block"
                 name="sale_quantity_button_minus"

--- a/addons/website_sale/static/src/js/product/product.xml
+++ b/addons/website_sale/static/src/js/product/product.xml
@@ -3,7 +3,6 @@
     <t t-inherit="sale.Product" t-inherit-mode="extension">
         <QuantityButtons position="attributes">
             <attribute name="t-if">this.props.can_be_sold</attribute>
-            <attribute name="class" add="css_quantity" separator=" "/>
         </QuantityButtons>
         <QuantityButtons position="after">
             <t t-call="website_sale.not_for_sale"/>

--- a/addons/website_sale/static/src/js/quantity_buttons/quantity_buttons.xml
+++ b/addons/website_sale/static/src/js/quantity_buttons/quantity_buttons.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-inherit="sale.QuantityButtons" t-inherit-mode="extension">
+        <div name="quantity_buttons_wrapper" position="attributes">
+            <attribute name="class" add="css_quantity" separator=" "/>
+        </div>
         <button name="sale_quantity_button_minus" position="attributes">
             <attribute name="class" remove="btn-secondary" add="btn-light" separator=" "/>
         </button>

--- a/addons/website_sale_collect/controllers/main.py
+++ b/addons/website_sale_collect/controllers/main.py
@@ -30,8 +30,8 @@ class WebsiteSaleCollect(WebsiteSale):
         location. """
         res = super()._prepare_checkout_page_values(order_sudo, **query_params)
         if order_sudo.carrier_id.delivery_type == 'in_store' and order_sudo.pickup_location_data:
-            res['unavailable_products'] = order_sudo._get_unavailable_products(
-                order_sudo.pickup_location_data.get('warehouse_id')
+            res['unavailable_order_lines'] = order_sudo._get_unavailable_order_lines(
+                order_sudo.pickup_location_data.get('id')
             )
         return res
 
@@ -46,7 +46,7 @@ class WebsiteSaleCollect(WebsiteSale):
                     _("Please choose a store to collect your order."),
                 ))
             else:
-                selected_wh_id = order.pickup_location_data['warehouse_id']
+                selected_wh_id = order.pickup_location_data['id']
                 if not order._is_in_stock(selected_wh_id):
                     errors.append((
                         _("Sorry, we are unable to ship your order."),

--- a/addons/website_sale_collect/controllers/payment.py
+++ b/addons/website_sale_collect/controllers/payment.py
@@ -32,8 +32,3 @@ class OnSitePaymentPortal(PaymentPortal):
             raise ValidationError(
                 _("You can only pay on site when selecting the pick up in store delivery method.")
             )
-
-        if sale_order.carrier_id.delivery_type == 'in_store':
-            sale_order.warehouse_id = sale_order.env['stock.warehouse'].browse(
-                sale_order.pickup_location_data['warehouse_id']
-            )

--- a/addons/website_sale_collect/models/delivery_carrier.py
+++ b/addons/website_sale_collect/models/delivery_carrier.py
@@ -86,7 +86,7 @@ class DeliveryCarrier(models.Model):
             # Format the pickup location values of the warehouse.
             try:
                 pickup_location_values = {
-                    'id': wh_location['id'],
+                    'id': wh.id,
                     'name': wh_location['name'].title(),
                     'street': wh_location['street'].title(),
                     'city': wh_location.city.title(),
@@ -94,7 +94,6 @@ class DeliveryCarrier(models.Model):
                     'country_code': wh_location.country_code,
                     'latitude': wh_location.partner_latitude,
                     'longitude': wh_location.partner_longitude,
-                    'warehouse_id': wh.id,
                     'additional_data': {'in_store_stock': in_store_stock_data},
                 }
             except AttributeError:

--- a/addons/website_sale_collect/models/product_template.py
+++ b/addons/website_sale_collect/models/product_template.py
@@ -27,7 +27,7 @@ class ProductTemplate(models.Model):
                 and order_sudo.pickup_location_data
             ):  # Get stock values for the product variant in the selected store.
                 res['in_store_stock'] = utils.format_product_stock_values(
-                    product_or_template.sudo(), order_sudo.pickup_location_data['warehouse_id']
+                    product_or_template.sudo(), order_sudo.pickup_location_data['id']
                 )
             else:
                 res['in_store_stock'] = {}

--- a/addons/website_sale_collect/models/sale_order.py
+++ b/addons/website_sale_collect/models/sale_order.py
@@ -10,6 +10,16 @@ from odoo.http import request
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
+    def set_delivery_line(self, carrier, amount):
+        """ Override of `website_sale` to recompute warehouse when a new delivery method
+        is not in-store anymore. """
+        self.filtered(
+            lambda so: (
+                so.carrier_id.delivery_type == 'in_store' and carrier.delivery_type != 'in_store'
+            )
+        )._compute_warehouse_id()
+        return super().set_delivery_line(carrier, amount)
+
     def _set_pickup_location(self, pickup_location_data):
         """ Override `website_sale` to set the pickup location for in-store delivery methods. """
         res = super()._set_pickup_location(pickup_location_data)
@@ -17,6 +27,7 @@ class SaleOrder(models.Model):
             return res
 
         self.pickup_location_data = json.loads(pickup_location_data)
+        self.warehouse_id = self.pickup_location_data['id']
 
     def _get_pickup_locations(self, zip_code=None, country=None, **kwargs):
         """ Override of `website_sale` to ensure that a country is provided when there is a zip
@@ -42,7 +53,7 @@ class SaleOrder(models.Model):
         if (
             self._has_deliverable_products()
             and self.carrier_id.delivery_type == 'in_store'
-            and not self._is_in_stock(self.pickup_location_data['warehouse_id'])
+            and not self._is_in_stock(self.warehouse_id.id)
         ):
             raise ValidationError(_("Some products are not available in the selected store."))
         return super()._check_cart_is_ready_to_be_paid()
@@ -56,17 +67,35 @@ class SaleOrder(models.Model):
         :return: Whether all storable products are in stock.
         :rtype: bool
         """
-        return not self._get_unavailable_products(wh_id)
+        return not self._get_unavailable_order_lines(wh_id)
 
-    def _get_unavailable_products(self, wh_id):
-        """ Return the products that are not in stock for the given warehouse.
+    def _get_unavailable_order_lines(self, wh_id):
+        """ Return the order lines with unavailable products for the given warehouse.
 
         :param int wh_id: The warehouse in which to check the stock, as a `stock.warehouse` id.
-        :return: The products that are not in stock.
-        :rtype: product.product
+        :return: The order lines with unavailable products.
+        :rtype: sale.order.line
         """
-        out_of_stock_products = self.order_line.filtered(
-            lambda l: l.is_storable
-            and l.product_uom_qty > l.product_id.with_context(warehouse_id=wh_id).free_qty
-        ).product_id
-        return out_of_stock_products
+        unavailable_order_lines = self.env['sale.order.line']
+        for ol in self.order_line:
+            if ol.is_storable:
+                product_free_qty = ol.product_id.with_context(warehouse_id=wh_id).free_qty
+                if ol.product_uom_qty > product_free_qty:
+                    ol.shop_warning = _(
+                        'Only %(new_qty)s available', new_qty=int(max(product_free_qty, 0))
+                    )
+                    unavailable_order_lines |= ol
+        return unavailable_order_lines
+
+    def _verify_updated_quantity(self, order_line, product_id, new_qty, **kwargs):
+        """ Override of `website_sale_stock` to skip the verification when click and collect
+        is activated. The quantity is verified later. """
+        self.ensure_one()
+        product = self.env['product.product'].browse(product_id)
+        if (
+            product.is_storable
+            and not product.allow_out_of_stock_order
+            and self.website_id.in_store_dm_id
+        ):
+            return new_qty, ''
+        return super()._verify_updated_quantity(order_line, product_id, new_qty, **kwargs)

--- a/addons/website_sale_collect/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.xml
+++ b/addons/website_sale_collect/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.xml
@@ -5,8 +5,8 @@
         <button id="submit_location_small" position="attributes">
             <attribute
                 name="t-att-disabled"
-                add="selectedLocation.additional_data and selectedLocation.additional_data.in_store_stock and !selectedLocation.additional_data.in_store_stock.in_stock"
-                separator=" or "
+                add="!selectedLocation?.additional_data?.in_store_stock?.in_stock"
+                separator=" || "
             />
         </button>
     </t>

--- a/addons/website_sale_collect/static/src/js/location_selector/map_container/map_container.xml
+++ b/addons/website_sale_collect/static/src/js/location_selector/map_container/map_container.xml
@@ -5,15 +5,15 @@
         <button id="submit_location_large" position="attributes">
             <attribute
                 name="t-att-disabled"
-                add="selectedLocation.additional_data and selectedLocation.additional_data.in_store_stock and !selectedLocation.additional_data.in_store_stock.in_stock"
-                separator=" or "
+                add="!selectedLocation?.additional_data?.in_store_stock?.in_stock"
+                separator=" || "
             />
         </button>
         <button id="submit_location_medium" position="attributes">
             <attribute
                 name="t-att-disabled"
-                add="selectedLocation.additional_data and selectedLocation.additional_data.in_store_stock and !selectedLocation.additional_data.in_store_stock.in_stock"
-                separator=" or "
+                add="!selectedLocation?.additional_data?.in_store_stock?.in_stock"
+                separator=" || "
             />
         </button>
     </t>

--- a/addons/website_sale_collect/static/src/js/product_configurator_dialog/product_configurator_dialog.js
+++ b/addons/website_sale_collect/static/src/js/product_configurator_dialog/product_configurator_dialog.js
@@ -1,0 +1,22 @@
+import {patch} from '@web/core/utils/patch';
+import {
+    ProductConfiguratorDialog
+} from '@sale/js/product_configurator_dialog/product_configurator_dialog';
+
+patch(ProductConfiguratorDialog, {
+    props: {
+        ...ProductConfiguratorDialog.props,
+        isClickAndCollectActive: {type: Boolean, optional: true},
+    },
+});
+
+patch(ProductConfiguratorDialog.prototype, {
+    /**
+     * Allow adding to cart when click and collect is activated.
+     *
+     * @override of `website_sale_stock`
+     */
+    _isQuantityAllowed(product, quantity) {
+        return super._isQuantityAllowed(...arguments) || this.props.isClickAndCollectActive;
+    },
+});

--- a/addons/website_sale_collect/static/src/js/variant_mixin.js
+++ b/addons/website_sale_collect/static/src/js/variant_mixin.js
@@ -1,0 +1,14 @@
+import VariantMixin from '@website_sale/js/sale_variant_mixin';
+
+const oldOnChangeCombinationStock = VariantMixin._onChangeCombinationStock;
+
+/**
+ * Prevent displaying stock values when click and collect is activated.
+ *
+ * @override of `website_sale_stock`
+ */
+VariantMixin._onChangeCombinationStock = function (ev, $parent, combination) {
+    if (!combination.show_click_and_collect_availability) {
+        return oldOnChangeCombinationStock.apply(this, arguments);
+    }
+}

--- a/addons/website_sale_collect/static/src/js/website_sale_configurators.js
+++ b/addons/website_sale_collect/static/src/js/website_sale_configurators.js
@@ -1,0 +1,16 @@
+import {WebsiteSale} from '@website_sale/js/website_sale';
+
+WebsiteSale.include({
+    /**
+     * When click and collect is activated allow adding a product in the cart via configurator.
+     *
+     * @override of `website_sale`
+     */
+    _getAdditionalDialogProps() {
+        const props = this._super(...arguments);
+        props.isClickAndCollectActive = Boolean(
+            this.el.querySelector('.o_click_and_collect_availability')
+        );
+        return props;
+    },
+})

--- a/addons/website_sale_collect/views/delivery_form_templates.xml
+++ b/addons/website_sale_collect/views/delivery_form_templates.xml
@@ -3,29 +3,30 @@
 
     <template id="unavailable_products_warning">
         <div name="unavailable_products_warning" class="alert alert-warning mt-2">
-             Some of the products are not available at <strong><t t-out="wh_name"/></strong>.
-             <div
-                 t-foreach="unavailable_products"
-                 t-as="product"
-                 t-attf-class="d-flex m-2 position-relative"
-             >
-                 <div class="d-flex align-items-center gap-2">
-                    <a t-att-href="product.website_url">
+            Some of the products are not available at <strong><t t-out="wh_name"/></strong>.
+            <div
+                t-foreach="unavailable_order_lines"
+                t-as="order_line"
+                t-attf-class="d-flex m-2 position-relative"
+            >
+                <div class="d-flex align-items-center gap-2">
+                    <a t-att-href="order_line.product_id.website_url">
                         <span
-                            t-field="product.image_128"
+                            t-field="order_line.product_id.image_128"
                             t-options="{'widget': 'image', 'qweb_img_responsive': False, 'class': 'o_image_64_max rounded'}"
                         />
                     </a>
-                    <t t-out="product.name"/>
+                    <t t-out="order_line.product_id.name"/>
                     <a
                         href='#'
                         class="js_delete_product small"
                         aria-label="Remove from cart"
                         title="Remove from cart"
                     >
-                        <i t-att-data-product-id="product.id" class="fa fa-trash"/>
+                        <i t-att-data-product-id="order_line.product_id.id" class="fa fa-trash"/>
                     </a>
-                 </div>
+                     ( <t t-out="order_line.shop_warning"/> )
+                </div>
              </div>
         </div>
     </template>
@@ -37,11 +38,10 @@
         <div name="o_pickup_location" position="after">
             <t t-if="dm.delivery_type=='in_store' and order.carrier_id.id==dm.id">
                 <t
-                    t-if="unavailable_products"
+                    t-if="unavailable_order_lines"
                     t-call="website_sale_collect.unavailable_products_warning"
                 >
                     <t t-set="wh_name" t-value="order.pickup_location_data.get('name')"/>
-                    <t t-set="unavailable_products" t-value="unavailable_products"/>
                 </t>
             </t>
         </div>

--- a/addons/website_sale_stock/views/res_config_settings_views.xml
+++ b/addons/website_sale_stock/views/res_config_settings_views.xml
@@ -14,7 +14,7 @@
                             groups="stock.group_stock_multi_warehouses">
                             <field name="website_company_id" invisible="1"/>
                             <label for="website_warehouse_id" string="Warehouse" class="col-lg-3 o_light_label" />
-                            <field name="website_warehouse_id" placeholder="All warehouses"/>
+                            <field name="website_warehouse_id"/>
                         </div>
                         <div class="content-group">
                             <div class="row mt16"


### PR DESCRIPTION
When warehouse is set on website then website_sale_stock adds logic to handle out of stock products, namely preventing to sell them or adding to the cart. However, when click and collect is activated user can choose a warehouse where the product is available that is not necessarily the one set on the website. For these cases user should be capable to add products in the cart. The validation of the availability is checked later in the /checkout and /payment.

