### PR TITLE
[FIX] point_of_sale: prevent Invalid props error on receipt reprint

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/reprint_receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/reprint_receipt_screen.js
@@ -10,7 +10,7 @@ export class ReprintReceiptScreen extends Component {
     static template = "point_of_sale.ReprintReceiptScreen";
     static components = { OrderReceipt };
     static storeOnOrder = false;
-    static props = ["order"];
+    static props = ["order", "isShown"];
     setup() {
         super.setup();
         this.pos = usePos();


### PR DESCRIPTION
Before this commit, attempting to reprint a receipt for an order would result in an "Invalid props" error.

opw-4191019

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
