### PR TITLE
[IMP] mail: improved Discuss Notification Settings clarity

### DIFF
--- a/addons/mail/data/ir_actions_client.xml
+++ b/addons/mail/data/ir_actions_client.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data>
         <record id="mail.discuss_notification_settings_action" model="ir.actions.client">
-            <field name="name">Notification Settings</field>
+            <field name="name">Notifications</field>
             <field name="tag">mail.discuss_notification_settings_action</field>
             <field name="target">new</field>
             <field name="context">{"dialog_size": "medium", "footer": false}</field>

--- a/addons/mail/static/src/discuss/core/common/action_panel.xml
+++ b/addons/mail/static/src/discuss/core/common/action_panel.xml
@@ -11,13 +11,13 @@
     </t>
 
     <t t-name="mail.ActionPanel.content">
-        <div class="o-mail-ActionPanel-header position-sticky top-0 pt-2 pb-1 d-flex flex-column bg-inherit" t-att-class="{ 'px-1': env.inChatWindow, 'px-2': !env.inChatWindow }">
+        <div class="o-mail-ActionPanel-header position-sticky top-0 pt-2 pb-1 d-flex flex-column bg-inherit small" t-att-class="{ 'px-1': env.inChatWindow, 'px-2': !env.inChatWindow }">
             <div class="d-flex align-items-baseline gap-1">
                 <button t-if="env.closeActionPanel" class="btn p-1 opacity-75 opacity-100-hover text-muted" title="Close panel" t-on-click.stop="env.closeActionPanel">
                     <i class="oi oi-arrow-left fa-fw"/>
                 </button>
-                <i t-if="props.icon" class="text-muted" t-att-class="props.icon"/>
-                <p t-if="props.title" class="fs-6 fw-bold text-uppercase m-0 text-muted flex-grow-1" t-esc="props.title"/>
+                <i t-if="props.icon" class="text-muted opacity-50" t-att-class="props.icon"/>
+                <p t-if="props.title" class="fw-bold text-uppercase m-0 text-muted opacity-50 flex-grow-1" t-esc="props.title"/>
             </div>
             <t t-slot="header"/>
         </div>

--- a/addons/mail/static/src/discuss/core/common/discuss_notification_settings.dark.scss
+++ b/addons/mail/static/src/discuss/core/common/discuss_notification_settings.dark.scss
@@ -1,0 +1,3 @@
+.o-mail-DiscussNotificationSettings {
+    --mail-DiscussNotificationSettings-btnSelectedBg: #{$gray-300};
+}

--- a/addons/mail/static/src/discuss/core/common/discuss_notification_settings.scss
+++ b/addons/mail/static/src/discuss/core/common/discuss_notification_settings.scss
@@ -1,0 +1,3 @@
+.o-mail-DiscussNotificationSettings button.o-selected {
+    background-color: var(--mail-DiscussNotificationSettings-btnSelectedBg, $gray-200);
+}

--- a/addons/mail/static/src/discuss/core/common/discuss_notification_settings.xml
+++ b/addons/mail/static/src/discuss/core/common/discuss_notification_settings.xml
@@ -5,18 +5,19 @@
         <div class="o-mail-DiscussNotificationSettings d-flex flex-column">
             <div class="d-flex flex-column my-1">
                 <label class="cursor-pointer d-flex align-items-center">
-                    <h5>Mute</h5>
+                    <h5>Mute all conversations</h5>
                     <div class="flex-grow-1"/>
                     <div class="form-check form-switch">
                         <input class="form-check-input" type="checkbox" role="switch" t-att-checked="store.settings.mute_until_dt" t-on-change="onChangeDisplayMuteDetails"/>
                     </div>
                 </label>
-                <span class="mt-1">Muting a server prevents unread indicators and notifications from appearing.</span>
+                <span class="mt-1 text-muted small">Muting prevents unread indicators and notifications from appearing.</span>
             </div>
-            <label t-if="store.settings.mute_until_dt" class="d-flex align-items-baseline my-2">
-                <h6 class="flex-shrink-0">
-                    <t t-esc="store.settings.getMuteUntilText(store.settings.mute_until_dt)"/>
-                </h6>
+            <label t-if="store.settings.mute_until_dt" class="d-flex align-items-baseline my-1">
+                <div class="d-flex flex-column">
+                    <h6 class="flex-shrink-0 mb-1">Mute duration</h6>
+                    <span class="text-muted smaller" t-esc="store.settings.getMuteUntilText(store.settings.mute_until_dt)"/>
+                </div>
                 <div class="flex-grow-1"/>
                 <select class="form-select w-auto d-flex" t-on-change="onChangeMuteDuration">
                     <option value="default">Select duration</option>
