### PR TITLE
[IMP] mrp: breadcrumbs naming improvement

### DIFF
--- a/addons/mrp/models/stock_picking.py
+++ b/addons/mrp/models/stock_picking.py
@@ -151,6 +151,7 @@ class StockPicking(models.Model):
     def action_view_mrp_production(self):
         self.ensure_one()
         action = {
+            'name': _("Manufacturing Orders"),
             'res_model': 'mrp.production',
             'type': 'ir.actions.act_window',
             'domain': [('id', 'in', self.production_ids.ids)],


### PR DESCRIPTION
Before this commit:
=======================
When accessing the manufacturing order tree view through the smart Manufacturing button on a transfer, the breadcrumb displayed 'Unnamed' instead of 'Manufacturing Orders.'

After this commit:
=====================
The breadcrumb now correctly shows 'Manufacturing Orders' when accessing the manufacturing order tree view via the smart button on a transfer, ensuring consistency with the normal tree view.

task-4190266
