### PR TITLE
[FIX] website_event_sale: fix website_sale_event_tour

### DIFF
--- a/addons/website_event_sale/static/tests/tours/helpers/WebsiteEventSaleTourMethods.js
+++ b/addons/website_event_sale/static/tests/tours/helpers/WebsiteEventSaleTourMethods.js
@@ -1,6 +1,12 @@
 /** @odoo-module **/
 import * as wsTourUtils from '@website_sale/js/tours/tour_utils';
 
+const closeModal = {
+    content: "Close the ticket picking modal",
+    trigger: `.modal-content button:contains("Close")`,
+    run: "click",
+};
+
 export function changePricelist(pricelistName) {
     return [
         {
@@ -24,8 +30,8 @@ export function changePricelist(pricelistName) {
         },
     ];
 }
-function checkPriceEvent(eventName, price) {
-    return [
+function checkPriceEvent(eventName, price, close = true) {
+    const steps = [
         {
             content: "Go to page Event",
             trigger: '.nav-link:contains("Event")',
@@ -45,21 +51,21 @@ function checkPriceEvent(eventName, price) {
             content: "Verify Price",
             trigger: `.oe_currency_value:contains(${price})`,
         },
-        {
-            content: "Open the ticket picking modal",
-            trigger: `.modal-content button:contains("Close")`,
-            run: "click",
-        },
-    ]
+    ];
+    if (close) {
+        steps.push(closeModal);
+    }
+    return steps;
 }
 function checkPriceDiscountEvent(eventName, price, discount) {
     return [
-        ...checkPriceEvent(eventName, price),
+        ...checkPriceEvent(eventName, price, false),
         {
             content: "Verify Price before discount",
             trigger: `del:contains(${discount})`,
         },
-    ]
+        closeModal,
+    ];
 }
 export function checkPriceCart(price) {
     return [


### PR DESCRIPTION
In this commit, we fix the function checkPriceDiscountEvent. In this one, we must close the modal after checking the discount otherwise the element is no longer in the DOM.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
