### PR TITLE
[FIX] web_editor: switch record doesn't transfer content

### DIFF
--- a/addons/web_editor/static/src/js/backend/html_field.js
+++ b/addons/web_editor/static/src/js/backend/html_field.js
@@ -33,6 +33,7 @@ import { uniqueId } from '@web/core/utils/functions';
 // Ensure `@web/views/fields/html/html_field` is loaded first as this module
 // must override the html field in the registry.
 import '@web/views/fields/html/html_field';
+import { Deferred } from "@web/core/utils/concurrency";
 
 let stripHistoryIds;
 
@@ -384,9 +385,15 @@ export class HtmlField extends Component {
         popover.style.left = leftPosition + 'px';
     }
     async commitChanges({ urgent, shouldInline } = {}) {
+        if (this.isCurrentlySaving && !urgent) {
+            await this.isCurrentlySaving;
+        }
         if (this._isDirty() || urgent || (shouldInline && this.props.isInlineStyle)) {
             let savePendingImagesPromise, toInlinePromise;
             if (this.wysiwyg && this.wysiwyg.odooEditor) {
+                if (!urgent) {
+                    this.isCurrentlySaving = new Deferred();
+                }
                 this.wysiwyg.odooEditor.observerUnactive('commitChanges');
                 savePendingImagesPromise = this.wysiwyg.savePendingImages();
                 if (this.props.isInlineStyle) {
@@ -404,6 +411,9 @@ export class HtmlField extends Component {
             }
             if (status(this) !== 'destroyed') {
                 await this.updateValue();
+            }
+            if (this.isCurrentlySaving) {
+                this.isCurrentlySaving.resolve();
             }
         }
     }

--- a/addons/web_editor/static/tests/html_field_tests.js
+++ b/addons/web_editor/static/tests/html_field_tests.js
@@ -27,6 +27,49 @@ async function iframeReady(iframe) {
     await nextTick(); // ensure document is loaded
 }
 
+
+const pasteImage = async (editor, base64ImageData) => {
+    // Create image file.
+    const binaryImageData = atob(base64ImageData);
+    const uint8Array = new Uint8Array(binaryImageData.length);
+    for (let i = 0; i < binaryImageData.length; i++) {
+        uint8Array[i] = binaryImageData.charCodeAt(i);
+    }
+    const file = new File([uint8Array], "test_image.png", { type: 'image/png' });
+
+    // Create a promise to get the created img elements
+    const pasteImagePromise = makeDeferred();
+    const observer = new MutationObserver(mutations => {
+        mutations
+            .filter(mutation => mutation.type === 'childList')
+            .forEach(mutation => {
+                mutation.addedNodes.forEach(node => {
+                    if (node instanceof HTMLElement) {
+                        pasteImagePromise.resolve(node);
+                    }
+                });
+            });
+    });
+    observer.observe(editor.editable, { subtree: true, childList: true });
+
+    // Simulate paste.
+    editor._onPaste({
+        preventDefault() { },
+        clipboardData: {
+            getData() { },
+            items: [{
+                kind: 'file',
+                type: 'image/png',
+                getAsFile: () => file,
+            }],
+        },
+    });
+
+    const img = await pasteImagePromise;
+    observer.disconnect();
+    return img;
+}
+
 QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
     let serverData;
     let target;
@@ -682,49 +725,6 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
             }
         };
 
