### PR TITLE
[FIX] {sale_purchase}_{stock,mrp}: Keep stat buttons in MTSO

### DIFF
--- a/addons/purchase_mrp/models/mrp_production.py
+++ b/addons/purchase_mrp/models/mrp_production.py
@@ -15,12 +15,11 @@ class MrpProduction(models.Model):
     @api.depends('procurement_group_id.stock_move_ids.created_purchase_line_ids.order_id', 'procurement_group_id.stock_move_ids.move_orig_ids.purchase_line_id.order_id')
     def _compute_purchase_order_count(self):
         for production in self:
-            production.purchase_order_count = len(production.procurement_group_id.stock_move_ids.created_purchase_line_ids.order_id |
-                                                  production.procurement_group_id.stock_move_ids.move_orig_ids.purchase_line_id.order_id)
+            production.purchase_order_count = len(production._get_purchase_orders())
 
     def action_view_purchase_orders(self):
         self.ensure_one()
-        purchase_order_ids = (self.procurement_group_id.stock_move_ids.created_purchase_line_ids.order_id | self.procurement_group_id.stock_move_ids.move_orig_ids.purchase_line_id.order_id).ids
+        purchase_order_ids = self._get_purchase_orders().ids
         action = {
             'res_model': 'purchase.order',
             'type': 'ir.actions.act_window',
@@ -43,6 +42,14 @@ class MrpProduction(models.Model):
         if not iterate_key and move_raw_id.created_purchase_line_ids:
             iterate_key = 'created_purchase_line_ids'
         return iterate_key
+
+    def _get_purchase_orders(self):
+        self.ensure_one()
+        linked_po = self.procurement_group_id.stock_move_ids.created_purchase_line_ids.order_id \
+                  | self.env['stock.move'].browse(self.procurement_group_id.stock_move_ids._rollup_move_origs()).purchase_line_id.order_id
+        group_po = self.procurement_group_id.purchase_line_ids.order_id
+
+        return linked_po | group_po
 
     def _prepare_merge_orig_links(self):
         origs = super()._prepare_merge_orig_links()

--- a/addons/purchase_mrp/models/purchase.py
+++ b/addons/purchase_mrp/models/purchase.py
@@ -21,7 +21,11 @@ class PurchaseOrder(models.Model):
             purchase.mrp_production_count = len(purchase._get_mrp_productions())
 
     def _get_mrp_productions(self, **kwargs):
-        return self.order_line.move_dest_ids.group_id.mrp_production_ids | self.order_line.move_ids.move_dest_ids.group_id.mrp_production_ids
+        linked_mo = self.order_line.move_dest_ids.group_id.mrp_production_ids \
+                  | self.env['stock.move'].browse(self.order_line.move_ids._rollup_move_dests()).group_id.mrp_production_ids
+        group_mo = self.order_line.group_id.mrp_production_ids
+
+        return linked_mo | group_mo
 
     def action_view_mrp_productions(self):
         self.ensure_one()

--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -155,6 +155,8 @@ class PurchaseOrder(models.Model):
                     moves_to_cancel_ids.update(move_dest_ids.ids)
                 else:
                     moves_to_recompute_ids.update(move_dest_ids.ids)
+            if order_line.group_id:
+                order_line.group_id.purchase_line_ids = [Command.unlink(order_line.id)]
 
         if moves_to_cancel_ids:
             moves_to_cancel = self.env['stock.move'].browse(moves_to_cancel_ids)

--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -30,6 +30,7 @@ class PurchaseOrderLine(models.Model):
     propagate_cancel = fields.Boolean('Propagate cancellation', default=True)
     forecasted_issue = fields.Boolean(compute='_compute_forecasted_issue')
     location_final_id = fields.Many2one('stock.location', 'Location from procurement')
+    group_id = fields.Many2one('procurement.group', 'Procurement group that generated this line')
 
     def _compute_qty_received_method(self):
         super(PurchaseOrderLine, self)._compute_qty_received_method()
@@ -328,6 +329,11 @@ class PurchaseOrderLine(models.Model):
         res['propagate_cancel'] = values.get('propagate_cancel')
         res['product_description_variants'] = values.get('product_description_variants')
         res['product_no_variant_attribute_value_ids'] = values.get('never_product_template_attribute_value_ids')
+
+        # Need to attach purchase order to procurement group for mtso
+        group = values.get('group_id')
+        if group and not res['move_dest_ids']:
+            res['group_id'] = values['group_id'].id
         return res
 
     def _create_stock_moves(self, picking):

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -272,6 +272,8 @@ class StockLot(models.Model):
 class ProcurementGroup(models.Model):
     _inherit = 'procurement.group'
 
+    purchase_line_ids = fields.One2many('purchase.order.line', 'group_id', string='Linked Purchase Order Lines', copy=False)
+
     @api.model
     def run(self, procurements, raise_user_error=True):
         wh_by_comp = dict()

--- a/addons/sale_purchase_stock/models/purchase_order.py
+++ b/addons/sale_purchase_stock/models/purchase_order.py
@@ -9,10 +9,14 @@ class PurchaseOrder(models.Model):
 
     @api.depends('order_line.move_dest_ids.group_id.sale_id', 'order_line.move_ids.move_dest_ids.group_id.sale_id')
     def _compute_sale_order_count(self):
-        super(PurchaseOrder, self)._compute_sale_order_count()
+        super()._compute_sale_order_count()
 
     def _get_sale_orders(self):
-        return super(PurchaseOrder, self)._get_sale_orders() | self.order_line.move_dest_ids.group_id.sale_id | self.order_line.move_ids.move_dest_ids.group_id.sale_id
+        linked_so = self.order_line.move_dest_ids.group_id.sale_id \
+                  | self.env['stock.move'].browse(self.order_line.move_ids._rollup_move_dests()).group_id.sale_id
+        group_so = self.order_line.group_id.sale_id
+
+        return super()._get_sale_orders() | linked_so | group_so
 
 
 class PurchaseOrderLine(models.Model):

--- a/addons/sale_purchase_stock/models/sale_order.py
+++ b/addons/sale_purchase_stock/models/sale_order.py
@@ -9,9 +9,11 @@ class SaleOrder(models.Model):
 
     @api.depends('procurement_group_id.stock_move_ids.created_purchase_line_ids.order_id', 'procurement_group_id.stock_move_ids.move_orig_ids.purchase_line_id.order_id')
     def _compute_purchase_order_count(self):
-        super(SaleOrder, self)._compute_purchase_order_count()
+        super()._compute_purchase_order_count()
 
     def _get_purchase_orders(self):
-        return super()._get_purchase_orders() \
-            | self.procurement_group_id.stock_move_ids.created_purchase_line_ids.order_id \
-            | self.env['stock.move'].browse(self.procurement_group_id.stock_move_ids._rollup_move_origs()).purchase_line_id.order_id
+        linked_po = self.procurement_group_id.stock_move_ids.created_purchase_line_ids.order_id \
+                  | self.env['stock.move'].browse(self.procurement_group_id.stock_move_ids._rollup_move_origs()).purchase_line_id.order_id
+        group_po = self.procurement_group_id.purchase_line_ids.order_id
+
+        return super()._get_purchase_orders() | linked_po | group_po


### PR DESCRIPTION
Following the changes on the MTSO in #177185, the moves created through MTSO are now always considered as 'make_to_stock', which means the stat buttons linking PO <-> SO or PO <-> MO are now broken with the default MTO route, as the link is no longer set on the purchase order.

To mitigate this, we add link to the procurement group that added generated the purchase order line when it's generated through mtso. This creates a direct link with the po line itself and allows to properly link PO <-> SO and PO <-> MO again.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
