### PR TITLE
[FIX] sale: remove done badge in portal

### DIFF
--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -101,7 +101,6 @@
                             <span class='d-block d-md-none'>Ref.</span>
                         </th>
                         <th class="text-end">Order Date</th>
-                        <th class="text-center"/>
                         <th class="text-end">Total</th>
                     </tr>
                 </thead>
@@ -111,11 +110,6 @@
                         <td class="text-end">
                             <span t-field="order.date_order" t-options="{'widget': 'date'}"/>&amp;nbsp;
                             <span class='d-none d-md-inline' t-field="order.date_order" t-options="{'time_only': True}"/>
-                        </td>
-                        <td class="text-center">
-                            <span t-if="order.locked"  class="badge rounded-pill text-bg-success">
-                                <i class="fa fa-fw fa-check" role="img" aria-label="Done" title="Done"/>Done
-                            </span>
                         </td>
                         <td class="text-end"><span t-field="order.amount_total"/></td>
                     </tr>


### PR DESCRIPTION
This commit removes the 'Done' badge displayed on the portal for sales orders that are locked.

opw-4166160

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
