### PR TITLE
[IMP] hr: allow manager selection from other companies

### DIFF
--- a/addons/hr/models/hr_employee_base.py
+++ b/addons/hr/models/hr_employee_base.py
@@ -42,7 +42,7 @@ class HrEmployeeBase(models.AbstractModel):
     resource_id = fields.Many2one('resource.resource')
     resource_calendar_id = fields.Many2one('resource.calendar', check_company=True)
     parent_id = fields.Many2one('hr.employee', 'Manager', compute="_compute_parent_id", store=True, readonly=False,
-        check_company=True)
+        domain="['|', ('company_id', '=', False), ('company_id', 'in', allowed_company_ids)]")
     coach_id = fields.Many2one(
         'hr.employee', 'Coach', compute='_compute_coach', store=True, readonly=False,
         check_company=True,


### PR DESCRIPTION
Before this commit, it was possible to define a manager from another company using very specific steps by changing employees company. This commit allows to do this by simply be in a multicompany environment.