### PR TITLE
[REV] stock: allow custom domain in SML X2many field

### DIFF
--- a/addons/stock/static/src/fields/stock_move_line_x2_many_field.js
+++ b/addons/stock/static/src/fields/stock_move_line_x2_many_field.js
@@ -42,13 +42,10 @@ export class SMLX2ManyField extends X2ManyField {
         const productName = this.props.record.data.product_id[1];
         const title = _t("Add line: %s", productName);
         const alreadySelected = this.props.record.data.move_line_ids.records.filter((line) => line.data.quant_id?.[0]);
-        let domain = [
+        const domain = [
             ["product_id", "=", this.props.record.data.product_id[0]],
             ["location_id", "child_of", this.props.context.default_location_id],
         ];
-        if (this.props.domain) {
-            domain = [...domain, ...this.props.domain()];
-        }
         if (alreadySelected.length) {
             domain.push(["id", "not in", alreadySelected.map((line) => line.data.quant_id[0])]);
         }


### PR DESCRIPTION
This reverts commit 5b999384a3ec51b8d9ff7b13b17508ebe6ac3ad5.

The original commit in v17 was ok, but in saas-17.2+, the MRP flow was broken due to this change.

Steps to reproduce:
- Open Manuf -> Create MO w/ product Drawer -> Confirm
- Open Detailed Operations. -> Add a line

opw-4201279
and many more opws linked in main ticket

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
