### PR TITLE
[FIX] website: fix s_timeline milestones alignment

### DIFF
--- a/addons/website/views/snippets/s_timeline.xml
+++ b/addons/website/views/snippets/s_timeline.xml
@@ -25,7 +25,7 @@
                     </div>
                     <div class="s_timeline_content w-0 w-md-100 h-0"/>
                 </div>
-                <div class="s_timeline_row position-relative d-flex gap-md-5 flex-column flex-md-row-reverse pb-4" data-name="Milestone">
+                <div class="s_timeline_row position-relative d-flex gap-md-5 flex-column flex-md-row pb-4" data-name="Milestone">
                     <div class="o_dot_line position-absolute top-0 bottom-0 w-0 mb-1 border-start pe-none"/>
                     <span class="o_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none text-o-color-1" contenteditable="false"/>
                     <div class="s_timeline_content w-100 ps-4 ps-md-0">
@@ -50,6 +50,7 @@
                 <div class="s_timeline_row position-relative d-flex flex-column flex-md-row gap-md-5 pb-4" data-name="Milestone">
                     <div class="o_dot_line position-absolute top-0 bottom-0 w-0 mb-1 border-start pe-none"/>
                     <span class="o_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none text-o-color-1" contenteditable="false"/>
+                    <div class="s_timeline_content w-0 w-md-100 h-0"/>
                     <div class="s_timeline_content w-100 ps-4 ps-md-0">
                         <div class="s_timeline_card s_card card my-0 ms-auto" style="border-width: 0px !important;" data-vxml="001" data-snippet="s_card" data-name="Milestone Event">
                             <div class="card-body">


### PR DESCRIPTION
Since [1], the second and third milestones are swapped and the last milestone spans over both sides of the timeline.

This commit repairs the `s_timeline` layout.

Steps to reproduce:
- Drop an `s_timeline` block into a page.

=> Second and third milestones were swapped and last milestone spanned over both sides of the timeline.

[1]: https://github.com/odoo/odoo/commit/6b8b26b769981aabfdf5b7d3287cf3dd13469819

task-4203966
