### PR TITLE
[FIX] account: overdue include full lines to pay in wizard

### DIFF
--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -1212,7 +1212,7 @@ class AccountPaymentRegister(models.TransientModel):
         else:
             # Don't group payments: Create one batch per move.
             if not self.group_payment:
-                lines_to_pay = self._get_total_amounts_to_pay(batches)['lines'] if self.installments_mode == 'next' else self.line_ids
+                lines_to_pay = self._get_total_amounts_to_pay(batches)['lines'] if self.installments_mode in ('next', 'overdue') else self.line_ids
                 new_batches = []
                 for batch_result in batches:
                     for line in batch_result['lines']:


### PR DESCRIPTION
Create an invoice with installment (with one overdue). 
Create a second one overdue.
Go in list view, select them and 'Pay'
The amount shown is rightly the value overdue.
Create Payments
=> All the amount is paid, not only overdue.

It should have the same working as for 'next', only select the ones you should pay.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
