### PR TITLE
[IMP] web, *: update kanban-menu for new kanban architecture

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -1,3 +1,78 @@
+// ------- Kanban Menu -------
+.o-dropdown--kanban-record-menu {
+    margin-top: -1px;
+    margin-bottom: 0px;
+    min-width: 9rem;
+
+    // Records colours
+    @include o-kanban-record-color;
+
+    $o-kanban-manage-toggle-height: 35px;
+
+    // Arbitrary value to place the dropdown-menu exactly below the
+    // dropdown-toggle (height is forced so that it works on Firefox)
+    top: $o-kanban-manage-toggle-height;
+
+    > div {
+        padding: 3px 0 3px 20px;
+        visibility: visible;
+        margin-bottom: 5px;
+    }
+
+    // Dropdown menu with complex layout
+    .container {
+        max-width: 400px;
+        margin-left: 0;
+        margin-right: 0;
+
+        .row {
+            display: flex;
+            flex-flow: row nowrap;
+            justify-content: space-between;
+            padding-left: $o-kanban-dashboard-dropdown-complex-gap*2;
+            padding-right: $o-kanban-dashboard-dropdown-complex-gap*2;
+        }
+
+        div[class*="col-"] {
+            flex: 1 1 percentage(1/3);
+            padding-left: $o-kanban-dashboard-dropdown-complex-gap;
+            padding-right: $o-kanban-dashboard-dropdown-complex-gap;
+            max-width: none;
+
+            > .o_kanban_card_manage_title {
+                margin: (($font-size-base * $line-height-base) / 2) 0;
+            }
+            > div:not(.o_kanban_card_manage_title) {
+                @include o-kanban-dashboard-dropdown-link($link-padding-gap: $o-kanban-dashboard-dropdown-complex-gap);
+            }
+        }
+
+        .row.o_kanban_card_manage_settings {
+            padding-top: $o-kanban-dashboard-dropdown-complex-gap*3;
+
+            &:not(:first-child) {
+                border-top: 1px solid $dropdown-divider-bg;
+            }
+
+            .o_kanban_colorpicker {
+                max-width: none;
+                padding: 0;
+                margin-left: 2px !important;
+            }
+
+            div[class*="col-"] + div[class*="col-"] {
+                border-left: 1px solid $dropdown-divider-bg;
+            }
+            > div:last-child {
+                @include o-kanban-dashboard-dropdown-link($link-padding-gap: $o-kanban-dashboard-dropdown-complex-gap);
+                padding-left: $dropdown-item-padding-x;
+                padding-right: $dropdown-item-padding-x;
+            }
+        }
+    }
+
+}
+
 // ------- Kanban View -------
 .o_kanban_view {
     @include media-breakpoint-down(md) {
@@ -218,15 +293,6 @@
         .dropdown {
             display: none;
         }
-    }
-
-    .o-dropdown--kanban-record-menu {
-        margin-top: -1px;
-        margin-bottom: 0px;
-        min-width: 9rem;
-    
-        // Records colours
-        @include o-kanban-record-color;
     }
 
     // Kanban Grouped Layout

--- a/addons/web/static/src/views/kanban/kanban_dashboard.scss
+++ b/addons/web/static/src/views/kanban/kanban_dashboard.scss
@@ -98,7 +98,8 @@
     }
 }
 
-.o-dropdown--kanban-record-menu {
+// retro-compatibility
+.o-dropdown--legacy-kanban-record-menu {
     $o-kanban-manage-toggle-height: 35px;
 
     // Arbitrary value to place the dropdown-menu exactly below the

--- a/addons/web/static/src/views/kanban/kanban_record.js
+++ b/addons/web/static/src/views/kanban/kanban_record.js
@@ -280,6 +280,14 @@ export class KanbanRecord extends Component {
         return classes.join(" ");
     }
 
+    getMenuClasses() {
+        if (this.props.archInfo.isLegacyArch) {
+            return "o-dropdown--legacy-kanban-record-menu";
+        } else {
+            return "o-dropdown--kanban-record-menu";
+        }
+    }
+
     /**
      * @param {MouseEvent} ev
      */
@@ -350,12 +358,9 @@ export class KanbanRecord extends Component {
                 break;
             }
             default: {
-                return this.notification.add(
-                    _t("Kanban: no action for type: %(type)s", { type }),
-                    {
-                        type: "danger",
-                    }
-                );
+                return this.notification.add(_t("Kanban: no action for type: %(type)s", { type }), {
+                    type: "danger",
+                });
             }
         }
     }

--- a/addons/web/static/src/views/kanban/kanban_record.xml
+++ b/addons/web/static/src/views/kanban/kanban_record.xml
@@ -15,7 +15,7 @@
 
     <t t-name="web.KanbanRecordMenu">
         <div t-if="showMenu" class="o_dropdown_kanban bg-transparent position-absolute end-0 top-0 w-auto">
-            <Dropdown menuClass="'o-dropdown--kanban-record-menu'" position="'bottom-end'">
+            <Dropdown menuClass="getMenuClasses()" position="'bottom-end'">
                 <button class="btn o-no-caret rounded-0" title="Dropdown menu">
                     <span class="fa fa-ellipsis-v"/>
                 </button>

--- a/addons/website_slides/views/slide_channel_views.xml
+++ b/addons/website_slides/views/slide_channel_views.xml
@@ -246,7 +246,7 @@
                     <field name="website_published"/>
                     <templates>
                         <t t-name="kanban-menu">
-                            <div role="menuitem" aria-haspopup="true" class="o_no_padding_kanban_colorpicker">
+                            <div role="menuitem" aria-haspopup="true">
                                 <field name="color" widget="kanban_color_picker"/>
                             </div>
                             <div class="o_kanban_slides_card_manage_pane">
@@ -286,7 +286,7 @@
                                     </div>
                                 </div>
                             </div>
-                            <div name="card_content" class="row mt3">
+                            <div name="card_content" class="row mt-auto">
                                 <a name="action_redirect_to_invited_members" type="object" class="d-flex flex-column align-items-center col-3 border-end">
                                     <field name="members_invited_count" class="fw-bold"/>
                                     <span class="text-muted">Invited</span>


### PR DESCRIPTION
*website_slides,mrp_plm,quality_control
This commit removes kanban-record-menu from kanban_dashboard and moves it to the generic CSS rule for kanban-menu. Unnecessary classes that no longer have an effect in the updated kanban architecture have been removed.

- Removed o_kanban_card_manage_section and o_no_padding_kanban_colorpicker class
- Renamed .oe_kanban_colorpicker to o_kanban_colorpicker

Task-3992107

enterprise PR - https://github.com/odoo/enterprise/pull/70352

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
