### PR TITLE
[FIX] website_sale: only show strikethrough price for discount rules

### DIFF
--- a/addons/product/models/product_pricelist_item.py
+++ b/addons/product/models/product_pricelist_item.py
@@ -549,24 +549,18 @@ class PricelistItem(models.Model):
         :returns: base price, expressed in provided pricelist currency
         :rtype: float
         """
-        pricelist_rule = self
-        pricelist_show_discount = pricelist_rule._show_discount()
-        if pricelist_rule and pricelist_show_discount:
-            pricelist_item = pricelist_rule
-            # Find the lowest pricelist rule whose pricelist is configured to show the discount
-            # to the customer.
-            while pricelist_item.base == 'pricelist':
-                rule_id = pricelist_item.base_pricelist_id._get_product_rule(*args, **kwargs)
-                rule_pricelist_item = self.env['product.pricelist.item'].browse(rule_id)
-                rule_show_discount = rule_pricelist_item._show_discount()
-                if rule_pricelist_item and rule_show_discount:
-                    pricelist_item = rule_pricelist_item
-                else:
-                    break
+        pricelist_item = self
+        # Find the lowest pricelist rule whose pricelist is configured to show the discount to the
+        # customer.
+        while pricelist_item.base == 'pricelist':
+            rule_id = pricelist_item.base_pricelist_id._get_product_rule(*args, **kwargs)
+            rule_pricelist_item = self.env['product.pricelist.item'].browse(rule_id)
+            if rule_pricelist_item and rule_pricelist_item.compute_price == 'percentage':
+                pricelist_item = rule_pricelist_item
+            else:
+                break
 
-            pricelist_rule = pricelist_item
-
-        return pricelist_rule._compute_base_price(*args, **kwargs)
+        return pricelist_item._compute_base_price(*args, **kwargs)
 
     @api.model
     def _is_discount_feature_enabled(self):
@@ -574,5 +568,8 @@ class PricelistItem(models.Model):
         return superuser.has_group('sale.group_discount_per_so_line')
 
     def _show_discount(self):
-        self and self.ensure_one()
+        if not self:
+            return False
+
+        self.ensure_one()
         return self._is_discount_feature_enabled() and self.compute_price == 'percentage'

--- a/addons/sale/controllers/product_configurator.py
+++ b/addons/sale/controllers/product_configurator.py
@@ -163,7 +163,7 @@ class SaleProductConfiguratorController(Controller):
         combination = request.env['product.template.attribute.value'].browse(ptav_ids)
         product = product_template._get_variant_for_combination(combination)
 
-        return self._get_basic_product_information(
+        values = self._get_basic_product_information(
             product or product_template,
             pricelist,
             combination,
@@ -173,6 +173,9 @@ class SaleProductConfiguratorController(Controller):
             date=datetime.fromisoformat(so_date),
             **kwargs,
         )
+        # Shouldn't be sent client-side
+        values.pop('pricelist_rule_id', None)
+        return values
 
     @route(route='/sale/product_configurator/get_optional_products', type='json', auth='user')
     def sale_product_configurator_get_optional_products(
@@ -295,7 +298,7 @@ class SaleProductConfiguratorController(Controller):
         )
         product_or_template = product or product_template
 
-        return dict(
+        values = dict(
             product_tmpl_id=product_template.id,
             **self._get_basic_product_information(
                 product_or_template,
@@ -329,6 +332,9 @@ class SaleProductConfiguratorController(Controller):
             archived_combinations=attribute_exclusions['archived_combinations'],
             parent_exclusions=attribute_exclusions['parent_exclusions'],
         )
+        # Shouldn't be sent client-side
+        values.pop('pricelist_rule_id', None)
+        return values
 
     def _get_basic_product_information(self, product_or_template, pricelist, combination, **kwargs):
         """ Return basic information about a product.
@@ -362,14 +368,16 @@ class SaleProductConfiguratorController(Controller):
                 basic_information.update(
                     display_name=f"{basic_information['display_name']} ({combination_name})"
                 )
