### PR TITLE
[IMP] web: kanban: remove user_context from rendering context

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_record.js
+++ b/addons/web/static/src/views/kanban/kanban_record.js
@@ -389,7 +389,6 @@ export class KanbanRecord extends Component {
             read_only_mode: this.props.readonly,
             record: this.dataState.record,
             selection_mode: this.props.forceGlobalClick,
-            user_context: user.context,
             widget: this.dataState.widget,
             __comp__: Object.assign(Object.create(this), { this: this }),
         };
@@ -397,6 +396,8 @@ export class KanbanRecord extends Component {
             // deprecated, use <field name="" widget="image"/>
             renderingContext.kanban_image = (...args) =>
                 getImageSrcFromRecordInfo(this.props.record, ...args);
+            // deprecated, use context instead
+            renderingContext.user_context = user.context;
         }
         return renderingContext;
     }

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -70,7 +70,6 @@ import { FileInput } from "@web/core/file_input/file_input";
 
 import { currencies } from "@web/core/currency";
 import { registry } from "@web/core/registry";
-import { user } from "@web/core/user";
 import { RelationalModel } from "@web/model/relational_model/relational_model";
 import { SampleServer } from "@web/model/sample_server";
 import { KanbanCompiler } from "@web/views/kanban/kanban_compiler";
@@ -755,27 +754,6 @@ test("context can be used in kanban template", async () => {
                 </templates>
             </kanban>`,
         context: { some_key: 1 },
-        domain: [["id", "=", 1]],
-    });
-
-    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(1);
-    expect(".o_kanban_record span:contains(yop)").toHaveCount(1);
-});
-
-test("user context can be used in kanban template", async () => {
-    patchWithCleanup(user, { context: { some_key: true } });
-
-    await mountView({
-        type: "kanban",
-        resModel: "partner",
-        arch: `
-            <kanban>
-                <templates>
-                    <div t-name="card">
-                        <field t-if="user_context.some_key" name="foo"/>
-                    </div>
-                </templates>
-            </kanban>`,
         domain: [["id", "=", 1]],
     });
 


### PR DESCRIPTION
Keys of the user_context are available in the context, so having the user_context is redundant. There was only 2 kanban archs using the user_context, both in sign, and the associated enterprise PR adapts them to use the context instead.

Note that we keep it in the rendering context of legacy kanban views (those still using `kanban-box`) for the sake of retro compatibility.

Part of task~3992107

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
