### PR TITLE
[FIX] point_of_sale: error when no cash

### DIFF
--- a/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.xml
+++ b/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.xml
@@ -58,7 +58,7 @@
                     </div>
                 </div>
                 <hr/>
-                <div class="mb-3">
+                <div t-if="pos.config.cash_control" class="mb-3">
                     <label class="form-label">Cash Count</label>
                     <div class="d-flex w-100 gap-2 mt-1">
                         <Input tModel="[state.payments[props.default_cash_details.id], 'counted']"


### PR DESCRIPTION
Fix error when no cash is available in the cash register.