@@ -27,10 +28,10 @@
             </label>
             <hr class="o-discuss-separator my-1"/>
             <div class="d-flex flex-column my-1">
-                <h5>Channel notification settings</h5>
-                <span class="mb-1">This setting will be applied to all channels using the default category.</span>
+                <h5>Channel Notifications</h5>
+                <span class="mb-1 text-muted small">This setting will be applied to all channels using the default notification settings.</span>
                 <t t-foreach="store.settings.NOTIFICATIONS" t-as="notif" t-key="notif.label">
-                    <button class="btn d-flex my-1" t-att-class="{'bg-300' : notif.label === store.settings.channel_notifications}" t-on-click="()=> this.store.settings.setCustomNotifications(notif.label)">
+                    <button class="btn d-flex my-1" t-att-class="{'o-selected' : notif.label === store.settings.channel_notifications}" t-on-click="()=> this.store.settings.setCustomNotifications(notif.label)">
                         <input class="form-check-input" type="radio" t-att-checked="notif.label === store.settings.channel_notifications"/>
                         <div class="d-flex flex-column text-start flex-grow-1 mx-3">
                             <span t-esc="notif.name"/>

--- a/addons/mail/static/src/discuss/core/common/notification_settings.dark.scss
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.dark.scss
@@ -1,0 +1,3 @@
+.o-discuss-NotificationSettings {
+    --mail-NotificationSettings-btnHoverBg: #{$gray-300};
+}

--- a/addons/mail/static/src/discuss/core/common/notification_settings.js
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.js
@@ -31,7 +31,7 @@ export class NotificationSettings extends Component {
         this.props.close?.();
     }
 
-    onClickServerMuted() {
+    onClickAllConversationsMuted() {
         this.dialog.add(NotificationDialog);
     }
 }

--- a/addons/mail/static/src/discuss/core/common/notification_settings.scss
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.scss
@@ -6,4 +6,12 @@
     .o-discuss-NotificationSettings-separator {
         min-width: 20px;
     }
+
+    button:hover {
+        background-color: var(--mail-NotificationSettings-btnHoverBg, $gray-200);
+    }
+}
+
+.o-discuss-NotificationSettings-defaultValue {
+    color: $o-action;
 }

--- a/addons/mail/static/src/discuss/core/common/notification_settings.xml
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.xml
@@ -5,56 +5,47 @@
         <ActionPanel title.translate="Notification Settings" resizable="false" icon="'fa fa-bell'">
             <div class="o-discuss-NotificationSettings">
                 <div t-if="store.settings.mute_until_dt" class="d-flex flex-column alert alert-warning">
-                    <span><i class="fa fa-exclamation-triangle"/> <a href="#" t-on-click="onClickServerMuted">Server is muted</a></span>
+                    <span><i class="fa fa-exclamation-triangle"/> <a href="#" t-on-click="onClickAllConversationsMuted">All conversations have been muted</a></span>
                 </div>
                 <t t-if="props.thread.mute_until_dt">
-                    <button class="btn w-100 d-flex p-1 opacity-75 opacity-100-hover" t-on-click="()=>this.setMute(false)">
+                    <button class="btn w-100 d-flex p-1 opacity-75" t-on-click="()=>this.setMute(false)">
                         <div class="d-flex flex-column flex-grow-1 px-2 py-1 w-100 rounded">
-                            <span class="fs-6 fw-bold text-wrap text-start text-break">Unmute Channel</span>
-                            <span class="fw-normal smaller" t-out="store.settings.getMuteUntilText(props.thread.mute_until_dt)"/>
+                            <span class="fs-6 fw-bold text-wrap text-start text-break">Unmute Conversation</span>
+                            <span class="fw-normal smaller text-start" t-out="store.settings.getMuteUntilText(props.thread.mute_until_dt)"/>
                         </div>
                     </button>
                 </t>
                 <div t-else="" class="d-flex">
-                    <Dropdown t-if="props.thread.channel_type === 'channel'" position="'right-start'" menuClass="'o-mail-NotificationSettings-submenu d-flex flex-column py-0 my-0'">
-                        <button class="btn w-100 d-flex p-1 opacity-75 opacity-100-hover">
+                    <Dropdown position="'right-start'" menuClass="'o-mail-NotificationSettings-submenu d-flex flex-column py-0 my-0'">
+                        <button class="btn w-100 d-flex p-1 opacity-75">
                             <div class="d-flex flex-grow-1 align-items-center px-2 py-1 w-100 rounded">
