### PR TITLE
[IMP] sale_purchase_project: add reinvoiced SO stat button in PO form

### DIFF
--- a/addons/sale/models/account_move_line.py
+++ b/addons/sale/models/account_move_line.py
@@ -15,6 +15,7 @@ class AccountMoveLine(models.Model):
         'invoice_line_id', 'order_line_id',
         string='Sales Order Lines', readonly=True, copy=False)
     sale_line_warn_msg = fields.Text(related='product_id.sale_line_warn_msg')
+    reinvoiced_sale_line_id = fields.Many2one('sale.order.line', index=True)
 
     def _copy_data_extend_business_fields(self, values):
         # OVERRIDE to copy the 'sale_line_ids' field as well.
@@ -70,7 +71,7 @@ class AccountMoveLine(models.Model):
         sale_line_values_to_create = []  # the list of creation values of sale line to create.
         existing_sale_line_cache = {}  # in the sales_price-delivery case, we can reuse the same sale line. This cache will avoid doing a search each time the case happen
         # `map_move_sale_line` is map where
-        #   - key is the move line identifier
+        #   - key is the move line record
         #   - value is either a sale.order.line record (existing case), or an integer representing the index of the sale line to create in
         #     the `sale_line_values_to_create` (not existing case, which will happen more often than the first one).
         map_move_sale_line = {}
@@ -114,7 +115,7 @@ class AccountMoveLine(models.Model):
                 map_entry_key = (sale_order.id, move_line.product_id.id, price)  # cache entry to limit the call to search
                 sale_line = existing_sale_line_cache.get(map_entry_key)
                 if sale_line:  # already search, so reuse it. sale_line can be sale.order.line record or index of a "to create values" in `sale_line_values_to_create`
-                    map_move_sale_line[move_line.id] = sale_line
+                    map_move_sale_line[move_line] = sale_line
                     existing_sale_line_cache[map_entry_key] = sale_line
                 else:  # search for existing sale line
                     sale_line = self.env['sale.order.line'].search([
@@ -124,29 +125,30 @@ class AccountMoveLine(models.Model):
                         ('is_expense', '=', True),
                     ], limit=1)
                     if sale_line:  # found existing one, so keep the browse record
-                        map_move_sale_line[move_line.id] = existing_sale_line_cache[map_entry_key] = sale_line
+                        map_move_sale_line[move_line] = existing_sale_line_cache[map_entry_key] = sale_line
                     else:  # should be create, so use the index of creation values instead of browse record
                         # save value to create it
                         sale_line_values_to_create.append(move_line._sale_prepare_sale_line_values(sale_order, price))
                         # store it in the cache of existing ones
                         existing_sale_line_cache[map_entry_key] = len(sale_line_values_to_create) - 1  # save the index of the value to create sale line
                         # store it in the map_move_sale_line map
-                        map_move_sale_line[move_line.id] = len(sale_line_values_to_create) - 1  # save the index of the value to create sale line
+                        map_move_sale_line[move_line] = len(sale_line_values_to_create) - 1  # save the index of the value to create sale line
 
             else:  # save its value to create it anyway
                 sale_line_values_to_create.append(move_line._sale_prepare_sale_line_values(sale_order, price))
-                map_move_sale_line[move_line.id] = len(sale_line_values_to_create) - 1  # save the index of the value to create sale line
+                map_move_sale_line[move_line] = len(sale_line_values_to_create) - 1  # save the index of the value to create sale line
 
         # create the sale lines in batch
         new_sale_lines = self.env['sale.order.line'].create(sale_line_values_to_create)
 
         # build result map by replacing index with newly created record of sale.order.line
         result = {}
-        for move_line_id, unknown_sale_line in map_move_sale_line.items():
+        for move_line, unknown_sale_line in map_move_sale_line.items():
             if isinstance(unknown_sale_line, int):  # index of newly created sale line
-                result[move_line_id] = new_sale_lines[unknown_sale_line]
+                result[move_line.id] = new_sale_lines[unknown_sale_line]
             elif isinstance(unknown_sale_line, models.BaseModel):  # already record of sale.order.line
-                result[move_line_id] = unknown_sale_line
+                result[move_line.id] = unknown_sale_line
+            move_line.reinvoiced_sale_line_id = result[move_line.id] # link the aml to its re-invoiced sol
         return result
 
     def _sale_determine_order(self):

--- a/addons/sale_purchase_project/__manifest__.py
+++ b/addons/sale_purchase_project/__manifest__.py
@@ -8,5 +8,8 @@
     'license': 'LGPL-3',
     'category': 'Sales',
     'depends': ['sale_purchase', 'project_purchase', 'sale_project'],
+    'data': [
+        'views/purchase_order_views.xml',
+    ],
     'auto_install': True,
 }

--- a/addons/sale_purchase_project/models/__init__.py
+++ b/addons/sale_purchase_project/models/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import purchase_order
 from . import sale_order_line

