### PR TITLE
[FIX] web: kanban: keep kanban-menu backward compatibility

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_arch_parser.js
+++ b/addons/web/static/src/views/kanban/kanban_arch_parser.js
@@ -22,7 +22,8 @@ import { Widget } from "@web/views/widgets/widget";
  * fields within all roots to avoid inconsistencies.
  */
 
-export const KANBAN_BOX_ATTRIBUTE = "kanban-box";
+export const LEGACY_KANBAN_BOX_ATTRIBUTE = "kanban-box";
+export const LEGACY_KANBAN_MENU_ATTRIBUTE = "kanban-menu";
 export const KANBAN_CARD_ATTRIBUTE = "card";
 export const KANBAN_MENU_ATTRIBUTE = "menu";
 
@@ -152,7 +153,7 @@ export class KanbanArchParser {
             console.warn("'kanban-box' is deprecated, use 'kanban-card' API instead");
         }
         if (!cardDoc) {
-            cardDoc = templateDocs[KANBAN_BOX_ATTRIBUTE];
+            cardDoc = templateDocs[LEGACY_KANBAN_BOX_ATTRIBUTE];
             if (!cardDoc) {
                 throw new Error(`Missing '${KANBAN_CARD_ATTRIBUTE}' template.`);
             }

--- a/addons/web/static/src/views/kanban/kanban_color_picker_legacy.js
+++ b/addons/web/static/src/views/kanban/kanban_color_picker_legacy.js
@@ -2,7 +2,7 @@ import { ColorList } from "@web/core/colorlist/colorlist";
 import { patch } from "@web/core/utils/patch";
 import { createElement } from "@web/core/utils/xml";
 
-import { KANBAN_BOX_ATTRIBUTE, KanbanArchParser } from "./kanban_arch_parser";
+import { LEGACY_KANBAN_BOX_ATTRIBUTE, KanbanArchParser } from "./kanban_arch_parser";
 import { KanbanCompiler } from "./kanban_compiler";
 import { KanbanRecord, getColorIndex } from "./kanban_record";
 
@@ -13,7 +13,7 @@ patch(KanbanArchParser.prototype, {
         const archInfo = super.parse(xmlDoc, models, modelName);
 
         // Color and color picker (first node found is taken for each)
-        const legacyCardDoc = archInfo.templateDocs[KANBAN_BOX_ATTRIBUTE];
+        const legacyCardDoc = archInfo.templateDocs[LEGACY_KANBAN_BOX_ATTRIBUTE];
         if (legacyCardDoc) {
             const cardColorEl = legacyCardDoc.querySelector("[color]");
             const cardColorField = cardColorEl && cardColorEl.getAttribute("color");

--- a/addons/web/static/src/views/kanban/kanban_record.js
+++ b/addons/web/static/src/views/kanban/kanban_record.js
@@ -15,7 +15,8 @@ import { useViewCompiler } from "@web/views/view_compiler";
 import { Widget } from "@web/views/widgets/widget";
 import { getFormattedValue } from "../utils";
 import {
-    KANBAN_BOX_ATTRIBUTE,
+    LEGACY_KANBAN_BOX_ATTRIBUTE,
+    LEGACY_KANBAN_MENU_ATTRIBUTE,
     KANBAN_CARD_ATTRIBUTE,
     KANBAN_MENU_ATTRIBUTE,
 } from "./kanban_arch_parser";
@@ -191,7 +192,8 @@ export class KanbanRecord extends Component {
         "progressBarState?",
     ];
     static Compiler = KanbanCompiler;
-    static KANBAN_BOX_ATTRIBUTE = KANBAN_BOX_ATTRIBUTE;
+    static LEGACY_KANBAN_BOX_ATTRIBUTE = LEGACY_KANBAN_BOX_ATTRIBUTE;
+    static LEGACY_KANBAN_MENU_ATTRIBUTE = LEGACY_KANBAN_MENU_ATTRIBUTE;
     static KANBAN_CARD_ATTRIBUTE = KANBAN_CARD_ATTRIBUTE;
     static KANBAN_MENU_ATTRIBUTE = KANBAN_MENU_ATTRIBUTE;
     static menuTemplate = "web.KanbanRecordMenu";
@@ -208,9 +210,10 @@ export class KanbanRecord extends Component {
 
         this.templates = useViewCompiler(ViewCompiler, templates);
 
-        if (this.constructor.KANBAN_MENU_ATTRIBUTE in templates) {
-            this.showMenu = true;
-        }
+        this.menuTemplateName = this.props.archInfo.isLegacyArch
+            ? this.constructor.LEGACY_KANBAN_MENU_ATTRIBUTE
+            : this.constructor.KANBAN_MENU_ATTRIBUTE;
+        this.showMenu = this.menuTemplateName in templates;
 
         this.dataState = useState({ record: {}, widget: {} });
         this.createWidget(this.props);
@@ -369,7 +372,7 @@ export class KanbanRecord extends Component {
 
     get mainTemplate() {
         return this.props.archInfo.isLegacyArch
-            ? this.templates[this.constructor.KANBAN_BOX_ATTRIBUTE]
+            ? this.templates[this.constructor.LEGACY_KANBAN_BOX_ATTRIBUTE]
             : this.templates[this.constructor.KANBAN_CARD_ATTRIBUTE];
     }
 

--- a/addons/web/static/src/views/kanban/kanban_record.xml
+++ b/addons/web/static/src/views/kanban/kanban_record.xml
@@ -21,7 +21,7 @@
                 </button>
                 <t t-set-slot="content">
                     <KanbanDropdownMenuWrapper>
-                        <t t-call="{{ templates[this.constructor.KANBAN_MENU_ATTRIBUTE] }}" t-call-context="renderingContext"/>
+                        <t t-call="{{ templates[this.menuTemplateName] }}" t-call-context="renderingContext"/>
                     </KanbanDropdownMenuWrapper>
                 </t>
             </Dropdown>

--- a/addons/web/static/tests/views/kanban/kanban_color_picker_legacy.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_color_picker_legacy.test.js
@@ -47,11 +47,11 @@ beforeEach(() => {
     });
 });
 
-test("oe_kanban_colorpicker in menu and kanban-box", async () => {
+test("oe_kanban_colorpicker in kanban-menu and kanban-box", async () => {
     const archInfo = parseArch(`
         <kanban>
             <templates>
-                <t t-name="menu">
+                <t t-name="kanban-menu">
                     <ul class="oe_kanban_colorpicker" data-field="kanban_menu_colorpicker" role="menu"/>
                 </t>
                 <t t-name="kanban-box"/>
@@ -65,7 +65,7 @@ test("oe_kanban_colorpicker in menu and kanban-box", async () => {
     const archInfo_1 = parseArch(`
         <kanban>
             <templates>
-                <t t-name="menu"/>
+                <t t-name="kanban-menu"/>
                 <t t-name="kanban-box">
                     <ul class="oe_kanban_colorpicker" data-field="kanban_box_color" role="menu"/>
                 </t>
@@ -92,7 +92,7 @@ test("kanban with colorpicker and node with color attribute", async () => {
             <kanban>
                 <field name="colorpickerField"/>
                 <templates>
-                    <t t-name="menu">
+                    <t t-name="kanban-menu">
                         <div class="oe_kanban_colorpicker" data-field="colorpickerField"/>
                     </t>
                     <t t-name="kanban-box">
@@ -125,7 +125,7 @@ test("edit the kanban color with the colorpicker", async () => {
             <kanban>
                 <field name="color"/>
                 <templates>
-                    <t t-name="menu">
+                    <t t-name="kanban-menu">
                         <div class="oe_kanban_colorpicker"/>
                     </t>
                     <t t-name="kanban-box">
@@ -166,7 +166,7 @@ test("colorpicker doesn't appear when missing access rights", async () => {
             <kanban edit="0">
                 <field name="color"/>
                 <templates>
-                    <t t-name="menu">
+                    <t t-name="kanban-menu">
                         <div class="oe_kanban_colorpicker"/>
                     </t>
                     <t t-name="kanban-box">

--- a/addons/web/static/tests/views/kanban/kanban_view_legacy.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view_legacy.test.js
@@ -1567,7 +1567,7 @@ test.tags("desktop")("set cover image", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="menu">
+                    <t t-name="kanban-menu">
                         <a type="set_cover" data-field="displayed_image_id" class="dropdown-item">Set Cover Image</a>
                     </t>
                     <t t-name="kanban-box">
@@ -1653,7 +1653,7 @@ test.tags("desktop")("open file explorer if no cover image", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="menu">
+                    <t t-name="kanban-menu">
                         <a type="set_cover" data-field="displayed_image_id" class="dropdown-item">Set Cover Image</a>
                     </t>
                     <t t-name="kanban-box">
@@ -1722,7 +1722,7 @@ test.tags("desktop")("unset cover image", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="menu">
+                    <t t-name="kanban-menu">
                         <a type="set_cover" data-field="displayed_image_id" class="dropdown-item">Set Cover Image</a>
                     </t>
                     <t t-name="kanban-box">


### PR DESCRIPTION
Commit [1] renamed `kanban-card` and `kanban-menu` template names into `card` and `menu`. This was meant to be done on kanban views using the new API (i.e. defining a `kanban-card` template instead of `kanban-box`), to keep backward compatibility. However, the renaming for the menu impacted both old and new API kanban views (as they both share the same template name), thus breaking legacy ones. This commit fixes the issue.

[1] odoo/odoo@233f03da5ae9c269618e6e28c775a123c0afca79

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
