### PR TITLE
[IMP] l10n_ar: new afip pos type

### DIFF
--- a/addons/l10n_ar/i18n/es_419.po
+++ b/addons/l10n_ar/i18n/es_419.po
@@ -1230,6 +1230,12 @@ msgid "Export Voucher - Online Invoice"
 msgstr "Comprobantes de exportación - Factura en línea"
 
 #. module: l10n_ar
+#. odoo-python
+#: code:addons/l10n_ar/models/account_journal.py:0
+msgid "External Fiscal Controller"
+msgstr "Controlador Fiscal Externo"
+
+#. module: l10n_ar
 #: model:l10n_latam.document.type,name:l10n_ar.nc_exterior
 msgid "FOREIGN CREDIT NOTES AND REIMBURSEMENTS"
 msgstr "NOTAS DE CRÉDITO Y REEMBOLSOS DEL EXTERIOR"

--- a/addons/l10n_ar/i18n/l10n_ar.pot
+++ b/addons/l10n_ar/i18n/l10n_ar.pot
@@ -1189,6 +1189,12 @@ msgid "Export Voucher - Online Invoice"
 msgstr ""
 
 #. module: l10n_ar
+#. odoo-python
+#: code:addons/l10n_ar/models/account_journal.py:0
+msgid "External Fiscal Controller"
+msgstr ""
+
+#. module: l10n_ar
 #: model:l10n_latam.document.type,name:l10n_ar.nc_exterior
 msgid "FOREIGN CREDIT NOTES AND REIMBURSEMENTS"
 msgstr ""

--- a/addons/l10n_ar/models/account_journal.py
+++ b/addons/l10n_ar/models/account_journal.py
@@ -45,6 +45,7 @@ class AccountJournal(models.Model):
             ('FEERCELP', _('Export Voucher - Billing Plus')),
             ('FEERCEL', _('Export Voucher - Online Invoice')),
             ('CPERCEL', _('Product Coding - Online Voucher')),
+            ('CF', _('External Fiscal Controller')),
         ]
 
     def _get_journal_letter(self, counterpart_partner=False):
@@ -103,7 +104,7 @@ class AccountJournal(models.Model):
         receipt_m_code = ['54']
         receipt_codes = ['4', '9', '15']
         expo_codes = ['19', '20', '21']
-        zeta_codes = ['80', '83']
+        tique_codes = ['81', '82', '83', '110', '112', '113', '115', '116', '118', '119', '120']
         codes_issuer_is_supplier = [
             '23', '24', '25', '26', '27', '28', '33', '43', '45', '46', '48', '58', '60', '61', '150', '151', '157',
             '158', '161', '162', '164', '166', '167', '171', '172', '180', '182', '186', '188', '332']
@@ -118,11 +119,9 @@ class AccountJournal(models.Model):
         elif afip_pos_system == 'II_IM':
             # pre-printed invoice
             codes = usual_codes + receipt_codes + expo_codes + invoice_m_code + receipt_m_code
-        elif afip_pos_system == 'RAW_MAW':
+        elif afip_pos_system in ['RAW_MAW', 'RLI_RLM']:
             # electronic/online invoice
             codes = usual_codes + receipt_codes + invoice_m_code + receipt_m_code + mipyme_codes
-        elif afip_pos_system == 'RLI_RLM':
-            codes = usual_codes + receipt_codes + invoice_m_code + receipt_m_code + mipyme_codes + zeta_codes
         elif afip_pos_system in ['CPERCEL', 'CPEWS']:
             # invoice with detail
             codes = usual_codes + invoice_m_code
@@ -131,6 +130,8 @@ class AccountJournal(models.Model):
             codes = usual_codes + mipyme_codes
         elif afip_pos_system in ['FEERCEL', 'FEEWS', 'FEERCELP']:
             codes = expo_codes
+        elif afip_pos_system == 'CF':
+            codes = tique_codes
         return [('code', 'in', codes)]
 
     @api.constrains('l10n_ar_afip_pos_system')


### PR DESCRIPTION
Add new afip pos type "External Fiscal Controller" and update document type codes for journals "Online Invoice" because that journals do not use zeta codes any more.

References: LATAM Task 1252 / Task Adhoc side: 42561


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
