### PR TITLE
[FIX] web: misplaced search panel tooltip

### DIFF
--- a/addons/web/static/src/search/search_panel/search_panel.xml
+++ b/addons/web/static/src/search/search_panel/search_panel.xml
@@ -166,6 +166,7 @@
                 <div
                     class="o_search_panel_label d-flex align-items-center overflow-hidden w-100 o_cursor_pointer mb-0"
                     t-att-class="{'o_with_counters': section.enableCounters }"
+                    t-att-data-tooltip="value.display_name"
                     >
                     <button class="o_toggle_fold btn p-0 flex-shrink-0 text-center">
                         <i
@@ -181,7 +182,6 @@
                         class="o_search_panel_label_title text-truncate"
                         t-att-class="{'fw-bold' : value.bold}"
                         t-esc="value.display_name"
-                        t-att-data-tooltip="value.display_name"
                         />
                 </div>
                 <small t-if="section.enableCounters and value.__count gt 0"


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/121963, there are tooltips on search panel items when the user hovers them. However, it is not very convenient since the user needs to hover precisely the span which contains the item name for the tooltip to pop up. This commit simply moves up the data-tooltip attribute in the elements hierarchy so that it will show for the whole button instead of only the title. This also fixes a bug with the tooltip position in the charts of account search panel as a side effect.

task-3917084
