### PR TITLE
[FIX] point_of_sale: use trigger functions for enter and escape

### DIFF
--- a/addons/point_of_sale/static/src/app/utils/input_popups/number_popup.js
+++ b/addons/point_of_sale/static/src/app/utils/input_popups/number_popup.js
@@ -29,7 +29,10 @@ export class NumberPopup extends Component {
 
     setup() {
         this.numberBuffer = useService("number_buffer");
-        this.numberBuffer.use();
+        this.numberBuffer.use({
+            triggerAtEnter: () => this.confirm(),
+            triggerAtEscape: () => this.cancel(),
+        });
         this.state = useState({
             buffer: this.props.startingValue,
         });


### PR DESCRIPTION
A change was made to simplify the number pad for point of sale, however, this change also removed the functionality of the enter and escape keys. This would cause the enter key to input a character instead of confirming.

Adding the triggerAtEnter and triggerAtEscape config back to the number buffer allows this functionality to be restored.

opw-4194518