### PR TITLE
[FIX] html_editor: set collapse selection in contenteditable false

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -417,10 +417,12 @@ export class SelectionPlugin extends Plugin {
         if (!this.isSelectionInEditable({ anchorNode, focusNode })) {
             throw new Error("Selection is not in editor");
         }
-        [anchorNode, anchorOffset] = normalizeCursorPosition(anchorNode, anchorOffset, "left");
+        const isCollapsed = anchorNode === focusNode && anchorOffset === focusOffset;
         [focusNode, focusOffset] = normalizeCursorPosition(focusNode, focusOffset, "right");
+        [anchorNode, anchorOffset] = isCollapsed
+            ? [focusNode, focusOffset]
+            : normalizeCursorPosition(anchorNode, anchorOffset, "left");
         if (normalize) {
-            const isCollapsed = anchorNode === focusNode && anchorOffset === focusOffset;
             // normalize selection
             [anchorNode, anchorOffset] = normalizeDeepCursorPosition(anchorNode, anchorOffset);
             [focusNode, focusOffset] = isCollapsed

--- a/addons/html_editor/static/src/others/qweb_plugin.js
+++ b/addons/html_editor/static/src/others/qweb_plugin.js
@@ -1,5 +1,6 @@
 import { Plugin } from "@html_editor/plugin";
 import { closestElement } from "@html_editor/utils/dom_traversal";
+import { leftPos, rightPos } from "@html_editor/utils/position";
 import { QWebPicker } from "./qweb_picker";
 
 const isUnsplittableQWebElement = (element) =>
@@ -71,7 +72,9 @@ export class QWebPlugin extends Plugin {
             closestElement(selection.anchorNode, "[t-field],[t-esc],[t-out]");
         if (qwebNode && this.editable.contains(qwebNode)) {
             // select the whole qweb node
-            this.shared.setSelection(selection);
+            const [anchorNode, anchorOffset] = leftPos(qwebNode);
+            const [focusNode, focusOffset] = rightPos(qwebNode);
+            this.shared.setSelection({ anchorNode, anchorOffset, focusNode, focusOffset });
         }
     }
 

--- a/addons/html_editor/static/tests/selection.test.js
+++ b/addons/html_editor/static/tests/selection.test.js
@@ -210,3 +210,12 @@ test("restore a selection when you are not in the editable shouldn't move the fo
     cursors.restore();
     expect(getActiveElement()).toBe(queryOne("input.test"));
 });
+
+test("set a collapse selection in a contenteditable false should move it after this node", async () => {
+    const { el, editor } = await setupEditor(`<p>ab<span contenteditable="false">cd</span>ef</p>`);
+    editor.shared.setSelection({
+        anchorNode: queryOne("span[contenteditable='false']"),
+        anchorOffset: 1,
+    });
+    expect(getContent(el)).toBe(`<p>ab<span contenteditable="false">cd</span>[]ef</p>`);
+});


### PR DESCRIPTION
After this commit, when we do a setSelection of a collapse selection in a contentEditable="false", we move the selection after the contentEditable="false" node.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
