### PR TITLE
[FIX] mail,im_livechat,*: sub-channel joining notification

### DIFF
--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -173,7 +173,7 @@ class LivechatController(http.Controller):
     def _post_feedback_message(self, channel, rating, reason):
         reason = Markup("<br>" + re.sub(r'\r\n|\r|\n', "<br>", reason) if reason else "")
         body = Markup(
-            """<div class="o_mail_notification o_hide_author">"""
+            """<div class="o_mail_notification">"""
             """%(rating)s: <img class="o_livechat_emoji_rating" src="%(rating_url)s" alt="rating"/>%(reason)s"""
             """</div>"""
         ) % {

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -139,7 +139,7 @@ class DiscussChannel(models.Model):
             # sudo: mail.message - posting visitor leave message is allowed
             self.sudo().message_post(
                 author_id=self.env.ref('base.partner_root').id,
-                body=Markup('<div class="o_mail_notification o_hide_author">%s</div>')
+                body=Markup('<div class="o_mail_notification">%s</div>')
                 % self._get_visitor_leave_message(**kwargs),
                 message_type='notification',
                 subtype_xmlid='mail.mt_comment'
@@ -309,3 +309,14 @@ class DiscussChannel(models.Model):
             self.sudo().livechat_active = False
             self._bus_send_store(Store(self, "livechat_active"))
         super()._action_unfollow(partner, guest, post_leave_message)
+
+    # -------------------------------------------------------------------------
+    # OVERRIDES
+    # -------------------------------------------------------------------------
+
+    def get_displayed_name(self, member=None, author=None):
+        if member.channel_id.channel_type != 'livechat':
+            return super().get_displayed_name(member, author)
+        member_name = member.partner_id.user_livechat_username or member.partner_id.name
+        author_name = author.user_id.livechat_username or author.name
+        return member_name, author_name

--- a/addons/im_livechat/models/discuss_channel_member.py
+++ b/addons/im_livechat/models/discuss_channel_member.py
@@ -61,3 +61,18 @@ class DiscussChannelMember(models.Model):
                 ]
             )
         return domain
+
+    # -------------------------------------------------------------------------
+    # OVERRIDES
+    # -------------------------------------------------------------------------
+
+    def _get_html_link(self, *args, for_persona=False, **kwargs):
+        if self.channel_id.channel_type == 'livechat' and self.partner_id:
+            # sudo: livechat operators can read livechat_username of other operators if they have one
+            user_setting_domain = [('user_id', '=', self.partner_id.user_id.id)]
+            user_setting = self.env["res.users.settings"].sudo().search(user_setting_domain)
+            mentioned_username = user_setting.livechat_username or self.partner_id.name
+            title = f"@{mentioned_username}"
+            return self.partner_id._get_html_link(title=title)
+        else:
+            return super()._get_html_link(for_persona=for_persona)

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -186,10 +186,12 @@ class ChatbotCase(chatbot_common.ChatbotCase):
             )
             transfer_message_data["mail.thread"][0]["display_name"] = "Testing Bot"
             joined_message_data = Store(messages[0]).get_result()
+            partner_employee = self.partner_employee
+            partner_employee_link = f'<a href="#" data-oe-model="res.partner" data-oe-id="{partner_employee.id}">@{partner_employee.name}</a>'
             joined_message_data["mail.message"][0].update(
                 {
-                    "author": {"id": self.partner_employee.id, "type": "partner"},
-                    "body": "<div class=\"o_mail_notification\">joined the channel</div>",
+                    "author": {"id": partner_employee.id, "type": "partner"},
+                    "body": f'<div class="o_mail_notification">{partner_employee_link} joined the channel</div>',
                     # thread not renamed yet at this step
                     "default_subject": "Testing Bot",
                     "record_name": "Testing Bot",

--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -203,7 +203,7 @@ class TestImLivechatMessage(HttpCase, MailCommon):
                                             "id": self.env.user.partner_id.id,
                                             "type": "partner",
                                         },
-                                        "body": '<div class="o_mail_notification o_hide_author">Rating: <img class="o_livechat_emoji_rating" src="/rating/static/src/img/rating_5.png" alt="rating"><br>Good service</div>',
+                                        "body": '<div class="o_mail_notification">Rating: <img class="o_livechat_emoji_rating" src="/rating/static/src/img/rating_5.png" alt="rating"><br>Good service</div>',
                                         "create_date": fields.Datetime.to_string(
                                             message.create_date
                                         ),

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -4,7 +4,7 @@
     <t t-name="mail.Message">
         <div t-if="message.isNotification" class="o-mail-NotificationMessage text-break mx-auto text-muted opacity-75 px-3 text-center smaller" t-on-click="onClickNotificationMessage"  t-att-class="props.className" t-ref="root">
             <i t-if="message.notificationIcon" t-attf-class="{{ message.notificationIcon }} me-1"/>
-            <span class="o-mail-NotificationMessage-author d-inline" t-if="message.author and !message.body.includes(escape(message.author.name))" t-esc="message.author.name"/> <t t-out="message.body"/>
+            <t t-out="message.body"/>
         </div>
         <ActionSwiper t-else="" onRightSwipe="hasTouch() and props.thread?.eq(store.inbox) ? { action: () => this.message.setDone(), bgColor: 'bg-success', icon: 'fa-check-circle' } : undefined">
             <div class="o-mail-Message position-relative rounded-0"

--- a/addons/mail/static/src/core/common/thread.scss
+++ b/addons/mail/static/src/core/common/thread.scss
@@ -27,12 +27,6 @@
     margin-bottom: 0;
 }
 
