### PR TITLE
[REF] web,*: kanban: remove isHtmlEmpty from rendering context

### DIFF
--- a/addons/account/views/account_payment_term_views.xml
+++ b/addons/account/views/account_payment_term_views.xml
@@ -107,7 +107,7 @@
                     <templates>
                         <t t-name="card">
                             <field class="fw-bolder fs-5" name="name"/>
-                            <field t-if="!widget.isHtmlEmpty(record.note.raw_value)" name="note"/>
+                            <field name="note"/>
                         </t>
                     </templates>
                 </kanban>

--- a/addons/gamification/views/gamification_badge_views.xml
+++ b/addons/gamification/views/gamification_badge_views.xml
@@ -135,7 +135,7 @@
                                 <field class="fw-bold" name="granted_count"/> granted,
                                 <field class="fw-bold" name="stat_this_month"/> this month
                             </div>
-                            <div t-if="!widget.isHtmlEmpty(record.description.value)">
+                            <div>
                                 <field class="fst-italic" name="description"/>
                                 <field name="unique_owner_ids" widget="many2many_avatar_user"/>
                             </div>

--- a/addons/web/static/src/views/kanban/kanban_record.js
+++ b/addons/web/static/src/views/kanban/kanban_record.js
@@ -246,8 +246,10 @@ export class KanbanRecord extends Component {
         this.dataState.widget = {
             deletable,
             editable,
-            isHtmlEmpty,
         };
+        if (archInfo.isLegacyArch) {
+            this.dataState.widget.isHtmlEmpty = isHtmlEmpty;
+        }
     }
 
     getRecordClasses() {

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -10704,47 +10704,6 @@ test.tags("desktop")("quick create: keyboard navigation to buttons", async () =>
     expect(".o_kanban_edit").toBeFocused();
 });
 
-test("kanban with isHtmlEmpty method", async () => {
-    Product._fields.description = fields.Html();
-    Product._records.push({
-        id: 11,
-        name: "product 11",
-        description: "<span class='text-info'>hello</hello>",
-    });
-    Product._records.push({
-        id: 12,
-        name: "product 12",
-        description: "<p class='a'><span style='color:red;'/><br/></p>",
-    });
-
-    await mountView({
-        type: "kanban",
-        resModel: "product",
-        arch: `
-            <kanban>
-                <templates>
-                    <t t-name="card">
-                        <field name="display_name"/>
-                        <div class="test" t-if="!widget.isHtmlEmpty(record.description.raw_value)">
-                            <field name="description"/>
-                        </div>
-                    </t>
-                </templates>
-            </kanban>`,
-        domain: [["id", "in", [11, 12]]],
-    });
-    expect(".o_kanban_record:first-child div.test").toHaveCount(1, {
-        message: "the container is displayed if description have actual content",
-    });
-    expect(queryText("span.text-info", { root: getKanbanRecord({ index: 0 }) })).toBe("hello", {
-        message: "the inner html content is rendered properly",
-    });
-    expect(".o_kanban_record:last-child div.test").toHaveCount(0, {
-        message:
-            "the container is not displayed if description just have formatting tags and no actual content",
-    });
-});
-
 test("progressbar filter state is kept unchanged when domain is updated (records still in group)", async () => {
     stepAllNetworkCalls();
 


### PR DESCRIPTION
*account,gamification

This commit removes a key from the `widget` object in the kanban rendering context of the new API. This commit also removes the only 2 usecases, which were in minor views and not really necessary. This allows to simplify the kanban views and in this case more specifically the rendering context.

Part of task~3992107

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
