### PR TITLE
[FIX] account: float_compare on tax updates

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -8,7 +8,7 @@ from odoo import SUPERUSER_ID
 from odoo.exceptions import UserError, ValidationError
 from odoo.http import request
 from odoo.addons.account.models.account_tax import TYPE_TAX_USE
-from odoo.tools import html_escape
+from odoo.tools import float_compare, html_escape
 
 
 import logging
@@ -137,11 +137,15 @@ def update_taxes_from_templates(cr, chart_template_xmlid):
             template_rep_lines = template.invoice_repartition_line_ids + template.refund_repartition_line_ids
             return (
                     tax.amount_type == template.amount_type
-                    and tax.amount == template.amount
+                    and float_compare(tax.amount, template.amount, precision_digits=4) == 0
                     and (
                          len(tax_rep_lines) == len(template_rep_lines)
                          and all(
-                             rep_line_tax.factor_percent == rep_line_template.factor_percent
+                             float_compare(
+                                 rep_line_tax.factor_percent,
+                                 rep_line_template.factor_percent,
+                                 precision_digits=4
+                             ) == 0
                              for rep_line_tax, rep_line_template in zip(tax_rep_lines, template_rep_lines)
                          )
                     )


### PR DESCRIPTION
When using the `upgrade_taxes_from_templates` function in an upgrade script to update taxes, we compared the tax amounts using a strict equals sign (`==`). However, due to floating point representation errors this could lead to taxes being duplicated.

If we have e.g. a tax with an amount of `1.4` in the database and our tax template has not changed, on upgrading the taxes the one of the template will evaluate to `1.4000000000000001` and not be strictly equal to the one in the database. It will thus mark the existing one as `[old]` and recreate it.

This fix makes sure we compare the amount using `float_compare` with a precision of 4 digits (the same as set on the `amount` fields).

Issue encountered during testing of task-4147046