### PR TITLE
[FIX] l10n_din5008_sale: Date localization issue

### DIFF
--- a/addons/l10n_din5008_sale/report/din5008_sale_templates.xml
+++ b/addons/l10n_din5008_sale/report/din5008_sale_templates.xml
@@ -8,38 +8,38 @@
                         <t t-if="doc.state in {'draft', 'sent'}">
                             <tr t-if="doc.name">
                                 <td>Quotation No.:</td>
-                                <td><t t-out="doc.name"/></td>
+                                <td><div t-field="doc.name"/></td>
                             </tr>
                             <tr t-if="doc.date_order">
                                 <td>Quotation Date:</td>
-                                <td><t t-out="doc.date_order" t-options="{'widget': 'date'}"/></td>
+                                <td><div t-field="doc.date_order" t-options="{'widget': 'date'}"/></td>
                             </tr>
                             <tr t-if="doc.validity_date">
                                 <td>Expiration:</td>
-                                <td><t t-out="doc.validity_date" t-options="{'widget': 'date'}"/></td>
+                                <td><div t-field="doc.validity_date" t-options="{'widget': 'date'}"/></td>
                             </tr>
                         </t>
                         <t t-else="">
                             <tr t-if="doc.name">
                                 <td>Order No.:</td>
-                                <td><t t-out="doc.name"/></td>
+                                <td><div t-field="doc.name"/></td>
                             </tr>
                             <tr t-if="doc.date_order">
                                 <td>Order Date:</td>
-                                <td><t t-out="doc.date_order" t-options="{'widget': 'date'}"/></td>
+                                <td><div t-field="doc.date_order" t-options="{'widget': 'date'}"/></td>
                             </tr>
                         </t>
                         <tr t-if="doc.client_order_ref">
                             <td>Customer Reference:</td>
-                            <td><t t-out="doc.client_order_ref"/></td>
+                            <td><div t-field="doc.client_order_ref"/></td>
                         </tr>
                         <tr t-if="doc.user_id">
                             <td>Salesperson:</td>
-                            <td><t t-out="doc.user_id.name"/></td>
+                            <td><div t-field="doc.user_id.name"/></td>
                         </tr>
                         <tr t-if="'incoterm' in doc._fields and doc.incoterm">
                             <td>Incoterm:</td>
-                            <td><t t-out="doc.incoterm.code"/></td>
+                            <td><div t-field="doc.incoterm.code"/></td>
                         </tr>
                     </table>
                 </div>


### PR DESCRIPTION
Change field calling convention to support dynamic localization and language formatting. Currently, all fields are called with `t-out` instead of `t-field`, making them non-language or locale-sensitive, which results in a uniform format regardless of user preferences.

Steps to produce:
1: installed l10n_din5008_sale
2: create a Quotation
3: Send it by email
4: Select DIN5008 in the template selector


opw-4189869