### PR TITLE
[FIX] account: matched payment copied when duplicating

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -206,6 +206,7 @@ class AccountMove(models.Model):
         relation='account_move__account_payment',
         column1='invoice_id',
         column2='payment_id',
+        copy=False,
     )
     payment_count = fields.Integer(compute='_compute_payment_count')
 


### PR DESCRIPTION
The matched_payment_ids field value is being copied when duplicating a bill. This causes the payment from the original bill to get linked to the new bill as well, which is unexpected.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
