### PR TITLE
[FIX] l10n_it_edi_doi: unsupported chatter syntax

### DIFF
--- a/addons/l10n_it_edi_doi/views/l10n_it_edi_doi_declaration_of_intent_views.xml
+++ b/addons/l10n_it_edi_doi/views/l10n_it_edi_doi_declaration_of_intent_views.xml
@@ -99,7 +99,11 @@
                         </group>
                     </group>
                 </sheet>
-                <chatter/>
+                <div class="oe_chatter">
+                    <field name="message_follower_ids" groups="base.group_user"/>
+                    <field name="message_ids"/>
+                    <field name="activity_ids"/>
+                </div>
             </form>
         </field>
     </record>


### PR DESCRIPTION
before this commit, in the view_l10n_it_edi_doi_form view the chatter is added/defined 
in the unsupported/invalid syntax(which is supported in master) and thus the 
chatter is missing in the form view

after this commit, the chatter will be shown in the corresponding form view




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
