### PR TITLE
[FIX] calendar: copy attachment raw data when sending mail

### DIFF
--- a/addons/calendar/models/calendar_attendee.py
+++ b/addons/calendar/models/calendar_attendee.py
@@ -117,25 +117,13 @@ class Attendee(models.Model):
         # get ics file for all meetings
         ics_files = self.mapped('event_id')._get_ics_file()
 
-        # If the mail template has attachments, prepare copies for each attendee (to be added to each attendee's mail)
-        if mail_template.attachment_ids:
-
-            # Setting res_model to ensure attachments are linked to the msg (otherwise only internal users are allowed link attachments)
-            attachments_values = [a.copy_data({'res_id': 0, 'res_model': 'mail.compose.message'})[0] for a in mail_template.attachment_ids]
-            attachments_values *= len(self)
-            attendee_attachment_ids = self.env['ir.attachment'].create(attachments_values).ids
-
-            # Map attendees to their respective attachments
-            template_attachment_count = len(mail_template.attachment_ids)
-            attendee_id_attachment_id_map = dict(zip(self.ids, split_every(template_attachment_count, attendee_attachment_ids, list)))
-
         for attendee in self:
             if attendee.email and attendee._should_notify_attendee():
                 event_id = attendee.event_id.id
                 ics_file = ics_files.get(event_id)
 
-                # Add template attachments copies to the attendee's email, if available
-                attachment_ids = attendee_id_attachment_id_map[attendee.id] if mail_template.attachment_ids else []
+                # Copy and add template attachments copies to the attendee's email, if available
+                attachment_ids = [a.copy({'res_id': 0, 'res_model': 'mail.compose.message'}).id for a in mail_template.attachment_ids]
 
                 if ics_file:
                     context = {


### PR DESCRIPTION
Steps to reproduce:
- Install Website and Appointments modules
- Add a sample attachment to the email template “Appointment: Attendee Invitation”
- Go to the website and book an appointment
- Check the email in the Emails technical menu

Issues:
The attachment size is 0, this is due to `copy_data` not being
implemented in `ir_attachment.py`. Because of this we are not copying
the raw attribute of the attachments, which is why we end up with an
empty file.

In order to solve this we just use the copy function which will copy the
raw attribute.

opw-4082806