### PR TITLE
[FIX] pos_sale: display only orders matching PoS currency

### DIFF
--- a/addons/pos_sale/static/src/overrides/components/control_buttons/control_buttons.js
+++ b/addons/pos_sale/static/src/overrides/components/control_buttons/control_buttons.js
@@ -13,6 +13,7 @@ patch(ControlButtons.prototype, {
             domain: [
                 ["state", "!=", "cancel"],
                 ["invoice_status", "!=", "invoiced"],
+                ["currency_id", "=", this.pos.currency.id],
             ],
             onSelected: async (resIds) => {
                 await this.pos.onClickSaleOrder(resIds[0]);

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -281,3 +281,16 @@ registry.category("web_tour.tours").add("PosSaleTeam", {
             PaymentScreen.clickValidate(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("PosOrdersListDifferentCurrency", {
+    test: true,
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            ProductScreen.clickControlButton("Quotation/Order"),
+            {
+                content: "Check that no orders are displayed",
+                trigger: '.o_nocontent_help p:contains("No record found")',
+            },
+        ].flat(),
+});


### PR DESCRIPTION
Problem:
After [commit](https://github.com/odoo/odoo/commit/075692961ec982af431890e4ac1c5017322d7e93), all sales orders are visible in PoS, but only orders with the same currency as the PoS should be shown.

Steps to reproduce:
- Create a sale order in a currency different from the PoS.
- Open the list of orders in PoS.
- The order with a different currency is visible, but it should not be displayed.

opw-4178592

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
