### PR TITLE
[FIX] web_editor, website: show animated snippets content within the snippets modal

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -2976,6 +2976,11 @@ we-select.o_grid we-toggler {
                     max-width: 100%;
                 }
             }
+
+            .o_animate {
+                visibility: visible;
+                animation-name: none;
+            }
         }
         .o_custom_snippet_wrap {
             margin-bottom: 96px !important;

--- a/addons/website/static/src/components/dialog/add_page_dialog.js
+++ b/addons/website/static/src/components/dialog/add_page_dialog.js
@@ -190,6 +190,10 @@ export class AddPageTemplatePreview extends Component {
                     /* Avoid the zoom's missing pixel. */
                     transform: scale(101%);
                 }
+                .o_animate {
+                    visibility: visible;
+                    animation-name: none;
+                }
             `;
             const cssText = document.createTextNode(css);
             styleEl.appendChild(cssText);


### PR DESCRIPTION
This PR aims to allow animated snippets to be visible within the
snippets selection modal.

Prior to this PR, the animated content of a snippet was not visible
within the modal. This is due to the fact that the `o_animate` class sets
a `visibility: hidden` by default. As this scenario is corner case and
none of the snippets were using animation, we did not really have the
need of introducing such CSS.

This PR simply add a CSS property to ensure the content of these
snippets will be visible within the modal.

task-4204911

| Master | This PR |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/2057ece5-3248-4ebb-8667-0153b60e3e89) | ![image](https://github.com/user-attachments/assets/7b9c8e93-efd2-4b25-b741-e98805185a9b) | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
