### PR TITLE
[FIX] stock: enable default min width on `stock_move_one2many` columns

### DIFF
--- a/addons/stock/static/src/views/picking_form/stock_move_one2many.js
+++ b/addons/stock/static/src/views/picking_form/stock_move_one2many.js
@@ -1,10 +1,10 @@
 /** @odoo-module **/
 
 import { registry } from "@web/core/registry";
-import { AutoColumnWidthListRenderer } from "@stock/views/list/auto_column_width_list_renderer";
 import { X2ManyField, x2ManyField } from "@web/views/fields/x2many/x2many_field";
+import { ListRenderer } from "@web/views/list/list_renderer";
 
-export class MovesListRenderer extends AutoColumnWidthListRenderer {
+export class MovesListRenderer extends ListRenderer {
     static recordRowTemplate = "stock.MovesListRenderer.RecordRow";
 
     processAllColumn(allColumns, list) {


### PR DESCRIPTION
Problem:
In saas-17.4, it's not possible to reduce the size of the columns in `stock_move_one2many` due to the missing `useMagicColumnWidths` hook. This hook provides a default minimum width, allowing the column width to adjust when fields have long content.

Steps to reproduce:
- Create a new manufacturing order.
- Add a product with a very long name.
- The width of the row is large and cannot be resized.

opw-4176861

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
