### PR TITLE
[FIX] l10n_in_edi: restrict GST E-Invoice (India) to Indian companies

### DIFF
--- a/addons/l10n_in_edi/models/account_edi_format.py
+++ b/addons/l10n_in_edi/models/account_edi_format.py
@@ -31,6 +31,13 @@ class AccountEdiFormat(models.Model):
             return False
         return super()._is_enabled_by_default_on_journal(journal)
 
+    def _is_compatible_with_journal(self, journal):
+        # OVERRIDE
+        self.ensure_one()
+        if self.code != 'in_einvoice_1_03':
+            return super()._is_compatible_with_journal(journal)
+        return journal.country_code == 'IN' and journal.type == 'sale'
+
     def _get_l10n_in_base_tags(self):
         return (
            self.env.ref('l10n_in.tax_tag_base_sgst').ids


### PR DESCRIPTION
before this PR:
In a multi-company environment, the GST E-Invoice (India) option appears for all companies, regardless of the company's country

after this PR:
on Journal, GST E-Invoice (India) option appears for only Indian companies
