### PR TITLE
[FIX] stock: compute the qty to order of orderpoint correctly

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -291,7 +291,10 @@ class StockWarehouseOrderpoint(models.Model):
 
     def _inverse_qty_to_order(self):
         for orderpoint in self:
-            orderpoint.qty_to_order_manual = orderpoint.qty_to_order
+            if orderpoint.trigger == 'auto':
+                orderpoint.qty_to_order_manual = 0
+            elif orderpoint.qty_to_order != orderpoint.qty_to_order_computed:
+                orderpoint.qty_to_order_manual = orderpoint.qty_to_order
 
     def _search_qty_to_order(self, operator, value):
         records = self.search_fetch([('qty_to_order_manual', 'in', [0, False])], ['qty_to_order_computed'])

--- a/addons/stock/tests/test_proc_rule.py
+++ b/addons/stock/tests/test_proc_rule.py
@@ -505,6 +505,29 @@ class TestProcRule(TransactionCase):
         # opening the replenishment should not raise a KeyError even if the location is archived
         self.env['stock.warehouse.orderpoint'].action_open_orderpoints()
 
+    def test_compute_qty_to_order(self):
+        """
+        Check that the quantity to order is updated in the orderpoint when a new demand is created.
+        """
+        orderpoint = self.env['stock.warehouse.orderpoint'].create({
+            'name': 'auto orderpoint',
+            'product_id': self.product.id,
+            'product_min_qty': 5,
+            'qty_to_order': 5,
+            'trigger': 'auto',
+        })
+        self.assertEqual(orderpoint.qty_to_order, 5)
+        stock_move = self.env['stock.move'].create({
+            'name': 'Test Move',
+            'product_id': self.product.id,
+            'product_uom': self.product.uom_id.id,
+            'product_uom_qty': 1,
+            'location_id': self.ref('stock.stock_location_stock'),
+            'location_dest_id': self.ref('stock.stock_location_customers'),
+        })
+        stock_move._action_confirm()
+        self.assertEqual(orderpoint.qty_to_order, 6)
+
 
 class TestProcRuleLoad(TransactionCase):
     def setUp(cls):

--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -59,7 +59,7 @@
                 <field name="product_min_qty" string="Min" optional="show"/>
                 <field name="product_max_qty" string="Max" optional="show"/>
                 <field name="qty_multiple" optional="hide"/>
-                <field name="qty_to_order"/>
+                <field name="qty_to_order" readonly="trigger == 'auto'"/>
                 <field name="qty_to_order_manual" column_invisible="True"/>
                 <button name="action_remove_manual_qty_to_order" type="object" icon="fa-undo" title="Remove manually entered value and replace by the quantity to order based on the forecasted quantities" invisible="not qty_to_order_manual"/>
                 <button name="action_remove_manual_qty_to_order" type="object" icon="fa-undo" title="-" class="disabled opacity-0" invisible="qty_to_order_manual"/>


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Create a storable product "P1".
   - Go to the Purchase tab > add a vendor.
   - Create an order point:
     - Min qty: 10
     - Trigger: Auto
   - Result > the quantity to order is updated to 10.
- Create a delivery with one unit of P1.
- Mark the delivery as 'To Do'.

**Problem:**
A purchase order is created with 10 units of P1 instead of 11.

**Explanation:**
When the minimum quantity is set to 10, the `_compute_qty_to_order` method is triggered. Since the `qty_to_order_manual` is 0, the `qty_to_order_computed` is using so computed with `_compute_qty_to_order_computed` and assigned to `qty_to_order`:
https://github.com/odoo/odoo/blob/156bed3f430d706e13822bbd95d91c8dfd3ea42d/addons/stock/models/stock_orderpoint.py#L274-L277

https://github.com/odoo/odoo/blob/156bed3f430d706e13822bbd95d91c8dfd3ea42d/addons/stock/models/stock_orderpoint.py#L292

Subsequently, the inverse method is triggered, and the value of `qty_to_order` is set in `qty_to_order_manual`:
https://github.com/odoo/odoo/blob/156bed3f430d706e13822bbd95d91c8dfd3ea42d/addons/stock/models/stock_orderpoint.py#L279-L281

Thus, when the delivery is confirmed, `_compute_qty_to_order` is called again. However, this time, as `qty_to_order_manual` is already set, its value is used instead of recalculating a new value using `_compute_qty_to_order_computed`.

opw-4150572
