### PR TITLE
[IMP] mail: message aligned right without wasted spacing on right

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -137,9 +137,10 @@ export class Composer extends Component {
         if (this.props.messageEdition) {
             this.props.messageEdition.composerOfThread = this;
         }
-        useChildSubEnv({
-            inComposer: true,
-        });
+        if (this.env.messageComposerResize) {
+            this.env.messageComposerResize.invoke = this.resize.bind(this);
+        }
+        useChildSubEnv({ inComposer: true });
         this.picker = usePicker(this.pickerSettings);
         useEffect(
             (focus) => {
@@ -160,10 +161,7 @@ export class Composer extends Component {
         );
         useEffect(
             () => {
-                if (this.fakeTextarea.el.scrollHeight) {
-                    this.ref.el.style.height = this.fakeTextarea.el.scrollHeight + "px";
-                }
-                this.saveContentDebounced();
+                this.resize();
             },
             () => [this.props.composer.text, this.ref.el]
         );
@@ -183,6 +181,13 @@ export class Composer extends Component {
                 this.restoreContent();
             }
         });
+    }
+
+    resize() {
+        if (this.fakeTextarea.el?.scrollHeight) {
+            this.ref.el.style.height = this.fakeTextarea.el.scrollHeight + "px";
+        }
+        this.saveContentDebounced();
     }
 
     get pickerSettings() {

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -23,6 +23,7 @@ import {
     useEffect,
     useRef,
     useState,
+    useSubEnv,
 } from "@odoo/owl";
 
 import { ActionSwiper } from "@web/core/action_swiper/action_swiper";
@@ -128,6 +129,21 @@ export class Message extends Component {
         this.ui = useState(useService("ui"));
         this.openReactionMenu = this.openReactionMenu.bind(this);
         this.optionsDropdown = useDropdownState();
+        useSubEnv({ messageComposerResize: {} }); // sub-composer expected to register its resize function as `invoke`
+        const messageBodyResizeObserver = new ResizeObserver(() => {
+            if (this.messageBody.el) {
+                this.shrinkWrap(this.messageBody.el);
+            }
+        });
+        useEffect(
+            (el) => {
+                messageBodyResizeObserver.observe(el);
+                return () => {
+                    messageBodyResizeObserver.unobserve(el);
+                };
+            },
+            () => [this.root.el]
+        );
         useChildSubEnv({
             message: this.props.message,
             alignedRight: this.isAlignedRight,
@@ -190,6 +206,27 @@ export class Message extends Component {
                 this.message.body,
             ]
         );
+    }
+
+    /** Courtesy of https://stackoverflow.com/a/78307608 */
+    shrinkWrap(element) {
+        const { firstChild, lastChild } = element;
+        if (!element || !firstChild || !lastChild) {
+            return;
+        }
+        element.style.width = "auto";
+        element.style.boxSizing = "auto";
+        if (this.state.isEditing) {
+            // Composer resize happens before message resize, so need to resize composer again
+            this.env.messageComposerResize?.invoke();
+            return;
+        }
+        const range = document.createRange();
+        range.setStartBefore(firstChild);
+        range.setEndAfter(lastChild);
+        const { width } = range.getBoundingClientRect();
+        element.style.width = width + "px";
+        element.style.boxSizing = "content-box";
     }
 
     get attClass() {


### PR DESCRIPTION
Before this commit, when a user posts a message in chat window with a single sentence, this message was displayed with lost of spacing on the right.

Steps to reproduce:
- As Mitchell Admin, open "general" channel in normal-sized chat window
- Type `@Marc Demo asjdoiasjdoiajsoidjsdd` without backquote, and mentioning Marc Demo
- Send the message => message body text is wrapped with lots of wasted spacing
   on the right.

This happens because message body is a `div` that contains a `span`. The `span` has `work-break` so it is squished, but the `div` does not adapt its width.

Strangely, there's no CSS feature to solve this issue. The visual of self-messages do not look good in such scenario, which happens quite frequently.

This commit fixes the issue by computing the width of parent container in JS. Code doesn't look very nice, but functionally this solves an annoying issue, therefore the "ugly" code is worth the cost.

<img width="944" alt="Screenshot 2024-09-23 at 19 32 46" src="https://github.com/user-attachments/assets/0dbc9cb3-d33e-4405-b8b0-8dfc193dfd84">

![Sep-23-2024 19-37-08](https://github.com/user-attachments/assets/8f8a69f0-a7a2-49e5-9156-b3d1ffdfe543)
