### PR TITLE
[FIX] product: do not show dialog when a record is not saved

### DIFF
--- a/addons/product/static/src/js/product_attribute_value_list.js
+++ b/addons/product/static/src/js/product_attribute_value_list.js
@@ -27,6 +27,9 @@ export class PAVListRenderer extends ListRenderer {
                 body: message,
             });
         }
+        if (record.isNew) {
+            return super.onDeleteRecord(...arguments);
+        }
         this.dialog.add(ConfirmationDialog, {
             title: _t("Bye-bye, record!"),
             body: deleteConfirmationMessage,


### PR DESCRIPTION
Steps to reproduce:
1) Create new attribute value (do not save)
2) Click on delete
3) Confirm deletion in the dialog

Reason: When the record is new it does not have resId. But `unlink`
only accepts list of type 'number' otherwise it throws an error.