+        price, pricelist_rule_id = pricelist._get_product_price_rule(
+            product_or_template.with_context(
+                **product_or_template._get_product_price_context(combination)
+            ),
+            **kwargs,
+        )
         return dict(
             **basic_information,
-            price=pricelist._get_product_price(
-                product_or_template.with_context(
-                    **product_or_template._get_product_price_context(combination)
-                ),
-                **kwargs,
-            ),
+            price=price,
+            pricelist_rule_id=pricelist_rule_id,
         )
 
     def _get_ptav_price_extra(self, ptav, currency, date, product_or_template):

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -543,7 +543,7 @@ class SaleOrderLine(models.Model):
 
         pricelist_price = self._get_pricelist_price()
 
-        if not self.pricelist_item_id or not self.pricelist_item_id._show_discount():
+        if not self.pricelist_item_id._show_discount():
             # No pricelist rule found => no discount from pricelist
             return pricelist_price
 
@@ -621,7 +621,7 @@ class SaleOrderLine(models.Model):
 
             line.discount = 0.0
 
-            if not (line.pricelist_item_id and line.pricelist_item_id._show_discount()):
+            if not line.pricelist_item_id._show_discount():
                 # No pricelist rule was found for the product
                 # therefore, the pricelist didn't apply any discount/change
                 # to the existing sales price.

--- a/addons/website_sale/controllers/product_configurator.py
+++ b/addons/website_sale/controllers/product_configurator.py
@@ -217,7 +217,8 @@ class WebsiteSaleProductConfiguratorController(SaleProductConfiguratorController
                 ),
                 currency,
                 date,
-                price,
+                basic_product_information['price'],
+                basic_product_information['pricelist_rule_id'],
             ) if 'price_info' not in basic_product_information else None
             if strikethrough_price:
                 basic_product_information['strikethrough_price'] = strikethrough_price
@@ -242,7 +243,7 @@ class WebsiteSaleProductConfiguratorController(SaleProductConfiguratorController
             return self._apply_taxes_to_price(price_extra, product_or_template, currency)
         return price_extra
 
-    def _get_strikethrough_price(self, product_or_template, currency, date, price):
+    def _get_strikethrough_price(self, product_or_template, currency, date, price, pricelist_rule_id=None):
         """ Return the strikethrough price of the product, if there is one.
 
         :param recordset product_or_template: The product for which to compute the strikethrough
@@ -255,18 +256,25 @@ class WebsiteSaleProductConfiguratorController(SaleProductConfiguratorController
         :rtype: float|None
         :return: The strikethrough price of the product, if there is one.
         """
+        pricelist_rule = request.env['product.pricelist.item'].browse(pricelist_rule_id)
+
         # First, try to use the base price as the strikethrough price.
         # Apply taxes before comparing it to the actual price.
-        base_price = self._apply_taxes_to_price(
-            request.env['product.pricelist.item']._compute_base_price(
-                product_or_template, 1.0, product_or_template.uom_id, date, currency
-            ),
-            product_or_template,
-            currency,
-        )
-        # Only show the base price if it's greater than the actual price.
-        if currency.compare_amounts(base_price, price) == 1:
-            return base_price
+        if pricelist_rule._show_discount_on_shop():
+            pricelist_base_price = self._apply_taxes_to_price(
+                pricelist_rule._compute_price_before_discount(
+                    product_or_template,
+                    1.0,
+                    product_or_template.uom_id,
+                    date,
+                    currency,
+                ),
+                product_or_template,
+                currency,
+            )
+            # Only show the base price if it's greater than the actual price.
+            if currency.compare_amounts(pricelist_base_price, price) == 1:
+                return pricelist_base_price
 
         # Second, try to use `compare_list_price` as the strikethrough price.
         # Don't apply taxes since this price should always be displayed as is.

--- a/addons/website_sale/models/__init__.py
+++ b/addons/website_sale/models/__init__.py
@@ -10,6 +10,7 @@ from . import product_attribute
 from . import product_document
 from . import product_image
 from . import product_pricelist
+from . import product_pricelist_item
 from . import product_product
 from . import product_public_category
 from . import product_ribbon

--- a/addons/website_sale/models/product_pricelist_item.py
+++ b/addons/website_sale/models/product_pricelist_item.py
@@ -1,0 +1,23 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class ProductPricelistItem(models.Model):
+    _inherit = 'product.pricelist.item'
+
+    def _show_discount_on_shop(self):
+        """On ecommerce, formula rules are also expected to show discounts.
+
+        Only for /shop, /product, and configurators, not on the cart or the checkout.
+        """
+        if not self:
+            return False
+
+        self.ensure_one()
+
+        return self.compute_price == 'percentage' or (
+            self.compute_price == 'formula'
+            and self.price_discount
+            and self.base in ('list_price', 'pricelist')
+        )

--- a/addons/website_sale/models/sale_order_line.py
+++ b/addons/website_sale/models/sale_order_line.py
@@ -24,22 +24,6 @@ class SaleOrderLine(models.Model):
     def get_description_following_lines(self):
         return self.name.splitlines()[1:]
 
-    def _get_pricelist_price_before_discount(self):
-        """On ecommerce orders, the base price must always be the sales price."""
-        self.ensure_one()
-        self.product_id.ensure_one()
-
-        if self.order_id.website_id:
-            return self.env['product.pricelist.item']._compute_price_before_discount(
-                product=self.product_id.with_context(**self._get_product_price_context()),
-                quantity=self.product_uom_qty or 1.0,
-                uom=self.product_uom,
-                date=self.order_id.date_order,
-                currency=self.currency_id,
-            )
-
-        return super()._get_pricelist_price_before_discount()
-
     def _get_shop_warning(self, clear=True):
         self.ensure_one()
         warn = self.shop_warning

--- a/addons/website_sale/tests/test_website_sale_configurator.py
+++ b/addons/website_sale/tests/test_website_sale_configurator.py
@@ -279,7 +279,8 @@ class TestWebsiteSaleProductConfigurator(TestProductConfiguratorCommon, HttpCase
             'item_ids': [
                 Command.create({
                     'applied_on': "1_product",
-                    'fixed_price': 50,
+                    'percent_price': 50,
+                    'compute_price': 'percentage',
                     'product_tmpl_id': main_product.id,
                 }),
             ],

--- a/addons/website_sale/tests/test_website_sale_pricelist.py
+++ b/addons/website_sale/tests/test_website_sale_pricelist.py
@@ -358,8 +358,8 @@ class TestWebsitePriceList(WebsiteSaleCommon):
         })
         self.pricelist.write({
             'item_ids': [Command.create({
-                'price_discount': 20,
-                'compute_price': 'formula',
+                'percent_price': 20,
+                'compute_price': 'percentage',
                 'product_tmpl_id': product_tmpl.id,
             })],
         })

