### PR TITLE
[FIX] mail: reduce visibility of channel seen indicator

### DIFF
--- a/addons/mail/static/src/core/public_web/notification_item.dark.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.dark.scss
@@ -9,7 +9,3 @@
         background-color: mix($o-gray-200, $o-gray-300) !important;
     }
 }
-
-.o-mail-NotificationItem-unreadIndicator {
-    opacity: 100%;
-}

--- a/addons/mail/static/src/core/public_web/notification_item.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.scss
@@ -46,7 +46,6 @@
 
 .o-mail-NotificationItem-unreadIndicator {
     color: darken($info, 5%);
-    opacity: 85%;
     font-size: 0.5rem;
     left: map-get($spacers, 2);
 }

--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -12,7 +12,7 @@
             'px-3 py-2': !ui.isSmall,
             'o-active': props.isActive,
         }">
-            <span class="o-mail-NotificationItem-unreadIndicator position-absolute" t-att-class="{ 'opacity-0': props.muted }"><i class="fa fa-circle"/></span>
+            <span class="o-mail-NotificationItem-unreadIndicator position-absolute opacity-50" t-att-class="{ 'opacity-0': props.muted }"><i class="fa fa-circle"/></span>
             <div class="position-relative bg-inherit m-1 flex-shrink-0" style="width:40px;height:40px;">
                 <img class="o_avatar w-100 h-100 rounded" alt="Notification Item Image" t-att-src="props.iconSrc"/>
                 <t t-slot="icon"/>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
@@ -74,6 +74,7 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .1;
 .o-mail-DiscussSidebar-unreadIndicator {
     font-size: 0.35rem;
     left: 6px;
+    opacity: 50%;
 
     &.o-compact {
         left: 1px;


### PR DESCRIPTION
The icon was too pronunced, especially in white theme.
This commit reduces the opacity.

Before / After
<img width="298" alt="Screenshot 2024-09-19 at 18 07 10" src="https://github.com/user-attachments/assets/68b6b5f5-a299-4c1b-9885-5878fb3b7a40"> <img width="301" alt="Screenshot 2024-09-19 at 18 06 52" src="https://github.com/user-attachments/assets/2e527fe6-41d2-4a49-9bda-c7c050589663">
