### PR TITLE
[FIX] account: fix portal access to invoices with payment term

### DIFF
--- a/addons/account/security/ir.model.access.csv
+++ b/addons/account/security/ir.model.access.csv
@@ -107,6 +107,7 @@ access_account_full_reconcile_group_invoice,account.full.reconcile.group.invoice
 access_account_full_reconcile,account.full.reconcile,model_account_full_reconcile,account.group_account_user,1,1,1,1
 
 access_account_payment_term_partner_manager,account.payment.term partner manager,model_account_payment_term,base.group_user,1,0,0,0
+access_account_payment_term_portal,account.payment.term,model_account_payment_term,base.group_portal,1,0,0,0
 access_account_payment_term_manager,account.payment.term,model_account_payment_term,account.group_account_manager,1,1,1,1
 access_account_payment_term_line_partner_manager,account.payment.term.line partner manager,model_account_payment_term_line,base.group_user,1,0,0,0
 access_account_payment_term_line_manager,account.payment.term.line,model_account_payment_term_line,account.group_account_manager,1,1,1,1


### PR DESCRIPTION
For customers with portal access to invoices with payment terms on it, access was denied with error message: no access to account.payment.term records.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
