### PR TITLE
[FIX] web: x2many came back to initial state when discard

### DIFF
--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -762,9 +762,11 @@ export class Record extends DataPoint {
                         });
                     }
                     staticList = this._createStaticListDatapoint(data, fieldName);
-                }
-                if (valueIsCommandList) {
-                    staticList._applyInitialCommands(value);
+                    if (valueIsCommandList) {
+                        staticList._applyInitialCommands(value);
+                    }
+                } else if (valueIsCommandList) {
+                    staticList._applyCommands(value);
                 }
                 parsedValues[fieldName] = staticList;
             } else {

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -5437,6 +5437,135 @@ QUnit.module("Views", (hooks) => {
         assert.containsNone(target, ".o_data_row");
     });
 
+    QUnit.test("discard changes on relational data on existing record", async function (assert) {
+        serverData.models.partner.records[0].product_ids = [37];
+        serverData.models.partner.records[0].bar = false;
+        serverData.models.partner.onchanges = {
+            bar(record) {
+                // when bar changes, push another record in product_ids.
+                record.product_ids = [[4, 41]];
+            },
+        };
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            resId: 1,
+            arch: `
+                <form>
+                    <field name="bar"/>
+                    <field name="product_ids" widget="one2many">
+                        <tree>
+                            <field name="display_name"/>
+                        </tree>
+                    </field>
+                </form>`,
+        });
+
+        assert.deepEqual(getNodesTextContent(target.querySelectorAll(".o_data_cell")), ["xphone"]);
+        assert.containsNone(target, ".o_field_widget[name=bar] input:checked");
+
+        // Click on bar
+        await click(target.querySelector(".o_field_widget[name=bar] input"));
+        assert.containsOnce(target, ".o_field_widget[name=bar] input:checked");
+        assert.deepEqual(getNodesTextContent(target.querySelectorAll(".o_data_cell")), [
+            "xphone",
+            "xpad",
+        ]);
+
+        // click on discard
+        await clickDiscard(target);
+        assert.deepEqual(getNodesTextContent(target.querySelectorAll(".o_data_cell")), ["xphone"]);
+        assert.containsNone(target, ".o_field_widget[name=bar] input:checked");
+    });
+
+    QUnit.test("discard changes on relational data on new record (1)", async function (assert) {
+        // When bar is changed, it pushes a record in product_ids
+        // After discarding, product_ids should be empty
+        serverData.models.partner.onchanges = {
+            bar(record) {
+                if (record.bar) {
+                    // when bar changes, push another record in product_ids.
+                    record.product_ids = [[4, 41]];
+                }
+            },
+        };
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <field name="bar"/>
+                    <field name="product_ids" widget="one2many">
+                        <tree>
+                            <field name="display_name"/>
+                        </tree>
+                    </field>
+                </form>`,
+        });
+
+        assert.deepEqual(getNodesTextContent(target.querySelectorAll(".o_data_cell")), []);
+        assert.containsNone(target, ".o_field_widget[name=bar] input:checked");
+
+        // Click on bar
+        await click(target.querySelector(".o_field_widget[name=bar] input"));
+        assert.containsOnce(target, ".o_field_widget[name=bar] input:checked");
+        assert.deepEqual(getNodesTextContent(target.querySelectorAll(".o_data_cell")), ["xpad"]);
+
+        // click on discard
+        await clickDiscard(target);
+        assert.deepEqual(getNodesTextContent(target.querySelectorAll(".o_data_cell")), []);
+        assert.containsNone(target, ".o_field_widget[name=bar] input:checked");
+    });
+
+    QUnit.test("discard changes on relational data on new record (2)", async function (assert) {
+        // An initial onChange push a record in product_ids
+        // When bar is changed, it pushes a second record in product_ids
+        // After discarding, product_ids should contain the inital record pushed by the inital onChange
+        serverData.models.partner.onchanges = {
+            product_ids(record) {
+                record.product_ids = [[4, 41]];
+            },
+            bar(record) {
+                // when bar changes, push another record in product_ids.
+                if (record.bar) {
+                    record.product_ids = [[4, 37]];
+                }
+            },
+        };
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <field name="bar"/>
+                    <field name="product_ids" widget="one2many">
+                        <tree>
+                            <field name="display_name"/>
+                        </tree>
+                    </field>
+                </form>`,
+        });
+
+        assert.deepEqual(getNodesTextContent(target.querySelectorAll(".o_data_cell")), ["xpad"]);
+        assert.containsNone(target, ".o_field_widget[name=bar] input:checked");
+
+        // Click on bar
+        await click(target.querySelector(".o_field_widget[name=bar] input"));
+        assert.containsOnce(target, ".o_field_widget[name=bar] input:checked");
+        assert.deepEqual(getNodesTextContent(target.querySelectorAll(".o_data_cell")), [
+            "xpad",
+            "xphone",
+        ]);
+
+        // click on discard
+        await clickDiscard(target);
+        assert.deepEqual(getNodesTextContent(target.querySelectorAll(".o_data_cell")), ["xpad"]);
+        assert.containsNone(target, ".o_field_widget[name=bar] input:checked");
+    });
+
     QUnit.test(
         "discard changes on a new (non dirty, except for defaults) form view",
         async function (assert) {


### PR DESCRIPTION
- Have a x2many on your view;
- Edit another field that through a onChange modify the x2many;
- Discard the changes.

Before this commit, the x2many didn't come back to its initial state.

Now, the x2many will came back to its initial state.

Note that this commit is a fix up of [1] which already address part of
this issue.

[1] https://github.com/odoo/odoo/commit/e450d03a5f4fc80198837cccf10fa349ecc205a9