### PR TITLE
[IMP] web: display view type when the breadcrumb is hovered

### DIFF
--- a/addons/web/controllers/action.py
+++ b/addons/web/controllers/action.py
@@ -80,10 +80,11 @@ class Action(Controller):
                     if record_id:
                         # some actions may not have a res_model (e.g. a client action)
                         if record_id == 'new':
-                            results.append({'display_name': _("New")})
+                            results.append({'display_name': _("New"), 'view_typpe': 'form'})
                         elif act['res_model']:
-                            results.append({'display_name': request.env[act['res_model']].browse(record_id).display_name})
+                            results.append({'display_name': request.env[act['res_model']].browse(record_id).display_name, 'view_type': 'form'})
                         else:
+                            # If an action don't have a res_model, we don't put the view_type, is probably a clien action
                             results.append({'display_name': act['display_name']})
                     else:
                         if act['res_model'] and act['type'] != 'ir.actions.client':
@@ -92,14 +93,17 @@ class Action(Controller):
                             name = act['display_name'] if any(view[1] != 'form' and view[1] != 'search' for view in act['views']) else None
                         else:
                             name = act['display_name']
-                        results.append({'display_name': name})
+                        if act.get('views'):
+                            results.append({'display_name': name, 'view_type': act['views'][0][1]})
+                        else:
+                            results.append({'display_name': name})
                 elif action.get('model'):
                     Model = request.env[action.get('model')]
                     if record_id:
                         if record_id == 'new':
-                            results.append({'display_name': _("New")})
+                            results.append({'display_name': _("New"), 'view_type': 'form'})
                         else:
-                            results.append({'display_name': Model.browse(record_id).display_name})
+                            results.append({'display_name': Model.browse(record_id).display_name, 'view_type': 'form'})
                     else:
                         # This case cannot be produced by the web client
                         raise BadRequest('Actions with a model should also have a resId')

--- a/addons/web/static/src/search/breadcrumbs/breadcrumbs.xml
+++ b/addons/web/static/src/search/breadcrumbs/breadcrumbs.xml
@@ -24,7 +24,7 @@
                             <t t-set-slot="content">
                                 <t t-foreach="collapsedBreadcrumbs" t-as="breadcrumb" t-key="breadcrumb.jsId">
                                     <DropdownItem onSelected="breadcrumb.onSelected"
-                                                  attrs="{ href: breadcrumb.url, 'data-tooltip': 'Back to &quot;' + breadcrumb.name + '&quot;' + (breadcrumb.isFormView ? ' form' : '')}">
+                                                  attrs="{ href: breadcrumb.url, 'data-tooltip': 'Back to &quot;' + breadcrumb.name + '&quot; ' + breadcrumb.viewType}">
                                         <t t-call="web.Breadcrumb.Name"/>
                                     </DropdownItem>
                                 </t>
@@ -33,7 +33,7 @@
                     </li>
                     <t t-foreach="visiblePathBreadcrumbs" t-as="breadcrumb" t-key="breadcrumb.jsId">
                         <li class="breadcrumb-item d-inline-flex min-w-0" t-att-class="{ o_back_button: breadcrumb_last }" t-att-data-hotkey="breadcrumb_last and 'b'" t-on-click.prevent="breadcrumb.onSelected">
-                            <a t-att-href="breadcrumb.url" class="fw-bold text-truncate" t-att-data-tooltip="'Back to &quot;' + breadcrumb.name + '&quot;' + (breadcrumb.isFormView ? ' form' : '')"><t t-call="web.Breadcrumb.Name"/></a>
+                            <a t-att-href="breadcrumb.url" class="fw-bold text-truncate" t-att-data-tooltip="'Back to &quot;' + breadcrumb.name + '&quot; ' + breadcrumb.viewType"><t t-call="web.Breadcrumb.Name"/></a>
                         </li>
                     </t>
                 </ol>

--- a/addons/web/static/tests/_framework/mock_server/mock_server.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_server.js
@@ -972,12 +972,16 @@ export class MockServer {
                             .display_name,
                     };
                 }
+                if (action.views) {
+                    return { display_name: action.name, view_type: action.views[0][1] };
+                }
                 return { display_name: action.name };
             } else if (model) {
                 if (resId) {
                     return {
                         display_name: this.env[model].read([resId], ["display_name"])[0]
                             .display_name,
+                        view_type: "form",
                     };
                 }
                 throw new Error("Actions with a model should also have a resId");

--- a/addons/web/static/tests/legacy/helpers/mock_server.js
+++ b/addons/web/static/tests/legacy/helpers/mock_server.js
@@ -793,10 +793,16 @@ export class MockServer {
                             .display_name,
                     };
                 }
