### PR TITLE
[FIX] website_sale_loyalty: show discount button in web editor

### DIFF
--- a/addons/website_sale_loyalty/controllers/delivery.py
+++ b/addons/website_sale_loyalty/controllers/delivery.py
@@ -16,4 +16,8 @@ class WebsiteSaleLoyaltyDelivery(Delivery):
                 sum(free_shipping_lines.mapped('price_subtotal')),
                 {'display_currency': order.currency_id}
             )
+        if order.reward_amount:
+            res['amount_discounted'] = Monetary.value_to_html(
+                order.reward_amount, {'display_currency': order.currency_id}
+            )
         return res

--- a/addons/website_sale_loyalty/static/src/js/checkout.js
+++ b/addons/website_sale_loyalty/static/src/js/checkout.js
@@ -9,9 +9,18 @@ WebsiteSaleCheckout.include({
         this._super.apply(this, arguments);
         if (result.amount_delivery_discounted) {
             // Update discount of the order
-            const cart_summary_discount_line = document.querySelector(
+            const cart_summary_delivery_discount_line = document.querySelector(
                 '[data-reward-type="shipping"]'
             )
+            if (cart_summary_delivery_discount_line) {
+                cart_summary_delivery_discount_line.innerHTML = result.amount_delivery_discounted;
+            }
+        }
+        if (result.amount_discounted) {
+            // Update discount of the order
+            const cart_summary_discount_line = document.querySelector(
+                '#order_discount .monetary_field'
+            );
             if (cart_summary_discount_line) {
                 cart_summary_discount_line.innerHTML = result.amount_delivery_discounted;
             }

--- a/addons/website_sale_loyalty/views/snippets.xml
+++ b/addons/website_sale_loyalty/views/snippets.xml
@@ -3,7 +3,7 @@
 
 <template id="snippet_options" inherit_id="website.snippet_options" name="Coupon Snippet Options">
     <xpath expr="." position="inside">
-        <div data-selector="main:has(.oe_website_sale .wizard)" data-page-options="true" groups="website.group_website_designer" data-no-check="true">
+        <div data-selector="main:has(.oe_website_sale .o_wizard)" data-page-options="true" groups="website.group_website_designer" data-no-check="true">
             <we-checkbox string="Show Discount in Subtotal"
                          data-customize-website-views="website_sale_loyalty.cart_discount"
                          data-no-preview="true"

--- a/addons/website_sale_loyalty/views/website_sale_templates.xml
+++ b/addons/website_sale_loyalty/views/website_sale_templates.xml
@@ -149,16 +149,19 @@
 
     <template id="cart_discount" name="Show Discount in Subtotal" active="False" inherit_id="website_sale.total">
         <xpath expr="//tr[@id='order_total_untaxed']" position="before">
-            <tr t-if="website_sale_order and website_sale_order.reward_amount">
-            <td class="text-end border-0 text-muted" title="Discounted amount">Discount:</td>
-            <td class="text-xl-end border-0 text-muted">
-                <span t-field="website_sale_order.reward_amount" style="white-space: nowrap;"
-                    class="monetary_field"
-                    t-options='{
-                            "widget": "monetary",
-                            "display_currency": website_sale_order.currency_id,
-                    }'/>
-            </td>
+            <tr id="order_discount">
+                <td colspan="2" class="text-muted border-0 ps-0 pt-0 pb-2">Discount</td>
+                <td class="text-end border-0 pe-0 pt-0 pb-2">
+                    <span
+                        t-field="website_sale_order.reward_amount"
+                        class="monetary_field"
+                        style="white-space: nowrap;"
+                        t-options="{
+                            'widget': 'monetary',
+                            'display_currency': website_sale_order.currency_id
+                        }"
+                    />
+                </td>
             </tr>
         </xpath>
     </template>


### PR DESCRIPTION
Since 0750eb6315fe9c2d1f1de36b9b756b5097ed11e0, enabling or disabling the discount subtotal in the checkout pages is impossible.

Now, the settings will be shown again in the website editor.

opw-3995547

