### PR TITLE
[FIX] project: allow upload on editing a message in project sharing

### DIFF
--- a/addons/project/static/src/project_sharing/chatter/composer_patch.js
+++ b/addons/project/static/src/project_sharing/chatter/composer_patch.js
@@ -12,10 +12,16 @@ patch(Composer.prototype, {
     },
 
     get isSendButtonDisabled() {
-        return !this.thread?.id || super.isSendButtonDisabled;
+        if (this.thread && !this.thread.id) {
+            return true;
+        }
+        return super.isSendButtonDisabled;
     },
 
     get allowUpload() {
-        return this.thread?.id && super.allowUpload;
+        if (this.thread && !this.thread.id) {
+            return false;
+        }
+        return super.allowUpload;
     },
 });


### PR DESCRIPTION
Overriding `allowUpload` in project sharing only takes into account that the attachment uploader icon is available in the main composer in the chatter. While it's possible to edit a message directly by clicking the edit icon in message actions. 
This fix also allows the attachment uploader icon to be displayed in the editing composer.

The same logic could be applied to `isSendButtonDisabled`.