### PR TITLE
[FIX] [16.0] hr_holidays: fix approval button is not showing.

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -1456,7 +1456,9 @@ class HolidaysRequest(models.Model):
                     holiday.check_access_rule('write')
 
                     # This handles states validate1 validate and refuse
-                    if holiday.employee_id == current_employee:
+                    if holiday.employee_id == current_employee\
+                            and self.env.user != holiday.employee_id.leave_manager_id\
+                            and not is_officer:
                         raise UserError(_('Only a Time Off Manager can approve/refuse its own requests.'))
 
                     if (state == 'validate1' and val_type == 'both') and holiday.holiday_type == 'employee':


### PR DESCRIPTION
**Issue**: Approval button not showing when creating a leave request (The leave approver is the employee themselves)

**Steps**:
1. Leave Type:
- Approval: By Employee's Approver and Time Off Officer
- Responsible Time Off Officer: Administrator

2. Employee Demo:
- Set the Timeoff approver for Demo: Demo (self-approver)
(As a department Manager, they can self-approve, then only the Time Off Manager needs to approve the second time)

3. Demo creates a leave request and accesses it:
- There is a self-assigned action, but the first approval button does not appear.
![Screenshot from 2024-09-23 16-25-12](https://github.com/user-attachments/assets/8be5bf46-6636-453d-98e8-ba86e02d49c3)

**Expected**: The approval button should appear as it does in Odoo 17.0.

**Solution**: Fix the code to same with Odoo 17.0 (partially addressed in PR [#122517](https://github.com/odoo/odoo/pull/122517)).
![Screenshot from 2024-09-23 16-43-24](https://github.com/user-attachments/assets/c69fbc43-3a7a-485a-ad4c-13a14892345e)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
