### PR TITLE
[FIX] mail: correct style of Discuss channel subthread lines

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -127,7 +127,7 @@
                     <line x1="0" y1="3" x2="0" y2="100%" stroke="currentColor" stroke-width="3"/>
                     <line x1="0" y1="100%" x2="100%" y2="100%" stroke="currentColor" stroke-width="3"/>
                 </svg>
-                <svg t-else="" class="position-absolute me-1" style="left: 20px; top: -15px;" xmlns="http://www.w3.org/2000/svg" width="12" height="30" viewBox="0 0 12 30">
+                <svg t-else="" class="position-absolute me-1" style="left: 20px; top: -20px;" xmlns="http://www.w3.org/2000/svg" width="12" height="34" viewBox="0 0 12 34">
                     <line x1="0" y1="3" x2="0" y2="100%" stroke="currentColor" stroke-width="3"/>
                     <line x1="0" y1="100%" x2="100%" y2="100%" stroke="currentColor" stroke-width="3"/>
                 </svg>


### PR DESCRIPTION
Recent PR adjusted some spacing of discuss items, which slightly offset the visual of lines of sub-threads in the discuss sidebar.

This commit adjust values to make lines look better as a continuous line, without any spacing in-between items.

Before / After

<img width="305" alt="Screenshot 2024-09-23 at 11 17 48" src="https://github.com/user-attachments/assets/ad5fab52-ce41-4269-95e0-fe8ebf0bbdd4"> <img width="300" alt="Screenshot 2024-09-23 at 11 14 18" src="https://github.com/user-attachments/assets/fc3054ec-dfee-4ffb-aa55-2220f76295bf">
