### PR TITLE
[FIX] base: Don't compute portal user signature

### DIFF
--- a/odoo/addons/base/security/base_groups.xml
+++ b/odoo/addons/base/security/base_groups.xml
@@ -89,6 +89,7 @@
             <field name="login">portaltemplate</field>
             <field name="active" eval="False"/>
             <field name="groups_id" eval="[Command.set([ref('base.group_portal')])]"/>
+            <field name="signature" /> <!-- Needed for avoiding the _compute_signature triggering on each update -->
         </record>
 
         <record id="default_template_user_config" model="ir.config_parameter">


### PR DESCRIPTION
**Steps to reproduce:**

- On a fresh install, grant to any contact portal access.

**Current behavior:**

The newly created user has in its signature the following text:

```
--
Portal User Template
```

**Expected behavior:**

No text

**Explanation:**

This is because there's no explicit signature set on the user "Portal User Template", which is the template used to create the portal users, and thus, the `compute_signature` method is triggered following the "name" dependency, assigning that one.

And this is even worst, as you may remove that content from the user, but on the next update, it will be rewritten again, as the record is noupdate=0 and the name is always rewritten, triggering again the signature computation.

**Solution:**

Indicate explicitly an empty signature on the XML record definition to avoid the triggering of `_compute_signature`.

@Tecnativa