-.o-mail-NotificationMessage:has(.o_hide_author) {
-    & .o-mail-NotificationMessage-author {
-        display: none!important;
-    }
-}
-
 .o-mail-Thread-banner {
     z-index: $o-mail-NavigableList-zIndex - 1;
     --border-opacity: 0.25;

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -124,7 +124,7 @@ export class DiscussChannel extends models.ServerModel {
             if (partner.id === this.env.user.partner_id) {
                 continue; // adding 'yourself' to the conversation is handled below
             }
-            const body = `<div class="o_mail_notification">invited ${partner.name} to the channel</div>`;
+            const body = `<div class="o_mail_notification">${this.env.user.name} invited ${partner.name} to the channel</div>`;
             const message_type = "notification";
             const subtype_xmlid = "mail.mt_comment";
             this.message_post(channel.id, makeKwArgs({ body, message_type, subtype_xmlid }));

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -91,7 +91,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                                             "id": self.env.user.partner_id.id,
                                             "type": "partner",
                                         },
-                                        "body": f'<div class="o_mail_notification">invited <a href="#" data-oe-model="res.partner" data-oe-id="{self.test_partner.id}">@Test Partner</a> to the channel</div>',
+                                        "body": f'<div class="o_mail_notification">{message.author_id.name} invited <a href="#" data-oe-model="res.partner" data-oe-id="{self.test_partner.id}">@Test Partner</a> to the channel</div>',
                                         "create_date": fields.Datetime.to_string(
                                             message.create_date
                                         ),

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -1321,7 +1321,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             return {
                 "attachment_ids": [],
                 "author": {"id": user_0.partner_id.id, "type": "partner"},
-                "body": f'<div class="o_mail_notification">invited <a href="#" data-oe-model="res.partner" data-oe-id="{user_9.partner_id.id}">@test9</a> to the channel</div>',
+                "body": f'<div class="o_mail_notification">{user_0.partner_id.name} invited <a href="#" data-oe-model="res.partner" data-oe-id="{user_9.partner_id.id}">@test9</a> to the channel</div>',
                 "create_date": create_date,
                 "date": date,
                 "default_subject": "public channel 2",
@@ -1355,7 +1355,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             return {
                 "attachment_ids": [],
                 "author": {"id": user_0.partner_id.id, "type": "partner"},
-                "body": f'<div class="o_mail_notification">invited <a href="#" data-oe-model="res.partner" data-oe-id="{user_12.partner_id.id}">@test12</a> to the channel</div>',
+                "body": f'<div class="o_mail_notification">{user_0.partner_id.name} invited <a href="#" data-oe-model="res.partner" data-oe-id="{user_12.partner_id.id}">@test12</a> to the channel</div>',
                 "create_date": create_date,
                 "date": date,
                 "default_subject": "group restricted channel 1",
@@ -1389,7 +1389,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             return {
                 "attachment_ids": [],
                 "author": {"id": user_0.partner_id.id, "type": "partner"},
-                "body": f'<div class="o_mail_notification">invited <a href="#" data-oe-model="res.partner" data-oe-id="{user_13.partner_id.id}">@test13</a> to the channel</div>',
+                "body": f'<div class="o_mail_notification">{user_0.partner_id.name} invited <a href="#" data-oe-model="res.partner" data-oe-id="{user_13.partner_id.id}">@test13</a> to the channel</div>',
                 "create_date": create_date,
                 "date": date,
                 "default_subject": "group restricted channel 2",


### PR DESCRIPTION
*=test_discuss_full

This commit addresses the following issues:

The message notifications were previously relying on the client code to
include the author's name. This PR updates the server-side code to include
the author's name directly in the message body before posting the notification.

In livechat, when an operator with a dedicated livechat username joins a
conversation, the username was missing from the notification message.
This PR resolves that issue as well.

Ent: https://github.com/odoo/enterprise/pull/76241
