### PR TITLE
[FIX] account: Error when add field x2many in res_company

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -396,7 +396,10 @@ class AccountChartTemplate(models.AbstractModel):
                     and isinstance(values[fname], (list, tuple))
                 ]
                 if x2manyfields:
-                    rec = self.ref(xmlid, raise_if_not_found=False)
+                    if isinstance(xmlid, int):
+                        rec = self.env[model_name].browse(xmlid).exists()
+                    else:
+                        rec = self.ref(xmlid, raise_if_not_found=False)
                     if rec:
                         for fname in x2manyfields:
                             for i, (line, (command, _id, vals)) in enumerate(zip(rec[fname], values[fname])):


### PR DESCRIPTION
template data of model res.company: {id: values}
template data of model account.journal, account.tax...: {xmlid: values}

An error occurred when adding the x2many field to res.company and try load template


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
