### PR TITLE
[FIX] website: display instagram videos vertically

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/video_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/video_selector.js
@@ -218,6 +218,13 @@ export class VideoSelector extends Component {
         return selectedMedia.map(video => {
             const div = document.createElement('div');
             div.dataset.oeExpression = video.src;
+            if (video.platform == "instagram") {
+                div.classList.add("media_iframe_video_instagram");
+                div.classList.remove("media_iframe_video_default");
+            } else {
+                div.classList.remove("media_iframe_video_instagram");
+                div.classList.add("media_iframe_video_default");
+            }
             div.innerHTML = `
                 <div class="css_editable_mode_display"></div>
                 <div class="media_iframe_video_size" contenteditable="false"></div>

--- a/addons/web_editor/tools.py
+++ b/addons/web_editor/tools.py
@@ -27,7 +27,7 @@ player_regexes = {
     'vimeo': r'^(?:(?:https?:)?//)?(?:www\.)?vimeo\.com\/(?P<id>[^/\?]+)(?:/(?P<hash>[^/\?]+))?(?:\?(?P<params>[^\s]+))?$',
     'vimeo_player': r'^(?:(?:https?:)?//)?player\.vimeo\.com\/video\/(?P<id>[^/\?]+)(?:\?(?P<params>[^\s]+))?$',
     'dailymotion': r'(https?:\/\/)(www\.)?(dailymotion\.com\/(embed\/video\/|embed\/|video\/|hub\/.*#video=)|dai\.ly\/)(?P<id>[A-Za-z0-9]{6,7})',
-    'instagram': r'(?:(.*)instagram.com|instagr\.am)/p/(.[a-zA-Z0-9-_\.]*)',
+    'instagram': r'(?:(.*)instagram.com|instagr\.am)/(p|reel)/(.[a-zA-Z0-9-_\.]*)',
     'youku': r'(?:(https?:\/\/)?(v\.youku\.com/v_show/id_|player\.youku\.com/player\.php/sid/|player\.youku\.com/embed/|cloud\.youku\.com/services/sharev\?vid=|video\.tudou\.com/v/)|youku:)(?P<id>[A-Za-z0-9]+)(?:\.html|/v\.swf|)',
 }
 
@@ -53,7 +53,7 @@ def get_video_source_data(video_url):
             return ('dailymotion', dailymotion_match.group("id"), dailymotion_match)
         instagram_match = re.search(player_regexes['instagram'], video_url)
         if instagram_match:
-            return ('instagram', instagram_match[2], instagram_match)
+            return ('instagram', instagram_match[3], instagram_match)
         youku_match = re.search(player_regexes['youku'], video_url)
         if youku_match:
             return ('youku', youku_match.group("id"), youku_match)

--- a/addons/website/static/src/js/content/inject_dom.js
+++ b/addons/website/static/src/js/content/inject_dom.js
@@ -41,6 +41,17 @@ export function setUtmsHtmlDataset() {
     }
 }
 
+function resizeVideos() {
+    const verticalVideoEls = document.querySelectorAll('.media_iframe_video_instagram');
+    for (const verticalVideoEl of verticalVideoEls) {
+        verticalVideoEl.style.height = (1.25*(verticalVideoEl.clientWidth-15)+54) + "px";
+    }
+    const horizontalVideoEls = document.querySelectorAll('.media_iframe_video_default');
+    for (const horizontalVideoEl of horizontalVideoEls) {
+        horizontalVideoEl.style.height = ((2/3)*(horizontalVideoEl.clientWidth)) + "px";
+    }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     // Transfer cookie/session data as HTML element's attributes so that CSS
     // selectors can be based on them.
@@ -54,3 +65,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     unhideConditionalElements();
 });
+
+window.addEventListener('resize', resizeVideos);
+
+window.addEventListener('DOMContentLoaded', resizeVideos);


### PR DESCRIPTION
Before this commit, all videos were displayed horizontally with
a 3/2 ratio. However, Instagram videos are in general displayed
vertically vith a 4/5 ratio. Moreover instagram embed include a
header and multiple elements below the video.

This commit adds enable the switch between instagram video format
and the default video format. It simplify the addition of other
types of vertical videos (youtube shorts, tiktok videos, ...)

This commit also adds reel Instagram videos to the valid URLs.

task-3693841