### PR TITLE
[FIX] phone_validation: botswana phone numbers

### DIFF
--- a/addons/phone_validation/lib/phonenumbers_patch/__init__.py
+++ b/addons/phone_validation/lib/phonenumbers_patch/__init__.py
@@ -67,6 +67,10 @@ else:
         # https://github.com/daviddrysdale/python-phonenumbers/blob/v8.13.40/python/phonenumbers/data/region_KE.py
         phonenumbers.phonemetadata.PhoneMetadata.register_region_loader('KE', _local_load_region)
 
+    if parse_version(phonenumbers.__version__) < parse_version('8.13.45'):
+        # https://github.com/daviddrysdale/python-phonenumbers/blob/v8.13.45/python/phonenumbers/data/region_BW.py
+        phonenumbers.phonemetadata.PhoneMetadata.register_region_loader('BW', _local_load_region)
+
     # MONKEY PATCHING phonemetadata to fix Brazilian phonenumbers following 2016 changes
     def _hook_load_region(code):
         if parse_version(phonenumbers.__version__) < parse_version('8.13.39'):

--- a/addons/phone_validation/lib/phonenumbers_patch/region_BW.py
+++ b/addons/phone_validation/lib/phonenumbers_patch/region_BW.py
@@ -1,0 +1,15 @@
+"""Auto-generated file, do not edit by hand. BW metadata"""
+from ..phonemetadata import NumberFormat, PhoneNumberDesc, PhoneMetadata
+
+PHONE_METADATA_BW = PhoneMetadata(id='BW', country_code=267, international_prefix='00',
+    general_desc=PhoneNumberDesc(national_number_pattern='(?:0800|(?:[37]|800)\\d)\\d{6}|(?:[2-6]\\d|90)\\d{5}', possible_length=(7, 8, 10)),
+    fixed_line=PhoneNumberDesc(national_number_pattern='(?:2(?:4[0-48]|6[0-24]|9[0578])|3(?:1[0-35-9]|55|[69]\\d|7[013]|81)|4(?:6[03]|7[1267]|9[0-5])|5(?:3[03489]|4[0489]|7[1-47]|88|9[0-49])|6(?:2[1-35]|5[149]|8[013467]))\\d{4}', example_number='2401234', possible_length=(7,)),
+    mobile=PhoneNumberDesc(national_number_pattern='(?:321|7[1-8]\\d)\\d{5}', example_number='71123456', possible_length=(8,)),
+    toll_free=PhoneNumberDesc(national_number_pattern='(?:0800|800\\d)\\d{6}', example_number='0800012345', possible_length=(10,)),
+    premium_rate=PhoneNumberDesc(national_number_pattern='90\\d{5}', example_number='9012345', possible_length=(7,)),
+    voip=PhoneNumberDesc(national_number_pattern='79(?:1(?:[0-2]\\d|3[0-3])|2[0-7]\\d)\\d{3}', example_number='79101234', possible_length=(8,)),
+    number_format=[NumberFormat(pattern='(\\d{2})(\\d{5})', format='\\1 \\2', leading_digits_pattern=['90']),
+        NumberFormat(pattern='(\\d{3})(\\d{4})', format='\\1 \\2', leading_digits_pattern=['[24-6]|3[15-9]']),
+        NumberFormat(pattern='(\\d{2})(\\d{3})(\\d{3})', format='\\1 \\2 \\3', leading_digits_pattern=['[37]']),
+        NumberFormat(pattern='(\\d{4})(\\d{3})(\\d{3})', format='\\1 \\2 \\3', leading_digits_pattern=['0']),
+        NumberFormat(pattern='(\\d{3})(\\d{4})(\\d{3})', format='\\1 \\2 \\3', leading_digits_pattern=['8'])])

--- a/addons/phone_validation/tests/test_phonenumbers_patch.py
+++ b/addons/phone_validation/tests/test_phonenumbers_patch.py
@@ -92,6 +92,14 @@ class TestPhonenumbersPatch(BaseCase):
         formatted = phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.INTERNATIONAL)
         self.assertEqual(formatted, '+55 11 2345-6789')
 
+    def test_region_BW_monkey_patch(self):
+        """Makes sure that patch for Botswana phone numbers work"""
+        parse_test_lines_BW = (
+            self.PhoneInputOutputLine("78234111", "BW"),
+            self.PhoneInputOutputLine("+267 79 225 123"),
+        )
+        self._assert_parsing_phonenumbers(parse_test_lines_BW)
+
     def test_region_CI_monkey_patch(self):
         """Makes sure that patch for Ivory Coast phone numbers work"""
         parse_test_lines_CI = (


### PR DESCRIPTION
Current behavior:
---
Botwanan numbers starting with 78 and 79 are not well supported.

Steps to reproduce:
---
```py
parsed = phonenumbers.parse('78 234 111', 'BW')
is_valid = phonenumbers.is_valid_number(parsed)
is_valid == False
```

Cause of the issue:
---
Old versions of phonenumbers (external library) are not up to date with the latest botswanan phone system changes 
Source 2024-04-12: https://www.itu.int/oth/T020200001C/en See table 8 of PDF range 78 200 000 – 78 499 999

Fix:
---
Monkey patched the library, similar as: https://github.com/odoo/odoo/commit/b7878038e0aca885aa174ccd74be9ffd4b393a89

opw-3942014

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
