### PR TITLE
[FIX] website: replace background-position of s_parallax style attribute

### DIFF
--- a/addons/website/views/new_page_template_templates.xml
+++ b/addons/website/views/new_page_template_templates.xml
@@ -941,7 +941,7 @@ overridden by modules), because:
         <attribute name="class" add="pb168 pt256" remove="o_half_screen_height" separator=" "/>
     </xpath>
     <xpath expr="//span[hasclass('s_parallax_bg')]" position="attributes">
-        <attribute name="style" add="background-position: 0% 44.4099%;" separator=" "/>
+        <attribute name="style" add="background-position: 0% 44.4099%;" remove="background-position: 50% 75%;" separator=";"/>
     </xpath>
 </template>
 


### PR DESCRIPTION
The `new_page_template_services_s_parallax` template wrongly adds the `background-position` of the `style` attribute.

This commit fixes this definition so that the old `background-position` is replaced.

Steps to reproduce:
- Add a new page
- In the Service tab, pick a template that contains a parallax block (at the time of writing, this is the case of the second one in the first column)
- Inspect the parallax block

=> The `background-position` was defined twice.

task-4206845
