### PR TITLE
[IMP] bus: expose worker state from the bus service

### DIFF
--- a/addons/bus/static/tests/legacy/websocket_worker_tests.js
+++ b/addons/bus/static/tests/legacy/websocket_worker_tests.js
@@ -10,6 +10,9 @@ QUnit.module("Websocket Worker");
 QUnit.test("connect event is broadcasted after calling start", async function (assert) {
     const worker = patchWebsocketWorkerWithCleanup({
         broadcast(type) {
+            if (type === "update_state") {
+                return;
+            }
             assert.step(`broadcast ${type}`);
         },
     });
@@ -22,6 +25,9 @@ QUnit.test("connect event is broadcasted after calling start", async function (a
 QUnit.test("disconnect event is broadcasted", async function (assert) {
     const worker = patchWebsocketWorkerWithCleanup({
         broadcast(type) {
+            if (type === "update_state") {
+                return;
+            }
             assert.step(`broadcast ${type}`);
         },
     });
@@ -42,6 +48,9 @@ QUnit.test("reconnecting/reconnect event is broadcasted", async function (assert
     });
     const worker = patchWebsocketWorkerWithCleanup({
         broadcast(type) {
+            if (type === "update_state") {
+                return;
+            }
             assert.step(`broadcast ${type}`);
         },
     });

--- a/doc/cla/individual/abichinger.md
+++ b/doc/cla/individual/abichinger.md
@@ -1,0 +1,11 @@
+Austria, 2024-09-16
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Andreas Bichinger andreas.bichinger@gmail.com https://github.com/abichinger


### PR DESCRIPTION
The bus service uses a SharedWorker to maintain the WebSocket
connection across tabs. One can subscribe to the lifecycle
events of the bus service (such as connect/disconnect) to monitor
the state of the worker connection. However, when a new tab opens,
it has no way to determine the current connection state. This PR
exposes the `workerState` property from the bus service, allowing
tabs to easily check the state of the worker connection.