### PR TITLE
[FIX] point_of_sale: make tip popup work with localized separator again

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -1,4 +1,5 @@
 import { _t } from "@web/core/l10n/translation";
+import { parseFloat } from "@web/views/fields/parsers";
 import { useErrorHandlers, useAsyncLockedMethod } from "@point_of_sale/app/utils/hooks";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";


### PR DESCRIPTION
During [this refactoring] the custom `parseFloat` function import was removed from the payment screen. This custom function took into account the localized decimal separator to parse the entered number in the tip popup.

By removing the import, the default JS `parseFloat` function was used, that only works with a `.` decimal separator. When you selected e.g. Spanish (Latin America) as a language that has `,` as a decimal separator, the payment screen would incorrectly parse the numeric string of the tip amount and cut off the part after the comma when saving it.

This commit adds the correct `parseFloat` import again, so it works with localized separators.

[this refactoring]: https://github.com/odoo/odoo/commit/2a5f1abf2e98ee09fa7a912b87d71879b5ff260b