### PR TITLE
[FIX] web: allow drag and drop elements in mass_mailing

### DIFF
--- a/addons/web/static/src/core/utils/draggable_hook_builder.js
+++ b/addons/web/static/src/core/utils/draggable_hook_builder.js
@@ -662,8 +662,12 @@ export function makeDraggableHook(hookParams) {
                 // https://bugzilla.mozilla.org/show_bug.cgi?id=1352061
                 // https://bugzilla.mozilla.org/show_bug.cgi?id=339293
                 safePrevent(ev);
-                if (document.activeElement && !document.activeElement.contains(ev.target)) {
-                    document.activeElement.blur();
+                let activeElement = document.activeElement;
+                if (activeElement && activeElement.nodeName && activeElement.nodeName === "IFRAME") {
+                    activeElement = activeElement.contentDocument.activeElement;
+                }
+                if (activeElement && !activeElement.contains(ev.target)) {
+                    activeElement.blur();
                 }
 
                 const { currentTarget, pointerId, target } = ev;


### PR DESCRIPTION
Issue:
======
We can move elements in mass mailing.

Steps to reproduce the issue:
=============================
- Create a new mass mailing with a template that have some blocks
- Try to drag one of the blocks to another position
- When you click on the button to drag, the right sidebar refreches

Origin of the issue:
====================
The issue was first introduced by [1].

The problem when we have the wysiwyg inside an iframe `document.activeElement` will be equal to the iframe element and the `ev.target` is the button of dragging. In reality the button is inside the iframe but the content of the iframe is like this `<iframe> \#document <iframe>` so contains returns false.

Soltuion:
=========
When the `activeElement` is an iframe we search inside its `contentDocument`.

opw-4196067

[1]: https://github.com/odoo/odoo/commit/ef97eaf9876bcf1712d4a6bfb91307875b0034ac