### PR TITLE
[FIX] sale_timesheet: use `always_range` option on invoice datepicker

### DIFF
--- a/addons/sale_timesheet/wizard/sale_make_invoice_advance_views.xml
+++ b/addons/sale_timesheet/wizard/sale_make_invoice_advance_views.xml
@@ -20,7 +20,7 @@
                         string="Timesheets Period"
                         widget="daterange"
                         required="date_start_invoice_timesheet or date_end_invoice_timesheet"
-                        options="{'end_date_field': 'date_end_invoice_timesheet'}"
+                        options="{'end_date_field': 'date_end_invoice_timesheet', 'always_range': true}"
                         title="Only timesheets not yet invoiced (and validated, if applicable) from this period will be invoiced. If the period is not indicated, all timesheets not yet invoiced (and validated, if applicable) will be invoiced without distinction."
                     />
                     <field name="date_end_invoice_timesheet" invisible="1" />


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Have an SO selling a timesheet-based service;
2. have at least some hours delivered via timesheets;
3. click on "Create Invoice";
4. select a date for "Timesheets Period".

Issue
-----
It first shows a datepicker for only the start date, only after closing it can you select a second date.

Cause
-----
The `daterange` widget doesn't actually default to a range, unless the date field is marked as required.

As seen in the `isRange` function, it opens a range picker when there are two values present, the field is required, or the `alwaysRange` property is `true`: https://github.com/odoo/odoo/blob/39029710bbce55889c6b951fc423c1254e05ff22/addons/web/static/src/views/fields/datetime/datetime_field.js#L215-L224

Solution
--------
Force the range picker on the `daterange` widget by setting the `always_range` option.

opw-4049959