### PR TITLE
[FIX] sale_timesheet: change rounding SOL remaining time display

### DIFF
--- a/addons/sale_timesheet/models/sale_order.py
+++ b/addons/sale_timesheet/models/sale_order.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import math
@@ -6,7 +5,7 @@ from collections import defaultdict
 
 from odoo import api, fields, models, _
 from odoo.osv import expression
-from odoo.tools import float_compare
+from odoo.tools import float_compare, format_duration
 
 
 class SaleOrder(models.Model):
@@ -152,18 +151,7 @@ class SaleOrderLine(models.Model):
                     encoding_uom = company.timesheet_encode_uom_id
                     remaining_time = ''
                     if encoding_uom == uom_hour:
-                        hours, minutes = divmod(abs(line.remaining_hours) * 60, 60)
-                        round_minutes = minutes / 30
-                        minutes = math.ceil(round_minutes) if line.remaining_hours >= 0 else math.floor(round_minutes)
-                        if minutes > 1:
-                            minutes = 0
-                            hours += 1
-                        else:
-                            minutes = minutes * 30
-                        remaining_time = ' ({sign}{hours:02.0f}:{minutes:02.0f})'.format(
-                            sign='-' if line.remaining_hours < 0 else '',
-                            hours=hours,
-                            minutes=minutes)
+                        remaining_time = f' ({format_duration(line.remaining_hours)})'
                     elif encoding_uom == uom_day:
                         remaining_days = company.project_time_mode_id._compute_quantity(line.remaining_hours, encoding_uom, round=False)
                         remaining_time = ' ({qty:.02f} {unit})'.format(


### PR DESCRIPTION
Steps
-----
- install sale_timesheet
- create a "30 hours" Unit of Measure in the Working Time category,
equal to 3.75 days
- create a service product with "30 hours" as the UoM
- create a SO with this product for a customer
- create a task for this customer and use the previously created SOL
- add 15 hours of timesheet

Issue
-----
The remaining hours on the SO appear as +/- 26:00 (with some minor
decimal precision inaccuracies), but the name of the SOL in the
"Sales Order Item" field shows 26:30 remaining.

Change
-----
Backport https://github.com/odoo/odoo/commit/d0cf7c0f2c039d55d024cf9a2e0676e11ba97338 which removes the
rounding by 30 minutes and uses `format_duration`

opw-3959886