### PR TITLE
[FIX] base: fix traceback when exporting the translation without model

### DIFF
--- a/odoo/addons/base/wizard/base_export_language_views.xml
+++ b/odoo/addons/base/wizard/base_export_language_views.xml
@@ -13,7 +13,7 @@
                         <field name="format"/>
                         <field name="export_type"/>
                         <field name="modules" widget="many2many_tags" options="{'no_create': True}" invisible="export_type == 'model'"/>
-                        <field name="model_id" options="{'no_create': True}" invisible="export_type == 'module'"/>
+                        <field name="model_id" options="{'no_create': True}" invisible="export_type == 'module'" required="export_type == 'model'"/>
                         <field name="model_name" invisible="1"/>
                         <field name="domain" widget="domain" options="{'model': 'model_name'}" invisible="export_type == 'module'"/>
                     </group>


### PR DESCRIPTION
Currently, a traceback is occurring when the user tries to export a translation 
without selecting the model when the export type is `model`

To reproduce this issue:

1) Try to export a translation without a model with the export type as `model`

Error:- 
```
KeyError: False
```

We can see that the model is not required when exporting a translation when the export type is `model`.

This leads to a Keyerror from the below line

https://github.com/odoo/odoo/blob/ce786882fe852786441ab86d9311aecc143cf57d/odoo/addons/base/wizard/base_export_language.py#L43-L44

Making the model as required in a stable version if the export type is `model` in XML is not
stable friendly.

So raising a `Usererror` will resolve this issue in stable.

Note:- Will make the model as required if the export_type is `model` in master in xml

sentry-5686584762
