### PR TITLE
[IMP] web, website, *: add "delay" option for blockUI service

### DIFF
--- a/addons/base_import/static/src/import_block_ui.xml
+++ b/addons/base_import/static/src/import_block_ui.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
+    <!-- TODO should re-use the blockUI template of web -->
     <t t-name="base_import.BlockUI">
         <div class="o_blockUI fixed-top d-flex justify-content-center align-items-center flex-column vh-100 bg-black-50">
             <div class="o_spinner mb-4">

--- a/addons/web/static/src/core/ui/block_ui.js
+++ b/addons/web/static/src/core/ui/block_ui.js
@@ -9,17 +9,25 @@ export class BlockUI extends Component {
     };
 
     static template = xml`
-        <div t-att-class="state.blockUI ? 'o_blockUI fixed-top d-flex justify-content-center align-items-center flex-column vh-100' : ''">
-          <t t-if="state.blockUI">
-            <div class="o_spinner mb-4">
-                <img src="/web/static/img/spin.svg" alt="Loading..."/>
+        <t t-if="state.blockState === BLOCK_STATES.UNBLOCKED">
+            <div/>
+        </t>
+        <t t-else="">
+            <t t-set="visiblyBlocked" t-value="state.blockState === BLOCK_STATES.VISIBLY_BLOCKED"/>
+            <div class="o_blockUI fixed-top d-flex justify-content-center align-items-center flex-column vh-100"
+                 t-att-class="visiblyBlocked ? '' : 'o_blockUI_invisible'">
+                <t t-if="visiblyBlocked">
+                    <div class="o_spinner mb-4">
+                        <img src="/web/static/img/spin.svg" alt="Loading..."/>
+                    </div>
+                    <div class="o_message text-center px-4">
+                        <t t-esc="state.line1"/><br/>
+                        <t t-esc="state.line2"/>
+                    </div>
+                </t>
             </div>
-            <div class="o_message text-center px-4">
-                <t t-esc="state.line1"/> <br/>
-                <t t-esc="state.line2"/>
-            </div>
-          </t>
-        </div>`;
+        </t>
+    `;
 
     setup() {
         this.messagesByDuration = [
@@ -50,8 +58,9 @@ export class BlockUI extends Component {
                 l1: _t("Maybe you should consider reloading the application by pressing F5..."),
             },
         ];
+        this.BLOCK_STATES = { UNBLOCKED: 0, BLOCKED: 1, VISIBLY_BLOCKED: 2 };
         this.state = useState({
-            blockUI: false,
+            blockState: this.BLOCK_STATES.UNBLOCKED,
             line1: "",
             line2: "",
         });
@@ -72,7 +81,15 @@ export class BlockUI extends Component {
     }
 
     block(ev) {
-        this.state.blockUI = true;
+        const showBlockedUI = () => (this.state.blockState = this.BLOCK_STATES.VISIBLY_BLOCKED);
+        const delay = ev.detail?.delay;
+        if (delay) {
+            this.state.blockState = this.BLOCK_STATES.BLOCKED;
+            this.showBlockedUITimer = setTimeout(showBlockedUI, delay);
+        } else {
+            showBlockedUI();
+        }
+
         if (ev.detail?.message) {
             this.state.line1 = ev.detail.message;
         } else {
@@ -81,7 +98,8 @@ export class BlockUI extends Component {
     }
 
     unblock() {
-        this.state.blockUI = false;
+        this.state.blockState = this.BLOCK_STATES.UNBLOCKED;
+        clearTimeout(this.showBlockedUITimer);
         clearTimeout(this.msgTimer);
         this.state.line1 = "";
         this.state.line2 = "";

--- a/addons/web/static/src/core/ui/block_ui.scss
+++ b/addons/web/static/src/core/ui/block_ui.scss
@@ -1,9 +1,11 @@
 .o_blockUI {
-	cursor: wait;
-	-webkit-backdrop-filter: blur(2px);
-	backdrop-filter: blur(2px);
-	background: rgba(#000, .5);
-	color: #fff;
-	// NOTE: The value of the z-index below mirrors the $zindex-tooltip one
-	z-index: 1070 !important;
+    cursor: wait;
+    z-index: $zindex-popover !important;
+
+    &:not(.o_blockUI_invisible) {
+        -webkit-backdrop-filter: blur(2px);
+        backdrop-filter: blur(2px);
+        background: rgba(#000, .5);
+        color: #fff;
+    }
 }

--- a/addons/web/static/src/core/ui/ui_service.js
+++ b/addons/web/static/src/core/ui/ui_service.js
@@ -154,9 +154,12 @@ export const uiService = {
         let blockCount = 0;
         function block(data) {
             blockCount++;
+            // TODO could probably be improved to handle multiple block demands
+            // but that have different messages and delays
             if (blockCount === 1) {
                 bus.trigger("BLOCK", {
                     message: data?.message,
+                    delay: data?.delay,
                 });
             }
         }

--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -464,7 +464,7 @@ export class ThemeSelectionScreen extends ApplyConfiguratorScreen {
         onMounted(async () => {
             // Add a loading effect during the loading of the images inside the
             // svgs.
-            this.uiService.block();
+            this.uiService.block({delay: 400});
             this.state.themes.forEach((theme, idx) => {
                 // Transform the text svg into a svg element.
                 const svgEl = new DOMParser().parseFromString(theme.svg, 'image/svg+xml').documentElement;

--- a/addons/website/static/src/client_actions/website_preview/website_preview.xml
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
+
+<!-- TODO should re-use the blockUI template of web -->
 <t t-name="website.BlockPreview">
     <div class="o_blockUI o_block_preview position-fixed d-flex justify-content-center align-items-center flex-column h-100 w-100 bg-black-50">
         <div class="o_spinner mb-4">


### PR DESCRIPTION
*: base_import

The blockUI service now supports a "delay" option to be able to delay the moment when the user sees the UI is blocked. Typically, it is to be used with < 1 second delays:

- The user clicks on a button, which triggers an action which should be quickly done (typically, a single RPC). We want to block the UI immediately because we don't want the user doing anything during that RPC for some reason.

- If the action is indeed quickly done: there was no need of a flicker of the screen showing a black blocked UI. It was blocked but the user did not see it, except for a "wait" cursor.

- If the action takes too much time for some reason (server load ?), then the user is shown the black blocked UI.

Note: we already have a similar system for frontend buttons (see the `makeButtonHandler` util and the `async` keyword in PublicWidget): we have a spinning animation on button but it does not appear immediately. Still, the button is blocked immediately.

This commit also uses the option for the first time: to prevent a flicker in the website configurator theme selection.

Related to task-4184418
