### PR TITLE
[IMP] snailmail: handle incompatible layouts

### DIFF
--- a/addons/snailmail/models/ir_actions_report.py
+++ b/addons/snailmail/models/ir_actions_report.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from odoo import models, fields, api, _
+from odoo import api, models
 
 
 class IrActionsReport(models.Model):

--- a/addons/snailmail/models/res_config_settings.py
+++ b/addons/snailmail/models/res_config_settings.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-	
 # Part of Odoo. See LICENSE file for full copyright and licensing details.	
 
-from odoo import fields, models	
+from odoo import api, fields, models
 
 
 class ResConfigSettings(models.TransientModel):	
@@ -10,3 +10,22 @@ class ResConfigSettings(models.TransientModel):
     snailmail_color = fields.Boolean(string='Print In Color', related='company_id.snailmail_color', readonly=False)
     snailmail_cover = fields.Boolean(string='Add a Cover Page', related='company_id.snailmail_cover', readonly=False)
     snailmail_duplex = fields.Boolean(string='Print Both sides', related='company_id.snailmail_duplex', readonly=False)
+
+    snailmail_cover_readonly = fields.Boolean(compute="_compute_cover_readonly", store=False)
+
+    def _is_layout_cover_required(self):
+        return self.external_report_layout_id in {
+            self.env.ref(f'web.external_layout_{layout}')
+            for layout in ('boxed', 'bold', 'striped')
+        }
+
+    @api.onchange('external_report_layout_id')
+    def _onchange_layout(self):
+        for record in self:
+            if self._is_layout_cover_required():
+                self.company_id.snailmail_cover = True
+
+    @api.depends('external_report_layout_id')
+    def _compute_cover_readonly(self):
+        for record in self:
+            record.snailmail_cover_readonly = self._is_layout_cover_required()

--- a/addons/snailmail_account/views/res_config_settings_views.xml
+++ b/addons/snailmail_account/views/res_config_settings_views.xml
@@ -27,7 +27,7 @@
                         <span class="fa fa-lg fa-building-o" title="Values set here are company-specific."/>
                     </div>
                     <div>
-                        <field name="snailmail_cover"/>
+                        <field name="snailmail_cover" readonly="snailmail_cover_readonly"/>
                         <label for="snailmail_cover"/>
                         <span class="fa fa-lg fa-building-o" title="Values set here are company-specific."/>
                     </div>


### PR DESCRIPTION
Some layouts are not fully supported by Pingen and modifications have to be made. Light: meets the requirements from Pingen. Boxed, Bold, Striped: have to be sent with a cover page. Bubble, Wave, Folder: are not supported and "Light" layout has to be used.

task-3790178
