### PR TITLE
[FIX] mail: notification settings menu width

### DIFF
--- a/addons/mail/static/src/discuss/core/common/notification_settings.xml
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.NotificationSettings">
-        <ActionPanel title.translate="Notification Settings" icon="'fa fa-bell'">
+        <ActionPanel title.translate="Notification Settings" resizable="false" icon="'fa fa-bell'">
             <div class="o-discuss-NotificationSettings">
                 <div t-if="store.settings.mute_until_dt" class="d-flex flex-column alert alert-warning">
                     <span><i class="fa fa-exclamation-triangle"/> <a href="#" t-on-click="onClickServerMuted">Server is muted</a></span>


### PR DESCRIPTION
**Current behavior before PR:**

Notification Settings menu was using `Resizable`, which was unnecessary for a component that doesn't need resizing. It also took up more space than required.

**Desired behavior after PR is merged:**

Made the Notification Settings menu non-resizable, optimizing space usage.

![Before](https://github.com/user-attachments/assets/09938348-95e4-4861-9a8e-87401b978f2a) ![image](https://github.com/user-attachments/assets/98b0e517-bdea-46c6-9cce-6fd7d22a14eb)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
