### PR TITLE
[FIX] website: prevent title squashing with `column_count_opt`

### DIFF
--- a/addons/website/views/snippets/s_cards_grid.xml
+++ b/addons/website/views/snippets/s_cards_grid.xml
@@ -4,7 +4,7 @@
 <template id="s_cards_grid" name="Cards Grid">
     <section class="s_cards_grid o_colored_level o_cc o_cc2 pt64 pb64">
         <div class="container">
-            <div class="row">
+            <div class="row s_nb_column_fixed">
                 <div class="col-lg-12">
                     <h3>Features that set us apart</h3>
                 </div>

--- a/addons/website/views/snippets/s_cards_soft.xml
+++ b/addons/website/views/snippets/s_cards_soft.xml
@@ -4,7 +4,7 @@
 <template id="s_cards_soft" name="Cards Soft">
     <section class="s_cards_soft o_cc o_cc1 pt48 pb32">
         <div class="container">
-            <div class="row">
+            <div class="row s_nb_column_fixed">
                 <div class="col-lg-12">
                     <h2 style="text-align: center;">Your Journey Begins Here</h2>
                     <p class="lead" style="text-align: center;">We make every moment count with solutions designed just for you.</p>

--- a/addons/website/views/snippets/s_company_team_detail.xml
+++ b/addons/website/views/snippets/s_company_team_detail.xml
@@ -4,7 +4,7 @@
 <template id="s_company_team_detail" name="Team Detail">
     <section class="s_company_team_detail o_cc o_cc1 pt64 pb64">
         <div class="container">
-            <div class="row">
+            <div class="row s_nb_column_fixed">
                 <div class="col-lg-12">
                     <h3>Meet our team</h3>
                     <p class="lead">Dedicated professionals driving our success</p>

--- a/addons/website/views/snippets/s_company_team_shapes.xml
+++ b/addons/website/views/snippets/s_company_team_shapes.xml
@@ -4,7 +4,7 @@
 <template id="s_company_team_shapes" name="Team Shapes">
     <section class="s_company_team_shapes o_cc o_cc2 pt48 pb48">
         <div class="o_container_small">
-            <div class="row">
+            <div class="row s_nb_column_fixed">
                 <div class="col-lg-12 pb24">
                     <h2 style="text-align: center;">Our talented crew</h2>
                 </div>

--- a/addons/website/views/snippets/s_faq_collapse.xml
+++ b/addons/website/views/snippets/s_faq_collapse.xml
@@ -4,7 +4,7 @@
 <template id="s_faq_collapse" name="FAQ">
     <section class="s_faq_collapse pt32 pb32" data-vcss="001">
         <div class="container">
-            <div class="row align-items-start">
+            <div class="row align-items-start s_nb_column_fixed">
                 <div class="col-lg-4 pt16">
                     <h3>Frequently asked questions</h3>
                     <p class="lead">Here are some common questions about our company.</p>

--- a/addons/website/views/snippets/s_faq_list.xml
+++ b/addons/website/views/snippets/s_faq_list.xml
@@ -4,7 +4,7 @@
 <template id="s_faq_list" name="FAQ List">
     <section class="s_faq_list pt56 pb56">
         <div class="container">
-            <div class="row">
+            <div class="row s_nb_column_fixed">
                 <div class="col-lg-12 pb24">
                     <h3>Need help?</h3>
                     <p class="lead">In this section, you can address common questions efficiently.</p>

--- a/addons/website/views/snippets/s_features_wave.xml
+++ b/addons/website/views/snippets/s_features_wave.xml
@@ -5,7 +5,7 @@
     <section class="s_features_wave o_cc o_cc5 pt64 pb64" data-oe-shape-data="{'shape':'web_editor/Wavy/11', 'showOnMobile':true}">
         <div class="o_we_shape o_web_editor_Wavy_11 o_shape_show_mobile"/>
         <div class="container">
-            <div class="row">
+            <div class="row s_nb_column_fixed">
                 <div class="col-lg-12 pb24">
                     <h3 style="text-align: center;">Everything you need</h3>
                     <p class="lead" style="text-align: center;">List and describe the key features of your solution or service.</p>

--- a/addons/website/views/snippets/s_key_benefits.xml
+++ b/addons/website/views/snippets/s_key_benefits.xml
@@ -4,7 +4,7 @@
 <template id="s_key_benefits" name="Key benefits">
     <section class="s_key_benefits pt48 pb48">
         <div class="container">
-            <div class="row">
+            <div class="row s_nb_column_fixed">
                 <div class="col-lg-12">
                     <p class="lead">
                         ✽&#160;&#160;What We Offer

--- a/addons/website/views/snippets/s_product_list.xml
+++ b/addons/website/views/snippets/s_product_list.xml
@@ -5,7 +5,7 @@
     <t t-set="url" t-value="url or '#'"/>
     <section class="s_product_list pt64 pb64" data-vcss="001">
         <div class="container">
-            <div class="row">
+            <div class="row s_nb_column_fixed">
                 <div class="col-lg-12">
                     <h2 class="h3-fs">Our finest selection</h2>
                 </div>

--- a/addons/website/views/snippets/s_references.xml
+++ b/addons/website/views/snippets/s_references.xml
@@ -4,7 +4,7 @@
 <template id="s_references" name="References">
     <section class="s_references o_cc o_cc1 pt80 pb80">
         <div class="container">
-            <div class="row">
+            <div class="row s_nb_column_fixed">
                 <div class="col-12 col-lg-12 pb24">
                     <h2 style="text-align: center;">Partners and references</h2>
                     <p class="lead" style="text-align: center;">Use this section to boost your company's credibility.</p>

--- a/addons/website/views/snippets/s_references_social.xml
+++ b/addons/website/views/snippets/s_references_social.xml
@@ -4,7 +4,7 @@
 <template id="s_references_social" name="References Social">
     <section class="s_references_social o_cc o_cc1 pt64 pb64">
         <div class="container">
-            <div class="row">
+            <div class="row s_nb_column_fixed">
                 <div class="col-lg-12">
                     <h2 style="text-align: center;">Our valued partners</h2>
                     <p class="lead" style="text-align: center;">We are in good company.</p>


### PR DESCRIPTION
Add `s_nb_column_fixed` class to those snippets using `col` for their titles.
The goal is to maintain layout  integrity when `column_count_opt` is enabled.
This temporary fix  prevents unexpected visual issues, especially for non-technical users.

Note: A layout refactor or a feature review will follow post-release.

task-4207173

|  ![image](https://github.com/user-attachments/assets/5d5fb107-c61d-4d78-9070-461b0b90a208)  | ![image](https://github.com/user-attachments/assets/1f8a08a4-df22-43de-98a0-cd2240bffd4d) |
|--------|--------|
|![image](https://github.com/user-attachments/assets/037ddaa7-ffa5-4de0-991c-8e6787c25490) | ![image](https://github.com/user-attachments/assets/7953bc85-60d4-4f06-b5c3-5da478a379d9) | 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
