### PR TITLE
[IMP] mail: better channel action hover style

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
@@ -33,9 +33,15 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .1;
 .o-mail-DiscussSidebar-item {
     &:hover .o-mail-DiscussSidebarChannel-commands {
         display: flex !important;
-        .btn-group .btn:not(:hover) {
-            border-color: transparent;
-            background-color: transparent;
+        .btn-group .btn {
+            &:hover {
+                border-color: rgba($o-action, .25);
+                background-color: $o-view-background-color !important;
+            }
+            &:not(:hover) {
+                border-color: transparent;
+                background-color: transparent;
+            }
         }
     }
 }


### PR DESCRIPTION
When channel item is hover or active, there's some colored background. Action hover effect was greying the action, which is not enough contrast. Darkening the background further would make icon not visible.

This commit fixes the issue by putting border and making background lighter on these buttons, so that their hover effect is very noticeable against the channel hover effect while keeping readable of action icon good.

Before / After
<img width="298" alt="Screenshot 2024-09-19 at 18 03 49" src="https://github.com/user-attachments/assets/b23c64ee-439c-4bb9-ab41-41850bdc5382">
<img width="301" alt="Screenshot 2024-09-19 at 18 03 30" src="https://github.com/user-attachments/assets/f3ce3e71-cf44-42ff-bca1-cd1c1383a8dd">
