### PR TITLE
[FIX] sale: default to user language if partner language is unavailable

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -347,7 +347,9 @@ class SaleOrder(models.Model):
                 order.note = _('Terms & Conditions: %s', baseurl)
                 del context
             elif not is_html_empty(self.env.company.invoice_terms):
-                order.note = order.with_context(lang=order.partner_id.lang).env.company.invoice_terms
+                if order.partner_id.lang:
+                    order = order.with_context(lang=order.partner_id.lang)
+                order.note = order.env.company.invoice_terms
 
     @api.model
     def _get_note_url(self):
@@ -1281,7 +1283,9 @@ class SaleOrder(models.Model):
         invoice_vals_list = []
         invoice_item_sequence = 0 # Incremental sequencing to keep the lines order on the invoice.
         for order in self:
-            order = order.with_company(order.company_id).with_context(lang=order.partner_invoice_id.lang)
+            if order.partner_invoice_id.lang:
+                order = order.with_context(lang=order.partner_invoice_id.lang)
+            order = order.with_company(order.company_id)
 
             invoice_vals = order._prepare_invoice()
             invoiceable_lines = order._get_invoiceable_lines(final)


### PR DESCRIPTION
Problem:
When creating a sale order without selecting a partner or if the partner has no language set, the note field displays the default terms in English, regardless of the user's language. It should display the note in the current user's language instead.

Steps to reproduce:
- Add default terms and conditions in both English and Arabic.
- Change the user language to Arabic.
- Create a new quotation without selecting a partner.
- The note is displayed in English, but it should be in Arabic as per the user’s language while no partner selected yet.

opw-4176183

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
