### PR TITLE
[REF] web,*: kanban remove last data-type/data-name

### DIFF
--- a/addons/crm/views/utm_campaign_views.xml
+++ b/addons/crm/views/utm_campaign_views.xml
@@ -16,7 +16,7 @@
                     <t t-set="crm_lead_count_label">Opportunities</t>
                 </t>
                 <a t-if="record.crm_lead_count" href="#" t-att-title="crm_lead_count_label" role="button"
-                    groups="sales_team.group_sale_salesman" data-type="object" data-name="action_redirect_to_leads_opportunities"
+                    groups="sales_team.group_sale_salesman" type="object" name="action_redirect_to_leads_opportunities"
                     class="btn-outline-primary rounded-pill me-1 order-3">
                     <span class="badge">
                         <i class="fa fa-fw fa-star" t-att-aria-label="crm_lead_count_label" role="img"/>

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -282,8 +282,8 @@
                             <field name="vehicle_properties" widget="properties"/>
                             <footer class="pt-0 mt-0" t-if="!selection_mode">
                                 <div class="d-flex fs-6">
-                                    <a t-if="record.contract_count.raw_value>0" data-type="object"
-                                        data-name="return_action_to_open" href="#" data-context='{"xml_id":"fleet_vehicle_log_contract_action"}'>
+                                    <a t-if="record.contract_count.raw_value>0" type="object"
+                                        name="return_action_to_open" href="#" data-context='{"xml_id":"fleet_vehicle_log_contract_action"}'>
                                         <field name="contract_count"/>
                                         Contract(s)
                                         <span t-if="record.contract_renewal_due_soon.raw_value and !record.contract_renewal_overdue.raw_value"

--- a/addons/link_tracker/views/utm_campaign_views.xml
+++ b/addons/link_tracker/views/utm_campaign_views.xml
@@ -21,7 +21,7 @@
         <field name="arch" type="xml">
             <xpath expr="//footer/div" position="inside">
                 <a t-if="record.click_count" href="#" title="Clicks" role="button"
-                    data-type="action" data-name="%(link_tracker_action_campaign)d"
+                    type="action" name="%(link_tracker_action_campaign)d"
                     class="btn-outline-primary rounded-pill me-1 order-4">
                     <span class="badge">
                         <i class="fa fa-fw fa-mouse-pointer" aria-label="Clicks" role="img"/>

--- a/addons/marketing_card/views/card_campaign_views.xml
+++ b/addons/marketing_card/views/card_campaign_views.xml
@@ -160,13 +160,13 @@
                         <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" class="mt-2"/>
                         <footer class="fs-6 pt-0">
                             <div>
-                                <a data-type="object" data-name="action_view_cards_shared" href="#" class="me-1">
+                                <a type="object" name="action_view_cards_shared" href="#" class="me-1">
                                     <span class="badge rounded-pill">
                                         <i class="fa fa-fw fa-share" aria-label="Shares" role="img" title="Shares"/>
                                         <field name="card_share_count"/>
                                     </span>
                                 </a>
-                                <a data-type="object" data-name="action_view_cards_clicked" href="#" class="me-1">
+                                <a type="object" name="action_view_cards_clicked" href="#" class="me-1">
                                     <span class="badge rounded-pill">
                                         <i class="fa fa-fw fa-mouse-pointer" aria-label="Clicks" role="img" title="Clicks"/>
                                         <field name="target_url_click_count"/>

--- a/addons/sale/views/utm_campaign_views.xml
+++ b/addons/sale/views/utm_campaign_views.xml
@@ -8,7 +8,7 @@
         <field name="arch" type="xml">
             <xpath expr="//footer/div" position="inside">
                 <a t-if="record.invoiced_amount" href="#" title="Revenues" role="button"
-                    groups="sales_team.group_sale_salesman" data-type="object" data-name="action_redirect_to_invoiced"
+                    groups="sales_team.group_sale_salesman" type="object" name="action_redirect_to_invoiced"
                     class="btn-outline-primary rounded-pill me-1 order-1">
                     <span class="badge">
                         <field name="currency_id" invisible="True"/>
@@ -16,7 +16,7 @@
                     </span>
                 </a>
                 <a t-if="record.quotation_count" href="#" title="Quotations" role="button"
-                    groups="sales_team.group_sale_salesman" data-type="object" data-name="action_redirect_to_quotations"
+                    groups="sales_team.group_sale_salesman" type="object" name="action_redirect_to_quotations"
                     class="btn-outline-primary rounded-pill me-1 order-2">
                     <span class="badge">
                         <i class="fa fa-fw fa-money me-1" aria-label="Quotations" role="img"/>

--- a/addons/web/static/src/views/kanban/kanban_compiler.js
+++ b/addons/web/static/src/views/kanban/kanban_compiler.js
@@ -45,18 +45,6 @@ export class KanbanCompiler extends ViewCompiler {
      * @override
      */
     compileButton(el, params) {
-        /**
-         * WOWL FIXME
-         * For some reason, buttons in some arch have a data-something instead of just a normal attribute.
-         * The new system only uses normal attributes.
-         * This is an ugly small compatibility trick to fix this.
-         */
-        if (el.hasAttribute("data-type")) {
-            for (const { name, value } of el.attributes) {
-                el.setAttribute(name.replace(/^data-/, ""), value);
-            }
-        }
-
         const type = el.getAttribute("type");
         if (!SPECIAL_TYPES.includes(type)) {
             // Not a supported action type.


### PR DESCRIPTION
This was a very old API that we kept supporting in v16 for retro compatibility but which has almost no usecases anymore. This PR adapts those last usecases and removes the compatibility layer.

Task~3992107

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
