### PR TITLE
[FIX] point_of_sale: retrieve role from the correct field

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.js
@@ -19,7 +19,7 @@ export class ProductInfoPopup extends Component {
     }
     _hasMarginsCostsAccessRights() {
         const isAccessibleToEveryUser = this.pos.config.is_margins_costs_accessible_to_every_user;
-        const isCashierManager = this.pos.get_cashier().raw.role === "manager";
+        const isCashierManager = this.pos.get_cashier().role === "manager";
         return isAccessibleToEveryUser || isCashierManager;
     }
 }

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -692,6 +692,7 @@ export class PosStore extends Reactive {
      * @returns {name: string, id: int, role: string}
      */
     get_cashier() {
+        this.user.role = this.user._raw.role;
         return this.user;
     }
     get_cashier_user_id() {

--- a/addons/pos_hr/static/tests/tours/PosHrTour.js
+++ b/addons/pos_hr/static/tests/tours/PosHrTour.js
@@ -107,3 +107,17 @@ registry.category("web_tour.tours").add("CashierStayLogged", {
             PosHr.loginScreenIsShown(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("CashierCanSeeProductInfo", {
+    test: true,
+    steps: () =>
+        [
+            PosHr.loginScreenIsShown(),
+            PosHr.clickLoginButton(),
+            SelectionPopup.has("Mitchell Admin", { run: "click" }),
+            Dialog.confirm("Open session"),
+            ProductScreen.clickInfoProduct("product_a"),
+            Dialog.confirm("Ok"),
+            Dialog.isNot(),
+        ].flat(),
+});

--- a/addons/pos_hr/tests/test_frontend.py
+++ b/addons/pos_hr/tests/test_frontend.py
@@ -65,3 +65,14 @@ class TestUi(TestPosHrHttpCommon):
             "CashierStayLogged",
             login="pos_admin",
         )
+
+    def test_cashier_can_see_product_info(self):
+        # open a session, the /pos/ui controller will redirect to it
+        self.product_a.available_in_pos = True
+        self.main_pos_config.with_user(self.pos_admin).open_ui()
+
+        self.start_tour(
+            "/pos/ui?config_id=%d" % self.main_pos_config.id,
+            "CashierCanSeeProductInfo",
+            login="pos_admin",
+        )


### PR DESCRIPTION
Problem:
The `role` attribute is being retrieved from the `raw` field, but when the page is refreshed, all attributes (including `role`) are set in the `cashier` object, not in `raw`.

Steps to reproduce:

- Set up a PoS session with the "Log in with Employees" setting enabled.
- Use a User/Employee with Administrator PoS access (e.g., Mitchell Admin).
- Start a PoS session.
- Refresh the page.
- Click the "i" icon to see more information about a product.
- A traceback occurs.

opw-4120414

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
