### PR TITLE
[FIX] account: allow changing report availability again

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -132,7 +132,7 @@ class AccountReport(models.Model):
         for report in self:
             if report.root_report_id and report.country_id:
                 report.availability_condition = 'country'
-            else:
+            elif not report.availability_condition:
                 report.availability_condition = 'always'
 
     @api.constrains('root_report_id')


### PR DESCRIPTION
On accounting reports you can set the availability based on various conditions. The `availability_condition` field is a stored computed one that depends on `country_id` since [this commit].

Since the field also has an `onchange` registered that empties the `country_id` field when the `availability_condition` is not `country`, setting the field to anything else than `country` triggers a recomputation of the `availability_condition`. This `compute` function defaults to setting the `availability_condition` to `always`. Thus you can never choose the option `coa` again.

This commit only sets the default `always` value in the `compute` function when there is no value set yet. That way the field doesn't reset itself to `always` on every computation of the field.

[this commit]: https://github.com/odoo/odoo/commit/73a8098f7c5247b4620170f90513b50672f9a776