### PR TITLE
[IMP] project: make state of task editable in popover of calendar view

### DIFF
--- a/addons/project/static/src/components/project_task_state_selection/project_task_stage_state_selection/project_task_stage_with_state_selection.js
+++ b/addons/project/static/src/components/project_task_state_selection/project_task_stage_state_selection/project_task_stage_with_state_selection.js
@@ -31,6 +31,7 @@ export class TaskStageWithStateSelection extends Component {
             ...this.stageProps,
             name: "state",
             readonly: this.props.stateReadonly,
+            autosave: !this.props.stateReadonly,
             viewType: this.props.viewType,
             showLabel: false,
         };
@@ -47,7 +48,7 @@ export const taskStageWithStateSelection = {
             default: true,
         },
     ],
-    fieldDependencies: [{ name: "state", type: "selection" }],
+    fieldDependencies: [{ name: "state", type: "selection", readonly: false }],
     supportedTypes: ["many2one"],
     extractProps({ options, viewType }) {
         return {

--- a/addons/project/static/tests/project_task_calendar.test.js
+++ b/addons/project/static/tests/project_task_calendar.test.js
@@ -86,6 +86,13 @@ test("test task_stage_with_state_selection widget with non-editable state", asyn
 });
 
 test("test task_stage_with_state_selection widget with editable state", async () => {
+    onRpc("web_save", ({ args }) => {
+        expect(args[1].state).toBe("03_approved", {
+            message: "The task should be approved",
+        });
+        expect.step("web_save");
+    });
+
     await mountView({
         ...calendarMountParams,
         arch: `
@@ -110,4 +117,5 @@ test("test task_stage_with_state_selection widget with editable state", async ()
     await click(".o_status_green"); // Checking if click on the state in selection menu works(changes in record)
     await animationFrame();
     expect(".o-dropdown .o_status").toHaveStyle({ color: "rgb(0, 136, 24)" });
+    expect.verifySteps(["web_save"]);
 });

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -831,7 +831,7 @@
                     <field name="partner_id" invisible="not partner_id"/>
                     <field name="priority" widget="priority"/>
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" invisible="not tag_ids"/>
-                    <field name="stage_id" invisible="not project_id or not stage_id" widget="task_stage_with_state_selection"/>
+                    <field name="stage_id" invisible="not project_id or not stage_id" widget="task_stage_with_state_selection" options="{'state_readonly': False}"/>
                     <field name="personal_stage_id" string="Personal Stage" options="{'no_open': True}" invisible="project_id or not personal_stage_id"/>
                     <field name="task_properties" invisible="not task_properties"/>
                 </calendar>


### PR DESCRIPTION
To avoid forcing the user to open the form view to change the state of a task, we allow the user to edit the state inside the popover of the calendar view. We remain consistent since it's also possible to alter the priority of a task inside the popover.

task-4173432

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
