### PR TITLE
[FIX] account, sale: Sale person and team

### DIFF
--- a/addons/account/demo/account_demo.py
+++ b/addons/account/demo/account_demo.py
@@ -76,7 +76,6 @@ class AccountChartTemplate(models.Model):
             f'{cid}_demo_invoice_5': {
                 'move_type': 'in_invoice',
                 'partner_id': ref('base.res_partner_12').id,
-                'invoice_user_id': ref('base.user_demo').id,
                 'invoice_payment_term_id': ref('account.account_payment_term_end_following_month').id,
                 'invoice_date': time.strftime('%Y-%m-01'),
                 'invoice_line_ids': [
@@ -86,7 +85,6 @@ class AccountChartTemplate(models.Model):
             },
             f'{cid}_demo_invoice_extract': {
                 'move_type': 'in_invoice',
-                'invoice_user_id': ref('base.user_demo').id,
             },
             f'{cid}_demo_invoice_equipment_purchase': {
                 'move_type': 'in_invoice',

--- a/addons/l10n_ar/tests/common.py
+++ b/addons/l10n_ar/tests/common.py
@@ -328,7 +328,6 @@ class TestAr(AccountTestInvoicingCommon):
             'test_invoice_1': {
                 "ref": "test_invoice_1: Invoice to gritti support service, vat 21",
                 "partner_id": self.res_partner_gritti_mono,
-                "invoice_user_id": invoice_user_id,
                 "invoice_payment_term_id": payment_term_id,
                 "move_type": "out_invoice",
                 "invoice_date": "2021-03-01",
@@ -340,7 +339,6 @@ class TestAr(AccountTestInvoicingCommon):
             'test_invoice_2': {
                 "ref": "test_invoice_2: Invoice to Servicios Globales with vat 21, 27 and 10,5",
                 "partner_id": self.res_partner_servicios_globales,
-                "invoice_user_id": invoice_user_id,
                 "invoice_payment_term_id": payment_term_id,
                 "move_type": "out_invoice",
                 "invoice_date": "2021-03-05",
@@ -354,7 +352,6 @@ class TestAr(AccountTestInvoicingCommon):
             'test_invoice_3': {
                 "ref": "test_invoice_3: Invoice to ADHOC with vat cero and 21",
                 "partner_id": self.res_partner_adhoc,
-                "invoice_user_id": invoice_user_id,
                 "invoice_payment_term_id": payment_term_id,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-01",
@@ -367,7 +364,6 @@ class TestAr(AccountTestInvoicingCommon):
             'test_invoice_4': {
                 'ref': 'test_invoice_4: Invoice to ADHOC with vat exempt and 21',
                 "partner_id": self.res_partner_adhoc,
-                "invoice_user_id": invoice_user_id,
                 "invoice_payment_term_id": payment_term_id,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-01",
@@ -380,7 +376,6 @@ class TestAr(AccountTestInvoicingCommon):
             'test_invoice_5': {
                 'ref': 'test_invoice_5: Invoice to ADHOC with all type of taxes',
                 "partner_id": self.res_partner_adhoc,
-                "invoice_user_id": invoice_user_id,
                 "invoice_payment_term_id": payment_term_id,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-13",
@@ -398,7 +393,6 @@ class TestAr(AccountTestInvoicingCommon):
                 'ref': 'test_invoice_6: Invoice to Montana Sur, fiscal position changes taxes to exempt',
                 "partner_id": self.res_partner_montana_sur,
                 "journal_id": self.sale_expo_journal_ri,
-                "invoice_user_id": invoice_user_id,
                 "invoice_payment_term_id": payment_term_id,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-03",
@@ -417,7 +411,6 @@ class TestAr(AccountTestInvoicingCommon):
                 'ref': 'test_invoice_7: Export invoice to Barcelona food, fiscal position changes tax to exempt (type 4 because it have services)',
                 "partner_id": self.res_partner_barcelona_food,
                 "journal_id": self.sale_expo_journal_ri,
-                "invoice_user_id": invoice_user_id,
                 "invoice_payment_term_id": payment_term_id,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-03",
@@ -435,7 +428,6 @@ class TestAr(AccountTestInvoicingCommon):
             'test_invoice_8': {
                 'ref': 'test_invoice_8: Invoice to consumidor final',
                 "partner_id": self.partner_cf,
-                "invoice_user_id": invoice_user_id,
                 "invoice_payment_term_id": payment_term_id,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-13",
@@ -447,7 +439,6 @@ class TestAr(AccountTestInvoicingCommon):
             'test_invoice_10': {
                 'ref': 'test_invoice_10; Invoice to ADHOC in USD and vat 21',
                 "partner_id": self.res_partner_adhoc,
-                "invoice_user_id": invoice_user_id,
                 "invoice_payment_term_id": payment_term_id,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-13",
@@ -460,7 +451,6 @@ class TestAr(AccountTestInvoicingCommon):
             'test_invoice_11': {
                 'ref': 'test_invoice_11: Invoice to ADHOC with many lines in order to prove rounding error, with 4 decimals of precision for the currency and 2 decimals for the product the error apperar',
                 "partner_id": self.res_partner_adhoc,
-                "invoice_user_id": invoice_user_id,
                 "invoice_payment_term_id": payment_term_id,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-13",
@@ -475,7 +465,6 @@ class TestAr(AccountTestInvoicingCommon):
             'test_invoice_12': {
                 'ref': 'test_invoice_12: Invoice to ADHOC with many lines in order to test rounding error, it is required to use a 4 decimal precision in prodct in order to the error occur',
                 "partner_id": self.res_partner_adhoc,
-                "invoice_user_id": invoice_user_id,
                 "invoice_payment_term_id": payment_term_id,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-13",
@@ -490,7 +479,6 @@ class TestAr(AccountTestInvoicingCommon):
             'test_invoice_13': {
                 'ref': 'test_invoice_13: Invoice to ADHOC with many lines in order to test zero amount invoices y rounding error. it is required to set the product decimal precision to 4 and change 260.59 for 260.60 in order to reproduce the error',
                 "partner_id": self.res_partner_adhoc,
-                "invoice_user_id": invoice_user_id,
                 "invoice_payment_term_id": payment_term_id,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-13",
@@ -510,7 +498,6 @@ class TestAr(AccountTestInvoicingCommon):
                 'ref': 'test_invoice_14: Export invoice to Barcelona food, fiscal position changes tax to exempt (type 1 because only products)',
                 "partner_id": self.res_partner_barcelona_food,
                 "journal_id": self.sale_expo_journal_ri,
-                "invoice_user_id": invoice_user_id,
                 "invoice_payment_term_id": payment_term_id,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-20",
@@ -524,7 +511,6 @@ class TestAr(AccountTestInvoicingCommon):
                 'ref': 'test_invoice_15: Export invoice to Barcelona food, fiscal position changes tax to exempt (type 2 because only service)',
                 "partner_id": self.res_partner_barcelona_food,
                 "journal_id": self.sale_expo_journal_ri,
-                "invoice_user_id": invoice_user_id,
                 "invoice_payment_term_id": payment_term_id,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-20",
@@ -538,7 +524,6 @@ class TestAr(AccountTestInvoicingCommon):
                 'ref': 'test_invoice_16: Export invoice to Barcelona food, fiscal position changes tax to exempt (type 1 because it have products only, used to test refund of expo)',
                 "partner_id": self.res_partner_barcelona_food,
                 "journal_id": self.sale_expo_journal_ri,
-                "invoice_user_id": invoice_user_id,
                 "invoice_payment_term_id": payment_term_id,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-22",
@@ -551,7 +536,6 @@ class TestAr(AccountTestInvoicingCommon):
             'test_invoice_17': {
                 'ref': 'test_invoice_17: Invoice to ADHOC with 100%% of discount',
                 "partner_id": self.res_partner_adhoc,
-                "invoice_user_id": invoice_user_id,
                 "invoice_payment_term_id": payment_term_id,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-13",
@@ -563,7 +547,6 @@ class TestAr(AccountTestInvoicingCommon):
             'test_invoice_18': {
                 'ref': 'test_invoice_18: Invoice to ADHOC with 100%% of discount and with different VAT aliquots',
                 "partner_id": self.res_partner_adhoc,
-                "invoice_user_id": invoice_user_id,
                 "invoice_payment_term_id": payment_term_id,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-13",
@@ -577,7 +560,6 @@ class TestAr(AccountTestInvoicingCommon):
             'test_invoice_19': {
                 'ref': 'test_invoice_19: Invoice to ADHOC with multiple taxes and perceptions',
                 "partner_id": self.res_partner_adhoc,
-                "invoice_user_id": invoice_user_id,
                 "invoice_payment_term_id": payment_term_id,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-13",
@@ -594,7 +576,6 @@ class TestAr(AccountTestInvoicingCommon):
             with Form(self.env['account.move'].with_context(default_move_type=values['move_type'])) as invoice_form:
                 invoice_form.ref = values['ref']
                 invoice_form.partner_id = values['partner_id']
-                invoice_form.invoice_user_id = values['invoice_user_id']
                 invoice_form.invoice_payment_term_id = values['invoice_payment_term_id']
                 if not use_current_date:
                     invoice_form.invoice_date = values['invoice_date']

--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -672,11 +672,7 @@ class PurchaseOrder(models.Model):
         immediately.
         """
         if not invoices:
-            # Invoice_ids may be filtered depending on the user. To ensure we get all
-            # invoices related to the purchase order, we read them in sudo to fill the
-            # cache.
             self.invalidate_model(['invoice_ids'])
-            self.sudo()._read(['invoice_ids'])
             invoices = self.invoice_ids
 
         result = self.env['ir.actions.act_window']._for_xml_id('account.action_move_in_invoice_type')

--- a/addons/purchase/tests/test_purchase_invoice.py
+++ b/addons/purchase/tests/test_purchase_invoice.py
@@ -847,7 +847,7 @@ class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):
 
     def test_invoice_user_id_on_bill(self):
         """
-        Test that the invoice_user_id field is set to current user when creating a vendor bill from a PO
+        Test that the invoice_user_id field is False when creating a vendor bill from a PO
         or when using Auto-Complete feature of a vendor bill.
         """
         group_purchase_user = self.env.ref('purchase.group_purchase_user')
@@ -878,9 +878,9 @@ class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):
         po1.order_line.qty_received = 1
         po1.action_create_invoice()
         invoice1 = po1.invoice_ids
-        self.assertEqual(invoice1.invoice_user_id, self.env.user)
+        self.assertFalse(invoice1.invoice_user_id)
         # creating bill with Auto_complete feature
         move_form = Form(self.env['account.move'].with_context(default_move_type='in_invoice'))
         move_form.purchase_vendor_bill_id = self.env['purchase.bill.union'].browse(-po2.id)
         invoice2 = move_form.save()
-        self.assertEqual(invoice2.invoice_user_id, self.env.user)
+        self.assertFalse(invoice2.invoice_user_id)

--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -31,8 +31,13 @@ class AccountMove(models.Model):
 
     @api.depends('invoice_user_id')
     def _compute_team_id(self):
+        applicable_moves = self.filtered(
+            lambda move:
+                move.is_sale_document(include_receipts=True)
+        )
+
         for ((user_id, company_id), moves) in groupby(
-            self,
+            applicable_moves,
             key=lambda m: (m.invoice_user_id.id, m.company_id.id)
         ):
             self.concat(*moves).team_id = self.env['crm.team'].with_context(


### PR DESCRIPTION
When creating a Vendor Bill, the default Sales Team & Person of the company is assigned to the Vendor Bill. The field isn't even displayed, it's hidden, you can only display it with Studio and can't even change it.

The fact is : purchases and sales are two completely different roles and business in companies. This has the indirect consequence that any user that follows the default Sales Team will get notified of any new Vendor Bill created in Accounting, which he very likely does not need/want to see.

This PR correct that by adding a condition on the filling of these fields. These
 fields will be filled when the move is a sale document.

backport of odoo/odoo#120628

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
