### PR TITLE
[IMP] spreadsheet_dashboard: pencil icon next to dashboard name

### DIFF
--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.js
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.js
@@ -1,6 +1,7 @@
 /** @odoo-module */
 
 import { registry } from "@web/core/registry";
+import { user } from "@web/core/user";
 import { ControlPanel } from "@web/search/control_panel/control_panel";
 import { DashboardLoader, Status } from "./dashboard_loader";
 import { SpreadsheetComponent } from "@spreadsheet/actions/spreadsheet_component";
@@ -33,6 +34,7 @@ export class SpreadsheetDashboardAction extends Component {
         this.controlPanelDisplay = {};
         this.orm = useService("orm");
         this.actionService = useService("action");
+        this.isDashboardAdmin = false;
         // Use the non-protected orm service (`this.env.services.orm` instead of `useService("orm")`)
         // because spreadsheets models are preserved across multiple components when navigating
         // with the breadcrumb
@@ -49,6 +51,11 @@ export class SpreadsheetDashboardAction extends Component {
             const activeDashboardId = this.getInitialActiveDashboard();
             if (activeDashboardId) {
                 this.openDashboard(activeDashboardId);
+            }
+            if (this.env.debug) {
+                this.isDashboardAdmin = await user.hasGroup(
+                    "spreadsheet_dashboard.group_dashboard_manager"
+                );
             }
         });
         useEffect(

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
@@ -85,8 +85,9 @@
                             <t t-esc="dashboard.displayName" />
                         </div>
                         <button
+                            t-if="isDashboardAdmin"
                             type="button"
-                            class="btn btn-link o_edit_dashboard oi oi-arrow-right"
+                            class="btn btn-link o_edit_dashboard fa fa-pencil"
                             tabindex="-1"
                             draggable="false"
                             aria-label="Edit"


### PR DESCRIPTION
## Description:

- Replaced the existing edit icon with a pencil icon positioned next to the dashboard name.
- The pencil icon is visible only to users with dashboard admin rights, and only when debug mode is enabled.

Task: [4172828](https://www.odoo.com/odoo/project/2328/tasks/4172828)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
