### PR TITLE
[FIX] mail,*: miss res+id when sending notif

### DIFF
--- a/addons/mail/static/src/core/web/mail_core_web_service.js
+++ b/addons/mail/static/src/core/web/mail_core_web_service.js
@@ -38,7 +38,7 @@ export class MailCoreWeb {
                 inbox.counter++;
             }
             inbox.messages.add(message);
-            if (notifId > message.thread.message_needaction_counter_bus_id) {
+            if (message.thread && notifId > message.thread.message_needaction_counter_bus_id) {
                 message.thread.message_needaction_counter++;
             }
         });


### PR DESCRIPTION
To reproduce the error:
- Set preference to Handle in Odoo
- Move forward the applicant to the next stage
- Inbox raise (Cannot read properties of undefined (reading 'message_needaction_counter_bus_id'))

The error is due to the fact that the res_id is not set and so that the thread in the message is not correctly set.
Also, guard message.thread in handling of mail.message/inbox because not all messages are linked to a thread and it makes sense functionally in rare case message is not linked to thread.

https://github.com/odoo/enterprise/pull/70372




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
