### PR TITLE
[FIX] mail: channel invitation style selection

### DIFF
--- a/addons/mail/static/src/discuss/core/common/channel_invitation.scss
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.scss
@@ -2,6 +2,18 @@
     min-height: 0;
 }
 
+.o-discuss-ChannelInvitation-selectable {
+    &.o-odd {
+        background-color: $gray-100 !important;;
+    }
+    &:hover {
+        background-color: mix($gray-100, $gray-200) !important;
+    }
+    &.o-selected {
+        background-color: mix($o-view-background-color, $o-action, 85%) !important;;
+    }
+}
+
 .o-discuss-ChannelInvitation-selectedList {
     max-height: 100px;
 


### PR DESCRIPTION
Selection of channel invitation items had a special style [1].

This was unintentionally removed in a recent PR that has been merged [2].

This commit reintroduces it.

[1] https://github.com/odoo/odoo/pull/178865

[2] https://github.com/odoo/odoo/commit/37568bc3e954741563f796562c784270ff10f1d0#diff-138a75139f9f51ece9df7d4552095699746c803963369aa35ade6ae5d71ffeb1L19

Before / After
<img width="425" alt="Screenshot 2024-09-19 at 19 01 23" src="https://github.com/user-attachments/assets/c4365dfd-479a-4a71-848d-49abbb75cb5c"> <img width="436" alt="Screenshot 2024-09-19 at 19 00 52" src="https://github.com/user-attachments/assets/326fda27-2965-4bf4-83fd-354bbe0be711">
