### PR TITLE
[FIX] l10n_nl: rename outdated tax btw_X0

### DIFF
--- a/addons/l10n_nl/migrations/3.1/post-migrate_update_taxes.py
+++ b/addons/l10n_nl/migrations/3.1/post-migrate_update_taxes.py
@@ -3,4 +3,14 @@ from odoo.addons.account.models.chart_template import update_taxes_from_template
 
 
 def migrate(cr, version):
+    cr.execute(
+        r"""
+        UPDATE ir_model_data
+           SET name = name || '_producten'
+         WHERE module = 'l10n_nl'
+           AND model = 'account.tax'
+           AND name ~ '^\d+_btw_X0$'
+        """
+    )
+
     update_taxes_from_templates(cr, 'l10n_nl.l10nnl_chart_template')


### PR DESCRIPTION
The **`btw_X0`** tax was updated [Here](https://github.com/odoo/odoo/commit/02ccb58401a45528adb77c768318c9f6dfdf05b6#diff-de6184d4eb5e7e2450afafb9d22046721e4931216a636ec6b945ea27a1488591L391). Despite this update, some customers are still using the original tax, which was mapped during migration [Here](https://github.com/odoo/odoo/blob/17.0/addons/l10n_nl/migrations/3.3/post-migrate_update_taxes.py#L22). As a result of these changes, the customers are unable to view the tax report correctly as it appeared in the production environment. To address this issue, I have renamed the XML ID of the tax.

opw-4091389
upg-1874716

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
