### PR TITLE
[IMP] web: warn if legacy kanban API is used

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_arch_parser.js
+++ b/addons/web/static/src/views/kanban/kanban_arch_parser.js
@@ -148,6 +148,9 @@ export class KanbanArchParser {
         // Concrete kanban box elements in the template
         let cardDoc = templateDocs[KANBAN_CARD_ATTRIBUTE];
         const isLegacyArch = !cardDoc;
+        if (isLegacyArch) {
+            console.warn("'kanban-box' is deprecated, use 'kanban-card' API instead");
+        }
         if (!cardDoc) {
             cardDoc = templateDocs[KANBAN_BOX_ATTRIBUTE];
             if (!cardDoc) {

--- a/addons/web/static/src/views/kanban/kanban_record.js
+++ b/addons/web/static/src/views/kanban/kanban_record.js
@@ -372,7 +372,7 @@ export class KanbanRecord extends Component {
     }
 
     /**
-     * Returns the kanban-box template's rendering context.
+     * Returns the card template's rendering context.
      *
      * Note: the keys answer to outdated standards but should not be altered for
      * the sake of compatibility.

--- a/addons/web/static/tests/views/kanban/kanban_color_picker_legacy.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_color_picker_legacy.test.js
@@ -1,4 +1,4 @@
-import { expect, test } from "@odoo/hoot";
+import { beforeEach, expect, test } from "@odoo/hoot";
 import { KanbanArchParser } from "@web/views/kanban/kanban_arch_parser";
 import { parseXML } from "@web/core/utils/xml";
 import {
@@ -10,6 +10,7 @@ import {
     models,
     mountView,
     onRpc,
+    patchWithCleanup,
     toggleKanbanRecordDropdown,
 } from "../../web_test_helpers";
 import { queryAll } from "@odoo/hoot-dom";
@@ -33,6 +34,18 @@ class Category extends models.Model {
 }
 
 defineModels([Category]);
+
+// avoid "kanban-box" deprecation warnings in this suite, which defines legacy kanban on purpose
+beforeEach(() => {
+    const originalConsoleWarn = console.warn;
+    patchWithCleanup(console, {
+        warn: (msg) => {
+            if (msg !== "'kanban-box' is deprecated, use 'kanban-card' API instead") {
+                originalConsoleWarn(msg);
+            }
+        },
+    });
+});
 
 test("oe_kanban_colorpicker in menu and kanban-box", async () => {
     const archInfo = parseArch(`

--- a/addons/web/static/tests/views/kanban/kanban_view_legacy.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view_legacy.test.js
@@ -184,6 +184,16 @@ defineModels([Partner, Product, Category, Currency, IrAttachment]);
 
 beforeEach(() => {
     patchWithCleanup(AnimatedNumber, { enableAnimations: false });
+
+    // avoid "kanban-box" deprecation warnings in this suite, which defines legacy kanban on purpose
+    const originalConsoleWarn = console.warn;
+    patchWithCleanup(console, {
+        warn: (msg) => {
+            if (msg !== "'kanban-box' is deprecated, use 'kanban-card' API instead") {
+                originalConsoleWarn(msg);
+            }
+        },
+    });
 });
 
 test("display full is supported on fields", async () => {
@@ -2099,7 +2109,13 @@ test("action/type attributes on kanban arch, type='action'", async () => {
 });
 
 test("Missing t-key is automatically filled with a warning", async () => {
-    patchWithCleanup(console, { warn: () => expect.step("warning") });
+    patchWithCleanup(console, {
+        warn: (msg) => {
+            if (msg !== "'kanban-box' is deprecated, use 'kanban-card' API instead") {
+                expect.step("warning");
+            }
+        },
+    });
 
     await mountView({
         type: "kanban",


### PR DESCRIPTION
This will ensure that we do not introduce legacy kanban anymore, as they are deprecated and their support will be dropped after 18.0.

Task~3992107

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
