### PR TITLE
[FIX] web: prevent dialog closure on tab change

### DIFF
--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -307,7 +307,8 @@ export class FormController extends Component {
 
         if (!this.env.inDialog) {
             useExternalListener(document, "visibilitychange", () => {
-                if (document.visibilityState === "hidden") {
+                const isDialogOpen = document.querySelector(".o_dialog");
+                if (document.visibilityState === "hidden" && !isDialogOpen) {
                     this.model.root.save();
                 }
             });


### PR DESCRIPTION
Problem:
When a dialog is open on a form (e.g., searching for a product while creating a sale order), switching browser tabs causes the dialog to close unexpectedly.

To fix this, we extend the solution from [this commit](https://github.com/odoo/odoo/commit/f59ed8d13e75868f58b33cd52ddd17590b690773) by preventing automatic saving if a dialog is currently open.

Steps to reproduce:
- Open any dialog on a form (e.g., search for a product while creating a sale order).
- Switch to another browser tab.
- The dialog closes.

opw-4143092

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
