### PR TITLE
[FIX] website: allow columns selection in `s_key_images`

### DIFF
--- a/addons/website/views/snippets/s_key_images.xml
+++ b/addons/website/views/snippets/s_key_images.xml
@@ -4,7 +4,7 @@
 <template id="s_key_images" name="Key Images">
     <section class="s_key_images pt72 pb72">
         <div class="container">
-            <div class="row s_nb_column_fixed">
+            <div class="row">
                 <div class="col-lg-12 pb32">
                     <h2>What we propose to our customers</h2>
                     <p class="lead">Dive deeper into our company’s abilities.</p>


### PR DESCRIPTION
This PR fixes an issue about the `s_key_images` number of columns being fixed.

Prior to this commit, the number of columns was fixed and thus not editable by the user. This would force users to play with the handle to achieve a layout, while it could be achieve in one click with the column selector.

task-4203160

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
