### PR TITLE
[FIX] point_of_sale: correct report calculation with multiple payments

### DIFF
--- a/addons/point_of_sale/report/pos_order_report.py
+++ b/addons/point_of_sale/report/pos_order_report.py
@@ -80,7 +80,7 @@ class PosOrderReport(models.Model):
                 LEFT JOIN pos_session ps ON (s.session_id=ps.id)
                 LEFT JOIN res_company co ON (s.company_id=co.id)
                 LEFT JOIN res_currency cu ON (co.currency_id=cu.id)
-                LEFT JOIN pos_payment pm ON (pm.pos_order_id=s.id)
+                LEFT JOIN (SELECT DISTINCT ON (pos_order_id) * FROM pos_payment) pm ON (pm.pos_order_id=s.id)
                 LEFT JOIN pos_payment_method ppm ON (pm.payment_method_id=ppm.id)
         """
 


### PR DESCRIPTION
Before this commit, in cases where an order contained more than one POS payment, all lines of that order were calculated multiple times in the POS order report due to the join operation with the pos_payment table.

opw-4192768

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
