### PR TITLE
[FIX] pos_event: don't modify products

### DIFF
--- a/addons/pos_event/models/event_ticket.py
+++ b/addons/pos_event/models/event_ticket.py
@@ -19,22 +19,3 @@ class EventTicket(models.Model):
     @api.model
     def _load_pos_data_fields(self, config_id):
         return ['id', 'name', 'event_id', 'seats_used', 'seats_available', 'price', 'product_id', 'seats_max', 'start_sale_datetime', 'end_sale_datetime']
-
-    @api.model_create_multi
-    def create(self, vals_list):
-        tickets = super().create(vals_list)
-        tickets.make_product_event_available_in_pos()
-        return tickets
-
-    def write(self, vals):
-        res = super().write(vals)
-        if 'product_id' in vals:
-            self.make_product_event_available_in_pos()
-        return res
-
-    def make_product_event_available_in_pos(self):
-        for ticket in self:
-            ticket.product_id.available_in_pos = True
-            if self.env.ref('pos_event.pos_category_event', raise_if_not_found=False):
-                ticket.product_id.pos_categ_ids = [(4, self.env.ref('pos_event.pos_category_event').id)]
-        return True


### PR DESCRIPTION
When you create a new event ticket, it'll automatically set the related products to "sellable in pos", this leads to add new products in POS that are runnig when anybody creates an event.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
