### PR TITLE
[IMP] (sale,purchase,account)(_edi*): add edi learning

### DIFF
--- a/addons/purchase_edi_ubl_bis3/models/purchase_edi_xml_ubl_bis3.py
+++ b/addons/purchase_edi_ubl_bis3/models/purchase_edi_xml_ubl_bis3.py
@@ -296,6 +296,10 @@ class PurchaseEdiXmlUbl_Bis3(models.AbstractModel):
         if supplier_info.product_name:
             line_item_node['cbc:Name']['_text'] = supplier_info.product_name
 
+        line_item_node['cac:BuyersItemIdentification'] = {
+            'cbc:ID': {'_text': product.default_code or product.id},
+        }
+
         # When generating purchase order (PO) we are not considered as the seller of the sale but
         # buyer. The `SellersItemIdentification` is therefore the PO's partner product ID.
         line_item_node['cac:SellersItemIdentification'] = {

--- a/addons/purchase_edi_ubl_bis3/tests/data/test_po_edi.xml
+++ b/addons/purchase_edi_ubl_bis3/tests/data/test_po_edi.xml
@@ -114,6 +114,9 @@
       <cac:Item>
         <cbc:Description>Product A description</cbc:Description>
         <cbc:Name>product_a</cbc:Name>
+        <cac:BuyersItemIdentification>
+          <cbc:ID>AAA</cbc:ID>
+        </cac:BuyersItemIdentification>
         <cac:ClassifiedTaxCategory>
           <cbc:ID>S</cbc:ID>
           <cbc:Percent>15.0</cbc:Percent>
@@ -135,6 +138,9 @@
       <cac:Item>
         <cbc:Description>Product A description</cbc:Description>
         <cbc:Name>product_a</cbc:Name>
+        <cac:BuyersItemIdentification>
+          <cbc:ID>AAA</cbc:ID>
+        </cac:BuyersItemIdentification>
         <cac:ClassifiedTaxCategory>
           <cbc:ID>S</cbc:ID>
           <cbc:Percent>15.0</cbc:Percent>

--- a/addons/purchase_edi_ubl_bis3/tests/test_purchase_order_edi_gen.py
+++ b/addons/purchase_edi_ubl_bis3/tests/test_purchase_order_edi_gen.py
@@ -12,6 +12,7 @@ class TestPurchaseOrderEDIGen(AccountTestInvoicingCommon):
     def test_purchase_order_download_edi(self):
         self.env.company.vat = 'BE0477472701'
         self.partner_a.vat = 'NL123456782B90'
+        self.product_a.default_code = 'AAA'
 
         po = self.env['purchase.order'].create({
             'name': 'My PO',

--- a/addons/sale_edi_ubl/__manifest__.py
+++ b/addons/sale_edi_ubl/__manifest__.py
@@ -10,6 +10,9 @@ When uploading or pasting Files in order list view with order related data insid
 File with embedded xml data will allow seller to retrieve Order data from Files.
     """,
     'depends': ['sale', 'account_edi_ubl_cii'],
+    'data': [
+        'security/ir.model.access.csv',
+    ],
     'auto_install': True,
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',

--- a/addons/sale_edi_ubl/models/__init__.py
+++ b/addons/sale_edi_ubl/models/__init__.py
@@ -1,4 +1,6 @@
 
+from . import customer_product_reference
 from . import product_product
 from . import sale_edi_xml_ubl_bis3
 from . import sale_order
+from . import sale_order_line

--- a/addons/sale_edi_ubl/models/customer_product_reference.py
+++ b/addons/sale_edi_ubl/models/customer_product_reference.py
@@ -1,0 +1,75 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class CustomerProductReference(models.Model):
+    _name = 'customer.product.reference'
+    _description = "Customer Product Reference"
+
+    product_id = fields.Many2one(
+        comodel_name='product.product',
+        index=True,
+        required=True,
+        ondelete='cascade',
+    )
+    partner_id = fields.Many2one(
+        comodel_name='res.partner',
+        required=True,
+        ondelete='cascade',
+    )
+    customer_product_reference = fields.Char(required=True)
+
+    _product_partner_unique = models.Constraint(
+        'unique (product_id, partner_id)',
+        'The customer reference with the same product and partner already exists!',
+    )
+
+    @api.model
+    def create_or_update_product_reference(self, partner, product, reference):
+        """Set customer product reference on product to be able to use that reference for next
+        Order extraction to set proper product from that reference.
+
+        Note: self.ensure_one()
+
+        :param recordset product: Product for which we are storing customer product reference.
+        :param recordset partner: Customer for which we are storing product reference.
+        :param str reference: Product reference in customer database.
+        :return: None
+        """
+
+        matching_partner_ref = self._find_matching_ref(partner, reference)
+        if not matching_partner_ref:
+            self.create({
+                'partner_id': partner.id,
+                'product_id': product.id,
+                'customer_product_reference': reference,
+            })
+        elif matching_partner_ref.product_id != product:
+            # Update to the latest product.
+            matching_partner_ref.product_id = product
+
+    @api.model
+    def find_product_matching_reference(self, partner, reference):
+        """Find the product linked to the given customer and product reference.
+
+        :param res.partner partner: The customer to look up.
+        :param str reference: The product reference to look up.
+        :return: The corresponding product.
+        :rtype: product.product
+        """
+        return self._find_matching_ref(partner, reference).product_id
+
+    @api.model
+    def _find_matching_ref(self, partner, product_ref):
+        """Find the customer product reference linked to the given customer and product reference.
+
+        :param res.partner partner: The customer to look up.
+        :param str product_ref: The product reference to look up.
+        :return: The corresponding customer product reference.
+        :rtype: customer.product.reference
+        """
+        return self.search([
+            ('partner_id', '=', partner.id),
+            ('customer_product_reference', '=', product_ref),
+        ], limit=1)

--- a/addons/sale_edi_ubl/models/sale_order_line.py
+++ b/addons/sale_edi_ubl/models/sale_order_line.py
@@ -1,0 +1,9 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    edi_customer_product_ref = fields.Char()

--- a/addons/sale_edi_ubl/security/ir.model.access.csv
+++ b/addons/sale_edi_ubl/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_product_partner_reference,access.product.partner.reference,model_customer_product_reference,sales_team.group_sale_salesman,1,1,1,0


### PR DESCRIPTION
This commit add functionality to make edi more efficient by
learning it from past PO order files extracted.
Working:
- when we extract file and didn't find any matching products
for line then store that customer product reference on SOL
after then Sales person will set proper product from his DB
or create one and set product then confirm order so On order
confirmation we extract product customer reference and store
it on `customer.product.reference` then when we extract new
file from same customer we look and don't find matching
product then we will look for product in
`customer.product.reference` and if we find matching product
then set that product on SOL.

task-4086173