### PR TITLE
[REF] html_editor: overlay API

### DIFF
--- a/addons/html_editor/static/src/core/overlay.js
+++ b/addons/html_editor/static/src/core/overlay.js
@@ -1,24 +1,35 @@
 import { Component, onWillDestroy, useEffect, useExternalListener, useRef, xml } from "@odoo/owl";
 import { usePosition } from "@web/core/position/position_hook";
 import { useActiveElement } from "@web/core/ui/ui_service";
-import { omit } from "@web/core/utils/objects";
 
 export class EditorOverlay extends Component {
     static template = xml`
-        <div t-ref="root" class="overlay">
+        <div t-ref="root" class="overlay" t-att-class="props.className" t-on-pointerdown.stop="() => {}">
             <t t-component="props.Component" t-props="props.props"/>
         </div>`;
 
     static props = {
         target: { validate: (el) => el.nodeType === Node.ELEMENT_NODE, optional: true },
         initialSelection: { type: Object, optional: true },
-        config: Object,
         Component: Function,
         props: { type: Object, optional: true },
         editable: { validate: (el) => el.nodeType === Node.ELEMENT_NODE },
         bus: Object,
         getContainer: Function,
         history: Object,
+        close: Function,
+
+        // Props from createOverlay
+        positionOptions: { type: Object, optional: true },
+        className: { type: String, optional: true },
+        closeOnPointerdown: { type: Boolean, optional: true },
+        hasAutofocus: { type: Boolean, optional: true },
+    };
+
+    static defaultProps = {
+        className: "",
+        closeOnPointerdown: true,
+        hasAutofocus: false,
     };
 
     setup() {
@@ -53,19 +64,28 @@ export class EditorOverlay extends Component {
             () => [rootRef.el]
         );
 
-        if (this.props.config.hasAutofocus) {
+        if (this.props.closeOnPointerdown) {
+            const editableDocument = this.props.editable.ownerDocument;
+            useExternalListener(editableDocument, "pointerdown", this.props.close);
+            // Listen to pointerdown outside the iframe
+            if (editableDocument !== document) {
+                useExternalListener(document, "pointerdown", this.props.close);
+            }
+        }
+
+        if (this.props.hasAutofocus) {
             useActiveElement("root");
         }
-        const positionConfig = {
+        const positionOptions = {
             position: "bottom-start",
             container: this.props.getContainer,
-            ...omit(this.props.config, "hasAutofocus", "onPositioned"),
+            ...this.props.positionOptions,
             onPositioned: (el, solution) => {
-                this.props.config.onPositioned?.(el, solution);
+                this.props.positionOptions?.onPositioned?.(el, solution);
                 this.updateVisibility(el, solution);
             },
         };
-        position = usePosition("root", getTarget, positionConfig);
+        position = usePosition("root", getTarget, positionOptions);
     }
 
     getSelectionTarget() {

--- a/addons/html_editor/static/src/core/overlay_plugin.js
+++ b/addons/html_editor/static/src/core/overlay_plugin.js
@@ -41,8 +41,8 @@ export class OverlayPlugin extends Plugin {
         }
     }
 
-    createOverlay(Component, config = {}) {
-        const overlay = new Overlay(this, Component, () => this.container, config);
+    createOverlay(Component, props = {}, options) {
+        const overlay = new Overlay(this, Component, () => this.container, props, options);
         this.overlays.push(overlay);
         return overlay;
     }
@@ -60,10 +60,11 @@ export class OverlayPlugin extends Plugin {
 }
 
 export class Overlay {
-    constructor(plugin, C, getContainer, config) {
+    constructor(plugin, C, getContainer, props, options) {
         this.plugin = plugin;
         this.C = C;
-        this.config = config;
+        this.editorOverlayProps = props;
+        this.options = options;
         this.isOpen = false;
         this._remove = null;
         this.component = null;
@@ -92,7 +93,7 @@ export class Overlay {
             this._remove = this.plugin.services.overlay.add(
                 EditorOverlay,
                 markRaw({
-                    config: this.config,
+                    ...this.editorOverlayProps,
                     Component: this.C,
                     editable: this.plugin.editable,
                     props,
@@ -100,13 +101,14 @@ export class Overlay {
                     initialSelection,
                     bus: this.bus,
                     getContainer: this.getContainer,
+                    close: this.close.bind(this),
                     history: {
                         enableObserver: this.plugin.shared.enableObserver,
                         disableObserver: this.plugin.shared.disableObserver,
                     },
                 }),
                 {
-                    sequence: this.config.sequence || 50,
+                    ...this.options,
                 }
             );
         }
@@ -117,7 +119,6 @@ export class Overlay {
         if (this._remove) {
             this._remove();
         }
-        this.config.onClose?.();
     }
 
     updatePosition() {

--- a/addons/html_editor/static/src/main/emoji_plugin.js
+++ b/addons/html_editor/static/src/main/emoji_plugin.js
@@ -1,18 +1,6 @@
 import { Plugin } from "@html_editor/plugin";
-import { Component, xml } from "@odoo/owl";
 import { EmojiPicker } from "@web/core/emoji_picker/emoji_picker";
 import { _t } from "@web/core/l10n/translation";
-
-class EditorEmojiPicker extends Component {
-    static template = xml`<div class="popover" t-on-mousedown.stop="() => {}">
-            <EmojiPicker t-props="props"/>
-        </div>`;
-    static components = { EmojiPicker };
-    static props = {
-        close: Function,
-        onSelect: Function,
-    };
-}
 
 export class EmojiPlugin extends Plugin {
     static name = "emoji";
@@ -34,11 +22,9 @@ export class EmojiPlugin extends Plugin {
     });
 
     setup() {
-        this.overlay = this.shared.createOverlay(EditorEmojiPicker, {
+        this.overlay = this.shared.createOverlay(EmojiPicker, {
             hasAutofocus: true,
-        });
-        this.addDomListener(this.document, "mousedown", () => {
-            this.overlay.close();
+            className: "popover",
         });
     }
 
@@ -53,14 +39,15 @@ export class EmojiPlugin extends Plugin {
             props: {
                 close: () => {
                     this.overlay.close();
+                    this.shared.focusEditable();
                 },
                 onSelect: (str) => {
-                    if (!onSelect) {
-                        this.shared.domInsert(str);
-                        this.dispatch("ADD_STEP");
+                    if (onSelect) {
+                        onSelect(str);
                         return;
                     }
-                    onSelect(str);
+                    this.shared.domInsert(str);
+                    this.dispatch("ADD_STEP");
                 },
             },
             target,

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -41,6 +41,7 @@ export class ColorPlugin extends Plugin {
                     type: "foreground",
                     getUsedCustomColors: () => p.getUsedCustomColors("color"),
                     getSelectedColors: () => p.selectedColors,
+                    focusEditable: () => p.shared.focusEditable(),
                 },
             },
             {
@@ -53,6 +54,7 @@ export class ColorPlugin extends Plugin {
                     type: "background",
                     getUsedCustomColors: () => p.getUsedCustomColors("background"),
                     getSelectedColors: () => p.selectedColors,
+                    focusEditable: () => p.shared.focusEditable(),
                 },
             },
         ],

--- a/addons/html_editor/static/src/main/font/color_selector.js
+++ b/addons/html_editor/static/src/main/font/color_selector.js
@@ -37,6 +37,7 @@ export class ColorSelector extends Component {
         type: String, // either foreground or background
         getUsedCustomColors: Function,
         getSelectedColors: Function,
+        focusEditable: Function,
         ...toolbarButtonProps,
     };
 
@@ -73,6 +74,7 @@ export class ColorSelector extends Component {
     applyColor(color) {
         this.currentCustomColor.color = color;
         this.props.dispatch("APPLY_COLOR", { color: color || "", mode: this.mode });
+        this.props.focusEditable();
     }
 
     onColorApply(ev) {

--- a/addons/html_editor/static/src/main/font/color_selector.xml
+++ b/addons/html_editor/static/src/main/font/color_selector.xml
@@ -10,7 +10,7 @@
                 </t>
             </button>
             <t t-set-slot="content">
-                <div class="o_font_color_selector user-select-none" data-prevent-closing-overlay="true">
+                <div class="o_font_color_selector user-select-none" t-on-pointerdown.stop="() => {}" data-prevent-closing-overlay="true">
                     <div class="mb-1 d-flex">
                         <button class="btn btn-sm btn-light ms-1"
                             t-att-class="{active: state.activeTab === 'solid'}"

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -185,9 +185,7 @@ export class LinkPlugin extends Plugin {
         };
     };
     setup() {
-        this.overlay = this.shared.createOverlay(LinkPopover, {
-            sequence: 40,
-        });
+        this.overlay = this.shared.createOverlay(LinkPopover, {}, { sequence: 40 });
         this.addDomListener(this.editable, "click", (ev) => {
             if (ev.target.tagName === "A" && ev.target.isContentEditable) {
                 ev.preventDefault();
@@ -200,6 +198,7 @@ export class LinkPlugin extends Plugin {
             "Create link",
             () => {
                 this.toggleLinkTools();
+                this.shared.focusEditable();
             },
             {
                 hotkey: "control+k",
@@ -359,6 +358,7 @@ export class LinkPlugin extends Plugin {
                     onApply: (url, _) => {
                         this.linkElement.href = url;
                         this.shared.setCursorEnd(this.linkElement);
+                        this.shared.focusEditable();
                         this.removeCurrentLinkIfEmtpy();
                         this.dispatch("ADD_STEP");
                     },
@@ -413,6 +413,7 @@ export class LinkPlugin extends Plugin {
                     } else {
                         this.linkElement.removeAttribute("class");
                     }
+                    this.shared.focusEditable();
                     this.removeCurrentLinkIfEmtpy();
                     this.dispatch("ADD_STEP");
                 },

--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -1,5 +1,5 @@
 import { _t } from "@web/core/l10n/translation";
-import { Component, useState, onMounted, useExternalListener, useRef } from "@odoo/owl";
+import { Component, useState, onMounted, useRef } from "@odoo/owl";
 import { useAutofocus, useService } from "@web/core/utils/hooks";
 import { browser } from "@web/core/browser/browser";
 import { cleanZWChars, deduceURLfromText } from "./utils";
@@ -75,7 +75,6 @@ export class LinkPopover extends Component {
                 this.loadAsyncLinkPreview();
             }
         });
-        useExternalListener(document, "mousedown", this.onClickAway, { capture: true });
     }
     initButtonStyle(className) {
         const styleArray = [
@@ -114,21 +113,21 @@ export class LinkPopover extends Component {
     onClickRemove() {
         this.props.onRemove();
     }
-    onClickAway(ev) {
-        if (
-            this.editingWrapper?.el &&
-            !this.editingWrapper?.el.contains(ev.target) &&
-            !this.props.linkEl.contains(ev.target)
-        ) {
-            this.props.onClose();
-        }
-    }
+
     onKeydownEnter(ev) {
         if (ev.key === "Enter") {
             ev.preventDefault();
             this.onClickApply();
         }
     }
+
+    onKeydown(ev) {
+        if (ev.key === "Escape") {
+            ev.preventDefault();
+            this.props.onClose();
+        }
+    }
+
     onClickReplaceTitle() {
         this.state.label = this.state.urlTitle;
         this.onClickApply();

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -1,7 +1,7 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="html_editor.linkPopover">
-        <div class="o-we-linkpopover d-flex bg-white overflow-auto shadow">
+        <div class="o-we-linkpopover d-flex bg-white overflow-auto shadow" t-on-keydown="onKeydown">
             <div t-if="state.editing" class="container-fluid d-flex vertical-center p-2" t-ref="editing-wrapper"  data-prevent-closing-overlay="true">
                 <div t-if="state.isImage" class="col p-2" style="max-width: 250px;">
                     <div class="input-group mb-1">

--- a/addons/html_editor/static/src/main/media/image_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_plugin.js
@@ -181,6 +181,7 @@ export class ImagePlugin extends Plugin {
             if (e.target.tagName === "IMG") {
                 const [anchorNode, anchorOffset, focusNode, focusOffset] = boundariesOut(e.target);
                 this.shared.setSelection({ anchorNode, anchorOffset, focusNode, focusOffset });
+                this.shared.focusEditable();
             }
         });
         this.fileViewer = createFileViewer();

--- a/addons/html_editor/static/src/main/powerbox/powerbox.js
+++ b/addons/html_editor/static/src/main/powerbox/powerbox.js
@@ -28,10 +28,6 @@ export class Powerbox extends Component {
         useExternalListener(this.props.document, "mousemove", () => {
             this.mouseSelectionActive = true;
         });
-
-        useExternalListener(this.props.document, "mousedown", (ev) => {
-            this.props.close();
-        });
     }
 
     get commands() {

--- a/addons/html_editor/static/src/main/table/table_menu.xml
+++ b/addons/html_editor/static/src/main/table/table_menu.xml
@@ -3,14 +3,16 @@
         <Dropdown menuClass="'m-0'" position="props.type === 'column' ? 'bottom' : 'right'" state="props.dropdownState">
             <button t-att-data-type="props.type" class="o-we-table-menu fa" t-attf-class="fa-ellipsis-{{props.type === 'column' ? 'h w-100' : 'v h-100'}}" />
             <t t-set-slot="content">
-                <t t-foreach="items" t-as="item" t-key="item_index">
-                    <DropdownItem onSelected="() => this.onSelected(item)">
-                        <div class="user-select-none" t-att-name="item.name">
-                            <span t-if="item.icon" class="me-2 fa" t-att-class="item.icon"/>
-                            <span t-esc="item.text"/>
-                        </div>
-                    </DropdownItem>
-                </t>
+                <div t-on-pointerdown.stop="() => {}">
+                    <t t-foreach="items" t-as="item" t-key="item_index">
+                        <DropdownItem onSelected="() => this.onSelected(item)">
+                            <div class="user-select-none" t-att-name="item.name">
+                                <span t-if="item.icon" class="me-2 fa" t-att-class="item.icon"/>
+                                <span t-esc="item.text"/>
+                            </div>
+                        </DropdownItem>
+                    </t>
+                 </div>
             </t>
         </Dropdown>
     </t>

--- a/addons/html_editor/static/src/main/table/table_picker.js
+++ b/addons/html_editor/static/src/main/table/table_picker.js
@@ -16,10 +16,6 @@ export class TablePicker extends Component {
             cols: 3,
             rows: 3,
         });
-        const editable = this.props.editable;
-        useExternalListener(editable.ownerDocument, "mousedown", (ev) => {
-            this.props.overlay.close();
-        });
         useExternalListener(this.props.editable, "keydown", (ev) => {
             const key = ev.key;
             const isRTL = this.props.direction === "rtl";

--- a/addons/html_editor/static/src/main/table/table_ui_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_ui_plugin.js
@@ -34,19 +34,21 @@ export class TableUIPlugin extends Plugin {
     setup() {
         /** @type {import("@html_editor/core/overlay_plugin").Overlay} */
         this.picker = this.shared.createOverlay(TablePicker, {
-            onPositioned: (picker, position) => {
-                const popperRect = picker.getBoundingClientRect();
-                const { left } = position;
-                if (this.config.direction === "rtl") {
-                    // position from the right instead of the left as it is needed
-                    // to ensure the expand animation is properly done
-                    if (left < 0) {
-                        picker.style.right = `${-popperRect.width - left}px`;
-                    } else {
-                        picker.style.right = `${window.innerWidth - left - popperRect.width}px`;
+            positionOptions: {
+                onPositioned: (picker, position) => {
+                    const popperRect = picker.getBoundingClientRect();
+                    const { left } = position;
+                    if (this.config.direction === "rtl") {
+                        // position from the right instead of the left as it is needed
+                        // to ensure the expand animation is properly done
+                        if (left < 0) {
+                            picker.style.right = `${-popperRect.width - left}px`;
+                        } else {
+                            picker.style.right = `${window.innerWidth - left - popperRect.width}px`;
+                        }
+                        picker.style.removeProperty("left");
                     }
-                    picker.style.removeProperty("left");
-                }
+                },
             },
         });
 
@@ -54,18 +56,22 @@ export class TableUIPlugin extends Plugin {
 
         /** @type {import("@html_editor/core/overlay_plugin").Overlay} */
         this.colMenu = this.shared.createOverlay(TableMenu, {
-            position: "top-fit",
-            onPositioned: (el, solution) => {
-                // Only accept top position as solution.
-                if (solution.direction !== "top") {
-                    el.style.display = "none"; // avoid glitch
-                    this.colMenu.close();
-                }
+            positionOptions: {
+                position: "top-fit",
+                onPositioned: (el, solution) => {
+                    // Only accept top position as solution.
+                    if (solution.direction !== "top") {
+                        el.style.display = "none"; // avoid glitch
+                        this.colMenu.close();
+                    }
+                },
             },
         });
         /** @type {import("@html_editor/core/overlay_plugin").Overlay} */
         this.rowMenu = this.shared.createOverlay(TableMenu, {
-            position: "left-fit",
+            positionOptions: {
+                position: "left-fit",
+            },
         });
         this.addDomListener(this.document, "pointermove", this.onMouseMove);
         const closeMenus = () => {
@@ -75,7 +81,6 @@ export class TableUIPlugin extends Plugin {
                 this.rowMenu.close();
             }
         };
-        this.addDomListener(this.document, "click", closeMenus);
         this.addDomListener(this.document, "scroll", closeMenus, true);
     }
 

--- a/addons/html_editor/static/src/main/toolbar/toolbar.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar.js
@@ -9,6 +9,7 @@ export class Toolbar extends Component {
             shape: {
                 dispatch: Function,
                 getSelection: Function,
+                focusEditable: Function,
                 buttonGroups: {
                     type: Array,
                     element: {
@@ -83,6 +84,11 @@ export class Toolbar extends Component {
             }
         }
         return this.props.toolbar.buttonGroups.filter((group) => group.namespace === undefined);
+    }
+
+    onButtonClick(button) {
+        button.action(this.props.toolbar.dispatch);
+        this.props.toolbar.focusEditable();
     }
 }
 

--- a/addons/html_editor/static/src/main/toolbar/toolbar.xml
+++ b/addons/html_editor/static/src/main/toolbar/toolbar.xml
@@ -21,7 +21,7 @@
                                 }"
                                 t-att-title="button.title"
                                 t-att-name="button.id"
-                                t-on-click="() => button.action(this.props.toolbar.dispatch)"
+                                t-on-click="() => this.onButtonClick(button)"
                             >
                                 <span t-if="button.icon" class="fa fa-fw" t-att-class="button.icon"/>
                                 <span t-if="button.text" t-esc="button.text"/>

--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -43,7 +43,12 @@ export class ToolbarPlugin extends Plugin {
         if (this.isMobileToolbar) {
             this.overlay = new MobileToolbarOverlay(this.editable);
         } else {
-            this.overlay = this.shared.createOverlay(Toolbar, { position: "top-start" });
+            this.overlay = this.shared.createOverlay(Toolbar, {
+                positionOptions: {
+                    position: "top-start",
+                },
+                closeOnPointerdown: false,
+            });
         }
         this.state = reactive({
             buttonsActiveState: this.buttonGroups.flatMap((g) =>
@@ -109,6 +114,7 @@ export class ToolbarPlugin extends Plugin {
             buttonGroups: this.buttonGroups,
             getSelection: () => this.shared.getEditableSelection(),
             state: this.state,
+            focusEditable: () => this.shared.focusEditable(),
         };
     }
 

--- a/addons/html_editor/static/src/others/dynamic_placeholder/dynamic_placeholder.js
+++ b/addons/html_editor/static/src/others/dynamic_placeholder/dynamic_placeholder.js
@@ -1,19 +1,6 @@
-import { _t } from "@web/core/l10n/translation";
 import { Plugin } from "@html_editor/plugin";
-import { Component, xml } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
 import { DynamicPlaceholderPopover } from "@web/views/fields/dynamic_placeholder_popover";
-
-class EditorDynamicPlaceholder extends Component {
-    static template = xml`<div class="popover" t-on-pointerdown.stop="() => {}">
-            <DynamicPlaceholderPopover t-props="props"/>
-        </div>`;
-    static components = { DynamicPlaceholderPopover };
-    static props = {
-        close: Function,
-        validate: Function,
-        resModel: String,
-    };
-}
 
 export class DynamicPlaceholderPlugin extends Plugin {
     static name = "dynamic_placeholder";
@@ -36,14 +23,9 @@ export class DynamicPlaceholderPlugin extends Plugin {
         this.defaultResModel = this.config.dynamicPlaceholderResModel;
 
         /** @type {import("@html_editor/core/overlay_plugin").Overlay} */
-        this.overlay = this.shared.createOverlay(EditorDynamicPlaceholder, {
+        this.overlay = this.shared.createOverlay(DynamicPlaceholderPopover, {
             hasAutofocus: true,
-        });
-
-        this.addDomListener(this.document, "pointerdown", (e) => {
-            if (this.overlay.isOpen) {
-                this.overlay.close();
-            }
+            className: "popover",
         });
     }
 
@@ -73,7 +55,6 @@ export class DynamicPlaceholderPlugin extends Plugin {
                 { type: "danger" }
             );
         }
-        this.preservedSelection = this.shared.preserveSelection();
         this.overlay.open({
             props: {
                 close: this.onClose.bind(this),
@@ -99,13 +80,11 @@ export class DynamicPlaceholderPlugin extends Plugin {
         }
 
         this.shared.domInsert(t);
-        this.editable.focus();
         this.dispatch("ADD_STEP");
     }
-    onClose() {
-        this.preservedSelection?.restore();
-        delete this.preservedSelection;
 
+    onClose() {
         this.overlay.close();
+        this.shared.focusEditable();
     }
 }

--- a/addons/html_editor/static/src/others/qweb_plugin.js
+++ b/addons/html_editor/static/src/others/qweb_plugin.js
@@ -22,7 +22,9 @@ export class QWebPlugin extends Plugin {
 
     setup() {
         this.editable.classList.add("odoo-editor-qweb");
-        this.picker = this.shared.createOverlay(QWebPicker, { position: "top-start" });
+        this.picker = this.shared.createOverlay(QWebPicker, {
+            positionOptions: { position: "top-start" },
+        });
         this.addDomListener(this.editable, "click", this.onClick);
         this.groupIndex = 0;
     }

--- a/addons/html_editor/static/tests/chatgpt.test.js
+++ b/addons/html_editor/static/tests/chatgpt.test.js
@@ -1,6 +1,6 @@
 import { expect, test } from "@odoo/hoot";
 import { setupEditor } from "./_helpers/editor";
-import { press, queryAll, waitFor } from "@odoo/hoot-dom";
+import { getActiveElement, press, queryAll, queryOne, waitFor } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { contains, onRpc } from "@web/../tests/web_test_helpers";
 import { insertText } from "./_helpers/user_actions";
@@ -284,4 +284,23 @@ test("Translate button should be positioned before ChatGPT button in toolbar", a
     expect(buttons).toHaveCount(2);
     expect(buttons[0]).toHaveAttribute("name", "translate");
     expect(buttons[1]).toHaveAttribute("name", "chatgpt");
+});
+
+test("press escape to close ChatGPT dialog", async () => {
+    const { editor, el } = await setupEditor("<p>te[]st</p>", {
+        config: { Plugins: [...MAIN_PLUGINS, ChatGPTPlugin] },
+    });
+
+    // Select ChatGPT in the Powerbox.
+    await openFromPowerbox(editor);
+
+    // Expect the ChatGPT Prompt Dialog to be open.
+    const promptDialogHeaderSelector = `.o_dialog .modal-header:contains("${PROMPT_DIALOG_TITLE}")`;
+    await waitFor(promptDialogHeaderSelector);
+    expect(getActiveElement()).toBe(queryOne('.modal [name="promptInput"]'));
+
+    press("escape");
+    await animationFrame();
+    expect(promptDialogHeaderSelector).toHaveCount(0);
+    expect(getContent(el)).toBe("<p>te[]st</p>");
 });

--- a/addons/html_editor/static/tests/emoji.test.js
+++ b/addons/html_editor/static/tests/emoji.test.js
@@ -6,7 +6,7 @@ import { setupEditor } from "./_helpers/editor";
 import { getContent } from "./_helpers/selection";
 import { insertText, undo } from "./_helpers/user_actions";
 
-test("add an emoji with powerbox", async () => {
+test.tags("desktop")("add an emoji with powerbox", async () => {
     const { el, editor } = await setupEditor("<p>ab[]</p>");
     await loadBundle("web.assets_emoji");
 
@@ -36,7 +36,7 @@ test("click on emoji command to open emoji picker", async () => {
     expect(".o-EmojiPicker").toHaveCount(1);
 });
 
-test("undo an emoji", async () => {
+test.tags("desktop")("undo an emoji", async () => {
     const { el, editor } = await setupEditor("<p>ab[]</p>");
     await loadBundle("web.assets_emoji");
     expect(getContent(el)).toBe("<p>ab[]</p>");
@@ -50,4 +50,20 @@ test("undo an emoji", async () => {
 
     undo(editor);
     expect(getContent(el)).toBe("<p>abtest[]</p>");
+});
+
+test("close emoji picker with escape", async () => {
+    const { el, editor } = await setupEditor("<p>ab[]</p>");
+    await loadBundle("web.assets_emoji");
+    expect(getContent(el)).toBe("<p>ab[]</p>");
+
+    insertText(editor, "/emoji");
+    press("enter");
+    await waitFor(".o-EmojiPicker", { timeout: 1000 });
+    expect(getContent(el)).toBe("<p>ab</p>");
+
+    press("escape");
+    await animationFrame();
+    expect(".o-EmojiPicker").toHaveCount(0);
+    expect(getContent(el)).toBe("<p>ab[]</p>");
 });

--- a/addons/html_editor/static/tests/history.test.js
+++ b/addons/html_editor/static/tests/history.test.js
@@ -277,7 +277,7 @@ describe("prevent mutationFilteredClasses to be set from history", () => {
 
     test("should prevent mutationFilteredClasses to be added when adding 2 classes", async () => {
         await testEditor({
-            contentBefore: `<p>a</p>`,
+            contentBefore: `<p>a[]</p>`,
             stepFunction: async (editor) => {
                 const p = editor.editable.querySelector("p");
                 p.className = "x y";
@@ -285,7 +285,7 @@ describe("prevent mutationFilteredClasses to be set from history", () => {
                 undo(editor);
                 redo(editor);
             },
-            contentAfter: `[]<p class="y">a</p>`,
+            contentAfter: `<p class="y">a[]</p>`,
             config: { Plugins: Plugins },
         });
     });

--- a/addons/html_editor/static/tests/insert/html.test.js
+++ b/addons/html_editor/static/tests/insert/html.test.js
@@ -130,6 +130,7 @@ describe("collapsed selection", () => {
             contentBefore: "<p>content</p>",
             stepFunction: async (editor) => {
                 editor.shared.setCursorEnd(editor.editable, false);
+                editor.shared.focusEditable();
                 editor.shared.domInsert(parseHTML(editor.document, "<p>def</p>"));
                 editor.dispatch("ADD_STEP");
             },
@@ -142,6 +143,7 @@ describe("collapsed selection", () => {
             contentBefore: "<p>content</p>",
             stepFunction: async (editor) => {
                 editor.shared.setCursorEnd(editor.editable, false);
+                editor.shared.focusEditable();
                 await tick();
                 editor.shared.domInsert(parseHTML(editor.document, "<div>abc</div><p>def</p>"));
                 editor.dispatch("ADD_STEP");

--- a/addons/html_editor/static/tests/insert/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/insert/paragraph_break.test.js
@@ -1,7 +1,8 @@
 import { describe, test } from "@odoo/hoot";
+import { press } from "@odoo/hoot-dom";
+import { tick } from "@odoo/hoot-mock";
 import { testEditor } from "../_helpers/editor";
 import { insertText, splitBlock } from "../_helpers/user_actions";
-import { tick } from "@odoo/hoot-mock";
 
 describe("Selection collapsed", () => {
     describe("Basic", () => {
@@ -345,6 +346,14 @@ describe("Selection collapsed", () => {
             });
         });
 
+        async function splitBlockA(editor) {
+            // splitBlock in an <a> tag will open the linkPopover which will take the focus.
+            // So we need to put the selection back into the editor
+            splitBlock(editor);
+            editor.shared.focusEditable();
+            await tick();
+        }
+
         // @todo: re-evaluate this possibly outdated comment:
         // skipping these tests cause with the link isolation the cursor can be put
         // inside/outside the link so the user can choose where to insert the line break
@@ -352,22 +361,22 @@ describe("Selection collapsed", () => {
         test("should insert line breaks outside the edges of an anchor in unbreakable", async () => {
             await testEditor({
                 contentBefore: "<div>ab<a>[]cd</a></div>",
-                stepFunction: splitBlock,
+                stepFunction: splitBlockA,
                 contentAfter: "<div>ab<br><a>[]cd</a></div>",
             });
             await testEditor({
                 contentBefore: "<div><a>a[]b</a></div>",
-                stepFunction: splitBlock,
+                stepFunction: splitBlockA,
                 contentAfter: "<div><a>a<br>[]b</a></div>",
             });
             await testEditor({
                 contentBefore: "<div><a>ab[]</a></div>",
-                stepFunction: splitBlock,
+                stepFunction: splitBlockA,
                 contentAfter: "<div><a>ab</a><br><br>[]</div>",
             });
             await testEditor({
                 contentBefore: "<div><a>ab[]</a>cd</div>",
-                stepFunction: splitBlock,
+                stepFunction: splitBlockA,
                 contentAfter: "<div><a>ab</a><br>[]cd</div>",
             });
         });
@@ -375,20 +384,14 @@ describe("Selection collapsed", () => {
         test("should insert a paragraph break outside the starting edge of an anchor", async () => {
             await testEditor({
                 contentBefore: "<p><a>[]ab</a></p>",
-                stepFunction: async (editor) => {
-                    splitBlock(editor);
-                    await tick();
-                },
+                stepFunction: splitBlockA,
                 contentAfterEdit:
                     '<p><br></p><p>\ufeff<a class="o_link_in_selection">\ufeff[]ab\ufeff</a>\ufeff</p>',
                 contentAfter: "<p><br></p><p><a>[]ab</a></p>",
             });
             await testEditor({
                 contentBefore: "<p>ab<a>[]cd</a></p>",
-                stepFunction: async (editor) => {
-                    splitBlock(editor);
-                    await tick();
-                },
+                stepFunction: splitBlockA,
                 contentAfterEdit:
                     '<p>ab</p><p>\ufeff<a class="o_link_in_selection">\ufeff[]cd\ufeff</a>\ufeff</p>',
                 contentAfter: "<p>ab</p><p><a>[]cd</a></p>",
@@ -397,10 +400,7 @@ describe("Selection collapsed", () => {
         test("should insert a paragraph break in the middle of an anchor", async () => {
             await testEditor({
                 contentBefore: "<p><a>a[]b</a></p>",
-                stepFunction: async (editor) => {
-                    splitBlock(editor);
-                    await tick();
-                },
+                stepFunction: splitBlockA,
                 contentAfterEdit:
                     '<p>\ufeff<a>\ufeffa\ufeff</a>\ufeff</p><p>\ufeff<a class="o_link_in_selection">\ufeff[]b\ufeff</a>\ufeff</p>',
                 contentAfter: "<p><a>a</a></p><p><a>[]b</a></p>",
@@ -409,13 +409,18 @@ describe("Selection collapsed", () => {
         test("should insert a paragraph break outside the ending edge of an anchor", async () => {
             await testEditor({
                 contentBefore: "<p><a>ab[]</a></p>",
-                stepFunction: splitBlock,
-                contentAfterEdit: `<p>\ufeff<a>\ufeffab\ufeff</a>\ufeff</p><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`,
-                contentAfter: "<p><a>ab</a></p><p>[]<br></p>",
+                stepFunction: async (editor) => {
+                    splitBlock(editor);
+                    press("enter");
+                    editor.shared.focusEditable();
+                    await tick();
+                },
+                contentAfterEdit: `<p>\ufeff<a href="">\ufeffab\ufeff</a>\ufeff</p><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`,
+                contentAfter: `<p><a href="">ab</a></p><p>[]<br></p>`,
             });
             await testEditor({
                 contentBefore: "<p><a>ab[]</a>cd</p>",
-                stepFunction: splitBlock,
+                stepFunction: splitBlockA,
                 contentAfterEdit: "<p>\ufeff<a>\ufeffab\ufeff</a>\ufeff</p><p>[]cd</p>",
                 contentAfter: "<p><a>ab</a></p><p>[]cd</p>",
             });

--- a/addons/html_editor/static/tests/media.test.js
+++ b/addons/html_editor/static/tests/media.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { click, press, waitFor } from "@odoo/hoot-dom";
+import { click, getActiveElement, press, queryOne, waitFor } from "@odoo/hoot-dom";
 import { animationFrame, tick } from "@odoo/hoot-mock";
 import { setupEditor } from "./_helpers/editor";
 import { makeMockEnv, onRpc } from "@web/../tests/web_test_helpers";
@@ -86,4 +86,22 @@ test("Can insert an image, and selection should be collapsed after it", async ()
     await animationFrame();
     expect("img[src='/web/static/img/logo2.png']").toHaveCount(1);
     expect(getContent(el).replace(/<img.*?>/, "<img>")).toBe("<p>a<img>[]bc</p>");
+});
+
+test("press escape to close media dialog", async () => {
+    onRpc("/web/dataset/call_kw/ir.attachment/search_read", () => {
+        return [];
+    });
+    const env = await makeMockEnv();
+    const { editor, el } = await setupEditor("<p>a[]bc</p>", { env });
+    insertText(editor, "/image");
+    await waitFor(".o-we-powerbox");
+    press("Enter");
+    await animationFrame();
+    expect(getActiveElement()).toBe(queryOne(".modal .o_select_media_dialog .o_we_search"));
+
+    press("escape");
+    await animationFrame();
+    expect(".modal .o_select_media_dialog").toHaveCount(0);
+    expect(getContent(el)).toBe("<p>a[]bc</p>");
 });

--- a/addons/html_editor/static/tests/selection.test.js
+++ b/addons/html_editor/static/tests/selection.test.js
@@ -217,5 +217,6 @@ test("set a collapse selection in a contenteditable false should move it after t
         anchorNode: queryOne("span[contenteditable='false']"),
         anchorOffset: 1,
     });
+    editor.shared.focusEditable();
     expect(getContent(el)).toBe(`<p>ab<span contenteditable="false">cd</span>[]ef</p>`);
 });

--- a/addons/html_editor/static/tests/utils/dom.test.js
+++ b/addons/html_editor/static/tests/utils/dom.test.js
@@ -188,6 +188,7 @@ describe("wrapInlinesInBlocks", () => {
         );
         const div = el.querySelector("div");
         editor.shared.setSelection({ anchorNode: div, anchorOffset: 0 });
+        editor.shared.focusEditable();
         editor.shared.domInsert(
             parseHTML(
                 editor.document,
@@ -216,6 +217,7 @@ describe("wrapInlinesInBlocks", () => {
         );
         const div = el.querySelector("div");
         editor.shared.setSelection({ anchorNode: div, anchorOffset: 0 });
+        editor.shared.focusEditable();
         editor.shared.domInsert(
             parseHTML(
                 editor.document,

--- a/addons/html_editor/static/tests/utils/selection.test.js
+++ b/addons/html_editor/static/tests/utils/selection.test.js
@@ -413,6 +413,7 @@ describe("setSelection", () => {
                     anchorOffset: 0,
                 })
             );
+            editor.shared.focusEditable();
             expect(result).toEqual([p.firstChild, 0, p.firstChild, 0]);
             const { anchorNode, anchorOffset, focusNode, focusOffset } = document.getSelection();
             expect([anchorNode, anchorOffset, focusNode, focusOffset]).toEqual([
@@ -432,6 +433,7 @@ describe("setSelection", () => {
                     anchorOffset: 2,
                 })
             );
+            editor.shared.focusEditable();
             expect(result).toEqual([p.firstChild, 2, p.firstChild, 2]);
             const { anchorNode, anchorOffset, focusNode, focusOffset } = document.getSelection();
             expect([anchorNode, anchorOffset, focusNode, focusOffset]).toEqual([
@@ -451,6 +453,7 @@ describe("setSelection", () => {
                     anchorOffset: 3,
                 })
             );
+            editor.shared.focusEditable();
             expect(result).toEqual([p.firstChild, 3, p.firstChild, 3]);
             const { anchorNode, anchorOffset, focusNode, focusOffset } = document.getSelection();
             expect([anchorNode, anchorOffset, focusNode, focusOffset]).toEqual([
@@ -471,6 +474,7 @@ describe("setSelection", () => {
                     anchorOffset: 2,
                 })
             );
+            editor.shared.focusEditable();
             expect(result).toEqual([cd, 2, cd, 2]);
             const { anchorNode, anchorOffset, focusNode, focusOffset } = document.getSelection();
             expect([anchorNode, anchorOffset, focusNode, focusOffset]).toEqual([cd, 2, cd, 2]);
@@ -486,6 +490,7 @@ describe("setSelection", () => {
                     anchorOffset: 0,
                 })
             );
+            editor.shared.focusEditable();
             expect(result).toEqual([ef, 0, ef, 0]);
             const { anchorNode, anchorOffset, focusNode, focusOffset } = document.getSelection();
             expect([anchorNode, anchorOffset, focusNode, focusOffset]).toEqual([ef, 0, ef, 0]);
@@ -501,6 +506,7 @@ describe("setSelection", () => {
                     anchorOffset: 2,
                 })
             );
+            editor.shared.focusEditable();
             expect(result).toEqual([efgh, 2, efgh, 2]);
             const { anchorNode, anchorOffset, focusNode, focusOffset } = document.getSelection();
             expect([anchorNode, anchorOffset, focusNode, focusOffset]).toEqual([efgh, 2, efgh, 2]);
@@ -516,6 +522,7 @@ describe("setSelection", () => {
                     anchorOffset: 2,
                 })
             );
+            editor.shared.focusEditable();
             expect(result).toEqual([ef, 2, ef, 2]);
             const { anchorNode, anchorOffset, focusNode, focusOffset } = document.getSelection();
             expect([anchorNode, anchorOffset, focusNode, focusOffset]).toEqual([ef, 2, ef, 2]);
@@ -532,6 +539,7 @@ describe("setSelection", () => {
                     anchorOffset: 0,
                 })
             );
+            editor.shared.focusEditable();
             expect(result).toEqual([ef, 2, ef, 2]);
             const { anchorNode, anchorOffset, focusNode, focusOffset } = document.getSelection();
             expect([anchorNode, anchorOffset, focusNode, focusOffset]).toEqual([ef, 2, ef, 2]);
@@ -542,6 +550,7 @@ describe("setSelection", () => {
                     { normalize: false }
                 )
             );
+            editor.shared.focusEditable();
             expect(nonNormalizedResult).toEqual([gh, 0, gh, 0]);
             const sel = document.getSelection();
             expect([sel.anchorNode, sel.anchorOffset, sel.focusNode, sel.focusOffset]).toEqual([
@@ -565,6 +574,7 @@ describe("setSelection", () => {
                     focusOffset: 3,
                 })
             );
+            editor.shared.focusEditable();
             expect(result).toEqual([p.firstChild, 0, p.firstChild, 3]);
             const { anchorNode, anchorOffset, focusNode, focusOffset } = document.getSelection();
             expect([anchorNode, anchorOffset, focusNode, focusOffset]).toEqual([
@@ -591,6 +601,7 @@ describe("setSelection", () => {
                     focusOffset: 0,
                 })
             );
+            editor.shared.focusEditable();
             expect(result).toEqual([ef, 1, qr, 2]);
             const { anchorNode, anchorOffset, focusNode, focusOffset } = document.getSelection();
             expect([anchorNode, anchorOffset, focusNode, focusOffset]).toEqual([ef, 1, qr, 2]);
@@ -629,6 +640,7 @@ describe("setSelection", () => {
                     focusOffset: 0,
                 })
             );
+            editor.shared.focusEditable();
             expect(result).toEqual([p.firstChild, 3, p.firstChild, 0]);
             const { anchorNode, anchorOffset, focusNode, focusOffset } = document.getSelection();
             expect([anchorNode, anchorOffset, focusNode, focusOffset]).toEqual([
@@ -655,6 +667,7 @@ describe("setSelection", () => {
                     focusOffset: 1,
                 })
             );
+            editor.shared.focusEditable();
             expect(result).toEqual([qr, 2, ef, 1]);
             const { anchorNode, anchorOffset, focusNode, focusOffset } = document.getSelection();
             expect([anchorNode, anchorOffset, focusNode, focusOffset]).toEqual([qr, 2, ef, 1]);
@@ -687,6 +700,7 @@ describe("setCursorStart", () => {
         const { editor, el } = await setupEditor("<p>abc</p>");
         const p = el.firstChild;
         const result = getProcessSelection(editor.shared.setCursorStart(p));
+        editor.shared.focusEditable();
         expect(result).toEqual([p.firstChild, 0, p.firstChild, 0]);
         const { anchorNode, anchorOffset, focusNode, focusOffset } = document.getSelection();
         expect([anchorNode, anchorOffset, focusNode, focusOffset]).toEqual([
@@ -703,6 +717,7 @@ describe("setCursorStart", () => {
         const b = p.childNodes[1].childNodes[1];
         const ef = b.firstChild;
         const result = getProcessSelection(editor.shared.setCursorStart(b));
+        editor.shared.focusEditable();
         expect(result).toEqual([ef, 0, ef, 0]);
         const { anchorNode, anchorOffset, focusNode, focusOffset } = document.getSelection();
         expect([anchorNode, anchorOffset, focusNode, focusOffset]).toEqual([ef, 0, ef, 0]);
@@ -714,6 +729,7 @@ describe("setCursorStart", () => {
         const ef = p.childNodes[1].childNodes[1].firstChild;
         const gh = p.childNodes[1].lastChild;
         const result = getProcessSelection(editor.shared.setCursorStart(gh));
+        editor.shared.focusEditable();
         expect(result).toEqual([ef, 2, ef, 2]);
         const { anchorNode, anchorOffset, focusNode, focusOffset } = document.getSelection();
         expect([anchorNode, anchorOffset, focusNode, focusOffset]).toEqual([ef, 2, ef, 2]);
@@ -736,6 +752,7 @@ describe("setCursorEnd", () => {
         const { editor, el } = await setupEditor("<p>abc</p>");
         const p = el.firstChild;
         const result = getProcessSelection(editor.shared.setCursorEnd(p));
+        editor.shared.focusEditable();
         expect(result).toEqual([p.firstChild, 3, p.firstChild, 3]);
         const { anchorNode, anchorOffset, focusNode, focusOffset } = document.getSelection();
         expect([anchorNode, anchorOffset, focusNode, focusOffset]).toEqual([
@@ -751,6 +768,7 @@ describe("setCursorEnd", () => {
         const p = el.firstChild;
         const cd = p.childNodes[1].firstChild;
         const result = getProcessSelection(editor.shared.setCursorEnd(cd));
+        editor.shared.focusEditable();
         expect(result).toEqual([cd, 2, cd, 2]);
         const { anchorNode, anchorOffset, focusNode, focusOffset } = document.getSelection();
         expect([anchorNode, anchorOffset, focusNode, focusOffset]).toEqual([cd, 2, cd, 2]);
@@ -762,6 +780,7 @@ describe("setCursorEnd", () => {
         const b = p.childNodes[1].childNodes[1];
         const ef = b.firstChild;
         const result = getProcessSelection(editor.shared.setCursorEnd(b));
+        editor.shared.focusEditable();
         expect(result).toEqual([ef, 2, ef, 2]);
         const { anchorNode, anchorOffset, focusNode, focusOffset } = document.getSelection();
         expect([anchorNode, anchorOffset, focusNode, focusOffset]).toEqual([ef, 2, ef, 2]);

--- a/addons/mail/static/src/core/web/mention_list.js
+++ b/addons/mail/static/src/core/web/mention_list.js
@@ -4,7 +4,6 @@ import { useService, useAutofocus } from "@web/core/utils/hooks";
 
 import { NavigableList } from "@mail/core/common/navigable_list";
 import { useSequential } from "@mail/utils/common/hooks";
-import { markEventHandled } from "@web/core/utils/misc";
 
 export class MentionList extends Component {
     static template = "mail.MentionList";
@@ -14,6 +13,10 @@ export class MentionList extends Component {
         close: { type: Function, optional: true },
         type: { type: String },
     };
+    static defaultProps = {
+        close: () => {},
+    };
+
     setup() {
         super.setup();
         this.state = useState({
@@ -73,7 +76,10 @@ export class MentionList extends Component {
             anchorRef: this.ref.el,
             position: "bottom-fit",
             isLoading: !!this.state.searchTerm && this.state.isFetching,
-            onSelect: this.props.onSelect,
+            onSelect: (...args) => {
+                this.props.onSelect(...args);
+                this.props.close();
+            },
             options: [],
         };
         switch (this.props.type) {
@@ -99,6 +105,11 @@ export class MentionList extends Component {
     }
 
     onKeydown(ev) {
-        markEventHandled(ev, "MentionList.onKeydown");
+        switch (ev.key) {
+            case "Escape": {
+                this.props.close();
+                break;
+            }
+        }
     }
 }

--- a/addons/web/static/src/views/fields/dynamic_placeholder_popover.js
+++ b/addons/web/static/src/views/fields/dynamic_placeholder_popover.js
@@ -55,8 +55,8 @@ export class DynamicPlaceholderPopover extends Component {
         this.state.defaultValue = value;
     }
     validate() {
-        this.props.close();
         this.props.validate(this.state.path, this.state.defaultValue);
+        this.props.close();
     }
 
     onBack() {


### PR DESCRIPTION
The purpose of this PR is to make it easier to use overlays in the editor.

1. Clarify the createOverlay API.
================================
Before, we mixed up the positioning hook options and the EditorOverlay props.
After, put all the positioning options in the positionOptions props
and move the sequence to the last param, which corresponds to the overlay
system options.

2. Automatically manage the close at pointerdown.
=================================================
Before, the logic for closing overlays outside the overlay was duplicated
in each component use by createOverlay.
After, the overlay editor is responsible for closing overlays when a pointerdown
occurs outsite of the overlay. You can disable this functionality with the closeOnPointerdown=‘false’ props.

3. Managing setSelections when the selection is not in the editable
===================================================================
For example, the selection is in the input of an overlay.
From this commit, when you call setSelection, if the selection is not in
the editable, you no longer force the selection to be moved into the editable,
you just update the activeSelection. When you want to force the restoration
of the selection in the editable, for example when you close an overlay,
you call the focusEditable function.
This change makes it possible to call functions that manipulate the selection
from the outside without having to refocus in the editor.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
