### PR TITLE
[IMP] board, *: simplify kanban archs

### DIFF
--- a/addons/board/static/tests/board.test.js
+++ b/addons/board/static/tests/board.test.js
@@ -373,8 +373,8 @@ describe.tags("desktop")("board_desktop", () => {
         Partner._views["kanban,5"] = `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`;
@@ -436,11 +436,9 @@ describe.tags("desktop")("board_desktop", () => {
         Partner._views.kanban = `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <div><field name="foo"/></div>
-                            <button name="sitting_on_a_park_bench" type="object">Eying little girls with bad intent</button>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
+                        <button name="sitting_on_a_park_bench" type="object">Eying little girls with bad intent</button>
                     </t>
                 </templates>
             </kanban>`;

--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -285,7 +285,7 @@
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                     <templates>
                     <t t-name="kanban-menu" groups="hr_contract.group_hr_contract_manager">
-                        <t t-if="widget.editable"><a role="menuitem" type="edit" class="dropdown-item">Edit Contract</a></t>
+                        <t t-if="widget.editable"><a role="menuitem" type="open" class="dropdown-item">Edit Contract</a></t>
                         <t t-if="widget.deletable"><a role="menuitem" type="delete" class="dropdown-item">Delete</a></t>
                     </t>
                     <t t-name="kanban-card">

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -371,7 +371,7 @@
                 <field name="can_approve"/>
                 <templates>
                     <t t-name="kanban-menu" groups="base.group_user">
-                        <a t-if="widget.editable" role="menuitem" type="edit" class="dropdown-item">Edit Allocation</a>
+                        <a t-if="widget.editable" role="menuitem" type="open" class="dropdown-item">Edit Allocation</a>
                         <a t-if="widget.deletable" role="menuitem" type="delete" class="dropdown-item">Delete</a>
                     </t>
                     <t t-name="kanban-card" class="flex-row">

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -112,7 +112,7 @@
                 <field name="supported_attachment_ids_count"/>
                 <templates>
                     <t t-name="kanban-menu" groups="base.group_user">
-                        <a t-if="widget.editable" role="menuitem" type="edit" class="dropdown-item">Edit Time Off</a>
+                        <a t-if="widget.editable" role="menuitem" type="open" class="dropdown-item">Edit Time Off</a>
                         <a t-if="widget.deletable" role="menuitem" type="delete" class="dropdown-item">Delete</a>
                     </t>
                     <t t-name="kanban-card" class="row g-0">

--- a/addons/hr_recruitment/views/hr_job_views.xml
+++ b/addons/hr_recruitment/views/hr_job_views.xml
@@ -62,7 +62,7 @@
                                     <field name="color" widget="kanban_color_picker"/>
                                 </div>
                                 <div class="col-6" role="menuitem">
-                                    <a class="dropdown-item" t-if="widget.editable" name="edit_job" type="edit">Configuration</a>
+                                    <a class="dropdown-item" t-if="widget.editable" name="edit_job" type="open">Configuration</a>
                                     <a class="dropdown-item" t-if="record.active.raw_value" type="archive" >Archive</a>
                                     <a class="dropdown-item" t-if="!record.active.raw_value" name="toggle_active" type="object">Unarchive</a>
                                 </div>
@@ -90,7 +90,7 @@
                                 </button>
                             </div>
                             <div class="col-5">
-                                <a name="edit_job" type="edit" t-attf-class="{{ record.no_of_recruitment.raw_value > 0 ? 'text-primary fw-bolder' : 'text-secondary' }}" groups="hr_recruitment.group_hr_recruitment_user">
+                                <a name="edit_job" type="open" t-attf-class="{{ record.no_of_recruitment.raw_value > 0 ? 'text-primary fw-bolder' : 'text-secondary' }}" groups="hr_recruitment.group_hr_recruitment_user">
                                     <field name="no_of_recruitment"/> To Recruit
                                 </a>
                                 <span t-attf-class="{{ record.no_of_recruitment.raw_value > 0 ? 'text-primary fw-bolder' : 'text-secondary' }}" groups="!hr_recruitment.group_hr_recruitment_user">

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -311,10 +311,8 @@ test("create new record and load it correctly", async () => {
             "kanban,false": `
                 <kanban>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div>
-                                <field name="name"/>
-                            </div>
+                        <t t-name="kanban-card">
+                            <field name="name"/>
                         </t>
                     </templates>
                 </kanban>

--- a/addons/lunch/static/tests/lunch_is_favorite_field.test.js
+++ b/addons/lunch/static/tests/lunch_is_favorite_field.test.js
@@ -21,11 +21,9 @@ class LunchProduct extends models.Model {
         "kanban,false": `
             <kanban class="o_kanban_test" edit="0">
                 <template>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="is_favorite" widget="lunch_is_favorite" nolabel="1"/>
-                            <field name="name"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="is_favorite" widget="lunch_is_favorite" nolabel="1"/>
+                        <field name="name"/>
                     </t>
                 </template>
             </kanban>

--- a/addons/mrp/views/stock_picking_views.xml
+++ b/addons/mrp/views/stock_picking_views.xml
@@ -52,7 +52,7 @@
                     <div t-if="widget.editable" class="o_kanban_card_manage_settings row">
                         <field name="is_favorite" widget="boolean_favorite" class="col-6"/>
                         <div class="col-6 text-end">
-                            <a class="dropdown-item" role="menuitem" type="edit">Configuration</a>
+                            <a class="dropdown-item" role="menuitem" type="open">Configuration</a>
                         </div>
                     </div>
                 </div>

--- a/addons/repair/views/stock_picking_views.xml
+++ b/addons/repair/views/stock_picking_views.xml
@@ -82,7 +82,7 @@
                         <div t-if="widget.editable" class="o_kanban_card_manage_settings row">
                             <field name="is_favorite" widget="boolean_favorite" class="col-6"/>
                             <div role="menuitem" class="col-6 text-end">
-                                <a class="dropdown-item" role="menuitem" type="edit">Configuration</a>
+                                <a class="dropdown-item" role="menuitem" type="open">Configuration</a>
                             </div>
                         </div>
                     </div>

--- a/addons/sale_pdf_quote_builder/views/quotation_document_views.xml
+++ b/addons/sale_pdf_quote_builder/views/quotation_document_views.xml
@@ -73,7 +73,7 @@
                 <field name="active"/>
                 <templates>
                     <t t-name="kanban-menu">
-                        <a t-if="widget.editable" type="edit" class="dropdown-item">Edit</a>
+                        <a t-if="widget.editable" type="open" class="dropdown-item">Edit</a>
                         <a t-if="widget.deletable" type="delete" class="dropdown-item">Delete</a>
                         <a
                             t-attf-href="/web/content/#{record.ir_attachment_id.raw_value}?download=true"

--- a/addons/sales_team/views/crm_team_views.xml
+++ b/addons/sales_team/views/crm_team_views.xml
@@ -153,7 +153,7 @@
                                     <field name="color" widget="kanban_color_picker"/>
                                 </div>
                                 <div role="menuitem" class="col-4">
-                                    <a class="dropdown-item" type="edit">Configuration</a>
+                                    <a class="dropdown-item" type="open">Configuration</a>
                                 </div>
                             </div>
                         </div>

--- a/addons/stock/views/stock_picking_type_views.xml
+++ b/addons/stock/views/stock_picking_type_views.xml
@@ -223,7 +223,7 @@
                             <div t-if="widget.editable" class="o_kanban_card_manage_settings row">
                                 <field name="is_favorite" widget="boolean_favorite" class="col-6"/>
                                 <div class="col-6 text-end">
-                                    <a class="dropdown-item" role="menuitem" type="edit">Configuration</a>
+                                    <a class="dropdown-item" role="menuitem" type="open">Configuration</a>
                                 </div>
                             </div>
                         </div>

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -12894,10 +12894,8 @@ test.tags("desktop")(`kanban view: press "hotkey" to execute header button actio
                 </header>
                 <field name="bar" />
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo" />
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,

--- a/addons/website_crm_partner_assign/views/crm_lead_views.xml
+++ b/addons/website_crm_partner_assign/views/crm_lead_views.xml
@@ -181,10 +181,7 @@
             <field name="model">crm.lead</field>
             <field name="inherit_id" ref="crm.crm_case_kanban_view_leads"/>
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='partner_id']" position="replace">
-                    <span t-att-title="record.partner_id.value">
-                        <field class="text-truncate" name="partner_id"/>
-                    </span>
+                <xpath expr="//field[@name='partner_id']" position="after">
                     <span class="text-truncate ms-1" t-if="record.partner_assigned_id.value">
                         (<i class="fa fa-long-arrow-right me-1" aria-label="Assigned Partner" title="Assigned Partner"/>
                         <span t-att-title="record.partner_assigned_id.value"><field name="partner_assigned_id"/></span>)

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -3236,8 +3236,7 @@ Forbidden owl directive used in arch (t-on-click).""",
 
     @mute_logger('odoo.addons.base.models.ir_ui_view')
     def test_forbidden_owl_directives_in_kanban(self):
-        arch = "<kanban><templates><t t-name='kanban-box'>%s</t></templates></kanban>"
-
+        arch = "<kanban><templates><t t-name='kanban-card'>%s</t></templates></kanban>"
         self.assertValid(arch % ('<span t-esc="record.resId"/>'))
         self.assertValid(arch % ('<t t-debug=""/>'))
 
@@ -3245,7 +3244,7 @@ Forbidden owl directive used in arch (t-on-click).""",
             arch % ('<span t-on-click="x.doIt()"/>'),
             """Error while validating view near:
 
-<kanban __validate__="1"><templates><t t-name="kanban-box"><span t-on-click="x.doIt()"/></t></templates></kanban>
+<kanban __validate__="1"><templates><t t-name="kanban-card"><span t-on-click="x.doIt()"/></t></templates></kanban>
 Forbidden owl directive used in arch (t-on-click).""",
         )
 
@@ -3271,13 +3270,13 @@ Forbidden attribute used in arch (data-tooltip-template)."""
 
     @mute_logger('odoo.addons.base.models.ir_ui_view')
     def test_forbidden_data_tooltip_attributes_in_kanban(self):
-        arch = "<kanban><templates><t t-name='kanban-box'>%s</t></templates></kanban>"
+        arch = "<kanban><templates><t t-name='kanban-card'>%s</t></templates></kanban>"
 
         self.assertInvalid(
             arch % ('<span data-tooltip="Test"/>'),
             """Error while validating view near:
 
-<kanban __validate__="1"><templates><t t-name="kanban-box"><span data-tooltip="Test"/></t></templates></kanban>
+<kanban __validate__="1"><templates><t t-name="kanban-card"><span data-tooltip="Test"/></t></templates></kanban>
 Forbidden attribute used in arch (data-tooltip)."""
         )
 
@@ -3285,7 +3284,7 @@ Forbidden attribute used in arch (data-tooltip)."""
             arch % ('<span data-tooltip-template="test"/>'),
             """Error while validating view near:
 
-<kanban __validate__="1"><templates><t t-name="kanban-box"><span data-tooltip-template="test"/></t></templates></kanban>
+<kanban __validate__="1"><templates><t t-name="kanban-card"><span data-tooltip-template="test"/></t></templates></kanban>
 Forbidden attribute used in arch (data-tooltip-template)."""
         )
 
@@ -3293,7 +3292,7 @@ Forbidden attribute used in arch (data-tooltip-template)."""
             arch % ('<span t-att-data-tooltip="test"/>'),
             """Error while validating view near:
 
-<kanban __validate__="1"><templates><t t-name="kanban-box"><span t-att-data-tooltip="test"/></t></templates></kanban>
+<kanban __validate__="1"><templates><t t-name="kanban-card"><span t-att-data-tooltip="test"/></t></templates></kanban>
 Forbidden attribute used in arch (t-att-data-tooltip)."""
         )
 
@@ -3301,18 +3300,18 @@ Forbidden attribute used in arch (t-att-data-tooltip)."""
             arch % ('<span t-attf-data-tooltip-template="{{ test }}"/>'),
             """Error while validating view near:
 
-<kanban __validate__="1"><templates><t t-name="kanban-box"><span t-attf-data-tooltip-template="{{ test }}"/></t></templates></kanban>
+<kanban __validate__="1"><templates><t t-name="kanban-card"><span t-attf-data-tooltip-template="{{ test }}"/></t></templates></kanban>
 Forbidden attribute used in arch (t-attf-data-tooltip-template)."""
         )
 
     @mute_logger('odoo.addons.base.models.ir_ui_view')
     def test_forbidden_use_of___comp___in_kanban(self):
-        arch = "<kanban><templates><t t-name='kanban-box'>%s</t></templates></kanban>"
+        arch = "<kanban><templates><t t-name='kanban-card'>%s</t></templates></kanban>"
         self.assertInvalid(
             arch % '<t t-esc="__comp__.props.resId"/>',
             """Error while validating view near:
 
-<kanban __validate__="1"><templates><t t-name="kanban-box"><t t-esc="__comp__.props.resId"/></t></templates></kanban>
+<kanban __validate__="1"><templates><t t-name="kanban-card"><t t-esc="__comp__.props.resId"/></t></templates></kanban>
 Forbidden use of `__comp__` in arch."""
         )
 


### PR DESCRIPTION
\* = [hr_contract, hr_holidays, hr_recruitment, html_editor, lunch, mrp, repair, sale_pdf_quote_builder, sales_team, stock, web,  website_crm_partner_assign, base]

In this commit we have simplified the kanban arch for the above-mentioned modules. The goal is to simplify them, make them easier to read and use bootstrap utility classnames.

- Previously, we used kanban-box, but now we are using kanban-card instead.
- Deprecated oe_kanban_global_click and oe_kanban_global_click_edit.
- More use of <field/> tags
- Removed the oe_kanban_colorpicker class and replaced it with the kanban_color_picker widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- kanban_image from rendering context, is deprecated so we use <field name=... widget=image/> instead
- kanban_color, kanban_getcolor and kanban_getcolorname are deprecated use new attribute highlight_color=color_field_name on root node

Community: https://github.com/odoo/enterprise/pull/70362

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
