### PR TITLE
[IMP] added wheel at the top in requirements.txt

### DIFF
--- a/doc/cla/individual/blessingmwiti.md
+++ b/doc/cla/individual/blessingmwiti.md
@@ -1,0 +1,11 @@
+Kenya, 2024-09-22
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Blessing Mwiti blessingmwiti@gmail.com https://github.com/blessingmwiti

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # The officially supported versions of the following packages are their
 # python3-* equivalent distributed in Ubuntu 22.04 and Debian 11
+wheel==0.44.0 # added wheel
 Babel==2.9.1 ; python_version < '3.11'  # min version = 2.6.0 (Focal with security backports)
 Babel==2.10.3 ; python_version >= '3.11'
 chardet==4.0.0 ; python_version < '3.11'  # (Jammy)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

I got tired of installing wheel manually, so i added wheel at the top of requirements.txt to be installed automatically

Current behavior before PR:

Had to manually install wheel

Desired behavior after PR is merged:

Wheel gets to be installed automatically




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
