### PR TITLE
[FIX] {sale_purchase}_{stock,mrp}: Keep stat buttons in MTSO

### DIFF
--- a/addons/purchase_mrp/models/mrp_production.py
+++ b/addons/purchase_mrp/models/mrp_production.py
@@ -15,12 +15,11 @@ class MrpProduction(models.Model):
     @api.depends('procurement_group_id.stock_move_ids.created_purchase_line_ids.order_id', 'procurement_group_id.stock_move_ids.move_orig_ids.purchase_line_id.order_id')
     def _compute_purchase_order_count(self):
         for production in self:
-            production.purchase_order_count = len(production.procurement_group_id.stock_move_ids.created_purchase_line_ids.order_id |
-                                                  production.procurement_group_id.stock_move_ids.move_orig_ids.purchase_line_id.order_id)
+            production.purchase_order_count = len(production._get_purchase_orders())
 
     def action_view_purchase_orders(self):
         self.ensure_one()
-        purchase_order_ids = (self.procurement_group_id.stock_move_ids.created_purchase_line_ids.order_id | self.procurement_group_id.stock_move_ids.move_orig_ids.purchase_line_id.order_id).ids
+        purchase_order_ids = self._get_purchase_orders().ids
         action = {
             'res_model': 'purchase.order',
             'type': 'ir.actions.act_window',
@@ -43,6 +42,14 @@ class MrpProduction(models.Model):
         if not iterate_key and move_raw_id.created_purchase_line_ids:
             iterate_key = 'created_purchase_line_ids'
         return iterate_key
+
+    def _get_purchase_orders(self):
+        self.ensure_one()
+        linked_po = self.procurement_group_id.stock_move_ids.created_purchase_line_ids.order_id \
+                  | self.env['stock.move'].browse(self.procurement_group_id.stock_move_ids._rollup_move_origs()).purchase_line_id.order_id
+        group_po = self.procurement_group_id.purchase_order_ids
+
+        return linked_po | group_po
 
     def _prepare_merge_orig_links(self):
         origs = super()._prepare_merge_orig_links()

--- a/addons/purchase_mrp/models/purchase.py
+++ b/addons/purchase_mrp/models/purchase.py
@@ -21,7 +21,11 @@ class PurchaseOrder(models.Model):
             purchase.mrp_production_count = len(purchase._get_mrp_productions())
 
     def _get_mrp_productions(self, **kwargs):
-        return self.order_line.move_dest_ids.group_id.mrp_production_ids | self.order_line.move_ids.move_dest_ids.group_id.mrp_production_ids
+        linked_mo = self.order_line.move_dest_ids.group_id.mrp_production_ids \
+                  | self.env['stock.move'].browse(self.order_line.move_ids._rollup_move_dests()).group_id.mrp_production_ids
+        group_mo = self.env['procurement.group'].search([('purchase_order_ids', 'in', self.ids)]).mrp_production_ids
+
+        return linked_mo | group_mo
 
     def action_view_mrp_productions(self):
         self.ensure_one()

--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -156,6 +156,10 @@ class PurchaseOrder(models.Model):
                 else:
                     moves_to_recompute_ids.update(move_dest_ids.ids)
 
+        linked_groups = self.env['procurement.group'].search([('purchase_order_ids', 'in', self.ids)])
+        if linked_groups:
+            linked_groups.purchase_order_ids = [Command.unlink(order_id) for order_id in self.ids]
+
         if moves_to_cancel_ids:
             moves_to_cancel = self.env['stock.move'].browse(moves_to_cancel_ids)
             moves_to_cancel._action_cancel()

--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -328,6 +328,11 @@ class PurchaseOrderLine(models.Model):
         res['propagate_cancel'] = values.get('propagate_cancel')
         res['product_description_variants'] = values.get('product_description_variants')
         res['product_no_variant_attribute_value_ids'] = values.get('never_product_template_attribute_value_ids')
+
+        # Need to attach purchase order to procurement group for mtso
+        group = values.get('group_id')
+        if group:
+            group.purchase_order_ids = [Command.link(po.id)]
         return res
 
     def _create_stock_moves(self, picking):

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -272,6 +272,10 @@ class StockLot(models.Model):
 class ProcurementGroup(models.Model):
     _inherit = 'procurement.group'
 
+    purchase_order_ids = fields.Many2many(
+        'purchase.order', 'procurement_group_purchase_order_rel',
+        'group_id', 'purchase_order_id', 'Linked Purchase Orders', copy=False)
+
     @api.model
     def run(self, procurements, raise_user_error=True):
         wh_by_comp = dict()

--- a/addons/sale_purchase_stock/models/purchase_order.py
+++ b/addons/sale_purchase_stock/models/purchase_order.py
@@ -9,10 +9,14 @@ class PurchaseOrder(models.Model):
 
     @api.depends('order_line.move_dest_ids.group_id.sale_id', 'order_line.move_ids.move_dest_ids.group_id.sale_id')
     def _compute_sale_order_count(self):
-        super(PurchaseOrder, self)._compute_sale_order_count()
+        super()._compute_sale_order_count()
 
     def _get_sale_orders(self):
-        return super(PurchaseOrder, self)._get_sale_orders() | self.order_line.move_dest_ids.group_id.sale_id | self.order_line.move_ids.move_dest_ids.group_id.sale_id
+        linked_so = self.order_line.move_dest_ids.group_id.sale_id \
+                  | self.env['stock.move'].browse(self.order_line.move_ids._rollup_move_dests()).group_id.sale_id
+        group_so = self.env['procurement.group'].search([('purchase_order_ids', 'in', self.ids)]).sale_id
+
+        return super()._get_sale_orders() | linked_so | group_so
 
 
 class PurchaseOrderLine(models.Model):

--- a/addons/sale_purchase_stock/models/sale_order.py
+++ b/addons/sale_purchase_stock/models/sale_order.py
@@ -9,9 +9,11 @@ class SaleOrder(models.Model):
 
     @api.depends('procurement_group_id.stock_move_ids.created_purchase_line_ids.order_id', 'procurement_group_id.stock_move_ids.move_orig_ids.purchase_line_id.order_id')
     def _compute_purchase_order_count(self):
-        super(SaleOrder, self)._compute_purchase_order_count()
+        super()._compute_purchase_order_count()
 
     def _get_purchase_orders(self):
-        return super()._get_purchase_orders() \
-            | self.procurement_group_id.stock_move_ids.created_purchase_line_ids.order_id \
-            | self.env['stock.move'].browse(self.procurement_group_id.stock_move_ids._rollup_move_origs()).purchase_line_id.order_id
+        linked_po = self.procurement_group_id.stock_move_ids.created_purchase_line_ids.order_id \
+                  | self.env['stock.move'].browse(self.procurement_group_id.stock_move_ids._rollup_move_origs()).purchase_line_id.order_id
+        group_po = self.procurement_group_id.purchase_order_ids
+
+        return super()._get_purchase_orders() | linked_po | group_po


### PR DESCRIPTION
Following the changes on the MTSO in #177185, the moves created through MTSO are now always considered as 'make_to_stock', which means the stat buttons linking PO <-> SO or PO <-> MO are now broken with the default MTO route, as the link is no longer set on the purchase order.

To avoid this, we add the `purchase_order_ids` directly to the procurement group and adds the impacted po to the triggering group if a purchase order line is generated through a procurement.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
