### PR TITLE
[IMP] website: support Google Consent Mode V2

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1870,3 +1870,16 @@ class Website(models.Model):
                         for word in re.findall(match_pattern, value):
                             if word[0] == search[0]:
                                 yield word.lower()
+
+    def _allConsentsGranted(self):
+        """
+        Checks if all (cookies) consents have been granted. Note that in the
+        case no cookies bar has been enabled, this considers that full consent
+        has been immediately given. Indeed, in that case, we suppose that the
+        user implemented his own consent behavior through custom code / app.
+        That custom code / app is able to override this function as desired and
+        xpath the `tracking_code_config` script in `website.layout`.
+        :return: True if all consents have been granted, False otherwise
+        """
+        self.ensure_one()
+        return not self.cookies_bar or self.env['ir.http']._is_allowed_cookie('optional')

--- a/addons/website/static/src/snippets/s_popup/000.js
+++ b/addons/website/static/src/snippets/s_popup/000.js
@@ -396,7 +396,11 @@ publicWidget.registry.cookies_bar = PopupWidget.extend({
      * @param ev
      */
     _onAcceptClick(ev) {
-        this.cookieValue = `{"required": true, "optional": ${ev.target.id === 'cookies-consent-all'}}`;
+        const isFullConsent = ev.target.id === "cookies-consent-all";
+        this.cookieValue = `{"required": true, "optional": ${isFullConsent}}`;
+        if (isFullConsent) {
+            document.dispatchEvent(new Event("optionalCookiesAccepted"));
+        }
         this._onHideModal();
         this.toggleEl && this.toggleEl.remove();
     },

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -201,13 +201,37 @@
     </xpath>
 
     <xpath expr="//div[@id='wrapwrap']" position="after">
-        <t t-if="website and website.google_analytics_key and request.env['ir.http']._is_allowed_cookie('optional') and not editable">
+        <t t-if="website and website.google_analytics_key and not editable">
             <script id="tracking_code" async="1" t-attf-src="https://www.googletagmanager.com/gtag/js?id={{ website.google_analytics_key }}"></script>
-            <script>
+            <script id="tracking_code_config">
                 window.dataLayer = window.dataLayer || [];
                 function gtag(){dataLayer.push(arguments);}
+                gtag('consent', 'default', {
+                    'ad_storage': 'denied',
+                    'ad_user_data': 'denied',
+                    'ad_personalization': 'denied',
+                    'analytics_storage': 'denied',
+                });
                 gtag('js', new Date());
                 gtag('config', '<t t-esc="website.google_analytics_key"/>');
+                function allConsentsGranted() {
+                    gtag('consent', 'update', {
+                        'ad_storage': 'granted',
+                        'ad_user_data': 'granted',
+                        'ad_personalization': 'granted',
+                        'analytics_storage': 'granted',
+                    });
+                }
+                <t t-if="website._allConsentsGranted()">
+                    allConsentsGranted();
+                </t>
+                <t t-else="">
+                    document.addEventListener(
+                        "optionalCookiesAccepted",
+                        allConsentsGranted,
+                        {once: true}
+                    );
+                </t>
             </script>
         </t>
         <t t-if="website and website.plausible_shared_key and not editable">


### PR DESCRIPTION
Commit [958b41c4] added an event triggered when clicking on "Accept all" on a cookie banner (in 17.4) and [cee8a5e6] added support for Google Consent Mode V2 in master (18.0).
This commit backports the relevant parts of both so that stable versions are compliant with Google's policy and that the analytics are properly working. The event will also make it easier for customers to add custom code working with Odoo's standard cookie banner.

Note that due to [958b41c4], the behavior of Google Consent Mode is slightly different in stable versions than in 17.4 and above:
- In stable, Google is called on page load with consents set on denied. This grants that only cookieless pings, non-identifying information is sent to Google (see [Google's documentation]). It is updated once the cookies are accepted.
- In 17.4 and above, Google is not called until the cookies are accepted and only then receives the default + updated consents.

[958b41c4]: https://github.com/odoo/odoo/commit/958b41c4acec7e1700ca4d6e0b25ee0ad2aac9f1
[cee8a5e6]: https://github.com/odoo/odoo/commit/cee8a5e6aafd9c05e5b2c027e52aee6b174a4ad5
[Google's documentation]: https://support.google.com/google-ads/answer/10000067

Related to task-3880544