### PR TITLE
[FIX] point_of_sale: fix discount values from pricelist on incoice

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -210,11 +210,11 @@ class PosOrder(models.Model):
         invoice_lines = []
         for line in self.lines:
             invoice_lines.append((0, None, self._prepare_invoice_line(line)))
-            if line.order_id.pricelist_id.discount_policy == 'without_discount' and float_compare(line.price_subtotal_incl, line.product_id.lst_price * line.qty, precision_rounding=self.currency_id.rounding) < 0:
+            if line.order_id.pricelist_id.discount_policy == 'without_discount' and float_compare(line.price_unit, line.product_id.lst_price, precision_rounding=self.currency_id.rounding) < 0:
                 invoice_lines.append((0, None, {
                     'name': _('Price discount from %s -> %s',
-                              float_repr(line.product_id.lst_price * line.qty, self.currency_id.decimal_places),
-                              float_repr(line.price_subtotal_incl, self.currency_id.decimal_places)),
+                              float_repr(line.product_id.lst_price, self.currency_id.decimal_places),
+                              float_repr(line.price_unit, self.currency_id.decimal_places)),
                     'display_type': 'line_note',
                 }))
             if line.customer_note:

--- a/addons/point_of_sale/tests/test_anglo_saxon.py
+++ b/addons/point_of_sale/tests/test_anglo_saxon.py
@@ -348,6 +348,12 @@ class TestAngloSaxonFlow(TestAngloSaxonCommon):
         pricelist = self.env['product.pricelist'].create({
             'name': 'Test Pricelist',
             'discount_policy': 'without_discount',
+            'item_ids': [(0, 0, {
+                'compute_price': 'percentage',
+                'percent_price': 5,
+                'min_quantity': 0,
+                'applied_on': '3_global',
+            })]
         })
         self.product.lst_price = 100
         self.pos_order_pos0 = self.PosOrder.create({
@@ -357,14 +363,15 @@ class TestAngloSaxonFlow(TestAngloSaxonCommon):
             'pricelist_id': pricelist.id,
             'lines': [(0, 0, {
                 'product_id': self.product.id,
-                'price_unit': 100,
+                'price_unit': 95,
                 'qty': 1.0,
-                'price_subtotal': 95,
-                'price_subtotal_incl': 95,
+                'tax_ids': [(6, 0, self.product.taxes_id.ids)],
+                'price_subtotal': 90.25,
+                'price_subtotal_incl': 103.79,
                 'discount': 5,
             })],
-            'amount_total': 95,
-            'amount_tax': 0,
+            'amount_total': 103.79,
+            'amount_tax': 13.51,
             'amount_paid': 0,
             'amount_return': 0,
             'to_invoice': True,
@@ -380,3 +387,8 @@ class TestAngloSaxonFlow(TestAngloSaxonCommon):
         res = self.pos_order_pos0.action_pos_order_invoice()
         invoice = self.env['account.move'].browse(res['res_id'])
         self.assertTrue('Price discount from 100.00 -> 95.00' in invoice.invoice_line_ids.filtered(lambda l: l.display_type == "line_note").display_name)
+        product_line = invoice.invoice_line_ids.filtered(lambda l: l.display_type == "product")
+        self.assertEqual(product_line.price_unit, 95)  # Only fiscal position applies
+        self.assertEqual(product_line.discount, 5)  # Disount is reflected
+        self.assertEqual(product_line.price_subtotal, 90.25)  # Discount applies on price_unit
+        self.assertEqual(product_line.price_total, 103.79)  # Taxes applied with price_total


### PR DESCRIPTION
Currently when invoicing through pos, multiple values related to price discounts are incorrect.

Steps to reproduce:
-------------------
* Go to the **Point of sale** app
* Under **Configuration**, select **Settings**
* Enable **Flexible Pricelists**
* Select **Advanced price rules**
* Create a pricelist, 10% discount on all products, visible on the invoice
* Go to the **Products list**
* Select any product and apply a tax (price excl)
* Open shop session
* Select the product with the tax
* Pay and invoice it
> Observation: In some cases the line "Price discounted from" does not appear on the invoice. And when it appears, values are not correct. If you also plied a discount on the product line in addition to the pricelist, values are completely mixed.

Why the fix:
------------
We see that we are curently comparing `line.price_subtotal_incl` with `line.product_id.lst_price * line.qty`.
https://github.com/odoo/odoo/blob/b49159db74cf4c8212a7bd3dfe551eb852df99f3/addons/point_of_sale/models/pos_order.py#L213-L219

To simplify, we consider a quantity of 1.
* `line.price_subtotal_incl` includes discounts (order line discounts and pricelist) and always represent a price with taxes included.
* `line.product_id.lst_price` reprensents the price set on the prodcut form. It does not account for any sort of discount. If the tax applied on the product is tax excl(resp. incl) it will be a price tex excl(resp. incl).

In the case where the pricelist discount is smaller than the tax amount, for products with tax excl, the `line.price_subtotal_incl` will still be greater than `line.product_id.lst_price` and that's why the invoice does not have the line "Price discounted from".

I asked MOBT the behavior expected. For the line "Price discounted from", this should only reflect discounts related to pricelist, and should represent the price tax excl/incl depending on the tax set up on the product page. Line discounts are already reflected on the invoice with `Disc.%`.

We choose to compare two values that reflect the same price tax configuration. We compare `line.product_id.lst_price` with `line.price_unit` as both will be tax excl(resp. incl) if the tax applied on the product is tax excl(resp. incl). We also remove the `line.qty` as both represent a price per qty.

opw-4170357