### PR TITLE
[FIX] l10n_latam_invoice_document: Consider default document type for debit notes

### DIFF
--- a/addons/l10n_latam_invoice_document/models/account_move.py
+++ b/addons/l10n_latam_invoice_document/models/account_move.py
@@ -221,6 +221,8 @@ class AccountMove(models.Model):
     def _compute_l10n_latam_document_type(self):
         for rec in self.filtered(lambda x: x.state == 'draft' and (not x.posted_before if x.move_type in ['out_invoice', 'out_refund'] else True)):
             document_types = rec.l10n_latam_available_document_type_ids._origin
+            if rec.debit_origin_id:
+                document_types = document_types.filtered(lambda x: x.internal_type == 'debit_note')
             if rec.l10n_latam_document_type_id not in document_types:
                 rec.l10n_latam_document_type_id = document_types and document_types[0].id
 


### PR DESCRIPTION

Restores code from v16 to define a default document type for debit notes on records with debit_origin_id.

Previously, when using the wizard to generate a debit note, the default document type (related to debit notes) was being overwritten by the first document type associated with invoices.

Although this behavior will be removed in v17, this fix is necessary to prevent overwriting the default value for now.

Note: It's still possible to use the document type for invoices. Therefore, the change only affects the computation of the default value.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