-        const pasteImage = async (editor) => {
-            // Create image file.
-            const base64ImageData = "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII"
-            const binaryImageData = atob(base64ImageData);
-            const uint8Array = new Uint8Array(binaryImageData.length);
-            for (let i = 0; i < binaryImageData.length; i++) {
-                uint8Array[i] = binaryImageData.charCodeAt(i);
-            }
-            const file = new File([uint8Array], "test_image.png", { type: 'image/png' });
-
-            // Create a promise to get the created img elements
-            const pasteImagePromise = makeDeferred();
-            const observer = new MutationObserver(mutations => {
-                mutations
-                    .filter(mutation => mutation.type === 'childList')
-                    .forEach(mutation => {
-                        mutation.addedNodes.forEach(node => {
-                            if (node instanceof HTMLElement) {
-                                pasteImagePromise.resolve(node);
-                            }
-                        });
-                    });
-            });
-            observer.observe(editor.editable, { subtree: true, childList: true });
-
-            // Simulate paste.
-            editor._onPaste({
-                preventDefault() {},
-                clipboardData: {
-                    getData() {},
-                    items: [{
-                        kind: 'file',
-                        type: 'image/png',
-                        getAsFile: () => file,
-                    }],
-                },
-            });
-
-            const img = await pasteImagePromise;
-            observer.disconnect();
-            return img;
-        }
-
         await makeView({
             type: "form",
             resId: 1,
@@ -744,7 +744,7 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
         Wysiwyg.setRange(paragraph);
 
         // Paste image.
-        const img = await pasteImage(editor);
+        const img = await pasteImage(editor, "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII");
         // Test environment replaces 'src' by 'data-src'.
         assert.ok(/^data:image\/png;base64,/.test(img.dataset['src']));
         assert.ok(img.classList.contains('o_b64_image_to_save'));
@@ -755,6 +755,72 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
         await htmlField.commitChanges();
         assert.equal(img.dataset['src'], '/test_image_url.png?access_token=1234');
         assert.ok(!img.classList.contains('o_b64_image_to_save'));
+    });
+
+    QUnit.test("Pasted/dropped images are saved and content not transfered to next record", async (assert) => {
+        serverData.models.partner.records = [
+            { id: 1, txt: "<p class='image_target'>first</p>" },
+            { id: 2, txt: "<p>second</p>" },
+        ];
+
+        // Patch to get a promise to get the htmlField component instance when
+        // the wysiwyg is instancied.
+        const htmlFieldPromise = makeDeferred();
+        patchWithCleanup(HtmlField.prototype, {
+            async startWysiwyg() {
+                await super.startWysiwyg(...arguments);
+                await nextTick();
+                htmlFieldPromise.resolve(this);
+            }
+        });
+
+        const mockRPC = async function (route, args) {
+            if (route === '/web_editor/attachment/add_data') {
+                return {
+                    image_src: '/test_image_url.png',
+                    access_token: '1234',
+                    public: false,
+                }
+            }
+            if (route.includes("web_save")){
+                // reading next record
+                return [{ id: 2, txt: "<p>second</p>" }];
+            }
+        };
+
+        await makeView({
+            type: "form",
+            resId: 1,
+            resIds: [1, 2],
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <field name="txt" widget="html"/>
+                </form>`,
+            mockRPC: mockRPC,
+        });
+        // Let the htmlField be mounted and recover the Component instance.
+        const htmlField = await htmlFieldPromise;
+        const editor = htmlField.wysiwyg.odooEditor;
+
+        const paragraph = editor.editable.querySelector(".image_target");
+        Wysiwyg.setRange(paragraph);
+
+        // Paste image.
+        const img = await pasteImage(editor, "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII");
+        // Restore 'src' attribute so that SavePendingImages can do its job.
+        img.src = img.dataset['src'];
+
+        const blurEvent = new Event('blur', {
+            bubbles: true,
+            cancelable: true
+        });
+        target.querySelector(".odoo-editor-editable").dispatchEvent(blurEvent);
+
+        await click(target.querySelector(".o_pager_next"));
+        await nextTick();
+        assert.containsOnce(target, ".odoo-editor-editable p:contains('second')");
     });
 
     QUnit.module('Odoo fields synchronisation');


### PR DESCRIPTION
Issue:
======
Going to next record in to do overrides the next record content with the older one.

Steps to reproduce the issue:
==============================
- Go to do and create 2 to-dos
- Add an image using copy paste
- Go to next record using the pager
- The record has the same content as the first one

Origin of the issue:
====================
The main reason behind the issue is a race condition. Basically there are 2 flows being executed in parallel:
- First flow is from `onWysiygBlur` which calls commit changes and save image changes. Since we have an image in the content, it will take longer to finish. the commit that was called now is fron emty content to the base64 image.
- The scond flow comes from the pager update which finds the content dirty because its old content is the base64 image ans its new content is the image with the url so it will call commit changes itself and it will load the next id.
- Currently we have the `_update` of the `commitChanges` from the `blur` event isn't done yet but we already changed the id of the record to the id of the new recod (comes fron pager).
- Now when the `_update` of the old `blur` event is executed, it will update the body of the new record and not the old record.

Solution:
=========
If the html field is already saving sonething we wait for it first. so In our case, the commit changes of the paged will do nothing since it will wait for the one of the `blur` event and the editable after it will be not dirty.

task-4082860