### PR TITLE
[IMP] mail: discuss composer max height increased

### DIFF
--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -72,10 +72,27 @@
 
 .o-mail-Composer-input {
     font-family: "text-emoji", $font-family-base;
-    max-height: 100px;
+    max-height: Min(100px, 60vh);
     resize: none;
 
-    .o-extended & {
+    .o-mail-Composer.o-chatWindow & {
+        @media (min-height: 325px) {
+            max-height: Min(350px, 70vh);
+        }
+    }
+    .o-mail-Composer.o-chatWindowBig & {
+        @media (min-height: 325px) {
+            max-height: Min(550px, 70vh);
+        }
+    }
+
+    .o-mail-Composer.o-discussApp & {
+        @media (min-height: 425px) {
+            max-height: 50vh;
+        }
+    }
+
+    .o-mail-Composer.o-extended & {
         max-height: Min(400px, 30vh);
     }
 

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -16,6 +16,8 @@
                     'o-focused': props.composer.isFocused,
                     'o-editing': props.composer.message,
                     'o-chatWindow': env.inChatWindow,
+                    'o-chatWindowBig': store.chatHub.isBig,
+                    'o-discussApp': env.inDiscussApp,
                 }" t-attf-class="{{ props.className }}">
             <div class="o-mail-Composer-sidebarMain flex-shrink-0" t-if="!compact and props.sidebar">
                 <img class="o-mail-Composer-avatar o_avatar rounded" t-att-src="store.self.avatarUrl" alt="Avatar of user"/>


### PR DESCRIPTION
In Discuss app and Chat windows, composer max height was only 100px.
This commit increases to a more useful 50vh for Discuss App and 70vh for Chat windows.

Before / After
![Screenshot 2024-09-20 at 17 13 52](https://github.com/user-attachments/assets/5b66d6bc-7b1c-40ff-8fe2-0da841f8976e)
![Screenshot 2024-09-20 at 17 12 58](https://github.com/user-attachments/assets/dc791710-e99b-4f83-bf91-f2ccdafa9319)

Before / After
![Screenshot 2024-09-20 at 17 13 43](https://github.com/user-attachments/assets/0df641d5-b371-4019-a7ba-fddf09dc8305)
![Screenshot 2024-09-20 at 17 13 14](https://github.com/user-attachments/assets/e0558c44-99b2-40ab-889f-61f8f6bb3676)