-                                <span class="text-wrap text-start text-break">Mute Channel</span>
+                                <span class="text-wrap text-start text-break">Mute Conversation</span>
                                 <div class="o-discuss-NotificationSettings-separator flex-grow-1"/>
                                 <i class="oi oi-arrow-right ms-2"/>
                             </div>
                         </button>
                         <t t-set-slot="content">
                             <t t-foreach="store.settings.MUTES" t-as="mute" t-key="mute.label">
-                                <DropdownItem class="'o-mail-NotificationSettings-muteDuration btn rounded-0 d-flex align-items-center px-2 py-2 m-0 opacity-75 opacity-100-hover'" onSelected="()=>this.setMute(mute.value)"><button class="btn p-0 mx-2 text-wrap text-start text-break" t-out="mute.name"/></DropdownItem>
+                                <DropdownItem class="'o-mail-NotificationSettings-muteDuration btn rounded-0 d-flex align-items-center px-2 py-2 m-0'" onSelected="()=>this.setMute(mute.value)"><button class="btn p-0 mx-2 text-wrap text-start text-break" t-out="mute.name"/></DropdownItem>
                             </t>
                         </t>
                     </Dropdown>
-                    <div t-else="" class="d-flex flex-column text-truncate">
-                        <div class="d-flex align-items-center rounded px-3 py-2 m-0">
-                            <span class="fs-6 fw-bold text-wrap text-start text-break">Mute Channel</span>
-                        </div>
-                        <hr class="solid mx-2 my-0"/>
-                        <t t-foreach="store.settings.MUTES" t-as="mute" t-key="mute.label">
-                            <button class="o-mail-NotificationSettings-muteDuration btn rounded d-flex align-items-center fs-6 fw-normal px-3 py-2 m-0 opacity-75 opacity-100-hover" t-att-title="mute.name" t-on-click="() => this.setMute(mute.value)" t-out="mute.name"/>
-                        </t>
-                    </div>
                 </div>
                 <t t-if="props.thread.channel_type === 'channel'">
-                    <hr class="solid mx-2 my-0"/>
-                    <button class="btn d-flex w-100 px-1 py-0 opacity-75 opacity-100-hover" t-on-click="() => store.settings.setCustomNotifications(false, props.thread)">
-                        <div class="d-flex flex-grow-1 align-items-center p-2 rounded">
+                    <hr class="solid m-2"/>
+                    <button class="btn d-flex w-100 px-1 py-0" t-on-click="() => store.settings.setCustomNotifications(false, props.thread)">
+                        <div class="d-flex flex-grow-1 align-items-center px-2 rounded">
                             <div class="d-flex flex-column align-items-start">
-                                <span class="fs-6 fw-normal text-wrap text-start text-break">Use Default</span>
-                                <span class="fw-bolder smaller"><t t-out="store.settings.NOTIFICATIONS.find((n) => n.label === store.settings.channel_notifications).name"/></span>
+                                <span class="fs-6 text-wrap text-start text-break">Use Default</span>
+                                <span class="fw-bolder o-xsmaller ps-2 o-discuss-NotificationSettings-defaultValue"><t t-out="store.settings.NOTIFICATIONS.find((n) => n.label === store.settings.channel_notifications).name"/></span>
                             </div>
                             <div class="o-discuss-NotificationSettings-separator flex-grow-1"/>
                             <input class="form-check-input" type="radio" t-att-checked="!props.thread.custom_notifications"/>
                         </div>
                     </button>
                     <t t-foreach="store.settings.NOTIFICATIONS" t-as="notif" t-key="notif.label">
