### PR TITLE
[FIX] account: Fix currency rounding issues when syncing invoice

### DIFF
--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -759,6 +759,40 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             'amount_total': 1384.0,
         })
 
+    def test_in_invoice_change_date_rounding_multi_currency(self):
+        new_currency_id = self.env['res.currency'].create({
+                'name': 'Test',
+                'symbol': 'T',
+                'rounding': 0.01,
+            })
+
+        self.env['res.currency.rate'].create([
+            {
+                'currency_id': new_currency_id.id,
+                'name': '2017-01-01',
+                'rate': 0.233661237937,
+            }, {
+                'currency_id': new_currency_id.id,
+                'name': '2016-01-01',
+                'rate': 0.233666697822,
+            }
+        ])
+
+
+        move_form = Form(self.env['account.move'].with_context(default_move_type='in_invoice', check_move_validity=True))
+        move_form.partner_id = self.partner_a
+        move_form.currency_id = new_currency_id
+        move_form.invoice_date = '2016-01-01'
+        move_form.invoice_payment_term_id = self.env['account.payment.term']
+        with move_form.invoice_line_ids.new() as line_form:
+            line_form.product_id = self.product_a
+            line_form.price_unit = 88.54
+
+        move_form.save()
+
+        move_form.invoice_date = '2017-01-01'
+        move_form.save()
+
     def test_compute_cash_rounding_lines(self):
         cash_rounding_add_invoice_line = self.env['account.cash.rounding'].create({
             'name': 'Add invoice line Rounding Down',


### PR DESCRIPTION
Currently, it is possible to create currency rounding issues on invoices with very specific workflows. Here is the setup to reproduce:
1. Create a 20% tax
2. Add currency exchange rates for 2 different dates. For the older date, set it to 0.233661237937 and for the newer date set the rate to 0.233666697822.
3. Create an invoice in the foreign currency for any product with a unit price of 88.54, and set the 20% tax on it. DO NOT set a date on the invoice yet
4. Save the Invoice
5. Change the date to the older date of the currency exchange rates, try to save again and the error will appear

This is due to the sync_invoices method doing a raw rounding of each aml balance, including the `payment_term` line, which can cause rounding mismatches. In the above example, the product line computes to 378.924638 in foreign currency, and the tax line rounds to 75.793487 in foreign currency. These will both round down, summing to 454.71. The payment_term line of 106.25 will be converted directly to foreign currency, yielding a value of 454.718125 which will round up. This will create an unbalanced journal entry which cannot be made. This only occurs when updating an existing invoice with a new date, as the `create` flow for `account_move` records creates the payment_term line based on the sum of the individual line balances.

The fix I have implemented translates this logic into the `sync_invoices` method; when sync invoices is called, the new logic will specifically check if the `currency_rate` has been updated in the recordset. If it has, then we go into a new flow which will re-round the non-payment term lines using the new rate, and aggregate those values. After all of the rounded values have been aggregated, the payment_term line's balance will be updated accordingly.

OPW-4078865


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
