### PR TITLE
[FIX] website: properly disable `s_product_list` old assets

### DIFF
--- a/addons/website/views/snippets/s_product_list.xml
+++ b/addons/website/views/snippets/s_product_list.xml
@@ -90,6 +90,7 @@
     <field name="name">Product list 000 variables SCSS</field>
     <field name="bundle">web._assets_primary_variables</field>
     <field name="path">website/static/src/snippets/s_product_list/000_variables.scss</field>
+    <field name="active" eval="False"/>
 </record>
 
 <record id="website.s_product_list_001_scss" model="ir.asset">


### PR DESCRIPTION
This problem was introduced with [1] which disabled part of the old CSS asset of the snippet, forgetting some other part to disable.

This breaks the `test_homepage_outdated_and_mega_menu_up_to_date` test which the mergebot missed in the first place for some reason... this will be investigated.

Note: this commit is not moving the 001 definition which is between two 000 asset parts, as it will actually be removed in another commit.

[1]: https://github.com/odoo/odoo/commit/501e284e6ab52d304d50e6055a7718cba1b70256

runbot-99109
