### PR TITLE
[IMP] portal: prevent composer autofocus on portal documents

### DIFF
--- a/addons/portal/static/src/chatter/core/composer_patch.js
+++ b/addons/portal/static/src/chatter/core/composer_patch.js
@@ -4,7 +4,7 @@ import { patch } from "@web/core/utils/patch";
 
 patch(Composer.prototype, {
     get placeholder() {
-        if (this.env.inPortalChatter) {
+        if (this.env.inFrontendPortalChatter) {
             return _t("Write a message…");
         }
         return super.placeholder;

--- a/addons/portal/static/src/chatter/core/portal_chatter.xml
+++ b/addons/portal/static/src/chatter/core/portal_chatter.xml
@@ -3,8 +3,8 @@
 
 <t t-name="portal.Chatter">
     <div t-if="state.thread" class="o-mail-Chatter w-100 h-100 flex-grow-1 d-flex pt-2" t-att-class="{ 'row':props.twoColumns, 'flex-column':!props.twoColumns }" t-on-scroll="onScrollDebounced" t-ref="root">
-        <div t-if="props.composer" class="o-mail-Chatter-top position-sticky top-0" t-att-class="{ 'col-lg-6':props.twoColumns, 'bg-view':env.inPortalChatter }" t-att-style="(!props.twoColumns and env.inPortalChatter) and 'top: -1px !important; margin-top:-15px; padding-top: 20px'" t-ref="top">
-            <Composer composer="state.thread.composer" autofocus="true" mode="'extended'" onPostCallback.bind="onPostCallback" dropzoneRef="rootRef" t-key="props.threadId"/>
+        <div t-if="props.composer" class="o-mail-Chatter-top position-sticky top-0" t-att-class="{ 'col-lg-6':props.twoColumns, 'bg-view':env.inFrontendPortalChatter }" t-att-style="(!props.twoColumns and env.inFrontendPortalChatter) and 'top: -1px !important; margin-top:-15px; padding-top: 20px'" t-ref="top">
+            <Composer composer="state.thread.composer" autofocus="env.inFrontendPortalChatter ? false : true" mode="'extended'" onPostCallback.bind="onPostCallback" dropzoneRef="rootRef" t-key="props.threadId"/>
         </div>
         <div class="o-mail-Chatter-content" t-att-class="{ 'col-lg-6':props.twoColumns }">
             <Thread thread="state.thread" t-key="state.thread.localId" order="'desc'" scrollRef="rootRef" jumpPresent="state.jumpThreadPresent"/>

--- a/addons/portal/static/src/chatter/frontend/composer_patch.js
+++ b/addons/portal/static/src/chatter/frontend/composer_patch.js
@@ -5,7 +5,7 @@ import { patch } from "@web/core/utils/patch";
 patch(Composer.prototype, {
     setup() {
         super.setup();
-        if (this.env.inPortalChatter) {
+        if (this.env.inFrontendPortalChatter) {
             this.suggestion = undefined;
         }
     },

--- a/addons/portal/static/src/chatter/frontend/portal_chatter.js
+++ b/addons/portal/static/src/chatter/frontend/portal_chatter.js
@@ -15,7 +15,7 @@ export class PortalChatter extends Component {
     setup() {
         useSubEnv({
             displayRating: this.props.displayRating,
-            inPortalChatter: true,
+            inFrontendPortalChatter: true,
         });
         this.overlayService = useService("overlay");
     }


### PR DESCRIPTION
Composer autofocus causes the page to scroll to the composer. While this behavior is desirable in backend chatter or project sharing (the composer is at the top of the page), it's a bit annoying in the portal, which automatically scrolls to the bottom of the page. This commit disables autofocus in that case.