### PR TITLE
[IMP] google_calendar: make credentials overridable

### DIFF
--- a/addons/google_calendar/models/res_users.py
+++ b/addons/google_calendar/models/res_users.py
@@ -7,7 +7,7 @@ import logging
 from odoo import api, fields, models, Command
 from odoo.addons.google_calendar.utils.google_calendar import GoogleCalendarService, InvalidSyncToken
 from odoo.addons.google_calendar.models.google_sync import google_calendar_token
-from odoo.addons.google_account.models.google_service import _get_client_secret
+from odoo.addons.google_account.models import google_service
 from odoo.loglevels import exception_to_unicode
 from odoo.tools import str2bool
 
@@ -166,7 +166,7 @@ class User(models.Model):
         """ Checks if both Client ID and Client Secret are defined in the database. """
         ICP_sudo = self.env['ir.config_parameter'].sudo()
         client_id = self.env['google.service']._get_client_id('calendar')
-        client_secret = _get_client_secret(ICP_sudo, 'calendar')
+        client_secret = google_service._get_client_secret(ICP_sudo, 'calendar')
         return bool(client_id and client_secret)
 
     @api.model

--- a/addons/google_calendar/utils/google_calendar.py
+++ b/addons/google_calendar/utils/google_calendar.py
@@ -123,7 +123,8 @@ class GoogleCalendarService():
         state = {
             'd': self.google_service.env.cr.dbname,
             's': 'calendar',
-            'f': from_url
+            'f': from_url,
+            'u': self.google_service.env['ir.config_parameter'].sudo().get_param('database.uuid'),
         }
         base_url = self.google_service._context.get('base_url') or self.google_service.get_base_url()
         return self.google_service._get_authorize_uri(


### PR DESCRIPTION
This commits changes the import of `_get_client_secret` which was being done directly to the function and now imports the whole class instead for making the service more overridable. Additionaly, it also adds the current customer's DB uuid in the authentication flow using it internally.

task-4199388