-                        <button class="btn w-100 d-flex px-1 py-0 opacity-75 opacity-100-hover" t-on-click="() => store.settings.setCustomNotifications(notif.label, props.thread)">
-                            <div class="d-flex flex-grow-1 align-items-center p-2 rounded">
+                        <button class="btn w-100 d-flex px-1 py-0" t-on-click="() => store.settings.setCustomNotifications(notif.label, props.thread)">
+                            <div class="d-flex flex-grow-1 align-items-center px-2 py-1 rounded">
                                 <span class="fs-6 fw-normal text-wrap text-start text-break" t-esc="notif.name"/>
                                 <div class="o-discuss-NotificationSettings-separator flex-grow-1"/>
                                 <input class="form-check-input ms-2" type="radio" t-att-checked="props.thread.custom_notifications === notif.label"/>

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -994,7 +994,7 @@ test("Notification settings rendering in chatwindow", async () => {
     await contains("button", { text: "All Messages" });
     await contains("button", { text: "Mentions Only", count: 2 }); // the extra is in the Use Default as subtitle
     await contains("button", { text: "Nothing" });
-    await click("button", { text: "Mute Channel" });
+    await click("button", { text: "Mute Conversation" });
     await contains("button", { text: "For 15 minutes" });
     await contains("button", { text: "For 1 hour" });
     await contains("button", { text: "For 3 hours" });

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -2008,7 +2008,7 @@ test("Notification settings: basic rendering", async () => {
     await contains("button", { text: "All Messages" });
     await contains("button", { text: "Mentions Only", count: 2 }); // the extra is in the Use Default as subtitle
     await contains("button", { text: "Nothing" });
-    await click("button", { text: "Mute Channel" });
+    await click("button", { text: "Mute Conversation" });
     await contains("button", { text: "For 15 minutes" });
     await contains("button", { text: "For 1 hour" });
     await contains("button", { text: "For 3 hours" });
@@ -2017,7 +2017,7 @@ test("Notification settings: basic rendering", async () => {
     await contains("button", { text: "Until I turn it back on" });
 });
 
-test("Notification settings: mute channel will change the style of sidebar", async () => {
+test("Notification settings: mute conversation will change the style of sidebar", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
         name: "Mario Party",
@@ -2031,13 +2031,13 @@ test("Notification settings: mute channel will change the style of sidebar", asy
         count: 0,
     });
     await click("[title='Notification Settings']");
-    await click("button", { text: "Mute Channel" });
+    await click("button", { text: "Mute Conversation" });
     await click("button", { text: "For 15 minutes" });
     await contains(".o-mail-DiscussSidebar-item", { text: "Mario Party" });
     await contains(".o-mail-DiscussSidebar-item[class*='opacity-50']", { text: "Mario Party" });
 });
 
-test("Notification settings: change the mute duration of the channel", async () => {
+test("Notification settings: change the mute duration of the conversation", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
         name: "Mario Party",
@@ -2051,16 +2051,16 @@ test("Notification settings: change the mute duration of the channel", async () 
         count: 0,
     });
     await click("[title='Notification Settings']");
-    await click("button", { text: "Mute Channel" });
+    await click("button", { text: "Mute Conversation" });
     await click("button", { text: "For 15 minutes" });
     await click("[title='Notification Settings']");
-    await click(".o-discuss-NotificationSettings span", { text: "Unmute Channel" });
+    await click(".o-discuss-NotificationSettings span", { text: "Unmute Conversation" });
     await click("[title='Notification Settings']");
-    await click("button", { text: "Mute Channel" });
+    await click("button", { text: "Mute Conversation" });
     await click("button", { text: "For 1 hour" });
 });
 
-test("Notification settings: mute/unmute channel works correctly", async () => {
+test("Notification settings: mute/unmute conversation works correctly", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
         name: "Mario Party",
@@ -2069,13 +2069,13 @@ test("Notification settings: mute/unmute channel works correctly", async () => {
     await start();
     await openDiscuss(channelId);
     await click("[title='Notification Settings']");
-    await click("button", { text: "Mute Channel" });
+    await click("button", { text: "Mute Conversation" });
     await click("button", { text: "For 15 minutes" });
     await click("[title='Notification Settings']");
-    await contains("button", { text: "Unmute Channel" });
-    await click("button", { text: "Unmute Channel" });
+    await contains("button", { text: "Unmute Conversation" });
+    await click("button", { text: "Unmute Conversation" });
     await click("[title='Notification Settings']");
-    await contains("button", { text: "Unmute Channel" });
+    await contains("button", { text: "Unmute Conversation" });
 });
 
 test("Newly created chat should be at the top of the direct message list", async () => {

--- a/addons/mail/views/mail_menus.xml
+++ b/addons/mail/views/mail_menus.xml
@@ -13,7 +13,7 @@
         parent="mail.menu_root_discuss"
         sequence="1"
     />
-    <menuitem name="Notification"
+    <menuitem name="Notifications"
         id="mail.menu_notification_settings"
         parent="mail.menu_configuration"
         action="mail.discuss_notification_settings_action"


### PR DESCRIPTION
Notification settings menu and screen had confusing wording.

This commit improves clarity of text and makes a few style tweaking to make content more readable.

task-4204137
