### PR TITLE
[FIX] mrp: always show kit comp under kit on delivery slip

### DIFF
--- a/addons/mrp/report/report_deliveryslip.xml
+++ b/addons/mrp/report/report_deliveryslip.xml
@@ -27,8 +27,8 @@
     </template>
 
     <template id="stock_report_delivery_kit_sections">
-        <!-- get all kits-related SML, including subkits and excluding the packaged SML -->
-        <t t-set="all_kits_move_lines" t-value="o.move_line_ids.filtered(lambda l: l.move_id.bom_line_id.bom_id.type == 'phantom' and not l.result_package_id)"/>
+        <!-- get all kits-related SML, including subkits -->
+        <t t-set="all_kits_move_lines" t-value="o.move_line_ids.filtered(lambda l: l.move_id.bom_line_id.bom_id.type == 'phantom')"/>
         <!-- do another map to get unique top level kits -->
         <t t-set="boms" t-value="has_kits.mapped('move_id.bom_line_id.bom_id')"/>
         <t t-foreach="boms" t-as="bom">


### PR DESCRIPTION
**Current behavior:**
If a kit component is packaged, it will only appear once on a delivery slip for the kit product under the package section.

**Expected behavior:**
It should always (also) be shown under the kit section.

**Steps to reproduce:**
1. Create a product with a kit bom with 2 components

2. Create on-hand quantities for the components, where one is in a package and the other is not

3. Create a delivery for the kit product, validate, print the delivery slip

**Cause of the issue:**
These move lines were intentionally separated.

**Fix:**
Remove the template logic where the lines that previously displayed such lines one time, prioritizing the package.

opw-4148795