### PR TITLE
[FIX] mrp_subcontracting: avoid error when showing subcontracting detail

### DIFF
--- a/addons/mrp_subcontracting/__manifest__.py
+++ b/addons/mrp_subcontracting/__manifest__.py
@@ -35,6 +35,7 @@
         'web.assets_backend': [
             'mrp_subcontracting/static/src/components/**/*',
             'mrp_subcontracting/static/src/views/**/*',
+            'mrp_subcontracting/static/src/subcontracting_portal/move_list_view.js',
         ],
         'web.assets_frontend': [
             'mrp_subcontracting/static/src/scss/subcontracting_portal.scss',


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1” with the following BoM:
    - Type: subcontracting
    - subcontractor: Azure interior
    - Components: C1:
        - Route of C1: Resupply subcontractor on Order

- Create a purchase order:
    - Vendor: Azure interior
    - Product: 1 unit of P1
    - Confirm the PO

- Go to the resupply of P1 and confirm it
- Go to the receipt and record the components

- Click on the subcontracting button

Problem:

An owl error is triggered:

```
Caused by: KeyNotFoundError: Cannot find key "subcontracting_portal_move_list_view" in the "views" registry
 Error: Cannot find key "subcontracting_portal_move_list_view" in the "views" registry
```

The file is not included in the web_asset_backend bundle but only in the client bundle.

This bug was introduced after the following commit:

https://github.com/odoo/odoo/commit/f1749d3299957e2949e0b78653266a5397bb213c#diff-2395c9159b2ea0bf841d6f47ad8299bfa34fa516650acb55ae1392fa3aa32870L321-R328

Previously, if the key was not found when the backend was loaded, the default was used. However, now the key must be found in the registry, otherwise an error is thrown.

opw-4194661
opw-4184122
opw-4181126
