### PR TITLE
[FIX] mail: chat window composer actions aligned

### DIFF
--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -30,6 +30,10 @@
     .o-mail-Composer-footer {
         grid-area: core-footer;
     }
+
+    &.o-chatWindow .o-mail-Composer-mainActions {
+        margin-top: map-get($spacers, 1) / 2;
+    }
 }
 
 .o-mail-Composer-actions {

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -78,7 +78,7 @@
                             'rounded': !props.composer.message,
                         }"
                     >
-                        <div class="d-flex flex-grow-1 align-items-baseline" t-att-class="{ 'mt-1': !props.composer.message and !env.inChatWindow }" t-ref="main-actions">
+                        <div class="o-mail-Composer-mainActions d-flex flex-grow-1 align-items-baseline" t-att-class="{ 'mt-1': !props.composer.message and !env.inChatWindow }" t-ref="main-actions">
                             <button class="btn border-0 p-1 rounded-pill" t-att-class="{'bg-300': this.picker.state.picker === this.picker.PICKERS.EMOJI}" aria-label="Emojis" t-on-click="onClickAddEmoji" t-ref="emoji-button"><i class="fa fa-fw fa-smile-o"/></button>
                             <FileUploader t-if="allowUpload" multiUpload="true" onUploaded.bind="(data) => { attachmentUploader.uploadData(data) }">
                                 <t t-set-slot="toggler">


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/180920/files

Composer default height has reduced in chat window. Actions are aligned with actions in non-chat window thanks to `mt-1`. This is too much spacing in with chat window composer, but by having no top margin the actions are slightly too high.

This commit fixes the issue by putting in the middle of `mt-0` and `mt-1`, so that composer actions are correctly aligned with 1st line of textarea of composer in chat window.

<img width="886" alt="Screenshot 2024-09-23 at 14 04 23" src="https://github.com/user-attachments/assets/e08a947b-18b0-4a6b-bf7e-8a13d2a3f227">
<img width="886" alt="Screenshot 2024-09-23 at 14 04 23 copy" src="https://github.com/user-attachments/assets/4df30fb4-14b5-4131-bdf5-bcbe00c7f7a7">
