### PR TITLE
[FIX] web_tour: custom tour cannot be run in Testing

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_service.js
+++ b/addons/web_tour/static/src/tour_service/tour_service.js
@@ -172,8 +172,12 @@ export const tourService = {
             let tour;
             if (tourConfig.fromDB) {
                 tour = await getTourFromDB(tourName);
-            } else {
+            } else if (tourRegistry.contains(tourName)) {
                 tour = getTourFromRegistry(tourName);
+            }
+
+            if (!tour) {
+                return;
             }
 
             tour.steps.forEach((step) => validateStep(step));
@@ -235,7 +239,7 @@ export const tourService = {
                 startTour(paramsTourName, { mode: "manual", fromDB: true });
             }
 
-            if (tourState.getCurrentTour() && tourRegistry.contains(tourState.getCurrentTour())) {
+            if (tourState.getCurrentTour()) {
                 resumeTour();
             } else if (session.current_tour) {
                 startTour(session.current_tour.name, {


### PR DESCRIPTION
The resume tour was not run if the tour wasn't in the registry. A custom tour is not in the registry, but in the DB. So now, the resume will check if it's in the registry only if the tour doesn't come from the DB.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
