### PR TITLE
[PERF] spreadsheet: don't throw error when loading list

### DIFF
--- a/addons/spreadsheet/static/src/list/plugins/list_ui_plugin.js
+++ b/addons/spreadsheet/static/src/list/plugins/list_ui_plugin.js
@@ -8,7 +8,7 @@ import { globalFiltersFieldMatchers } from "@spreadsheet/global_filters/plugins/
 import { OdooUIPlugin } from "@spreadsheet/plugins";
 
 const { astToFormula } = spreadsheet;
-const { isEvaluationError, toString } = spreadsheet.helpers;
+const { isEvaluationError } = spreadsheet.helpers;
 
 /**
  * @typedef {import("./list_core_plugin").SpreadsheetList} SpreadsheetList
@@ -297,7 +297,7 @@ export class ListUIPlugin extends OdooUIPlugin {
         const dataSource = this.getters.getListDataSource(listId);
         dataSource.addFieldToFetch(fieldName);
         const value = dataSource.getListCellValue(position, fieldName);
-        if (isEvaluationError(toString(value))) {
+        if (typeof value === "object" && isEvaluationError(value.value)) {
             return value;
         }
         const field = dataSource.getField(fieldName);


### PR DESCRIPTION
This `if` is meant to detect when the list is loading and return the error instead of throwing it (throwing is slow)
...except `toString` throws if the value is an error :man_facepalming:

Issue introduced with 5b6c2f7589131c59fdd27368aaf1fbb79bdd9b55

Task: 4199066


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
