### PR TITLE
[IMP] mail: smaller composer in chat window

### DIFF
--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -56,7 +56,13 @@
     padding-bottom: 10px;
     padding-left: (map-get($spacers, 2) + map-get($spacers, 3)) / 2;
     padding-right: (map-get($spacers, 2) + map-get($spacers, 3)) / 2;
+
     line-height: 1.42857143 !important; // so that input is rounded to 20px = 14px (base font) * 1.42857143 (line-height)
+
+    .o-mail-Composer.o-chatWindow & {
+        padding-top: 7px;
+        padding-bottom: 7px;
+    }
 
     .o-mail-Composer.o-editing & {
         padding-left: map-get($spacers, 2);
@@ -74,6 +80,7 @@
     }
 
     &::placeholder {
+        opacity: 75%;
         @include text-truncate();
     }
 }

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -15,6 +15,7 @@
                     'o-hasSelfAvatar': !env.inChatWindow and thread,
                     'o-focused': props.composer.isFocused,
                     'o-editing': props.composer.message,
+                    'o-chatWindow': env.inChatWindow,
                 }" t-attf-class="{{ props.className }}">
             <div class="o-mail-Composer-sidebarMain flex-shrink-0" t-if="!compact and props.sidebar">
                 <img class="o-mail-Composer-avatar o_avatar rounded" t-att-src="store.self.avatarUrl" alt="Avatar of user"/>
@@ -41,7 +42,6 @@
                     <div class="position-relative flex-grow-1">
                         <textarea class="o-mail-Composer-input o-mail-Composer-inputStyle form-control o-mail-Composer-bg border-0 rounded-3 shadow-none overflow-auto"
                             t-ref="textarea"
-                            style="height:40px;"
                             t-on-keydown="onKeydown"
                             t-on-focusin="onFocusin"
                             t-on-focusout="() => this.props.composer.isFocused = false"
@@ -73,7 +73,7 @@
                             'rounded': !props.composer.message,
                         }"
                     >
-                        <div class="d-flex flex-grow-1 align-items-baseline" t-att-class="{ 'mt-1': !props.composer.message }" t-ref="main-actions">
+                        <div class="d-flex flex-grow-1 align-items-baseline" t-att-class="{ 'mt-1': !props.composer.message and !env.inChatWindow }" t-ref="main-actions">
                             <button class="btn border-0 p-1 rounded-pill" t-att-class="{'bg-300': this.picker.state.picker === this.picker.PICKERS.EMOJI}" aria-label="Emojis" t-on-click="onClickAddEmoji" t-ref="emoji-button"><i class="fa fa-fw fa-smile-o"/></button>
                             <FileUploader t-if="allowUpload" multiUpload="true" onUploaded.bind="(data) => { attachmentUploader.uploadData(data) }">
                                 <t t-set-slot="toggler">


### PR DESCRIPTION
Also reducing slightly opacity of placeholder, so that it's easier to see that input is empty.

Before / After
![Screenshot 2024-09-20 at 16 23 19](https://github.com/user-attachments/assets/9f8b44fd-e451-4c6d-8642-e164d3d2b187)
![Screenshot 2024-09-20 at 16 21 31](https://github.com/user-attachments/assets/c3344920-8fd8-493f-895e-c6c947f19460)
