### PR TITLE
[FIX] sale_pdf_quote_builder: prevent error when upload pdf for quotation header

### DIFF
--- a/addons/sale_pdf_quote_builder/i18n/sale_pdf_quote_builder.pot
+++ b/addons/sale_pdf_quote_builder/i18n/sale_pdf_quote_builder.pot
@@ -52,6 +52,13 @@ msgid "Config Settings"
 msgstr ""
 
 #. module: sale_pdf_quote_builder
+#. odoo-python
+#: code:addons/sale_pdf_quote_builder/utils.py:0
+#, python-format
+msgid "Error when reading the pdf file: %s"
+msgstr ""
+
+#. module: sale_pdf_quote_builder
 #: model:ir.model.fields,field_description:sale_pdf_quote_builder.field_res_company__sale_footer
 #: model:ir.model.fields,field_description:sale_pdf_quote_builder.field_res_config_settings__sale_footer
 #: model:ir.model.fields,field_description:sale_pdf_quote_builder.field_sale_order_template__sale_footer

--- a/addons/sale_pdf_quote_builder/utils.py
+++ b/addons/sale_pdf_quote_builder/utils.py
@@ -6,9 +6,18 @@ from odoo import _
 from odoo.exceptions import ValidationError
 from odoo.tools import pdf
 
+try:
+    from PyPDF2.errors import PdfReadError
+except ImportError:
+    from PyPDF2.utils import PdfReadError
+
 
 def _ensure_document_not_encrypted(document):
-    if pdf.PdfFileReader(io.BytesIO(document), strict=False).isEncrypted:
+    try:
+        pdf_reader = pdf.PdfFileReader(io.BytesIO(document), strict=False)
+    except PdfReadError as e:
+        raise ValidationError(_('Error when reading the pdf file: %s', e))
+    if pdf_reader.isEncrypted:
         raise ValidationError(_(
             "It seems that we're not able to process this pdf inside a quotation. It is either "
             "encrypted, or encoded in a format we do not support."


### PR DESCRIPTION
Currently, an error occurs when uploading an invalid PDF as a quotation header pages.

Step to produce:

- Install the 'sale_pdf_quote_builder' module.
- Open a sales configuration, And unload an invalid pdf file as a 'Header pages' in the 'Quotations & Orders' section

```PdfReadError:EOF marker not found```

An error occurs when the system tries to read file content through the PDF file reader at [1]. But it is invalid.

Link [1]: https://github.com/odoo/odoo/blob/32c521820e77f67966fa71c7ecabde09d2ab27d4/addons/sale_pdf_quote_builder/utils.py#L11

To handle this issue, Add a try-except block to ensure that if an error occurs during the pdf file read it raises a validation error.

Sentry-5879869841

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
