### PR TITLE
[FIX] hr_holidays : cache issues

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -575,7 +575,7 @@ class HolidaysAllocation(models.Model):
         if self.type_request_unit in ['hour']:
             return float_round(fake_allocation.number_of_hours_display - self.number_of_hours_display, precision_digits=2)
         res = round((fake_allocation.number_of_days - self.number_of_days), 2)
-        self._invalidate_cache()
+        fake_allocation._invalidate_cache(['number_of_days', 'number_of_days_display', 'lastcall', 'nextcall', 'number_of_hours_display'])
         return res
 
     ####################################################

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -1868,6 +1868,48 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
 
             self.assertEqual(allocation.lastcall, datetime.date(2017, 12, 5))
 
+    def test_accrual_allocation_data_persists(self):
+        leave_type = self.env['hr.leave.type'].create({
+            'name': 'Test Leave Type',
+            'time_type': 'leave',
+            'requires_allocation': 'yes',
+            'allocation_validation_type': 'no',
+        })
+        accrual_plan = self.env['hr.leave.accrual.plan'].create({
+            'name': 'Accrual Plan For Test',
+            'accrued_gain_time': 'start',
+            'carryover_date': 'year_start',
+            'level_ids': [(0, 0, {
+                'start_count': 1,
+                'start_type': 'day',
+                'added_value': 1,
+                'added_value_type': 'day',
+                'frequency': 'daily',
+                'cap_accrued_time': True,
+                'maximum_leave': 10
+            })],
+        })
+
+        def get_remaining_leaves(*args):
+            return leave_type.get_allocation_data(self.employee_emp, datetime.date(*args))[self.employee_emp][0][1][
+                'remaining_leaves']
+
+        with freeze_time("2024-03-01"):
+            # Simulate creating an allocation from frontend interface
+            with Form(self.env['hr.leave.allocation']) as f:
+                f.allocation_type = "accrual"
+                f.accrual_plan_id = accrual_plan
+                f.employee_ids.add(self.employee_emp)
+                f.holiday_status_id = leave_type
+                f.date_from = '2024-02-01'
+                f.private_name = "Accrual allocation for employee"
+
+            allocation = f.record
+            allocation.action_validate()
+
+            first_result = get_remaining_leaves(2024, 2, 21)
+            self.assertEqual(get_remaining_leaves(2024, 2, 21), first_result, "Function return result should persist")
+
     def test_future_accural_time_with_leaves_taken_in_the_past(self):
         leave_type = self.env['hr.leave.type'].create({
             'name': 'Test Leave Type',
@@ -1890,7 +1932,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             })],
         })
 
-        def get_reamining_leaves(*args):
+        def get_remaining_leaves(*args):
             return leave_type.get_allocation_data(self.employee_emp, datetime.date(*args))[self.employee_emp][0][1][
                 'remaining_leaves']
 
@@ -1906,7 +1948,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
 
             allocation = f.record
             allocation.action_validate()
-            self.assertEqual(get_reamining_leaves(2024, 3, 1), 10, "The cap is reached, no more leaves should be accrued")
+            self.assertEqual(get_remaining_leaves(2024, 3, 1), 10, "The cap is reached, no more leaves should be accrued")
 
             leave = self.env['hr.leave'].create({
                 'name': 'leave',
@@ -1916,10 +1958,9 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'request_date_to': '2024-03-01',
             })
             leave.action_validate()
-            self.assertEqual(get_reamining_leaves(2024, 3, 1), 5, "5 day should be deduced from the allocation")
-            self.assertEqual(get_reamining_leaves(2024, 3, 3), 7, "2 days should be added to the accrual allocation")
-            self.assertEqual(get_reamining_leaves(2024, 3, 3), 7, "Function return result should persist")
-            self.assertEqual(get_reamining_leaves(2024, 3, 10), 10, "Accrual allocation should be capped at 10")
+            self.assertEqual(get_remaining_leaves(2024, 3, 1), 5, "5 day should be deduced from the allocation")
+            self.assertEqual(get_remaining_leaves(2024, 3, 3), 7, "2 days should be added to the accrual allocation")
+            self.assertEqual(get_remaining_leaves(2024, 3, 10), 10, "Accrual allocation should be capped at 10")
 
             leave = self.env['hr.leave'].create({
                 'name': 'leave',
@@ -1929,8 +1970,8 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'request_date_to': '2024-03-08',
             })
             leave.action_validate()
-            self.assertEqual(get_reamining_leaves(2024, 3, 4), 3, "5 days should be deduced from the allocation and a new day should be accrued")
-            self.assertEqual(get_reamining_leaves(2024, 3, 11), 10, "Accrual allocation should be capped at 10")
+            self.assertEqual(get_remaining_leaves(2024, 3, 4), 3, "5 days should be deduced from the allocation and a new day should be accrued")
+            self.assertEqual(get_remaining_leaves(2024, 3, 11), 10, "Accrual allocation should be capped at 10")
 
     @freeze_time('2024-01-01')
     def test_validate_leaves_with_more_days_than_allocation(self):


### PR DESCRIPTION
There were some cache inconsistencies when computing remaining leaves on the dashboard or in the accrual scheduled actions due to commit 7ef0ad2.

The cache invalidation is necessary to avoid issues when the call to process_accrual is made twice in a row, but the cache invalidation was too broad.

This commit aims at only invalidating the part of the cache that were causing issues when computing the remaining leaves.

opw-4167557
opw-4167582
opw-4175815
opw-4149134
opw-4241970
