### PR TITLE
[REF] web,*: kanban: remove unnecessary classname on action buttons

### DIFF
--- a/addons/account/static/src/components/account_file_uploader/account_file_uploader.scss
+++ b/addons/account/static/src/components/account_file_uploader/account_file_uploader.scss
@@ -1,5 +1,5 @@
 .o_widget_account_file_uploader {
-  .oe_kanban_action_button {
+  button.oe_kanban_action {
     a {
       color: var(--btn-color);
     }

--- a/addons/account/static/src/scss/account_journal_dashboard.scss
+++ b/addons/account/static/src/scss/account_journal_dashboard.scss
@@ -9,7 +9,7 @@
         }
 
         @include media-breakpoint-up(sm) {
-            .oe_kanban_action_button {
+            button.oe_kanban_action {
                 margin-bottom: 5px;
             }
         }

--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -297,13 +297,13 @@
                             </t>
                             <t t-if="journal_type == 'purchase'">
                                 <div t-if="!journal_is_empty" class="d-flex">
-                                    <widget name="account_file_uploader" btnClass="btn btn-primary oe_kanban_action_button"/>
+                                    <widget name="account_file_uploader" btnClass="btn btn-primary oe_kanban_action"/>
                                     <div class="ms-1">
                                         <button type="object" name="action_create_new" class="btn-secondary " groups="account.group_account_invoice">New</button>
                                     </div>
                                 </div>
                                 <div t-else="">
-                                    <widget name="account_file_uploader" btnClass="btn btn-primary oe_kanban_action_button"/>
+                                    <widget name="account_file_uploader" btnClass="btn btn-primary oe_kanban_action"/>
                                     <widget name="bill_upload_guide"/>
                                 </div>
                             </t>

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -188,7 +188,7 @@
                                                 </t>
                                             </div>
                                             <t t-if="!read_only_mode">
-                                                <a type="edit" t-attf-class="oe_kanban_action oe_kanban_action_a text-black">
+                                                <a type="edit" t-attf-class="oe_kanban_action text-black">
                                                     <t t-call="level_content"/>
                                                 </a>
                                             </t>

--- a/addons/hr_recruitment/static/src/js/tours/hr_recruitment.js
+++ b/addons/hr_recruitment/static/src/js/tours/hr_recruitment.js
@@ -70,7 +70,7 @@ registry.category("web_tour.tours").add('hr_recruitment_tour',{
     trigger: ".o_hr_recruitment_kanban",
 },
 {
-    trigger: ".oe_kanban_action_button",
+    trigger: "button.oe_kanban_action",
     content: markup(_t("<b>Did you apply by sending an email?</b> Check incoming applications.")),
     tooltipPosition: "bottom",
     run: "click",

--- a/addons/web/static/src/views/kanban/kanban_compiler.js
+++ b/addons/web/static/src/views/kanban/kanban_compiler.js
@@ -47,14 +47,11 @@ export class KanbanCompiler extends ViewCompiler {
     compileButton(el, params) {
         const type = el.getAttribute("type");
         if (!SPECIAL_TYPES.includes(type)) {
-            // Not a supported action type.
+            // Not a kanban-specific action type.
             return super.compileButton(el, params);
         }
 
-        combineAttributes(el, "class", [
-            "oe_kanban_action",
-            `oe_kanban_action_${getTag(el, true)}`,
-        ]);
+        combineAttributes(el, "class", ["oe_kanban_action"]);
 
         if (ACTION_TYPES.includes(type)) {
             if (!el.hasAttribute("debounce")) {

--- a/addons/web/static/tests/views/fields/one2many_field.test.js
+++ b/addons/web/static/tests/views/fields/one2many_field.test.js
@@ -5727,7 +5727,7 @@ test("one2many kanban with action button", async () => {
         resId: 1,
     });
 
-    await contains(".oe_kanban_action_button").click();
+    await contains("button.oe_kanban_action").click();
 });
 
 test("one2many without inline tree arch", async () => {

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -942,26 +942,26 @@ test("view button and string interpolated attribute in kanban", async () => {
             </kanban>`,
     });
     expect.verifySteps([
-        "[one] className: 'hola oe_kanban_action oe_kanban_action_a'",
-        "[two] className: 'hola oe_kanban_action oe_kanban_action_a hello'",
-        "[sri] className: 'hola oe_kanban_action oe_kanban_action_a yop'",
-        "[foa] className: 'hola oe_kanban_action oe_kanban_action_a yop olleh'",
-        "[fye] className: 'hola oe_kanban_action oe_kanban_action_a hello yop'",
-        "[one] className: 'hola oe_kanban_action oe_kanban_action_a'",
-        "[two] className: 'hola oe_kanban_action oe_kanban_action_a hello'",
-        "[sri] className: 'hola oe_kanban_action oe_kanban_action_a blip'",
-        "[foa] className: 'hola oe_kanban_action oe_kanban_action_a blip olleh'",
-        "[fye] className: 'hola oe_kanban_action oe_kanban_action_a hello blip'",
-        "[one] className: 'hola oe_kanban_action oe_kanban_action_a'",
-        "[two] className: 'hola oe_kanban_action oe_kanban_action_a hello'",
-        "[sri] className: 'hola oe_kanban_action oe_kanban_action_a gnap'",
-        "[foa] className: 'hola oe_kanban_action oe_kanban_action_a gnap olleh'",
-        "[fye] className: 'hola oe_kanban_action oe_kanban_action_a hello gnap'",
-        "[one] className: 'hola oe_kanban_action oe_kanban_action_a'",
-        "[two] className: 'hola oe_kanban_action oe_kanban_action_a hello'",
-        "[sri] className: 'hola oe_kanban_action oe_kanban_action_a blip'",
-        "[foa] className: 'hola oe_kanban_action oe_kanban_action_a blip olleh'",
-        "[fye] className: 'hola oe_kanban_action oe_kanban_action_a hello blip'",
+        "[one] className: 'hola oe_kanban_action'",
+        "[two] className: 'hola oe_kanban_action hello'",
+        "[sri] className: 'hola oe_kanban_action yop'",
+        "[foa] className: 'hola oe_kanban_action yop olleh'",
+        "[fye] className: 'hola oe_kanban_action hello yop'",
+        "[one] className: 'hola oe_kanban_action'",
+        "[two] className: 'hola oe_kanban_action hello'",
+        "[sri] className: 'hola oe_kanban_action blip'",
+        "[foa] className: 'hola oe_kanban_action blip olleh'",
+        "[fye] className: 'hola oe_kanban_action hello blip'",
+        "[one] className: 'hola oe_kanban_action'",
+        "[two] className: 'hola oe_kanban_action hello'",
+        "[sri] className: 'hola oe_kanban_action gnap'",
+        "[foa] className: 'hola oe_kanban_action gnap olleh'",
+        "[fye] className: 'hola oe_kanban_action hello gnap'",
+        "[one] className: 'hola oe_kanban_action'",
+        "[two] className: 'hola oe_kanban_action hello'",
+        "[sri] className: 'hola oe_kanban_action blip'",
+        "[foa] className: 'hola oe_kanban_action blip olleh'",
+        "[fye] className: 'hola oe_kanban_action hello blip'",
     ]);
 });
 
@@ -8039,7 +8039,7 @@ test("properly evaluate more complex domains", async () => {
             </kanban>`,
     });
 
-    expect("button.float-end.oe_kanban_action_button").toHaveCount(1, {
+    expect("button.float-end.oe_kanban_action").toHaveCount(1, {
         message: "only one button should be visible",
     });
 });

--- a/addons/web/static/tests/views/kanban/kanban_view_legacy.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view_legacy.test.js
@@ -552,26 +552,26 @@ test("view button and string interpolated attribute in kanban", async () => {
             </kanban>`,
     });
     expect.verifySteps([
-        "[one] className: 'hola oe_kanban_action oe_kanban_action_a'",
-        "[two] className: 'hola oe_kanban_action oe_kanban_action_a hello'",
-        "[sri] className: 'hola oe_kanban_action oe_kanban_action_a yop'",
-        "[foa] className: 'hola oe_kanban_action oe_kanban_action_a yop olleh'",
-        "[fye] className: 'hola oe_kanban_action oe_kanban_action_a hello yop'",
-        "[one] className: 'hola oe_kanban_action oe_kanban_action_a'",
-        "[two] className: 'hola oe_kanban_action oe_kanban_action_a hello'",
-        "[sri] className: 'hola oe_kanban_action oe_kanban_action_a blip'",
-        "[foa] className: 'hola oe_kanban_action oe_kanban_action_a blip olleh'",
-        "[fye] className: 'hola oe_kanban_action oe_kanban_action_a hello blip'",
-        "[one] className: 'hola oe_kanban_action oe_kanban_action_a'",
-        "[two] className: 'hola oe_kanban_action oe_kanban_action_a hello'",
-        "[sri] className: 'hola oe_kanban_action oe_kanban_action_a gnap'",
-        "[foa] className: 'hola oe_kanban_action oe_kanban_action_a gnap olleh'",
-        "[fye] className: 'hola oe_kanban_action oe_kanban_action_a hello gnap'",
-        "[one] className: 'hola oe_kanban_action oe_kanban_action_a'",
-        "[two] className: 'hola oe_kanban_action oe_kanban_action_a hello'",
-        "[sri] className: 'hola oe_kanban_action oe_kanban_action_a blip'",
-        "[foa] className: 'hola oe_kanban_action oe_kanban_action_a blip olleh'",
-        "[fye] className: 'hola oe_kanban_action oe_kanban_action_a hello blip'",
+        "[one] className: 'hola oe_kanban_action'",
+        "[two] className: 'hola oe_kanban_action hello'",
+        "[sri] className: 'hola oe_kanban_action yop'",
+        "[foa] className: 'hola oe_kanban_action yop olleh'",
+        "[fye] className: 'hola oe_kanban_action hello yop'",
+        "[one] className: 'hola oe_kanban_action'",
+        "[two] className: 'hola oe_kanban_action hello'",
+        "[sri] className: 'hola oe_kanban_action blip'",
+        "[foa] className: 'hola oe_kanban_action blip olleh'",
+        "[fye] className: 'hola oe_kanban_action hello blip'",
+        "[one] className: 'hola oe_kanban_action'",
+        "[two] className: 'hola oe_kanban_action hello'",
+        "[sri] className: 'hola oe_kanban_action gnap'",
+        "[foa] className: 'hola oe_kanban_action gnap olleh'",
+        "[fye] className: 'hola oe_kanban_action hello gnap'",
+        "[one] className: 'hola oe_kanban_action'",
+        "[two] className: 'hola oe_kanban_action hello'",
+        "[sri] className: 'hola oe_kanban_action blip'",
+        "[foa] className: 'hola oe_kanban_action blip olleh'",
+        "[fye] className: 'hola oe_kanban_action hello blip'",
     ]);
 });
 
@@ -1248,7 +1248,7 @@ test("properly evaluate more complex domains", async () => {
             </kanban>`,
     });
 
-    expect("button.float-end.oe_kanban_action_button").toHaveCount(1, {
+    expect("button.float-end.oe_kanban_action").toHaveCount(1, {
         message: "only one button should be visible",
     });
 });

--- a/addons/website_hr_recruitment/static/src/js/widgets/copy_link_menuitem.xml
+++ b/addons/website_hr_recruitment/static/src/js/widgets/copy_link_menuitem.xml
@@ -12,7 +12,7 @@
         <a
             t-ref="button"
             role="button"
-            class="oe_kanban_action oe_kanban_action_a"
+            class="oe_kanban_action"
             t-on-click.stop="onClick">
             <span t-esc="props.copyText"/>
         </a>


### PR DESCRIPTION
Action buttons (i.e. `<a>` or `<button>` tags) automically came with two classnames: `oe_kanban_action` and `oe_kanban_action_${tagName}`. The latter wasn't really necessary, so this commit removes it.

Part of task~3992107 aiming at simplifying kanban views

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
