### PR TITLE
[FIX] website_sms: fix space between buttons

### DIFF
--- a/addons/website/views/website_visitor_views.xml
+++ b/addons/website/views/website_visitor_views.xml
@@ -147,9 +147,9 @@
                             <div t-if="record.page_count.raw_value">Last Page<field name="last_visited_page_id" class="float-end fw-bold"/></div>
                             <div>Visits<field name="visit_count" class="float-end fw-bold"/></div>
                             <div t-if="record.page_count.raw_value" id="o_page_count">Visited Pages<span class="float-end fw-bold"><field name="page_count"/></span></div>
-                            <div class="w_visitor_kanban_actions">
+                            <div name="w_visitor_kanban_actions" class="d-flex gap-1">
                                 <button name="action_send_mail" type="object"
-                                        class="btn btn-secondary me-1" invisible="not email">
+                                        class="btn btn-secondary" invisible="not email">
                                         Email
                                 </button>
                             </div>

--- a/addons/website_livechat/views/website_visitor_views.xml
+++ b/addons/website_livechat/views/website_visitor_views.xml
@@ -36,7 +36,7 @@
                 <field name="livechat_operator_id"/>
                 <field name="session_count"/>
             </field>
-            <xpath expr="//div[hasclass('w_visitor_kanban_actions')]" position="before">
+            <xpath expr="//div[@name='w_visitor_kanban_actions']" position="before">
                 <div t-if="record.session_count.raw_value">Chats<field name="session_count" class="float-end fw-bold"/></div>
                 <div t-if="record.livechat_operator_id.raw_value">
                     Speaking With
@@ -64,7 +64,7 @@
                 </div>
                 <div t-else="" class="col-lg d-none d-lg-block"/>
             </xpath>
-            <xpath expr="//div[hasclass('w_visitor_kanban_actions')]" position="inside">
+            <xpath expr="//div[@name='w_visitor_kanban_actions']" position="inside">
                 <button name="action_send_chat_request" type="object"
                         class="btn btn-secondary"
                         invisible="livechat_operator_id or not is_connected">

--- a/addons/website_sms/views/website_visitor_views.xml
+++ b/addons/website_sms/views/website_visitor_views.xml
@@ -20,7 +20,7 @@
             <field name="country_id" position="after">
                 <field name="mobile" widget="phone"/>
             </field>
-            <xpath expr="//div[hasclass('w_visitor_kanban_actions')]" position="inside">
+            <xpath expr="//div[@name='w_visitor_kanban_actions']" position="inside">
                 <button name="action_send_sms" type="object" class="btn btn-secondary"
                         invisible="not mobile">SMS
                 </button>


### PR DESCRIPTION
before this commit there is no space between 'sms' and 'chat' buttons.

after this commit added a space between both buttons.

enterprise PR-https://github.com/odoo/enterprise/pull/70742

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr