### PR TITLE
[FIX] web_tour: fix "tour pointer" indicating to scroll inside the modal

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_pointer_state.js
+++ b/addons/web_tour/static/src/tour_service/tour_pointer_state.js
@@ -128,7 +128,16 @@ export function createPointerState() {
                         setState({ anchor, content, onClick: null, position, isVisible: true });
                         return;
                     }
-                    const { x, y, width, height } = scrollParent.getBoundingClientRect();
+                    let { x, y, width, height } = scrollParent.getBoundingClientRect();
+
+                    // If the scrolling element is within an iframe the offsets
+                    // must be computed taking into account the iframe.
+                    const iframeEl = scrollParent.ownerDocument.defaultView.frameElement;
+                    if (iframeEl) {
+                        const iframeOffset = iframeEl.getBoundingClientRect();
+                        x += iframeOffset.x;
+                        y += iframeOffset.y;
+                    }
                     floatingAnchor.style.left = `${x + width / 2}px`;
                     if (intersection.targetPosition === "out-below") {
                         position = "top";


### PR DESCRIPTION
Before this commit, the "tour pointers" that indicated to users that they needed to scroll the "snippets modal" were misaligned. Their position did not account for the iframe offset of the modal.

task-4072655