### PR TITLE
[FIX] stock_fleet: remove replace in report

### DIFF
--- a/addons/stock_fleet/report/report_picking_batch.xml
+++ b/addons/stock_fleet/report/report_picking_batch.xml
@@ -1,10 +1,6 @@
 <odoo>
     <template id="report_picking_batch_inherit" inherit_id="stock_picking_batch.report_picking_batch">
-        <xpath expr="//div[hasclass('page')]/div[2]" position="replace">
-            <div t-if="o.user_id">
-                <strong>Responsible:</strong>
-                <span t-field="o.user_id">John Doe</span>
-            </div>
+        <xpath expr="//div[hasclass('page')]/div[2]" position="after">
             <div t-if="o.dock_id">
                 <strong>Dock:</strong>
                 <span t-field="o.dock_id"/>
@@ -18,37 +14,13 @@
                 <span t-field="o.vehicle_category_id"/>
             </div><br/>
         </xpath>
-        <xpath expr="//table[hasclass('table')]" position="replace">
-            <table class="table table-condensed">
-                <thead>
-                    <tr>
-                        <th>Sequence</th>
-                        <th>Transfer</th>
-                        <th>Barcode</th>
-                        <th>Status</th>
-                        <th>Scheduled Date</th>
-                    </tr>
-                </thead>
-                <tbody>
-                   <tr t-foreach="o.picking_ids" t-as="pick" order="batch_sequence">
-                        <td>
-                            <span t-field="pick.batch_sequence"/>
-                        </td>
-                        <td>
-                            <span t-field="pick.display_name">Transfer Name</span>
-                        </td>
-                        <td>
-                            <span t-field="pick.name" t-options="{'widget': 'barcode', 'quiet': 0, 'width': 400, 'height': 100, 'img_style': 'width:200px;height:50px;'}">Transfer</span>
-                        </td>
-                        <td>
-                            <span t-field="pick.state">Confirmed</span>
-                        </td>
-                        <td >
-                            <span t-field="pick.scheduled_date">2023-08-20</span>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+        <xpath expr="//table[hasclass('table')]//thead//tr//th" position="before">
+            <th>Sequence</th>
+        </xpath>
+        <xpath expr="//table[hasclass('table')]//tbody//tr//td" position="before">
+            <td>
+                <span t-field="pick.batch_sequence"/>
+            </td>
         </xpath>
     </template>
 </odoo>

--- a/addons/stock_picking_batch/report/report_picking_batch.xml
+++ b/addons/stock_picking_batch/report/report_picking_batch.xml
@@ -33,7 +33,7 @@
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    <tr t-foreach="o.picking_ids" t-as="pick">
+                                    <tr t-foreach="o.picking_ids.sorted(lambda p: p.batch_sequence)" t-as="pick">
                                         <td>
                                             <span t-field="pick.name">Transfer Name</span>
                                         </td>
@@ -77,7 +77,7 @@
                                 <t t-foreach="locations" t-as="location_from">
                                     <t t-set="loc_move_line" t-value="move_line_ids.filtered(lambda x: x.location_id==location_from)"/>
                                     <t t-foreach="loc_move_line.location_dest_id" t-as="location_dest">
-                                        <t t-set="move_lines" t-value="loc_move_line.filtered(lambda x: x.location_dest_id==location_dest)"/>
+                                        <t t-set="move_lines" t-value="loc_move_line.filtered(lambda x: x.location_dest_id==location_dest).sorted(lambda ml: ml.picking_id.batch_sequence)"/>
                                         <t t-set="products" t-value="move_lines.product_id"/>
                                         <tbody>
                                             <tr>


### PR DESCRIPTION
remove the replace section in the report. Instead use a better xpath with before/after. Also correctly order the pickings. order is not an existing argument, so use a sort instead

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
