### PR TITLE
[FIX] website_sale: correctly fetch categories

### DIFF
--- a/addons/website_sale/static/src/js/editor/snippets.options.js
+++ b/addons/website_sale/static/src/js/editor/snippets.options.js
@@ -1,8 +1,15 @@
 import options from "@web_editor/js/editor/snippets.options";
 
 options.registry.MegaMenuLayout = options.registry.MegaMenuLayout.extend({
-    _fetchEcommerceCategories() {
-        return this.containerEl.classList.contains('fetchEcomCategories');
+
+    /**
+     * Initialize fetchEcomCategories.
+     *
+     * @returns {void}
+     */
+    start() {
+        this._super();
+        this.fetchEcomCategories = this.containerEl.classList.contains('fetchEcomCategories');
     },
 
     /**
@@ -13,7 +20,7 @@ options.registry.MegaMenuLayout = options.registry.MegaMenuLayout.extend({
      */
     _getCurrentTemplateXMLID: function () {
         let currentTemplateXMLID = this._super();
-        if (this._fetchEcommerceCategories()) {
+        if (this.fetchEcomCategories) {
             currentTemplateXMLID = currentTemplateXMLID.replace('website.', 'website_sale.');
         }
         return currentTemplateXMLID;
@@ -22,8 +29,7 @@ options.registry.MegaMenuLayout = options.registry.MegaMenuLayout.extend({
     /**
      * Refresh the current mega menu template.
      *
-     * @private
-     * @returns {void} xmlid of the current template.
+     * @returns {void}
      */
     async refreshMegaMenuTemplate() {
         const xmlid = this._getCurrentTemplateXMLID();
@@ -34,5 +40,21 @@ options.registry.MegaMenuLayout = options.registry.MegaMenuLayout.extend({
          */
         await this._getTemplate(xmlid);
         await this.selectTemplate(true, xmlid);
+    },
+
+    /**
+     * Toggle the state of the button and refresh the mega menu template.
+     *
+     * @returns {void}
+     */
+    async toggleFetchEcomCategories(){
+        /**
+         * The class applied by `selectClass` in the web editor is applied
+         * after calling this method. Therefore, we need to track the
+         * changes manually in a variable to ensure that the right template
+         * is rendered by `refreshMegaMenuTemplate`.
+         */
+        this.fetchEcomCategories = !this.fetchEcomCategories;
+        await this.refreshMegaMenuTemplate();
     },
 });

--- a/addons/website_sale/views/snippets/s_mega_menu/big_icons_subtitles.xml
+++ b/addons/website_sale/views/snippets/s_mega_menu/big_icons_subtitles.xml
@@ -28,6 +28,7 @@
                                 >
                                     <div class="d-flex align-items-center">
                                         <img
+                                            t-if="category.image_1920"
                                             t-att-src="image_data_uri(category.image_1920)"
                                             class="fa rounded rounded-circle shadow me-3"
                                             alt=""

--- a/addons/website_sale/views/snippets/s_mega_menu/cards.xml
+++ b/addons/website_sale/views/snippets/s_mega_menu/cards.xml
@@ -23,6 +23,7 @@
                             >
                                 <div class="mb-3 rounded shadow" style="height:80px">
                                     <img
+                                        t-if="category.image_1920"
                                         t-att-src="image_data_uri(category.image_1920)"
                                         class="img-fluid w-100 h-100 object-fit-cover"
                                         alt=""

--- a/addons/website_sale/views/snippets/s_mega_menu/images_subtitles.xml
+++ b/addons/website_sale/views/snippets/s_mega_menu/images_subtitles.xml
@@ -24,6 +24,7 @@
                                 >
                                     <div class="d-flex">
                                         <img
+                                            t-if="category.image_1920"
                                             t-att-src="image_data_uri(category.image_1920)"
                                             class="me-3 rounded shadow"
                                             alt=""

--- a/addons/website_sale/views/snippets/s_mega_menu/little_icons.xml
+++ b/addons/website_sale/views/snippets/s_mega_menu/little_icons.xml
@@ -23,6 +23,7 @@
                                     class="col-lg-4 nav-link o_default_snippet_text px-2 rounded text-wrap"
                                 >
                                     <img
+                                        t-if="category.image_1920"
                                         t-att-src="image_data_uri(category.image_1920)"
                                         class="fa fa-fw me-2"
                                         alt=""

--- a/addons/website_sale/views/snippets/s_mega_menu/thumbnails.xml
+++ b/addons/website_sale/views/snippets/s_mega_menu/thumbnails.xml
@@ -27,6 +27,7 @@
                                 class="nav-link o_default_snippet_text p-0"
                             >
                                 <img
+                                    t-if="category.image_1920"
                                     t-att-src="image_data_uri(category.image_1920)"
                                     class="img-fluid rounded shadow"
                                     alt=""

--- a/addons/website_sale/views/snippets/snippets.xml
+++ b/addons/website_sale/views/snippets/snippets.xml
@@ -397,14 +397,15 @@
         </div>
     </xpath>
     <xpath expr="//div[@data-js='MegaMenuLayout']" position="inside">
-        <we-row>
+        <t t-set="categories" t-value="request.env['product.public.category'].search([])"/>
+        <we-row t-if="categories">
             <we-title class="o_long_title">eCommerce Categories</we-title>
             <div class="o_switch ms-4">
                 <we-checkbox
                     class="o_mega_menu"
                     data-name="fetch_ecom_categories_opt"
                     data-select-class="fetchEcomCategories"
-                    data-refresh-mega-menu-template=""
+                    data-toggle-fetch-ecom-categories=""
                     data-no-preview="true"
                 />
             </div>


### PR DESCRIPTION
With previous commit f354cb8794c9fd2b5183e520ce292adbe547ba4c, a new feature was introduced to be able to load categories to your mega menu however there was a bug that the button was not synced to fetching the categories.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
