### PR TITLE
[FIX] l10n_vn_edi_viettel: Correct sinvoice xml page on move

### DIFF
--- a/addons/l10n_vn_edi_viettel/models/account_move.py
+++ b/addons/l10n_vn_edi_viettel/models/account_move.py
@@ -143,6 +143,11 @@ class AccountMove(models.Model):
         check_company=True,
         export_string_translation=False,
     )
+    l10n_vn_edi_reversed_entry_invoice_number = fields.Char(
+        string='Revered Entry SInvoice Number',  # Need string here to avoid same label warning
+        related='reversed_entry_id.l10n_vn_edi_invoice_number',
+        export_string_translation=False,
+    )
 
     @api.depends('l10n_vn_edi_invoice_state')
     def _compute_show_reset_to_draft_button(self):

--- a/addons/l10n_vn_edi_viettel/views/account_move_views.xml
+++ b/addons/l10n_vn_edi_viettel/views/account_move_views.xml
@@ -18,6 +18,7 @@
                       invisible="move_type not in ['out_invoice', 'out_refund'] or country_code != 'VN'">
                     <group>
                         <field name="l10n_vn_edi_replacement_origin_id" invisible="1"/>
+                        <field name="l10n_vn_edi_reversed_entry_invoice_number" invisible="1"/>
                         <group>
                             <field name="l10n_vn_edi_invoice_symbol" readonly="l10n_vn_edi_invoice_number"/>
                             <field name="l10n_vn_edi_issue_date" invisible="not l10n_vn_edi_invoice_number"/>
@@ -28,8 +29,8 @@
                             <field name="l10n_vn_edi_reservation_code" invisible="not l10n_vn_edi_invoice_number"/>
                         </group>
                         <group string="Agreement"
-                               invisible="(not l10n_vn_edi_replacement_origin_id or not l10n_vn_edi_replacement_origin_id.l10n_vn_edi_invoice_number)
-                               and (not reversed_entry_id or not reversed_entry_id.l10n_vn_edi_invoice_number)">
+                               invisible="not l10n_vn_edi_replacement_origin_id
+                               and (not reversed_entry_id or not l10n_vn_edi_reversed_entry_invoice_number)">
                             <field name="l10n_vn_edi_adjustment_type" readonly="l10n_vn_edi_invoice_number"/>
                             <field name="l10n_vn_edi_agreement_document_name" readonly="l10n_vn_edi_invoice_number"/>
                             <field name="l10n_vn_edi_agreement_document_date" readonly="l10n_vn_edi_invoice_number"/>


### PR DESCRIPTION
* PROPBLEM: In form view we try to use m2o.field_name which is
'l10n_vn_edi_replacement_origin_id.l10n_vn_edi_invoice_number', odoo
doesn't
support that so it will not work at least in form view
* SOLUTION: this commit make the invisible condition more simpler and
create a non-store field to fix the issue

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