+                if (act.views) {
+                    return { display_name: act.name, view_type: act.views[0][1] };
+                }
                 return { display_name: act.name };
             } else if (model) {
                 if (resId) {
-                    return { display_name: this.models[model].records[resId].display_name };
+                    return {
+                        display_name: this.models[model].records[resId].display_name,
+                        view_type: "form",
+                    };
                 }
                 throw new Error("Actions with a model should also have a resId");
             }

--- a/addons/web/static/tests/search/control_panel.test.js
+++ b/addons/web/static/tests/search/control_panel.test.js
@@ -45,11 +45,13 @@ test.tags`desktop`("breadcrumbs", async () => {
                     jsId: "controller_7",
                     name: "Previous",
                     onSelected: () => expect.step("controller_7"),
+                    viewType: "kanban",
                 },
                 {
                     jsId: "controller_9",
                     name: "Current",
                     onSelected: () => expect.step("controller_9"),
+                    viewType: "form",
                 },
             ],
         }
@@ -60,6 +62,10 @@ test.tags`desktop`("breadcrumbs", async () => {
     expect(breadcrumbItems[0]).toHaveText("Previous");
     expect(breadcrumbItems[1]).toHaveText("Current");
     expect(breadcrumbItems[1]).toHaveClass("active");
+    expect(breadcrumbItems[0].children[0]).toHaveAttribute(
+        "data-tooltip",
+        'Back to "Previous" kanban'
+    );
 
     click(breadcrumbItems[0]);
     expect.verifySteps(["controller_7"]);

--- a/addons/web/static/tests/webclient/actions/load_state.test.js
+++ b/addons/web/static/tests/webclient/actions/load_state.test.js
@@ -748,6 +748,10 @@ describe(`new urls`, () => {
         expect(browser.location.href).toBe("http://example.com/odoo/action-3/new", {
             message: "the url did not change",
         });
+        expect(`.o_breadcrumb li.breadcrumb-item a`).toHaveAttribute(
+            "data-tooltip",
+            'Back to "Partners" list'
+        );
         expect.verifySteps([
             "/web/webclient/translations",
             "/web/webclient/load_menus",
@@ -793,6 +797,10 @@ describe(`new urls`, () => {
             "Partners",
             "Second record",
         ]);
+        expect(`.o_breadcrumb li.breadcrumb-item a`).toHaveAttribute(
+            "data-tooltip",
+            'Back to "Partners" list'
+        );
         expect(browser.location.href).toBe("http://example.com/odoo/action-3/2", {
             message: "the url did not change",
         });
@@ -986,6 +994,10 @@ describe(`new urls`, () => {
         await mountWebClient();
         expect(`.o_form_view`).toHaveCount(1);
         expect(queryAllTexts`.breadcrumb-item, .o_breadcrumb .active`).toEqual(["Partner", "New"]);
+        expect(`.o_breadcrumb li.breadcrumb-item a`).toHaveAttribute(
+            "data-tooltip",
+            'Back to "Partner" list'
+        );
         expect.verifySteps([
             "/web/webclient/translations",
             "/web/webclient/load_menus",
@@ -1283,6 +1295,10 @@ describe(`new urls`, () => {
 
         await contains(`.breadcrumb .dropdown-toggle`).click();
         expect(`.o-overlay-container .dropdown-menu`).toHaveText("Partners Action 27");
+        expect(`.o-overlay-container .dropdown-menu a`).toHaveAttribute(
+            "data-tooltip",
+            'Back to "Partners Action 27" list'
+        );
         expect(queryAllTexts`.breadcrumb-item, .o_breadcrumb .active`).toEqual([
             "",
             "Second record",
@@ -1295,7 +1311,7 @@ describe(`new urls`, () => {
         );
         expect(queryAllAttributes(".o_breadcrumb li.breadcrumb-item a", "data-tooltip")).toEqual([
             'Back to "Second record" form',
-            'Back to "Partners Action 28"',
+            'Back to "Partners Action 28 kanban"',
         ]);
     });
 
@@ -1320,6 +1336,10 @@ describe(`new urls`, () => {
             "Partners",
             "Second record",
         ]);
+        expect(`.o_breadcrumb li.breadcrumb-item a`).toHaveAttribute(
+            "data-tooltip",
+            'Back to "Partners" list'
+        );
         expect.verifySteps([
             "/web/webclient/translations",
             "/web/webclient/load_menus",


### PR DESCRIPTION
This commit adds the view type to the tooltip when the breadcrumb is hovered. This commit also adds a tooltip on the collapsed breadcrumb items.

task-id: 4070508

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
