### PR TITLE
[FIX] web_editor: replace css variables to computed value in to_inline

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -41,6 +41,20 @@ export const TABLE_STYLES = {
     'line-height': 'inherit',
 };
 
+const GROUPED_STYLES = {
+    border: [
+        "border-top-width", "border-right-width", "border-bottom-width", "border-left-width",
+        "border-top-style", "border-right-style", "border-bottom-style", "border-left-style",
+        "border-top-color", "border-right-color", "border-bottom-color", "border-left-color",
+    ],
+    padding: ["padding-top", "padding-bottom", "padding-left", "padding-right"],
+    margin: ["margin-top", "margin-bottom", "margin-left", "margin-right"],
+    "border-radius": [
+        "border-top-left-radius", "border-top-right-radius",
+        "border-bottom-right-radius", "border-bottom-left-radius",
+    ],
+};
+
 //--------------------------------------------------------------------------
 // Public
 //--------------------------------------------------------------------------
@@ -1523,6 +1537,29 @@ function _getMatchedCSSRules(node, cssRules, checkBlacklisted = false) {
             processedStyle[key] = value.replace(/\s*!important\s*$/, '');
         }
     };
+    // In case the groupStyle have var in its value, the substyles will not have
+    // any value assigned in cssRules thus we loose the style since the groupStyle
+    // doesn't appear too in cssRules. As a solution we added those substyle using
+    // their computed values
+    const computedStyle = getComputedStyle(node);
+    for (const groupName in GROUPED_STYLES) {
+        // We exclude the 'margin' and 'padding' styles from force apply because
+        // it's common that they have a value set by auto which doesn't make sense to
+        // force their computed value.
+        const force = !groupName.includes("margin") && !groupName.includes("padding");
+        const hasSubStyleApplied = GROUPED_STYLES[groupName].some(
+            (styleName) => styleName in processedStyle
+        );
+        if (!force && hasSubStyleApplied) {
+            continue;
+        }
+        for (const styleName of GROUPED_STYLES[groupName]) {
+            const styleValue = computedStyle.getPropertyValue(styleName);
+            if (styleValue && typeof styleValue === "string" && styleValue.length) {
+                processedStyle[styleName] = styleValue;
+            }
+        }
+    }
 
     if (processedStyle.display === 'block' && !(node.classList && node.classList.contains('oe-nested'))) {
         delete processedStyle.display;
@@ -1562,6 +1599,20 @@ function _getMatchedCSSRules(node, cssRules, checkBlacklisted = false) {
         delete processedStyle['border-bottom-right-radius'];
         delete processedStyle['border-top-left-radius'];
         delete processedStyle['border-top-right-radius'];
+    }
+    if (processedStyle['border-left-color']) {
+        processedStyle['border-color'] = processedStyle['border-left-color'];
+        delete processedStyle['border-right-color'];
+        delete processedStyle['border-bottom-color'];
+        delete processedStyle['border-top-color'];
+        delete processedStyle['border-left-color'];
+    }
+    if (processedStyle['border-left-width']) {
+        processedStyle['border-width'] = processedStyle['border-left-width'];
+        delete processedStyle['border-right-width'];
+        delete processedStyle['border-bottom-width'];
+        delete processedStyle['border-top-width'];
+        delete processedStyle['border-left-width'];
     }
 
     // If the border styling is initial we remove it to simplify the css tags

--- a/addons/web_editor/static/tests/convert_inline_tests.js
+++ b/addons/web_editor/static/tests/convert_inline_tests.js
@@ -635,9 +635,9 @@ QUnit.module('convert_inline', {}, function () {
         // Some positional properties (eg., padding-right, margin-left) are not
         // concatenated (eg., as padding, margin) because they were defined with
         // variables (var) or calculated (calc).
-        const containerStyle = `margin: 0px auto; box-sizing: border-box; max-width: 1320px; padding-left: 16px; padding-right: 16px; width: 100%;`;
-        const rowStyle = `box-sizing: border-box; margin-left: -16px; margin-right: -16px; margin-top: 0px;`;
-        const colStyle = `box-sizing: border-box; margin-top: 0px; padding-left: 16px; padding-right: 16px; max-width: 100%; width: 100%;`;
+        const containerStyle = `border-width: 0px; border-color: rgb(55, 65, 81); border-radius: 0px; border-style: none; margin: 0px auto; box-sizing: border-box; max-width: 1320px; padding-left: 16px; padding-right: 16px; width: 100%;`;
+        const rowStyle = `border-width: 0px; border-color: rgb(55, 65, 81); border-radius: 0px; border-style: none; padding: 0px; box-sizing: border-box; margin-left: -16px; margin-right: -16px; margin-top: 0px;`;
+        const colStyle = `border-width: 0px; border-color: rgb(55, 65, 81); border-radius: 0px; border-style: none; box-sizing: border-box; margin-top: 0px; padding-left: 16px; padding-right: 16px; max-width: 100%; width: 100%;`;
         assert.strictEqual($editable.html(),
             `<div class="container" style="${containerStyle}" width="100%">` +
             `<div class="row" style="${rowStyle}">` +
@@ -1001,7 +1001,7 @@ QUnit.module('convert_inline', {}, function () {
         $iframeEditable.append(`<div class="o_layout" style="padding: 50px;"></div>`);
         convertInline.classToStyle($iframeEditable, convertInline.getCSSRules($iframeEditable[0].ownerDocument));
         assert.strictEqual($iframeEditable.html(),
-            `<div class="o_layout" style="box-sizing:border-box;font-size:50px;color:white;background-color:red;padding: 50px;"></div>`,
+            `<div class="o_layout" style="border-width:0px;border-color:rgb(255, 255, 255);border-radius:0px;border-style:none;margin:0px;box-sizing:border-box;font-size:50px;color:white;background-color:red;padding: 50px;"></div>`,
             "should have given all styles of body to .o_layout");
         styleSheet.deleteRule(0);
 


### PR DESCRIPTION
Issue:
======
Sent emails buttons arent correctly styled.

Steps to reproduce the issue:
=============================
- Go to email templates
- Add primary button
- Send a message with the created template
- The button isn't correctly rendered

Origin of the issue:
====================
The grouped styles like `border`. `padding` and `border-radius` doesn't
propagate their values to their substyles when there are variables used
in the value.

Solution:
=========
We handle those cases alone, by reapplying the group style again by
using the computed values since they may have some values using var from
a parent style

opw-4199180
