### PR TITLE
[REF] web: remove jquery usage in view_hook

### DIFF
--- a/addons/web/static/src/views/view_hook.js
+++ b/addons/web/static/src/views/view_hook.js
@@ -50,15 +50,6 @@ export function useActionLinks({ resModel, reload }) {
     const orm = useService("orm");
     const { doAction } = useService("action");
 
-    function checkAndCollapseBootstrap(target) {
-        // the handler should have stopped the Event
-        // But we still need to alert bootstrap if we need to
-        // This function should be removed when we get rid of bootstrap as a JS framework
-        if (target.dataset.bsToggle === "collapse") {
-            $(target).trigger("click.bs.collapse.data-api");
-        }
-    }
-
     async function handler(ev) {
         ev.preventDefault();
         ev.stopPropagation();
@@ -114,7 +105,6 @@ export function useActionLinks({ resModel, reload }) {
             }
             keepLast.add(doAction(action, options));
         }
-        checkAndCollapseBootstrap(target);
     }
 
     return (ev) => {


### PR DESCRIPTION
jQuery is no longer (always) available in the backend. In a view hook, we still used it to ensure no bootstrap tooltips remained in the DOM after clicking on a view button. This code is actually no longer necessary, as there're no bootstrap tooltips in views anymore, so we can remove it.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
