### PR TITLE
[IMP] mail: discuss action panel show icon

### DIFF
--- a/addons/mail/static/src/core/common/search_messages_panel.xml
+++ b/addons/mail/static/src/core/common/search_messages_panel.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.SearchMessagesPanel">
-        <ActionPanel title="env.inChatter ? undefined : title" minWidth="200" initialWidth="400">
+        <ActionPanel title="env.inChatter ? undefined : title" minWidth="200" initialWidth="400" icon="'oi oi-search'">
             <div class="d-flex py-2">
                 <div class="input-group">
                     <div class="o_searchview form-control d-flex align-items-center bg-view p-0" role="search" aria-autocomplete="list">

--- a/addons/mail/static/src/discuss/call/common/call_settings.xml
+++ b/addons/mail/static/src/discuss/call/common/call_settings.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.CallSettings">
-        <ActionPanel t-if="props.withActionPanel" title.translate="Voice settings">
+        <ActionPanel t-if="props.withActionPanel" title.translate="Voice settings" icon="'fa fa-gear'">
             <t t-call="discuss.CallSettings.content" />
         </ActionPanel>
         <t t-else="" t-call="discuss.CallSettings.content" />

--- a/addons/mail/static/src/discuss/core/common/action_panel.js
+++ b/addons/mail/static/src/discuss/core/common/action_panel.js
@@ -12,6 +12,7 @@ export class ActionPanel extends Component {
     static template = "mail.ActionPanel";
     static components = { ResizablePanel };
     static props = {
+        icon: { type: String, optional: true },
         title: { type: String, optional: true },
         resizable: { type: Boolean, optional: true },
         slots: { type: Object, optional: true },

--- a/addons/mail/static/src/discuss/core/common/action_panel.xml
+++ b/addons/mail/static/src/discuss/core/common/action_panel.xml
@@ -16,6 +16,7 @@
                 <button t-if="env.closeActionPanel" class="btn p-1 opacity-75 opacity-100-hover text-muted" title="Close panel" t-on-click.stop="env.closeActionPanel">
                     <i class="oi oi-arrow-left fa-fw"/>
                 </button>
+                <i t-if="props.icon" class="text-muted" t-att-class="props.icon"/>
                 <p t-if="props.title" class="fs-6 fw-bold text-uppercase m-0 text-muted flex-grow-1" t-esc="props.title"/>
             </div>
             <t t-slot="header"/>

--- a/addons/mail/static/src/discuss/core/common/attachment_panel.xml
+++ b/addons/mail/static/src/discuss/core/common/attachment_panel.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.AttachmentPanel">
-        <ActionPanel title.translate="Attachments" minWidth="200" initialWidth="400">
+        <ActionPanel title.translate="Attachments" minWidth="200" initialWidth="400" icon="'fa fa-paperclip'">
             <div class="d-flex flex-column py-2 flex-grow-1">
                 <div t-if="hasToggleAllowPublicUpload" class="form-check form-switch mx-4">
                     <label class="form-check-label">

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.ChannelInvitation">
-        <ActionPanel title.translate="Invite people" resizable="false">
+        <ActionPanel title.translate="Invite people" resizable="false" icon="'fa fa-user-plus'">
             <div class="d-flex flex-column flex-grow-1 bg-inherit" t-att-class="{ 'o-mail-Discuss-threadActionPopover': props.hasSizeConstraints }">
                 <t t-if="store.self.type === 'partner'">
                     <input class="o-discuss-ChannelInvitation-search form-control lh-1 px-2 bg-view" t-ref="input" placeholder="Type the name of a person" t-on-input="onInput"/>

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -2,8 +2,8 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.ChannelMemberList">
-        <ActionPanel title.translate="Members" minWidth="200">
-            <button t-on-click="() => props.openChannelInvitePanel({ keepPrevious: env.inChatWindow })" class="btn btn-secondary m-2 mt-0">Invite a User</button>
+        <ActionPanel title.translate="Members" minWidth="200" icon="'fa fa-users'">
+            <button t-on-click="() => props.openChannelInvitePanel({ keepPrevious: env.inChatWindow })" class="btn btn-sm btn-secondary m-2 mt-0 d-flex align-items-center justify-content-center gap-1"><i class="fa fa-user-plus"/><span>Invite a User</span></button>
             <t t-if="props.thread.onlineMembers.length > 0">
                 <h6 class="text-muted pt-2 text-uppercase smaller">
                     Online -

--- a/addons/mail/static/src/discuss/core/common/notification_settings.xml
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.NotificationSettings">
-        <ActionPanel title.translate="Notification Settings">
+        <ActionPanel title.translate="Notification Settings" icon="'fa fa-bell'">
             <div class="o-discuss-NotificationSettings">
                 <div t-if="store.settings.mute_until_dt" class="d-flex flex-column alert alert-warning">
                     <span><i class="fa fa-exclamation-triangle"/> <a href="#" t-on-click="onClickServerMuted">Server is muted</a></span>

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.SubChannelList">
-        <ActionPanel title.translate="Threads" resizable="false">
+        <ActionPanel title.translate="Threads" resizable="false" icon="'fa fa-comments-o'">
             <t t-set-slot="header">
                 <div class="d-flex align-items-center mx-1">
                     <div class="input-group my-2 me-2">

--- a/addons/mail/static/src/discuss/message_pin/common/pinned_messages_panel.xml
+++ b/addons/mail/static/src/discuss/message_pin/common/pinned_messages_panel.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="discuss.PinnedMessagesPanel">
-        <ActionPanel title.translate="Pinned Messages" minWidth="200" initialWidth="400">
+        <ActionPanel title.translate="Pinned Messages" minWidth="200" initialWidth="400" icon="'fa fa-thumb-tack'">
             <MessageCardList emptyText="emptyText" messages="props.thread.pinnedMessages" thread="props.thread" mode="'pin'"/>
         </ActionPanel>
     </t>


### PR DESCRIPTION
Also button "Invite a User" has matching icon of channel invitation panel

Before / After
<img width="323" alt="Screenshot 2024-09-19 at 19 11 57" src="https://github.com/user-attachments/assets/ec32f215-531a-4226-84e2-50af48f6979d"> <img width="320" alt="Screenshot 2024-09-19 at 19 10 34" src="https://github.com/user-attachments/assets/6b9f3c64-8631-4dda-b7c7-d090a904e825">
