### PR TITLE
[FIX] account_peppol: handle phonenumbers import error

### DIFF
--- a/addons/account_peppol/__manifest__.py
+++ b/addons/account_peppol/__manifest__.py
@@ -13,6 +13,9 @@
         'account_edi_proxy_client',
         'account_edi_ubl_cii',
     ],
+    'external_dependencies': {
+        'python': ['phonenumbers']
+    },
     'data': [
         'data/cron.xml',
         'data/res_partner_data.xml',

--- a/addons/account_peppol/wizard/peppol_registration.py
+++ b/addons/account_peppol/wizard/peppol_registration.py
@@ -1,6 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import contextlib
-import phonenumbers
+try:
+    import phonenumbers
+except ImportError:
+    phonenumbers = None
 
 from odoo import _, api, fields, models, modules
 from odoo.exceptions import UserError, ValidationError
@@ -65,6 +68,7 @@ class PeppolRegistration(models.TransientModel):
     def _onchange_phone_number(self):
         for wizard in self:
             if wizard.phone_number:
+                wizard.company_id._sanitize_peppol_phone_number(wizard.phone_number)
                 with contextlib.suppress(phonenumbers.NumberParseException):
                     parsed_phone_number = phonenumbers.parse(
                         wizard.phone_number,


### PR DESCRIPTION
Before this commit, when we tried to import the module phonenumbers which might not be installed on the computer. We got a traceback.

Now we raise an error if it could not be imported informing the user to import it

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
