### PR TITLE
[FIX] l10n_ca: saskatchewan tax report credit notes

### DIFF
--- a/addons/l10n_ca/data/template/account.tax-ca_2023.csv
+++ b/addons/l10n_ca/data/template/account.tax-ca_2023.csv
@@ -9,7 +9,7 @@
 "","","","","","","","","","","","tax","refund","-Ca103||-CaQc103","l10n_ca_231000","",""
 "pst_sale_tax_6","6% PST SK","6%","6% PST SK","sale","6.0","percent","20","False","tax_group_pst_6","","base","invoice","+CaSk8Base","","6% TVP SK","6% TVP SK"
 "","","","","","","","","","","","tax","invoice","+CaSk8","l10n_ca_232000","",""
-"","","","","","","","","","","","base","refund","","","",""
+"","","","","","","","","","","","base","refund","-CaSk8Base","","",""
 "","","","","","","","","","","","tax","refund","+CaSk3","l10n_ca_232000","",""
 "pst_sale_tax_7_bc","7% PST BC","7%","7% PST BC","sale","7.0","percent","20","False","tax_group_pst_7","","base","invoice","","","7% TVP BC","7% TVP BC"
 "","","","","","","","","","","","tax","invoice","+CaBcB","l10n_ca_232000","",""


### PR DESCRIPTION
In de29ff9cee5be830b8d2aaf2c703f4f13ee24dec, we missed a tag for
credit notes on PST tax for saskatchewan tax report.

opw-3955926
