### PR TITLE
[FIX] product: fix traceback when user searches product in optional product

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import copy
 import itertools
 import logging
 from collections import defaultdict
@@ -538,7 +539,7 @@ class ProductTemplate(models.Model):
         Product = self.env['product.product']
         templates = self.browse()
 
-        product_domain = domain.copy()
+        product_domain = copy.deepcopy(domain)
         if search_pp:
             for term in product_domain:  # Replace id related leaf to product_tmpl_id
                 if term[0] == 'id':


### PR DESCRIPTION
Currently, a traceback will occur when the user tries to give a value in the optional product.

Error:-
```
 Invalid field product.template.product_tmpl_id in leaf ('product_tmpl_id', '!=', 6043)
```


This is because of the changes from the commit:-
https://github.com/odoo/odoo/pull/111575/commits/6fce58ead5185157339e98d7281ab338d38560ed

Here product_domain is getting the value from domain.copy().

```
We know that in python list, copy() creates a reference to the original object. 
If you change the copied object - you change the original object
```

https://github.com/odoo/odoo/blob/0faca9ff9e1f35d5ed863d7daf61b71217015b01/addons/product/models/product_template.py#L541-L545

which means if we change the value of `product_domain` the value of the `domain` will also change.

So the domain will contain `product_tmpl_id` instead of `id` 
and it leads to a traceback when searching `product_tmpl_id` from `product.template`.

sentry-5804120310