### PR TITLE
[FIX] mail: do not upload parent icon from sub-thread

### DIFF
--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -10,7 +10,7 @@
                 <t t-if="thread">
                     <div t-if="['channel', 'group', 'chat'].includes(thread.channel_type)" class="o-mail-Discuss-threadAvatar position-relative align-self-center align-items-center mt-2 mb-2 me-2">
                         <img class="rounded" t-att-src="thread.parent_channel_id?.avatarUrl ?? thread.avatarUrl" alt="Thread Image"/>
-                        <FileUploader t-if="thread.is_editable" acceptedFileExtensions="'.bmp, .jpg, .jpeg, .png, .svg'" showUploadingText="false" multiUpload="false" onUploaded.bind="(data) => this.onFileUploaded(data)">
+                        <FileUploader t-if="!thread.parent_channel_id and thread.is_editable" acceptedFileExtensions="'.bmp, .jpg, .jpeg, .png, .svg'" showUploadingText="false" multiUpload="false" onUploaded.bind="(data) => this.onFileUploaded(data)">
                             <t t-set-slot="toggler">
                                 <a href="#" class="position-absolute z-1 h-100 w-100 rounded start-0 bottom-0" title="Upload Avatar">
                                     <i class="position-absolute top-50 start-50 fa fa-sm fa-pencil text-white"/>
@@ -88,7 +88,7 @@
                 </t>
             </div>
             <div class="o-mail-Discuss-main d-flex overflow-hidden flex-grow-1" t-ref="main">
-                <t t-if="ui.isSmall" t-call="mail.Discuss.loading"/>                
+                <t t-if="ui.isSmall" t-call="mail.Discuss.loading"/>
                 <div class="o-mail-Discuss-core overflow-auto d-flex flex-grow-1" t-ref="core">
                     <t t-if="thread">
                         <div class="d-flex flex-column flex-grow-1">


### PR DESCRIPTION
Sub-threads show their parent channel's icon in the discuss
header. However, when uploading a new icon nothing happens:
the icon is actually updated for the sub-thread. We should not
allow to upload any icon in this case as it does not make sense
to do so.