### PR TITLE
[ADD] l10n_ec_sale: set default payment method(SRI) in SO/Subscription and propagate to Invoice

### DIFF
--- a/addons/l10n_ec/data/l10n_ec.sri.payment.csv
+++ b/addons/l10n_ec/data/l10n_ec.sri.payment.csv
@@ -1,9 +1,9 @@
-id,code,name,active
-P1,01,No use of the financial system,1
-P15,15,Offset of Debts,1
-P16,16,Debit Card,1
-P17,17,Electronic Cash,0
-P18,18,Prepaid Card,0
-P19,19,Credit Card,1
-P20,20,Others with use of the financial system,1
-P21,21,Endorsement of Securities,0
+id,sequence,code,name,active
+P1,10,01,No use of the financial system,1
+P15,10,15,Offset of Debts,1
+P16,10,16,Debit Card,1
+P17,10,17,Electronic Cash,0
+P18,10,18,Prepaid Card,0
+P19,10,19,Credit Card,1
+P20,10,20,Others with use of the financial system,1
+P21,10,21,Endorsement of Securities,0

--- a/addons/l10n_ec/models/account_move.py
+++ b/addons/l10n_ec/models/account_move.py
@@ -134,6 +134,7 @@ class AccountMove(models.Model):
         comodel_name="l10n_ec.sri.payment",
         string="Payment Method (SRI)",
         help="Ecuador: Payment Methods Defined by the SRI.",
+        default=lambda self: self.env['l10n_ec.sri.payment'].search([], limit=1),
     )
 
     @api.model

--- a/addons/l10n_ec/models/l10n_ec_sri_payment.py
+++ b/addons/l10n_ec/models/l10n_ec_sri_payment.py
@@ -8,7 +8,9 @@ class SriPayment(models.Model):
 
     _name = "l10n_ec.sri.payment"
     _description = "SRI Payment Method"
+    _order = "sequence, id"
 
+    sequence = fields.Integer("Sequence", default=10)
     name = fields.Char("Name", translate=True)
     code = fields.Char("Code")
     active = fields.Boolean("Active", default=True)

--- a/addons/l10n_ec/views/l10n_ec_sri_payment.xml
+++ b/addons/l10n_ec/views/l10n_ec_sri_payment.xml
@@ -24,6 +24,7 @@
         <field name="type">list</field>
         <field name="arch" type="xml">
             <list string="Payment Method" create="0" edit="0">
+                <field name="sequence" widget="handle"/>
                 <field name="code"/>
                 <field name="name"/>
                 <field name="active" widget="boolean_toggle"/>

--- a/addons/l10n_ec_sale/__init__.py
+++ b/addons/l10n_ec_sale/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/l10n_ec_sale/__manifest__.py
+++ b/addons/l10n_ec_sale/__manifest__.py
@@ -1,0 +1,17 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'Ecuador - Sale',
+    'version': '1.0',
+    'description': """Ecuador Sale""",
+    'category': 'Accounting/Localizations/Sale',
+    'depends': [
+        'l10n_ec',
+        'sale',
+    ],
+    'data': [
+        'views/sale_views.xml',
+    ],
+    'auto_install': True,
+    'license': 'LGPL-3',
+}

--- a/addons/l10n_ec_sale/i18n/l10n_ec_sale.pot
+++ b/addons/l10n_ec_sale/i18n/l10n_ec_sale.pot
@@ -1,0 +1,31 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_ec_sale
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.1alpha1+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-10-08 09:58+0000\n"
+"PO-Revision-Date: 2024-10-08 09:58+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_ec_sale
+#: model:ir.model.fields,help:l10n_ec_sale.field_sale_order__l10n_ec_sri_payment_id
+msgid "Ecuador: Payment Methods Defined by the SRI."
+msgstr ""
+
+#. module: l10n_ec_sale
+#: model:ir.model.fields,field_description:l10n_ec_sale.field_sale_order__l10n_ec_sri_payment_id
+msgid "Payment Method (SRI)"
+msgstr ""
+
+#. module: l10n_ec_sale
+#: model:ir.model,name:l10n_ec_sale.model_sale_order
+msgid "Sales Order"
+msgstr ""

--- a/addons/l10n_ec_sale/models/__init__.py
+++ b/addons/l10n_ec_sale/models/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import sale_order

