### PR TITLE
[FIX][16.0] point of sale report - make the total number of orders under analysis acceptable for accounting purposes

### DIFF
--- a/addons/point_of_sale/report/pos_order_report.py
+++ b/addons/point_of_sale/report/pos_order_report.py
@@ -45,7 +45,7 @@ class PosOrderReport(models.Model):
                 s.date_order AS date,
                 SUM(l.qty) AS product_qty,
                 SUM(l.qty * l.price_unit / CASE COALESCE(s.currency_rate, 0) WHEN 0 THEN 1.0 ELSE s.currency_rate END) AS price_sub_total,
-                SUM(ROUND((l.price_subtotal_incl) / CASE COALESCE(s.currency_rate, 0) WHEN 0 THEN 1.0 ELSE s.currency_rate END, cu.decimal_places)) AS price_total,
+                ROUND(SUM(l.price_subtotal_incl / CASE COALESCE(s.currency_rate, 0) WHEN 0 THEN 1.0 ELSE s.currency_rate END), cu.decimal_places) AS price_total,
                 SUM((l.qty * l.price_unit) * (l.discount / 100) / CASE COALESCE(s.currency_rate, 0) WHEN 0 THEN 1.0 ELSE s.currency_rate END) AS total_discount,
                 CASE
                     WHEN SUM(l.qty * u.factor) = 0 THEN NULL
@@ -84,13 +84,14 @@ class PosOrderReport(models.Model):
     def _group_by(self):
         return """
             GROUP BY
-                s.id, s.date_order, s.partner_id,s.state, pt.categ_id,
+                s.id, s.date_order, s.partner_id, s.state, pt.categ_id,
                 s.user_id, s.company_id, s.sale_journal,
                 s.pricelist_id, s.account_move, s.create_date, s.session_id,
                 l.product_id,
                 pt.categ_id, pt.pos_categ_id,
                 p.product_tmpl_id,
-                ps.config_id
+                ps.config_id,
+                cu.decimal_places
         """
 
     def init(self):

--- a/doc/cla/individual/PlantBasedStudio.md
+++ b/doc/cla/individual/PlantBasedStudio.md
@@ -1,0 +1,11 @@
+France, 2024-09-20
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Horvat Damien <ultrarushgame@gmail.com> https://github.com/PlantBasedStudio


### PR DESCRIPTION
**Description of the problem/feature addressed by this PR:**

**Explanation :** 

The current total calculation method rounds up each order at the point of sale, taking into account the currency used. With a large number of orders, you end up with cumulative rounding and large discrepancies between the figures in the accounts and the total in the pivot view.

**To reproduce the error :** 

Place a large number of point-of-sale orders in currency with 2 decimal places. The more orders there are, the more discrepancies there will be between the pivot view and the accounting entries on the order total.  


**Current behavior before PR :** 

The figure given is due to a calculation line that rounds the values before adding them together. 

**Desired behavior after PR :**

For this to be accurate, the amounts must first be summed before rounding to avoid a cumulative rounding error.




**I changed this line of point_of_sale/report/pos_order_report.py :** 
`SUM(ROUND((l.price_subtotal_incl) / CASE COALESCE(s.currency_rate, 0) WHEN 0 THEN 1.0 ELSE s.currency_rate END, cu.decimal_places)) AS price_total,`

**To :** 
`ROUND(SUM(l.price_subtotal_incl / CASE COALESCE(s.currency_rate, 0) WHEN 0 THEN 1.0 ELSE s.currency_rate END), cu.decimal_places) AS price_total,`

Can I get help to validate this PR, a review or help to validate the test? 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
