### PR TITLE
[FIX] website: remove dialog previews from generated pages

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -770,6 +770,11 @@ class Website(models.Model):
                     # for compatibility code
                     el.attrib['data-snippet'] = snippet
 
+                    # Remove the previews needed for the snippets dialog
+                    dialog_preview_els = el.find_class('s_dialog_preview')
+                    for preview_el in dialog_preview_els:
+                        preview_el.getparent().remove(preview_el)
+
                     # Tweak the shape of the first snippet to connect it
                     # properly with the header color in some themes
                     if i == 1:

--- a/addons/website/static/src/components/dialog/add_page_dialog.js
+++ b/addons/website/static/src/components/dialog/add_page_dialog.js
@@ -263,7 +263,7 @@ export class AddPageTemplatePreview extends Component {
             return;
         }
         const wrapEl = this.iframeRef.el.contentDocument.getElementById("wrap").cloneNode(true);
-        for (const previewEl of wrapEl.querySelectorAll(".o_new_page_snippet_preview")) {
+        for (const previewEl of wrapEl.querySelectorAll(".o_new_page_snippet_preview, .s_dialog_preview")) {
             previewEl.remove();
         }
         this.env.addPage(wrapEl.innerHTML, this.props.template.name && _t("Copy of %s", this.props.template.name));

--- a/addons/website/views/snippets/s_faq_horizontal.xml
+++ b/addons/website/views/snippets/s_faq_horizontal.xml
@@ -43,7 +43,7 @@
                                 <canvas height="0"/>
                             </div>
                             <!-- Graph's preview: removed automatically on drop  -->
-                            <img src="website/static/src/img/snippets_previews/s_faq_horizontal_2_preview.jpg" class="s_dialog_preview w-100"/>
+                            <img src="/website/static/src/img/snippets_previews/s_faq_horizontal_2_preview.jpg" class="s_dialog_preview w-100"/>
                             <!-- ==============================================  -->
                             <p><br/>Users can participate in beta testing programs, providing feedback on upcoming releases and influencing the future direction of the platform. By staying current with updates, you can take advantage of the latest tools and features, ensuring your business remains competitive and efficient.</p>
                         </span>


### PR DESCRIPTION
[FIX] website: remove dialog previews from generated pages

Since commit [1], a snippets dialog is used to add snippets in pages. In
order for dynamic elements to be visible in the modal, fake previews are
used. They are then removed once the snippet is dropped. These previews
can be recognized by their `s_dialog_preview` class.

However, the configurator and the new page templates flows have been
forgotten. Indeed, when creating a new website with a theme dropping
snippets with previews in it, or when creating a new page from a new
page template containing these snippets, the previews are still present
in the generated pages, which should not happen.

This commit removes the dialog previews from these generated pages.

[1]: https://github.com/odoo/odoo/commit/edf81c13d8f2f6d29a77d68cbfa0dc9216da3c2a

task-4185274

---
[FIX] website: allow `s_faq_horizontal` to be in new page templates

When adding the `s_faq_horizontal` snippet in a new page template, it
cannot be loaded because its preview image cannot be found.

This commit fixes the path of this image.

task-4185274