### PR TITLE
[IMP] mass_mailing: remove tooltip

### DIFF
--- a/addons/mass_mailing/static/src/xml/mass_mailing.xml
+++ b/addons/mass_mailing/static/src/xml/mass_mailing.xml
@@ -8,9 +8,6 @@
         </t>
     </div>
     <div t-name="mass_mailing.theme_selector_new" class="o_mail_theme_selector_new">
-        <div t-attf-class="o_mailing_template_message text-white text-start mx-4 pt-2 px-1 #{templates.length ? 'd-none': ''}">
-            Click on the ⭐ next to the subject to save this mailing as a <span t-esc="modelName"/> template
-        </div>
         <div class="o_mailing_template_preview_wrapper d-inline-block w-100">
             <div t-foreach="templates" t-as="template" t-key="template_index"
                 class="o_mail_template_preview d-inline-block dropdown-item"


### PR DESCRIPTION
This PR ensures that the tooltip is no longer displayed in mass_mailing template since the button's functionality is already clear. 

Task-4196854