### PR TITLE
[FIX] account: fix credit note button shortcut key not working

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -755,7 +755,7 @@
                         <button name="action_reverse" string='Credit Note'
                                 type='object' groups="account.group_account_invoice"
                                 invisible="move_type not in ('out_invoice', 'in_invoice') or state != 'posted'"
-                                data-hotkey="n"/>
+                                data-hotkey="shift+n"/>
                         <!-- Cancel -->
                         <button name="button_cancel" string="Cancel Entry" type="object" groups="account.group_account_invoice" data-hotkey="x"
                                 invisible="not id or state != 'draft' or move_type != 'entry'"/>


### PR DESCRIPTION
This commit changes the shortcut key to open credit note from 'alt+n'  to 'alt+shift+n' .  'alt+n' is already taken to move next in the list view hence credit note button was not working.

task-3769922
