### PR TITLE
[FIX] stock_picking_batch: fix computing batch display name

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -71,7 +71,7 @@ class StockPickingBatch(models.Model):
         if not self.env.context.get('add_to_existing_batch'):
             return super()._compute_display_name()
         for batch in self:
-            batch.display_name = f"{batch.display_name}: {batch.description}" if batch.description else batch.display_name
+            batch.display_name = f"{batch.name}: {batch.description}" if batch.description else batch.name
 
     @api.depends('picking_type_id')
     def _compute_show_lots_text(self):


### PR DESCRIPTION
Steps to reproduce:
- Create a batch transfer (or more).
- Open the list view of stock pickings.
- Select one (or more) stock pickings.
- From the actions menu, select "Add to batch".
- Select "Add to existing batch".
- Click on the many2one field to view the available batches.

Current behavior:
Batches without description appear as "Unnamed" and batches with description appear as "False: <description>".

This was because the definition of `_compute_display_name` was circular: display_name = `{display_name}: {description}` in case of using the add to batch wizard, or `{display_name}` otherwise. This commit uses `name` instead since `display_name` is not yet defined at this point.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
