### PR TITLE
[REF] gamification,hr_holidays: kanban: use correct t-att

### DIFF
--- a/addons/gamification/views/gamification_badge_user_views.xml
+++ b/addons/gamification/views/gamification_badge_user_views.xml
@@ -10,10 +10,10 @@
                 <templates>
                     <t t-name="kanban-card" class="row g-0">
                         <aside class="col-2">
-                            <field name="badge_id" widget="image" options="{'preview_image': 'image_1024'}" t-att-title="badge_name" t-att-alt="badge_name" />
+                            <field name="badge_id" widget="image" options="{'preview_image': 'image_1024'}" t-att-alt="record.badge_name.value" />
                         </aside>
                         <main class="col ps-2">
-                            <field class="fw-bold fs-5 mt0 mb0" type="open" name="badge_name"/>
+                            <field class="fw-bold fs-5" type="open" name="badge_name"/>
                             <field name="comment"/>
                             <p>Granted by <field name="create_uid" /> the <t t-esc="luxon.DateTime.fromISO(record.create_date.raw_value).toFormat('D')" /></p>
                         </main>

--- a/addons/gamification/views/gamification_badge_views.xml
+++ b/addons/gamification/views/gamification_badge_views.xml
@@ -118,11 +118,11 @@
                 <templates>
                     <t t-name="kanban-card" class="row g-0">
                         <aside class="col-2">
-                            <field name="image_1024" widget="image" t-att-title="name" t-att-alt="name"/>
+                            <field name="image_1024" widget="image" t-att-alt="record.name.value"/>
                         </aside>
                         <main class="col ps-2">
                             <span>
-                                <field class="fw-bold fs-5" name="name"/>
+                                <field class="fw-bold fs-5 me-1" name="name"/>
                                 <t t-if="record.remaining_sending.value != -1">
                                     <field name="stat_my_monthly_sending"/>/<field name="rule_max_number"/>
                                 </t>

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -173,8 +173,6 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='number_of_days']/../.." position='before'>
                 <field name="employee_id" widget="image" options="{'preview_image': 'avatar_128'}"
-                    t-att-title="record.employee_id.value"
-                    t-att-alt="record.employee_id.value"
                     class="o_image_64_cover float-start me-2 col-3"/>
             </xpath>
             <xpath expr="//field[@name='name']" position="replace"/>


### PR DESCRIPTION
This commit is a followup of task~3992107. It removes unnecessary attrs spotted while browsing through those simplified archs. Indeed, the image widget automatically sets the display_name as `alt` when set on a many2one field. For the `t-att-title`, it is not supported on image fields, but it wasn't really necessary where we removed it as the same field is displayed as title of the card anyway.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
