### PR TITLE
[IMP] base, *:  Remove obsolete SCSS and CSS from Kanban view

### DIFF
--- a/addons/crm/static/src/scss/crm.scss
+++ b/addons/crm/static/src/scss/crm.scss
@@ -6,18 +6,6 @@
     }
 }
 
-.o_opportunity_kanban .o_kanban_renderer {
-    .oe_kanban_card_ribbon {
-        min-height: 105px;
-        .o_kanban_record_title {
-            max-width: calc(100% - 65px);
-        }
-        .o_kanban_record_subtitle {
-            max-width: calc(100% - 35px);
-        }
-    }
-}
-
 .crm_lead_merge_summary {
     blockquote {
         font-style: normal;

--- a/addons/event/static/src/scss/event.scss
+++ b/addons/event/static/src/scss/event.scss
@@ -2,34 +2,6 @@
     .o_kanban_record > div {
         min-height: 140px;
     }
-    .o_kanban_content {
-        .o_event_fontsize_09 {
-            font-size: .9rem;
-        }
-
-        .o_event_fontsize_20 {
-            font-size: 2rem;
-        }
-    }
-}
-
-.o_kanban_view.o_event_attendee_kanban_view .o_kanban_renderer {
-    @media (max-width: 768px) {
-        .o_event_registration_kanban {
-            min-height: 80px;
-        }
-    }
-    // Used to align the kanban buttons as fa-check and fa-undo don't have the same width
-    .o_event_registration_kanban .fa-undo {
-        padding-left: 1px;
-        padding-right: 1px;
-    }
-    .oe_kanban_card_ribbon {
-        // Used for "Group By"
-        div.row {
-            min-height: 95px;
-        }
-    }
 }
 
 .o_event_registration_view_tree {

--- a/addons/hr_contract/static/src/scss/state_selection.scss
+++ b/addons/hr_contract/static/src/scss/state_selection.scss
@@ -1,9 +1,0 @@
-.o_hr_contract_state {
-    .o_status {
-        vertical-align: unset !important;
-    }
-}
-
-.o_hr_contract_job_id {
-    min-height: 1.5rem;
-}

--- a/addons/im_livechat/static/src/scss/im_livechat_history.scss
+++ b/addons/im_livechat/static/src/scss/im_livechat_history.scss
@@ -23,14 +23,8 @@
                     word-break: break-all;
                 }
             }
-            .oe_module_vignette {
-                text-align: left;
-            }
             .o_kanban_image {
                 padding-top: 8px;
-            }
-            .oe_module_desc {
-                padding: 8px 8px 0px 64px;
             }
         }
     }

--- a/addons/mail/static/src/scss/kanban_view.scss
+++ b/addons/mail/static/src/scss/kanban_view.scss
@@ -1,11 +1,5 @@
 $o-kanban-attachement-image-size: 80px;
 
-.o_discuss_channel_kanban {
-    .o_module_desc_short {
-        max-width: 90%;
-    }
-}
-
 .o_kanban_renderer {
     .o_kanban_record.o_kanban_attachment {
         padding: map-get($spacers, 0);

--- a/addons/mail_group/static/src/css/mail_group_backend.scss
+++ b/addons/mail_group/static/src/css/mail_group_backend.scss
@@ -3,7 +3,3 @@
         min-width: 100px;
     }
 }
-
-.o_mg_description {
-    height: 20px;
-}

--- a/addons/product/views/product_document_views.xml
+++ b/addons/product/views/product_document_views.xml
@@ -71,7 +71,7 @@
                             <t t-set="binaryPreviewable"
                                 t-value="new RegExp('(image|video|application/pdf|text)').test(record.mimetype.value) &amp;&amp; record.type.raw_value === 'binary'"/>
                             <div t-attf-class="o_kanban_image_wrapper #{(webimage or binaryPreviewable) ? 'o_kanban_previewer' : ''}">
-                                <div t-if="record.type.raw_value == 'url'" class="o_url_image fa fa-link fa-3x text-muted" aria-label="Image is a link"/>
+                                <div t-if="record.type.raw_value == 'url'" class="fa fa-link fa-3x text-muted" aria-label="Image is a link"/>
                                 <img t-elif="webimage" t-attf-src="/web/image/#{record.ir_attachment_id.raw_value}" width="100" height="100" alt="Document" class="o_attachment_image"/>
                                 <div t-else="" class="o_image o_image_thumbnail" t-att-data-mimetype="record.mimetype.value"/>
                             </div>

