### PR TITLE
[FIX] list: vectorized list cell not recognized

### DIFF
--- a/addons/spreadsheet/static/src/list/plugins/list_ui_plugin.js
+++ b/addons/spreadsheet/static/src/list/plugins/list_ui_plugin.js
@@ -289,7 +289,7 @@ export class ListUIPlugin extends OdooUIPlugin {
      * @returns {string|undefined}
      */
     getListIdFromPosition(position) {
-        const cell = this.getters.getCell(position);
+        const cell = this.getters.getCorrespondingFormulaCell(position);
         const sheetId = position.sheetId;
         if (cell && cell.isFormula) {
             const listFunction = getFirstListFunction(cell.compiledFormula.tokens);

--- a/addons/spreadsheet/static/tests/lists/list_plugin.test.js
+++ b/addons/spreadsheet/static/tests/lists/list_plugin.test.js
@@ -200,6 +200,14 @@ test("can get a listId from cell formula with other numerical values", async fun
     expect(listId).toBe("1");
 });
 
+test("can get a listId from a vectorized cell formula", async function () {
+    const { model } = await createSpreadsheetWithList();
+    const sheetId = model.getters.getActiveSheetId();
+    setCellContent(model, "G1", '=LIST(1,SEQUENCE(10),"foo")');
+    expect(model.getters.getListIdFromPosition({ sheetId, col: 0, row: 0 })).toBe("1");
+    expect(model.getters.getListIdFromPosition({ sheetId, col: 0, row: 5 })).toBe("1");
+});
+
 test("List datasource is loaded with correct linesNumber", async function () {
     const { model } = await createSpreadsheetWithList({ linesNumber: 2 });
     const [listId] = model.getters.getListIds();


### PR DESCRIPTION
With the new `SEQUENCE` function and the formula vectorization, we can write spread formulas for lists
(e.g. `=ODOO.LIST(1, SEQUENCE(5), "name")`), but the spreaded cells were not recognized as list cells. This caused issues of missing list menu items & missing highlights.

Task: [4199994](https://www.odoo.com/web#id=4199994&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
