### PR TITLE
[FIX] website_forum: ensure forum description teaser translation

### DIFF
--- a/addons/website_forum/models/forum.py
+++ b/addons/website_forum/models/forum.py
@@ -142,14 +142,18 @@ class Forum(models.Model):
     @api.depends('description')
     def _compute_teaser(self):
         for forum in self:
+            forum.teaser = forum._generate_teaser()
+    
+    def _generate_teaser(self):
+        for forum in self:
             if forum.description:
                 desc = forum.description.replace('\n', ' ')
                 if len(forum.description) > 180:
-                    forum.teaser = desc[:180] + '...'
+                    return desc[:180] + '...'
                 else:
-                    forum.teaser = forum.description
+                    return forum.description
             else:
-                forum.teaser = ""
+                return ""
 
     @api.depends('post_ids.state', 'post_ids.views', 'post_ids.child_count', 'post_ids.favourite_count')
     def _compute_forum_statistics(self):

--- a/addons/website_forum/views/website_forum.xml
+++ b/addons/website_forum/views/website_forum.xml
@@ -471,8 +471,9 @@
                         <h3 class="h4" t-field="forum.name"/>
                     </a>
                     <p class="m-0 flex-grow-1"
-                    placeholder="Description"
-                    t-field="forum.teaser"/>
+                        placeholder="Description">
+                        <t t-esc="forum._generate_teaser()"/>
+                    </p>
                     <t t-if="is_view_active('website_forum.opt_post_count') or is_view_active('website_forum.opt_last_post')" t-call="website_forum.forum_post_options"/>
                 </div>
             </div>


### PR DESCRIPTION
On the forum page, the forum's description teaser fails to get translated.

Steps to reproduce:
1- Create a new forum page by navigating to: Website → Configuration → Forums → Forums.
2- Add the title and description in the secondary language.
3- Navigate to the website
4- Access the forum page.
5- Change the website's language from the language selector.

OPW-4143090

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
