### PR TITLE
[FIX] account: account group with branches

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -931,9 +931,12 @@ class AccountGroup(models.Model):
               LEFT JOIN account_group agroup
                      ON agroup.code_prefix_start <= LEFT(account.code, char_length(agroup.code_prefix_start))
                     AND agroup.code_prefix_end >= LEFT(account.code, char_length(agroup.code_prefix_end))
-                    AND agroup.company_id = split_part(account_company.parent_path, '/', 1)::int
+                    AND agroup.company_id::text = ANY(string_to_array(account_company.parent_path, '/'))
                   WHERE %s
-               ORDER BY account.id, char_length(agroup.code_prefix_start) DESC, agroup.id
+               ORDER BY account.id,
+                        array_position(string_to_array(account_company.parent_path, '/'), agroup.company_id::text) DESC,
+                        char_length(agroup.code_prefix_start) DESC,
+                        agroup.id
             )
             UPDATE account_account
                SET group_id = rel.group_id


### PR DESCRIPTION
When on a branch, creating accounts and then an account group that encompasses those accounts, the account group wasn't set because the 'relation' table assigned the account's account group to NULL

task: 4207385




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
