### PR TITLE
[16.0] [FIX] mail: message css office 365 table

### DIFF
--- a/addons/mail/static/src/components/message/message.scss
+++ b/addons/mail/static/src/components/message/message.scss
@@ -26,12 +26,12 @@
         max-width: 100%;
         overflow-x: auto;
         overflow-y: hidden;
+    }
 
-        // overflow: auto can break rendering of next element of a frequent broken Outlook 365
-        // warning table. If detected, we prevent the issue by removing flotation.
-        &table[align="left"][width="100%"] {
-            float: none;
-        }
+    // overflow: auto can break rendering of next element of a frequent broken Outlook 365
+    // warning table. If detected, we prevent the issue by removing flotation.
+    table[align="left"][width="100%"] {
+        float: none;
     }
 
     img {


### PR DESCRIPTION
This issue was already fixed in c9e94bc78, but it's not working properly. The explanation on that commit is correct, however the resulting CSS from that SCSS is not a valid one:

```css
.o_Message_content *:not(li):nottable(li div)[align="left"][width="100%"] {
  float: none;
}
```

The result is actually weird, which may be due to an issue in the SCSS compiler.

In any case, this commit fixes the SCSS, so that it's compiled like this:

```css
.o_Message_content table[align="left"][width="100%"] {
  float: none;
}
```

Which actually makes more sense, IMHO.

---

Here's a screenshot of runbot:
<img width="1686" alt="Screenshot 2024-09-23 at 3 46 27 PM" src="https://github.com/user-attachments/assets/1dbf2ea6-e918-4d51-b15c-6ad7c493af1c">


---

@nle-odoo @alexkuhn : I ping you as I see you worked on https://github.com/odoo/odoo/pull/101295, so you probably remember this issue



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
