### PR TITLE
[FIX] stock_account: avoid trying to reconcile same journal item twice

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -233,6 +233,7 @@ class AccountMove(models.Model):
                     else:
                         reconcile_plan += [product_account_moves]
         self.env['account.move.line']._reconcile_plan(reconcile_plan)
+        no_exchange_reconcile_plan = [amls.filtered(lambda aml: not aml.reconciled) for amls in no_exchange_reconcile_plan]
         self.env['account.move.line'].with_context(no_exchange_difference=True)._reconcile_plan(no_exchange_reconcile_plan)
 
     def _get_invoiced_lot_values(self):


### PR DESCRIPTION
This commit fixes a bug introduced by [#166482](https://github.com/odoo/odoo/pull/166482), where it attempts to reconcile an account_move_line twice, and fails to do so the second time, which prevents the confirmation of invoices.

The fix adds a step to remove already reconciled items from the reconciliation plan.

opw-4148669

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
