### PR TITLE
[FIX] pos_loyalty: loyalty reward after less required points

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_order.js
@@ -1241,7 +1241,7 @@ patch(PosOrder.prototype, {
                 reward.program_id.applies_on !== "future"
             ) {
                 const line = this.get_orderlines().find(
-                    (line) => line._reward_product_id === product.id
+                    (line) => line._reward_product_id?.id === product.id
                 );
                 // Compute the correction points once even if there are multiple reward lines.
                 // This is because _getPointsCorrection is taking into account all the lines already.


### PR DESCRIPTION
Before this commit:
==========
- Rewards were being applied even when loyalty points were insufficient for the redemption of loyalty rewards.

After this commit:
==========
- Reward products will not be applied if the customer's loyalty points are Insufficient for the specific reward product.

task-4126886

Related PR: https://github.com/odoo/odoo/pull/180972 