### PR TITLE
[IMP] mail: make mention style more readable

### DIFF
--- a/addons/mail/static/src/core/common/core.dark.scss
+++ b/addons/mail/static/src/core/common/core.dark.scss
@@ -3,11 +3,11 @@
 }
 
 a.o_mail_redirect, a.o_channel_redirect {
-    @include o-mention-variant(rgba($primary, .2), rgba($primary, .2), lighten($link-color, 5%), rgba($primary, .3), rgba($primary, .3), lighten($link-color, 10%));
+    @include o-mention-variant(rgba(lighten($o-action, 5%), .1), rgba(lighten($o-action, 5%), .15), lighten($o-action, 5%), rgba(lighten($o-action, 5%), .2), rgba(lighten($o-action, 5%), .3), lighten($o-action, 10%));
 }
 
 a.o-discuss-mention {
-    @include o-mention-variant(rgba($primary, .2), rgba($primary, .2), lighten($link-color, 5%), rgba($primary, .2), rgba($primary, .2), lighten($link-color, 5%));
+    @include o-mention-variant(rgba(lighten($o-action, 5%), .1), rgba(lighten($o-action, 5%), .15), lighten($o-action, 5%), rgba(lighten($o-action, 5%), .1), rgba(lighten($o-action, 5%), .15), lighten($o-action, 5%));
 }
 
 .o-mail-DiscussSystray-class {

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -108,14 +108,16 @@ a.o_mail_redirect, a.o_channel_redirect, a.o-discuss-mention {
     @include rfs($btn-font-size-sm, $btn-font-size-sm);
     border-radius: $btn-border-radius-sm;
     padding: 0rem 0.1875rem;
+    border: 1px solid;
+    font-weight: $font-weight-bold;
 }
 
 a.o_mail_redirect, a.o_channel_redirect {
-    @include o-mention-variant(rgba($primary, .2), rgba($primary, .2), darken($link-color, 5%), rgba($primary, .3), rgba($primary, .3), darken($link-color, 10%));
+    @include o-mention-variant(rgba($primary, .15), rgba($primary, .25), darken($primary, 10%), rgba($primary, .2), rgba($primary, .5), darken($primary, 15%));
 }
 
 a.o-discuss-mention {
-    @include o-mention-variant(rgba($primary, .2), rgba($primary, .2), darken($link-color, 5%), rgba($primary, .2), rgba($primary, .2), darken($link-color, 5%));
+    @include o-mention-variant(rgba($primary, .15), rgba($primary, .25), darken($primary, 10%), rgba($primary, .15), rgba($primary, .25), darken($primary, 10%));
     cursor: default !important;
 }
 


### PR DESCRIPTION
Mentions were hard to read because background is too dark compared to text, resulting to bad contrast.

_Note: "Marc Demo" mention in chat window is mouse-hovered in screens below_

Before / After (white theme)
![before-white](https://github.com/user-attachments/assets/6c69b8b8-1c1e-4c46-9a9d-c4885dd468bd)
<img width="1275" alt="after-white" src="https://github.com/user-attachments/assets/e982c1c1-cfbb-45d2-93b4-74e28eaa414e">

Before / After (dark theme)
![before-dark](https://github.com/user-attachments/assets/1e749733-f0fb-435b-b0bc-20c46a2004e6)
<img width="1255" alt="Screenshot 2024-09-23 at 15 34 16" src="https://github.com/user-attachments/assets/d293f5b0-3259-4dd8-8cf6-20242806f98b">
