### PR TITLE
[REF] *: replace kanban-card with card & kanban-menu with menu

### DIFF
--- a/addons/account/static/tests/legacy/bills_upload.js
+++ b/addons/account/static/tests/legacy/bills_upload.js
@@ -90,7 +90,7 @@ QUnit.module("Widgets", (hooks) => {
         serverData.views["partner,false,kanban"] = `
             <kanban js_class="account_documents_kanban">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="display_name"/>
                     </t>
                 </templates>

--- a/addons/account/views/account_account_views.xml
+++ b/addons/account/views/account_account_views.xml
@@ -118,7 +118,7 @@
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile">
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <div class="row">
                                 <div class="col-8">
                                     <field class="fw-bolder" name="name"/>

--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -15,7 +15,7 @@
                 <field name="alias_domain_id"/>
                 <field name="bank_account_id"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <t t-value="JSON.parse(record.kanban_dashboard.raw_value)" t-set="dashboard"/>
                         <t t-value="record.type.raw_value" t-set="journal_type"/>
                         <t t-value="!record.has_entries.raw_value" t-set="journal_is_empty"/>
@@ -56,7 +56,7 @@
                         </t>
                     </t>
 
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <t t-value="JSON.parse(record.kanban_dashboard.raw_value)" t-set="dashboard"/>
                         <t t-value="record.type.raw_value" t-set="journal_type"/>
                         <div class="container">

--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -216,7 +216,7 @@
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile">
                     <templates>
-                        <t t-name="kanban-card" class="row g-0">
+                        <t t-name="card" class="row g-0">
                             <div class="col-6">
                                 <field class="fw-bolder" name="name"/>
                             </div>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -92,7 +92,7 @@
                 <kanban class="o_kanban_mobile" create="false" group_create="false">
                     <field name="company_currency_id"/>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <div class="row mb4">
                                 <div class="col-8">
                                     <field name="account_id"/>
@@ -668,7 +668,7 @@
                 <kanban class="o_kanban_mobile" sample="1" js_class="account_documents_kanban">
                     <field name="currency_id"/>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <div class="row mb4">
                                 <div class="col-6">
                                     <field class="fw-bold" name="partner_id" invisible="not partner_id" readonly="state != 'draft'" />
@@ -1156,7 +1156,7 @@
                                     <kanban class="o_kanban_mobile">
                                         <!-- Displayed fields -->
                                         <templates>
-                                            <t t-name="kanban-card">
+                                            <t t-name="card">
                                                 <div t-attf-class="ps-0 pe-0 {{ record.display_type.raw_value ? 'o_is_' + record.display_type.raw_value : '' }}">
                                                     <t t-if="!['line_note', 'line_section'].includes(record.display_type.raw_value)">
                                                         <div class="row g-0">

--- a/addons/account/views/account_payment_method.xml
+++ b/addons/account/views/account_payment_method.xml
@@ -17,7 +17,7 @@
         <field name="model">account.payment.method.line</field>
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
-                <t t-name="kanban-card">
+                <t t-name="card">
                     <field name="display_name"/>
                 </t>
             </kanban>

--- a/addons/account/views/account_payment_term_views.xml
+++ b/addons/account/views/account_payment_term_views.xml
@@ -105,7 +105,7 @@
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile">
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field class="fw-bolder fs-5" name="name"/>
                             <field t-if="!widget.isHtmlEmpty(record.note.raw_value)" name="note"/>
                         </t>

--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -61,7 +61,7 @@
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile" create="0" group_create="0" sample="1">
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <div class="row mb4">
                                 <div class="col-6">
                                    <field class="fw-bolder" name="name"/>

--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -72,7 +72,7 @@
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile">
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <div class="row mb4">
                                 <div class="col-6">
                                     <field class="fw-bolder" name="name"/>

--- a/addons/analytic/views/analytic_account_views.xml
+++ b/addons/analytic/views/analytic_account_views.xml
@@ -85,7 +85,7 @@
                <kanban class="o_kanban_mobile">
                    <field name="currency_id"/>
                    <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <div t-attf-class="#{!selection_mode ? 'text-center' : ''}">
                                 <field class="fw-bold fs-5" name="display_name"/>
                             </div>

--- a/addons/analytic/views/analytic_line_views.xml
+++ b/addons/analytic/views/analytic_line_views.xml
@@ -124,7 +124,7 @@
                 <field name="account_id"/>
                 <field name="currency_id"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div class="d-flex justify-content-between" >
                             <field class="fw-bold fs-5" name="name"/>
                             <field class="text-end fw-bold fs-5" name="date"/>

--- a/addons/auth_passkey/views/res_users_views.xml
+++ b/addons/auth_passkey/views/res_users_views.xml
@@ -10,10 +10,10 @@
                     <field colspan="4" name="auth_passkey_key_ids" string="">
                         <kanban create="false" can_open="false">
                             <templates>
-                                <t t-name="kanban-menu">
+                                <t t-name="menu">
                                     <a role="menuitem" type="delete" class="dropdown-item">Delete</a>
                                 </t>
-                                <t t-name="kanban-card">
+                                <t t-name="card">
                                     <field name="name" class="fw-bold fs-5"/>
                                     <small>Created: <field name="create_date"/></small>
                                     <small>Last used: <field name="write_date"/></small>
@@ -43,11 +43,11 @@
                         <field colspan="4" name="auth_passkey_key_ids">
                             <kanban create="false" can_open="false">
                                 <templates>
-                                    <t t-name="kanban-menu">
+                                    <t t-name="menu">
                                         <a role="menuitem" type="object" name="action_rename_passkey" class="dropdown-item">Rename</a>
                                         <a role="menuitem" type="object" name="action_delete_passkey" class="dropdown-item">Delete</a>
                                     </t>
-                                    <t t-name="kanban-card">
+                                    <t t-name="card">
                                         <field name="name" class="fw-bold fs-5"/>
                                         <small>Created: <field name="create_date"/></small>
                                         <small>Last used: <field name="write_date"/></small>

--- a/addons/base_automation/static/tests/kanban_header_patch.test.js
+++ b/addons/base_automation/static/tests/kanban_header_patch.test.js
@@ -67,7 +67,7 @@ test.tags("desktop")("basic grouped rendering with automations", async () => {
             <kanban class="o_kanban_test">
                 <field name="bar" />
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo" />
                     </t>
                 </templates>

--- a/addons/base_automation/views/base_automation_views.xml
+++ b/addons/base_automation/views/base_automation_views.xml
@@ -140,7 +140,7 @@
                                         <field name="update_field_type"/>
                                         <field name="update_m2m_operation"/>
                                         <templates>
-                                            <t t-name="kanban-card" class="flex-row align-items-center gap-1">
+                                            <t t-name="card" class="flex-row align-items-center gap-1">
                                                 <field name="sequence" widget="handle" class="px-1" />
                                                 <!-- Icon section -->
                                                 <i
@@ -229,7 +229,7 @@
                 >
                     <field name="active"/>
                     <templates>
-                        <t t-name="kanban-card" class="flex-md-row">
+                        <t t-name="card" class="flex-md-row">
                             <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active" />
                             <div class="d-flex align-items-center w-100 w-md-25 o_automation_base_info">
                                 <div class="d-flex flex-column">

--- a/addons/base_import/static/tests/import_records_tests.js
+++ b/addons/base_import/static/tests/import_records_tests.js
@@ -134,7 +134,7 @@ QUnit.module("Base Import Tests", (hooks) => {
             arch: `
                 <kanban>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="foo"/>
                         </t>
                     </templates>
@@ -160,7 +160,7 @@ QUnit.module("Base Import Tests", (hooks) => {
                 arch: `
                     <kanban create="0">
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="foo"/>
                             </t>
                         </templates>
@@ -184,7 +184,7 @@ QUnit.module("Base Import Tests", (hooks) => {
                 arch: `
                     <kanban import="0">
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="foo"/>
                             </t>
                         </templates>

--- a/addons/base_import_module/views/ir_module_views.xml
+++ b/addons/base_import_module/views/ir_module_views.xml
@@ -16,7 +16,7 @@
                 <xpath expr="//button[@name='button_immediate_install']" position="attributes">
                     <attribute name="invisible">state != 'uninstalled' or (module_type and module_type != 'official')</attribute>
                 </xpath>
-                <xpath expr="//t[@t-name='kanban-menu']/a[@type='open']" position="attributes">
+                <xpath expr="//t[@t-name='menu']/a[@type='open']" position="attributes">
                     <attribute name="context">{'module_type': module_type, 'module_name':name}</attribute>
                     <attribute name="type">object</attribute>
                     <attribute name="name">more_info</attribute>

--- a/addons/board/static/tests/board.test.js
+++ b/addons/board/static/tests/board.test.js
@@ -373,7 +373,7 @@ describe.tags("desktop")("board_desktop", () => {
         Partner._views["kanban,5"] = `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -436,7 +436,7 @@ describe.tags("desktop")("board_desktop", () => {
         Partner._views.kanban = `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                         <button name="sitting_on_a_park_bench" type="object">Eying little girls with bad intent</button>
                     </t>

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -259,7 +259,7 @@
                                 <kanban class="o_kanban_mobile" create="false" delete="false">
 
                                     <templates>
-                                        <t t-name="kanban-card">
+                                        <t t-name="card">
                                             <field name="partner_id"/>
                                             <field name="email" widget="email"/>
                                             <span>Status: <field name="state" /></span>

--- a/addons/crm/static/tests/crm_kanban_progress_bar_mrr_sum_field_tests.js
+++ b/addons/crm/static/tests/crm_kanban_progress_bar_mrr_sum_field_tests.js
@@ -80,7 +80,7 @@ QUnit.module('Crm Kanban Progressbar', {
                     <field name="activity_state"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}' sum_field="expected_revenue" recurring_revenue_sum_field="recurring_revenue_monthly"/>
                     <templates>
-                        <t t-name="kanban-card" class="flex-row justify-content-between">
+                        <t t-name="card" class="flex-row justify-content-between">
                             <field name="name" class="p-2"/>
                             <field name="recurring_revenue_monthly" class="p-2"/>
                         </t>
@@ -106,7 +106,7 @@ QUnit.module('Crm Kanban Progressbar', {
                     <field name="activity_state"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}' sum_field="expected_revenue" recurring_revenue_sum_field="recurring_revenue_monthly"/>
                     <templates>
-                        <t t-name="kanban-card" class="flex-row justify-content-between">
+                        <t t-name="card" class="flex-row justify-content-between">
                             <field name="name" class="p-2"/>
                             <field name="recurring_revenue_monthly" class="p-2"/>
                         </t>
@@ -134,7 +134,7 @@ QUnit.module('Crm Kanban Progressbar', {
                     <field name="activity_state"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}' sum_field="expected_revenue" recurring_revenue_sum_field="recurring_revenue_monthly"/>
                     <templates>
-                        <t t-name="kanban-card" class="flex-row justify-content-between">
+                        <t t-name="card" class="flex-row justify-content-between">
                             <field name="name" class="p-2"/>
                             <field name="expected_revenue" class="p-2"/>
                             <field name="recurring_revenue_monthly" class="p-2"/>
@@ -182,7 +182,7 @@ QUnit.module('Crm Kanban Progressbar', {
                     <field name="activity_state"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}' sum_field="expected_revenue" recurring_revenue_sum_field="recurring_revenue_monthly"/>
                     <templates>
-                        <t t-name="kanban-card" class="flex-row justify-content-between">
+                        <t t-name="card" class="flex-row justify-content-between">
                             <field name="name" class="p-2"/>
                             <field name="expected_revenue" class="p-2"/>
                             <field name="recurring_revenue_monthly" class="p-2"/>

--- a/addons/crm/static/tests/crm_rainbowman_tests.js
+++ b/addons/crm/static/tests/crm_rainbowman_tests.js
@@ -101,7 +101,7 @@ QUnit.module('Crm Rainbowman Triggers', {
             arch: `
                 <kanban js_class="crm_kanban">
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="name"/>
                         </t>
                     </templates>

--- a/addons/crm/static/tests/forecast_kanban_tests.js
+++ b/addons/crm/static/tests/forecast_kanban_tests.js
@@ -21,7 +21,7 @@ QUnit.module('Crm Forecast Model Extension', {
             arch: `
                 <kanban js_class="forecast_kanban">
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="name"/>
                         </t>
                     </templates>
@@ -139,7 +139,7 @@ QUnit.module('Crm Fill Temporal Service', {
             arch: `
                 <kanban js_class="forecast_kanban">
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="name"/>
                         </t>
                     </templates>
@@ -284,7 +284,7 @@ QUnit.module('Crm Forecast main flow with progressBars', (hooks) => {
                 <kanban js_class="forecast_kanban">
                     <progressbar field="color" colors='{"s": "success", "w": "warning", "d": "danger"}'  sum_field="int_field"/>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="name"/>
                         </t>
                     </templates>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -391,7 +391,7 @@
                 <kanban class="o_kanban_mobile" archivable="false" js_class="crm_kanban" sample="1">
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="name" class="fw-bold fs-5"/>
                             <field name="contact_name"/>
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
@@ -527,12 +527,12 @@
                         sum_field="expected_revenue" recurring_revenue_sum_field="recurring_revenue_monthly"
                         help="This bar allows to filter the opportunities based on scheduled activities."/>
                     <templates>
-                        <t t-name="kanban-menu">
+                        <t t-name="menu">
                             <t t-if="widget.editable"><a role="menuitem" type="open" class="dropdown-item">Edit</a></t>
                             <t t-if="widget.deletable"><a role="menuitem" type="delete" class="dropdown-item">Delete</a></t>
                             <field name="color" widget="kanban_color_picker"/>
                         </t>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <t t-set="lost_ribbon" t-value="!record.active.raw_value and record.probability and record.probability.raw_value == 0"/>
                             <widget name="web_ribbon" title="lost" bg_color="text-bg-danger" invisible="probability &gt; 0 or active"/>
                             <field class="fw-bold fs-5" name="name"/>

--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -233,7 +233,7 @@
                 <field name="date_end"/>
                 <field name="legend_done"/>
                 <templates>
-                    <t t-name="kanban-card" class="p-0 row">
+                    <t t-name="card" class="p-0 row">
                         <aside class="col-4 text-bg-primary p-2 text-center d-flex flex-column justify-content-center">
                             <div t-esc="luxon.DateTime.fromISO(record.date_begin.raw_value).toFormat('d')" class="fs-1"/>
                             <div>

--- a/addons/event/views/event_registration_views.xml
+++ b/addons/event/views/event_registration_views.xml
@@ -98,7 +98,7 @@
                                     <field name="event_id"/>
                                     <field name="question_type"/>
                                     <templates>
-                                        <t t-name="kanban-card" class="justify-content-between">
+                                        <t t-name="card" class="justify-content-between">
                                             <field class="fw-bold fs-5" name="question_id" domain="[('event_id', '=', event_id)]"/>
                                             <field name="value_answer_id"
                                                 invisible="question_type != 'simple_choice'"
@@ -157,7 +157,7 @@
                             </t>
                         </div>
                     </t>
-                    <t t-name="kanban-card" class="row g-0">
+                    <t t-name="card" class="row g-0">
                         <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                         <div class="col-8 col-md-9">
                             <field class="d-block fw-bold fs-5" name="name"/>

--- a/addons/event/views/event_ticket_views.xml
+++ b/addons/event/views/event_ticket_views.xml
@@ -113,7 +113,7 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div class="d-flex">
                             <field class="fw-bolder" name="name"/>
                         </div>

--- a/addons/event_booth/views/event_booth_views.xml
+++ b/addons/event_booth/views/event_booth_views.xml
@@ -98,7 +98,7 @@
             <kanban default_group_by="state" quick_create_view="event_booth.event_booth_view_form_quick_create" sample="1">
                 <field name="name"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field class="fw-bold fs-5" name="name"/>
                         <footer class="p-0 fs-6">
                             <field name="booth_category_id"/>

--- a/addons/fleet/views/fleet_vehicle_cost_views.xml
+++ b/addons/fleet/views/fleet_vehicle_cost_views.xml
@@ -97,7 +97,7 @@
             <kanban class="o_kanban_mobile" sample="1">
                 <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div class="d-flex justify-content-between align-items-center">
                             <field name="vehicle_id" class="fw-bold" widget="res_partner_many2one"/>
                             <field class="badge text-bg-secondary" name="state"/>
@@ -265,7 +265,7 @@
                 <field name="currency_id"/>
                 <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div class="flex-row">
                             <field name="vehicle_id" widget="image" options="{'preview_image': 'image_128'}" class="float-start col-2 pe-2"/>
                             <div class="col-10 pe-2 text-truncate">

--- a/addons/fleet/views/fleet_vehicle_model_views.xml
+++ b/addons/fleet/views/fleet_vehicle_model_views.xml
@@ -76,7 +76,7 @@
                             <field name="vendors">
                                 <kanban quick_create="false" create="true">
                                     <templates>
-                                        <t t-name="kanban-card" class="flex-row fw-bold">
+                                        <t t-name="card" class="flex-row fw-bold">
                                             <field name="name"/>
                                             <div class="text-muted ms-auto">
                                                 <t t-if="record.phone.raw_value"><field name="phone"/><br/></t>
@@ -115,7 +115,7 @@
         <field name="arch" type="xml">
             <kanban string="Models">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field class="fw-bold" name="name"/>
                         <field name="brand_id"/>
                     </t>
@@ -199,7 +199,7 @@
             <kanban default_order="name">
                 <field name="active"/>
                 <templates>
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <a role="menuitem" type="open" class="dropdown-item">Configuration</a>
                         <a role="menuitem" type="object" name="toggle_active" class="dropdown-item">
                             <t t-if="record.active.raw_value">Archive</t>
@@ -207,7 +207,7 @@
                         </a>
                         <a role="menuitem" t-if="widget.deletable" type="delete" class="dropdown-item">Delete</a>
                     </t>
-                    <t t-name="kanban-card" class="flex-row p-1">
+                    <t t-name="card" class="flex-row p-1">
                         <aside>
                             <field name="image_128" widget="image" options="{'img_class': 'object-fit-contain'}"/>
                         </aside>

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -262,7 +262,7 @@
                 <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
 
                 <templates>
-                    <t t-name="kanban-card" class="flex-row">
+                    <t t-name="card" class="flex-row">
                         <aside class="d-flex align-items-center me-2">
                             <field name="image_128" widget="image" options="{'img_class': 'object-fit-cover'}"/>
                         </aside>
@@ -395,7 +395,7 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div class="d-flex">
                             <field class="fw-bold" name="vehicle_id"/>
                             <field class="fw-bold ms-auto" name="date"/>

--- a/addons/gamification/views/gamification_badge_user_views.xml
+++ b/addons/gamification/views/gamification_badge_user_views.xml
@@ -8,7 +8,7 @@
             <kanban action="action_open_badge" type="object">
                 <field name="create_date"/>
                 <templates>
-                    <t t-name="kanban-card" class="row g-0">
+                    <t t-name="card" class="row g-0">
                         <aside class="col-2">
                             <field name="badge_id" widget="image" options="{'preview_image': 'image_1024'}" t-att-title="badge_name" t-att-alt="badge_name" />
                         </aside>

--- a/addons/gamification/views/gamification_badge_views.xml
+++ b/addons/gamification/views/gamification_badge_views.xml
@@ -116,7 +116,7 @@
             <kanban>
                 <field name="remaining_sending" />
                 <templates>
-                    <t t-name="kanban-card" class="row g-0">
+                    <t t-name="card" class="row g-0">
                         <aside class="col-2">
                             <field name="image_1024" widget="image" t-att-title="name" t-att-alt="name"/>
                         </aside>

--- a/addons/gamification/views/gamification_challenge_views.xml
+++ b/addons/gamification/views/gamification_challenge_views.xml
@@ -129,7 +129,7 @@
             <kanban string="Challenges">
                 <field name="line_ids"/>
                 <templates>
-                    <t t-name="kanban-card" class="fw-bold">
+                    <t t-name="card" class="fw-bold">
                         <field class="fs-5" name="name"/>
                         <a type="action" name="%(goals_from_challenge_act)d" class="me-2" tabindex="-1">
                             <t t-esc="record.line_ids.raw_value.length"/> Goals

--- a/addons/gamification/views/gamification_goal_views.xml
+++ b/addons/gamification/views/gamification_goal_views.xml
@@ -153,7 +153,7 @@
                 <field name="definition_display"/>
                 <field name="last_update"/>
                 <templates>
-                    <t t-name="kanban-card" class="text-center">
+                    <t t-name="card" class="text-center">
                         <field class="fw-bold fs-4" name="definition_id" />
                         <div class="d-flex justify-content-center mt-3">
                             <field class="o_image_24_cover me-1 rounded" name="user_id" widget="image" options="{'preview_image': 'avatar_128'}"/>

--- a/addons/hr/static/tests/legacy/m2x_avatar_employee_tests.js
+++ b/addons/hr/static/tests/legacy/m2x_avatar_employee_tests.js
@@ -155,7 +155,7 @@ QUnit.module("M2XAvatarEmployee", ({ beforeEach }) => {
         const views = {
             "m2x.avatar.employee,false,kanban": `<kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="employee_id" widget="many2one_avatar_employee"/>
                     </t>
                 </templates>
@@ -228,7 +228,7 @@ QUnit.module("M2XAvatarEmployee", ({ beforeEach }) => {
             const views = {
                 "m2x.avatar.employee,false,kanban": `<kanban>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="employee_id" widget="many2one_avatar_employee"/>
                         </t>
                     </templates>
@@ -267,7 +267,7 @@ QUnit.module("M2XAvatarEmployee", ({ beforeEach }) => {
         const views = {
             "m2x.avatar.employee,false,kanban": `<kanban>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="employee_id" widget="many2one_avatar_employee" options="{'relation': 'hr.employee.public'}"/>
                         </t>
                     </templates>
@@ -619,7 +619,7 @@ QUnit.module("M2XAvatarEmployee", ({ beforeEach }) => {
         const views = {
             "m2x.avatar.employee,false,kanban": `<kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <footer>
                             <field name="employee_ids" widget="many2many_avatar_employee"/>
                         </footer>

--- a/addons/hr/static/tests/legacy/web/m2x_avatar_user_tests.js
+++ b/addons/hr/static/tests/legacy/web/m2x_avatar_user_tests.js
@@ -95,7 +95,7 @@ QUnit.module("M2XAvatarUser", ({ beforeEach }) => {
             "m2x.avatar.user,false,kanban": `
                     <kanban>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="user_id" widget="many2one_avatar_user"/>
                             </t>
                         </templates>

--- a/addons/hr/views/hr_department_views.xml
+++ b/addons/hr/views/hr_department_views.xml
@@ -79,7 +79,7 @@
                 <kanban highlight_color="color" class="o_hr_department_kanban o_kanban_small_column" can_open="0" sample="1">
                     <field name="active"/>
                     <templates>
-                        <t t-name="kanban-menu" t-if="!selection_mode">
+                        <t t-name="menu" t-if="!selection_mode">
                             <div class="container">
                                 <div class="row">
                                     <div class="col-6">
@@ -111,7 +111,7 @@
                                 </div>
                             </div>
                         </t>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <a type="open"><field name="name" class="fw-bold fs-4 d-bolck ms-2"/></a>
                             <field name="manager_id" widget="many2one_avatar_employee" options="{'display_avatar_name': True}" readonly="1" class="text-muted ms-2"/>
                             <div class="small mt-1 ms-2" groups="base.group_multi_company">

--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -127,7 +127,7 @@
                     <field name="show_hr_icon_display"/>
                     <field name="image_128" />
                     <templates>
-                        <t t-name="kanban-card" class="flex-row">
+                        <t t-name="card" class="flex-row">
                             <aside class="o_kanban_aside_full">
                                 <t t-if="!record.image_1024.raw_value">
                                     <field name="avatar_128" class="d-block position-relative"

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -294,7 +294,7 @@
                     <field name="image_128" />
                     <field name="company_id"/>
                     <templates>
-                        <t t-name="kanban-card" class="flex-row">
+                        <t t-name="card" class="flex-row">
                             <aside class="o_kanban_aside_full">
                                 <t t-if="record.image_1024.raw_value">
                                     <field name="image_1024" widget="background_image" options="{'zoom': true, 'zoom_delay': 1000, 'preview_image':'image_128'}" class="d-block position-relative"/>

--- a/addons/hr/views/hr_job_views.xml
+++ b/addons/hr/views/hr_job_views.xml
@@ -61,7 +61,7 @@
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile" sample="1">
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field class="fw-bold" name="name"/>
                             <field name="department_id"/>
                             <span t-if="!selection_mode">Vacancies: <field name="expected_employees"/></span>

--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -50,7 +50,7 @@
                 <field name="check_in"/>
                 <field name="check_out"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="employee_id" widget="many2one_avatar_user" options="{'display_avatar_name': True}" class="fs-5 fw-bold mb-2"/>
                         <hr class="mt4 mb8"/>
                         <div>

--- a/addons/hr_attendance/views/hr_employee_view.xml
+++ b/addons/hr_attendance/views/hr_employee_view.xml
@@ -112,7 +112,7 @@
             <kanban create="false">
                 <field name="attendance_state"/>
                 <templates>
-                    <t t-name="kanban-card" class="flex-row">
+                    <t t-name="card" class="flex-row">
                         <aside>
                             <field name="avatar_128" widget="image" alt="Employee" class="mb-0"/>
                         </aside>

--- a/addons/hr_contract/report/hr_contract_history_report_views.xml
+++ b/addons/hr_contract/report/hr_contract_history_report_views.xml
@@ -177,7 +177,7 @@
             <kanban default_order="date_end" sample="1" create="0">
                 <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field class="fw-bold fs-5" name="display_name"/>
                         <field class="text-muted" name="job_id"/>
                         <field class="ms-auto" name="employee_id" widget="many2one_avatar_employee"/>

--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -288,11 +288,11 @@
                     <field name="activity_state"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                     <templates>
-                    <t t-name="kanban-menu" groups="hr_contract.group_hr_contract_manager">
+                    <t t-name="menu" groups="hr_contract.group_hr_contract_manager">
                         <t t-if="widget.editable"><a role="menuitem" type="open" class="dropdown-item">Edit Contract</a></t>
                         <t t-if="widget.deletable"><a role="menuitem" type="delete" class="dropdown-item">Delete</a></t>
                     </t>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field class="fw-bold fs-5" name="name"/>
                         <field class="text-muted" name="job_id"/>
                         <field class="text-muted" name="department_id"/>

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -295,7 +295,7 @@
                     <field name="currency_id"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <div class="d-flex">
                                 <field class="fw-bold fs-5" name="name"/>
                                 <field class="fw-bold ms-auto" name="total_amount_currency" widget="monetary"/>
@@ -942,7 +942,7 @@
                 <kanban class="o_kanban_mobile" sample="1">
                     <field name="currency_id"/>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <div class="d-flex">
                                 <field class="fw-bold fs-5" name="name"/>
                                 <field class="fw-bold ms-auto" name="total_amount" widget="monetary"/>

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -177,7 +177,7 @@
                                 <field name="accrual_validity_type"/>
                                 <field name="cap_accrued_time"/>
                                 <templates>
-                                    <div t-name="kanban-card" class="bg-transparent border-0">
+                                    <div t-name="card" class="bg-transparent border-0">
                                         <div class="o_hr_holidays_body">
                                             <div class="o_hr_holidays_timeline text-center">
                                                 <t t-if="record.start_count.raw_value > 0">

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -370,11 +370,11 @@
             <kanban class="o_kanban_mobile" create="0" sample="1">
                 <field name="can_approve"/>
                 <templates>
-                    <t t-name="kanban-menu" groups="base.group_user">
+                    <t t-name="menu" groups="base.group_user">
                         <a t-if="widget.editable" role="menuitem" type="open" class="dropdown-item">Edit Allocation</a>
                         <a t-if="widget.deletable" role="menuitem" type="delete" class="dropdown-item">Delete</a>
                     </t>
-                    <t t-name="kanban-card" class="flex-row">
+                    <t t-name="card" class="flex-row">
                         <aside>
                             <field name="employee_id"
                                 widget="image"

--- a/addons/hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays/views/hr_leave_type_views.xml
@@ -111,7 +111,7 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field class="fw-bold" name="name"/>
                         <div>
                             Max Time Off: <field name="max_leaves"/>

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -111,11 +111,11 @@
             <kanban class="o_kanban_mobile" create="0" sample="1">
                 <field name="supported_attachment_ids_count"/>
                 <templates>
-                    <t t-name="kanban-menu" groups="base.group_user">
+                    <t t-name="menu" groups="base.group_user">
                         <a t-if="widget.editable" role="menuitem" type="open" class="dropdown-item">Edit Time Off</a>
                         <a t-if="widget.deletable" role="menuitem" type="delete" class="dropdown-item">Delete</a>
                     </t>
-                    <t t-name="kanban-card" class="row g-0">
+                    <t t-name="card" class="row g-0">
                         <div class="ms-3 col">
                             <span class="badge rounded-pill float-end"><field name="number_of_days"/> days</span>
                             <field class="fw-bold fs-5" name="employee_id"/>

--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -329,14 +329,14 @@
                 <field name="company_id" invisible="1"/> <!-- We need to keep this field as it is used in the domain of user_id in the model -->
                 <progressbar field="kanban_state" colors='{"done": "success", "blocked": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <a role="menuitem" name="action_create_meeting" type="object" class="dropdown-item">Schedule Interview</a>
                         <a role="menuitem" name="archive_applicant" type="object" class="dropdown-item">Refuse</a>
                         <a t-if="record.active.raw_value" role="menuitem" type="archive" class="dropdown-item">Archive</a>
                         <a t-if="!record.active.raw_value" role="menuitem" type="unarchive" class="dropdown-item">Unarchive</a>
                         <t t-if="widget.deletable"><a role="menuitem" type="delete" class="dropdown-item">Delete</a></t>
                     </t>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <widget name="web_ribbon" title="Hired" bg_color="text-bg-success" invisible="not date_closed"/>
                         <widget name="web_ribbon" title="Refused" bg_color="text-bg-danger" invisible="application_status != 'refused'"/>
                         <widget name="web_ribbon" title="Archived" bg_color="text-bg-secondary" invisible="application_status != 'archived'"/>

--- a/addons/hr_recruitment/views/hr_candidate_views.xml
+++ b/addons/hr_recruitment/views/hr_candidate_views.xml
@@ -119,7 +119,7 @@
                 <field name="color"/>
                 <field name="company_id"/>
                 <templates>
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <a role="menuitem" name="action_create_meeting" type="object" class="dropdown-item">Schedule Interview</a>
                         <a t-if="record.active.raw_value" role="menuitem" type="archive" class="dropdown-item">Archive</a>
                         <a t-if="!record.active.raw_value" role="menuitem" type="unarchive" class="dropdown-item">Unarchive</a>
@@ -127,7 +127,7 @@
                         <div role="separator" class="dropdown-divider"></div>
                         <field name="color" widget="kanban_color_picker"/>
                     </t>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field t-if="record.partner_name.raw_value" class="fw-bold fs-5" name="partner_name"/>
                         <field t-else="" class="fw-bold fs-5" name="partner_id"/>
                         <field name="categ_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>

--- a/addons/hr_recruitment/views/hr_job_views.xml
+++ b/addons/hr_recruitment/views/hr_job_views.xml
@@ -23,7 +23,7 @@
                 <field name="active"/>
                 <field name="alias_email"/>
                 <templates>
-                    <t t-name="kanban-menu" groups="hr_recruitment.group_hr_recruitment_user">
+                    <t t-name="menu" groups="hr_recruitment.group_hr_recruitment_user">
                         <div class="container">
                             <div class="row">
                                 <div class="col-6">
@@ -69,7 +69,7 @@
                             </div>
                         </div>
                     </t>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div class="d-flex align-items-baseline gap-1 ms-2">
                             <field name="is_favorite" widget="boolean_favorite" nolabel="1"/>
                             <div class="o_kanban_card_header_title d-flex flex-column">

--- a/addons/hr_recruitment/views/hr_recruitment_stage_views.xml
+++ b/addons/hr_recruitment/views/hr_recruitment_stage_views.xml
@@ -36,7 +36,7 @@
             <field name="arch" type="xml">
                 <kanban>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field class="fw-bolder" name="name"/>
                             <div class="d-flex">
                                 Folded in Recruitment Pipe:

--- a/addons/hr_skills/static/tests/many2one_avatar_employee.test.js
+++ b/addons/hr_skills/static/tests/many2one_avatar_employee.test.js
@@ -32,7 +32,7 @@ test("many2one_avatar_employee widget in kanban view with skills on avatar card"
         resModel: "m2o.avatar.employee",
         arch: `<kanban>
             <templates>
-                <t t-name="kanban-card">
+                <t t-name="card">
                     <field name="employee_id" widget="many2one_avatar_employee"/>
                 </t>
             </templates>

--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -288,7 +288,7 @@
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile" sample="1">
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <div class="d-flex flex-row">
                                 <span t-att-title="record.employee_id.value">
                                     <field name="employee_id" widget="image" options="{'preview_image': 'avatar_128'}" class="o_image_64_cover me-2 float-start"/>

--- a/addons/hr_timesheet/views/project_task_sharing_views.xml
+++ b/addons/hr_timesheet/views/project_task_sharing_views.xml
@@ -55,7 +55,7 @@
                         </list>
                         <kanban class="o_kanban_mobile">
                             <templates>
-                                <t t-name="kanban-card" class="row g-0">
+                                <t t-name="card" class="row g-0">
                                     <field name="employee_id" class="col-6 fw-bold"/>
                                     <field name="date" class="col-6 text-end fw-bold" />
                                     <field name="name" class="col-6 text-muted"/>

--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -55,7 +55,7 @@
                         </list>
                         <kanban class="o_kanban_mobile">
                             <templates>
-                                <t t-name="kanban-card">
+                                <t t-name="card">
                                     <div class="row">
                                         <div class="col-6 d-flex">
                                             <field name="employee_id" class="me-1" widget="many2one_avatar_employee" context="{'active_test': True}" readonly="readonly_timesheet"/>

--- a/addons/hr_work_entry/views/hr_work_entry_views.xml
+++ b/addons/hr_work_entry/views/hr_work_entry_views.xml
@@ -214,10 +214,10 @@
         <field name="arch" type="xml">
             <kanban highlight_color="color">
                 <templates>
-                    <t t-name="kanban-menu" t-if="!selection_mode">
+                    <t t-name="menu" t-if="!selection_mode">
                         <field name="color" widget="kanban_color_picker"/>
                     </t>
-                    <t t-name="kanban-card" t-attf-class="#{!selection_mode ? record.color.raw_value : ''}">
+                    <t t-name="card" t-attf-class="#{!selection_mode ? record.color.raw_value : ''}">
                         <field class="fw-bold fs-5" name="name"/>
                         <field class="text-muted" name="code"/>
                     </t>

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -311,7 +311,7 @@ test("create new record and load it correctly", async () => {
             "kanban,false": `
                 <kanban>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="name"/>
                         </t>
                     </templates>

--- a/addons/im_livechat/views/discuss_channel_views.xml
+++ b/addons/im_livechat/views/discuss_channel_views.xml
@@ -46,7 +46,7 @@
             <field name="arch" type="xml">
                 <kanban js_class="im_livechat.discuss_channel_kanban" class="o_kanban_mobile" sample="1" quick_create="false">
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <div class="d-flex">
                                 <div class="d-flex flex-column">
                                     <field class="fw-bolder" name="name"/>

--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -26,13 +26,13 @@
                     <field name="are_you_inside"/>
                     <field name="rating_count"/>
                     <templates>
-                        <t t-name="kanban-menu">
+                        <t t-name="menu">
                             <div class="container">
                                 <a type="object" name="action_view_rating" class="dropdown-item" role="menuitem">Ratings</a>
                                 <a type="open" class="dropdown-item" role="menuitem">Configure Channel</a>
                             </div>
                         </t>
-                        <t t-name="kanban-card" class="p-0 row g-0">
+                        <t t-name="card" class="p-0 row g-0">
                             <aside t-if="record.image_128.raw_value" class="ps-4 col-3" t-att-class="{'o-livechat-ChannelKanban-highlighted': record.available_operator_ids.raw_value.length > 0}">
                                 <field  name="image_128" widget="image" options="{'img_class': 'object-fit-contain'}" alt="Channel"/>
                             </aside>
@@ -96,7 +96,7 @@
                                     <field name="user_ids" nolabel="1" colspan="2" domain="[['groups_id', 'not in', %(base.group_portal)d]]">
                                         <kanban>
                                             <templates>
-                                                <t t-name="kanban-card" class="flex-row">
+                                                <t t-name="card" class="flex-row">
                                                     <aside>
                                                         <field name="avatar_1024" widget="image" alt="User"/>
                                                     </aside>
@@ -197,7 +197,7 @@
             <field name="arch" type="xml">
                 <kanban>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="action"/>
                             <field name="regex_url" />
                             <field name="country_ids" widget="many2many_tags" />

--- a/addons/loyalty/views/loyalty_reward_views.xml
+++ b/addons/loyalty/views/loyalty_reward_views.xml
@@ -82,7 +82,7 @@
                 <field name="program_type"/>
                 <field name="user_has_debug"/>
                 <templates>
-                    <t t-name="kanban-card" class="flex-row">
+                    <t t-name="card" class="flex-row">
                         <div class="mw-75 flex-grow-1" name="reward_info">
                             <t t-if="record.reward_type.raw_value === 'discount'">
 

--- a/addons/loyalty/views/loyalty_rule_views.xml
+++ b/addons/loyalty/views/loyalty_rule_views.xml
@@ -63,7 +63,7 @@
                 <field name="program_type"/>
                 <field name="user_has_debug"/>
                 <templates>
-                    <t t-name="kanban-card" class="flex-row">
+                    <t t-name="card" class="flex-row">
                         <div class="mw-75 flex-grow-1">
                             <div t-if="record.code.raw_value">Discount code <field name="code"/></div>
                             <div t-if="record.minimum_qty.raw_value > 0">If minimum <field name="minimum_qty"/> item(s) bought</div>

--- a/addons/lunch/report/lunch_cashmove_report_views.xml
+++ b/addons/lunch/report/lunch_cashmove_report_views.xml
@@ -82,7 +82,7 @@
             <kanban class="o_kanban_mobile">
                 <field name="currency_id"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div class="row mb4">
                             <div class="col-8 fw-bold fs-5">
                                 <field name="description" />

--- a/addons/lunch/static/tests/lunch_is_favorite_field.test.js
+++ b/addons/lunch/static/tests/lunch_is_favorite_field.test.js
@@ -21,7 +21,7 @@ class LunchProduct extends models.Model {
         "kanban,false": `
             <kanban class="o_kanban_test" edit="0">
                 <template>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="is_favorite" widget="lunch_is_favorite" nolabel="1"/>
                         <field name="name"/>
                     </t>

--- a/addons/lunch/static/tests/lunch_kanban.test.js
+++ b/addons/lunch/static/tests/lunch_kanban.test.js
@@ -32,7 +32,7 @@ async function mountLunchView() {
             arch: `
             <kanban js_class="lunch_kanban">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="name"/>
                         <field name="price"/>
                     </t>

--- a/addons/lunch/views/lunch_alert_views.xml
+++ b/addons/lunch/views/lunch_alert_views.xml
@@ -76,7 +76,7 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field class="fw-bold fs-5" name="name"/>
                         <div>
                             <field name="mode"/>

--- a/addons/lunch/views/lunch_cashmove_views.xml
+++ b/addons/lunch/views/lunch_cashmove_views.xml
@@ -53,7 +53,7 @@
             <kanban class="o_kanban_mobile">
                 <field name="currency_id"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div class="row mb4">
                             <div class="col-8 fw-bold fs-5">
                                 <field name="description" />

--- a/addons/lunch/views/lunch_location_views.xml
+++ b/addons/lunch/views/lunch_location_views.xml
@@ -47,7 +47,7 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="name" class="fw-bold fs-5"/>
                         <field name="company_id" groups="base.group_multi_company"/>
                         <field name="address"/>

--- a/addons/lunch/views/lunch_orders_views.xml
+++ b/addons/lunch/views/lunch_orders_views.xml
@@ -70,7 +70,7 @@
                 <field name="currency_id"/>
                 <field name="notified"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div class="d-flex">
                             <field name="product_id" class="fw-bold fs-5"/>
                             <field name="state" widget="label_selection" options="{'classes': {'new': 'default', 'confirmed': 'success', 'cancelled':'danger'}}" class="ms-auto"/>

--- a/addons/lunch/views/lunch_product_views.xml
+++ b/addons/lunch/views/lunch_product_views.xml
@@ -106,7 +106,7 @@
                 <field name="currency_id"/>
                 <field name="is_new"/>
                 <templates>
-                    <t t-name="kanban-card" class="row g-0">
+                    <t t-name="card" class="row g-0">
                         <aside class="col-4">
                             <field name="image_128" options="{'placeholder': '/lunch/static/img/lunch.png', 'size': [94, 94], 'img_class': 'w-100 h-100'}" widget="image"/>
                         </aside>
@@ -147,7 +147,7 @@
                 <field name="description"/>
                 <field name="currency_id"/>
                 <templates>
-                    <t t-name="kanban-card" class="flex-row">
+                    <t t-name="card" class="flex-row">
                         <aside class="o_kanban_aside_full d-none d-md-block">
                             <field name="image_128" widget="image" alt="Product Image"/>
                         </aside>
@@ -226,7 +226,7 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <aside class="d-none d-md-block">
                             <field name="image_128" widget="image"/>
                         </aside>

--- a/addons/lunch/views/lunch_supplier_views.xml
+++ b/addons/lunch/views/lunch_supplier_views.xml
@@ -117,7 +117,7 @@
         <field name="arch" type="xml">
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <main>
                             <field name="display_name" class="fw-bold fs-5"/>
                             <field t-if="record.city.raw_value and !record.country_id.raw_value" name="city"/>

--- a/addons/mail/static/tests/legacy/web/fields/m2x_avatar_user_tests.js
+++ b/addons/mail/static/tests/legacy/web/fields/m2x_avatar_user_tests.js
@@ -60,7 +60,7 @@ test("many2many_avatar_user in kanban view", async () => {
         "m2x.avatar.user,false,kanban": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="user_id"/>
                         <field name="user_ids" widget="many2many_avatar_user"/>
                     </t>
@@ -331,7 +331,7 @@ test("avatar_user widget displays the appropriate user image in kanban view", as
         "m2x.avatar.user,false,kanban": `
                 <kanban>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="user_id" widget="many2one_avatar_user"/>
                         </t>
                     </templates>
@@ -374,7 +374,7 @@ test("avatar card preview", async (assert) => {
         "m2x.avatar.user,false,kanban": `
                 <kanban>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="user_id" widget="many2one_avatar_user"/>
                         </t>
                     </templates>

--- a/addons/mail/views/discuss_channel_views.xml
+++ b/addons/mail/views/discuss_channel_views.xml
@@ -12,7 +12,7 @@
                     <field name="group_ids"/>
                     <field name="active"/>
                     <templates>
-                        <t t-name="kanban-card" class="row g-0">
+                        <t t-name="card" class="row g-0">
                             <widget name="web_ribbon" class="d-flex" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                             <aside class="col-2 my-auto">
                                 <field name="avatar_128" widget="image" options="{'size': [50, 50]}" alt="Channel"/>

--- a/addons/mail/views/mail_activity_plan_views.xml
+++ b/addons/mail/views/mail_activity_plan_views.xml
@@ -84,7 +84,7 @@
                                     <kanban class="o_kanban_mobile">
                                         <field name="icon"/>
                                         <templates>
-                                            <t t-name="kanban-card">
+                                            <t t-name="card">
                                                 <div class="fw-bold fs-5">
                                                     <i t-if="record.icon.value"
                                                         t-attf-class="fa #{record.icon.value} fa-fw "
@@ -117,7 +117,7 @@
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile">
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="name" class="fw-bolder"/>
                             <field name="res_model_id"/>
                             <div>

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -109,7 +109,7 @@
             <kanban class="o_kanban_mobile">
                 <field name="icon"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div class="fw-bold fs-5">
                             <i t-if="record.icon.value" t-attf-class="fa #{record.icon.value} fa-fw"
                                role="img" aria-label="Activity Type Name" title="Activity Type Name"/>
@@ -352,7 +352,7 @@
             <kanban string="Activity" action="action_open_document" type="object">
                 <templates>
                     <field name="active" invisible="1"/>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div class="d-flex justify-content-between">
                             <span>
                                 <field name="res_name" class="fw-bold" />

--- a/addons/mail/views/mail_message_views.xml
+++ b/addons/mail/views/mail_message_views.xml
@@ -140,11 +140,11 @@
                     <field name="mimetype"/>
                     <field name="type"/>
                     <templates>
-                        <t t-name="kanban-menu">
+                        <t t-name="menu">
                             <a t-attf-href="/web/content/ir.attachment/#{record.id.raw_value}/datas?download=true" download="" class="dropdown-item">Download</a>
                             <a t-if="widget.deletable" role="menuitem" type="delete" class="dropdown-item">Delete</a>
                         </t>
-                        <t t-name="kanban-card" class="o_kanban_attachment flex-row">
+                        <t t-name="card" class="o_kanban_attachment flex-row">
                             <aside class="o_kanban_image m-1">
                                 <div class="o_kanban_image_wrapper d-flex align-items-center justify-content-center">
                                     <t t-set="webimage" t-value="new RegExp('image.*(gif|jpeg|jpg|png|webp)').test(record.mimetype.value)"/>

--- a/addons/mail_group/views/mail_group_views.xml
+++ b/addons/mail_group/views/mail_group_views.xml
@@ -19,7 +19,7 @@
             <kanban string="Mail Groups" sample="1">
                 <field name="is_member"/>
                 <templates>
-                    <t t-name="kanban-card" class="flex-row">
+                    <t t-name="card" class="flex-row">
                         <aside>
                             <field name="image_128" widget="image" alt="Group"/>
                         </aside>

--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -160,12 +160,12 @@
                 <field name="archive" />
                 <progressbar field="kanban_state" colors='{"done": "success", "blocked": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <t t-if="widget.editable"><a role="menuitem" type="open" class="dropdown-item">Edit...</a></t>
                         <t t-if="widget.deletable"><a role="menuitem" type="delete" class="dropdown-item">Delete</a></t>
                         <field name="color" widget="kanban_color_picker"/>
                     </t>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="name" class="fw-bold fs-5"/>
                         <span name="owner_user_id" t-if="record.owner_user_id.raw_value">Requested by: <field name="owner_user_id"/></span>
                         <span t-if="record.equipment_id.raw_value"><field name="equipment_id"/><span t-if="record.category_id.raw_value"> (<field name="category_id"/>)</span></span>
@@ -460,14 +460,14 @@
             <kanban highlight_color="color" sample="1">
                 <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <t t-if="widget.editable"><a role="menuitem" type="open" class="dropdown-item">Edit...</a></t>
                         <t t-if="widget.deletable"><a role="menuitem" type="delete" class="dropdown-item">Delete</a></t>
                         <div role="separator" class="dropdown-divider"></div>
                         <div role="separator" class="dropdown-header">Record Colour</div>
                         <field name="color" widget="kanban_color_picker"/>
                     </t>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div>
                             <field name="name" class="fw-bold fs-5"/>
                             <span t-if="record.model.raw_value" class="fw-bold small"> (<field name="model"/>)</span>
@@ -663,7 +663,7 @@
         <field name="arch" type="xml">
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="name" class="fw-bolder mb-1"/>
                         <div class="d-flex mt-1 align-items-center smaller">
                             <strong>Equipment:</strong><field name="equipment_count" class="ms-1"/>
@@ -720,7 +720,7 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="name" class="fw-bolder"/>
                     </t>
                 </templates>
@@ -786,7 +786,7 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="name" class="fw-bold"/>
                     </t>
                 </templates>
@@ -800,7 +800,7 @@
         <field name="arch" type="xml">
             <kanban highlight_color="color" class="o_maintenance_team_kanban" create="0" can_open="0">
                 <templates>
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <div class="container">
                             <div class="row">
                                 <div class="col-6">
@@ -849,7 +849,7 @@
                             </div>
                         </div>
                     </t>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <a name="%(hr_equipment_todo_request_action_from_dashboard)d" type="action">
                             <field name="name" class="fw-bold fs-4 ms-2"/>
                         </a>

--- a/addons/marketing_card/views/card_campaign_views.xml
+++ b/addons/marketing_card/views/card_campaign_views.xml
@@ -155,7 +155,7 @@
         <field name="arch" type="xml">
             <kanban sample="1">
                 <templates>
-                    <t t-name="kanban-card" class="o_marketing_card_campaign_kanban">
+                    <t t-name="card" class="o_marketing_card_campaign_kanban">
                         <field name="name" class="fw-bolder fs-5"/>
                         <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" class="mt-2"/>
                         <footer class="fs-6 pt-0">

--- a/addons/mass_mailing/views/mailing_contact_views.xml
+++ b/addons/mass_mailing/views/mailing_contact_views.xml
@@ -71,7 +71,7 @@
                         context="{'from_mailing_list_ids': context.get('active_ids') if context.get('active_model') == 'mailing.list' else False}"/>
                 </header>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div class="d-flex">
                             <field name="name" class="fw-bolder fs-5"/>
                             <div class="badge rounded-pill ms-auto" title="Number of bounced email.">

--- a/addons/mass_mailing/views/mailing_list_views.xml
+++ b/addons/mass_mailing/views/mailing_list_views.xml
@@ -110,7 +110,7 @@
             <kanban class="o_kanban_mobile o_kanban_mailing_list" sample="1">
                 <field name="active"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <!-- Card when the Kanban view is grouped  -->
                         <div class="o_mailing_list_kanban_grouped d-flex flex-column h-100">
                             <field name="name" class="fw-bold fs-2 mb-3 text-truncate"/>

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -403,7 +403,7 @@
                     <field name='next_departure'/>
                     <field name='active'/>
                     <templates>
-                        <t t-name="kanban-menu" t-if="!selection_mode">
+                        <t t-name="menu" t-if="!selection_mode">
                             <field name="color" widget="kanban_color_picker"/>
                             <t t-if="widget.deletable">
                                 <a role="menuitem" type="delete" class="dropdown-item">Delete</a>
@@ -413,7 +413,7 @@
                                 <t t-if="!record.active.raw_value">Restore</t>
                             </a>
                         </t>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="subject" class="my-1 text-truncate fs-3 fw-bold"/>
                             <field name="campaign_id" invisible="not sent_date" class="fw-bold fs-5" groups="mass_mailing.group_mass_mailing_campaign"/>
                             <div>

--- a/addons/membership/views/product_views.xml
+++ b/addons/membership/views/product_views.xml
@@ -45,7 +45,7 @@
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile">
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <div class="d-flex">
                                 <field name="name" class="fw-bolder fs-5"/>
                                 <span class="badge rounded-pill ms-auto"><i class="fa fa-money" role="img" aria-label="Price" title="Price"/> <field name="list_price"/></span>

--- a/addons/mrp/static/tests/mrp_document_kanban.test.js
+++ b/addons/mrp/static/tests/mrp_document_kanban.test.js
@@ -18,7 +18,7 @@ describe.current.tags("desktop");
 defineMrpModels();
 
 const newArchs = {
-    "product.document,false,kanban": `<kanban js_class="product_documents_kanban" create="false"><templates><t t-name="kanban-card">
+    "product.document,false,kanban": `<kanban js_class="product_documents_kanban" create="false"><templates><t t-name="card">
                     <field name="name"/>
                 </t></templates></kanban>`,
 };
@@ -74,7 +74,7 @@ test("mrp: click on image opens attachment viewer", async () => {
         "product.document,false,kanban": `
                 <kanban js_class="product_documents_kanban" create="false">
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <div class="o_kanban_previewer" t-if="record.ir_attachment_id.raw_value">
                                 <field name="ir_attachment_id" invisible="1"/>
                                 <img t-attf-src="/web/image/#{record.ir_attachment_id.raw_value}" width="100" height="100" alt="Document" class="o_attachment_image"/>

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -201,7 +201,7 @@
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile" sample="1">
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <div>
                                 <field name="product_tmpl_id" class="fw-medium fs-5"/>
                                 <span class="float-end badge rounded-pill"><field name="product_qty"/> <field name="product_uom_id" class="small"/></span>

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -569,7 +569,7 @@
                     <field name="state"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <div class="d-flex mb-1">
                                 <field name="priority" widget="priority"/>
                                 <field name="product_id" class="fw-bolder fs-6 ms-1"/>

--- a/addons/mrp/views/mrp_unbuild_views.xml
+++ b/addons/mrp/views/mrp_unbuild_views.xml
@@ -50,7 +50,7 @@
                 <kanban class="o_kanban_mobile" sample="1">
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <div class="d-flex fw-bold mb-1">
                                 <field name="name" class="fs-5"/>
                                 <field name="product_qty" class="ms-auto me-1 fs-6"/>

--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -57,7 +57,7 @@
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile">
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="name" class="fw-bolder"/>
                             <field t-if="record.code.raw_value" name="code"/>
                         </t>
@@ -146,7 +146,7 @@
                     <field name="working_state"/>
                     <field name="oee_target"/>
                     <templates>
-                        <t t-name="kanban-menu">
+                        <t t-name="menu">
                             <div class="container">
                                 <div class="row">
                                     <div class="col-6">
@@ -185,7 +185,7 @@
                                 </div>
                             </div>
                         </t>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <div class="ms-1">
                                 <div style="display: inline-block" name="wc_stages">
                                     <a name="%(act_mrp_block_workcenter)d" type="action" class="o_status float-end"
@@ -460,7 +460,7 @@
         <field name="arch" type="xml">
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div>
                             <strong>Reason: </strong><field name="name"/>
                         </div>

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -358,7 +358,7 @@
                 <field name="date_start"/>
                 <field name="production_date"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div class="d-flex o_kanban_record_top">
                             <div class="o_kanban_workorder_title h4">
                                 <field name="production_id"/> - <field name="name"/>

--- a/addons/mrp/views/stock_picking_views.xml
+++ b/addons/mrp/views/stock_picking_views.xml
@@ -5,7 +5,7 @@
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="stock.stock_picking_type_kanban"/>
         <field name="arch" type="xml">
-            <xpath expr="//t[@t-name='kanban-menu']" position="inside">
+            <xpath expr="//t[@t-name='menu']" position="inside">
                 <div class="container" t-if="record.code.raw_value == 'mrp_operation'">
                     <div class="row">
                         <div class="col-6" name="picking_left_manage_pane">

--- a/addons/payment/views/payment_method_views.xml
+++ b/addons/payment/views/payment_method_views.xml
@@ -104,7 +104,7 @@
         <field name="arch" type="xml">
             <kanban>
                 <templates>
-                    <t t-name="kanban-card" class="flex-row">
+                    <t t-name="card" class="flex-row">
                         <field name="name" class="fw-bolder"/>
                         <field name="image" widget="image" class="ms-auto"/>
                     </t>

--- a/addons/payment/views/payment_provider_views.xml
+++ b/addons/payment/views/payment_provider_views.xml
@@ -142,7 +142,7 @@
                 <field name="module_state"/>
                 <field name="module_to_buy"/>
                 <templates>
-                    <t t-name="kanban-card" class="flex-row">
+                    <t t-name="card" class="flex-row">
                         <t t-set="installed" t-value="!record.module_id.value || (record.module_id.value &amp;&amp; record.module_state.raw_value === 'installed')"/>
                         <t t-set="to_buy" t-value="record.module_to_buy.raw_value === true"/>
                         <t t-set="is_disabled" t-value="record.state.raw_value=='disabled'"/>

--- a/addons/payment/views/payment_transaction_views.xml
+++ b/addons/payment/views/payment_transaction_views.xml
@@ -92,7 +92,7 @@
             <kanban class="o_kanban_mobile" create="false">
                 <field name="currency_id"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div class="d-flex">
                             <field name="reference" class="fw-bolder"/>
                             <field name="amount" class="ms-auto"/>

--- a/addons/point_of_sale/views/point_of_sale_dashboard.xml
+++ b/addons/point_of_sale/views/point_of_sale_dashboard.xml
@@ -64,7 +64,7 @@
                 <field name="pos_session_duration"/>
                 <field name="currency_id"/>
                 <templates>
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <div class="container dropdown-pos-config">
                             <div class="row" style="min-width:200px">
                                 <div class="col-6 o_kanban_manage_view">
@@ -98,7 +98,7 @@
                             </div>
                         </div>
                     </t>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div name="card_title" class="mb-4 ms-2">
                             <field name="name" class="fw-bold fs-4 d-block"/>
                             <div t-if="!record.current_session_id.raw_value &amp;&amp; record.pos_session_username.value" class="badge text-bg-info d-inline-block">Opened by <field name="pos_session_username"/></div>

--- a/addons/point_of_sale/views/pos_category_view.xml
+++ b/addons/point_of_sale/views/pos_category_view.xml
@@ -43,7 +43,7 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
                 <templates>
-                    <t t-name="kanban-card" class="row g-0">
+                    <t t-name="card" class="row g-0">
                         <aside class="col-4">
                             <field name="image_128" widget="image" alt="Category" options="{'size': [100, 100], 'img_class': 'h-100'}"/>
                         </aside>

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -62,7 +62,7 @@
                     <page string="Products" name="products">
                       <field name="lines" colspan="4" nolabel="1" readonly="state != 'draft'" mode="list,kanban">
                             <kanban class="o_kanban_mobile">
-                                <t t-name="kanban-card" class="row g-0">
+                                <t t-name="card" class="row g-0">
                                     <aside class="col-2 pe-3">
                                         <field name="product_id" widget="image" options="{'preview_image': 'image_128'}"/>
                                     </aside>
@@ -216,7 +216,7 @@
             <kanban class="o_kanban_mobile" create="0" sample="1">
                 <field name="currency_id"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                             <div class="d-flex mb-1">
                                 <span t-if="record.partner_id.value">
                                     <field name="partner_id" class="fw-bolder"/>

--- a/addons/point_of_sale/views/pos_session_view.xml
+++ b/addons/point_of_sale/views/pos_session_view.xml
@@ -102,7 +102,7 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile" create="0" sample="1">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div class="d-flex">
                             <field name="config_id" class="fw-bolder mb-1"/>
                             <field name="state" widget="label_selection" options="{'classes': {'opening_control': 'default',

--- a/addons/pos_restaurant/views/pos_restaurant_views.xml
+++ b/addons/pos_restaurant/views/pos_restaurant_views.xml
@@ -61,7 +61,7 @@
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile">
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <div><strong>Floor Name: </strong><field name="name"/></div>
                             <div class="d-flex">
                                 <strong>Point of Sales:</strong><field name="pos_config_ids" class="ms-1"/>

--- a/addons/product/views/product_document_views.xml
+++ b/addons/product/views/product_document_views.xml
@@ -58,12 +58,12 @@
                 <field name="active"/>
                 <field name="res_model"/>
                 <templates>
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <a t-if="widget.editable" type="open" class="dropdown-item">Edit</a>
                         <a t-if="widget.deletable" type="delete" class="dropdown-item">Delete</a>
                         <a t-attf-href="/web/content/#{record.ir_attachment_id.raw_value}?download=true" download="" class="dropdown-item">Download</a>
                     </t>
-                    <t t-name="kanban-card" class="o_kanban_attachment flex-row">
+                    <t t-name="card" class="o_kanban_attachment flex-row">
                         <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                         <widget name="web_ribbon" title="Variant" bg_color="text-bg-secondary" invisible="not active or res_model != 'product.product'" groups="product.group_product_variant"/>
                         <aside class="o_kanban_image m-2">

--- a/addons/product/views/product_pricelist_views.xml
+++ b/addons/product/views/product_pricelist_views.xml
@@ -35,7 +35,7 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile" sample="1">
                 <templates>
-                    <t t-name="kanban-card" class="flex-row fw-bolder">
+                    <t t-name="card" class="flex-row fw-bolder">
                         <field name="name"/>
                         <div class="ms-auto align-items-center">
                             <i class="fa fa-money" role="img" aria-label="Currency" title="Currency"></i> <field name="currency_id"/>

--- a/addons/product/views/product_supplierinfo_views.xml
+++ b/addons/product/views/product_supplierinfo_views.xml
@@ -69,7 +69,7 @@
             <kanban class="o_kanban_mobile">
                 <field name="currency_id"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div class="d-flex fw-bolder mb4">
                             <field name="partner_id" />
                             <field name="price" widget="monetary" class="ms-auto"/>

--- a/addons/product/views/product_template_views.xml
+++ b/addons/product/views/product_template_views.xml
@@ -101,7 +101,7 @@
                 <field name="categ_id"/>
                 <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-card" class="flex-row">
+                    <t t-name="card" class="flex-row">
                         <main class="pe-2">
                             <div class="mb-1">
                                 <div class="d-flex mb-0 h5">

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -551,7 +551,7 @@
                     <field name="color"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                     <templates>
-                        <t t-name="kanban-card" class="row g-0">
+                        <t t-name="card" class="row g-0">
                             <main class="col-10 pe-2">
                                 <div class="d-flex mb-1 h5">
                                     <field class="me-1" name="is_favorite" widget="boolean_favorite" nolabel="1"/>
@@ -638,12 +638,12 @@ action = {
             <kanban records_draggable="0" js_class="product_kanban_catalog">
                 <field name="id"/>
                 <templates>
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <div class="o_product_catalog_cancel_global_click">
                             <a role="menuitem" type="open" class="dropdown-item border-top-0">Edit</a>
                         </div>
                     </t>
-                    <t t-name="kanban-card" class="p-0">
+                    <t t-name="card" class="p-0">
                     <!-- TODO : not getting border when select record -->
                         <div class="d-flex flex-grow-1 m-2">
                             <div class="p-2 pt-1 d-flex flex-column m-0"

--- a/addons/project/static/tests/legacy/project_state_selection_tests.js
+++ b/addons/project/static/tests/legacy/project_state_selection_tests.js
@@ -40,7 +40,7 @@ QUnit.module("Project", (hooks) => {
             arch: `
                 <kanban  class="o_kanban_test">
                     <template>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="last_update_status" widget="project_state_selection"/>
                         </t>
                     </template>

--- a/addons/project/static/tests/legacy/project_status_with_color_selection_tests.js
+++ b/addons/project/static/tests/legacy/project_status_with_color_selection_tests.js
@@ -36,7 +36,7 @@ QUnit.module("Project", (hooks) => {
             arch: `
                 <kanban  class="o_kanban_test">
                     <template>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="status" widget="status_with_color" readonly="1" status_label="test status label"/>
                         </t>
                     </template>

--- a/addons/project/static/tests/legacy/project_subtask_kanban_list_form_tests.js
+++ b/addons/project/static/tests/legacy/project_subtask_kanban_list_form_tests.js
@@ -50,7 +50,7 @@ QUnit.module('Subtask Kanban List tests', {
                     <field name="user_ids"/>
                     <field name="state"/>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="display_name" widget="name_with_subtask_count"/>
                             <t t-if="record.project_id.raw_value and record.subtask_count.raw_value">
                                 <widget name="subtask_counter"/>

--- a/addons/project/static/tests/legacy/project_task_groupby_tests.js
+++ b/addons/project/static/tests/legacy/project_task_groupby_tests.js
@@ -104,7 +104,7 @@ QUnit.module("Project", (hooks) => {
         const views = {
             "project.task,false,kanban": `<kanban js_class="project_task_kanban" default_group_by="project_id">
                     <templates>
-                        <t t-name="kanban-card"/>
+                        <t t-name="card"/>
                     </templates>
                 </kanban>`,
         };
@@ -125,7 +125,7 @@ QUnit.module("Project", (hooks) => {
         const views = {
             "project.task,false,kanban": `<kanban js_class="project_task_kanban" default_group_by="user_ids">
                     <templates>
-                        <t t-name="kanban-card"/>
+                        <t t-name="card"/>
                     </templates>
                 </kanban>`,
         };
@@ -146,7 +146,7 @@ QUnit.module("Project", (hooks) => {
         const views = {
             "project.task,false,kanban": `<kanban js_class="project_task_kanban" default_group_by="date_deadline">
                     <templates>
-                        <t t-name="kanban-card"/>
+                        <t t-name="card"/>
                     </templates>
                 </kanban>`,
         };

--- a/addons/project/static/tests/legacy/project_task_state_selection_tests.js
+++ b/addons/project/static/tests/legacy/project_task_state_selection_tests.js
@@ -33,7 +33,7 @@ QUnit.module('Task State Tests', {
             "project.task,false,kanban":
                 `<kanban js_class="project_task_kanban">
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="state" widget="project_task_state_selection" class="project_task_state_test"/>
                         </t>
                     </templates>

--- a/addons/project/static/tests/legacy/views/project_task_kanban/project_task_kanban_view_tests.js
+++ b/addons/project/static/tests/legacy/views/project_task_kanban/project_task_kanban_view_tests.js
@@ -29,7 +29,7 @@ QUnit.module('Project', {
             "project.task,false,kanban":
                 `<kanban js_class="project_task_kanban">
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="name"/>
                         </t>
                     </templates>

--- a/addons/project/static/tests/project_is_favorite_field.test.js
+++ b/addons/project/static/tests/project_is_favorite_field.test.js
@@ -18,7 +18,7 @@ beforeEach(() => {
         "kanban,false": `
             <kanban class="o_kanban_test" edit="0">
                 <template>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="is_favorite" widget="project_is_favorite" nolabel="1"/>
                         <field name="name"/>
                     </t>

--- a/addons/project/static/tests/project_project_state_selection.test.js
+++ b/addons/project/static/tests/project_project_state_selection.test.js
@@ -33,7 +33,7 @@ test("project.project (kanban): check that ProjectStateSelectionField does not p
         arch: `
             <kanban class="o_kanban_test">
                 <template>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="last_update_status" widget="project_state_selection"/>
                     </t>
                 </template>

--- a/addons/project/static/tests/project_task_groupby.test.js
+++ b/addons/project/static/tests/project_task_groupby.test.js
@@ -53,7 +53,7 @@ test("project.task (kanban): check group label for no project", async () => {
         arch: `
             <kanban js_class="project_task_kanban" default_group_by="project_id">
                 <templates>
-                    <t t-name="kanban-card"/>
+                    <t t-name="card"/>
                 </templates>
             </kanban>
         `,
@@ -68,7 +68,7 @@ test("project.task (kanban): check group label for no assignees", async () => {
         arch: `
             <kanban js_class="project_task_kanban" default_group_by="user_ids">
                 <templates>
-                    <t t-name="kanban-card"/>
+                    <t t-name="card"/>
                 </templates>
             </kanban>
         `,
@@ -83,7 +83,7 @@ test("project.task (kanban): check group label for no deadline", async () => {
         arch: `
             <kanban js_class="project_task_kanban" default_group_by="date_deadline">
                 <templates>
-                    <t t-name="kanban-card"/>
+                    <t t-name="card"/>
                 </templates>
             </kanban>
         `,

--- a/addons/project/static/tests/project_task_kanban_view.test.js
+++ b/addons/project/static/tests/project_task_kanban_view.test.js
@@ -16,7 +16,7 @@ test("shadow stages should be displayed in the project Kanban", async () => {
         arch: `
             <kanban default_group_by="stage_id" js_class="project_task_kanban">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="name"/>
                     </t>
                 </templates>

--- a/addons/project/static/tests/project_task_state_selection.test.js
+++ b/addons/project/static/tests/project_task_state_selection.test.js
@@ -14,7 +14,7 @@ test("project.task (kanban): check task state widget", async () => {
         arch: `
             <kanban js_class="project_task_kanban">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="state" widget="project_task_state_selection" class="project_task_state_test"/>
                     </t>
                 </templates>

--- a/addons/project/static/tests/project_task_subtask.test.js
+++ b/addons/project/static/tests/project_task_subtask.test.js
@@ -96,7 +96,7 @@ beforeEach(() => {
                 <field name="user_ids"/>
                 <field name="state"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div>
                             <field name="display_name" widget="name_with_subtask_count"/>
                             <t t-if="record.project_id.raw_value and record.subtask_count.raw_value">

--- a/addons/project/static/tests/project_update_with_color.test.js
+++ b/addons/project/static/tests/project_update_with_color.test.js
@@ -28,7 +28,7 @@ test("project.update (kanban): check that ProjectStatusWithColorSelectionField i
         arch: `
             <kanban  class="o_kanban_test">
                 <template>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="status" widget="status_with_color" readonly="1" status_label="test status label"/>
                     </t>
                 </template>

--- a/addons/project/views/project_project_stage_views.xml
+++ b/addons/project/views/project_project_stage_views.xml
@@ -58,7 +58,7 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile" sample="1" quick_create_view="project.project_project_stage_view_form_quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="name" class="fw-bolder mb-4"/>
                         <field name="mail_template_id" class="text-muted mb-2" invisible="not mail_template_id"/>
                         <field name="company_id" groups="base.group_multi_company" invisible="not company_id" class="mb-2"/>

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -305,7 +305,7 @@
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile">
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="name" class="fw-bolder" string="Project Name"/>
                             <div class="d-flex">
                                 <field name="partner_id" string="Contact"/>
@@ -388,7 +388,7 @@
                     <progressbar field="last_update_status" colors='{"on_track": "success", "at_risk": "warning", "off_track": "danger", "on_hold": "info", "done": "purple"}'/>
                     <field name="sequence" widget="handle"/>
                     <templates>
-                        <t t-name="kanban-menu" groups="base.group_user">
+                        <t t-name="menu" groups="base.group_user">
                             <div class="container">
                                 <div class="row">
                                     <div name="card_menu_view" class="col-6">
@@ -432,7 +432,7 @@
                                 </div>
                             </div>
                         </t>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <div class="o_project_kanban_main d-flex align-items-baseline gap-1 ms-1">
                                 <field name="is_favorite" widget="project_is_favorite" nolabel="1"/>
                                 <div class="mw-100 pb-4 me-5">

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -36,11 +36,11 @@
                 <field name="has_late_and_unreached_milestone"/>
                 <progressbar field="state" colors='{"1_done": "success", "03_approved": "success", "02_changes_requested": "warning", "1_canceled": "danger", "04_waiting_normal": "200", "01_in_progress": "200"}'/>
                 <templates>
-                <t t-name="kanban-menu" t-if="!selection_mode">
+                <t t-name="menu" t-if="!selection_mode">
                     <div role="separator" class="dropdown-divider"></div>
                     <field name="color" widget="kanban_color_picker"/>
                 </t>
-                <t t-name="kanban-card">
+                <t t-name="card">
                     <div t-att-class="{'opacity-50': ['1_done', '1_canceled'].includes(record.state.raw_value)}">
                         <field name="name" class="fw-bolder fs-5" widget="name_with_subtask_count"/>
                         <field name="project_id" invisible="context.get('default_project_id', False)" required="1" class="text-muted"/>

--- a/addons/project/views/project_task_type_views.xml
+++ b/addons/project/views/project_task_type_views.xml
@@ -88,7 +88,7 @@
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile" sample="1" default_group_by="project_ids">
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="name" class="fw-bolder text-truncate"/>
                             <field name="project_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                         </t>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -668,13 +668,13 @@
                     <field name="subtask_count"/>
                     <progressbar field="state" colors='{"1_done": "success-done", "1_canceled": "danger", "03_approved": "success", "02_changes_requested": "warning", "04_waiting_normal": "info", "01_in_progress": "200" }'/>
                     <templates>
-                    <t t-name="kanban-menu" t-if="!selection_mode" groups="base.group_user">
+                    <t t-name="menu" t-if="!selection_mode" groups="base.group_user">
                         <a t-if="widget.editable" role="menuitem" type="set_cover" class="dropdown-item" data-field="displayed_image_id">Set Cover Image</a>
                         <a name="%(portal.portal_share_action)d" role="menuitem" type="action" class="dropdown-item" context="{'dialog_size': 'medium'}">Share Task</a>
                         <div role="separator" class="dropdown-divider"></div>
                         <field name="color" widget="kanban_color_picker"/>
                     </t>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div t-att-class="['1_done', '1_canceled'].includes(record.state.raw_value) ? 'opacity-50' : ''">
                             <field name="name" class="fw-bold fs-5"/>
                             <div class="text-muted">

--- a/addons/project/views/project_update_views.xml
+++ b/addons/project/views/project_update_views.xml
@@ -65,7 +65,7 @@
             <kanban highlight_color="color" sample="1" js_class="project_update_kanban">
                 <field name="color"/>
                 <templates>
-                    <t t-name="kanban-card" class="flex-row align-items-center">
+                    <t t-name="card" class="flex-row align-items-center">
                         <!-- Project Update Kanban View is always ungrouped - see js_class -->
                         <div class="pb-0 mb-2 mr8 o_pupdate_kanban_width">
                             <field name="name_cropped" class="fw-bolder"/>

--- a/addons/project_todo/static/tests/todo_done_checkmark.test.js
+++ b/addons/project_todo/static/tests/todo_done_checkmark.test.js
@@ -34,7 +34,7 @@ beforeEach(() => {
         kanban: `
             <kanban>
                 <template>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="state" widget="todo_done_checkmark"/>
                     </t>
                 </template>

--- a/addons/project_todo/views/project_task_views.xml
+++ b/addons/project_todo/views/project_task_views.xml
@@ -21,12 +21,12 @@
                 <field name="state"/>
                 <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <a t-if="widget.editable" role="menuitem" type="set_cover" class="dropdown-item" data-field="displayed_image_id">Set Cover Image</a>
                         <a role="menuitem" type="delete" class="dropdown-item">Delete</a>
                         <field name="color" widget="kanban_color_picker"/>
                     </t>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <t t-set="todoHasAssignees" t-value="record.user_ids.raw_value.length &gt; 1"/>
                         <div t-att-class="{'opacity-50': ['1_done', '1_canceled'].includes(record.state.raw_value)}">
                             <field name="name" class="fw-bolder fs-5" widget="name_with_subtask_count"/>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -322,7 +322,7 @@
                                      <field name="display_type"/>
                                      <field name="tax_calculation_rounding_method"/>
                                      <templates>
-                                         <t t-name="kanban-card">
+                                         <t t-name="card">
                                             <t t-if="!record.display_type.raw_value">
                                                 <div class="row">
                                                     <field name="product_id" class="fw-bold col-8"/>
@@ -480,7 +480,7 @@
                     <field name="currency_id"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <div class="d-flex mb-3">
                                 <field name="priority" widget="priority" class="mt-1 me-1"/>
                                 <field name="partner_id" class="fw-bolder fs-5"/>

--- a/addons/purchase_requisition/views/purchase_requisition_views.xml
+++ b/addons/purchase_requisition/views/purchase_requisition_views.xml
@@ -144,7 +144,7 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile" sample="1">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div class="d-flex mb-1">
                             <field name="name" class="fw-bolder fs-5"/>
                             <field name="state" widget="label_selection" options="{'classes': {'draft': 'default', 'done': 'success', 'close': 'danger'}}" readonly="1" class="ms-auto"/>

--- a/addons/rating/views/rating_rating_views.xml
+++ b/addons/rating/views/rating_rating_views.xml
@@ -87,7 +87,7 @@
             <field name="arch" type="xml">
                 <kanban create="false" sample="1">
                     <templates>
-                        <t t-name="kanban-card" class="row g-0">
+                        <t t-name="card" class="row g-0">
                             <aside class="col-4 my-auto align-self-center">
                                 <field name="rating_image" widget="image" class="bg-view ms-3" />
                             </aside>
@@ -126,7 +126,7 @@
                 <kanban create="false" class="o_rating_rating_kanban">
                     <field name="rating"/>
                     <templates>
-                        <t t-name="kanban-card" class="row g-0">
+                        <t t-name="card" class="row g-0">
                             <t t-set="val_stars" t-value="Math.round(record.rating.raw_value * 10) / 10"/>
                             <t t-set="val_integer" t-value="Math.floor(val_stars)"/>
                             <t t-set="val_decimal" t-value="val_stars - val_integer"/>

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -206,7 +206,7 @@
             <kanban class="o_kanban_mobile" sample="1" quick_create="false">
                 <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div class="row">
                             <field name="name" class="col-6 fw-bolder mb-1"/>
                             <field name="state" class="col-6 text-end mb-1" widget="label_selection" options="{'classes': {'draft': 'info', 'cancel': 'danger', 'done': 'success', 'under_repair': 'secondary'}}"/>

--- a/addons/repair/views/stock_picking_views.xml
+++ b/addons/repair/views/stock_picking_views.xml
@@ -57,7 +57,7 @@
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="stock.stock_picking_type_kanban"/>
         <field name="arch" type="xml">
-            <xpath expr="//t[@t-name='kanban-menu']" position="inside">
+            <xpath expr="//t[@t-name='menu']" position="inside">
                 <div class="container" t-if="record.code.raw_value == 'repair_operation'">
                         <div class="row">
                             <div class="col-6" name="picking_left_manage_pane">

--- a/addons/resource_mail/static/tests/many2one_avatar_resource.test.js
+++ b/addons/resource_mail/static/tests/many2one_avatar_resource.test.js
@@ -98,7 +98,7 @@ test("many2one_avatar_resource widget in kanban view", async () => {
     await openKanbanView("resource.task", {
         arch: `<kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="display_name"/>
                         <field name="resource_id" widget="many2one_avatar_resource"/>
                     </t>

--- a/addons/sale/static/tests/sales_team_dashboard_tests.js
+++ b/addons/sale/static/tests/sales_team_dashboard_tests.js
@@ -59,7 +59,7 @@ QUnit.test("edit progressbar target", async (assert) => {
             <kanban>
                 <field name="invoiced_target"/>
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="invoiced" widget="sales_team_progressbar" options="{'current_value': 'invoiced', 'max_value': 'invoiced_target', 'editable': true, 'edit_max_value': true}"/>
                     </div>
                 </templates>

--- a/addons/sale/views/product_views.xml
+++ b/addons/sale/views/product_views.xml
@@ -110,7 +110,7 @@
         <field name="inherit_id" ref="product.product_view_kanban_catalog"/>
         <field name="model">product.product</field>
         <field name="arch" type="xml">
-            <xpath expr="//t[@t-name='kanban-menu']" position="attributes">
+            <xpath expr="//t[@t-name='menu']" position="attributes">
                 <attribute name="groups">sales_team.group_sale_manager</attribute>
             </xpath>
         </field>

--- a/addons/sale/views/sale_order_line_views.xml
+++ b/addons/sale/views/sale_order_line_views.xml
@@ -126,7 +126,7 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="display_name"/>
                     </t>
                 </templates>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -74,7 +74,7 @@
                 <progressbar field="activity_state"
                     colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div class="d-flex mb-2">
                             <field name="partner_id" class="fw-bolder fs-5" />
                             <field name="amount_total" widget="monetary" class="fw-bolder ms-auto"/>
@@ -678,7 +678,7 @@
                                             class="btn-secondary"/>
                                 </control>
                                 <templates>
-                                    <t t-name="kanban-card" class="row g-0 ps-0 pe-0">
+                                    <t t-name="card" class="row g-0 ps-0 pe-0">
                                         <t t-if="!record.display_type.raw_value">
                                             <aside class="col-2 p-1">
                                                 <span t-att-title="record.product_id.value">

--- a/addons/sale_management/views/sale_order_views.xml
+++ b/addons/sale_management/views/sale_order_views.xml
@@ -27,7 +27,7 @@
                         <kanban class="o_kanban_mobile">
                             <field name="is_present" />
                             <templates>
-                                <t t-name="kanban-card">
+                                <t t-name="card">
                                     <div class="row">
                                         <field name="product_id" class="col-10 fw-bolder"/>
                                         <button name="button_add_to_order"

--- a/addons/sale_pdf_quote_builder/views/quotation_document_views.xml
+++ b/addons/sale_pdf_quote_builder/views/quotation_document_views.xml
@@ -72,7 +72,7 @@
                 <field name="name"/>
                 <field name="active"/>
                 <templates>
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <a t-if="widget.editable" type="open" class="dropdown-item">Edit</a>
                         <a t-if="widget.deletable" type="delete" class="dropdown-item">Delete</a>
                         <a
@@ -81,7 +81,7 @@
                             class="dropdown-item"
                         >Download</a>
                     </t>
-                    <t t-name="kanban-card" class="o_kanban_attachment flex-row">
+                    <t t-name="card" class="o_kanban_attachment flex-row">
                         <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                         <aside>
                             <div class="o_image ms-3" t-att-data-mimetype="record.mimetype.value"/>

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -41,7 +41,7 @@
                         <kanban class="o_kanban_mobile">
                             <field name="currency_id"/>
                             <templates>
-                                <t t-name="kanban-card">
+                                <t t-name="card">
                                     <div class="row">
                                         <div class="col-8 d-flex">
                                             <field name="employee_id" widget="many2one_avatar_employee"/>

--- a/addons/sales_team/views/crm_team_member_views.xml
+++ b/addons/sales_team/views/crm_team_member_views.xml
@@ -52,7 +52,7 @@
                 class="o_crm_team_member_kanban">
                 <field name="active"/>
                 <templates>
-                    <t t-name="kanban-card" class="flex-row mb-3">
+                    <t t-name="card" class="flex-row mb-3">
                         <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                         <aside>
                             <field name="user_id" widget="image" options="{'preview_image': 'avatar_128'}" class="o_image_64_cover" alt="Avatar"/>

--- a/addons/sales_team/views/crm_team_views.xml
+++ b/addons/sales_team/views/crm_team_views.xml
@@ -56,7 +56,7 @@
                                 class="w-100">
                                 <kanban>
                                     <templates>
-                                        <t t-name="kanban-card" class="flex-row">
+                                        <t t-name="card" class="flex-row">
                                             <aside>
                                                 <field name="avatar_128" widget="image" class="o_image_64_cover" alt="Avatar"/>
                                             </aside>
@@ -108,7 +108,7 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile" sample="1">
                 <templates>
-                    <t t-name="kanban-card" class="row g-0">
+                    <t t-name="card" class="row g-0">
                         <field name="name" class="col-6 fw-bold"/>
                         <div class="col-6">
                             <field name="user_id" class="float-end"/>
@@ -127,7 +127,7 @@
         <field name="arch" type="xml">
             <kanban class="o_crm_team_kanban" highlight_color="color" create="0" can_open="0" sample="1">
                 <templates>
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <div class="container">
                             <div class="row">
                                 <div name="manage_view" class="col-4">
@@ -158,7 +158,7 @@
                             </div>
                         </div>
                     </t>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="name" class="fw-bold text-truncate fs-4 ms-2"/>
                         <div class="row mt-3 px-2">
                             <div class="col-4" name="to_replace_in_sale_crm">

--- a/addons/sms/static/tests/web/sms_button.test.js
+++ b/addons/sms/static/tests/web/sms_button.test.js
@@ -116,7 +116,7 @@ test(
                         <field name="partner_ids">
                         <kanban>
                             <templates>
-                                <t t-name="kanban-card">
+                                <t t-name="card">
                                     <field name="display_name"/>
                                 </t>
                             </templates>

--- a/addons/stock/views/stock_lot_views.xml
+++ b/addons/stock/views/stock_lot_views.xml
@@ -84,7 +84,7 @@
         <field name="arch" type="xml">
             <kanban group_create="false" group_delete="false">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="name" class="fw-bolder fs-5"/>
                         <field name="product_id" class="small"/>
                         <field name="lot_properties" widget="properties"/>

--- a/addons/stock/views/stock_move_line_views.xml
+++ b/addons/stock/views/stock_move_line_views.xml
@@ -165,7 +165,7 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div class="row">
                             <field name="reference" class="col-6"/>
                             <field name="date" class="col-6 text-end"/>

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -99,7 +99,7 @@
                     <field name="product_qty" readonly="1" force_save="0"/>
                     <field name="is_inventory"/>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="product_id" readonly="state == 'done'" class="fw-bold fs-5"/>
                             <div invisible="not is_inventory">
                                 <span>Initial Demand <field name="product_uom_qty" readonly="state == 'done'"/></span><br/>

--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -6,7 +6,7 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div class="d-flex">
                             <field name="name" class="fw-bold fs-5 mb-1"/>
                             <span class="badge rounded-pill ms-auto mt-1"><strong>Min qty:</strong><field name="product_min_qty"/></span>

--- a/addons/stock/views/stock_picking_type_views.xml
+++ b/addons/stock/views/stock_picking_type_views.xml
@@ -181,7 +181,7 @@
                 <field name="count_move_ready"/>
                 <field name="show_picking_type" invisible="1"/>
                 <templates>
-                    <t t-name="kanban-menu" t-if="!selection_mode">
+                    <t t-name="menu" t-if="!selection_mode">
                         <div class="container" t-if="record.show_picking_type.raw_value">
                             <div class="row">
                                 <div class="col-6">
@@ -223,7 +223,7 @@
                             </div>
                         </div>
                     </t>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div t-if="record.show_picking_type.raw_value" name="stock_picking" class="px-2">
                             <a t-if="!selection_mode" type="object" name="get_stock_picking_action_picking_type">
                                 <field class="fw-bold fs-4" name="name"/>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -39,7 +39,7 @@
                     <field name="picking_type_id"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <div class="d-flex mb-1">
                                 <field name="priority" widget="priority" class="pt-1"/>
                                 <field name="name" class="fw-bold fs-5 ms-1"/>

--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -298,7 +298,7 @@
                         </list>
                         <kanban class="o_kanban_mobile">
                             <templates>
-                                <t t-name="kanban-card">
+                                <t t-name="card">
                                     <field name="product_id" class="fw-bold"/>
                                     <field name="lot_id"/>
                                     <div class="d-flex">
@@ -334,7 +334,7 @@
         <field name="arch" type="xml">
             <kanban sample="1" group_create="0">
                 <templates>
-                    <t t-name="kanban-card" class="row g-0">
+                    <t t-name="card" class="row g-0">
                         <field name="name" class="col-6 fw-bold fs-5"/>
                         <field name="package_type_id" class="col-6"/>
                     </t>

--- a/addons/stock/views/stock_scrap_views.xml
+++ b/addons/stock/views/stock_scrap_views.xml
@@ -86,7 +86,7 @@
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile" sample="1">
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <div class="row">
                                 <field name="name" class="col-6 fw-bolder"/>
                                 <div class="col-6 fw-bolder text-end">

--- a/addons/stock/wizard/stock_package_destination_views.xml
+++ b/addons/stock/wizard/stock_package_destination_views.xml
@@ -18,7 +18,7 @@
                         </list>
                         <kanban>
                             <templates>
-                                <t t-name="kanban-card">
+                                <t t-name="card">
                                     <div class="row">
                                         <field name="product_id" class="col-6"/>
                                         <field name="quantity" class="col-6" String="quantity"/>

--- a/addons/stock_landed_costs/views/stock_landed_cost_views.xml
+++ b/addons/stock_landed_costs/views/stock_landed_cost_views.xml
@@ -155,7 +155,7 @@
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile">
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <div class="row mb-1">
                                 <field name="name" class="col-6 fw-bolder"/>
                                 <div class="col-6">

--- a/addons/stock_picking_batch/views/stock_picking_batch_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_batch_views.xml
@@ -154,7 +154,7 @@
             <kanban class="o_kanban_mobile" sample="1">
                 <field name="company_id"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div class="d-flex">
                             <field name="name" class="fw-bolder fs-5"/>
                             <field name="state" widget="label_selection" class="ms-auto"/>

--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -229,7 +229,7 @@
                 <field name="session_state"/>
                 <field name="session_available"/>
                 <templates>
-                    <div t-name="kanban-menu" t-if="widget.editable">
+                    <div t-name="menu" t-if="widget.editable">
                         <a role="menuitem" type="open" class="dropdown-item">Edit Survey</a>
                         <a t-if="record.active.raw_value" role="menuitem" type="object" class="dropdown-item" name="action_send_survey">Share</a>
                         <a t-if="widget.deletable" role="menuitem" type="delete" class="dropdown-item">Delete</a>
@@ -237,7 +237,7 @@
                         <div role="separator" class="dropdown-item-text">Color</div>
                         <field name="color" widget="kanban_color_picker"/>
                     </div>
-                    <div t-name="kanban-card"
+                    <div t-name="card"
                         t-attf-class="o_survey_kanban_card #{record.certification.raw_value ? 'o_survey_kanban_card_certification' : ''}" class="px-0">
                         <!-- displayed in ungrouped mode -->
                         <div class="o_survey_kanban_card_ungrouped row mx-4">

--- a/addons/survey/views/survey_user_views.xml
+++ b/addons/survey/views/survey_user_views.xml
@@ -138,7 +138,7 @@
         <field name="arch" type="xml">
             <kanban create="false" group_create="false">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="survey_id" class="fw-bold fs-5 mb-1"/>
                         <footer class="fs-6 pt-0">
                             <field name="create_date"/>

--- a/addons/test_base_automation/tests/test_tour.py
+++ b/addons/test_base_automation/tests/test_tour.py
@@ -47,7 +47,7 @@ class BaseAutomationTestUi(HttpCase):
                 "arch": """
                     <kanban default_group_by="tag_ids">
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="name" />
                             </t>
                         </templates>

--- a/addons/test_website/views/test_model_multi_website_views.xml
+++ b/addons/test_website/views/test_model_multi_website_views.xml
@@ -8,7 +8,7 @@
     <field name="arch" type="xml">
         <kanban js_class="website_pages_kanban" class="o_kanban_mobile" action="open_website_url" type="object" sample="1">
             <templates>
-                <t t-name="kanban-card">
+                <t t-name="card">
                     <field name="name" class="text-truncate fw-bolder mb-auto"/>
                     <div class="text-muted fw-bolder" t-if="record.website_id.value" groups="website.group_multi_website">
                         <i class="fa fa-globe me-1" title="Website"/>

--- a/addons/test_website/views/test_model_views.xml
+++ b/addons/test_website/views/test_model_views.xml
@@ -8,7 +8,7 @@
     <field name="arch" type="xml">
         <kanban js_class="website_pages_kanban" class="o_kanban_mobile" action="open_website_url" type="object" sample="1">
             <templates>
-                <t t-name="kanban-card">
+                <t t-name="card">
                     <field class="text-truncate mb-auto fw-bolder" name="name"/>
                     <div class="d-flex border-top mt-2 pt-2">
                         <field name="is_published" widget="boolean_toggle"/>

--- a/addons/utm/views/utm_campaign_views.xml
+++ b/addons/utm/views/utm_campaign_views.xml
@@ -90,7 +90,7 @@
                 <field name="stage_id"/>
                 <field name='active'/>
                 <templates>
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <t t-if="widget.editable">
                             <a role="menuitem" type="open" class="dropdown-item">Edit</a>
                         </t>
@@ -104,7 +104,7 @@
                         <div role="separator" class="dropdown-divider"/>
                         <field name="color" widget="kanban_color_picker"/>
                     </t>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="title" class="fw-bold fs-5"/>
                         <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                         <ul id="o_utm_actions" class="list-group list-group-horizontal my-0"/>

--- a/addons/web/static/src/views/kanban/kanban_arch_parser.js
+++ b/addons/web/static/src/views/kanban/kanban_arch_parser.js
@@ -9,7 +9,7 @@ import { Widget } from "@web/views/widgets/widget";
  * NOTE ON 't-name="kanban-box"':
  *
  * "kanban-box" is deprecated. Kanban archs converted to the new (v18) API must
- * define a "kanban-card" template instead.
+ * define a "card" template instead.
  *
  * Multiple roots are supported in kanban box template definitions, however there
  * are a few things to keep in mind when doing so:
@@ -23,8 +23,8 @@ import { Widget } from "@web/views/widgets/widget";
  */
 
 export const KANBAN_BOX_ATTRIBUTE = "kanban-box";
-export const KANBAN_CARD_ATTRIBUTE = "kanban-card";
-export const KANBAN_MENU_ATTRIBUTE = "kanban-menu";
+export const KANBAN_CARD_ATTRIBUTE = "card";
+export const KANBAN_MENU_ATTRIBUTE = "menu";
 
 export class KanbanArchParser {
     parse(xmlDoc, models, modelName) {

--- a/addons/web/static/tests/core/domain_field.test.js
+++ b/addons/web/static/tests/core/domain_field.test.js
@@ -700,7 +700,7 @@ test.tags("desktop")("domain field in kanban view", async function () {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo" widget="domain" options="{'model': 'partner.type'}" />
                     </t>
                 </templates>

--- a/addons/web/static/tests/legacy/mobile/views/fields/many2one_barcode_field_tests.js
+++ b/addons/web/static/tests/legacy/mobile/views/fields/many2one_barcode_field_tests.js
@@ -68,7 +68,7 @@ QUnit.module("Fields", (hooks) => {
             },
             views: {
                 "product.product,false,kanban": `
-                    <kanban><templates><t t-name="kanban-card">
+                    <kanban><templates><t t-name="card">
                         <field name="id"/>
                         <field name="name"/>
                         <field name="barcode"/>

--- a/addons/web/static/tests/legacy/mobile/views/form_view_tests.js
+++ b/addons/web/static/tests/legacy/mobile/views/form_view_tests.js
@@ -246,7 +246,7 @@ QUnit.module("Mobile Views", ({ beforeEach }) => {
                 "partner,false,kanban": `
                     <kanban>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="display_name" />
                             </t>
                         </templates>

--- a/addons/web/static/tests/legacy/mobile/views/kanban_view_tests.js
+++ b/addons/web/static/tests/legacy/mobile/views/kanban_view_tests.js
@@ -73,7 +73,7 @@ QUnit.module("Views", (hooks) => {
                 <kanban>
                     <progressbar field="foo" colors='{"yop": "success", "blip": "danger"}'/>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="foo"/>
                         </t>
                     </templates>

--- a/addons/web/static/tests/legacy/mobile/views/view_dialog/select_create_dialog_tests.js
+++ b/addons/web/static/tests/legacy/mobile/views/view_dialog/select_create_dialog_tests.js
@@ -41,13 +41,13 @@ QUnit.module("ViewDialogs", (hooks) => {
             },
             views: {
                 "product,false,kanban": `
-                    <kanban><templates><t t-name="kanban-card">
+                    <kanban><templates><t t-name="card">
                         <field name="id"/>
                         <field name="name"/>
                     </t></templates></kanban>
                 `,
                 "sale_order_line,false,kanban": `
-                    <kanban><templates><t t-name="kanban-card">
+                    <kanban><templates><t t-name="card">
                         <field name="id"/>
                     </t></templates></kanban>
                 `,
@@ -105,7 +105,7 @@ QUnit.module("ViewDialogs", (hooks) => {
         serverData.views["product,false,kanban"] = `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                          <div class="o_primary" t-if="!selection_mode">
                             <a type="object" name="some_action">
                                 <field name="name"/>

--- a/addons/web/static/tests/legacy/mobile/webclient/window_action_tests.js
+++ b/addons/web/static/tests/legacy/mobile/webclient/window_action_tests.js
@@ -31,7 +31,7 @@ QUnit.module("ActionManager", (hooks) => {
                 "project,false,kanban": `
                 <kanban>
                     <templates>
-                        <t t-name='kanban-card'>
+                        <t t-name='card'>
                             <field name='foo' />
                         </t>
                     </templates>

--- a/addons/web/static/tests/legacy/webclient/helpers.js
+++ b/addons/web/static/tests/legacy/webclient/helpers.js
@@ -336,7 +336,7 @@ export function getActionManagerServerData() {
     const archs = {
         // kanban views
         "partner,1,kanban":
-            '<kanban><templates><t t-name="kanban-card">' +
+            '<kanban><templates><t t-name="card">' +
             '<field name="foo"/>' +
             "</t></templates></kanban>",
         // list views

--- a/addons/web/static/tests/search/control_panel.test.js
+++ b/addons/web/static/tests/search/control_panel.test.js
@@ -18,7 +18,7 @@ class Foo extends models.Model {
     _views = {
         search: `<search/>`,
         list: `<list/>`,
-        kanban: `<kanban><t t-name="kanban-card"></t></kanban>`,
+        kanban: `<kanban><t t-name="card"></t></kanban>`,
     };
 }
 defineModels([Foo]);
@@ -41,8 +41,16 @@ test.tags`desktop`("breadcrumbs", async () => {
         { resModel: "foo" },
         {
             breadcrumbs: [
-                { jsId: "controller_7", name: "Previous", onSelected: () => expect.step("controller_7") },
-                { jsId: "controller_9", name: "Current", onSelected: () => expect.step("controller_9") },
+                {
+                    jsId: "controller_7",
+                    name: "Previous",
+                    onSelected: () => expect.step("controller_7"),
+                },
+                {
+                    jsId: "controller_9",
+                    name: "Current",
+                    onSelected: () => expect.step("controller_9"),
+                },
             ],
         }
     );

--- a/addons/web/static/tests/search/search_panel_desktop.test.js
+++ b/addons/web/static/tests/search/search_panel_desktop.test.js
@@ -131,7 +131,7 @@ class Partner extends models.Model {
         kanban: /* xml */ `
             <kanban>
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="foo"/>
                     </div>
                 </templates>

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -613,7 +613,7 @@ test(`filter panel autocomplete: updates when typing`, async () => {
 test(`check the avatar of the attendee in the calendar filter panel`, async () => {
     CalendarPartner._views = {
         list: `<list><field name="name"/></list>`,
-        kanban: `<kanban><templates><t name="kanban-card"><field name="name"/></t></templates></kanban>`,
+        kanban: `<kanban><templates><t name="card"><field name="name"/></t></templates></kanban>`,
         search: `<search/>`,
     };
     CalendarPartner._records.push(
@@ -907,7 +907,7 @@ test.tags("desktop")(`add a filter with the search more dialog on desktop`, asyn
 test.tags("mobile")(`add a filter with the search more dialog on mobile`, async () => {
     CalendarPartner._views = {
         list: `<list><field name="name"/></list>`,
-        kanban: `<kanban><templates><t t-name="kanban-card"><field class="o_data_row" name="name"/></t></templates></kanban>`,
+        kanban: `<kanban><templates><t t-name="card"><field class="o_data_row" name="name"/></t></templates></kanban>`,
         search: `<search/>`,
     };
     CalendarPartner._records.push(
@@ -3092,7 +3092,7 @@ test.tags("desktop")(`Update event with filters on desktop`, async () => {
 test.tags("mobile")(`Update event with filters on mobile`, async () => {
     CalendarUsers._records.push({ id: 5, name: "user 5", partner_id: 3 });
     CalendarUsers._views = {
-        kanban: `<kanban><templates><t t-name="kanban-card"><field name="name"/></t></templates></kanban>`,
+        kanban: `<kanban><templates><t t-name="card"><field name="name"/></t></templates></kanban>`,
         search: `<search/>`,
     };
     Event._views = {

--- a/addons/web/static/tests/views/fields/boolean_favorite_field.test.js
+++ b/addons/web/static/tests/views/fields/boolean_favorite_field.test.js
@@ -31,7 +31,7 @@ test("FavoriteField in kanban view", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="bar" widget="boolean_favorite"/>
                     </t>
                 </templates>
@@ -68,7 +68,7 @@ test("FavoriteField saves changes by default", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="bar" widget="boolean_favorite"/>
                     </t>
                 </templates>
@@ -99,7 +99,7 @@ test("FavoriteField does not save if autosave option is set to false", async () 
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="bar" widget="boolean_favorite" options="{'autosave': False}"/>
                     </t>
                 </templates>
@@ -229,7 +229,7 @@ test("FavoriteField in kanban view with readonly attribute", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="bar" widget="boolean_favorite" readonly="1"/>
                     </t>
                 </templates>

--- a/addons/web/static/tests/views/fields/daterange_field.test.js
+++ b/addons/web/static/tests/views/fields/daterange_field.test.js
@@ -1077,7 +1077,7 @@ test("daterange field in kanban with show_time option", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="datetime" widget="daterange" options="{'show_time': false, 'end_date_field': 'datetime_end'}"/>
                     </t>
                 </templates>

--- a/addons/web/static/tests/views/fields/datetime_field.test.js
+++ b/addons/web/static/tests/views/fields/datetime_field.test.js
@@ -556,7 +556,7 @@ test("datetime field (with widget) in kanban with show_time option", async () =>
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="datetime" widget="datetime" options="{'show_time': false}"/>
                     </t>
                 </templates>
@@ -625,7 +625,7 @@ test("datetime field in kanban view with condensed option", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="datetime" options="{'condensed': true}"/>
                     </t>
                 </templates>

--- a/addons/web/static/tests/views/fields/float_toggle_field.test.js
+++ b/addons/web/static/tests/views/fields/float_toggle_field.test.js
@@ -71,7 +71,7 @@ test("kanban view (readonly) with option force_button", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="float_field" widget="float_toggle" options="{'force_button': true}"/>
                     </t>
                 </templates>

--- a/addons/web/static/tests/views/fields/gauge_field.test.js
+++ b/addons/web/static/tests/views/fields/gauge_field.test.js
@@ -20,7 +20,7 @@ test("GaugeField in kanban view", async () => {
         <kanban>
             <field name="another_int_field"/>
             <templates>
-                <t t-name="kanban-card">
+                <t t-name="card">
                     <field name="int_field" widget="gauge" options="{'max_field': 'another_int_field'}"/>
                 </t>
             </templates>

--- a/addons/web/static/tests/views/fields/html_field.test.js
+++ b/addons/web/static/tests/views/fields/html_field.test.js
@@ -119,7 +119,7 @@ test("html fields are correctly rendered in kanban view", async () => {
         arch: /* xml */ `
             <kanban class="o_kanban_test">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="txt"/>
                     </t>
                 </templates>

--- a/addons/web/static/tests/views/fields/image_field.test.js
+++ b/addons/web/static/tests/views/fields/image_field.test.js
@@ -543,7 +543,7 @@ test("ImageField in subviews is loaded correctly", async () => {
                 <field name="timmy" widget="many2many" mode="kanban">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="name" />
                             </t>
                         </templates>
@@ -779,7 +779,7 @@ test("convert image to webp", async () => {
             expect(args[0][0].mimetype).toBe("image/jpeg");
             return true;
         }
-    })
+    });
 
     const imageData = Uint8Array.from([...atob(MY_IMAGE)].map((c) => c.charCodeAt(0)));
     await mountView({
@@ -799,4 +799,4 @@ test("convert image to webp", async () => {
         { message: "image field should not be set" }
     );
     await setFiles(imageFile);
-})
+});

--- a/addons/web/static/tests/views/fields/image_url_field.test.js
+++ b/addons/web/static/tests/views/fields/image_url_field.test.js
@@ -81,7 +81,7 @@ test("ImageUrlField in subviews are loaded correctly", async () => {
                 <field name="timmy" widget="many2many" mode="kanban">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="display_name"/>
                             </t>
                         </templates>
@@ -152,7 +152,7 @@ test("image url fields in kanban don't stop opening record", async () => {
         arch: /* xml */ `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo" widget="image_url"/>
                     </t>
                 </templates>

--- a/addons/web/static/tests/views/fields/journal_dashboard_graph_field.test.js
+++ b/addons/web/static/tests/views/fields/journal_dashboard_graph_field.test.js
@@ -92,7 +92,7 @@ test.tags("desktop")("JournalDashboardGraphField is rendered correctly", async (
             <kanban>
                 <field name="graph_type"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="graph_data" t-att-graph_type="record.graph_type.raw_value" widget="dashboard_graph"/>
                     </t>
                 </templates>
@@ -127,7 +127,7 @@ test("rendering of a JournalDashboardGraphField in an updated grouped kanban vie
             <kanban>
                 <field name="graph_type"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="graph_data" t-att-graph_type="record.graph_type.raw_value" widget="dashboard_graph"/>
                     </t>
                 </templates>

--- a/addons/web/static/tests/views/fields/many2many_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_field.test.js
@@ -241,7 +241,7 @@ test.tags("desktop")("many2many kanban: edition", async () => {
                 <field name="timmy">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <div>
                                     <a
                                         t-if="!read_only_mode"
@@ -341,7 +341,7 @@ test("many2many kanban(editable): properly handle add-label node attribute", asy
                     <field name="timmy" add-label="Add timmy" mode="kanban">
                         <kanban>
                             <templates>
-                                <t t-name="kanban-card">
+                                <t t-name="card">
                                     <field name="name"/>
                                 </t>
                             </templates>
@@ -410,7 +410,7 @@ test("many2many kanban: create action disabled", async () => {
                 <field name="timmy">
                     <kanban create="0">
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <div>
                                     <a t-if="!read_only_mode" type="delete" class="fa fa-times float-end delete_icon"/>
                                     <field name="name"/>
@@ -447,7 +447,7 @@ test("many2many kanban: conditional create/delete actions", async () => {
                 <field name="timmy" options="{'create': [('color', '=', 'red')], 'delete': [('color', '=', 'red')]}">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="name"/>
                             </t>
                         </templates>
@@ -987,7 +987,7 @@ test("many2many field with link option (kanban)", async () => {
                 <field name="timmy" options="{'link': [('color', '=', 'red')]}">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="name"/>
                             </t>
                         </templates>
@@ -1028,7 +1028,7 @@ test('many2many field with link option (kanban, create="0")', async () => {
                 <field name="timmy" options="{'link': [('color', '=', 'red')]}">
                     <kanban create="0">
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="name"/>
                             </t>
                         </templates>
@@ -1194,12 +1194,11 @@ test("many2many with a domain", async () => {
 test("many2many list (editable): edition concurrence", async () => {
     Partner._records[0].timmy = [1, 2];
     PartnerType._records.push({ id: 15, name: "bronze", color: 6 });
-    PartnerType._fields.float_field = fields.Float({string: "Float"});
+    PartnerType._fields.float_field = fields.Float({ string: "Float" });
     PartnerType._views = {
         list: '<list><field name="name"/></list>',
         search: '<search><field name="name" string="Name"/></search>',
     };
-
 
     onRpc((args) => {
         expect.step(args.method);
@@ -1404,7 +1403,7 @@ test("onchange with 40+ commands for a many2many", async () => {
                 <field name="timmy">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="name"/>
                             </t>
                         </templates>
@@ -1463,7 +1462,7 @@ test.tags("desktop")("onchange with 40+ commands for a many2many on desktop", as
                 <field name="timmy">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="name"/>
                             </t>
                         </templates>
@@ -1631,7 +1630,7 @@ test("many2many kanban: action/type attribute", async () => {
                 <field name="timmy">
                     <kanban action="a1" type="object">
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="name"/>
                             </t>
                         </templates>

--- a/addons/web/static/tests/views/fields/many2many_tags_avatar_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_avatar_field.test.js
@@ -238,7 +238,7 @@ test("widget many2many_tags_avatar in kanban view", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="name"/>
                         <footer>
                             <field name="partner_ids" widget="many2many_tags_avatar"/>
@@ -321,7 +321,7 @@ test("widget many2many_tags_avatar add/remove tags in kanban view", async () => 
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="name"/>
                         <footer>
                             <field name="partner_ids" widget="many2many_tags_avatar"/>
@@ -368,7 +368,7 @@ test("widget many2many_tags_avatar quick add tags and close in kanban view with 
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="name"/>
                         <footer>
                             <field name="partner_ids" widget="many2many_tags_avatar"/>
@@ -394,7 +394,7 @@ test("widget many2many_tags_avatar in kanban view missing access rights", async 
         arch: `
             <kanban edit="0" create="0">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="name"/>
                         <footer>
                             <field name="partner_ids" widget="many2many_tags_avatar"/>

--- a/addons/web/static/tests/views/fields/many2one_avatar_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_avatar_field.test.js
@@ -324,7 +324,7 @@ test.tags("desktop")("widget many2one_avatar in kanban view (load more dialog)",
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <footer>
                             <field name="user_id" widget="many2one_avatar"/>
                         </footer>
@@ -355,7 +355,7 @@ test("widget many2one_avatar in kanban view", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <footer>
                             <field name="user_id" widget="many2one_avatar"/>
                         </footer>
@@ -392,7 +392,7 @@ test("widget many2one_avatar in kanban view without access rights", async () => 
         arch: `
             <kanban edit="0" create="0">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <footer>
                             <field name="user_id" widget="many2one_avatar"/>
                         </footer>

--- a/addons/web/static/tests/views/fields/one2many_field.test.js
+++ b/addons/web/static/tests/views/fields/one2many_field.test.js
@@ -2297,7 +2297,7 @@ test("one2many field when using the pager", async () => {
                 <field name="p">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="name"/>
                             </t>
                         </templates>
@@ -2394,7 +2394,7 @@ test("edition of one2many field with pager", async () => {
                 <field name="p">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <div>
                                     <a t-if="!read_only_mode" type="delete" class="fa fa-times float-end delete_icon"/>
                                     <field name="name"/>
@@ -2529,7 +2529,7 @@ test.tags("desktop")("edition of one2many field with pager on desktop", async ()
                 <field name="p">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <div>
                                     <a t-if="!read_only_mode" type="delete" class="fa fa-times float-end delete_icon"/>
                                     <field name="name"/>
@@ -2609,7 +2609,7 @@ test("When viewing one2many records in an embedded kanban, the delete button sho
                 <field name="turtles">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <h3>Record 1</h3>
                             </t>
                         </templates>
@@ -2640,7 +2640,7 @@ test("open a record in a one2many kanban (mode 'readonly')", async () => {
                 <field name="turtles">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="name"/>
                             </t>
                         </templates>
@@ -2673,7 +2673,7 @@ test("open a record in a one2many kanban (mode 'edit')", async () => {
                 <field name="turtles">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="name"/>
                             </t>
                         </templates>
@@ -2756,7 +2756,7 @@ test("open a record in a one2many kanban with an x2m in the form", async () => {
                 <field name="p">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="name"/>
                             </t>
                         </templates>
@@ -2798,7 +2798,7 @@ test("one2many in kanban: add a line custom control create editable", async () =
                             <create string="Add pasta" context="{'default_name': 'pasta'}"/>
                         </control>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="name"/>
                             </t>
                         </templates>
@@ -2850,7 +2850,7 @@ test("one2many in kanban: add a line custom control create editable (2)", async 
                             <button string="Action Button" name="do_something" type="object" context="{'parent_id': parent.id}"/>
                         </control>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="name"/>
                             </t>
                         </templates>
@@ -3373,7 +3373,7 @@ test("one2many kanban: edition", async () => {
                 <field name="p">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <div>
                                     <a t-if="!read_only_mode" type="delete" class="fa fa-times float-end delete_icon"/>
                                     <field name="name"/>
@@ -3448,7 +3448,7 @@ test("one2many kanban (editable): properly handle add-label node attribute", asy
                 <field name="turtles" add-label="Add turtle" mode="kanban">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="name"/>
                             </t>
                         </templates>
@@ -3475,7 +3475,7 @@ test("one2many kanban: create action disabled", async () => {
                 <field name="p">
                     <kanban create="0">
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <div>
                                     <a t-if="!read_only_mode" type="delete" class="fa fa-times float-end delete_icon"/>
                                     <field name="name"/>
@@ -3504,7 +3504,7 @@ test("one2many kanban: conditional create/delete actions", async () => {
                 <field name="p" options="{'create': [('bar', '=', True)], 'delete': [('bar', '=', True)]}">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="name"/>
                             </t>
                         </templates>
@@ -5716,7 +5716,7 @@ test("one2many kanban with action button", async () => {
                 <field name="p">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="foo"/>
                                 <button name="method_name" type="object" class="fa fa-plus"/>
                             </t>
@@ -6413,7 +6413,7 @@ test("one2many field with virtual ids", async () => {
                                 <field name="p" mode="kanban">
                                     <kanban>
                                         <templates>
-                                            <t t-name="kanban-card">
+                                            <t t-name="card">
                                                 <field name="id" class="o_test_id"/>
                                                 <field name="foo" class="o_test_foo"/>
                                             </t>
@@ -6504,7 +6504,7 @@ test("one2many field with virtual ids with kanban button", async () => {
                 <field name="p" mode="kanban">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="foo"/>
                                 <button type="object" class="btn btn-link fa fa-shopping-cart" name="button_warn" string="button_warn" warn="warn" />
                                 <button type="object" class="btn btn-link fa fa-shopping-cart" name="button_disabled" string="button_disabled" />
@@ -6801,7 +6801,7 @@ test('x2many fields use their "mode" attribute', async () => {
                         </list>
                         <kanban>
                             <templates>
-                                <t t-name="kanban-card">
+                                <t t-name="card">
                                     <field name="turtle_int"/>
                                 </t>
                             </templates>
@@ -9524,7 +9524,7 @@ test("field context is correctly passed to x2m subviews", async () => {
                 <field name="turtles" context="{'some_key': 1}">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <t t-if="context.some_key">
                                     <field name="turtle_foo"/>
                                 </t>
@@ -9560,7 +9560,7 @@ test.tags("desktop")("one2many kanban with widget handle", async () => {
                     <kanban>
                         <field name="turtle_int" widget="handle"/>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="turtle_foo"/>
                             </t>
                         </templates>
@@ -11432,7 +11432,7 @@ test("one2many can delete a new record", async () => {
                 <field name="p">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="foo"/>
                             </t>
                         </templates>
@@ -11894,7 +11894,7 @@ test("kanban one2many in opened view form", async () => {
                         <field name="p">
                             <kanban class="o-custom-class" can_open="0">
                                 <templates>
-                                    <t t-name="kanban-card">
+                                    <t t-name="card">
                                         <field name="name"/>
                                     </t>
                                 </templates>
@@ -11923,7 +11923,7 @@ test("kanban one2many in opened view form (with _view_ref)", async () => {
         [["kanban", 1234]]: /* xml */ `
             <kanban class="o-custom-class" can_open="0">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="name"/>
                     </t>
                 </templates>
@@ -11970,7 +11970,7 @@ test("kanban one2many (with widget) in opened view form", async () => {
                 <field name="p">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="name" widget="char"/>
                             </t>
                         </templates>
@@ -12779,7 +12779,7 @@ test("x2many kanban with float field in form (non inline) but not in kanban", as
                 <field name="turtles" invisible="not bar">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="name"/>
                             </t>
                         </templates>

--- a/addons/web/static/tests/views/fields/priority_field.test.js
+++ b/addons/web/static/tests/views/fields/priority_field.test.js
@@ -183,7 +183,7 @@ test("PriorityField can write after adding a record -- kanban", async () => {
         arch: /* xml */ `
             <kanban on_create="quick_create" quick_create_view="myquickview">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="selection" widget="priority"/>
                     </t>
                 </templates>

--- a/addons/web/static/tests/views/fields/progress_bar_field.test.js
+++ b/addons/web/static/tests/views/fields/progress_bar_field.test.js
@@ -215,7 +215,7 @@ test("ProgressBarField: field is editable in kanban", async () => {
         arch: /* xml */ `
                 <kanban>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="int_field" title="ProgressBarTitle" widget="progressbar" options="{'editable': true, 'max_value': 'float_field'}" />
                         </t>
                     </templates>
@@ -254,7 +254,7 @@ test("force readonly in kanban", async (assert) => {
         arch: /* xml */ `
         <kanban>
             <templates>
-                <t t-name="kanban-card">
+                <t t-name="card">
                     <field name="int_field" widget="progressbar" options="{'editable': true, 'max_value': 'float_field', 'readonly': True}" />
                 </t>
             </templates>
@@ -277,7 +277,7 @@ test("ProgressBarField: readonly and editable attrs/options in kanban", async ()
         arch: /* xml */ `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="int_field" readonly="1" widget="progressbar" options="{'max_value': 'float_field'}" />
                         <field name="int_field2" widget="progressbar" options="{'max_value': 'float_field'}" />
                         <field name="int_field3" widget="progressbar" options="{'editable': true, 'max_value': 'float_field'}" />

--- a/addons/web/static/tests/views/fields/properties_field.test.js
+++ b/addons/web/static/tests/views/fields/properties_field.test.js
@@ -1375,7 +1375,7 @@ test("properties: kanban view", async () => {
         arch: /* xml */ `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="company_id"/> <hr/>
                         <field name="display_name"/> <hr/>
                         <field name="properties" widget="properties"/>
@@ -1428,7 +1428,7 @@ test("properties: kanban view with date and datetime property fields", async () 
         arch: /* xml */ `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="company_id"/> <hr/>
                         <field name="display_name"/> <hr/>
                         <field name="properties" widget="properties"/>
@@ -1476,7 +1476,7 @@ test("properties: kanban view with multiple sources of properties definitions", 
         arch: /* xml */ `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="company_id"/> <hr/>
                         <field name="display_name"/> <hr/>
                         <field name="properties" widget="properties"/>
@@ -1549,7 +1549,7 @@ test("properties: kanban view with label and border", async () => {
         arch: /* xml */ `
                 <kanban>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="company_id"/> <hr/>
                             <field name="display_name"/> <hr/>
                             <field name="properties" widget="properties"/>
@@ -1596,7 +1596,7 @@ test("properties: kanban view without properties", async () => {
         arch: /* xml */ `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="company_id"/> <hr/>
                         <field name="display_name"/> <hr/>
                         <field name="properties" widget="properties"/>
@@ -1614,7 +1614,7 @@ test.tags("desktop")("properties: switch view on desktop", async () => {
     Partner._views[["search", false]] = /* xml */ `<search/>`;
     Partner._views[["kanban", 99]] = /* xml */ `<kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="company_id"/> <hr/>
                         <field name="display_name"/> <hr/>
                         <field name="properties" widget="properties"/>
@@ -1647,7 +1647,7 @@ test.tags("mobile")("properties: switch view on mobile", async () => {
     Partner._views[["search", false]] = /* xml */ `<search/>`;
     Partner._views[["kanban", 99]] = /* xml */ `<kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="company_id"/> <hr/>
                         <field name="display_name"/> <hr/>
                         <field name="properties" widget="properties"/>

--- a/addons/web/static/tests/views/fields/selection_field.test.js
+++ b/addons/web/static/tests/views/fields/selection_field.test.js
@@ -315,7 +315,7 @@ test("SelectionField in kanban view", async () => {
         arch: /* xml */ `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="color" widget="selection" />
                     </t>
                 </templates>
@@ -346,7 +346,7 @@ test("SelectionField - auto save record in kanban view", async () => {
         arch: /* xml */ `
                 <kanban>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="color" widget="selection" />
                         </t>
                     </templates>
@@ -366,7 +366,7 @@ test("SelectionField don't open form view on click in kanban view", async functi
         arch: /* xml */ `
                 <kanban>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="color" widget="selection" />
                         </t>
                     </templates>
@@ -399,7 +399,7 @@ test("SelectionField is disabled if field readonly", async () => {
         arch: /* xml */ `
                 <kanban>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="color" widget="selection" />
                         </t>
                     </templates>
@@ -420,7 +420,7 @@ test("SelectionField is disabled with a readonly attribute", async () => {
         arch: /* xml */ `
                 <kanban>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="color" widget="selection" readonly="1" />
                         </t>
                     </templates>
@@ -446,7 +446,7 @@ test("SelectionField in kanban view with handle widget", async () => {
         arch: /* xml */ `
                 <kanban>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="color" widget="selection"/>
                         </t>
                     </templates>

--- a/addons/web/static/tests/views/fields/state_selection_field.test.js
+++ b/addons/web/static/tests/views/fields/state_selection_field.test.js
@@ -413,7 +413,7 @@ test("works when required in a readonly view", async () => {
         arch: /* xml */ `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="selection" widget="state_selection" required="1"/>
                     </t>
                 </templates>

--- a/addons/web/static/tests/views/form/auto_save.test.js
+++ b/addons/web/static/tests/views/form/auto_save.test.js
@@ -19,7 +19,7 @@ import {
 import { WebClient } from "@web/webclient/webclient";
 
 const hideTab = async () => {
-    const prop = Object.getOwnPropertyDescriptor(Document.prototype, "visibilityState")
+    const prop = Object.getOwnPropertyDescriptor(Document.prototype, "visibilityState");
     Object.defineProperty(document, "visibilityState", {
         value: "hidden",
         configurable: true,
@@ -284,7 +284,7 @@ test.tags("desktop")(`save when action changed`, async () => {
         kanban: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card"/>
+                    <t t-name="card"/>
                 </templates>
             </kanban>
         `,

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -894,7 +894,7 @@ test(`Form and subview with _view_ref contexts`, async () => {
         kanban: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="color"/>
                     </t>
                 </templates>
@@ -959,7 +959,7 @@ test(`Form and subsubview with only _view_ref contexts`, async () => {
         kanban: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="name"/>
                     </t>
                 </templates>
@@ -973,7 +973,7 @@ test(`Form and subsubview with only _view_ref contexts`, async () => {
         kanban: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="name"/>
                     </t>
                 </templates>
@@ -7171,7 +7171,7 @@ test(`non inline subview and create=0 in action context`, async () => {
     Product._views = {
         kanban: `
             <kanban>
-                <templates><t t-name="kanban-card">
+                <templates><t t-name="card">
                     <field name="name"/>
                 </t></templates>
             </kanban>
@@ -9849,7 +9849,7 @@ test.tags("desktop")(`discard after a failed save (and close notifications)`, as
         kanban: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo" />
                     </t>
                 </templates>
@@ -9894,7 +9894,7 @@ test(`one2many create record dialog shouldn't have a 'remove' button`, async () 
                 <field name="child_ids">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="foo"/>
                             </t>
                         </templates>
@@ -10683,7 +10683,7 @@ test.tags("desktop")(`empty x2manys when coming form a list with sample data`, a
                 <field name="child_ids">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-card">
+                            <t t-name="card">
                                 <field name="name"/>
                             </t>
                         </templates>

--- a/addons/web/static/tests/views/kanban/kanban_color_picker_legacy.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_color_picker_legacy.test.js
@@ -34,11 +34,11 @@ class Category extends models.Model {
 
 defineModels([Category]);
 
-test("oe_kanban_colorpicker in kanban-menu and kanban-box", async () => {
+test("oe_kanban_colorpicker in menu and kanban-box", async () => {
     const archInfo = parseArch(`
         <kanban>
             <templates>
-                <t t-name="kanban-menu">
+                <t t-name="menu">
                     <ul class="oe_kanban_colorpicker" data-field="kanban_menu_colorpicker" role="menu"/>
                 </t>
                 <t t-name="kanban-box"/>
@@ -52,7 +52,7 @@ test("oe_kanban_colorpicker in kanban-menu and kanban-box", async () => {
     const archInfo_1 = parseArch(`
         <kanban>
             <templates>
-                <t t-name="kanban-menu"/>
+                <t t-name="menu"/>
                 <t t-name="kanban-box">
                     <ul class="oe_kanban_colorpicker" data-field="kanban_box_color" role="menu"/>
                 </t>
@@ -79,7 +79,7 @@ test("kanban with colorpicker and node with color attribute", async () => {
             <kanban>
                 <field name="colorpickerField"/>
                 <templates>
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <div class="oe_kanban_colorpicker" data-field="colorpickerField"/>
                     </t>
                     <t t-name="kanban-box">
@@ -112,7 +112,7 @@ test("edit the kanban color with the colorpicker", async () => {
             <kanban>
                 <field name="color"/>
                 <templates>
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <div class="oe_kanban_colorpicker"/>
                     </t>
                     <t t-name="kanban-box">
@@ -153,7 +153,7 @@ test("colorpicker doesn't appear when missing access rights", async () => {
             <kanban edit="0">
                 <field name="color"/>
                 <templates>
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <div class="oe_kanban_colorpicker"/>
                     </t>
                     <t t-name="kanban-box">

--- a/addons/web/static/tests/views/kanban/kanban_compiler.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_compiler.test.js
@@ -13,7 +13,7 @@ test("bootstrap dropdowns with kanban_ignore_dropdown class should be left as is
     const arch = `
         <kanban>
             <templates>
-                <t t-name="kanban-card">
+                <t t-name="card">
                     <button name="dropdown" class="kanban_ignore_dropdown" type="button" data-bs-toggle="dropdown">Boostrap dropdown</button>
                     <div class="dropdown-menu kanban_ignore_dropdown" role="menu">
                         <span>Dropdown content</span>
@@ -25,7 +25,7 @@ test("bootstrap dropdowns with kanban_ignore_dropdown class should be left as is
         <t t-translation="off">
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <button name="dropdown" class="kanban_ignore_dropdown" type="button" data-bs-toggle="dropdown">Boostrap dropdown</button>
                         <div class="dropdown-menu kanban_ignore_dropdown" role="menu">
                             <span>Dropdown content</span>

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -232,7 +232,7 @@ test("basic ungrouped rendering", async () => {
         arch: `
             <kanban class="o_kanban_test">
             <templates>
-                <t t-name="kanban-card">
+                <t t-name="card">
                     <field name="foo"/>
                 </t>
             </templates>
@@ -254,7 +254,7 @@ test("kanban rendering with class and style attributes", async () => {
         arch: `
             <kanban class="myCustomClass" style="border: 1px solid red;">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -278,7 +278,7 @@ test("generic tags are case insensitive", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <Div class="test">Hello</Div>
                     </t>
                 </templates>
@@ -295,7 +295,7 @@ test("kanban records are clickable by default", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -315,7 +315,7 @@ test("kanban records with global_click='0'", async () => {
         arch: `
             <kanban can_open="0">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -336,7 +336,7 @@ test("float fields are formatted properly without using a widget", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="float_field" digits="[0,5]"/>
                         <field name="float_field" digits="[0,3]"/>
                     </t>
@@ -377,7 +377,7 @@ test("field with widget and attributes in kanban", async () => {
             <kanban>
                 <field name="foo"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="int_field" widget="my_field"
                             str="some string"
                             bool="true"
@@ -397,7 +397,7 @@ test("kanban with integer field with human_readable option", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="int_field" options="{'human_readable': true}"/>
                     </t>
                 </templates>
@@ -416,7 +416,7 @@ test.tags("desktop")("Hide tooltip when user click inside a kanban headers item"
             <kanban default_group_by="product_id">
                 <field name="product_id" options='{"group_by_tooltip": {"name": "Name"}}'/>
                 <templates>
-                    <t t-name="kanban-card"/>
+                    <t t-name="card"/>
                 </templates>
             </kanban>`,
     });
@@ -450,7 +450,7 @@ test("display full is supported on fields", async () => {
         arch: `
         <kanban class="o_kanban_test">
             <templates>
-                <t t-name="kanban-card">
+                <t t-name="card">
                     <field name="foo" display="full"/>
                 </t>
             </templates>
@@ -484,7 +484,7 @@ test.tags("desktop")("basic grouped rendering", async () => {
         arch: `
             <kanban class="o_kanban_test">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo" />
                     </t>
                 </templates>
@@ -533,7 +533,7 @@ test("basic grouped rendering with no record", async () => {
         arch: `
             <kanban class="o_kanban_test">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo" />
                     </t>
                 </templates>
@@ -558,7 +558,7 @@ test("grouped rendering with active field (archivable by default)", async () => 
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -595,7 +595,7 @@ test("grouped rendering with active field (archivable true)", async () => {
         arch: `
             <kanban archivable="true">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -633,7 +633,7 @@ test.tags("desktop")("empty group when grouped by date", async () => {
         resModel: "partner",
         arch: `<kanban>
             <templates>
-                <t t-name="kanban-card">
+                <t t-name="card">
                     <field name="foo"/>
                 </t>
             </templates>
@@ -664,7 +664,7 @@ test("grouped rendering with active field (archivable false)", async () => {
         arch: `
             <kanban archivable="false">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -693,7 +693,7 @@ test.tags("desktop")("m2m grouped rendering with active field (archivable true)"
         arch: `
             <kanban archivable="true">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -731,7 +731,7 @@ test("kanban grouped by date field", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -749,7 +749,7 @@ test("context can be used in kanban template", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field t-if="context.some_key" name="foo"/>
                     </t>
                 </templates>
@@ -771,7 +771,7 @@ test("user context can be used in kanban template", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field t-if="user_context.some_key" name="foo"/>
                     </div>
                 </templates>
@@ -790,7 +790,7 @@ test("kanban with sub-template", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <t t-call="another-template"/>
                     </t>
                     <t t-name="another-template">
@@ -816,7 +816,7 @@ test("kanban with t-set outside card", async () => {
             <kanban>
                 <field name="int_field"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <t t-set="x" t-value="record.int_field.value"/>
                         <div>
                             <t t-esc="x"/>
@@ -836,7 +836,7 @@ test("kanban with t-if/t-else on field", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field t-if="record.int_field.value > -1" name="int_field"/>
                         <t t-else="">Negative value</t>
                     </t>
@@ -859,7 +859,7 @@ test("kanban with t-if/t-else on field with widget", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field t-if="record.int_field.value > -1" name="int_field" widget="integer"/>
                         <t t-else="">Negative value</t>
                     </t>
@@ -897,7 +897,7 @@ test("field with widget and dynamic attributes in kanban", async () => {
             <kanban>
                 <field name="foo"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="int_field" widget="my_field"
                             t-att-dyn-bool="record.foo.value.length > 3"
                             t-attf-interp-str="hello {{record.foo.value}}"
@@ -931,7 +931,7 @@ test("view button and string interpolated attribute in kanban", async () => {
             <kanban>
                 <field name="foo"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <a name="one" type="object" class="hola"/>
                         <a name="two" type="object" class="hola" t-attf-class="hello"/>
                         <a name="sri" type="object" class="hola" t-attf-class="{{record.foo.value}}"/>
@@ -972,7 +972,7 @@ test("pager should be hidden in grouped mode", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -992,7 +992,7 @@ test("there should be no limit on the number of fetched groups", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -1016,7 +1016,7 @@ test("pager, ungrouped, with default limit", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -1033,7 +1033,7 @@ test.tags("desktop")("pager, ungrouped, with default limit on desktop", async ()
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -1056,7 +1056,7 @@ test("pager, ungrouped, with limit given in options", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -1072,7 +1072,7 @@ test.tags("desktop")("pager, ungrouped, with limit given in options on desktop",
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -1097,7 +1097,7 @@ test("pager, ungrouped, with limit set on arch and given in options", async () =
         arch: `
             <kanban limit="3">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -1116,7 +1116,7 @@ test.tags("desktop")(
             arch: `
             <kanban limit="3">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -1140,7 +1140,7 @@ test.tags("desktop")("pager, ungrouped, with count limit reached", async () => {
         arch: `
             <kanban limit="2">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -1176,7 +1176,7 @@ test("pager, ungrouped, with count limit reached, click next", async () => {
         arch: `
             <kanban limit="2">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -1208,7 +1208,7 @@ test.tags("desktop")(
             arch: `
             <kanban limit="2">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -1238,7 +1238,7 @@ test("pager, ungrouped, with count limit reached, click next (2)", async () => {
         arch: `
             <kanban limit="2">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -1277,7 +1277,7 @@ test.tags("desktop")(
             arch: `
             <kanban limit="2">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -1312,7 +1312,7 @@ test("pager, ungrouped, with count limit reached, click previous", async () => {
         arch: `
             <kanban limit="2">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -1346,7 +1346,7 @@ test.tags("desktop")(
             arch: `
             <kanban limit="2">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -1375,7 +1375,7 @@ test.tags("desktop")("pager, ungrouped, with count limit reached, edit pager", a
         arch: `
             <kanban limit="2">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -1418,7 +1418,7 @@ test.tags("desktop")("count_limit attrs set in arch", async () => {
         arch: `
             <kanban limit="2" count_limit="3">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -1450,7 +1450,7 @@ test.tags("desktop")("pager, ungrouped, deleting all records from last page", as
         arch: `
             <kanban limit="3">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <a role="menuitem" type="delete" class="dropdown-item">Delete</a>
                         <field name="foo"/>
                     </t>
@@ -1502,7 +1502,7 @@ test.tags("desktop")("pager, update calls onUpdatedPager", async () => {
         arch: `
             <kanban js_class="test_kanban_view">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -1525,7 +1525,7 @@ test("click on a button type='delete' to delete a record in a column", async () 
         arch: `
             <kanban limit="3">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <a role="menuitem" type="delete" class="dropdown-item o_delete">Delete</a>
                         <field name="foo"/>
                     </t>
@@ -1558,7 +1558,7 @@ test("click on a button type='archive' to archive a record in a column", async (
         arch: `
             <kanban limit="3">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <a role="menuitem" type="archive" class="dropdown-item o_archive">archive</a>
                         <field name="foo"/>
                     </t>
@@ -1591,7 +1591,7 @@ test("click on a button type='unarchive' to unarchive a record in a column", asy
         arch: `
             <kanban limit="3">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <a role="menuitem" type="unarchive" class="dropdown-item o_unarchive">unarchive</a>
                         <field name="foo"/>
                     </t>
@@ -1626,7 +1626,7 @@ test.tags("desktop")("kanban with an action id as on_create attrs", async () => 
         arch: `
             <kanban on_create="some.action">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -1653,7 +1653,7 @@ test.tags("desktop")("grouped kanban with quick_create attrs set to false", asyn
         arch: `
             <kanban quick_create="false" on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -1678,7 +1678,7 @@ test.tags("desktop")("create in grouped on m2o", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -1703,7 +1703,7 @@ test("create in grouped on char", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -1727,7 +1727,7 @@ test("prevent deletion when grouped by many2many field", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                         <t t-if="widget.deletable"><span class="thisisdeletable">delete</span></t>
                     </t>
@@ -1757,7 +1757,7 @@ test.tags("desktop")("kanban grouped by many2one: false column is folded by defa
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -1790,7 +1790,7 @@ test.tags("desktop")("quick created records in grouped kanban are on displayed t
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="display_name"/>
                     </t>
                 </templates>
@@ -1844,7 +1844,7 @@ test.tags("desktop")("quick create record without quick_create_view", async () =
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -1907,7 +1907,7 @@ test.tags("desktop")("quick create record with quick_create_view", async () => {
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -1975,7 +1975,7 @@ test.tags("desktop")("quick create record flickering", async () => {
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -2022,7 +2022,7 @@ test.tags("desktop")("quick create record flickering (load more)", async () => {
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -2057,7 +2057,7 @@ test.tags("desktop")("quick create record should focus default field", async fun
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -2084,7 +2084,7 @@ test.tags("desktop")("quick create record should focus first field input", async
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -2109,7 +2109,7 @@ test.tags("desktop")("quick_create_view without quick_create option", async () =
         arch: `
             <kanban quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -2151,7 +2151,7 @@ test.tags("desktop")("quick create record in grouped on m2o (no quick_create_vie
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -2211,7 +2211,7 @@ test.tags("desktop")("quick create record in grouped on m2o (with quick_create_v
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -2262,7 +2262,7 @@ test("quick create record in grouped on m2m (no quick_create_view)", async () =>
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -2306,7 +2306,7 @@ test.tags("desktop")("quick create record in grouped on m2m in the None column",
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -2361,7 +2361,7 @@ test("quick create record in grouped on m2m (field not in template)", async () =
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -2415,7 +2415,7 @@ test("quick create record in grouped on m2m (field in the form view)", async () 
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -2461,7 +2461,7 @@ test.tags("desktop")("quick create record validation: stays open when invalid", 
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -2514,7 +2514,7 @@ test.tags("desktop")("quick create record with default values and onchanges", as
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -2563,7 +2563,7 @@ test("quick create record with quick_create_view: modifiers", async () => {
         arch: `
             <kanban quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -2609,7 +2609,7 @@ test("quick create record with onchange of field marked readonly", async () => {
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -2652,7 +2652,7 @@ test("quick create record and change state in grouped mode", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="foo"/>
                         <footer>
                             <field name="kanban_state" widget="state_selection"/>
@@ -2683,7 +2683,7 @@ test("window resize should not change quick create form size", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -2709,7 +2709,7 @@ test("quick create record: cancel and validate without using the buttons", async
         arch: `
             <kanban quick_create_view="some_view_ref" on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -2775,7 +2775,7 @@ test("quick create record: validate with ENTER", async () => {
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -2813,7 +2813,7 @@ test("quick create record: prevent multiple adds with ENTER", async () => {
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -2862,7 +2862,7 @@ test("quick create record: prevent multiple adds with Add clicked", async () => 
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -2906,7 +2906,7 @@ test.tags("desktop")("save a quick create record and create a new one simultaneo
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="display_name"/>
                     </t>
                 </templates>
@@ -2971,7 +2971,7 @@ test("quick create record: prevent multiple adds with ENTER, with onchange", asy
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -3051,7 +3051,7 @@ test("quick create record: click Add to create, with delayed onchange", async ()
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                         <field name="int_field"/>
                     </t>
@@ -3102,7 +3102,7 @@ test.tags("desktop")("quick create when first column is folded", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -3140,7 +3140,7 @@ test("quick create record: cancel when not dirty", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -3230,7 +3230,7 @@ test.tags("desktop")("quick create record: cancel when modal is opened", async (
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -3271,7 +3271,7 @@ test("quick create record: cancel when dirty", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -3341,7 +3341,7 @@ test("quick create record and edit in grouped mode", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -3377,7 +3377,7 @@ test.tags("desktop")("quick create several records in a row", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -3427,7 +3427,7 @@ test("quick create is disabled until record is created and read", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -3482,7 +3482,7 @@ test.tags("desktop")("quick create record fail in grouped by many2one", async ()
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -3514,7 +3514,7 @@ test("quick create record and click Edit, name_create fails", async () => {
     Partner._views["kanban,false"] = `
         <kanban sample="1">
             <templates>
-                <t t-name="kanban-card">
+                <t t-name="card">
                     <field name="foo"/>
                 </t>
             </templates>
@@ -3581,7 +3581,7 @@ test.tags("desktop")("quick create record is re-enabled after discard on failure
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -3631,7 +3631,7 @@ test("quick create record fails in grouped by char", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -3679,7 +3679,7 @@ test("quick create record fails in grouped by selection", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="state"/>
                     </t>
                 </templates>
@@ -3729,7 +3729,7 @@ test.tags("desktop")("quick create record in empty grouped kanban", async () => 
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -3754,7 +3754,7 @@ test.tags("desktop")("quick create record in grouped on date(time) field", async
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="display_name"/>
                     </t>
                 </templates>
@@ -3802,7 +3802,7 @@ test("quick create record feature is properly enabled/disabled at reload", async
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="display_name"/>
                     </t>
                 </templates>
@@ -3848,7 +3848,7 @@ test("quick create record in grouped by char field", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="display_name"/>
                     </t>
                 </templates>
@@ -3879,7 +3879,7 @@ test("quick create record in grouped by boolean field", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="display_name"/>
                     </t>
                 </templates>
@@ -3910,7 +3910,7 @@ test("quick create record in grouped on selection field", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="display_name"/>
                     </t>
                 </templates>
@@ -3950,7 +3950,7 @@ test("quick create record in grouped by char field (within quick_create_view)", 
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -3986,7 +3986,7 @@ test("quick create record in grouped by boolean field (within quick_create_view)
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="bar"/>
                     </t>
                 </templates>
@@ -4025,7 +4025,7 @@ test("quick create record in grouped by selection field (within quick_create_vie
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="state"/>
                     </t>
                 </templates>
@@ -4066,7 +4066,7 @@ test.tags("desktop")("quick create record while adding a new column", async () =
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -4127,7 +4127,7 @@ test.tags("desktop")("close a column while quick creating a record", async () =>
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -4174,7 +4174,7 @@ test("quick create record: open on a column while another column has already one
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -4218,7 +4218,7 @@ test("many2many_tags in kanban views", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="category_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                         <field name="foo"/>
                         <field name="state" widget="priority"/>
@@ -4279,7 +4279,7 @@ test("priority field should not be editable when missing access rights", async (
         arch: `
             <kanban edit="0">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                         <field name="state" widget="priority"/>
                     </t>
@@ -4312,7 +4312,7 @@ test("Do not open record when clicking on `a` with `href`", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                         <a class="o_test_link" href="#">test link</a>
                     </t>
@@ -4359,7 +4359,7 @@ test("Open record when clicking on widget field", async function (assert) {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="salary" widget="monetary"/>
                     </t>
                 </templates>
@@ -4398,7 +4398,7 @@ test("o2m loaded in only one batch", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="subtask_ids" widget="many2many_tags"/>
                     </t>
                 </templates>
@@ -4429,7 +4429,7 @@ test.tags("desktop")("kanban with many2many, load and reload", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="category_ids" widget="many2many_tags"/>
                     </t>
                 </templates>
@@ -4467,7 +4467,7 @@ test.tags("desktop")("kanban with reference field", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="ref_product"/>
                     </t>
                 </templates>
@@ -4498,7 +4498,7 @@ test.tags("desktop")("drag and drop a record with load more", async () => {
         arch: `
             <kanban limit="1">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="id"/>
                     </t>
                 </templates>
@@ -4527,7 +4527,7 @@ test.tags("desktop")("can drag and drop a record from one column to the next", a
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                         <t t-if="widget.editable">
                             <span class="thisiseditable">edit</span>
@@ -4570,7 +4570,7 @@ test.tags("desktop")(
             arch: `
                 <kanban>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="foo"/>
                         </t>
                     </templates>
@@ -4604,7 +4604,7 @@ test.tags("desktop")(
             arch: `
                 <kanban>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="foo"/>
                         </t>
                     </templates>
@@ -4639,7 +4639,7 @@ test.tags("desktop")("drag and drop highlight on hover", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -4667,7 +4667,7 @@ test("drag and drop outside of a column", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -4703,7 +4703,7 @@ test.tags("desktop")("drag and drop a record, grouped by selection", async () =>
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="state"/>
                     </t>
                 </templates>
@@ -4753,7 +4753,7 @@ test.tags("desktop")("prevent drag and drop of record if grouped by readonly", a
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div>
                             <field name="foo"/>
                             <field name="product_id" readonly="0" invisible="1"/>
@@ -4874,7 +4874,7 @@ test("prevent drag and drop if grouped by date/datetime field", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -4943,7 +4943,7 @@ test.tags("desktop")("prevent drag and drop if grouped by many2many field", asyn
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -5031,7 +5031,7 @@ test("Ensuring each progress bar has some space", async () => {
             <kanban>
                 <progressbar field="state" colors='{"abc": "success", "def": "warning", "ghi": "danger"}' />
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="state" widget="state_selection" />
                         <field name="foo" />
                     </div>
@@ -5050,7 +5050,7 @@ test("completely prevent drag and drop if records_draggable set to false", async
         arch: `
             <kanban records_draggable="false">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -5104,7 +5104,7 @@ test.tags("desktop")("prevent drag and drop of record if save fails", async () =
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                         <field name="product_id"/>
                     </t>
@@ -5152,7 +5152,7 @@ test("kanban view with default_group_by", async () => {
         arch: `
             <kanban default_group_by="bar">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -5189,7 +5189,7 @@ test.tags("desktop")("kanban view not groupable", async () => {
         arch: `
             <kanban default_group_by="bar">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -5219,7 +5219,7 @@ test("kanban view with create=False", async () => {
         arch: `
             <kanban create="0">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -5236,7 +5236,7 @@ test("kanban view with create=False and groupby", async () => {
         arch: `
             <kanban create="0">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -5256,7 +5256,7 @@ test("clicking on a link triggers correct event", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <a type="edit">Edit</a>
                     </t>
                 </templates>
@@ -5276,7 +5276,7 @@ test.tags("desktop")("environment is updated when (un)folding groups", async () 
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="id"/>
                     </t>
                 </templates>
@@ -5316,7 +5316,7 @@ test.tags("desktop")("create a column in grouped on m2o", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -5407,7 +5407,7 @@ test("create a column in grouped on m2o without sequence field on view model", a
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -5452,7 +5452,7 @@ test.tags("desktop")("auto fold group when reach the limit", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -5515,7 +5515,7 @@ test.tags("desktop")("auto fold group when reach the limit (2)", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -5559,7 +5559,7 @@ test.tags("desktop")("show/hide help message (ESC) in quick create [REQUIRE FOCU
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -5598,7 +5598,7 @@ test.tags("desktop")("delete a column in grouped on m2o", async () => {
         arch: `
             <kanban class="o_kanban_test" on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -5739,7 +5739,7 @@ test("create a column, delete it and create another one", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -5797,7 +5797,7 @@ test("delete an empty column, then a column with records.", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -5846,7 +5846,7 @@ test.tags("desktop")("edit a column in grouped on m2o", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -5923,7 +5923,7 @@ test("edit a column propagates right context", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -5942,7 +5942,7 @@ test("quick create column should be opened if there is no column", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -5965,7 +5965,7 @@ test("quick create column should close on window click if there is no column", a
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -5993,7 +5993,7 @@ test("quick create several columns in a row", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -6043,7 +6043,7 @@ test.tags("desktop")("quick create column with enter", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -6085,7 +6085,7 @@ test.tags("desktop")("quick create column and examples", async () => {
         arch: `
             <kanban examples="test">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -6165,7 +6165,7 @@ test("quick create column with x_name as _rec_name", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -6204,7 +6204,7 @@ test.tags("desktop")("count of folded groups in empty kanban with sample data", 
         arch: `
             <kanban sample="1">
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="foo"/>
                     </div>
                 </templates>
@@ -6252,7 +6252,7 @@ test.tags("desktop")("quick create column and examples: with folded columns", as
         arch: `
             <kanban examples="test">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -6306,7 +6306,7 @@ test.tags("desktop")("quick create column's apply button's display text", async 
         arch: `
             <kanban examples="test">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -6350,7 +6350,7 @@ test.tags("desktop")("create column and examples background with ghostColumns ti
         arch: `
             <kanban examples="test">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -6384,7 +6384,7 @@ test("create column and examples background without ghostColumns titles", async 
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -6430,7 +6430,7 @@ test("nocontent helper after adding a record (kanban with progressbar)", async (
             <kanban >
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -6478,7 +6478,7 @@ test.tags("desktop")("ungrouped kanban view can be grouped, then ungrouped", asy
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -6513,7 +6513,7 @@ test("no content helper when archive all records in kanban group", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -6545,7 +6545,7 @@ test.tags("desktop")("no content helper when no data", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -6586,7 +6586,7 @@ test("no nocontent helper for grouped kanban with empty groups", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -6608,7 +6608,7 @@ test("no nocontent helper for grouped kanban with no records", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -6636,7 +6636,7 @@ test("no nocontent helper is shown when no longer creating column", async () => 
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -6686,7 +6686,7 @@ test("no nocontent helper is hidden when quick creating a column", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -6726,7 +6726,7 @@ test("remove nocontent helper after adding a record", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -6768,7 +6768,7 @@ test("remove nocontent helper when adding a record", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -6809,7 +6809,7 @@ test("nocontent helper is displayed again after canceling quick create", async (
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -6836,7 +6836,7 @@ test("nocontent helper for grouped kanban (on m2o field) with no records with no
         arch: `
             <kanban group_create="false">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -6864,7 +6864,7 @@ test("nocontent helper for grouped kanban (on date field) with no records with n
         arch: `
             <kanban group_create="false">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -6887,7 +6887,7 @@ test("empty grouped kanban with sample data and no columns", async () => {
         arch: `
             <kanban sample="1">
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="foo"/>
                     </div>
                 </templates>
@@ -6934,7 +6934,7 @@ test("empty kanban with sample data grouped by date range (fill temporal)", asyn
             <kanban sample="1">
                 <progressbar field="state" sum_field="int_field" help="progress" colors="{}"/>
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="foo"/>
                         <field name="int_field"/>
                     </div>
@@ -6970,7 +6970,7 @@ test("empty grouped kanban with sample data and click quick create", async () =>
         arch: `
             <kanban sample="1">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -7021,7 +7021,7 @@ test.tags("desktop")("quick create record in grouped kanban with sample data", a
         arch: `
             <kanban sample="1" on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -7063,7 +7063,7 @@ test("empty grouped kanban with sample data and cancel quick create", async () =
         arch: `
             <kanban sample="1">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -7104,7 +7104,7 @@ test.tags("desktop")("empty grouped kanban with sample data: keynav", async () =
         arch: `
             <kanban sample="1">
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="foo"/>
                         <field name="state" widget="priority"/>
                     </div>
@@ -7131,7 +7131,7 @@ test.tags("desktop")("empty kanban with sample data", async () => {
         arch: `
             <kanban sample="1">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -7176,7 +7176,7 @@ test("empty grouped kanban with sample data and many2many_tags", async () => {
         arch: `
             <kanban sample="1">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="int_field"/>
                         <field name="category_ids" widget="many2many_tags"/>
                     </t>
@@ -7206,7 +7206,7 @@ test.tags("desktop")("sample data does not change after reload with sample data"
     Partner._views["kanban,false"] = `
         <kanban sample="1">
             <templates>
-                <t t-name="kanban-card">
+                <t t-name="card">
                     <field name="int_field"/>
                 </t>
             </templates>
@@ -7258,7 +7258,7 @@ test.tags("desktop")("non empty kanban with sample data", async () => {
         arch: `
             <kanban sample="1">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -7299,7 +7299,7 @@ test("empty grouped kanban with sample data: add a column", async () => {
         arch: `
             <kanban sample="1">
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="foo"/>
                     </div>
                 </templates>
@@ -7343,7 +7343,7 @@ test.tags("desktop")("empty grouped kanban with sample data: cannot fold a colum
         arch: `
             <kanban sample="1">
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="foo"/>
                     </div>
                 </templates>
@@ -7389,7 +7389,7 @@ test("empty grouped kanban with sample data: delete a column", async () => {
         arch: `
             <kanban sample="1">
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="foo"/>
                     </div>
                 </templates>
@@ -7433,7 +7433,7 @@ test("empty grouped kanban with sample data: add a column and delete it right aw
         arch: `
             <kanban sample="1">
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="foo"/>
                     </div>
                 </templates>
@@ -7491,7 +7491,7 @@ test.tags("desktop")("kanban with sample data: do an on_create action", async ()
         arch: `
             <kanban sample="1" on_create="myCreateAction">
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="foo"/>
                     </div>
                 </templates>
@@ -7535,7 +7535,7 @@ test("kanban with sample data grouped by m2o and existing groups", async () => {
         arch: `
             <kanban sample="1">
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="product_id"/>
                     </div>
                 </templates>
@@ -7557,7 +7557,7 @@ test.tags("desktop")("bounce create button when no data and click on empty area"
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -7591,7 +7591,7 @@ test("buttons with modifiers", async () => {
                 <field name="bar"/>
                 <field name="state"/>
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <button class="o_btn_test_1" type="object" name="a1" invisible="foo != 'yop'"/>
                         <button class="o_btn_test_2" type="object" name="a2" invisible="bar and state not in ['abc', 'def']"/>
                     </div>
@@ -7620,7 +7620,7 @@ test("support styling of anchor tags with action type", async function (assert) 
         arch: `
             <kanban>
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="foo"/>
                         <a type="action" name="42" class="btn-primary" style="margin-left: 10px"><i class="oi oi-arrow-right"/> Click me !</a>
                     </div>
@@ -7650,7 +7650,7 @@ test("button executes action and reloads", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="foo"/>
                         <button type="object" name="a1" class="a1"/>
                     </div>
@@ -7694,7 +7694,7 @@ test("button executes action and check domain", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="foo"/>
                         <button type="object" name="a1" />
                         <button type="object" name="toggle_active" class="toggle-active" />
@@ -7719,7 +7719,7 @@ test("field tag with modifiers but no widget", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo" invisible="id == 1"/>
                     </t>
                 </templates>
@@ -7737,7 +7737,7 @@ test("field tag with widget and class attributes", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo" widget="char" class="hi"/>
                     </t>
                 </templates>
@@ -7757,7 +7757,7 @@ test("rendering date and datetime (value)", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field class="date" name="date"/>
                         <field class="datetime" name="datetime"/>
                     </t>
@@ -7783,7 +7783,7 @@ test("rendering date and datetime (raw value)", async () => {
                 <field name="date"/>
                 <field name="datetime"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <span class="date" t-esc="record.date.raw_value"/>
                         <span class="datetime" t-esc="record.datetime.raw_value"/>
                     </t>
@@ -7808,7 +7808,7 @@ test("rendering many2one (value)", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="product_id" class="product_id"/>
                     </t>
                 </templates>
@@ -7828,7 +7828,7 @@ test("rendering many2one (raw value)", async () => {
             <kanban>
                 <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <span class="product_id" t-esc="record.product_id.raw_value"/>
                     </t>
                 </templates>
@@ -7849,7 +7849,7 @@ test("evaluate conditions on relational fields", async () => {
                 <field name="product_id"/>
                 <field name="category_ids"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <button t-if="!record.product_id.raw_value" class="btn_a">A</button>
                         <button t-if="!record.category_ids.raw_value.length" class="btn_b">B</button>
                     </t>
@@ -7877,7 +7877,7 @@ test.tags("desktop")("resequence columns in grouped by m2o", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="id"/>
                     </t>
                 </templates>
@@ -7928,7 +7928,7 @@ test.tags("desktop")("resequence all when creating new record + partial resequen
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="id"/>
                     </t>
                 </templates>
@@ -7971,7 +7971,7 @@ test("prevent resequence columns if groups_draggable=false", async () => {
         arch: `
             <kanban groups_draggable='0'>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="id"/>
                     </t>
                 </templates>
@@ -8006,7 +8006,7 @@ test("open config dropdown on kanban with records and groups draggable off", asy
         arch: `
             <kanban groups_draggable='0' records_draggable='0'>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="id"/>
                     </t>
                 </templates>
@@ -8031,7 +8031,7 @@ test("properly evaluate more complex domains", async () => {
                 <field name="bar"/>
                 <field name="category_ids"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                         <button type="object" invisible="bar or category_ids" class="btn btn-primary float-end" name="arbitrary">Join</button>
                     </t>
@@ -8055,7 +8055,7 @@ test("kanban with color attribute", async () => {
             <kanban highlight_color="color">
                 <field name="color"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="name"/>
                     </t>
                 </templates>
@@ -8079,10 +8079,10 @@ test("edit the kanban color with the colorpicker", async () => {
         arch: `
             <kanban highlight_color="color">
                 <templates>
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <field name="color" widget="kanban_color_picker"/>
                     </t>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="name"/>
                     </t>
                 </templates>
@@ -8124,10 +8124,10 @@ test("kanban with colorpicker and node with color attribute", async () => {
         arch: `
             <kanban highlight_color="colorpickerField">
                 <templates>
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <field name="colorpickerField" widget="kanban_color_picker"/>
                     </t>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="name"/>
                     </t>
                 </templates>
@@ -8156,10 +8156,10 @@ test("edit the kanban color with translated colors resulting in the same terms",
         arch: `
             <kanban highlight_color="color">
                 <templates>
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <field name="color" widget="kanban_color_picker"/>
                     </t>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="name"/>
                     </t>
                 </templates>
@@ -8178,10 +8178,10 @@ test("colorpicker doesn't appear when missing access rights", async () => {
         arch: `
             <kanban edit="0">
                 <templates>
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <field name="color" widget="kanban_color_picker"/>
                     </t>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="name"/>
                     </t>
                 </templates>
@@ -8203,7 +8203,7 @@ test("load more records in column", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="id"/>
                     </t>
                 </templates>
@@ -8254,7 +8254,7 @@ test("load more records in column with x2many", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="category_ids"/>
                         <field name="foo"/>
                     </t>
@@ -8292,7 +8292,7 @@ test("update buttons after column creation", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -8325,7 +8325,7 @@ test.tags("desktop")("group_by_tooltip option when grouping on a many2one", asyn
             <kanban default_group_by="bar">
                 <field name="product_id" options='{"group_by_tooltip": {"name": "Kikou"}}'/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -8393,7 +8393,7 @@ test.tags("desktop")("asynchronous tooltips when grouped", async () => {
             <kanban default_group_by="product_id">
                 <field name="product_id" options='{"group_by_tooltip": {"name": "Name"}}'/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -8435,7 +8435,7 @@ test.tags("desktop")("loads data tooltips only when first opening", async () => 
             <kanban default_group_by="product_id">
                 <field name="product_id" options='{"group_by_tooltip": {"name": "Name"}}'/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -8468,7 +8468,7 @@ test.tags("desktop")("move a record then put it again in the same column", async
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="display_name"/>
                     </t>
                 </templates>
@@ -8518,7 +8518,7 @@ test.tags("desktop")("resequence a record twice", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="display_name"/>
                     </t>
                 </templates>
@@ -8586,7 +8586,7 @@ test("basic support for widgets (being Owl Components)", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                         <widget name="test"/>
                     </t>
@@ -8619,7 +8619,7 @@ test("kanban card: record value should be updated", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo" class="foo"/>
                         <widget name="test"/>
                     </t>
@@ -8646,7 +8646,7 @@ test("column progressbars properly work", async () => {
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -8682,7 +8682,7 @@ test("filter on progressbar in new groups", async () => {
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -8733,7 +8733,7 @@ test('column progressbars: "false" bar is clickable', async () => {
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -8790,7 +8790,7 @@ test('column progressbars: "false" bar with sum_field', async () => {
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -8833,7 +8833,7 @@ test("column progressbars should not crash in non grouped views", async () => {
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -8867,7 +8867,7 @@ test("column progressbars: creating a new column should create a new progressbar
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -8908,7 +8908,7 @@ test("column progressbars on quick create properly update counter", async () => 
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -8955,7 +8955,7 @@ test("column progressbars are working with load more", async () => {
             <kanban limit="1">
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="id"/>
                     </t>
                 </templates>
@@ -8998,7 +8998,7 @@ test("column progressbars with an active filter are working with load more", asy
             <kanban limit="1">
                 <progressbar field="foo" colors='{"blork": "success"}'/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="id"/>
                     </t>
                 </templates>
@@ -9041,7 +9041,7 @@ test("column progressbars on archiving records update counter", async () => {
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -9091,7 +9091,7 @@ test("kanban with progressbars: correctly update env when archiving records", as
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="id"/>
                     </t>
                 </templates>
@@ -9132,7 +9132,7 @@ test("RPCs when (re)loading kanban view progressbars", async () => {
             <kanban>
             <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
             <templates>
-                <t t-name="kanban-card">
+                <t t-name="card">
                     <field name="foo"/>
                 </t>
             </templates>
@@ -9172,7 +9172,7 @@ test("RPCs when (de)activating kanban view progressbar filters", async () => {
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -9231,7 +9231,7 @@ test.tags("desktop")("drag & drop records grouped by m2o with progressbar", asyn
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="int_field"/>
                     </t>
                 </templates>
@@ -9309,7 +9309,7 @@ test.tags("desktop")("d&d records grouped by date with progressbar with aggregat
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="int_field"/>
                     </t>
                 </templates>
@@ -9351,7 +9351,7 @@ test("progress bar subgroup count recompute", async () => {
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -9387,7 +9387,7 @@ test.tags("desktop")("progress bar recompute after d&d to and from other column"
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -9434,7 +9434,7 @@ test("progress bar recompute after filter selection", async () => {
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -9487,7 +9487,7 @@ test("progress bar recompute after filter selection (aggregates)", async () => {
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -9547,7 +9547,7 @@ test("progress bar with aggregates: activate bars (grouped by boolean)", async (
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -9583,7 +9583,7 @@ test("progress bar with aggregates: activate bars (grouped by many2one)", async 
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -9619,7 +9619,7 @@ test("progress bar with aggregates: activate bars (grouped by date)", async () =
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -9659,7 +9659,7 @@ test("progress bar with aggregates: Archive All in a column", async () => {
         arch: `
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
-                <templates><t t-name="kanban-card">
+                <templates><t t-name="card">
                         <field name="foo"/>
                 </t></templates>
             </kanban>`,
@@ -9696,7 +9696,7 @@ test.tags("desktop")("load more should load correct records after drag&drop even
         arch: `
             <kanban limit="1">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="id"/>
                     </t>
                 </templates>
@@ -9732,7 +9732,7 @@ test.tags("desktop")("column progressbars on quick create with quick_create_view
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -9783,7 +9783,7 @@ test.tags("desktop")("progressbars and active filter with quick_create_view", as
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -9859,7 +9859,7 @@ test.tags("desktop")("quickcreate in first column after moving a record from it"
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -9900,7 +9900,7 @@ test.tags("desktop")("grouped kanban: clear groupby when reloading", async () =>
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -9939,7 +9939,7 @@ test.tags("desktop")("quick_create on grouped kanban without column", async () =
         arch: `
             <kanban group_create="0" on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -9961,7 +9961,7 @@ test("keynav: right/left", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -9985,7 +9985,7 @@ test("keynav: down, with focus is inside a card", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                         <a href="#" class="o-this-is-focussable">ho! this is focussable</a>
                     </t>
@@ -10006,7 +10006,7 @@ test.tags("desktop")("keynav: grouped kanban", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -10084,7 +10084,7 @@ test.tags("desktop")("keynav: grouped kanban with empty columns", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -10132,7 +10132,7 @@ test.tags("desktop")("keynav: no global_click, press ENTER on card with a link",
         arch: `
             <kanban can_open="0">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <a type="archive">Archive</a>
                     </t>
                 </templates>
@@ -10161,7 +10161,7 @@ test.tags("desktop")("keynav: kanban with global_click", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                         <a name="action_test" type="object" />
                     </t>
@@ -10197,7 +10197,7 @@ test.tags("desktop")(`kanban should ask to scroll to top on page changes`, async
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -10246,7 +10246,7 @@ test.tags("mobile")(`kanban should ask to scroll to top on page changes (mobile)
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -10303,10 +10303,10 @@ test.tags("desktop")("set cover image", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <a type="set_cover" data-field="displayed_image_id" class="dropdown-item">Set Cover Image</a>
                     </t>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                         <field name="displayed_image_id" widget="attachment_image"/>
                     </t>
@@ -10385,10 +10385,10 @@ test.tags("desktop")("open file explorer if no cover image", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <a type="set_cover" data-field="displayed_image_id" class="dropdown-item">Set Cover Image</a>
                     </t>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                         <field name="displayed_image_id" widget="attachment_image"/>
                     </t>
@@ -10450,10 +10450,10 @@ test.tags("desktop")("unset cover image", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <a type="set_cover" data-field="displayed_image_id" class="dropdown-item">Set Cover Image</a>
                     </t>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                         <field name="displayed_image_id" widget="attachment_image"/>
                     </t>
@@ -10517,7 +10517,7 @@ test.tags("desktop")("ungrouped kanban with handle field", async () => {
             <kanban>
                 <field name="int_field" widget="handle" />
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -10543,7 +10543,7 @@ test("ungrouped kanban without handle field", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -10570,7 +10570,7 @@ test("click on image field in kanban (with default global_click)", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="image" widget="image"/>
                     </t>
                 </templates>
@@ -10594,7 +10594,7 @@ test("kanban view with boolean field", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="bar"/>
                     </t>
                 </templates>
@@ -10613,7 +10613,7 @@ test("kanban view with boolean widget", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="bar" widget="boolean"/>
                     </t>
                 </templates>
@@ -10632,7 +10632,7 @@ test("kanban view with boolean toggle widget", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="bar" widget="boolean_toggle"/>
                     </t>
                 </templates>
@@ -10662,7 +10662,7 @@ test("kanban view with monetary and currency fields without widget", async () =>
             <kanban>
                 <field name="currency_id"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="salary"/>
                     </t>
                 </templates>
@@ -10682,7 +10682,7 @@ test.tags("desktop")("quick create: keyboard navigation to buttons", async () =>
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="display_name"/>
                     </div>
                 </templates>
@@ -10723,7 +10723,7 @@ test("kanban with isHtmlEmpty method", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="display_name"/>
                         <div class="test" t-if="!widget.isHtmlEmpty(record.description.raw_value)">
                             <field name="description"/>
@@ -10755,7 +10755,7 @@ test("progressbar filter state is kept unchanged when domain is updated (records
             <kanban default_group_by="bar">
                 <progressbar field="foo" colors='{"yop": "success", "blip": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="id"/>
                         <field name="foo"/>
                     </t>
@@ -10829,7 +10829,7 @@ test("progressbar filter state is kept unchanged when domain is updated (emptyin
             <kanban default_group_by="bar">
                 <progressbar field="foo" colors='{"yop": "success", "blip": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div>
                             <field name="id"/>
                             <field name="foo"/>
@@ -10916,7 +10916,7 @@ test.tags("desktop")("filtered column counters when dropping in non-matching rec
             <kanban default_group_by="bar">
                 <progressbar field="foo" colors='{"yop": "success", "blip": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div>
                             <field name="id"/>
                             <field name="foo"/>
@@ -10984,7 +10984,7 @@ test.tags("desktop")("filtered column is reloaded when dragging out its last rec
             <kanban default_group_by="bar">
                 <progressbar field="foo" colors='{"yop": "success", "blip": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div>
                             <field name="id"/>
                             <field name="foo"/>
@@ -11064,7 +11064,7 @@ test("kanban widget can extract props from attrs", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <widget name="widget_test_option" title="Widget with Option"/>
                     </t>
                 </templates>
@@ -11093,7 +11093,7 @@ test("action/type attributes on kanban arch, type='object'", async () => {
         arch: `
             <kanban action="a1" type="object">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <p>some value</p><field name="foo"/>
                     </t>
                 </templates>
@@ -11126,7 +11126,7 @@ test("action/type attributes on kanban arch, type='action'", async () => {
         arch: `
             <kanban action="a1" type="action">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <p>some value</p><field name="foo"/>
                     </t>
                 </templates>
@@ -11152,7 +11152,7 @@ test("Missing t-key is automatically filled with a warning", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div>
                             <span t-foreach="[1, 2, 3]" t-as="i" t-esc="i" />
                         </div>
@@ -11182,7 +11182,7 @@ test("Quick created record is rendered after load", async () => {
                 <field name="category_ids" />
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <span t-esc="record.category_ids.raw_value.length" />
                     </t>
                 </templates>
@@ -11214,7 +11214,7 @@ test("Allow use of 'editable'/'deletable' in ungrouped kanban", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <button t-if="widget.editable">EDIT</button>
                         <button t-if="widget.deletable">DELETE</button>
                     </div>
@@ -11235,7 +11235,7 @@ test.tags("desktop")("folded groups kept when leaving/coming back", async () => 
         "kanban,false": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="int_field"/>
                     </t>
                 </templates>
@@ -11284,7 +11284,7 @@ test.tags("desktop")("filter groups kept when leaving/coming back", async () => 
             <kanban>
                 <progressbar field="state" colors='{"abc": "success", "def": "warning", "ghi": "danger"}' />
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="id" />
                     </t>
                 </templates>
@@ -11342,7 +11342,7 @@ test.tags("desktop")("folded groups kept when leaving/coming back (grouped by da
         "kanban,false": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="int_field"/>
                     </t>
                 </templates>
@@ -11389,7 +11389,7 @@ test.tags("desktop")("loaded records kept when leaving/coming back", async () =>
         "kanban,false": `
             <kanban limit="1">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="int_field"/>
                     </t>
                 </templates>
@@ -11436,7 +11436,7 @@ test("basic rendering with 2 groupbys", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo" />
                     </t>
                 </templates>
@@ -11473,7 +11473,7 @@ test("basic rendering with a date groupby with a granularity", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo" />
                     </t>
                 </templates>
@@ -11502,7 +11502,7 @@ test.tags("desktop")("quick create record and click outside (no dirty input)", a
         arch: `
             <kanban limit="2">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -11558,7 +11558,7 @@ test.tags("desktop")("quick create record and click outside (with dirty input)",
         arch: `
             <kanban limit="2">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -11623,7 +11623,7 @@ test("quick create record and click on 'Load more'", async () => {
         arch: `
             <kanban limit="2">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -11654,10 +11654,10 @@ test("dropdown is closed on item click", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <a role="menuitem" class="dropdown-item">Item</a>
                     </t>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div/>
                     </t>
                 </templates>
@@ -11685,7 +11685,7 @@ test("can use JSON in kanban template", async () => {
             <kanban>
                 <field name="foo"/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div>
                             <span t-foreach="JSON.parse(record.foo.raw_value)" t-as="v" t-key="v_index" t-esc="v"/>
                         </div>
@@ -11711,7 +11711,7 @@ test("Color '200' (gray) can be used twice (for false value and another value) i
             <kanban>
                 <progressbar field="foo" colors='{"yop": "200", "gnap": "warning", "blip": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="state"/>
                     </t>
                 </templates>
@@ -11775,7 +11775,7 @@ test("update field on which progress bars are computed", async () => {
             <kanban>
                 <progressbar field="state" colors='{"abc": "success", "def": "warning", "ghi": "danger"}' />
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="state" widget="state_selection" />
                         <field name="id" />
                     </div>
@@ -11871,7 +11871,7 @@ test("load more button shouldn't be visible when unfiltering column", async () =
             <kanban>
                 <progressbar field="state" colors='{"abc": "success", "def": "warning", "ghi": "danger"}' />
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="state" widget="state_selection" />
                         <field name="id" />
                     </div>
@@ -11928,7 +11928,7 @@ test("click on the progressBar of a new column", async () => {
             <kanban on_create="quick_create">
                 <progressbar field="state" colors='{"abc": "success", "def": "warning", "ghi": "danger"}' />
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="state" widget="state_selection" />
                         <field name="id" />
                     </div>
@@ -11966,7 +11966,7 @@ test.tags("desktop")("keep focus in cp when pressing arrowdown and no kanban car
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="display_name"/>
                     </t>
                 </templates>
@@ -12020,7 +12020,7 @@ test.tags("desktop")("no leak of TransactionInProgress (grouped case)", async ()
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -12091,7 +12091,7 @@ test.tags("desktop")("no leak of TransactionInProgress (not grouped case)", asyn
             <kanban records_draggable="1">
                 <field name="int_field" widget="handle" />
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -12166,7 +12166,7 @@ test("fieldDependencies support for fields", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo" widget="custom_field"/>
                     </t>
                 </templates>
@@ -12195,7 +12195,7 @@ test("fieldDependencies support for fields: dependence on a relational field", a
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo" widget="custom_field"/>
                     </t>
                 </templates>
@@ -12218,7 +12218,7 @@ test("column quick create - title and placeholder", async function (assert) {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="int_field"/>
                     </t>
                 </templates>
@@ -12242,7 +12242,7 @@ test.tags("desktop")("fold a column and drag record on it should not unfold it",
         arch: `
             <kanban>
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="id"/>
                     </div>
                 </templates>
@@ -12284,7 +12284,7 @@ test.tags("desktop")("drag record on initially folded column should not unfold i
         arch: `
             <kanban>
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="id"/>
                     </div>
                 </templates>
@@ -12317,7 +12317,7 @@ test.tags("desktop")("drag record to folded column, with progressbars", async ()
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field" />
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="id" />
                     </div>
                 </templates>
@@ -12377,7 +12377,7 @@ test.tags("desktop")("quick create record in grouped kanban in a form view dialo
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <t t-if="record.foo.raw_value" t-set="foo"/>
                         <field name="foo"/>
                     </t>
@@ -12441,7 +12441,7 @@ test.tags("desktop")("no sample data when all groups are folded then one is unfo
         arch: `
             <kanban sample="1">
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="id"/>
                     </div>
                 </templates>
@@ -12473,7 +12473,7 @@ test.tags("desktop")("no content helper, all groups folded with (unloaded) recor
         arch: `
             <kanban>
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="id"/>
                     </div>
                 </templates>
@@ -12496,7 +12496,7 @@ test.tags("desktop")("Move multiple records in different columns simultaneously"
         arch: `
             <kanban>
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="id" />
                     </div>
                 </templates>
@@ -12533,7 +12533,7 @@ test.tags("desktop")("drag & drop: content scrolls when reaching the edges", asy
         arch: `
             <kanban>
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="id" />
                     </div>
                 </templates>
@@ -12603,7 +12603,7 @@ test("attribute default_order", async () => {
         arch: `
             <kanban default_order="int">
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="int" />
                     </div>
                 </templates>
@@ -12627,7 +12627,7 @@ test.tags("desktop")("d&d records grouped by m2o with m2o displayed in records",
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="product_id" widget="many2one"/>
                     </t>
                 </templates>
@@ -12664,7 +12664,7 @@ test("Can't use KanbanRecord implementation details in arch", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div>
                             <t t-esc="__owl__"/>
                             <t t-esc="props"/>
@@ -12707,7 +12707,7 @@ test.tags("desktop")("rerenders only once after resequencing records", async () 
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -12808,7 +12808,7 @@ test("sample server: _mockWebReadGroup API", async () => {
         arch: `
             <kanban sample="1">
                 <templates>
-                    <div t-name="kanban-card">
+                    <div t-name="card">
                         <field name="display_name"/>
                     </div>
                 </templates>
@@ -12847,7 +12847,7 @@ test.tags("desktop")("scroll on group unfold and progressbar click", async () =>
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field" />
                 <templates>
-                    <t t-name="kanban-card">Record</t>
+                    <t t-name="card">Record</t>
                 </templates>
             </kanban>`,
         groupBy: ["product_id"],
@@ -12894,7 +12894,7 @@ test.tags("desktop")(`kanban view: press "hotkey" to execute header button actio
                 </header>
                 <field name="bar" />
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -12948,7 +12948,7 @@ test.tags("desktop")("action button in controlPanel with display='always'", asyn
                     <button name="default-selection" type="object" class="default-selection" string="default-selection"/>
                 </header>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo" />
                     </t>
                 </templates>
@@ -12975,7 +12975,7 @@ test.tags("desktop")("Keep scrollTop when loading records with load more", async
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <div style="height:1000px;"><field name="id"/></div>
                     </t>
                 </templates>
@@ -13000,7 +13000,7 @@ test("Kanban: no reset of the groupby when a non-empty column is deleted", async
         arch: `
             <kanban default_group_by="product_id">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -13052,7 +13052,7 @@ test.tags("desktop")("searchbar filters are displayed directly", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -13087,7 +13087,7 @@ test("searchbar filters are displayed directly (with progressbar)", async () => 
             <kanban>
                 <progressbar field="state" colors='{"abc": "success", "def": "warning", "ghi": "danger"}' />
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -13223,7 +13223,7 @@ test.tags("desktop")("group by properties and drag and drop", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                         <field name="properties"/>
                     </t>
@@ -13282,7 +13282,7 @@ test("kanbans with basic and custom compiler, same arch", async () => {
     Partner._views["kanban,false"] = `
         <kanban js_class="my_kanban">
             <templates>
-                <t t-name="kanban-card">
+                <t t-name="card">
                     <div><field name="foo"/></div>
                 </t>
             </templates>
@@ -13321,7 +13321,7 @@ test("grouped on field with readonly expression depending on context", async () 
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="product_id" readonly="context.get('abc')" />
                     </t>
                 </templates>
@@ -13352,7 +13352,7 @@ test.tags("desktop")("grouped on field with readonly expression depending on fie
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo" />
                         <field name="product_id" readonly="foo == 'yop'" />
                     </t>
@@ -13379,7 +13379,7 @@ test.tags("desktop")("quick create a column by pressing enter when input is focu
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -13413,7 +13413,7 @@ test("Correct values for progress bar with toggling filter and slow RPC", async 
             <kanban>
                 <progressbar field="state" colors='{"abc": "success", "def": "warning", "ghi": "danger"}' />
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -13472,7 +13472,7 @@ test.tags("desktop")("click on empty kanban must shake the NEW button", async ()
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>

--- a/addons/web/static/tests/views/kanban/kanban_view_legacy.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view_legacy.test.js
@@ -1557,7 +1557,7 @@ test.tags("desktop")("set cover image", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <a type="set_cover" data-field="displayed_image_id" class="dropdown-item">Set Cover Image</a>
                     </t>
                     <t t-name="kanban-box">
@@ -1643,7 +1643,7 @@ test.tags("desktop")("open file explorer if no cover image", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <a type="set_cover" data-field="displayed_image_id" class="dropdown-item">Set Cover Image</a>
                     </t>
                     <t t-name="kanban-box">
@@ -1712,7 +1712,7 @@ test.tags("desktop")("unset cover image", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <a type="set_cover" data-field="displayed_image_id" class="dropdown-item">Set Cover Image</a>
                     </t>
                     <t t-name="kanban-box">

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -5559,7 +5559,7 @@ test(`Navigate between the list and kanban view using the command palette`, asyn
         list: `<list><field name="display_name"/></list>`,
         kanban: `
             <kanban class="o_kanban_test">
-                <templates><t t-name="kanban-card">
+                <templates><t t-name="card">
                     <field name="foo"/>
                 </t></templates>
             </kanban>
@@ -13321,7 +13321,7 @@ test(`change the viewType of the current action`, async () => {
         "kanban,1": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>

--- a/addons/web/static/tests/webclient/actions/client_action.test.js
+++ b/addons/web/static/tests/webclient/actions/client_action.test.js
@@ -50,7 +50,7 @@ class Partner extends models.Model {
         "kanban,false": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="display_name"/>
                     </t>
                 </templates>

--- a/addons/web/static/tests/webclient/actions/close_action.test.js
+++ b/addons/web/static/tests/webclient/actions/close_action.test.js
@@ -36,7 +36,7 @@ class Partner extends models.Model {
         "kanban,1": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="display_name"/>
                     </t>
                 </templates>

--- a/addons/web/static/tests/webclient/actions/concurrency.test.js
+++ b/addons/web/static/tests/webclient/actions/concurrency.test.js
@@ -51,7 +51,7 @@ class Partner extends models.Model {
         "kanban,1": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="display_name"/>
                     </t>
                 </templates>

--- a/addons/web/static/tests/webclient/actions/effect.test.js
+++ b/addons/web/static/tests/webclient/actions/effect.test.js
@@ -38,7 +38,7 @@ class Partner extends models.Model {
         "kanban,1": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="display_name"/>
                     </t>
                 </templates>

--- a/addons/web/static/tests/webclient/actions/embedded_action.test.js
+++ b/addons/web/static/tests/webclient/actions/embedded_action.test.js
@@ -66,7 +66,7 @@ class Partner extends models.Model {
         "kanban,1": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -89,7 +89,7 @@ class Pony extends models.Model {
         "list,false": `<list><field name="name"/></list>`,
         "kanban,false": `<kanban>
                             <templates>
-                                <t t-name="kanban-card">
+                                <t t-name="card">
                                     <field name="name"/>
                                 </t>
                             </templates>
@@ -205,9 +205,7 @@ test("can click on a embedded action and execute the corresponding action (with 
     await contains(
         ".o_popover.dropdown-menu .dropdown-item > div > span:contains('Embedded Action 2')"
     ).click();
-    await contains(
-        ".o_embedded_actions > button > span:contains('Embedded Action 2')"
-    ).click();
+    await contains(".o_embedded_actions > button > span:contains('Embedded Action 2')").click();
     await runAllTimers();
     expect(router.current.action).toBe(3, {
         message: "the current action should be the one of the embedded action previously clicked",
@@ -237,9 +235,7 @@ test("can click on a embedded action and execute the corresponding action (with 
     await contains(
         ".o_popover.dropdown-menu .dropdown-item > div > span:contains('Embedded Action 3')"
     ).click();
-    await contains(
-        ".o_embedded_actions > button > span:contains('Embedded Action 3')"
-    ).click();
+    await contains(".o_embedded_actions > button > span:contains('Embedded Action 3')").click();
     await runAllTimers();
     expect(router.current.action).toBe(4, {
         message: "the current action should be the one of the embedded action previously clicked",
@@ -274,9 +270,7 @@ test("breadcrumbs are updated when clicking on embeddeds", async () => {
     ).click();
     expect(".o_control_panel .breadcrumb-item").toHaveCount(0);
     expect(".o_control_panel .o_breadcrumb .active").toHaveText("Partners Action 1");
-    await contains(
-        ".o_embedded_actions > button > span:contains('Embedded Action 2')"
-    ).click();
+    await contains(".o_embedded_actions > button > span:contains('Embedded Action 2')").click();
     await runAllTimers();
     expect(router.current.action).toBe(3, {
         message: "the current action should be the one of the embedded action previously clicked",
@@ -285,9 +279,7 @@ test("breadcrumbs are updated when clicking on embeddeds", async () => {
         "Partners Action 1",
         "Favorite Ponies",
     ]);
-    await contains(
-        ".o_embedded_actions > button > span:contains('Embedded Action 3')"
-    ).click();
+    await contains(".o_embedded_actions > button > span:contains('Embedded Action 3')").click();
     await runAllTimers();
     expect(router.current.action).toBe(4, {
         message: "the current action should be the one of the embedded action previously clicked",
@@ -317,9 +309,7 @@ test("a view coming from a embedded can be saved in the embedded actions", async
     await contains(
         ".o_popover.dropdown-menu .dropdown-item > div > span:contains('Embedded Action 2')"
     ).click();
-    await contains(
-        ".o_embedded_actions > button > span:contains('Embedded Action 2')"
-    ).click();
+    await contains(".o_embedded_actions > button > span:contains('Embedded Action 2')").click();
     await runAllTimers();
     expect(router.current.action).toBe(3, {
         message: "the current action should be the one of the embedded action previously clicked",

--- a/addons/web/static/tests/webclient/actions/error_handling.test.js
+++ b/addons/web/static/tests/webclient/actions/error_handling.test.js
@@ -32,7 +32,7 @@ class Partner extends models.Model {
         "kanban,1": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="display_name"/>
                     </t>
                 </templates>

--- a/addons/web/static/tests/webclient/actions/load_state.test.js
+++ b/addons/web/static/tests/webclient/actions/load_state.test.js
@@ -161,7 +161,7 @@ class Partner extends models.Model {
         kanban: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>

--- a/addons/web/static/tests/webclient/actions/push_state.test.js
+++ b/addons/web/static/tests/webclient/actions/push_state.test.js
@@ -111,7 +111,7 @@ class Partner extends models.Model {
         kanban: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>

--- a/addons/web/static/tests/webclient/actions/report_action.test.js
+++ b/addons/web/static/tests/webclient/actions/report_action.test.js
@@ -42,7 +42,7 @@ class Partner extends models.Model {
         "kanban,1": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="display_name"/>
                     </t>
                 </templates>

--- a/addons/web/static/tests/webclient/actions/server_action.test.js
+++ b/addons/web/static/tests/webclient/actions/server_action.test.js
@@ -32,7 +32,7 @@ class Partner extends models.Model {
         "kanban,1": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="display_name"/>
                     </t>
                 </templates>

--- a/addons/web/static/tests/webclient/actions/target.test.js
+++ b/addons/web/static/tests/webclient/actions/target.test.js
@@ -45,7 +45,7 @@ class Partner extends models.Model {
         "kanban,1": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="display_name"/>
                     </t>
                 </templates>

--- a/addons/web/static/tests/webclient/actions/window_action.test.js
+++ b/addons/web/static/tests/webclient/actions/window_action.test.js
@@ -93,7 +93,7 @@ class Partner extends models.Model {
         "kanban,1": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
@@ -317,7 +317,7 @@ test.tags("desktop")("switching into a view with mode=edit lands in edit mode", 
     Partner._views["kanban,1"] = `
         <kanban on_create="quick_create" default_group_by="m2o">
             <templates>
-                <t t-name="kanban-card">
+                <t t-name="card">
                     <field name="foo"/>
                 </t>
             </templates>
@@ -2631,7 +2631,7 @@ test.tags("desktop")("sample server: populate groups", async () => {
         "kanban,false": `
             <kanban sample="1" default_group_by="write_date:month">
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="display_name"/>
                     </t>
                 </templates>

--- a/addons/web/static/tests/webclient/clickbot.test.js
+++ b/addons/web/static/tests/webclient/clickbot.test.js
@@ -46,7 +46,7 @@ class Foo extends models.Model {
         `,
         kanban: /* xml */ `
             <kanban class="o_kanban_test">
-                <templates><t t-name="kanban-card">
+                <templates><t t-name="card">
                     <field name="foo"/>
                 </t></templates>
             </kanban>

--- a/addons/website/views/website_controller_pages_views.xml
+++ b/addons/website/views/website_controller_pages_views.xml
@@ -67,7 +67,7 @@
     <field name="model">website.controller.page</field>
     <field name="arch" type="xml">
         <kanban class="o-website-controller-page-kanban">
-            <t t-name="kanban-card">
+            <t t-name="card">
                 <field name="website_published" invisible="1" />
                 <widget name="web_ribbon" text="Published" invisible="not website_published" />
                 <widget name="web_ribbon" text="Unpublished" invisible="website_published" bg_color="text-bg-danger" />

--- a/addons/website/views/website_pages_views.xml
+++ b/addons/website/views/website_pages_views.xml
@@ -127,7 +127,7 @@
         <kanban js_class="website_pages_kanban" action="open_website_url" type="object" sample="1">
             <field name="is_homepage"/>
             <templates>
-                <t t-name="kanban-card">
+                <t t-name="card">
                     <div class="text-truncate fw-bold fs-3">
                         <i t-if="record.is_homepage.raw_value" class="fa fa-home pe-2"
                             title="Home page of the current website"/>

--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -250,7 +250,7 @@
                     <field name="display_name"/>
                     <field name="is_installed_on_current_website"/>
                     <templates>
-                        <div t-name="kanban-card" t-attf-class="o_theme_preview #{record.is_installed_on_current_website.raw_value? 'o_theme_installed' : ''}">
+                        <div t-name="card" t-attf-class="o_theme_preview #{record.is_installed_on_current_website.raw_value? 'o_theme_installed' : ''}">
                             <t t-set="has_image" t-value="record.image_ids.raw_value.length > 0"/>
                             <t t-set="has_screenshot" t-value="record.image_ids.raw_value.length > 1"/>
                             <t t-set="image_url" t-value="has_image ? '/web/image/' + record.image_ids.raw_value[0] : record.icon.value"/>

--- a/addons/website/views/website_visitor_views.xml
+++ b/addons/website/views/website_visitor_views.xml
@@ -86,7 +86,7 @@
                 <field name="is_connected"/>
                 <field name="partner_image"/>
                 <templates>
-                    <t t-name="kanban-card" class="p-0">
+                    <t t-name="card" class="p-0">
                         <!-- displayed in ungrouped mode -->
                         <div class="o_kanban_detail_ungrouped row mx-0">
                             <div class="col-lg-2 col-sm-8 col-12 py-0 my-2 my-lg-0">

--- a/addons/website_blog/views/website_pages_views.xml
+++ b/addons/website_blog/views/website_pages_views.xml
@@ -48,7 +48,7 @@
     <field name="arch" type="xml">
         <kanban js_class="website_pages_kanban" class="o_kanban_mobile" action="open_website_url" type="object" sample="1">
             <templates>
-                <t t-name="kanban-card">
+                <t t-name="card">
                     <div class="row mb-auto">
                         <div class="col-8 fw-bolder">
                             <field class="text-truncate" name="name"/>

--- a/addons/website_event_exhibitor/views/event_sponsor_views.xml
+++ b/addons/website_event_exhibitor/views/event_sponsor_views.xml
@@ -167,7 +167,7 @@
         <field name="arch" type="xml">
             <kanban sample="1">
                 <templates>
-                    <t t-name="kanban-card" class="row g-0">
+                    <t t-name="card" class="row g-0">
                         <widget name="web_ribbon" title="Published" bg_color="text-bg-success" invisible="not is_published or not active"/>
                         <aside class="col-3 o_kanban_aside_full ms-1">
                             <field name="image_128" widget="image" options="{'img_class': 'object-fit-contain'}" alt="Sponsor image"/>

--- a/addons/website_event_track/views/event_track_stage_views.xml
+++ b/addons/website_event_track/views/event_track_stage_views.xml
@@ -78,7 +78,7 @@
         <field name="arch" type="xml">
             <kanban>
                 <templates>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="name" class="fw-medium fs-5"/>
                     </t>
                 </templates>

--- a/addons/website_event_track/views/event_track_views.xml
+++ b/addons/website_event_track/views/event_track_views.xml
@@ -38,13 +38,13 @@
                 <field name="legend_done"/>
                 <templates>
                     <progressbar field="kanban_state" colors='{"done": "success", "blocked": "danger"}'/>
-                    <t t-name="kanban-menu" groups="base.group_user">
+                    <t t-name="menu" groups="base.group_user">
                         <a role="menuitem" t-att-href="record.website_url.value" class="dropdown-item">View Track</a>
                         <t t-if="widget.editable"><a role="menuitem" type="open" class="dropdown-item">Edit Track</a></t>
                         <t t-if="widget.deletable"><a role="menuitem" type="delete" class="dropdown-item">Delete</a></t>
                         <field name="color" widget="kanban_color_picker"/>
                     </t>
-                    <t t-name="kanban-card">
+                    <t t-name="card">
                         <field name="name" class="fw-medium fs-5"/>
                         <div t-if="duration" class="d-flex"><field name="duration" widget="float_time"/>hours</div>
                         <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>

--- a/addons/website_forum/views/forum_post_views.xml
+++ b/addons/website_forum/views/forum_post_views.xml
@@ -135,7 +135,7 @@
         <kanban js_class="website_pages_kanban" create="false" action="go_to_website" type="object" sample="1">
             <field name="parent_id"/>
             <templates>
-                <t t-name="kanban-card">
+                <t t-name="card">
                     <field name="name" class="text-truncate fw-bold"/>
                     <div class="text-muted text-truncate fw-bold" t-if="record.website_id.value" groups="website.group_multi_website">
                         <i class="fa fa-globe me-1" title="Website"/>

--- a/addons/website_hr_recruitment/views/hr_job_views.xml
+++ b/addons/website_hr_recruitment/views/hr_job_views.xml
@@ -8,7 +8,7 @@
             <xpath expr="//kanban" position="attributes">
                 <attribute name="default_order">is_published desc, is_favorite desc, create_date DESC</attribute>
             </xpath>
-            <xpath expr="//t[@t-name='kanban-card']/div" position="before">
+            <xpath expr="//t[@t-name='card']/div" position="before">
                 <field name="website_published" invisible="1"/>
                 <widget name="web_ribbon" title="Published" bg_color="text-bg-success" invisible="not website_published"/>
             </xpath>

--- a/addons/website_sale/views/product_image_views.xml
+++ b/addons/website_sale/views/product_image_views.xml
@@ -43,7 +43,7 @@
             <kanban string="Product Images" default_order="sequence">
                 <field name="sequence" widget="handle"/>
                 <templates>
-                    <t t-name="kanban-card" class="p-0 border-0">
+                    <t t-name="card" class="p-0 border-0">
                         <div class="card">
                             <div class="o_squared_image">
                                 <field class="card-img-top" name="image_1920" widget="x2_many_image"/>

--- a/addons/website_slides/views/slide_channel_partner_views.xml
+++ b/addons/website_slides/views/slide_channel_partner_views.xml
@@ -66,7 +66,7 @@
             <field name="arch" type="xml">
                 <kanban can_open="0" string="Attendees" class="o_slide_attendee_kanban">
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <field name="channel_id" class="fw-bolder fs-5"/>
                             <field name="partner_id"/>
                             <footer class="fs-6 mt-2">

--- a/addons/website_slides/views/slide_channel_views.xml
+++ b/addons/website_slides/views/slide_channel_views.xml
@@ -245,7 +245,7 @@
                 <kanban highlight_color="color" string="eLearning Overview" class="o_slide_kanban o_slide_channel_kanban" edit="false" sample="1">
                     <field name="website_published"/>
                     <templates>
-                        <t t-name="kanban-menu">
+                        <t t-name="menu">
                             <div role="menuitem" aria-haspopup="true">
                                 <field name="color" widget="kanban_color_picker"/>
                             </div>
@@ -258,7 +258,7 @@
                                 <a role="menuitem" name="action_channel_invite" class="dropdown-item" type="object">Invite</a>
                             </div>
                         </t>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                             <widget name="web_ribbon" title="Published" bg_color="text-bg-success" invisible="not website_published or not active"/>
                             <field name="name" class="fw-bold fs-4 me-auto ms-1"/>

--- a/addons/website_slides/views/slide_slide_views.xml
+++ b/addons/website_slides/views/slide_slide_views.xml
@@ -204,7 +204,7 @@
                     class="o_slide_kanban"
                     sample="1">
                     <templates>
-                        <t t-name="kanban-card" class="flex-row">
+                        <t t-name="card" class="flex-row">
                             <aside class="o_kanban_aside_full">
                                 <t t-if="record.image_128.raw_value">
                                     <div class="o_kanban_image_fill position-relative w-100">

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -2481,7 +2481,7 @@ class Model(models.AbstractModel):
         """
 
         field = E.field(name=self._rec_name_fallback())
-        kanban_card = E.t(field, {'t-name': "kanban-card"})
+        kanban_card = E.t(field, {'t-name': "card"})
         templates = E.templates(kanban_card)
         return E.kanban(templates, string=self._description)
 

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -3236,7 +3236,7 @@ Forbidden owl directive used in arch (t-on-click).""",
 
     @mute_logger('odoo.addons.base.models.ir_ui_view')
     def test_forbidden_owl_directives_in_kanban(self):
-        arch = "<kanban><templates><t t-name='kanban-card'>%s</t></templates></kanban>"
+        arch = "<kanban><templates><t t-name='card'>%s</t></templates></kanban>"
         self.assertValid(arch % ('<span t-esc="record.resId"/>'))
         self.assertValid(arch % ('<t t-debug=""/>'))
 
@@ -3244,7 +3244,7 @@ Forbidden owl directive used in arch (t-on-click).""",
             arch % ('<span t-on-click="x.doIt()"/>'),
             """Error while validating view near:
 
-<kanban __validate__="1"><templates><t t-name="kanban-card"><span t-on-click="x.doIt()"/></t></templates></kanban>
+<kanban __validate__="1"><templates><t t-name="card"><span t-on-click="x.doIt()"/></t></templates></kanban>
 Forbidden owl directive used in arch (t-on-click).""",
         )
 
@@ -3270,13 +3270,13 @@ Forbidden attribute used in arch (data-tooltip-template)."""
 
     @mute_logger('odoo.addons.base.models.ir_ui_view')
     def test_forbidden_data_tooltip_attributes_in_kanban(self):
-        arch = "<kanban><templates><t t-name='kanban-card'>%s</t></templates></kanban>"
+        arch = "<kanban><templates><t t-name='card'>%s</t></templates></kanban>"
 
         self.assertInvalid(
             arch % ('<span data-tooltip="Test"/>'),
             """Error while validating view near:
 
-<kanban __validate__="1"><templates><t t-name="kanban-card"><span data-tooltip="Test"/></t></templates></kanban>
+<kanban __validate__="1"><templates><t t-name="card"><span data-tooltip="Test"/></t></templates></kanban>
 Forbidden attribute used in arch (data-tooltip)."""
         )
 
@@ -3284,7 +3284,7 @@ Forbidden attribute used in arch (data-tooltip)."""
             arch % ('<span data-tooltip-template="test"/>'),
             """Error while validating view near:
 
-<kanban __validate__="1"><templates><t t-name="kanban-card"><span data-tooltip-template="test"/></t></templates></kanban>
+<kanban __validate__="1"><templates><t t-name="card"><span data-tooltip-template="test"/></t></templates></kanban>
 Forbidden attribute used in arch (data-tooltip-template)."""
         )
 
@@ -3292,7 +3292,7 @@ Forbidden attribute used in arch (data-tooltip-template)."""
             arch % ('<span t-att-data-tooltip="test"/>'),
             """Error while validating view near:
 
-<kanban __validate__="1"><templates><t t-name="kanban-card"><span t-att-data-tooltip="test"/></t></templates></kanban>
+<kanban __validate__="1"><templates><t t-name="card"><span t-att-data-tooltip="test"/></t></templates></kanban>
 Forbidden attribute used in arch (t-att-data-tooltip)."""
         )
 
@@ -3300,18 +3300,18 @@ Forbidden attribute used in arch (t-att-data-tooltip)."""
             arch % ('<span t-attf-data-tooltip-template="{{ test }}"/>'),
             """Error while validating view near:
 
-<kanban __validate__="1"><templates><t t-name="kanban-card"><span t-attf-data-tooltip-template="{{ test }}"/></t></templates></kanban>
+<kanban __validate__="1"><templates><t t-name="card"><span t-attf-data-tooltip-template="{{ test }}"/></t></templates></kanban>
 Forbidden attribute used in arch (t-attf-data-tooltip-template)."""
         )
 
     @mute_logger('odoo.addons.base.models.ir_ui_view')
     def test_forbidden_use_of___comp___in_kanban(self):
-        arch = "<kanban><templates><t t-name='kanban-card'>%s</t></templates></kanban>"
+        arch = "<kanban><templates><t t-name='card'>%s</t></templates></kanban>"
         self.assertInvalid(
             arch % '<t t-esc="__comp__.props.resId"/>',
             """Error while validating view near:
 
-<kanban __validate__="1"><templates><t t-name="kanban-card"><t t-esc="__comp__.props.resId"/></t></templates></kanban>
+<kanban __validate__="1"><templates><t t-name="card"><t t-esc="__comp__.props.resId"/></t></templates></kanban>
 Forbidden use of `__comp__` in arch."""
         )
 

--- a/odoo/addons/base/views/ir_module_views.xml
+++ b/odoo/addons/base/views/ir_module_views.xml
@@ -158,14 +158,14 @@
                   <field name="website"/>
                   <field name="application"/>
                   <templates>
-                    <t t-name="kanban-menu">
+                    <t t-name="menu">
                         <t t-set="installed" t-value="record.state.raw_value == 'installed'"/>
                         <a type="open" class="dropdown-item">Module Info</a>
                         <a t-if="record.website.raw_value" role="menuitem" class="dropdown-item o-hidden-ios" t-att-href="record.website.raw_value" target="_blank">Learn More</a>
                         <a t-if="installed" name="button_immediate_upgrade" type="object" role="menuitem" class="dropdown-item" groups="base.group_system">Upgrade</a>
                         <a t-if="installed" name="button_uninstall_wizard" type="object" role="menuitem" class="dropdown-item" groups="base.group_system">Uninstall</a>
                     </t>
-                    <t t-name="kanban-card" class="flex-row align-items-center">
+                    <t t-name="card" class="flex-row align-items-center">
                         <aside>
                             <field name="icon" widget="image_url" options="{'size': [50, 50]}" alt="Icon"/>
                             <field t-if="record.icon_flag" name="icon_flag" class="oe_module_flag"/>

--- a/odoo/addons/base/views/res_company_views.xml
+++ b/odoo/addons/base/views/res_company_views.xml
@@ -77,7 +77,7 @@
             <field name="arch" type="xml">
                 <kanban>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                             <div t-attf-class="#{!selection_mode ? 'text-center' : ''}">
                                 <i class="fa fa-building" role="img" aria-label="Enterprise" title="Enterprise"></i> <field class="fw-bold fs-5" name="name"/>
                             </div>

--- a/odoo/addons/base/views/res_currency_views.xml
+++ b/odoo/addons/base/views/res_currency_views.xml
@@ -102,7 +102,7 @@
                 <kanban class="o_kanban_mobile">
                     <field name="active"/>
                     <templates>
-                        <t t-name="kanban-card">
+                        <t t-name="card">
                                 <div class="row mb4">
                                     <div class="col-2 text-nowrap">
                                         <field class="fw-bold fs-3" name="name"/>

--- a/odoo/addons/base/views/res_device_views.xml
+++ b/odoo/addons/base/views/res_device_views.xml
@@ -52,7 +52,7 @@
                     <field name="last_activity"/>
                     <field name="is_current"/>
                     <templates>
-                        <t t-name="kanban-card" class="flex-row">
+                        <t t-name="card" class="flex-row">
                             <t t-if="record.device_type.raw_value === 'computer'">
                                 <span class="fa fa-laptop fs-1" title="Computer" role="img" aria-label="Computer"/>
                             </t>

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -220,7 +220,7 @@
                                     <field name="type"/>
                                     <field name="is_company"/>
                                     <templates>
-                                        <t t-name="kanban-card" class="flex-row">
+                                        <t t-name="card" class="flex-row">
                                             <aside class="o_kanban_aside_full">
                                                 <field name="avatar_128" class="o_kanban_image_fill w-100" widget="image" options="{'img_class': 'object-fit-cover'}" alt="Contact image"/>
                                             </aside>
@@ -401,7 +401,7 @@
                     <field name="is_company"/>
                     <field name="active"/>
                     <templates>
-                        <t t-name="kanban-card" class="flex-row">
+                        <t t-name="card" class="flex-row">
                             <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                             <aside class="o_kanban_aside_full">
                                 <t t-if="!record.is_company.raw_value">

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -272,7 +272,7 @@
                     <field name="active"/>
                     <field name="login_date"/>
                     <templates>
-                        <t t-name="kanban-card" class="flex-row">
+                        <t t-name="card" class="flex-row">
                             <aside class="w-25 p-1">
                                 <field name="avatar_128" widget="image" alt="Avatar"/>
                             </aside>

--- a/odoo/addons/base/wizard/base_module_uninstall_views.xml
+++ b/odoo/addons/base/wizard/base_module_uninstall_views.xml
@@ -20,7 +20,7 @@
                         <kanban create="false" class="o_modules_kanban">
                             <field name="state"/>
                                 <templates>
-                                    <t t-name="kanban-card" class="flex-row align-items-center">
+                                    <t t-name="card" class="flex-row align-items-center">
                                         <aside>
                                             <field name="icon" widget="image_url" options="{'size': [50, 50]}" alt="Icon"/>
                                         </aside>


### PR DESCRIPTION
Kanban templates have been reworked. In the new API, the main template is named kanban-card instead of kanban-box. The Activity and Hierarchy views follow a similar API, with their main templates being activity_box and hierarchy_box, respectively. The goal is to standardize these three views by defining a similar rendering context available in the arch.

As part of this effort, we have renamed kanban-card to card and kanban-menu to menu.

Task-4169388

enterprise PR: https://github.com/odoo/enterprise/pull/70460

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
