### PR TITLE
[FIX] l10n_br_website_sale: don't modify non-Brazilian websites

### DIFF
--- a/addons/l10n_br_website_sale/static/src/js/address.js
+++ b/addons/l10n_br_website_sale/static/src/js/address.js
@@ -16,6 +16,10 @@ websiteSaleAddress.include({
     },
 
     _onChangeZip: function() {
+        if (this.countryCode !== 'BR') {
+            return;
+        }
+
         const newZip = this.addressForm.zip.value.padEnd(5, '0');
 
         for (let option of this.addressForm.querySelectorAll('select[name="city_id"]:not(.d-none) > option')) {
@@ -60,6 +64,10 @@ websiteSaleAddress.include({
 
     async _changeCountry(ev) {
         const res = await this._super(...arguments);
+        if (this.countryCode !== 'BR') {
+            return res;
+        }
+
         const countryOption = this.addressForm.country_id;
         const selectedCountryCode = countryOption.value ? countryOption.selectedOptions[0].getAttribute('code') : '';
 

--- a/addons/l10n_br_website_sale/views/templates.xml
+++ b/addons/l10n_br_website_sale/views/templates.xml
@@ -52,27 +52,29 @@
             <attribute name="class" separator=" " add="o_standard_address"/>
         </div>
         <div id="div_street" position="after">
-            <div id="div_street_name" t-attf-class="col-lg-8 mb-2 o_extended_address">
-                <label class="col-form-label" for="o_street_name">Street</label>
-                <input id="o_street_name" type="text" name="street_name" class="form-control" t-att-value="partner_sudo.street_name"/>
-            </div>
-            <div id="div_street_number" t-attf-class="col-lg-4 mb-2 o_extended_address">
-                <label class="col-form-label" for="o_street_number">Street Number</label>
-                <input id="o_street_number" type="text" name="street_number" class="form-control" t-att-value="partner_sudo.street_number"/>
-            </div>
-            <div class="w-100"/>
-            <div id="div_street_number2" t-attf-class="col-lg-6 mb-2 o_extended_address">
-                <label class="col-form-label" for="o_street_number2">Complement</label>
-                <input id="o_street_number2" type="text" name="street_number2" class="form-control" t-att-value="partner_sudo.street_number2"/>
-            </div>
-            <div id="div_street2" position="move"/>
+            <t t-if="res_company.account_fiscal_country_id.code == 'BR'">
+                <div id="div_street_name" t-attf-class="col-lg-8 mb-2 o_extended_address">
+                    <label class="col-form-label" for="o_street_name">Street</label>
+                    <input id="o_street_name" type="text" name="street_name" class="form-control" t-att-value="partner_sudo.street_name"/>
+                </div>
+                <div id="div_street_number" t-attf-class="col-lg-4 mb-2 o_extended_address">
+                    <label class="col-form-label" for="o_street_number">Street Number</label>
+                    <input id="o_street_number" type="text" name="street_number" class="form-control" t-att-value="partner_sudo.street_number"/>
+                </div>
+                <div class="w-100"/>
+                <div id="div_street_number2" t-attf-class="col-lg-6 mb-2 o_extended_address">
+                    <label class="col-form-label" for="o_street_number2">Complement</label>
+                    <input id="o_street_number2" type="text" name="street_number2" class="form-control" t-att-value="partner_sudo.street_number2"/>
+                </div>
+                <div id="div_street2" position="move"/>
+            </t>
         </div>
         <!-- street2 is used for neighborhood in Brazil, change the default label -->
         <label for="o_street2" position="attributes">
             <attribute name="t-attf-class" separator=" " add="col-form-label label-optional o_standard_address"/>
         </label>
         <label for="o_street2" position="after">
-            <label t-attf-class="col-form-label label-optional o_extended_address" for="o_street2">Neighborhood</label>
+            <label t-if="res_company.account_fiscal_country_id.code == 'BR'" t-attf-class="col-form-label label-optional o_extended_address" for="o_street2">Neighborhood</label>
         </label>
     </template>
 


### PR DESCRIPTION
Localization-specific code for eCommerce is only meant to be active when the website belongs to the localized company. This helps keep everything working in multi-company databases.

This makes sure to only modify the website_sale.address template for Brazilian companies (was only done for o_city_id before).

JS was also modified to only act on Brazilian company websites. In particular, _changeCountry was hiding the `city` input when Brazil was selected, even when the website belonged to e.g. a US company. In this case, there is no `city_id` input and so there was no way to input the city. Finally, _onChangeZip was deactivated as well for consistency, although it probably doesn't cause any issues.

task-4198591

## PR Note
This is what it currently looks like if you select Brazil on a website not associated to a Brazilian company:
![image](https://github.com/user-attachments/assets/1b763c13-fd95-4be9-a06d-5d4d8fa8cb68)
