### PR TITLE
[FIX] purchase_stock: return intercompany-transit linked to PO

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -246,7 +246,7 @@ class StockMove(models.Model):
 
     def _is_purchase_return(self):
         self.ensure_one()
-        return self.location_dest_id.usage == "supplier"
+        return self.location_dest_id.usage == "supplier" or self.location_dest_id == self.env.ref('stock.stock_location_inter_wh', raise_if_not_found=False)
 
     def _get_all_related_aml(self):
         # The back and for between account_move and account_move_line is necessary to catch the


### PR DESCRIPTION
### Steps to reproduce:

- Have two companies: COMP1, COMP2
- In the settings Enable Multi-step routes Prior to 17.2:
- Inventory > Configuration > Warehouse Management > Locations
- Unarchive: Virtual Locations/Inter-company transit and set is Return Locations
- With COMP1: Create and confirm a PO with COMP2 as vendor for 10 units of a storable product
- Validate the receipt and return. Select the Virtual Locations/Inter-company transit as return location and validate
#### > On the POL the received quantity went from 10 to 20 rather than 0

### Note:

Starting from 17.2, the Inter-company transit location is the default location destination of the return rather than (Partner/Vendor). It also changed its reference to `stock_location_inter_company` so that the fix should be adapted in that version.

### Cause of the Issue:

Currently, the qty_received is computed with respect to moves linkes to the POL. However, a move is flagged as a return only if the usage of its destination supplier (dropshipping and subcontracting flow excluded): https://github.com/odoo/odoo/blob/f494496b5142af23ee46ce249a1063f9d6caf403/addons/purchase_stock/models/stock_move.py#L247-L249 and if it is not flagged a return, its quantity is counted positively rather than negatively in the received quantity:
https://github.com/odoo/odoo/blob/f494496b5142af23ee46ce249a1063f9d6caf403/addons/purchase_stock/models/purchase.py#L348-L370

opw-4190647
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
