### PR TITLE
[FIX] mail: text overflow issue for mailbox item label

### DIFF
--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -52,7 +52,7 @@
                 <t t-if="props.thread.isLoaded and props.showEmptyMessage">
                     <t name="empty-message">
                         <span class="fs-1" style="filter: grayscale(1);">😶</span>
-                        <span class="fst-italic">The conversation is empty.</span>
+                        <span>The conversation is empty.</span>
                     </t>
                 </t>
             </div>

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.xml
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.xml
@@ -9,7 +9,7 @@
                             <button class="o-mail-DiscussSidebar-compactBtn btn btn-light py-1 align-items-center justify-content-center smaller" t-att-aria-label="compactBtnText" t-att-class="{ 'ms-auto me-0': !store.discuss.isSidebarCompact, 'position-absolute': !store.discuss.isSidebarCompact and !store.inPublicPage, 'o-compact': store.discuss.isSidebarCompact }" t-on-click="() => this.store.discuss.isSidebarCompact = !this.store.discuss.isSidebarCompact" t-ref="compact-btn"><i class="oi fa-fw" t-att-class="store.discuss.isSidebarCompact ? 'oi-arrow-right' : 'oi-arrow-left'"/></button>
                             <t t-set-slot="content">
                                 <div t-ref="compact-floating">
-                                    <span class="fst-italic user-select-none" t-esc="compactBtnText"/>
+                                    <span class="text-muted user-select-none" t-esc="compactBtnText"/>
                                 </div>
                             </t>
                         </Dropdown>

--- a/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
@@ -14,7 +14,7 @@
             <t t-call="mail.Mailbox.main"/>
             <t t-set-slot="content">
                 <div class="overflow-hidden" t-ref="floating">
-                    <span class="fst-italic user-select-none" t-esc="mailbox.name"/>
+                    <span class="text-muted user-select-none" t-esc="mailbox.name"/>
                 </div>
             </t>
         </Dropdown>

--- a/addons/mail/static/src/core/web/discuss_sidebar_patch.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_patch.xml
@@ -6,7 +6,7 @@
                 <t t-call="mail.DiscussSidebar.startMeetingButton"/>
                 <t t-set-slot="content">
                     <div t-ref="meeting-floating">
-                        <span class="fst-italic user-select-none" t-esc="startMeetingText"/>
+                        <span class="text-muted user-select-none" t-esc="startMeetingText"/>
                     </div>
                 </t>
             </Dropdown>


### PR DESCRIPTION
Purpose of this commit:
Previously, the text labels for mailbox sidebar items like 'Starred' and 'History' were 
being not fully displayed due to hidden overflow. This commit resolves the issue 
by ensuring the full text is displayed.

BEFORE:
![image](https://github.com/user-attachments/assets/ac2a7205-693a-4f12-914d-76f5a1a2ab05)
AFTER:
![Screenshot 2024-09-24 at 15 11 12](https://github.com/user-attachments/assets/1a58f9e4-bbf7-4063-8097-6be3ab9a9fde)
