### PR TITLE
[FIX] point_of_sale: handle missing session_id on order sync

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -18,6 +18,10 @@ export class PosOrder extends Base {
     setup(vals) {
         super.setup(vals);
 
+        if (!this.session_id && !this.finalized) {
+            this.update({ session_id: this.session });
+        }
+
         // Data present in python model
         this.date_order = vals.date_order || serializeDateTime(luxon.DateTime.now());
         this.to_invoice = vals.to_invoice || false;


### PR DESCRIPTION
Before this commit, attempting to sync a paid order that had not been previously synced in a newly opened session would result in an error due to the absence of the `session_id`.

opw-4182909

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
