### PR TITLE
[IMP] mail: indicate sub-thread parent name

### DIFF
--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -15,7 +15,6 @@
                     body="message?.inlineBody or message?.subtype_description"
                     counter="thread.needactionCounter"
                     datetime="message?.datetime"
-                    displayName="thread.displayName"
                     iconSrc="thread.avatarUrl"
                     hasMarkAsReadButton="thread.isUnread"
                     muted="thread.mute_until_dt ? 2 : !thread.isUnread ? 1 : 0"
@@ -23,6 +22,14 @@
                     onSwipeRight="hasTouch() and thread.isUnread ? { action: () => this.markAsRead(thread), icon: 'fa-check-circle', bgColor: 'bg-success' } : undefined"
                     onSwipeLeft="hasTouch() and thread.canUnpin ? { action: () => thread.unpin(), icon: 'fa-times-circle', bgColor: 'bg-danger' } : undefined"
                 >
+                    <t t-set-slot="name">
+                        <div t-if="thread.parent_channel_id" class="d-flex align-items-center">
+                            <span class="text-truncate flex-shrink-0 opacity-75 mw-50" t-esc="thread.parent_channel_id.displayName"/>
+                            <i class="oi oi-chevron-right o-xsmaller mx-1"/>
+                            <span class="text-truncate min-w-0" t-esc="thread.displayName"/>
+                        </div>
+                        <t t-else="" t-esc="thread.displayName"/>
+                    </t>
                     <t t-set-slot="icon">
                         <ImStatus t-if="thread.channel_type === 'chat' and thread.correspondent" member="thread.correspondent" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>
                         <CountryFlag t-if="thread.anonymous_country" country="thread.anonymous_country" class="'o-mail-NotificationItem-country position-absolute border'"/>

--- a/addons/mail/static/src/core/public_web/notification_item.js
+++ b/addons/mail/static/src/core/public_web/notification_item.js
@@ -15,7 +15,6 @@ export class NotificationItem extends Component {
         "body?",
         "counter?",
         "datetime?",
-        "displayName?",
         "first?",
         "hasMarkAsReadButton?",
         "iconSrc?",
@@ -28,7 +27,6 @@ export class NotificationItem extends Component {
     ];
     static defaultProps = {
         counter: 0,
-        displayName: "",
         muted: 0,
     };
     static template = "mail.NotificationItem";

--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -19,7 +19,9 @@
             </div>
             <div class="d-flex flex-column flex-grow-1 align-self-start overflow-auto">
                 <div class="d-flex text-nowrap">
-                    <span class="o-mail-NotificationItem-name text-truncate fw-bold" t-att-class="{ 'fw-bold': props.muted, 'fw-bolder': !props.muted }" t-esc="props.displayName"/>
+                    <span class="o-mail-NotificationItem-name text-truncate fw-bold" t-att-class="{ 'fw-bold': props.muted, 'fw-bolder': !props.muted }">
+                        <t t-slot="name"/>
+                    </span>
                     <span class="flex-grow-1"/>
                     <small t-if="props.datetime" class="o-mail-NotificationItem-date ms-2 opacity-75" t-att-class="{ 'fw-bolder': !props.muted, 'text-muted': props.muted }" t-att-title="props.datetime?.toLocaleString(DateTime.DATETIME_SHORT) ?? ''">
                         <t t-esc="dateText"/>

--- a/addons/mail/static/src/core/web/command_palette.xml
+++ b/addons/mail/static/src/core/web/command_palette.xml
@@ -5,7 +5,11 @@
         <div class="o_command_default d-flex align-items-center px-4 py-2">
             <img class="rounded me-2" t-if="props.imgUrl" t-att-src="props.imgUrl"  style="width: 25px; height: 25px"/>
             <ImStatus t-if="props.persona" className="'me-1'" persona="props.persona"/>
-            <span class="pe-1 text-ellipsis fw-bold">
+            <span class="pe-1 text-ellipsis fw-bold d-flex align-items-center">
+                <t t-if="props.channel?.parent_channel_id">
+                    <span class="text-truncate flex-shrink-0 opacity-75 mw-50" t-esc="props.channel?.parent_channel_id.displayName"/>
+                    <i class="oi oi-chevron-right o-xsmaller mx-1"/>
+                </t>
                 <t t-slot="name" />
             </span>
             <span t-if="props.persona and props.persona.email" t-out="'- ' + props.persona.email"/>

--- a/addons/mail/static/src/core/web/messaging_menu_patch.xml
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.xml
@@ -15,7 +15,7 @@
             </div>
         </xpath>
     </t>
-    
+
     <t t-inherit="mail.MessagingMenu.content" t-inherit-mode="extension">
         <xpath expr="//*[@t-ref='notification-list']" position="before">
             <div class="o-mail-MessagingMenu-header d-flex" t-att-class="{'border-start-0 border-end-0': ui.isSmall, 'flex-shrink-0': !env.inDiscussApp }">
@@ -43,11 +43,11 @@
                 <NotificationItem
                     isActive="state.activeIndex === itemIndex"
                     body="installationRequest.body"
-                    displayName="installationRequest.displayName"
                     iconSrc="installationRequest.iconSrc"
                     onClick="installationRequest.onClick"
                     onSwipeRight="hasTouch() ? { action: () => this.pwa.decline(), icon: 'fa-times-circle', bgColor: 'bg-warning' } : undefined"
                 >
+                    <t t-set-slot="name"><t  t-esc="installationRequest.displayName"/></t>
                     <t t-set-slot="icon">
                         <ImStatus persona="installationRequest.partner" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>
                     </t>
@@ -65,10 +65,10 @@
                 <NotificationItem
                     isActive="state.activeIndex === itemIndex"
                     body="notificationRequest.body"
-                    displayName="notificationRequest.displayName"
                     iconSrc="notificationRequest.iconSrc"
                     onClick="() => notification.requestPermission()"
                 >
+                    <t t-set-slot="name"><t t-esc="notificationRequest.displayName"/></t>
                     <t t-set-slot="icon">
                         <ImStatus persona="notificationRequest.partner" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>
                     </t>
@@ -82,12 +82,13 @@
                         body="failure.body"
                         counter="failure.notifications.length > 1 ? failure.notifications.length : undefined"
                         datetime="failure.datetime"
-                        displayName="failure.modelName"
                         iconSrc="failure.iconSrc"
                         hasMarkAsReadButton="true"
                         onClick="(isMarkAsRead) => isMarkAsRead ? this.cancelNotifications(failure) : this.onClickFailure(failure)"
                         onSwipeRight="hasTouch() ? { action: () => this.cancelNotifications(failure), icon: 'fa-times-circle', bgColor: 'bg-warning' } : undefined"
-                    />
+                    >
+                        <t t-set-slot="name"><t t-esc="failure.modelName"/></t>
+                    </NotificationItem>
                     <t t-set="itemIndex" t-value="itemIndex + 1"/>
                 </t>
             </t>


### PR DESCRIPTION
This PR adds the sub-thread's parent name to the messaging
menu/command palette items. It's easier to navigate sub-threads
this way.

![image](https://github.com/user-attachments/assets/8c36f3c5-5693-4ede-9744-56ccc8d31456)
![image](https://github.com/user-attachments/assets/e9641319-bbd4-47f1-9eda-3c80def142b7)
