### PR TITLE
[FIX] purchase_stock: allow a salesman to confirm SO with orderpoint

### DIFF
--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -245,7 +245,7 @@ class StockRule(models.Model):
             date=line.order_id.date_order and line.order_id.date_order.date(),
             uom_id=product_id.uom_po_id)
 
-        price_unit = self.env['account.tax']._fix_tax_included_price_company(seller.price, line.product_id.supplier_taxes_id, line.taxes_id, company_id) if seller else 0.0
+        price_unit = self.env['account.tax']._fix_tax_included_price_company(seller.price, line.product_id.supplier_taxes_id, line.sudo().taxes_id, company_id) if seller else 0.0
         if price_unit and seller and line.order_id.currency_id and seller.currency_id != line.order_id.currency_id:
             price_unit = seller.currency_id._convert(
                 price_unit, line.order_id.currency_id, line.order_id.company_id, fields.Date.today())

--- a/addons/sale_purchase_stock/tests/test_access_rights.py
+++ b/addons/sale_purchase_stock/tests/test_access_rights.py
@@ -74,3 +74,51 @@ class TestAccessRights(TestCommonSalePurchaseNoChart):
         })
 
         self.assertIn(so.name, po.activity_ids.note)
+
+    def test_access_saleperson_with_orderpoint(self):
+        """
+        Suppose a user with no rights on SO creates a product with an orderpoint,
+        then creates an SO, SO the PO will be generated. After creating a second SO,
+        the PO should be updated since it has not been confirmed yet.
+        """
+        seller = self.env['product.supplierinfo'].create({
+            'partner_id': self.partner_a.id,
+            'price': 8,
+        })
+        product = self.env['product.product'].create({
+            'name': 'SuperProduct',
+            'type': 'product',
+            'seller_ids': [(6, 0, seller.ids)],
+        })
+        self.env['stock.warehouse.orderpoint'].create({
+            'name': 'orderpoint test',
+            'product_id': product.id,
+            'product_min_qty': 0,
+            'product_max_qty': 1,
+            'route_id': self.env.ref('purchase_stock.route_warehouse0_buy').id,
+        })
+        # Create a SO that will automatically generate a SO since we have an orderpoint"
+        so = self.env['sale.order'].with_user(self.user_salesperson).create({
+            'partner_id': self.partner_b.id,
+            'user_id': self.user_salesperson.id,
+            'order_line': [
+                (0, 0, {
+                    'product_id': product.id,
+                    'product_uom_qty': 10,
+                    'product_uom': product.uom_id.id,
+                    'price_unit': product.list_price,
+                })]
+        })
+        so.action_confirm()
+        # Create a second SO, and since a PO has already been created but not yet validated, it will be updated.
+        so_2 = so.copy()
+        # Find the PO that will be updated in order to invalidate its cache,
+        # so the fields will be reloaded with the sales user.
+        po = self.env['purchase.order'].search([('partner_id', '=', self.partner_a.id)])
+        self.assertEqual(po.order_line[0].product_qty, 11)
+        po.order_line[0].invalidate_recordset()
+        # Confirm the second SO and verify if PO has been updated.
+        so_2.action_confirm()
+        self.assertEqual(po.order_line[0].product_qty, 21)
+        po.button_confirm()
+        self.assertEqual(po.state, 'purchase')


### PR DESCRIPTION
**Steps to reproduce the bug:**

- Create a storable product “P1”:
  - Vendor: Azure Interior
  - Reordering rule:
    - Trigger: Auto
    - Route: Buy

- Go to the user settings and give Marc Demo access only to Sales.
- Log in as Marc.
- Create a sales order:
  - Product: 1 unit of P1.
- Confirm the SO.
- A purchase order is created.
- Create a second SO with another 1 unit of P1.
- Confirm it.

**Problem:**
An error is triggered:
`odoo.exceptions.AccessError: You are not allowed to access 'Purchase Order Line' (purchase.order.line) records.`

When the second SO is confirmed, a quantity request is made, triggering the "buy" rule. A check is made if there is a candidate “purchase order line” with the same specifications to update its quantity instead of creating a new one:
https://github.com/odoo/odoo/blob/a9cbd2a2ae2e21f1ba14379aecd908c44497b8ab/addons/purchase_stock/models/stock_rule.py#L130-L136

The function `_update_purchase_order_line` is called, where access to the taxes associated with the purchase order line is attempted: https://github.com/odoo/odoo/blob/a9cbd2a2ae2e21f1ba14379aecd908c44497b8ab/addons/purchase_stock/models/stock_rule.py#L248

Since it’s a Many2Many field, a query is made to fetch all the records. However, because the user does not have access to the `account.tax` model, an error is triggered.

opw-4193125
