### PR TITLE
[FIX] mail: unwanted spacing below message composer

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -29,7 +29,7 @@ import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { FileUploader } from "@web/views/fields/file_handler";
 import { escape, sprintf } from "@web/core/utils/strings";
-import { isMobileOS } from "@web/core/browser/feature_detection";
+import { isDisplayStandalone, isIOS, isMobileOS } from "@web/core/browser/feature_detection";
 
 const EDIT_CLICK_TYPE = {
     CANCEL: "cancel",
@@ -87,6 +87,7 @@ export class Composer extends Component {
     setup() {
         super.setup();
         this.isMobileOS = isMobileOS();
+        this.isIosPwa = isIOS() && isDisplayStandalone();
         this.SEND_KEYBIND_TO_SEND = markup(
             _t("<samp>%(send_keybind)s</samp><i> to send</i>", { send_keybind: this.sendKeybind })
         );
@@ -563,7 +564,9 @@ export class Composer extends Component {
                     this.notifySendFromMailbox();
                 }
                 if (accidentalDiscard) {
-                    const editor = document.querySelector(".o_mail_composer_form_view .note-editable");
+                    const editor = document.querySelector(
+                        ".o_mail_composer_form_view .note-editable"
+                    );
                     const editorIsEmpty = !editor || !editor.innerText.replace(/^\s*$/gm, "");
                     if (!editorIsEmpty) {
                         this.saveContent();

--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -125,7 +125,7 @@
 .o-mail-Composer-compactContainer {
     --border-opacity: 0.75;
 
-    &.o-mobile:not(:focus-within) {
+    &.o-iosPwa:not(:focus-within) {
         margin-bottom: map-get($spacers, 5) !important;
     }
 

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -35,9 +35,9 @@
                 <div class="d-flex o-mail-Composer-bg flex-grow-1 border"
                     t-att-class="{
                         'o-mail-Composer-compactContainer m-1 shadow-sm border-secondary': compact and !props.composer.message,
-                        'o-mobile rounded-3': isMobileOS,
-                        'rounded-3' : normal,
-                        'rounded-3 align-self-stretch' : extended,
+                        'o-iosPwa': isIosPwa,
+                        'rounded-3' : normal or isMobileOS or extended,
+                        'align-self-stretch' : extended,
                         'flex-column': extended or props.composer.message,
                     }"
                     t-ref="input-container"


### PR DESCRIPTION
Purpose of this commit:
Previously, there was unnecessary space below the compose area in the mobile view. This space was generally present on all phones but was intended only for iOS devices. This commit adjusts the layout accordingly

task-4207316