--- a/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
+++ b/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
@@ -26,8 +26,8 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
             'currency_id': self.other_currency.id,
             'company_id': self.env.company.id,
             'item_ids': [Command.create({
-                'price_discount': 10,
-                'compute_price': 'formula',
+                'percent_price': 10,
+                'compute_price': 'percentage',
             })],
         })
 
@@ -115,7 +115,7 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
 
         combination_info = product._get_combination_info()
         self.assertEqual(combination_info['price'], 575, "500$ + 15% tax")
-        self.assertEqual(combination_info['list_price'], 2530, "500$ + 15% tax (2)")
+        self.assertEqual(combination_info['list_price'], 575, "500$ + 15% tax (2)")
         self.assertEqual(combination_info['price_extra'], 230, "200$ + 15% tax")
 
         # Setup fiscal position 15% => 0%.
@@ -136,7 +136,7 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
         website.invalidate_recordset(['fiscal_position_id'])
         combination_info = product._get_combination_info()
         self.assertEqual(combination_info['price'], 500, "500% + 0% tax (mapped from fp 15% -> 0%)")
-        self.assertEqual(combination_info['list_price'], 2200, "500% + 0% tax (mapped from fp 15% -> 0%)")
+        self.assertEqual(combination_info['list_price'], 500, "500% + 0% tax (mapped from fp 15% -> 0%)")
         self.assertEqual(combination_info['price_extra'], 200, "200% + 0% tax (mapped from fp 15% -> 0%)")
 
         # Try same flow with tax included
@@ -147,7 +147,7 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
         website.invalidate_recordset(['fiscal_position_id'])
         combination_info = product._get_combination_info()
         self.assertEqual(combination_info['price'], 500, "434.78$ + 15% tax")
