### PR TITLE
[FIX] point_of_sale: fixup bugs oxp 2024

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -283,7 +283,11 @@ patch(PosStore.prototype, {
             if (orders.length > 0) {
                 this.set_order(orders[0]);
                 this.orderToTransferUuid = null;
-                this.showScreen(orders[0].get_screen_data().name);
+                const props = {};
+                if (orders[0].get_screen_data().name === "PaymentScreen") {
+                    props.orderUuid = orders[0].uuid;
+                }
+                this.showScreen(orders[0].get_screen_data().name, props);
             } else {
                 this.add_new_order();
                 this.showScreen("ProductScreen");

--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -169,7 +169,7 @@ patch(PosStore.prototype, {
             title: _t("Down Payment"),
             subtitle: sprintf(
                 _t("Due balance: %s"),
-                this.env.utils.formatCurrency(sale_order.amount_total)
+                this.env.utils.formatCurrency(sale_order.amount_unpaid)
             ),
             buttons: enhancedButtons(),
             formatDisplayedValue: (x) => (isPercentage ? `% ${x}` : x),

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -221,11 +221,23 @@ export class SelfOrder extends Reactive {
         };
 
         if (Object.entries(selectedValues).length > 0) {
-            values.attribute_value_ids = Object.values(selectedValues).map((a) => {
-                const attrVal = this.models["product.template.attribute.value"].get(a);
-                values.price_extra += attrVal.price_extra;
-                return ["link", attrVal];
-            });
+            values.attribute_value_ids = Object.entries(selectedValues).reduce(
+                (acc, [attributeId, options]) => {
+                    const optionEntries = Object.entries(
+                        typeof options === "object" ? options : { [options]: true }
+                    ).filter(([, isSelected]) => isSelected); // Only true values
+
+                    optionEntries.forEach(([optionId]) => {
+                        const attrVal = this.models["product.template.attribute.value"].get(
+                            Number(optionId)
+                        );
+                        values.price_extra += attrVal.price_extra;
+                        acc.push(["link", attrVal]);
+                    });
+                    return acc;
+                },
+                []
+            );
 
             if (Object.values(customValues).length > 0) {
                 values.custom_attribute_value_ids = Object.values(customValues)


### PR DESCRIPTION
In this commit:
====
- Order total was not shown properly when loading sales order in POS, instead of
unpaid amount, total amount was shown everytime in due balance.
- Fixed Traceback on adding product in cart which contains addons.
- Fixed Traceback while opening an order that is in the payment stage in the
  restaurant from floorscreen.