### PR TITLE
[IMP] point_of_sale: improve combo display on cart/preparation display

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -109,10 +109,12 @@ class PosOrder(models.Model):
                 continue
 
             line = line[2]
-
             if line.get('combo_line_ids'):
                 filtered_lines = list(filter(lambda l: l[0] in [0, 1] and l[2].get('id') and l[2].get('id') in line.get('combo_line_ids'), order_vals['lines']))
-                acc[line['uuid']] = [l[2]['uuid'] for l in filtered_lines]
+                if line['uuid'] in acc:
+                    acc[line['uuid']].append([l[2]['uuid'] for l in filtered_lines])
+                else:
+                    acc[line['uuid']] = [l[2]['uuid'] for l in filtered_lines]
 
             line['combo_line_ids'] = False
             line['combo_parent_id'] = False

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -706,6 +706,21 @@ export class PosOrderline extends Base {
     isSelected() {
         return this.order_id?.uiState?.selected_orderline_uuid === this.uuid;
     }
+    setDirty(processedLines = new Set()) {
+        if (processedLines.has(this)) {
+            return;
+        }
+        processedLines.add(this);
+        super.setDirty();
+        const linesToSetDirty = [
+            this.combo_parent_id,
+            ...(this.combo_parent_id?.combo_line_ids || []),
+            ...(this.combo_line_ids || []),
+        ].filter(Boolean);
+        for (const line of linesToSetDirty) {
+            line.setDirty(processedLines);
+        }
+    }
 }
 
 registry.category("pos_available_models").add(PosOrderline.pythonModel, PosOrderline);

--- a/addons/pos_restaurant/static/src/app/models/pos_order_line.js
+++ b/addons/pos_restaurant/static/src/app/models/pos_order_line.js
@@ -16,6 +16,22 @@ patch(PosOrderline.prototype, {
         if (this.uiState.hasChange || this.skip_change) {
             this.setDirty();
             this.skip_change = !this.skip_change;
+            // update with the combo parent if applicable
+            if (this.combo_parent_id) {
+                const parent = this.combo_parent_id;
+                parent.skip_change = this.skip_change;
+                this.updateChildrenSkipChange(parent);
+            }
+            if (this.combo_line_ids) {
+                this.updateChildrenSkipChange(this);
+            }
+        }
+    },
+    updateChildrenSkipChange(parentOrderline) {
+        for (const comboLine of parentOrderline.combo_line_ids) {
+            if (comboLine.uiState.hasChange || comboLine.skip_change) {
+                comboLine.skip_change = this.skip_change;
+            }
         }
     },
     showSkipChange() {


### PR DESCRIPTION
- Indent child combo product in prepatration display
- Implemented synchronization between combo lines and parent orderlines for consistent handling of the `skip_change` state across all related lines.
- Added a parent-child connection for orderlines in preparation display so that we can check the combo parent only to send the combo-lines to the next change and vice versa.

Task ID: 4180121
Related: https://github.com/odoo/enterprise/pull/70365
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
