### PR TITLE
[FIX] mail: canned replies 'Tab to select' in chat window

### DIFF
--- a/addons/mail/static/src/core/common/navigable_list.js
+++ b/addons/mail/static/src/core/common/navigable_list.js
@@ -164,6 +164,9 @@ export class NavigableList extends Component {
             default:
                 return;
         }
+        if (this.props.options.length !== 0) {
+            ev.stopPropagation();
+        }
         ev.preventDefault();
     }
 


### PR DESCRIPTION
Before this commit, using "Tab to select" of canned response in chat window was not working.

This happens because the Tab event is bubbling to chat window, which attempts to focus another chat window, thus removing the selection of canned response suggestion.

This commit fixes the issue by stopping propagation of keydown event when the keyboard event is effectively managed by the suggestion list.

Before
![not-working](https://github.com/user-attachments/assets/95163391-cbd5-46e9-aef6-31155dab8483)

After
![working](https://github.com/user-attachments/assets/3fb4fdcd-2b3f-4f01-ab9b-03237bc02f5a)