-        self.assertEqual(combination_info['list_price'], 2200, "434.78$ + 15% tax (2)")
+        self.assertEqual(combination_info['list_price'], 500, "434.78$ + 15% tax (2)")
         self.assertEqual(combination_info['price_extra'], 200, "173.91$ + 15% tax")
 
         # Now with fiscal position, taxes should be mapped
@@ -155,12 +155,12 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
         website.invalidate_recordset(['fiscal_position_id'])
         combination_info = product._get_combination_info()
         self.assertEqual(round(combination_info['price'], 2), 434.78, "434.78$ + 0% tax (mapped from fp 15% -> 0%)")
-        self.assertEqual(round(combination_info['list_price'], 2), 1913.04, "434.78$ + 0% tax (mapped from fp 15% -> 0%)")
+        self.assertEqual(round(combination_info['list_price'], 2), 434.78, "434.78$ + 0% tax (mapped from fp 15% -> 0%)")
         self.assertEqual(combination_info['price_extra'], 173.91, "173.91$ + 0% tax (mapped from fp 15% -> 0%)")
 
         # Try same flow with tax included for apply tax
         tax0.write({'name': "Test tax 5", 'amount': 5, 'price_include': True})
         combination_info = product._get_combination_info()
         self.assertEqual(round(combination_info['price'], 2), 456.52, "434.78$ + 5% tax (mapped from fp 15% -> 5% for BE)")
-        self.assertEqual(round(combination_info['list_price'], 2), 2008.7, "434.78$ + 5% tax (mapped from fp 15% -> 5% for BE)")
+        self.assertEqual(round(combination_info['list_price'], 2), 456.52, "434.78$ + 5% tax (mapped from fp 15% -> 5% for BE)")
         self.assertEqual(combination_info['price_extra'], 182.61, "173.91$ + 5% tax (mapped from fp 15% -> 5% for BE)")

--- a/addons/website_sale/tests/test_website_sale_show_compare_list_price.py
+++ b/addons/website_sale/tests/test_website_sale_show_compare_list_price.py
@@ -75,8 +75,8 @@ class WebsiteSaleShopPriceListCompareListPriceDispayTests(AccountTestInvoicingHt
                 Command.create({
                     'applied_on': '1_product',
                     'product_tmpl_id': cls.test_product_with_pricelist_and_compare_list_price.id,
-                    'compute_price': 'fixed',
-                    'fixed_price': 3500,
+                    'compute_price': 'percentage',
+                    'percent_price': 12.5,
                 })
             ]
         })
@@ -90,14 +90,14 @@ class WebsiteSaleShopPriceListCompareListPriceDispayTests(AccountTestInvoicingHt
                 Command.create({
                     'applied_on': '1_product',
                     'product_tmpl_id': cls.test_product_with_pricelist.id,
-                    'compute_price': 'fixed',
-                    'fixed_price': 1500,
+                    'compute_price': 'percentage',
+                    'percent_price': 25,
                 }),
                 Command.create({
                     'applied_on': '1_product',
                     'product_tmpl_id': cls.test_product_with_pricelist_and_compare_list_price.id,
-                    'compute_price': 'fixed',
-                    'fixed_price': 3500,
+                    'compute_price': 'percentage',
+                    'percent_price': 12.5,
                 })
             ]
         })


### PR DESCRIPTION
**Steps:**
- Create a new pricelist
- Apply pricelist rules
- For eg: Apply it on Acoustic Bloc Screen, with a fixed price of 20.
- When seen on the shop page or product page, it shows a strikethrough price
along with the original price
- Same happens when we use formula instead of fixed price.

**Changes:**
Changed some test cases because currently, the pricelist had fixed price
which was causing the strikethrough to not appear. But due to the code
change, it will now not appear, hence giving the percentage price to the
tour to run it smoothly.

**Before this commit:**
The strikethrough prices on the shop page were shown for all the pricelist rules

**After this commit:**
The strikethrough prices are now shown everywhere only if the pricelist rule is a 'discount'.
Formula based discount rules strikethrough prices are also displayed on the shop/configurator and product pages, but not on the cart and subsequent steps of the checkout to allow customer to apply discounts while still keeping 'beautiful' prices.

**Affected version:** saas-17.4~master
opw-4181825