### PR TITLE
[FIX] mail: consistent channel member list section name style

### DIFF
--- a/addons/mail/static/src/discuss/core/common/channel_member_list.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.js
@@ -2,6 +2,7 @@ import { ImStatus } from "@mail/core/common/im_status";
 import { ActionPanel } from "@mail/discuss/core/common/action_panel";
 
 import { Component, onWillUpdateProps, onWillStart, useState } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
 
 import { useService } from "@web/core/utils/hooks";
 
@@ -22,6 +23,18 @@ export class ChannelMemberList extends Component {
             if (nextProps.thread.fetchMembersState === "not_fetched") {
                 nextProps.thread.fetchChannelMembers();
             }
+        });
+    }
+
+    get onlineSectionText() {
+        return _t("Online - %(online_count)s", {
+            online_count: this.props.thread.onlineMembers.length,
+        });
+    }
+
+    get offlineSectionText() {
+        return _t("Offline - %(offline_count)s", {
+            offline_count: this.props.thread.offlineMembers.length,
         });
     }
 

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -5,19 +5,17 @@
         <ActionPanel title.translate="Members" minWidth="200" icon="'fa fa-users'">
             <button t-on-click="() => props.openChannelInvitePanel({ keepPrevious: env.inChatWindow })" class="btn btn-sm btn-secondary m-2 mt-0 d-flex align-items-center justify-content-center gap-1"><i class="fa fa-user-plus"/><span>Invite a User</span></button>
             <t t-if="props.thread.onlineMembers.length > 0">
-                <h6 class="text-muted pt-2 text-uppercase smaller">
-                    Online -
-                    <t t-esc="props.thread.onlineMembers.length"/>
-                </h6>
+                <t t-call="discuss.ChannelMemberList.section">
+                    <t t-set="sectionName" t-value="onlineSectionText"/>
+                </t>
                 <div class="d-flex flex-column bg-inherit gap-1">
                     <t t-foreach="props.thread.onlineMembers" t-as="member" t-key="member.id" t-call="discuss.channel_member"/>
                 </div>
             </t>
             <t name="offlineMembers" t-if="props.thread.offlineMembers.length > 0">
-                <h6 class="text-muted pt-2 text-uppercase smaller">
-                    Offline -
-                    <t t-esc="props.thread.offlineMembers.length"/>
-                </h6>
+                <t t-call="discuss.ChannelMemberList.section">
+                    <t t-set="sectionName" t-value="offlineSectionText"/>
+                </t>
                 <div class="d-flex flex-column bg-inherit gap-1">
                     <t t-foreach="props.thread.offlineMembers" t-as="member" t-key="member.id" t-call="discuss.channel_member">
                         <t t-set="offline" t-value="1"/>
@@ -30,6 +28,10 @@
                 <button class="btn btn-secondary" title="Load more" t-on-click.stop="() => props.thread.fetchChannelMembers()">Load more</button>
             </div>
         </ActionPanel>
+    </t>
+
+    <t t-name="discuss.ChannelMemberList.section">
+        <h6 class="text-muted pt-2 text-uppercase smaller" t-esc="sectionName"/>
     </t>
 
     <t t-name="discuss.channel_member">


### PR DESCRIPTION
Define a `t-name` for the section part of `ChannelMemberList`, so that it can be reused with ease while having same default style.

https://github.com/odoo/enterprise/pull/70477