### PR TITLE
[FIX] website: fix `s_big_number` wrong gradient implementation

### DIFF
--- a/addons/website/views/snippets/s_big_number.xml
+++ b/addons/website/views/snippets/s_big_number.xml
@@ -7,13 +7,15 @@
         <div class="container">
             <div class="row s_nb_column_fixed">
                 <h2 style="text-align: center;">
-                    <div style="font-size: 10.75rem;">
-                        <font class="text-gradient" style="background-image: linear-gradient(0deg, rgb(222, 222, 222) 25%, rgb(29, 32, 48) 80%);">
+                    <span style="font-size: 10.75rem;">
+                        <font class="text-gradient" style="background-image: linear-gradient(0deg, var(--o-color-4) 25%, var(--o-color-5) 90%);">
                             87%
                         </font>
-                    </div>
+                    </span>
                 </h2>
-                <div style="font-size: 2.25rem; text-align: center;">customer satisfaction</div>
+                <p style="text-align: center;">
+                    <span style="font-size: 2.25rem;"> customer satisfaction</span>
+                </p>
             </div>
         </div>
     </section>


### PR DESCRIPTION
This PR aims to fix a wrong implementation of gradients on the `s_big_number` snippet within the context of the web editor.

Prior to this commit, the `s_big_number` snippet was using a gradient composed of the right color, but being declared as `RGB` values.

While this is working as expected and looking like it uses the right `--o-color-*`, it's indeed working with the specific color applied in first place. If a user changes the color palette of the website, the snippet will look terrible as it doesn't adapt to the new palette.

This PR fixes the issue by using the right implementation with CSS variables.

task-4202371

- requires https://github.com/odoo/design-themes/pull/930

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
