### PR TITLE
[FIX] account: accounting dashboard new and upload button in single line

### DIFF
--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -205,7 +205,7 @@
 
                     <t t-name="JournalMiscelaneous">
                         <div id="dashboard_misc_left" class="col mb-3 mb-sm-0">
-                            <button id="new_misc_entry_button" type="object" name="action_create_new" class="btn btn-primary" groups="account.group_account_user">
+                            <button id="new_misc_entry_button" type="object" name="action_create_new" class="btn btn-primary float-start me-1" groups="account.group_account_user">
                                 New
                             </button>
                         </div>


### PR DESCRIPTION
Before this commit new and upload buttons not in a single line.

After this commit new and upload buttons should be in a single line.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
