### PR TITLE
[FIX] account: clear attachment ids to proccess on import error

### DIFF
--- a/addons/account/static/src/components/bills_upload/bills_upload.js
+++ b/addons/account/static/src/components/bills_upload/bills_upload.js
@@ -42,10 +42,18 @@ export class AccountFileUploader extends Component {
     }
 
     async onUploadComplete() {
-        const action = await this.orm.call("account.journal", "create_document_from_attachment", ["", this.attachmentIdsToProcess], {
-            context: { ...this.extraContext, ...this.env.searchModel.context },
-        });
-        this.attachmentIdsToProcess = [];
+        let action;
+        try {
+            action = await this.orm.call(
+                "account.journal",
+                "create_document_from_attachment",
+                ["", this.attachmentIdsToProcess],
+                { context: { ...this.extraContext, ...this.env.searchModel.context } },
+            );
+        } finally {
+            // ensures attachments are cleared on success as well as on error
+            this.attachmentIdsToProcess = [];
+        }
         if (action.context && action.context.notifications) {
             for (let [file, msg] of Object.entries(action.context.notifications)) {
                 this.notification.add(


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Try to import a malformed OFX file into a bank journal;
2. close traceback;
3. try to import a valid OFX or CSV file.

Issue
-----
Same traceback as first upload.

Cause
-----
There's no error handling on the RPC call. If the file is successfully imported, the `attachmentIdsToProcess` gets clear, but if there's an error, the bad file remains in the queue until leaving the view.

Solution
--------
Put the RPC call in a `try` block, and clear the `attachmentIdsToProcess` in `finally` to ensure this happens regardless of outcome.

opw-4113740