### PR TITLE
[FIX] mail: sub channel create race condition

### DIFF
--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -157,7 +157,10 @@ class ChannelController(http.Controller):
         if not channel:
             raise NotFound()
         sub_channel = channel._create_sub_channel(from_message_id, name)
-        return Store(sub_channel).add(sub_channel, {"forceOpen": True}).get_result()
+        return {
+            "data": Store(sub_channel).add(sub_channel).get_result(),
+            "sub_channel": Store.one_id(sub_channel),
+        }
 
     @http.route("/discuss/channel/sub_channel/fetch", methods=["POST"], type="json", auth="public")
     @add_guest_to_context

--- a/addons/mail/static/src/discuss/core/public_web/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/public_web/@types/models.d.ts
@@ -1,7 +1,6 @@
 declare module "models" {
     export interface Thread {
         displayInSidebar: boolean;
-        forceOpen: boolean;
         from_message_id: Message;
         parent_channel_id: Thread;
         readonly hasSubChannelFeature: boolean;

--- a/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
@@ -63,14 +63,6 @@ patch(Thread.prototype, {
                 );
             },
         });
-        this.forceOpen = Record.attr(false, {
-            onUpdate() {
-                if (this.forceOpen) {
-                    this.open();
-                    this.forceOpen = false;
-                }
-            },
-        });
         this.loadSubChannelsDone = false;
         this.lastSubChannelLoaded = null;
     },
@@ -98,12 +90,13 @@ patch(Thread.prototype, {
      * @param {string} [param0.searchTerm]
      */
     async createSubChannel({ initialMessage, name } = {}) {
-        const data = await rpc("/discuss/channel/sub_channel/create", {
+        const { data, sub_channel } = await rpc("/discuss/channel/sub_channel/create", {
             parent_channel_id: this.id,
             from_message_id: initialMessage?.id,
             name,
         });
         this.store.insert(data);
+        this.store.Thread.get(sub_channel).open();
     },
     /**
      * @param {*} param0

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -587,7 +587,6 @@ export class DiscussChannel extends models.ServerModel {
             })
         );
         const store = new mailDataHelpers.Store(subChannels);
-        store.add(subChannels, { forceOpen: true });
         BusBus._sendone(partner, "mail.record/insert", store.get_result());
         this.message_post(
             self.id,
@@ -597,7 +596,10 @@ export class DiscussChannel extends models.ServerModel {
                 subtype_xmlid: "mail.mt_comment",
             })
         );
-        return store.get_result();
+        return {
+            data: store.get_result(),
+            sub_channel: mailDataHelpers.Store.one_id(subChannels),
+        };
     }
 
     /** @param {number} id */


### PR DESCRIPTION
When a sub-channel is created, a flag is set on the data so that the sub-channel opens after its been inserted in the store. However, this approach is subject to race condition. This PR replaces the flag by explicit sub-channel opening.

fixes runbot-98437,98539