### PR TITLE
[FIX] mail: fix discuss composer style

### DIFF
--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -42,6 +42,7 @@
                     <div class="position-relative flex-grow-1">
                         <t t-set="inputClasses" t-value="'o-mail-Composer-inputStyle form-control border-0 rounded-3'"/>
                         <textarea class="o-mail-Composer-input o-mail-Composer-bg shadow-none overflow-auto"
+                            t-att-class="inputClasses"
                             t-ref="textarea"
                             t-on-keydown="onKeydown"
                             t-on-focusin="onFocusin"


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/180761

Original PR made the right fix but last PR in forward-port has a typo, which results in wrong composer style.

This commit fixes the typo.

Before / After
![Screenshot 2024-09-21 at 13 57 06](https://github.com/user-attachments/assets/ea6721bc-7ddb-4570-aac1-44f029b4c597)
![Screenshot 2024-09-21 at 13 56 51](https://github.com/user-attachments/assets/fd579a95-d616-4a9a-a10e-0c11a5d5a182)
