### PR TITLE
[FIX] mail: generate mails during mass-mailing in small batches

### DIFF
--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -41,7 +41,7 @@ class MailComposer(models.TransientModel):
     _inherit = 'mail.composer.mixin'
     _description = 'Email composition wizard'
     _log_access = True
-    _batch_size = 500
+    _batch_size = 50
 
     @api.model
     def default_get(self, fields_list):
@@ -392,7 +392,7 @@ class MailComposer(models.TransientModel):
             else:
                 active_res_ids = parse_res_ids(self.env.context.get('active_ids'))
                 # beware, field is limited in storage, usage of active_ids in context still required
-                if active_res_ids and len(active_res_ids) <= self._batch_size:
+                if active_res_ids and len(active_res_ids) <= 500:
                     composer.res_ids = f"{self.env.context['active_ids']}"
                 elif not active_res_ids and self.env.context.get('active_id'):
                     composer.res_ids = f"{[self.env.context['active_id']]}"
@@ -728,7 +728,7 @@ class MailComposer(models.TransientModel):
 
         batch_size = int(
             self.env['ir.config_parameter'].sudo().get_param('mail.batch_size')
-        ) or self._batch_size  # be sure to not have 0, as otherwise no iteration is done
+        ) or self._batch_size or 50  # be sure to not have 0, as otherwise no iteration is done
         for res_ids_iter in tools.split_every(batch_size, res_ids):
             res_ids_values = list(self._prepare_mail_values(res_ids_iter).values())
 

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -2963,7 +2963,7 @@ class TestComposerResultsMass(TestMailComposer):
             composer = composer_form.save()
             self.assertTrue(composer.composition_batch)
             self.assertEqual(composer.composition_mode, 'mass_mail')
-            self.assertFalse(composer.res_ids)
+            self.assertEqual(sorted(literal_eval(composer.res_ids)), sorted(self.test_records.ids))
 
             with self.mock_mail_gateway(mail_unlink_sent=True):
                 composer._action_send_mail()


### PR DESCRIPTION
## Description
Following cef5ae8a80988c4e0529c1770b1c1e573490f6e7, the default `batch_size` for generating the mails was changed from `500`->`50`. But one instance seems to have been missed, during the generation of mails in the wizard, which is used by the mass-mailing cron.
To address this, we are just changing `self.batch_size` in the wizard from `500`->`50` (the variable may have been overridden in custom code, so we keep the static variable)

Backport of ac51f29f91e34cf4794164658a8c27d8b7759230

## Reference
opw-4142511

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
