### PR TITLE
[IMP] mail: better see notification items at a glance

### DIFF
--- a/addons/mail/static/src/core/public_web/messaging_menu.scss
+++ b/addons/mail/static/src/core/public_web/messaging_menu.scss
@@ -1,5 +1,5 @@
 .o-mail-MessagingMenu {
-    width: 450px;
+    width: 475px;
     min-height: 50px;
     max-height: Min(calc(#{ $o-dropdown-max-height } - 5px), 630px); // -5px for borders
     background-color: var(--mail-MessagingMenu-bg, $o-view-background-color);
@@ -7,7 +7,6 @@
 
 .o-mail-MessagingMenu-list {
     background-color: var(--mail-MessagingMenu-bg, $o-view-background-color);
-    gap: map-get($spacers, 1) / 2;
 }
 
 .o-mail-MessagingMenu-navbar button.o-active {

--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -7,7 +7,7 @@
 
 <t t-name="mail.MessagingMenu.content">
     <div t-if="!(ui.isSmall and env.inDiscussApp and store.discuss.activeTab === 'main')" t-att-class="`${discussSystray.contentClass} o-mail-MessagingMenu`">
-        <div t-if="!env.inDiscussApp or store.discuss.activeTab !== 'main'" class="o-mail-MessagingMenu-list d-flex flex-column overflow-auto flex-grow-1 list-group list-group-flush" t-ref="notification-list">
+        <div t-if="!env.inDiscussApp or store.discuss.activeTab !== 'main'" class="o-mail-MessagingMenu-list d-flex flex-column overflow-auto flex-grow-1 list-group list-group-flush px-2 py-1 gap-1" t-ref="notification-list">
             <t t-foreach="threads" name="threads" t-as="thread" t-key="thread.localId">
                 <t t-set="message" t-value="thread.isChatChannel or (thread.channel_type === 'channel' and thread.needactionMessages.length === 0) ? thread.newestPersistentNotEmptyOfAllMessage : thread.needactionMessages.at(-1)"/>
                 <NotificationItem

--- a/addons/mail/static/src/core/public_web/notification_item.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.scss
@@ -5,12 +5,13 @@
 
     &.o-important {
         background-color: mix($o-gray-100, $o-info, 92.5%) !important;
+        border-color: darken(mix($o-gray-100, $o-info, 92.5%), 5%) !important;
     }
     &.o-active {
         outline-color: rgba($o-action, var(--mail-NotificationItem-activeOutlineOpacity, 0.5));
     }
     &:hover, &.o-active {
-        background-color: $o-gray-100 !important;
+        background-color: mix($o-gray-100, $o-gray-200) !important;
 
         &.o-important {
             background-color: mix($o-gray-100, $o-info, 87.5%) !important;

--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -3,10 +3,10 @@
 
 <t t-name="mail.NotificationItem">
     <ActionSwiper onLeftSwipe="props.onSwipeLeft ? props.onSwipeLeft : undefined" onRightSwipe="props.onSwipeRight ? props.onSwipeRight : undefined">
-        <button class="o-mail-NotificationItem list-group-item d-flex cursor-pointer align-items-center w-100 gap-2 position-relative border-0" t-on-click="onClick" t-ref="root" t-att-class="{
+        <button class="o-mail-NotificationItem list-group-item d-flex cursor-pointer align-items-center w-100 gap-2 position-relative border rounded" t-on-click="onClick" t-ref="root" t-att-class="{
             'o-important': props.muted === 0,
-            'text-muted': props.muted === 1,
-            'opacity-50': props.muted === 2,
+            'text-muted border-transparent': props.muted === 1,
+            'opacity-50 border-transparent': props.muted === 2,
             'py-3 o-small': ui.isSmall,
             'border-top-0': props.first,
             'px-3 py-2': !ui.isSmall,


### PR DESCRIPTION
This commit add horizontal spacing on messaging menu items, so that each item are more easily visible.
Padding and slight darkened border is put on important notifications so that there's slightly more contrast to also ease how many important items there are at a very quick glance.


Before
<img width="988" alt="Screenshot 2024-09-19 at 18 41 49" src="https://github.com/user-attachments/assets/8da68754-641d-4285-87ba-ed0a41bb965c">
After
<img width="988" alt="Screenshot 2024-09-19 at 18 42 16" src="https://github.com/user-attachments/assets/aed13ce0-f943-40ee-adfa-ed3b14340caa">