--- a/addons/sale_purchase_project/models/purchase_order.py
+++ b/addons/sale_purchase_project/models/purchase_order.py
@@ -1,0 +1,34 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, _
+
+
+class PurchaseOrder(models.Model):
+    _inherit = 'purchase.order'
+
+    reinvoiced_so_count = fields.Integer(compute='_compute_reinvoiced_so_count')
+
+    def _compute_reinvoiced_so_count(self):
+        for order in self:
+            order.reinvoiced_so_count = len(order.invoice_ids.invoice_line_ids.reinvoiced_sale_line_id.order_id)
+
+    def action_open_sale_orders(self):
+        self.ensure_one()
+        sale_orders = self.invoice_ids.invoice_line_ids.reinvoiced_sale_line_id.order_id
+        action = {
+            'name': _('Re-Invoiced Sales Orders %s', self.name),
+            'type': 'ir.actions.act_window',
+            'res_model': 'sale.order',
+            'view_mode': 'list,kanban,form,calendar,pivot,graph,activity',
+            'context': {
+                'create': False,
+            },
+        }
+        if len(sale_orders) == 1:
+            action.update({
+                'res_id': sale_orders.id,
+                'view_mode': 'form',
+            })
+        else:
+            action['domain'] = [('id', 'in', sale_orders.ids)]
+        return action

--- a/addons/sale_purchase_project/tests/test_sale_purchase_project.py
+++ b/addons/sale_purchase_project/tests/test_sale_purchase_project.py
@@ -1,11 +1,13 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
 from odoo.tests import tagged
 from odoo.addons.sale_purchase.tests.test_sale_purchase import TestSalePurchase
+from odoo.addons.sale_project.tests.test_reinvoice import TestReInvoice
 
 
 @tagged('-at_install', 'post_install')
-class TestSalePurchaseProject(TestSalePurchase):
+class TestSalePurchaseProject(TestSalePurchase, TestReInvoice):
 
     def test_pol_analytic_distribution(self):
         """Confirming SO, analytic accounts from the project's SO should be set as Analytic Distribution in POL."""
@@ -41,3 +43,50 @@ class TestSalePurchaseProject(TestSalePurchase):
 
         self.assertEqual(purchase_line1.analytic_distribution, {str(self.sale_order_1.project_id[self.analytic_plan._column_name()].id): 100}, "Analytic Distribution in PO should be same as Analytic Account set in SO")
         self.assertEqual(purchase_line2.analytic_distribution, {str(self.test_analytic_account_2.id): 100}, "Analytic Distribution in PO should be same as Analytic Distribution set in SOL")
+
+    def test_purchase_order_reinvoiced_so_count(self):
+        serv_cost = self.env['product.product'].create({
+            'name': "Ordered at cost",
+            'standard_price': 160,
+            'list_price': 180,
+            'type': 'consu',
+            'invoice_policy': 'order',
+            'expense_policy': 'cost',
+            'default_code': 'PROD_COST',
+            'service_type': 'manual',
+        })
+        project = self.env['project.project'].create({
+            'name': 'SO Project',
+            self.analytic_plan._column_name(): self.test_analytic_account_1.id,
+        })
+        self.sale_order.project_id = project
+        self.sale_order.action_confirm()
+
+        purchase_order = self.env['purchase.order'].create({
+            'name': 'PO Project',
+            'partner_id': self.partner_a.id,
+            'project_id': project.id,
+            'order_line': [
+                Command.create({
+                    'product_id': serv_cost.id,
+                    'product_qty': 2,
+                })
+            ]
+        })
+        purchase_order.button_confirm()
+        purchase_order.order_line.qty_received = 2
+        purchase_order.action_create_invoice()
+
+        invoice = purchase_order.invoice_ids
+        invoice.invoice_date = self.sale_order.date_order
+        invoice.action_post()
+        self.assertEqual(
+            invoice.invoice_line_ids.reinvoiced_sale_line_id,
+            self.sale_order.order_line,
+            "The generated SO line should be linked to the invoice line from which it was reinvoiced.",
+        )
+        self.assertEqual(
+            purchase_order.reinvoiced_so_count,
+            1,
+            "There should be exactly one SO from which a reinvoicing was done from the purchase orders's bills.",
+        )

--- a/addons/sale_purchase_project/views/purchase_order_views.xml
+++ b/addons/sale_purchase_project/views/purchase_order_views.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="purchase_order_form" model="ir.ui.view">
+        <field name="name">purchase.order.inherit.sale_purchase_project</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button
+                    class="oe_stat_button"
+                    name="action_open_sale_orders"
+                    type="object"
+                    icon="fa-usd"
+                    groups="sales_team.group_sale_salesman_all_leads"
+                    invisible="reinvoiced_so_count == 0">
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_value">
+                            <field name="reinvoiced_so_count"/>
+                        </span>
+                        <span class="o_stat_text">Re-Invoiced Sales Orders</span>
+                    </div>
+                </button>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
To be consistent with the reinvoicing in expenses, we introduce a new stat button which links the reinvoiced sales orders from the vendor bills of the purchase order. This stat button appears in the form view of purchase orders. The idea is to be more transparent to the user by showing the smartbutton so that they would understand that the line was added there automatically. Moreover, when multiples lines have been reinvoiced, it may be difficult to find which sale orders have been impacted.

task-4196812

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
