### PR TITLE
[FIX] website_sale: show comparison price on products page

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -4,7 +4,7 @@ import logging
 
 from odoo import api, fields, models
 from odoo.osv import expression
-from odoo.tools import float_is_zero, is_html_empty
+from odoo.tools import float_compare, float_is_zero, is_html_empty
 from odoo.tools.translate import html_translate
 
 from odoo.addons.http_routing.models.ir_http import slug, unslug
@@ -294,7 +294,7 @@ class ProductTemplate(models.Model):
                     uom=template.uom_id,
                     currency=currency,
                 )
-                if pricelist_base_price != pricelist_price:
+                if float_compare(pricelist_base_price, pricelist_price, precision_rounding=currency.rounding) > 0:
                     base_price = pricelist_base_price
                     template_price_vals['base_price'] = self._apply_taxes_to_price(
                         base_price, currency, product_taxes, taxes, self, website=website,


### PR DESCRIPTION
**Issue:**
On the main product page of the client’s shop, only the current price is displayed, and the strikethrough price (comparison price) is not shown. This issue arises even when comparison prices are enabled on the website.

**Cause:**
At first it was decided that the base price should be given priority over compare price and hence if base price was already set, compare price shouldn't be shown.

**Fix:**
This commit modifies the condition that gives priority to compare price over base price.

**Before this commit:**
The comparison price was shown in the individual product but wasn't shown on the shop page with all products

**After this commit:**
The comparison price is shown even for the shop page.

**Affected version**: saas-17.4~master
**opw**-4191727
