### PR TITLE
[FIX] web_editor: click on hex_input for background color picker

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -1860,7 +1860,7 @@ const ColorpickerUserValueWidget = SelectUserValueWidget.extend({
      * @override
      */
     _shouldIgnoreClick(ev) {
-        return ev.__isColorpickerClick || this._super(...arguments);
+        return ev.originalEvent.__isColorpickerClick || this._super(...arguments);
     },
     /**
      * Browses the colorpicker XML template to return all possible values of


### PR DESCRIPTION
The goal of this commit is to be able to use the colorpicker's input hex for the background of a block in the website build. Before to this commit, the colorpicker closes when you click in the input hex color.

How to reproduce:
- Go to website builder
- Select a block
- Click on the background picker
- Go to the "custom" tab
- Click on the hex color input

Before this commit:
    The color picker closes

After this commit:
    The color picker is still there and the focus is put on the hex input.

The issue was introduced in the PR odoo/odoo#180468

TaskID: 4206800

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
