### PR TITLE
[FIX] product: products always grouped by category when click smart button on product category

### DIFF
--- a/addons/point_of_sale/views/product_view.xml
+++ b/addons/point_of_sale/views/product_view.xml
@@ -11,7 +11,7 @@
             <filter name="filter_to_sell" position="before">
                <filter name="filter_to_availabe_pos" string="Available in POS" domain="[('available_in_pos', '=', True)]"/>
             </filter>
-            <filter name="categ_id" position="after">
+            <filter name="group_by_categ_id" position="after">
                 <filter string="POS Product Category" name="pos_categ_ids" context="{'group_by':'pos_categ_ids'}"/>
             </filter>
         </field>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -252,8 +252,8 @@
                 <separator/>
                 <filter string="Archived" name="inactive" domain="[('active','=',False)]"/>
                 <group expand="1" string="Group By">
-                    <filter string="Product Type" name="type" context="{'group_by':'type'}"/>
-                    <filter string="Product Category" name="categ_id" context="{'group_by':'categ_id'}"/>
+                    <filter string="Product Type" name="group_by_type" context="{'group_by':'type'}"/>
+                    <filter string="Product Category" name="group_by_categ_id" context="{'group_by':'categ_id'}"/>
                 </group>
             </search>
         </field>
@@ -287,7 +287,7 @@
                     <field name="product_template_attribute_value_ids" groups="product.group_product_variant"/>
                     <field name="product_tmpl_id" string="Product Template"/>
                 </field>
-                <filter name="categ_id" position="after">
+                <filter name="group_by_categ_id" position="after">
                     <filter string="Product Template" name="group_by_product_tmpl_id" context="{'group_by':'product_tmpl_id'}"/>
                 </filter>
             </field>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

- product_template_search_view : there are one field and one filter named 'categ_id'.

- smart button on product.product_category_form_view  : `context="{'search_default_categ_id': id, 'default_categ_id': id, 'group_expand': True}"`

So the field and filter named 'categ_id' are both activated in the search view, products are grouped by category.

![截图 2024-09-24 18-21-37](https://github.com/user-attachments/assets/1a55d184-3aa6-46ec-a7b1-86367f7c748e)
![截图 2024-09-24 18-21-53](https://github.com/user-attachments/assets/77bec0d9-c0a3-4f5f-8b01-973d9c3fd656)

Products should not be grouped, especially when there is only one product category.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
