### PR TITLE
[FIX] sale_purchase_stock,purchase_mrp: Keep MTO link in multi-step

### DIFF
--- a/addons/purchase_mrp/models/purchase.py
+++ b/addons/purchase_mrp/models/purchase.py
@@ -21,7 +21,8 @@ class PurchaseOrder(models.Model):
             purchase.mrp_production_count = len(purchase._get_mrp_productions())
 
     def _get_mrp_productions(self, **kwargs):
-        return self.order_line.move_dest_ids.group_id.mrp_production_ids | self.order_line.move_ids.move_dest_ids.group_id.mrp_production_ids
+        return self.order_line.move_dest_ids.group_id.mrp_production_ids \
+            | self.env['stock.move'].browse(self.order_line.move_ids._rollup_move_dests()).group_id.mrp_production_ids
 
     def action_view_mrp_productions(self):
         self.ensure_one()

--- a/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
+++ b/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
@@ -1173,6 +1173,16 @@ class TestPurchaseMrpFlow(AccountTestInvoicingCommon):
         self.assertEqual(len(replenishments), 1)
         self.assertEqual(replenishments[0]['summary']['name'], purchase.name)
 
+        purchase.button_confirm()
+        self.assertEqual(production.purchase_order_count, 1)
+        self.assertEqual(purchase.mrp_production_count, 2)
+
+        receipt = purchase.picking_ids
+        receipt.move_ids.write({'quantity': 6, 'picked': True})
+        receipt._action_done()
+        self.assertEqual(production.purchase_order_count, 1)
+        self.assertEqual(purchase.mrp_production_count, 2)
+
     def test_total_cost_share_rounded_to_precision(self):
         kit, compo01, compo02 = self.env['product.product'].create([{
             'name': name,

--- a/addons/sale_purchase_stock/models/purchase_order.py
+++ b/addons/sale_purchase_stock/models/purchase_order.py
@@ -12,4 +12,6 @@ class PurchaseOrder(models.Model):
         super(PurchaseOrder, self)._compute_sale_order_count()
 
     def _get_sale_orders(self):
-        return super(PurchaseOrder, self)._get_sale_orders() | self.order_line.move_dest_ids.group_id.sale_id | self.order_line.move_ids.move_dest_ids.group_id.sale_id
+        return super()._get_sale_orders() \
+            | self.order_line.move_dest_ids.group_id.sale_id \
+            | self.env['stock.move'].browse(self.order_line.move_ids._rollup_move_dests()).group_id.sale_id

--- a/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
+++ b/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
@@ -175,9 +175,14 @@ class TestSalePurchaseStockFlow(TransactionCase):
         sale.action_confirm()
         self.assertEqual(sale.purchase_order_count, 1)
         purchase = sale._get_purchase_orders()
+        self.assertEqual(purchase.sale_order_count, 1)
         purchase.button_confirm()
+        # Re-check it as it's using a different link field
+        self.assertEqual(sale.purchase_order_count, 1)
+        self.assertEqual(purchase.sale_order_count, 1)
 
         receipt = purchase.picking_ids
         receipt.move_ids.write({'quantity': 1, 'picked': True})
         receipt._action_done()
         self.assertEqual(sale.purchase_order_count, 1)
+        self.assertEqual(purchase.sale_order_count, 1)


### PR DESCRIPTION
Follow-up on #179964, but this time properly checking if the link is still usable from both sides (i.e. both PO *and* SO).

Also fixes the issue with the link from PO <-> MO in the same way.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
