### PR TITLE
[IMP] pos_self_order: revamp kiosk opening system

### DIFF
--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -337,6 +337,35 @@ class PosConfig(models.Model):
             'context': ctx
         }
 
+    def action_install_kiosk_pwa(self):
+        self.ensure_one()
+        self_url = self._get_self_order_route()
+        scoped_url = f"/scoped_app?app_id=pos_self_order&path={self_url}"
+        return {
+            'type': 'ir.actions.act_url',
+            'url': scoped_url,
+            'target': 'new',
+        }
+
+    def open_kiosk_in_new_tab(self):
+        return {
+            'type': 'ir.actions.act_url',
+            'url': self.get_kiosk_url(),
+            'target': 'new',
+        }
+
+    # This method will open the kiosk on IOT if one of them is linked,
+    # otherwise it will open a new tab with the kiosk url
+    def open_kiosk(self):
+        self.ensure_one()
+
+        if not self.current_session_id:
+            session = self.env['pos.session'].create({'user_id': self.env.uid, 'config_id': self.id})
+            session.set_opening_control(0, "")
+            self._notify('STATUS', {'status': 'open'})
+
+        return self.open_kiosk_in_new_tab()
+
     def get_kiosk_url(self):
         return self.self_ordering_url
 

--- a/addons/pos_self_order/views/point_of_sale_dashboard.xml
+++ b/addons/pos_self_order/views/point_of_sale_dashboard.xml
@@ -48,16 +48,16 @@
                 <field name="self_ordering_mode" invisible="1" />
                 <field name="current_session_id" invisible="1" />
                 <div class="col-6 d-flex flex-column align-items-start" invisible="not self_ordering_mode == 'kiosk'">
-                    <button t-if="!record.current_session_id.raw_value" class="btn btn-primary pos_open_session_btn" name="action_open_wizard" type="object">
-                        Start Kiosk
+                    <button t-if="!record.current_session_id.raw_value" class="btn btn-primary pos_open_session_btn open-kiosk" name="open_kiosk" type="object">
+                        <span >Start Kiosk</span>
                     </button>
-                    <button t-else="" name="action_close_kiosk_session" class="btn btn-secondary" type="object">
+                    <button t-else="" name="action_close_kiosk_session" class="btn mt-1 btn-secondary" type="object">
                         Close Session
                     </button>
-                    <button t-if="record.current_session_id.raw_value" class="btn-link mt-2" name="action_open_wizard" type="object">
-                        Open Kiosk
-                    </button>
                 </div>
+            </xpath>
+            <xpath expr="//div[hasclass('o_kanban_card_manage_settings')]/div" position='inside'>
+                <a t-if="record.self_ordering_mode.raw_value == 'kiosk'" name="action_install_kiosk_pwa" type="object">Install Application</a>
             </xpath>
             <xpath expr="//div[@name='card_left']" position="attributes">
                 <field name="self_ordering_mode" invisible="1" />


### PR DESCRIPTION
Before, to open a kiosk, a popup was displayed with different choices. This wasn't user-friendly and could be confusing for the user. The user had to choose between a target _blank link of the kiosk or iot boxes.

Now, the user can set an iot box screen in the config of the kiosk and when he click on open kiosk, if there is an iot box screen set, the kiosk will be opened on the iot box screen, otherwise, it will be opened in a new tab directly.

It's always possible to open the PWA installation from the little 3 dots

taskId: 4200021
