### PR TITLE
[FIX] project, hr_timesheet: fix project name overflow in kanban card

### DIFF
--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -293,7 +293,7 @@
                                 <span t-att-title="record.employee_id.value">
                                     <field name="employee_id" widget="image" options="{'preview_image': 'avatar_128'}" class="o_image_64_cover me-2 float-start"/>
                                 </span>
-                                <div class="d-flex flex-column text-truncate lh-sm col-10">
+                                <div class="d-flex flex-column text-truncate lh-sm col-9">
                                     <span class="text-truncate" invisible="context.get('default_project_id')" t-att-title="record.project_id.value">
                                         <field name="project_id" class="p-0 fw-bold fs-5"/>
                                     </span>

--- a/addons/project/static/src/scss/project_dashboard.scss
+++ b/addons/project/static/src/scss/project_dashboard.scss
@@ -1,7 +1,7 @@
 .o_project_kanban .o_kanban_renderer {
 
     .o_project_kanban_main {
-        max-width: 300px;
+        max-width: 90%;
 
         // Prevents the kanban settings menu from overflowing and creating a scrollbar.
         .o_kanban_card_manage_pane .o_kanban_card_manage_section a {


### PR DESCRIPTION
Before:
The project name was overflowing in the Kanban card, causing layout issues.

After:
The project name now displays correctly within the Kanban card.

Fix:
Adjusted and added CSS classes to the Kanban card to properly handle long project names.

Task:4198771
