### PR TITLE
[FIX] mail: canned replies suggestion name truncates less

### DIFF
--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -167,7 +167,7 @@
         <strong class="px-2 py-1 align-self-center flex-shrink-1 text-truncate">
             <t t-esc="option.source"/>
         </strong>
-        <em class="text-600 text-truncate align-self-center">
+        <em class="text-600 text-truncate align-self-center" style="flex-basis: 20%;">
             <t t-esc="option.label"/>
         </em>
     </t>


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/180438

PR above fixes an issue where the canned reponse was overflowing in chat window when its name is longer than composer width.

The fix however introduced problem where description was truncating the name of canned response heavily. The description is usually very long while the name is short, and people tend to find the canned response based on name, so this makes canned response less practical.

This commit fixes the issue by forcing description to take up to 20% width when both the name and description overflow.

opw-4196113

Before / After
<img width="322" alt="Screenshot 2024-09-19 at 17 04 01" src="https://github.com/user-attachments/assets/f74bdd9f-b94e-4887-a033-8eec2cf22aae">
<img width="320" alt="Screenshot 2024-09-19 at 17 04 17" src="https://github.com/user-attachments/assets/0d243371-f6b7-40cd-9d89-97d18d387ab8">

