### PR TITLE
[REF] point_of_sale, pos_*: tours > checkDelay 50ms

### DIFF
--- a/addons/point_of_sale/static/tests/tours/chrome_tour.js
+++ b/addons/point_of_sale/static/tests/tours/chrome_tour.js
@@ -8,6 +8,7 @@ import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("ChromeTour", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -111,6 +112,7 @@ registry.category("web_tour.tours").add("ChromeTour", {
 
 registry.category("web_tour.tours").add("OrderModificationAfterValidationError", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -12,6 +12,7 @@ import * as ProductConfiguratorPopup from "@point_of_sale/../tests/tours/utils/p
 
 registry.category("web_tour.tours").add("ProductScreenTour", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             // Go by default to home category
@@ -129,6 +130,7 @@ registry.category("web_tour.tours").add("ProductScreenTour", {
 
 registry.category("web_tour.tours").add("FiscalPositionNoTax", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -147,6 +149,7 @@ registry.category("web_tour.tours").add("FiscalPositionNoTax", {
 
 registry.category("web_tour.tours").add("FiscalPositionIncl", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -168,6 +171,7 @@ registry.category("web_tour.tours").add("FiscalPositionIncl", {
 
 registry.category("web_tour.tours").add("FiscalPositionExcl", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -186,6 +190,7 @@ registry.category("web_tour.tours").add("FiscalPositionExcl", {
 
 registry.category("web_tour.tours").add("CashClosingDetails", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -209,6 +214,7 @@ registry.category("web_tour.tours").add("CashClosingDetails", {
 
 registry.category("web_tour.tours").add("ShowTaxExcludedTour", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -222,6 +228,7 @@ registry.category("web_tour.tours").add("ShowTaxExcludedTour", {
 
 registry.category("web_tour.tours").add("limitedProductPricelistLoading", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -244,6 +251,7 @@ registry.category("web_tour.tours").add("limitedProductPricelistLoading", {
 
 registry.category("web_tour.tours").add("MultiProductOptionsTour", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -260,6 +268,7 @@ registry.category("web_tour.tours").add("MultiProductOptionsTour", {
 
 registry.category("web_tour.tours").add("TranslateProductNameTour", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -271,6 +280,7 @@ registry.category("web_tour.tours").add("TranslateProductNameTour", {
 
 registry.category("web_tour.tours").add("DecimalCommaOrderlinePrice", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -284,6 +294,7 @@ registry.category("web_tour.tours").add("DecimalCommaOrderlinePrice", {
 
 registry.category("web_tour.tours").add("CheckProductInformation", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -309,6 +320,7 @@ registry.category("web_tour.tours").add("CheckProductInformation", {
 
 registry.category("web_tour.tours").add("PosCustomerAllFieldsDisplayed", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/point_of_sale/static/tests/tours/receipt_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/receipt_screen_tour.js
@@ -10,6 +10,7 @@ import { inLeftSide } from "@point_of_sale/../tests/tours/utils/common";
 
 registry.category("web_tour.tours").add("ReceiptScreenTour", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             // press close button in receipt screen
@@ -76,6 +77,7 @@ registry.category("web_tour.tours").add("ReceiptScreenTour", {
 
 registry.category("web_tour.tours").add("ReceiptScreenDiscountWithPricelistTour", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -92,6 +94,7 @@ registry.category("web_tour.tours").add("ReceiptScreenDiscountWithPricelistTour"
 
 registry.category("web_tour.tours").add("OrderPaidInCash", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -117,6 +120,7 @@ registry.category("web_tour.tours").add("OrderPaidInCash", {
 
 registry.category("web_tour.tours").add("ReceiptTrackingMethodTour", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/point_of_sale/static/tests/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/ticket_screen_tour.js
@@ -12,6 +12,7 @@ import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("TicketScreenTour", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -160,6 +161,7 @@ registry.category("web_tour.tours").add("TicketScreenTour", {
 
 registry.category("web_tour.tours").add("FiscalPositionNoTaxRefund", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -185,6 +187,7 @@ registry.category("web_tour.tours").add("FiscalPositionNoTaxRefund", {
 
 registry.category("web_tour.tours").add("LotRefundTour", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -210,6 +213,7 @@ registry.category("web_tour.tours").add("LotRefundTour", {
 
 registry.category("web_tour.tours").add("RefundFewQuantities", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_loyalty/static/tests/tours/e_wallet_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/e_wallet_program_tour.js
@@ -8,6 +8,7 @@ import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("EWalletProgramTour1", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -34,6 +35,7 @@ registry.category("web_tour.tours").add("EWalletProgramTour1", {
 const getEWalletText = (suffix) => "eWallet" + (suffix !== "" ? ` ${suffix}` : "");
 registry.category("web_tour.tours").add("EWalletProgramTour2", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -100,6 +102,7 @@ registry.category("web_tour.tours").add("EWalletProgramTour2", {
 
 registry.category("web_tour.tours").add("ExpiredEWalletProgramTour", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -116,6 +119,7 @@ registry.category("web_tour.tours").add("ExpiredEWalletProgramTour", {
 
 registry.category("web_tour.tours").add("PosLoyaltyPointsEwallet", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_reward_button_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_reward_button_tour.js
@@ -7,6 +7,7 @@ import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -129,6 +130,7 @@ registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour", {
 
 registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour2", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -147,6 +149,7 @@ registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour2", {
 
 registry.category("web_tour.tours").add("PosLoyaltySpecificDiscountTour", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -172,6 +175,7 @@ registry.category("web_tour.tours").add("PosLoyaltySpecificDiscountTour", {
 
 registry.category("web_tour.tours").add("PosLoyaltySpecificDiscountWithFreeProductTour", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -188,6 +192,7 @@ registry.category("web_tour.tours").add("PosLoyaltySpecificDiscountWithFreeProdu
 
 registry.category("web_tour.tours").add("PosLoyaltySpecificDiscountWithRewardProductDomainTour", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -205,6 +210,7 @@ registry.category("web_tour.tours").add("PosLoyaltySpecificDiscountWithRewardPro
 
 registry.category("web_tour.tours").add("PosLoyaltyRewardProductTag", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
@@ -9,6 +9,7 @@ import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("PosResTicketScreenTour", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -37,6 +38,7 @@ registry.category("web_tour.tours").add("PosResTicketScreenTour", {
 
 registry.category("web_tour.tours").add("OrderNumberConflictTour", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_restaurant/static/tests/tours/tip_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/tip_screen_tour.js
@@ -13,6 +13,7 @@ import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("PosResTipScreenTour", {
     test: true,
+    checkDelay: 50,
     steps: () =>
         [
             // Create order that is synced when draft.


### PR DESCRIPTION
In this commit, we force the value of checkDelay to 50ms. checkDelay is the time after which we will look for the trigger in the DOM if there is no more mutation. By default, this value is 750ms (see macro.js). However, the tricks listed in this PR are able to run at 50ms which allows to reduce the execution time of these tricks.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
