### PR TITLE
[IMP] mail: seen indicator slight improvements

### DIFF
--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -29,6 +29,7 @@
 .o-mail-Message-seenContainer {
     font-size: 0.65rem;
     right: 2px;
+    bottom: -2px;
 }
 
 .o-mail-Message-sidebar {

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -68,7 +68,7 @@
                                     <t t-if="message.message_type !== 'notification' and !message.is_transient and (message.hasTextContent or message.subtype_description or state.isEditing or message.edited)">
                                         <LinkPreviewList t-if="!state.isEditing and message.linkPreviewSquash" linkPreviews="message.linkPreviews" deletable="false"/>
                                         <t t-else="">
-                                            <div class="position-relative overflow-x-auto d-inline-block" t-att-class="{ 'w-100': state.isEditing }">
+                                            <div class="position-relative overflow-x-auto overflow-y-hidden d-inline-block" t-att-class="{ 'w-100': state.isEditing }">
                                                 <div class="o-mail-Message-bubble rounded-bottom-3 position-absolute top-0 start-0 w-100 h-100" t-att-class="{
                                                     'border': state.isEditing and !message.is_note,
                                                     'o-blue border border-info': message.bubbleColor === 'blue',
@@ -101,7 +101,7 @@
                                                         <t t-if="showSubtypeDescription" t-out="props.messageSearch?.highlight(message.subtype_description) ?? message.subtype_description"/>
                                                     </t>
                                                 </div>
-                                                <div class="o-mail-Message-seenContainer position-absolute bottom-0">
+                                                <div class="o-mail-Message-seenContainer position-absolute">
                                                     <MessageSeenIndicator
                                                         t-if="showSeenIndicator"
                                                         message="props.message"

--- a/addons/mail/static/src/core/common/message_seen_indicator.js
+++ b/addons/mail/static/src/core/common/message_seen_indicator.js
@@ -42,6 +42,9 @@ export class MessageSeenIndicator extends Component {
 
     get summary() {
         if (this.props.message.hasEveryoneSeen) {
+            if (this.props.thread.channelMembers.length === 2) {
+                return _t("Seen by %(user)s", { user: this.props.thread.correspondent.name });
+            }
             return _t("Seen by everyone");
         }
         const seenMembers = this.props.message.channelMemberHaveSeen;

--- a/addons/mail/static/src/core/common/message_seen_indicator.xml
+++ b/addons/mail/static/src/core/common/message_seen_indicator.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.MessageSeenIndicator">
-        <span class="o-mail-MessageSeenIndicator position-relative" t-att-class="{ 'opacity-50': !props.message.hasEveryoneSeen, 'o-all-seen text-primary': props.message.hasEveryoneSeen, 'cursor-pointer': props.message.channelMemberHaveSeen.length }" t-att-title="summary" t-attf-class="{{ props.className }}" t-on-click="openDialog">
+        <span class="o-mail-MessageSeenIndicator position-relative" t-att-class="{ 'opacity-50': !props.message.hasEveryoneSeen, 'text-primary opacity-75': props.message.hasEveryoneSeen, 'cursor-pointer': props.message.channelMemberHaveSeen.length }" t-att-title="summary" t-attf-class="{{ props.className }}" t-on-click="openDialog">
             <t t-if="!props.message.isMessagePreviousToLastSelfMessageSeenByEveryone">
                 <i t-if="props.message.hasSomeoneFetched or props.message.hasSomeoneSeen" class="fa fa-check ps-1"/>
                 <i t-if="props.message.hasSomeoneSeen" class="o-second start-0 fa fa-check position-absolute"/>

--- a/addons/mail/static/tests/message/message_seen_indicator.test.js
+++ b/addons/mail/static/tests/message/message_seen_indicator.test.js
@@ -8,7 +8,7 @@ import {
 } from "@mail/../tests/mail_test_helpers";
 import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
 
-import { describe, expect, test } from "@odoo/hoot";
+import { describe, test } from "@odoo/hoot";
 import { Command, serverState, withUser } from "@web/../tests/web_test_helpers";
 
 import { rpc } from "@web/core/network/rpc";
@@ -46,8 +46,9 @@ test("rendering when just one has received the message", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-MessageSeenIndicator");
-    expect($(".o-mail-MessageSeenIndicator")).not.toHaveClass("o-all-seen");
-    await contains(".o-mail-MessageSeenIndicator i");
+    await contains(".o-mail-MessageSeenIndicator[title='Sent']");
+    await contains(".o-mail-MessageSeenIndicator .fa-check", { count: 1 });
+    await contains(".o-mail-MessageSeenIndicator.text-primary", { count: 0 });
 });
 
 test("rendering when everyone have received the message", async () => {
@@ -77,8 +78,9 @@ test("rendering when everyone have received the message", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-MessageSeenIndicator");
-    expect($(".o-mail-MessageSeenIndicator")).not.toHaveClass("o-all-seen");
-    await contains(".o-mail-MessageSeenIndicator i");
+    await contains(".o-mail-MessageSeenIndicator[title='Sent']");
+    await contains(".o-mail-MessageSeenIndicator .fa-check", { count: 1 });
+    await contains(".o-mail-MessageSeenIndicator.text-primary", { count: 0 });
 });
 
 test("rendering when just one has seen the message", async () => {
@@ -115,8 +117,9 @@ test("rendering when just one has seen the message", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-MessageSeenIndicator");
-    expect($(".o-mail-MessageSeenIndicator")).not.toHaveClass("o-all-seen");
-    await contains(".o-mail-MessageSeenIndicator i", { count: 2 });
+    await contains(".o-mail-MessageSeenIndicator[title='Seen by Demo User']");
+    await contains(".o-mail-MessageSeenIndicator .fa-check", { count: 2 });
+    await contains(".o-mail-MessageSeenIndicator.text-primary", { count: 0 });
 });
 
 test("rendering when just one has seen & received the message", async () => {
@@ -149,8 +152,9 @@ test("rendering when just one has seen & received the message", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-MessageSeenIndicator");
-    expect($(".o-mail-MessageSeenIndicator")).not.toHaveClass("o-all-seen");
-    await contains(".o-mail-MessageSeenIndicator i", { count: 2 });
+    await contains(".o-mail-MessageSeenIndicator[title='Seen by Demo User']");
+    await contains(".o-mail-MessageSeenIndicator .fa-check", { count: 2 });
+    await contains(".o-mail-MessageSeenIndicator.text-primary", { count: 0 });
 });
 
 test("rendering when just everyone has seen the message", async () => {
@@ -180,8 +184,9 @@ test("rendering when just everyone has seen the message", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-MessageSeenIndicator");
-    expect($(".o-mail-MessageSeenIndicator")).toHaveClass("o-all-seen");
-    await contains(".o-mail-MessageSeenIndicator i", { count: 2 });
+    await contains(".o-mail-MessageSeenIndicator[title='Seen by everyone']");
+    await contains(".o-mail-MessageSeenIndicator .fa-check", { count: 2 });
+    await contains(".o-mail-MessageSeenIndicator.text-primary", { count: 1 });
 });
 
 test("'channel_fetch' notification received is correctly handled", async () => {
@@ -204,7 +209,7 @@ test("'channel_fetch' notification received is correctly handled", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Message");
-    await contains(".o-mail-MessageSeenIndicator i", { count: 0 });
+    await contains(".o-mail-MessageSeenIndicator .fa-check", { count: 0 });
 
     const channel = pyEnv["discuss.channel"].search_read([["id", "=", channelId]])[0];
     // Simulate received channel fetched notification
@@ -217,7 +222,7 @@ test("'channel_fetch' notification received is correctly handled", async () => {
         last_message_id: 100,
         partner_id: partnerId,
     });
-    await contains(".o-mail-MessageSeenIndicator i");
+    await contains(".o-mail-MessageSeenIndicator .fa-check", { count: 1 });
 });
 
 test("mark channel as seen from the bus", async () => {
@@ -240,7 +245,7 @@ test("mark channel as seen from the bus", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Message");
-    await contains(".o-mail-MessageSeenIndicator i", { count: 0 });
+    await contains(".o-mail-MessageSeenIndicator .fa-check", { count: 0 });
     const channel = pyEnv["discuss.channel"].search_read([["id", "=", channelId]])[0];
     // Simulate received channel seen notification
     pyEnv["bus.bus"]._sendone(
@@ -254,7 +259,8 @@ test("mark channel as seen from the bus", async () => {
             { seen_message_id: messageId }
         ).get_result()
     );
-    await contains(".o-mail-MessageSeenIndicator i", { count: 2 });
+    await contains(".o-mail-MessageSeenIndicator[title='Seen by test']");
+    await contains(".o-mail-MessageSeenIndicator .fa-check", { count: 2 });
 });
 
 test("should display message indicator when message is fetched/seen", async () => {
@@ -277,7 +283,7 @@ test("should display message indicator when message is fetched/seen", async () =
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Message");
-    await contains(".o-mail-MessageSeenIndicator i", { count: 0 });
+    await contains(".o-mail-MessageSeenIndicator .fa-check", { count: 0 });
     const channel = pyEnv["discuss.channel"].search_read([["id", "=", channelId]])[0];
     // Simulate received channel fetched notification
     pyEnv["bus.bus"]._sendone(channel, "discuss.channel.member/fetched", {
@@ -289,7 +295,7 @@ test("should display message indicator when message is fetched/seen", async () =
         last_message_id: messageId,
         partner_id: partnerId,
     });
-    await contains(".o-mail-MessageSeenIndicator i");
+    await contains(".o-mail-MessageSeenIndicator .fa-check", { count: 1 });
     // Simulate received channel seen notification
     pyEnv["bus.bus"]._sendone(
         channel,
@@ -302,7 +308,7 @@ test("should display message indicator when message is fetched/seen", async () =
             { seen_message_id: messageId }
         ).get_result()
     );
-    await contains(".o-mail-MessageSeenIndicator i", { count: 2 });
+    await contains(".o-mail-MessageSeenIndicator .fa-check", { count: 2 });
 });
 
 test("do not show message seen indicator on the last message seen by everyone when the current user is not author of the message", async () => {
@@ -361,7 +367,7 @@ test("do not show message seen indicator on all the messages of the current user
     await openDiscuss(channelId);
     await contains(".o-mail-Message", {
         text: "Message before last seen",
-        contains: [".o-mail-MessageSeenIndicator", { contains: ["i", { count: 0 }] }],
+        contains: [".o-mail-MessageSeenIndicator", { contains: [".fa-check", { count: 0 }] }],
     });
 });
 
@@ -390,8 +396,7 @@ test("only show messaging seen indicator if authored by me, after last seen by a
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Message");
-    await contains(".o-mail-MessageSeenIndicator");
-    await contains(".o-mail-MessageSeenIndicator i");
+    await contains(".o-mail-MessageSeenIndicator .fa-check", { count: 1 });
 });
 
 test("no seen indicator in 'channel' channels (with is_typing)", async () => {
@@ -444,10 +449,10 @@ test("no seen indicator in 'channel' channels (with is_typing)", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Message", { text: "channel-msg" });
-    await contains(".o-mail-MessageSeenIndicator i", { count: 0 }); // none in channel
+    await contains(".o-mail-MessageSeenIndicator .fa-check", { count: 0 }); // none in channel
     await click(".o-mail-DiscussSidebar-item", { text: "Demo User" });
     await contains(".o-mail-Message", { text: "chat-msg" });
-    await contains(".o-mail-MessageSeenIndicator i", { count: 1 }); // received in chat
+    await contains(".o-mail-MessageSeenIndicator .fa-check", { count: 1 }); // received in chat
     // simulate channel read by Demo User in both threads
     await withUser(demoUserId, () =>
         rpc("/discuss/channel/mark_as_read", {
@@ -474,10 +479,10 @@ test("no seen indicator in 'channel' channels (with is_typing)", async () => {
             is_typing: true,
         })
     );
-    await contains(".o-mail-MessageSeenIndicator i", { count: 2 }); // seen in chat
+    await contains(".o-mail-MessageSeenIndicator .fa-check", { count: 2 }); // seen in chat
     await click(".o-mail-DiscussSidebar-item", { text: "test-channel" });
     await contains(".o-mail-Message", { text: "channel-msg" });
-    await contains(".o-mail-MessageSeenIndicator i", { count: 0 }); // none in channel
+    await contains(".o-mail-MessageSeenIndicator .fa-check", { count: 0 }); // none in channel
 });
 
 test("Show everyone seen title on message seen indicator", async () => {


### PR DESCRIPTION
- When conversation has 2 members, show "Seen by correspondent" rather than "Seen by everyone"
- Slightly reduce opacity of seen indicator when seen by everyone, so that this is less distracting compared to message content
- Slightly move indicator down, so it's less likely to overlap with message content

Took also opportunity to do minor test cleaning, while putting test coverage of "Seen by correspondent" feature.

Task-4198929

https://github.com/odoo/enterprise/pull/70399

Before
![Screenshot 2024-09-20 at 14 40 59](https://github.com/user-attachments/assets/6ae4fd86-4725-4b5c-aba7-82fd06e619a2)
After
![Screenshot 2024-09-20 at 14 24 36](https://github.com/user-attachments/assets/ba8e6ccb-178c-46ba-b852-76b5ae20d7fa)
