### PR TITLE
[FIX] purchase_stock,stock_account: aml zero quantity case

### DIFF
--- a/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
+++ b/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
@@ -512,3 +512,33 @@ class TestValuationReconciliation(ValuationReconciliationTestCommon):
 
         picking2 = purchase_order2.picking_ids[0]
         self.assertEqual(picking2.state, 'done')
+
+    def test_manual_cost_adjustment_journal_items_quantity(self):
+        """ The quantity field of `account.move.line` should be permitted to be zero, e.g., in the
+        case of modifying an automatically valuated product's cost.
+        """
+        self.stock_account_product_categ.property_cost_method = 'average'
+        self.product_a.write({
+            'categ_id': self.stock_account_product_categ.id,
+            'detailed_type': 'product',
+        })
+
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'product_id': self.product_a.id,
+                'product_uom_qty': 5,
+                'price_unit': 4,
+            })],
+        })
+        purchase_order.button_confirm()
+        purchase_order.picking_ids.move_line_ids.qty_done = 5
+        purchase_order.picking_ids.button_validate()
+        with Form(self.product_a) as product_form:
+            product_form.standard_price = 3
+
+        cost_change_journal_items = self.env['account.move.line'].search([
+            ('product_id', '=', self.product_a.id),
+            '|', ('debit', '=', 5), ('credit', '=', 5),
+        ])
+        self.assertEqual(cost_change_journal_items.mapped('quantity'), [0, 0])

--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -301,6 +301,7 @@ class ProductProduct(models.Model):
                     'debit': abs(value),
                     'credit': 0,
                     'product_id': product.id,
+                    'quantity': 0,
                 }), (0, 0, {
                     'name': _(
                         '%(user)s changed cost from %(previous)s to %(new_price)s - %(product)s',
@@ -313,6 +314,7 @@ class ProductProduct(models.Model):
                     'debit': 0,
                     'credit': abs(value),
                     'product_id': product.id,
+                    'quantity': 0,
                 })],
             }
             am_vals_list.append(move_vals)


### PR DESCRIPTION
**Current behavior:**
Manually adjusting a FIFO/AVCO product's cost creates a journal
items with non-zero quantity, despite there not being a logical
quantity associated with this entry.

**Expected behavior:**
AMLs generated for this move have 0 quantity.

**Steps to reproduce:**
*Having accounting, purchase_stock*
1. Create a storable product with `average` costing

2. Create a purchase order for some of the product with some
     arbitrary price unit, receive the product

3. In the product form, change the cost to a smaller value

4. In the journal items pivot view, select the `quantity` field
     from the 'Measures' dropdown in the top left, expand the
     stock valuation journal on the left axis, observe that the
     change in cost has created 2 balancing AMLs, each with
     quantity == 1

**Cause of the issue:**
This case was not handled and quantity is always set to 1 if
falsy.

**Fix:**
Create the AMLs created in the cost change handle with
quantity=0. While it does risk being overwritten to 1 if the
`display_type` of the line changes, the diff is minimal and
use-case is non-critical- which makes it the best solution here.

opw-4090620