### PR TITLE
[FIX] product: remove readonly from is_favorite on product form view

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -49,7 +49,7 @@
                         <label for="name" string="Product Name"/>
                         <h1>
                             <div class="d-flex">
-                                <field name="is_favorite" widget="boolean_favorite" class="me-3" nolabel="1" readonly="1"/>
+                                <field name="is_favorite" widget="boolean_favorite" class="me-3" nolabel="1"/>
                                 <field class="text-break" name="name" options="{'line_breaks': False}" widget="text" placeholder="e.g. Cheese Burger"/>
                             </div>
                         </h1>


### PR DESCRIPTION
A change was made in https://github.com/odoo/odoo/pull/168464 that made the favorite button unusable on the view. Customers were expecting the functionality to continue working as it has and being able to star and unstar on the form.

opw-4142528
