### PR TITLE
[15.0][IMP] sale_project: Avoid sale order group from sale order tasks action

### DIFF
--- a/addons/sale_project/views/project_sharing_views.xml
+++ b/addons/sale_project/views/project_sharing_views.xml
@@ -33,7 +33,9 @@
                 <field name="sale_order_id" string="Sale Order" filter_domain="['|', ('sale_order_id', 'ilike', self), ('sale_line_id', 'ilike', self)]"/>
             </xpath>
             <xpath expr="//group/filter[@name='customer']" position="after">
-                <filter name="sale_order_id" string="Sales Order Id" context="{'group_by': 'sale_order_id'}" />
+                <!-- TODO: Remove me in master -->
+                <filter name="sale_order_id" string="Sales Order Id" invisible="1" />
+                <filter name="group_by_sale_order" string="Sales Order" context="{'group_by': 'sale_order_id'}" />
             </xpath>
         </field>
     </record>

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -95,7 +95,8 @@
             </xpath>
             <xpath expr="//search/group/filter[@name='customer']" position="after">
                 <!-- TODO: Remove me in master -->
-                <filter string="Sales Order" name="sale_order_id" context="{'group_by': 'sale_order_id'}" invisible="1"/>
+                <filter string="Sales Order" name="sale_order_id" invisible="1"/>
+                <filter string="Sales Order" name="group_by_sale_order" context="{'group_by': 'sale_order_id'}" invisible="1"/>
                 <filter string="Sales Order Item" name="sale_line_id" context="{'group_by': 'sale_line_id'}"/>
             </xpath>
         </field>


### PR DESCRIPTION
Filter name match with a field name and when you use search_default_sale_order_id the records are grouped by sale_order_id.

https://github.com/odoo/odoo/blob/5b63d6f8e75df06b8a83c93b15c7d3451eb9dbbc/addons/sale_project/models/sale_order.py#L95

![image](https://github.com/user-attachments/assets/8ab01b0d-8206-45ae-8991-985e487cced4)

The problem is that when clicking from the sales order form view on the smartbutton tasks, the tasks are grouped by sales order instead of by stage, which is the expected grouping.

The original filter is maintained by removing the context during stable releases, to avoid inheritance problems in case the filter name has been used to extend views.

@Tecnativa TT50965
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
