### PR TITLE
[FIX] web_editor: highlight the selected option in customization panel

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -555,6 +555,10 @@
                     background: $o-we-dropdown-item-bg-hover;
                     color: $o-we-dropdown-item-hover-color;
                 }
+                &.active {
+                    background: $o-we-dropdown-item-active-bg;
+                    color: $o-we-dropdown-item-active-color;
+                }
             }
 
             .o_we_font_size_badge {
@@ -725,6 +729,8 @@
                     justify-content: space-between;
 
                     span {
+                        overflow: hidden;
+                        text-overflow: ellipsis;
                         color: white;
 
                         pre, blockquote {


### PR DESCRIPTION
Before this commit, the selected value in dropdowns within the text editor toolbar was barely visible.

This commit adds styles to highlight the selected option, making it clearly visible and aligned with the other dropdowns for better user experience and consistency.

Before:
![image](https://github.com/user-attachments/assets/e4ee1705-ab80-488e-a93e-83810781b43a)

After:
![image](https://github.com/user-attachments/assets/d90e594f-a060-45b1-ab6b-31b435fc3c84)


task-4150489