### PR TITLE
[FIX] account: cancel asset when using audit trail

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4450,7 +4450,8 @@ class AccountMove(models.Model):
     def _can_be_unlinked(self):
         self.ensure_one()
         lock_date = self.company_id._get_user_fiscal_lock_date(self.journal_id)
-        return not self.inalterable_hash and self.date > lock_date
+        is_part_of_audit_trail = self.posted_before and self.company_id.check_account_audit_trail
+        return not self.inalterable_hash and self.date > lock_date and not is_part_of_audit_trail
 
     def _unlink_or_reverse(self):
         if not self:


### PR DESCRIPTION
At the moment cancelling assets is impossible when audit trail is enabled because it tries to unlink the move. It should be possible, in which case the move should be reversed instead.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