--- a/addons/l10n_ec_sale/models/sale_order.py
+++ b/addons/l10n_ec_sale/models/sale_order.py
@@ -1,0 +1,18 @@
+from odoo import fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    l10n_ec_sri_payment_id = fields.Many2one(
+        comodel_name="l10n_ec.sri.payment",
+        string="Payment Method (SRI)",
+        help="Ecuador: Payment Methods Defined by the SRI.",
+        default=lambda self: self.env['l10n_ec.sri.payment'].search([], limit=1),
+    )
+
+    def _prepare_invoice(self):
+        res = super()._prepare_invoice()
+        if self.country_code == 'EC':
+            res['l10n_ec_sri_payment_id'] = self.l10n_ec_sri_payment_id.id
+        return res

--- a/addons/l10n_ec_sale/tests/__init__.py
+++ b/addons/l10n_ec_sale/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_l10n_ec_account_sale

--- a/addons/l10n_ec_sale/tests/test_l10n_ec_account_sale.py
+++ b/addons/l10n_ec_sale/tests/test_l10n_ec_account_sale.py
@@ -1,0 +1,66 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.fields import Command
+from odoo.tests import tagged
+
+from odoo.addons.sale.tests.common import TestSaleCommon
+
+
+@tagged('post_install_l10n', '-at_install', 'post_install')
+class TestL10nECAccountSale(TestSaleCommon):
+
+    @classmethod
+    @TestSaleCommon.setup_country('ec')
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.sri_payment_method = cls.env['l10n_ec.sri.payment'].create({
+            'name': 'new sri',
+            'active': True,
+            'code': 'new',
+        })
+        cls.sale_order = cls.env['sale.order'].create({
+            'partner_id': cls.partner_a.id,
+            'partner_invoice_id': cls.partner_a.id,
+            'partner_shipping_id': cls.partner_a.id,
+            'pricelist_id': cls.company_data['default_pricelist'].id,
+            'order_line': [
+                Command.create({
+                    'product_id': cls.company_data['product_order_no'].id,
+                    'product_uom_qty': 5,
+                    'tax_id': False,
+                }),
+            ]
+        })
+
+        cls.context = {
+            'active_model': 'sale.order',
+            'active_ids': [cls.sale_order.id],
+            'active_id': cls.sale_order.id,
+            'default_journal_id': cls.company_data['default_journal_sale'].id,
+        }
+
+    def test_create_sale_order_with_default_sri_payment(self):
+        first_sri_payment_method = self.env['l10n_ec.sri.payment'].search([], limit=1)
+
+        self.assertEqual(self.sale_order.l10n_ec_sri_payment_id, first_sri_payment_method)
+
+        # Set sri payment method with sequence less than first one
+        self.sri_payment_method.sequence = first_sri_payment_method.sequence - 1
+
+        new_sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'partner_invoice_id': self.partner_a.id,
+            'partner_shipping_id': self.partner_a.id,
+            'pricelist_id': self.company_data['default_pricelist'].id,
+        })
+        self.assertEqual(new_sale_order.l10n_ec_sri_payment_id, self.sri_payment_method)
+
+    def test_propagate_sri_payment_to_invoice(self):
+        self.sale_order.l10n_ec_sri_payment_id = self.sri_payment_method.id
+        self.sale_order.action_confirm()
+        payment = self.env['sale.advance.payment.inv'].with_context(self.context).create({
+            'advance_payment_method': 'delivered',
+        })
+        payment.create_invoices()
+        invoice = self.sale_order.invoice_ids
+        self.assertEqual(self.sale_order.l10n_ec_sri_payment_id, invoice.l10n_ec_sri_payment_id)

--- a/addons/l10n_ec_sale/views/sale_views.xml
+++ b/addons/l10n_ec_sale/views/sale_views.xml
@@ -1,0 +1,12 @@
+<odoo>
+    <record id="view_order_form_inherit_l10n_ec_sale" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit.l10n_ec_sale</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='journal_id']" position="after">
+                <field name="l10n_ec_sri_payment_id" invisible="country_code != 'EC'"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_ec_website_sale/__manifest__.py
+++ b/addons/l10n_ec_website_sale/__manifest__.py
@@ -6,7 +6,7 @@
     'description': """Make ecommerce work for Ecuador.""",
     'depends': [
         'website_sale',
-        'l10n_ec',
+        'l10n_ec_sale',
     ],
     'data': [
         'data/ir_model_fields.xml',


### PR DESCRIPTION
Added sequence to l10n_ec.sri.payment to allow users to select the default to be picked in SO by setting it to be the first in the list then this value is carried over to the invoice.

related: https://github.com/odoo/enterprise/pull/71437

task-4107994

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
