### PR TITLE
[FIX] website: allow inner form to change background

### DIFF
--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <template id="s_website_form" name="Form">
-    <section class="s_website_form o_cc o_cc2 pt64 pb64" data-vcss="001" data-snippet="s_website_form">
+    <section class="s_website_form pt64 pb64" data-vcss="001" data-snippet="s_website_form">
         <div class="o_container_small">
             <form action="/website/form/" method="post" enctype="multipart/form-data" class="o_mark_required" data-mark="*" data-pre-fill="true" data-model_name="mail.mail" data-success-mode="redirect" data-success-page="/contactus-thank-you">
                 <div class="row text-center">

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -898,7 +898,7 @@
     <t t-set="only_bg_image_exclude" t-value="''"/>
 
     <t t-set="both_bg_color_image_selector" t-value="'section, .carousel-item, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .parallax, .s_text_cover .row > .o_not_editable'"/>
-    <t t-set="both_bg_color_image_exclude" t-value="base_only_bg_image_selector + ', .s_carousel_wrapper, .s_image_gallery .carousel-item, .s_google_map, .s_map, [data-snippet] :not(.oe_structure) > [data-snippet], .s_masonry_block .s_col_no_resize, .s_quotes_carousel_wrapper, .s_carousel_intro_wrapper'"/>
+    <t t-set="both_bg_color_image_exclude" t-value="base_only_bg_image_selector + ', .s_carousel_wrapper, .s_image_gallery .carousel-item, .s_google_map, .s_map, [data-snippet] :not(.oe_structure) > [data-snippet]:not(.s_website_form), .s_masonry_block .s_col_no_resize, .s_quotes_carousel_wrapper, .s_carousel_intro_wrapper'"/>
 
     <t t-call="website.snippet_options_background_options">
         <t t-set="selector" t-value="both_bg_color_image_selector"/>


### PR DESCRIPTION
Prior to this commit, the inner form snippet had a predefined `o_cc2` color, which could not be changed. This could create layout issues depending on which parent snippet the user dragged this inner snippet onto.

This commit allows to change or remove the background color of this inner form snippet.

task-4206683

| Before | After |
|--------|--------|
| <img width="1784" alt="Capture d’écran 2024-09-24 à 11 26 00" src="https://github.com/user-attachments/assets/f3093ee9-0c13-499c-8b71-5e883544612d"> | <img width="1775" alt="Capture d’écran 2024-09-24 à 11 26 31" src="https://github.com/user-attachments/assets/dacc95ad-f8e1-4362-beaa-f4b1e987c815"> |
 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
