### PR TITLE
[FIX] hr: fix traceback in department kanban view

### DIFF
--- a/addons/hr/models/hr_department.py
+++ b/addons/hr/models/hr_department.py
@@ -161,7 +161,7 @@ class Department(models.Model):
             'name': _("Employees"),
             'type': 'ir.actions.act_window',
             'res_model': res_model,
-            'view_mode': 'tree,kanban,form',
+            'view_mode': 'list,kanban,form',
             'search_view_id': [search_view_id, 'search'],
             'context': {
                 'searchpanel_default_department_id': self.id,

--- a/addons/hr_skills/report/hr_employee_skill_report_views.xml
+++ b/addons/hr_skills/report/hr_employee_skill_report_views.xml
@@ -81,7 +81,7 @@
     <record id="action_hr_employee_skill_log_department" model="ir.actions.act_window">
         <field name="name">Skill History Report</field>
         <field name="res_model">hr.employee.skill.report</field>
-        <field name="view_mode">graph,pivot,tree</field>
+        <field name="view_mode">graph,pivot,list</field>
         <field name="context">{'fill_temporal': 0, 'search_default_group_by_skill_type_id': 1, 'search_default_group_by_skill_id': 2}</field>
         <field name="target">current</field>
     </record>


### PR DESCRIPTION
Steps:
- Install the hr and hr_skills module
- open department kanban view
- Click on the Employees button or skills history from the three-dot menu.

##

Description of the issue/feature this PR addresses:
In the HR module, clicking the Employees button or selecting skills history from the department kanban view triggers a traceback error.

##

Cause
The error is caused by the action passing the wrong view mode. Instead of using the 'list' view, it  passes the 'tree' view, leading to the traceback.

##

Fix:
This PR fixes the issue by changing the view mode from 'tree' to 'list'.

task-4203028