--- a/addons/project_todo/static/src/scss/todo.scss
+++ b/addons/project_todo/static/src/scss/todo.scss
@@ -15,10 +15,6 @@
     }
 }
 
-.o_todo_kanban_card_body {
-    padding-left: 9px;
-}
-
 .o_todo_hide_avatar .o_avatar {
     display: none;
 }

--- a/addons/web/static/src/core/utils/draggable_hook_builder.js
+++ b/addons/web/static/src/core/utils/draggable_hook_builder.js
@@ -678,7 +678,7 @@ export function makeDraggableHook(hookParams) {
 
                 // In FireFox: elements with `overflow: hidden` will prevent mouseenter and mouseleave
                 // events from firing on elements underneath them. This is the case when dragging a card
-                // by the `.o_kanban_record_headings` element. In such cases, we can prevent the default
+                // by the heading. In such cases, we can prevent the default
                 // action on the pointerdown event to allow pointer events to fire properly.
                 // https://bugzilla.mozilla.org/show_bug.cgi?id=1352061
                 // https://bugzilla.mozilla.org/show_bug.cgi?id=339293

--- a/addons/web/static/src/views/kanban/kanban_record_legacy.scss
+++ b/addons/web/static/src/views/kanban/kanban_record_legacy.scss
@@ -45,14 +45,6 @@
                 right: auto;
             }
 
-            .o_kanban_record_headings {
-                line-height: 1.2;
-                flex: 1 1 auto;
-                // Ensure long word doesn't break out of container
-                word-wrap: break-word;
-                overflow: hidden;
-            }
-            
             .o_field_priority {
                 margin: auto;
             }
@@ -62,15 +54,6 @@
             @include o-kanban-record-title();
             overflow-wrap: break-word;
             word-wrap: break-word;
-        }
-
-        .o_kanban_record_subtitle {
-            display: block;
-            margin-top: calc(var(--KanbanRecord-gap-v) * 0.5);
-
-            i.fa[role="img"] {
-                margin-right: 2px;
-            }
         }
 
         .o_kanban_record_bottom {
@@ -287,18 +270,6 @@
 
             img {
                 max-width: 100%;
-            }
-        }
-
-        .o_kanban_button {
-            margin-top: 15px;
-
-            > button,
-            > a {
-                @include o-position-absolute(
-                    $right: var(--KanbanRecord-padding-h),
-                    $bottom: var(--KanbanRecord-padding-v)
-                );
             }
         }
 

--- a/odoo/addons/base/static/src/css/modules.css
+++ b/odoo/addons/base/static/src/css/modules.css
@@ -1,29 +1,9 @@
-
-.oe_module_icon {
-    width: 50px;
-    max-height: 50px;
-    max-width: 23%;
-    float: left;
-}
-
 .oe_module_flag {
     position: absolute;
     left: 12px;
     top: calc(50% - 35px);
     font: 27px icon;
     text-shadow: 0px 0px 5px rgba(0, 0, 0, 0.5);
-}
-
-.oe_module_desc {
-    font-size: 13px;
-    padding-left: 10px;
-    width: 77%;
-}
-
-.o_kanban_view.o_modules_kanban .o_kanban_renderer .oe_module_vignette,
-.o_modules_field .o_modules_kanban .oe_module_vignette {
-    align-items: center;
-    display: flex;
 }
 
 .o_kanban_view.o_modules_kanban .o_kanban_renderer .o_kanban_record .o_dropdown_kanban,
@@ -40,31 +20,6 @@
 .o_modules_field .o_modules_kanban .o_kanban_renderer {
     --KanbanRecord-width: 280px;
     --KanbanRecord-width-small: 280px;
-}
-
-.oe_module_name > span  {
-    color: #999999;
-    min-height: 26px;
-    line-height: 1.1;
-    display: block;
-}
-
-.oe_module_desc p {
-    margin: 3px 0 3px;
-}
-
-.oe_module_desc > h4 {
-    margin-right: 20px;
-
-    max-width: 100%;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    vertical-align: top;
-}
-
-.oe_module_desc {
-    min-width: 0;
 }
 
 .o_module_form.o_form_view .oe_avatar > img {


### PR DESCRIPTION
\* = [web, project_todo, product, mail_group, mail, im_livechat, hr_contract, event, crm]

In an effort to simplify the Kanban architecture, we previously removed several SCSS and CSS elements from the Kanban view. As a result, many of the associated classes have become redundant and are no longer functional.

This commit aims to remove all such trivial and ineffective classes, improving overall code clarity and maintainability.

Task-3992107