### PR TITLE
[REF] html_editor: clean the resource API for plugins

### DIFF
--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -89,8 +89,6 @@ export class ClipboardPlugin extends Plugin {
         this.addDomListener(this.editable, "paste", this.onPaste);
         this.addDomListener(this.editable, "dragstart", this.onDragStart);
         this.addDomListener(this.editable, "drop", this.onDrop);
-        this.resources["handle_paste_text"] = this.resources["handle_paste_text"] || [];
-        this.resources["before_paste"] = this.resources["before_paste"] || [];
     }
 
     onCut(ev) {
@@ -213,7 +211,7 @@ export class ClipboardPlugin extends Plugin {
 
         this.dispatch("HISTORY_STAGE_SELECTION");
 
-        this.resources["before_paste"].forEach((handler) => handler(selection));
+        this.getResource("before_paste").forEach((handler) => handler(selection));
         // refresh selection after potential changes from `before_paste` handlers
         selection = this.shared.getEditableSelection();
 
@@ -286,7 +284,7 @@ export class ClipboardPlugin extends Plugin {
      */
     handlePasteText(selection, clipboardData) {
         const text = clipboardData.getData("text/plain");
-        if (this.resources["handle_paste_text"].some((handler) => handler(selection, text))) {
+        if (this.getResource("handle_paste_text").some((handler) => handler(selection, text))) {
             return;
         } else {
             this.pasteText(selection, text);

--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -28,7 +28,7 @@ export class DomPlugin extends Plugin {
     static name = "dom";
     static dependencies = ["selection", "split"];
     static shared = ["domInsert", "copyAttributes"];
-    static resources = () => ({
+    resources = {
         powerboxItems: {
             name: _t("Separator"),
             description: _t("Insert a horizontal rule separator"),
@@ -38,7 +38,7 @@ export class DomPlugin extends Plugin {
                 dispatch("INSERT_SEPARATOR");
             },
         },
-    });
+    };
     contentEditableToRemove = new Set();
 
     handleCommand(command, payload) {

--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -95,16 +95,16 @@ export class HistoryPlugin extends Plugin {
         "serializeSelection",
         "getNodeById",
     ];
-    static resources = () => ({
+    resources = {
         shortcuts: [
             { hotkey: "control+z", command: "HISTORY_UNDO" },
             { hotkey: "control+y", command: "HISTORY_REDO" },
             { hotkey: "control+shift+z", command: "HISTORY_REDO" },
         ],
-    });
+    };
 
     setup() {
-        this.mutationFilteredClasses = new Set(this.resources["mutation_filtered_classes"]);
+        this.mutationFilteredClasses = new Set(this.getResource("mutation_filtered_classes"));
         this._onKeyupResetContenteditableNodes = [];
         this.addDomListener(this.document, "beforeinput", this._onDocumentBeforeInput.bind(this));
         this.addDomListener(this.document, "input", this._onDocumentInput.bind(this));
@@ -181,7 +181,7 @@ export class HistoryPlugin extends Plugin {
         }
         this.steps = steps;
         // todo: to test
-        this.resources.historyResetFromSteps?.forEach((cb) => cb());
+        this.getResource("historyResetFromSteps").forEach((cb) => cb());
 
         this.enableObserver();
         this.dispatch("HISTORY_RESET_FROM_STEPS");
@@ -212,7 +212,7 @@ export class HistoryPlugin extends Plugin {
      * @param { HistoryStep } step
      */
     processHistoryStep(step) {
-        for (const fn of this.resources["process_history_step"] || []) {
+        for (const fn of this.getResource("process_history_step")) {
             step = fn(step);
         }
         return step;
@@ -248,7 +248,7 @@ export class HistoryPlugin extends Plugin {
         if (!records.length) {
             return [];
         }
-        this.resources["handleNewRecords"]?.forEach((cb) => cb(records));
+        this.getResource("handleNewRecords").forEach((cb) => cb(records));
         this.stageRecords(records);
         return records;
     }
@@ -297,7 +297,7 @@ export class HistoryPlugin extends Plugin {
         this.dispatch("BEFORE_FILTERING_MUTATION_RECORDS", {
             records,
         });
-        for (const callback of this.resources["is_mutation_record_savable"]) {
+        for (const callback of this.getResource("is_mutation_record_savable")) {
             records = records.filter(callback);
         }
 
@@ -428,7 +428,7 @@ export class HistoryPlugin extends Plugin {
                         value: record.target.getAttribute(record.attributeName),
                         oldValue: record.oldValue,
                     });
-                    for (const cb of this.resources["on_change_attribute"] || []) {
+                    for (const cb of this.getResource("on_change_attribute")) {
                         cb({
                             target: record.target,
                             attributeName: record.attributeName,
@@ -651,7 +651,7 @@ export class HistoryPlugin extends Plugin {
      * @param { number } index
      */
     isReversibleStep(index) {
-        for (const cb of this.resources["is_reversible_step"] || []) {
+        for (const cb of this.getResource("is_reversible_step")) {
             const result = cb(index);
             if (typeof result !== "undefined") {
                 return result;
@@ -734,7 +734,7 @@ export class HistoryPlugin extends Plugin {
                     const node = this.idToNodeMap.get(mutation.id);
                     if (node) {
                         let value = this.getAttributeValue(mutation.attributeName, mutation.value);
-                        for (const cb of this.resources["on_change_attribute"] || []) {
+                        for (const cb of this.getResource("on_change_attribute")) {
                             value =
                                 cb(
                                     {
@@ -803,7 +803,7 @@ export class HistoryPlugin extends Plugin {
                             mutation.attributeName,
                             mutation.oldValue
                         );
-                        for (const cb of this.resources["on_change_attribute"] || []) {
+                        for (const cb of this.getResource("on_change_attribute")) {
                             value =
                                 cb(
                                     {
@@ -1001,7 +1001,7 @@ export class HistoryPlugin extends Plugin {
      * @param { string } attributeValue
      */
     setAttribute(node, attributeName, attributeValue) {
-        for (const cb of this.resources["set_attribute"] || []) {
+        for (const cb of this.getResource("set_attribute")) {
             const result = cb(node, attributeName, attributeValue);
             if (result) {
                 return;
@@ -1068,7 +1068,7 @@ export class HistoryPlugin extends Plugin {
             result.textValue = node.nodeValue;
         } else if (node.nodeType === Node.ELEMENT_NODE) {
             let childrenToSerialize;
-            for (const cb of this.resources["filter_descendants_to_serialize"] || []) {
+            for (const cb of this.getResource("filter_descendants_to_serialize")) {
                 childrenToSerialize = cb(node);
                 if (childrenToSerialize) {
                     break;

--- a/addons/html_editor/static/src/core/input_plugin.js
+++ b/addons/html_editor/static/src/core/input_plugin.js
@@ -3,24 +3,20 @@ import { Plugin } from "../plugin";
 export class InputPlugin extends Plugin {
     static name = "input";
     setup() {
-        const sequence = (resource) => resource.sequence ?? 50;
-        this.resources.onBeforeInput?.sort((a, b) => sequence(a) - sequence(b));
-        this.resources.onInput?.sort((a, b) => sequence(a) - sequence(b));
-
         this.addDomListener(this.editable, "beforeinput", this.onBeforeInput);
         this.addDomListener(this.editable, "input", this.onInput);
     }
 
     onBeforeInput(ev) {
         this.dispatch("HISTORY_STAGE_SELECTION");
-        for (const { handler } of this.resources.onBeforeInput || []) {
+        for (const handler of this.getResource("onBeforeInput")) {
             handler(ev);
         }
     }
 
     onInput(ev) {
         this.dispatch("ADD_STEP");
-        for (const { handler } of this.resources.onInput || []) {
+        for (const handler of this.getResource("onInput")) {
             handler(ev);
         }
     }

--- a/addons/html_editor/static/src/core/line_break_plugin.js
+++ b/addons/html_editor/static/src/core/line_break_plugin.js
@@ -7,10 +7,9 @@ export class LineBreakPlugin extends Plugin {
     static dependencies = ["selection", "split"];
     static name = "line_break";
     static shared = ["insertLineBreakElement"];
-    /** @type { (p: LineBreakPlugin) => Record<string, any> } */
-    static resources = (p) => ({
-        onBeforeInput: { handler: p.onBeforeInput.bind(p) },
-    });
+    resources = {
+        onBeforeInput: this.onBeforeInput.bind(this),
+    };
 
     handleCommand(command, payload) {
         switch (command) {
@@ -48,7 +47,7 @@ export class LineBreakPlugin extends Plugin {
             targetNode = targetNode.parentElement;
         }
 
-        for (const { callback } of this.resources.handle_insert_line_break_element || []) {
+        for (const callback of this.getResource("handle_insert_line_break_element")) {
             if (callback({ targetNode, targetOffset })) {
                 return;
             }

--- a/addons/html_editor/static/src/core/protected_node_plugin.js
+++ b/addons/html_editor/static/src/core/protected_node_plugin.js
@@ -7,15 +7,12 @@ const UNPROTECTED_SELECTOR = `[data-oe-protected="false"]`;
 
 export class ProtectedNodePlugin extends Plugin {
     static name = "protected_node";
-    /** @type { function(ProtectedNodePlugin):Record<string, any> } **/
-    static resources(p) {
-        return {
-            is_mutation_record_savable: p.isMutationRecordSavable.bind(p),
-            filter_descendants_to_remove: p.filterDescendantsToRemove.bind(p),
-            isUnsplittable: isProtecting, // avoid merge
-        };
-    }
     static shared = ["setProtectingNode"];
+    resources = {
+        is_mutation_record_savable: this.isMutationRecordSavable.bind(this),
+        filter_descendants_to_remove: this.filterDescendantsToRemove.bind(this),
+        isUnsplittable: isProtecting, // avoid merge
+    };
 
     setup() {
         this.protectedNodes = new WeakSet();

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -123,9 +123,9 @@ export class SelectionPlugin extends Plugin {
         "focusEditable",
         // "collapseIfZWS",
     ];
-    static resources = () => ({
+    resources = {
         shortcuts: [{ hotkey: "control+a", command: "SELECT_ALL" }],
-    });
+    };
 
     setup() {
         this.resetSelection();
@@ -191,7 +191,7 @@ export class SelectionPlugin extends Plugin {
                 return;
             }
         }
-        for (const handler of this.resources.onSelectionChange || []) {
+        for (const handler of this.getResource("onSelectionChange")) {
             handler(selectionData);
         }
     }
@@ -554,7 +554,7 @@ export class SelectionPlugin extends Plugin {
         range.setEnd(selection.endContainer, selection.endOffset);
         const isNodeFullySelected = (node) =>
             // Custom rules
-            this.resources.considerNodeFullySelected?.some((cb) => cb(node, selection)) ||
+            this.getResource("considerNodeFullySelected").some((cb) => cb(node, selection)) ||
             // Default rule
             (range.isPointInRange(node, 0) && range.isPointInRange(node, nodeSize(node)));
         return this.getTraversedNodes().filter(isNodeFullySelected);
@@ -584,7 +584,7 @@ export class SelectionPlugin extends Plugin {
                 return nodes.filter((node) => !edgeNodes.has(node));
             },
             // Custom modifiers
-            ...(this.resources.modifyTraversedNodes || []),
+            ...this.getResource("modifyTraversedNodes"),
         ];
 
         for (const modifier of modifiers) {
@@ -856,7 +856,7 @@ export class SelectionPlugin extends Plugin {
         const domDirection = (screenDirection === "left") ^ isRtl ? "previous" : "next";
 
         // Whether the character next to the cursor should be skipped.
-        const shouldSkipCallbacks = this.resources.arrows_should_skip || [];
+        const shouldSkipCallbacks = this.getResource("arrows_should_skip");
         let adjacentCharacter = getAdjacentCharacter(selection, domDirection, this.editable);
         let shouldSkip = shouldSkipCallbacks.some((cb) => cb(ev, adjacentCharacter));
 

--- a/addons/html_editor/static/src/core/shortcut_plugin.js
+++ b/addons/html_editor/static/src/core/shortcut_plugin.js
@@ -11,7 +11,7 @@ export class ShortCutPlugin extends Plugin {
         if (document !== this.document) {
             hotkeyService.registerIframe({ contentWindow: this.document.defaultView });
         }
-        for (const shortcut of this.resources["shortcuts"]) {
+        for (const shortcut of this.getResource("shortcuts")) {
             this.addShortcut(shortcut.hotkey, () => {
                 this.dispatch(shortcut.command);
             });

--- a/addons/html_editor/static/src/core/split_plugin.js
+++ b/addons/html_editor/static/src/core/split_plugin.js
@@ -19,22 +19,21 @@ export class SplitPlugin extends Plugin {
         "splitSelection",
         "isUnsplittable",
     ];
-    /** @type { (p: SplitPlugin) => Record<string, any> } */
-    static resources = (p) => ({
+    resources = {
         isUnsplittable: [
             // An unremovable element is also unmergeable (as merging two
             // elements results in removing one of them).
             // An unmergeable element is unsplittable and vice-versa (as
             // split and merge are reverse operations from one another).
             // Therefore, unremovable nodes are also unsplittable.
-            (element) => p.resources.isUnremovable?.some((predicate) => predicate(element)),
+            (element) => this.getResource("isUnremovable").some((predicate) => predicate(element)),
             // "Unbreakable" is a legacy term that means unsplittable and
             // unmergeable.
             (element) => element.classList.contains("oe_unbreakable"),
             (element) => ["DIV", "SECTION"].includes(element.tagName),
         ],
-        onBeforeInput: { handler: p.onBeforeInput.bind(p) },
-    });
+        onBeforeInput: this.onBeforeInput.bind(this),
+    };
 
     handleCommand(command, payload) {
         switch (command) {
@@ -83,7 +82,7 @@ export class SplitPlugin extends Plugin {
         }
         const blockToSplit = closestElement(targetNode, isBlock);
 
-        for (const { callback } of this.resources["split_element_block"]) {
+        for (const callback of this.getResource("split_element_block")) {
             if (callback({ targetNode, targetOffset, blockToSplit })) {
                 return [undefined, undefined];
             }
@@ -139,7 +138,7 @@ export class SplitPlugin extends Plugin {
     isUnsplittable(node) {
         return (
             node.nodeType === Node.ELEMENT_NODE &&
-            this.resources.isUnsplittable.some((predicate) => predicate(node))
+            this.getResource("isUnsplittable").some((predicate) => predicate(node))
         );
     }
 

--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -21,6 +21,7 @@ import { useRecordObserver } from "@web/model/relational_model/utils";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
 import { TranslationButton } from "@web/views/fields/translation_button";
 import { HtmlViewer } from "./html_viewer";
+import { withSequence } from "@html_editor/utils/resource";
 
 /**
  * Check whether the current value contains nodes that would break
@@ -247,10 +248,9 @@ export class HtmlField extends Component {
         }
         if (this.props.codeview) {
             config.resources = {
-                toolbarCategory: {
+                toolbarCategory: withSequence(100, {
                     id: "codeview",
-                    sequence: 100,
-                },
+                }),
                 toolbarItems: {
                     id: "codeview",
                     category: "codeview",

--- a/addons/html_editor/static/src/main/banner_plugin.js
+++ b/addons/html_editor/static/src/main/banner_plugin.js
@@ -1,6 +1,7 @@
 import { Plugin } from "@html_editor/plugin";
 import { closestElement } from "@html_editor/utils/dom_traversal";
 import { parseHTML } from "@html_editor/utils/html";
+import { withSequence } from "@html_editor/utils/resource";
 import { _t } from "@web/core/l10n/translation";
 
 function isAvailable(node) {
@@ -9,9 +10,8 @@ function isAvailable(node) {
 export class BannerPlugin extends Plugin {
     static name = "banner";
     static dependencies = ["dom", "emoji", "selection"];
-    /** @type { (p: BannerPlugin) => Record<string, any> } */
-    static resources = (p) => ({
-        powerboxCategory: { id: "banner", name: _t("Banner"), sequence: 20 },
+    resources = {
+        powerboxCategory: withSequence(20, { id: "banner", name: _t("Banner") }),
         powerboxItems: [
             {
                 category: "banner",
@@ -19,8 +19,8 @@ export class BannerPlugin extends Plugin {
                 description: _t("Insert an info banner"),
                 fontawesome: "fa-info-circle",
                 isAvailable,
-                action() {
-                    p.insertBanner(_t("Banner Info"), "💡", "info");
+                action: () => {
+                    this.insertBanner(_t("Banner Info"), "💡", "info");
                 },
             },
             {
@@ -29,8 +29,8 @@ export class BannerPlugin extends Plugin {
                 description: _t("Insert an success banner"),
                 fontawesome: "fa-check-circle",
                 isAvailable,
-                action() {
-                    p.insertBanner(_t("Banner Success"), "✅", "success");
+                action: () => {
+                    this.insertBanner(_t("Banner Success"), "✅", "success");
                 },
             },
             {
@@ -39,8 +39,8 @@ export class BannerPlugin extends Plugin {
                 description: _t("Insert an warning banner"),
                 fontawesome: "fa-exclamation-triangle",
                 isAvailable,
-                action() {
-                    p.insertBanner(_t("Banner Warning"), "⚠️", "warning");
+                action: () => {
+                    this.insertBanner(_t("Banner Warning"), "⚠️", "warning");
                 },
             },
             {
@@ -49,12 +49,12 @@ export class BannerPlugin extends Plugin {
                 description: _t("Insert an danger banner"),
                 fontawesome: "fa-exclamation-circle",
                 isAvailable,
-                action() {
-                    p.insertBanner(_t("Banner Danger"), "❌", "danger");
+                action: () => {
+                    this.insertBanner(_t("Banner Danger"), "❌", "danger");
                 },
             },
         ],
-    });
+    };
 
     setup() {
         this.addDomListener(this.editable, "click", (e) => {

--- a/addons/html_editor/static/src/main/chatgpt/chatgpt_plugin.js
+++ b/addons/html_editor/static/src/main/chatgpt/chatgpt_plugin.js
@@ -5,16 +5,15 @@ import { ChatGPTPromptDialog } from "./chatgpt_prompt_dialog";
 import { ChatGPTAlternativesDialog } from "./chatgpt_alternatives_dialog";
 import { ChatGPTTranslateDialog } from "./chatgpt_translate_dialog";
 import { LanguageSelector } from "./language_selector";
+import { withSequence } from "@html_editor/utils/resource";
 
 export class ChatGPTPlugin extends Plugin {
     static name = "chatgpt";
     static dependencies = ["selection", "history", "dom", "sanitize", "dialog"];
-    /** @type { (p: ChatGPTPlugin) => Record<string, any> } */
-    static resources = (p) => ({
-        toolbarCategory: {
+    resources = {
+        toolbarCategory: withSequence(50, {
             id: "ai",
-            sequence: 50,
-        },
+        }),
         toolbarItems: [
             {
                 id: "translate",
@@ -37,7 +36,7 @@ export class ChatGPTPlugin extends Plugin {
             },
         ],
 
-        powerboxCategory: { id: "ai", name: _t("AI Tools"), sequence: 70 },
+        powerboxCategory: withSequence(70, { id: "ai", name: _t("AI Tools") }),
         powerboxItems: {
             name: _t("ChatGPT"),
             description: _t("Generate or transform content with AI."),
@@ -49,7 +48,7 @@ export class ChatGPTPlugin extends Plugin {
             },
             // isAvailable: () => !this.odooEditor.isSelectionInBlockRoot(), // TODO!
         },
-    });
+    };
 
     handleCommand(command, payload) {
         switch (command) {

--- a/addons/html_editor/static/src/main/column_plugin.js
+++ b/addons/html_editor/static/src/main/column_plugin.js
@@ -31,7 +31,7 @@ function columnisAvailable(numberOfColumns) {
 export class ColumnPlugin extends Plugin {
     static name = "column";
     static dependencies = ["selection"];
-    static resources = () => ({
+    resources = {
         isUnremovable: isUnremovableColumn,
         powerboxItems: [
             {
@@ -85,7 +85,7 @@ export class ColumnPlugin extends Plugin {
                 text: _t("Empty column"),
             },
         ],
-    });
+    };
 
     handleCommand(command, payload) {
         switch (command) {

--- a/addons/html_editor/static/src/main/emoji_plugin.js
+++ b/addons/html_editor/static/src/main/emoji_plugin.js
@@ -6,20 +6,19 @@ export class EmojiPlugin extends Plugin {
     static name = "emoji";
     static dependencies = ["overlay", "dom", "selection"];
     static shared = ["showEmojiPicker"];
-    /** @type { (p: EmojiPlugin) => Record<string, any> } */
-    static resources = (p) => ({
+    resources = {
         powerboxItems: [
             {
                 category: "widget",
                 name: _t("Emoji"),
                 description: _t("Add an emoji"),
                 fontawesome: "fa-smile-o",
-                action() {
-                    p.showEmojiPicker();
+                action: () => {
+                    this.showEmojiPicker();
                 },
             },
         ],
-    });
+    };
 
     setup() {
         this.overlay = this.shared.createOverlay(EmojiPicker, {

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -20,17 +20,16 @@ import { isCSSColor } from "@web/core/utils/colors";
 import { ColorSelector } from "./color_selector";
 import { reactive } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
+import { withSequence } from "@html_editor/utils/resource";
 
 export class ColorPlugin extends Plugin {
     static name = "color";
     static dependencies = ["selection", "split", "history", "format"];
     static shared = ["colorElement"];
-    /** @type { (p: ColorPlugin) => Record<string, any> } */
-    static resources = (p) => ({
-        toolbarCategory: {
+    resources = {
+        toolbarCategory: withSequence(25, {
             id: "color",
-            sequence: 25,
-        },
+        }),
         toolbarItems: [
             {
                 id: "forecolor",
@@ -39,9 +38,9 @@ export class ColorPlugin extends Plugin {
                 Component: ColorSelector,
                 props: {
                     type: "foreground",
-                    getUsedCustomColors: () => p.getUsedCustomColors("color"),
-                    getSelectedColors: () => p.selectedColors,
-                    focusEditable: () => p.shared.focusEditable(),
+                    getUsedCustomColors: () => this.getUsedCustomColors("color"),
+                    getSelectedColors: () => this.selectedColors,
+                    focusEditable: () => this.shared.focusEditable(),
                 },
             },
             {
@@ -52,16 +51,16 @@ export class ColorPlugin extends Plugin {
                 Component: ColorSelector,
                 props: {
                     type: "background",
-                    getUsedCustomColors: () => p.getUsedCustomColors("background"),
-                    getSelectedColors: () => p.selectedColors,
-                    focusEditable: () => p.shared.focusEditable(),
+                    getUsedCustomColors: () => this.getUsedCustomColors("background"),
+                    getSelectedColors: () => this.selectedColors,
+                    focusEditable: () => this.shared.focusEditable(),
                 },
             },
         ],
 
-        onSelectionChange: p.updateSelectedColor.bind(p),
-        removeFormat: p.removeAllColor.bind(p),
-    });
+        onSelectionChange: this.updateSelectedColor.bind(this),
+        removeFormat: this.removeAllColor.bind(this),
+    };
 
     setup() {
         this.selectedColors = reactive({ color: "", backgroundColor: "" });
@@ -140,7 +139,7 @@ export class ColorPlugin extends Plugin {
      * @param {string} mode 'color' or 'backgroundColor'
      */
     applyColor(color, mode) {
-        for (const cb of this.resources.colorApply || []) {
+        for (const cb of this.getResource("colorApply") || []) {
             if (cb(color, mode)) {
                 return;
             }

--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -16,6 +16,7 @@ import {
 import { DIRECTIONS } from "@html_editor/utils/position";
 import { _t } from "@web/core/l10n/translation";
 import { FontSelector } from "./font_selector";
+import { withSequence } from "@html_editor/utils/resource";
 
 export const fontItems = [
     {
@@ -97,21 +98,21 @@ const handledElemSelector = [...headingTags, "PRE", "BLOCKQUOTE"].join(", ");
 export class FontPlugin extends Plugin {
     static name = "font";
     static dependencies = ["split", "selection"];
-    /** @type { (p: FontPlugin) => Record<string, any> } */
-    static resources = (p) => ({
+    resources = {
         split_element_block: [
-            { callback: p.handleSplitBlockPRE.bind(p) },
-            { callback: p.handleSplitBlockHeading.bind(p) },
+            this.handleSplitBlockPRE.bind(this),
+            this.handleSplitBlockHeading.bind(this),
         ],
-        onInput: { handler: p.onInput.bind(p) },
-        handle_delete_backward: { callback: p.handleDeleteBackward.bind(p), sequence: 20 },
-        handle_delete_backward_word: { callback: p.handleDeleteBackward.bind(p), sequence: 20 },
+        onInput: this.onInput.bind(this),
+        handle_delete_backward: withSequence(20, this.handleDeleteBackward.bind(this)),
+        handle_delete_backward_word: this.handleDeleteBackward.bind(this),
         toolbarCategory: [
-            {
+            withSequence(10, {
                 id: "font",
-                sequence: 10,
-            },
-            { id: "font-size", sequence: 29 },
+            }),
+            withSequence(29, {
+                id: "font-size",
+            }),
         ],
         toolbarItems: [
             {
@@ -130,14 +131,14 @@ export class FontPlugin extends Plugin {
                 title: _t("Font size"),
                 Component: FontSelector,
                 props: {
-                    getItems: () => p.fontSizeItems,
+                    getItems: () => this.fontSizeItems,
                     isFontSize: true,
                     command: "FORMAT_FONT_SIZE_CLASSNAME",
-                    document: p.document,
+                    document: this.document,
                 },
             },
         ],
-        powerboxCategory: { id: "format", name: _t("Format"), sequence: 30 },
+        powerboxCategory: withSequence(30, { id: "format", name: _t("Format") }),
         powerboxItems: [
             {
                 name: _t("Heading 1"),
@@ -204,7 +205,7 @@ export class FontPlugin extends Plugin {
             { selector: "PRE", text: _t("Code") },
             { selector: "BLOCKQUOTE", text: _t("Quote") },
         ],
-    });
+    };
 
     get fontSizeItems() {
         const style = getHtmlStyle(this.document);
@@ -299,7 +300,9 @@ export class FontPlugin extends Plugin {
             return;
         }
         // Check if unremovable.
-        if (this.resources.isUnremovable.some((predicate) => predicate(closestHandledElement))) {
+        if (
+            this.getResource("isUnremovable").some((predicate) => predicate(closestHandledElement))
+        ) {
             return;
         }
         const p = this.document.createElement("p");

--- a/addons/html_editor/static/src/main/hint_plugin.js
+++ b/addons/html_editor/static/src/main/hint_plugin.js
@@ -25,25 +25,22 @@ function target(selectionData, editable) {
 export class HintPlugin extends Plugin {
     static name = "hint";
     static dependencies = ["history", "selection"];
-    /** @type { (p: HintPlugin) => Record<string, any> } */
-    static resources = (p) => {
-        const resources = {
-            mutation_filtered_classes: ["o-we-hint"],
-            is_mutation_record_savable: isMutationRecordSavable,
-            onSelectionChange: p.updateHints.bind(p),
-            onExternalHistorySteps: () => {
-                p.clearHints();
-                p.updateHints();
-            },
-        };
-        if (p.config.placeholder) {
-            resources.hints = {
-                text: p.config.placeholder,
-                target,
-            };
-        }
-
-        return resources;
+    resources = {
+        mutation_filtered_classes: ["o-we-hint"],
+        is_mutation_record_savable: isMutationRecordSavable,
+        onSelectionChange: this.updateHints.bind(this),
+        onExternalHistorySteps: () => {
+            this.clearHints();
+            this.updateHints();
+        },
+        ...(this.config.placeholder && {
+            hints: [
+                {
+                    text: this.config.placeholder,
+                    target,
+                },
+            ],
+        }),
     };
 
     setup() {
@@ -81,7 +78,7 @@ export class HintPlugin extends Plugin {
             this.removeHint(blockEl);
         }
         if (editableSelection.isCollapsed) {
-            for (const hint of this.resources["hints"]) {
+            for (const hint of this.getResource("hints")) {
                 if (hint.selector) {
                     const el = closestBlock(editableSelection.anchorNode);
                     if (el && el.matches(hint.selector) && !isProtected(el) && isEmptyBlock(el)) {

--- a/addons/html_editor/static/src/main/inline_code.js
+++ b/addons/html_editor/static/src/main/inline_code.js
@@ -5,10 +5,9 @@ import { DIRECTIONS } from "@html_editor/utils/position";
 export class InlineCodePlugin extends Plugin {
     static name = "inline_code";
     static dependencies = ["selection", "split"];
-    /** @type { (p: InlineCodePlugin) => Record<string, any> } */
-    static resources = (p) => ({
-        onInput: { handler: p.onInput.bind(p) },
-    });
+    resources = {
+        onInput: this.onInput.bind(this),
+    };
 
     onInput(ev) {
         const selection = this.shared.getEditableSelection();

--- a/addons/html_editor/static/src/main/link/link_paste_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_paste_plugin.js
@@ -7,15 +7,10 @@ import { leftPos } from "@html_editor/utils/position";
 export class LinkPastePlugin extends Plugin {
     static name = "link_paste";
     static dependencies = ["link", "clipboard", "selection", "dom"];
-    /** @type { (p: LinkPastePlugin) => Record<string, any> } */
-    static resources = (p) => ({
-        before_paste: p.removeFullySelectedLink.bind(p),
-        handle_paste_text: p.handlePasteText.bind(p),
-    });
-
-    setup() {
-        this.resources["handle_paste_url"] = this.resources["handle_paste_url"] || [];
-    }
+    resources = {
+        before_paste: this.removeFullySelectedLink.bind(this),
+        handle_paste_text: this.handlePasteText.bind(this),
+    };
 
     /**
      * @param {EditorSelection} selection
@@ -54,7 +49,9 @@ export class LinkPastePlugin extends Plugin {
             this.handlePasteTextUrlInsideLink(text, url);
             return;
         }
-        const isHandled = this.resources["handle_paste_url"].some((handler) => handler(text, url));
+        const isHandled = this.getResource("handle_paste_url").some((handler) =>
+            handler(text, url)
+        );
         if (isHandled) {
             return;
         }

--- a/addons/html_editor/static/src/main/link/link_selection_odoo_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_selection_odoo_plugin.js
@@ -2,7 +2,7 @@ import { Plugin } from "@html_editor/plugin";
 import { isBlock } from "@html_editor/utils/blocks";
 
 export class OdooLinkSelectionPlugin extends Plugin {
-    static resources = () => ({
+    resources = {
         excludeLinkZwnbsp: [
             (link) =>
                 [link, ...link.querySelectorAll("*")].some(
@@ -11,5 +11,5 @@ export class OdooLinkSelectionPlugin extends Plugin {
             (link) => link.matches("nav a, a.nav-link"),
         ],
         excludeLinkVisualIndication: (link) => link.matches(".btn"),
-    });
+    };
 }

--- a/addons/html_editor/static/src/main/link/link_selection_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_selection_plugin.js
@@ -52,15 +52,14 @@ export class LinkSelectionPlugin extends Plugin {
     static dependencies = ["selection"];
     // TODO ABD: refactor to handle Knowledge comments inside this plugin without sharing padLinkWithZwnbsp.
     static shared = ["padLinkWithZwnbsp"];
-    /** @type { (p: LinkSelectionPlugin) => Record<string, any> } */
-    static resources = (p) => ({
+    resources = {
         mutation_filtered_classes: ["o_link_in_selection"],
         link_ignore_classes: ["o_link_in_selection"],
-        onSelectionChange: p.resetLinkInSelection.bind(p),
+        onSelectionChange: this.resetLinkInSelection.bind(this),
         arrows_should_skip: (ev, char, lastSkipped) =>
             // Skip first FEFF, but not the second one (unless shift is pressed).
             char === "\uFEFF" && (ev.shiftKey || lastSkipped !== "\uFEFF"),
-    });
+    };
 
     handleCommand(command, payload) {
         switch (command) {
@@ -175,14 +174,14 @@ export class LinkSelectionPlugin extends Plugin {
             this.editable.contains(link) &&
             !isProtected(link) &&
             !isProtecting(link) &&
-            !this.resources.excludeLinkZwnbsp?.some((callback) => callback(link))
+            !this.getResource("excludeLinkZwnbsp").some((callback) => callback(link))
         );
     }
 
     isLinkEligibleForVisualIndication(link) {
         return (
             this.isLinkEligibleForZwnbsp(link) &&
-            !this.resources.excludeLinkVisualIndication?.some((callback) => callback(link))
+            !this.getResource("excludeLinkVisualIndication").some((callback) => callback(link))
         );
     }
 

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -22,6 +22,7 @@ import { _t } from "@web/core/l10n/translation";
 import { compareListTypes, createList, insertListAfter, isListItem } from "./utils";
 import { callbacksForCursorUpdate } from "@html_editor/utils/selection";
 import { getListMode, switchListMode } from "@html_editor/utils/list";
+import { withSequence } from "@html_editor/utils/resource";
 
 function isListActive(listMode) {
     return (selection) => {
@@ -33,17 +34,15 @@ function isListActive(listMode) {
 export class ListPlugin extends Plugin {
     static name = "list";
     static dependencies = ["tabulation", "split", "selection", "delete", "dom"];
-    /** @type { (p: ListPlugin) => Record<string, any> } */
-    static resources = (p) => ({
-        handle_delete_backward: { callback: p.handleDeleteBackward.bind(p), sequence: 10 },
-        handle_delete_range: { callback: p.handleDeleteRange.bind(p) },
-        handle_tab: { callback: p.handleTab.bind(p), sequence: 10 },
-        handle_shift_tab: { callback: p.handleShiftTab.bind(p), sequence: 10 },
-        split_element_block: { callback: p.handleSplitBlock.bind(p) },
-        toolbarCategory: {
+    resources = {
+        handle_delete_backward: this.handleDeleteBackward.bind(this),
+        handle_delete_range: this.handleDeleteRange.bind(this),
+        handle_tab: this.handleTab.bind(this),
+        handle_shift_tab: this.handleShiftTab.bind(this),
+        split_element_block: this.handleSplitBlock.bind(this),
+        toolbarCategory: withSequence(30, {
             id: "list",
-            sequence: 30,
-        },
+        }),
         toolbarItems: [
             {
                 id: "bulleted_list",
@@ -107,8 +106,8 @@ export class ListPlugin extends Plugin {
             },
         ],
         hints: [{ selector: "LI", text: _t("List") }],
-        onInput: { handler: p.onInput.bind(p) },
-    });
+        onInput: this.onInput.bind(this),
+    };
 
     setup() {
         this.addDomListener(this.editable, "touchstart", this.onPointerdown);

--- a/addons/html_editor/static/src/main/media/icon_plugin.js
+++ b/addons/html_editor/static/src/main/media/icon_plugin.js
@@ -1,3 +1,4 @@
+import { withSequence } from "@html_editor/utils/resource";
 import { Plugin } from "../../plugin";
 import { _t } from "@web/core/l10n/translation";
 
@@ -5,109 +6,105 @@ export class IconPlugin extends Plugin {
     static name = "icon";
     static dependencies = ["history", "link", "selection", "color"];
     /** @type { (p: IconPlugin) => Record<string, any> } */
-    static resources(p) {
-        return {
-            toolbarNamespace: [
-                {
-                    id: "icon",
-                    isApplied: (traversedNodes) =>
-                        traversedNodes.every(
-                            (node) =>
-                                // All nodes should be icons, its ZWS child or its ancestors
-                                node.classList?.contains("fa") ||
-                                node.parentElement.classList.contains("fa") ||
-                                (node.querySelector?.(".fa") && node.isContentEditable !== false)
-                        ),
+    resources = {
+        toolbarNamespace: [
+            {
+                id: "icon",
+                isApplied: (traversedNodes) =>
+                    traversedNodes.every(
+                        (node) =>
+                            // All nodes should be icons, its ZWS child or its ancestors
+                            node.classList?.contains("fa") ||
+                            node.parentElement.classList.contains("fa") ||
+                            (node.querySelector?.(".fa") && node.isContentEditable !== false)
+                    ),
+            },
+        ],
+        toolbarCategory: [
+            withSequence(1, {
+                id: "icon_color",
+                namespace: "icon",
+            }),
+            withSequence(1, {
+                id: "icon_size",
+                namespace: "icon",
+            }),
+            withSequence(3, { id: "icon_spin", namespace: "icon" }),
+        ],
+        toolbarItems: [
+            {
+                id: "icon_forecolor",
+                category: "icon_color",
+                inherit: "forecolor",
+            },
+            {
+                id: "icon_backcolor",
+                category: "icon_color",
+                inherit: "backcolor",
+            },
+            {
+                id: "icon_size_1",
+                category: "icon_size",
+                action(dispatch) {
+                    dispatch("RESIZE_ICON", "1");
                 },
-            ],
-            toolbarCategory: [
-                {
-                    id: "icon_color",
-                    sequence: 1,
-                    namespace: "icon",
+                text: "1x",
+                title: _t("Icon size 1x"),
+                isFormatApplied: () => this.hasIconSize("1"),
+            },
+            {
+                id: "icon_size_2",
+                category: "icon_size",
+                action(dispatch) {
+                    dispatch("RESIZE_ICON", "2");
                 },
-                {
-                    id: "icon_size",
-                    sequence: 1,
-                    namespace: "icon",
+                text: "2x",
+                title: _t("Icon size 2x"),
+                isFormatApplied: () => this.hasIconSize("2"),
+            },
+            {
+                id: "icon_size_3",
+                category: "icon_size",
+                action(dispatch) {
+                    dispatch("RESIZE_ICON", "3");
                 },
-                { id: "icon_spin", sequence: 3, namespace: "icon" },
-            ],
-            toolbarItems: [
-                {
-                    id: "icon_forecolor",
-                    category: "icon_color",
-                    inherit: "forecolor",
+                text: "3x",
+                title: _t("Icon size 3x"),
+                isFormatApplied: () => this.hasIconSize("3"),
+            },
+            {
+                id: "icon_size_4",
+                category: "icon_size",
+                action(dispatch) {
+                    dispatch("RESIZE_ICON", "4");
                 },
-                {
-                    id: "icon_backcolor",
-                    category: "icon_color",
-                    inherit: "backcolor",
+                text: "4x",
+                title: _t("Icon size 4x"),
+                isFormatApplied: () => this.hasIconSize("4"),
+            },
+            {
+                id: "icon_size_5",
+                category: "icon_size",
+                action(dispatch) {
+                    dispatch("RESIZE_ICON", "5");
                 },
-                {
-                    id: "icon_size_1",
-                    category: "icon_size",
-                    action(dispatch) {
-                        dispatch("RESIZE_ICON", "1");
-                    },
-                    text: "1x",
-                    title: _t("Icon size 1x"),
-                    isFormatApplied: () => p.hasIconSize("1"),
+                text: "5x",
+                title: _t("Icon size 5x"),
+                isFormatApplied: () => this.hasIconSize("5"),
+            },
+            {
+                id: "icon_spin",
+                category: "icon_spin",
+                action(dispatch) {
+                    dispatch("TOGGLE_SPIN_ICON");
                 },
-                {
-                    id: "icon_size_2",
-                    category: "icon_size",
-                    action(dispatch) {
-                        dispatch("RESIZE_ICON", "2");
-                    },
-                    text: "2x",
-                    title: _t("Icon size 2x"),
-                    isFormatApplied: () => p.hasIconSize("2"),
-                },
-                {
-                    id: "icon_size_3",
-                    category: "icon_size",
-                    action(dispatch) {
-                        dispatch("RESIZE_ICON", "3");
-                    },
-                    text: "3x",
-                    title: _t("Icon size 3x"),
-                    isFormatApplied: () => p.hasIconSize("3"),
-                },
-                {
-                    id: "icon_size_4",
-                    category: "icon_size",
-                    action(dispatch) {
-                        dispatch("RESIZE_ICON", "4");
-                    },
-                    text: "4x",
-                    title: _t("Icon size 4x"),
-                    isFormatApplied: () => p.hasIconSize("4"),
-                },
-                {
-                    id: "icon_size_5",
-                    category: "icon_size",
-                    action(dispatch) {
-                        dispatch("RESIZE_ICON", "5");
-                    },
-                    text: "5x",
-                    title: _t("Icon size 5x"),
-                    isFormatApplied: () => p.hasIconSize("5"),
-                },
-                {
-                    id: "icon_spin",
-                    category: "icon_spin",
-                    action(dispatch) {
-                        dispatch("TOGGLE_SPIN_ICON");
-                    },
-                    icon: "fa-play",
-                    title: _t("Toggle icon spin"),
-                    isFormatApplied: () => p.hasSpinIcon(),
-                },
-            ],
-            colorApply: p.applyIconColor.bind(p),
-        };
-    }
+                icon: "fa-play",
+                title: _t("Toggle icon spin"),
+                isFormatApplied: () => this.hasSpinIcon(),
+            },
+        ],
+        colorApply: this.applyIconColor.bind(this),
+    };
 
     getSelectedIcon() {
         const selectedNodes = this.shared.getSelectedNodes();

--- a/addons/html_editor/static/src/main/media/image_crop_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_crop_plugin.js
@@ -3,31 +3,28 @@ import { Plugin } from "../../plugin";
 import { _t } from "@web/core/l10n/translation";
 import { ImageCrop } from "./image_crop";
 import { loadBundle } from "@web/core/assets";
+import { withSequence } from "@html_editor/utils/resource";
 
 export class ImageCropPlugin extends Plugin {
     static name = "image_crop";
     static dependencies = ["image", "selection"];
-    /** @type { (p: ImageCropPlugin) => Record<string, any> } */
-    static resources(p) {
-        return {
-            toolbarCategory: {
+    resources = {
+        toolbarCategory: withSequence(27, {
+            id: "image_crop",
+            namespace: "image",
+        }),
+        toolbarItems: [
+            {
                 id: "image_crop",
-                namespace: "image",
-                sequence: 27,
-            },
-            toolbarItems: [
-                {
-                    id: "image_crop",
-                    category: "image_crop",
-                    title: _t("Crop image"),
-                    icon: "fa-crop",
-                    action(dispatch) {
-                        dispatch("CROP_IMAGE");
-                    },
+                category: "image_crop",
+                title: _t("Crop image"),
+                icon: "fa-crop",
+                action(dispatch) {
+                    dispatch("CROP_IMAGE");
                 },
-            ],
-        };
-    }
+            },
+        ],
+    };
 
     setup() {
         this.imageCropProps = {

--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -10,61 +10,68 @@ import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
 import { MediaDialog } from "./media_dialog/media_dialog";
 import { rightPos } from "@html_editor/utils/position";
+import { withSequence } from "@html_editor/utils/resource";
 
 const MEDIA_SELECTOR = `${ICON_SELECTOR} , .o_image, .media_iframe_video`;
+
+/**
+ * @param {MediaPlugin} plugin
+ */
+const getPowerboxItems = (plugin) => {
+    const powerboxItems = [];
+    if (!plugin.config.disableImage) {
+        powerboxItems.push({
+            name: _t("Image"),
+            description: _t("Insert an image"),
+            category: "media",
+            fontawesome: "fa-file-image-o",
+            action() {
+                plugin.openMediaDialog();
+            },
+        });
+    }
+    if (!plugin.config.disableVideo) {
+        powerboxItems.push({
+            name: _t("Video"),
+            description: _t("Insert a video"),
+            category: "media",
+            fontawesome: "fa-file-video-o",
+            action() {
+                plugin.openMediaDialog({
+                    noVideos: false,
+                    noImages: true,
+                    noIcons: true,
+                    noDocuments: true,
+                });
+            },
+        });
+    }
+    return powerboxItems;
+};
 
 export class MediaPlugin extends Plugin {
     static name = "media";
     static dependencies = ["selection", "history", "dom", "dialog"];
     static shared = ["savePendingImages"];
-    /** @type { (p: MediaPlugin) => Record<string, any> } */
-    static resources = (p) => {
-        const powerboxItems = [];
-        if (!p.config.disableImage) {
-            powerboxItems.push({
-                name: _t("Image"),
-                description: _t("Insert an image"),
-                category: "media",
-                fontawesome: "fa-file-image-o",
-                action() {
-                    p.openMediaDialog();
+    resources = {
+        powerboxCategory: withSequence(40, { id: "media", name: _t("Media") }),
+        powerboxItems: getPowerboxItems(this),
+        toolbarCategory: withSequence(29, {
+            id: "replace_image",
+            namespace: "image",
+        }),
+        toolbarItems: [
+            {
+                id: "replace_image",
+                category: "replace_image",
+                action(dispatch) {
+                    dispatch("REPLACE_IMAGE");
                 },
-            });
-        }
-        if (!p.config.disableVideo) {
-            powerboxItems.push({
-                name: _t("Video"),
-                description: _t("Insert a video"),
-                category: "media",
-                fontawesome: "fa-file-video-o",
-                action() {
-                    p.openMediaDialog({
-                        noVideos: false,
-                        noImages: true,
-                        noIcons: true,
-                        noDocuments: true,
-                    });
-                },
-            });
-        }
-        const resources = {
-            powerboxCategory: { id: "media", name: _t("Media"), sequence: 40 },
-            powerboxItems,
-            toolbarCategory: { id: "replace_image", sequence: 29, namespace: "image" },
-            toolbarItems: [
-                {
-                    id: "replace_image",
-                    category: "replace_image",
-                    action(dispatch) {
-                        dispatch("REPLACE_IMAGE");
-                    },
-                    title: _t("Replace media"),
-                    text: "Replace",
-                },
-            ],
-            isUnsplittable: isIconElement, // avoid merge
-        };
-        return resources;
+                title: _t("Replace media"),
+                text: "Replace",
+            },
+        ],
+        isUnsplittable: isIconElement, // avoid merge
     };
 
     get recordInfo() {

--- a/addons/html_editor/static/src/main/movenode_plugin.js
+++ b/addons/html_editor/static/src/main/movenode_plugin.js
@@ -12,15 +12,14 @@ const ALLOWED_ELEMENTS =
 export class MoveNodePlugin extends Plugin {
     static name = "movenode";
     static dependencies = ["selection", "position", "local-overlay"];
-    /** @type { (p: MoveNodePlugin) => Record<string, any> } */
-    static resources = (p) => ({
+    resources = {
         layoutGeometryChange: () => {
-            if (p.currentMovableElement) {
-                p.setMovableElement(p.currentMovableElement);
+            if (this.currentMovableElement) {
+                this.setMovableElement(this.currentMovableElement);
             }
-            p.updateHooks();
+            this.updateHooks();
         },
-    });
+    };
 
     setup() {
         this.intersectionObserver = new IntersectionObserver(
@@ -209,7 +208,7 @@ export class MoveNodePlugin extends Plugin {
     setMovableElement(movableElement) {
         this.removeMoveWidget();
         this.currentMovableElement = movableElement;
-        this.resources.setMovableElement?.forEach((cb) => cb(movableElement));
+        this.getResource("setMovableElement").forEach((cb) => cb(movableElement));
 
         const containerRect = this.widgetContainer.getBoundingClientRect();
         const anchorBlockRect = this.currentMovableElement.getBoundingClientRect();
@@ -259,7 +258,7 @@ export class MoveNodePlugin extends Plugin {
         }
     }
     removeMoveWidget() {
-        this.resources.unsetMovableElement?.forEach((cb) => cb());
+        this.getResource("unsetMovableElement").forEach((cb) => cb());
         this.moveWidget?.remove();
         this.moveWidget = undefined;
         this.currentMovableElement = undefined;

--- a/addons/html_editor/static/src/main/position_plugin.js
+++ b/addons/html_editor/static/src/main/position_plugin.js
@@ -9,12 +9,11 @@ import { couldBeScrollableX, couldBeScrollableY } from "@web/core/utils/scrollin
  */
 export class PositionPlugin extends Plugin {
     static name = "position";
-    /** @type { (p: PositionPlugin) => Record<string, any> } */
-    static resources = (p) => ({
+    resources = {
         // todo: it is strange that the position plugin is aware of onExternalHistorySteps and historyResetFromSteps.
-        onExternalHistorySteps: p.layoutGeometryChange.bind(p),
-        historyResetFromSteps: p.layoutGeometryChange.bind(p),
-    });
+        onExternalHistorySteps: this.layoutGeometryChange.bind(this),
+        historyResetFromSteps: this.layoutGeometryChange.bind(this),
+    };
 
     setup() {
         this.layoutGeometryChange = throttleForAnimation(this.layoutGeometryChange.bind(this));
@@ -48,6 +47,6 @@ export class PositionPlugin extends Plugin {
         super.destroy();
     }
     layoutGeometryChange() {
-        this.resources.layoutGeometryChange?.forEach((cb) => cb());
+        this.getResource("layoutGeometryChange").forEach((cb) => cb());
     }
 }

--- a/addons/html_editor/static/src/main/powerbox/powerbox_plugin.js
+++ b/addons/html_editor/static/src/main/powerbox/powerbox_plugin.js
@@ -4,6 +4,7 @@ import { reactive } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { rotate } from "@web/core/utils/arrays";
 import { Powerbox } from "./powerbox";
+import { withSequence } from "@html_editor/utils/resource";
 
 /**
  * @typedef {Object} CategoriesConfig
@@ -42,16 +43,16 @@ export class PowerboxPlugin extends Plugin {
     static name = "powerbox";
     static dependencies = ["overlay", "selection", "history"];
     static shared = ["openPowerbox", "updatePowerbox", "closePowerbox"];
-    static resources = () => ({
+    resources = {
         hints: {
             text: _t('Type "/" for commands'),
             target,
         },
         powerboxCategory: [
-            { id: "structure", name: _t("Structure"), sequence: 10 },
-            { id: "widget", name: _t("Widget"), sequence: 60 },
+            withSequence(10, { id: "structure", name: _t("Structure") }),
+            withSequence(60, { id: "widget", name: _t("Widget") }),
         ],
-    });
+    };
 
     setup() {
         /** @type {import("@html_editor/core/overlay_plugin").Overlay} */

--- a/addons/html_editor/static/src/main/powerbox/search_powerbox_plugin.js
+++ b/addons/html_editor/static/src/main/powerbox/search_powerbox_plugin.js
@@ -9,21 +9,20 @@ import { Plugin } from "../../plugin";
 export class SearchPowerboxPlugin extends Plugin {
     static name = "search_powerbox";
     static dependencies = ["powerbox", "selection", "history"];
-    /** @type { (p: SearchPowerboxPlugin) => Record<string, any> } */
-    static resources = (p) => ({
-        onBeforeInput: { handler: p.onBeforeInput.bind(p) },
-        onInput: { handler: p.onInput.bind(p) },
-    });
+    resources = {
+        onBeforeInput: this.onBeforeInput.bind(this),
+        onInput: this.onInput.bind(this),
+    };
     setup() {
         const categoryIds = new Set();
-        for (const category of this.resources.powerboxCategory) {
+        for (const category of this.getResource("powerboxCategory")) {
             if (categoryIds.has(category.id)) {
                 throw new Error(`Duplicate category id: ${category.id}`);
             }
             categoryIds.add(category.id);
         }
-        this.categories = this.resources.powerboxCategory.sort((a, b) => a.sequence - b.sequence);
-        this.commands = this.resources.powerboxItems.map((command) => ({
+        this.categories = this.getResource("powerboxCategory");
+        this.commands = this.getResource("powerboxItems").map((command) => ({
             ...command,
             categoryName: this.categories.find((category) => category.id === command.category).name,
         }));

--- a/addons/html_editor/static/src/main/signature_plugin.js
+++ b/addons/html_editor/static/src/main/signature_plugin.js
@@ -2,25 +2,25 @@ import { Plugin } from "@html_editor/plugin";
 import { _t } from "@web/core/l10n/translation";
 import { parseHTML } from "@html_editor/utils/html";
 import { user } from "@web/core/user";
+import { withSequence } from "@html_editor/utils/resource";
 
 export class SignaturePlugin extends Plugin {
     static name = "signature";
     static dependencies = ["dom"];
-    /** @type { (p: SignaturePlugin) => Record<string, any> } */
-    static resources = (p) => ({
-        powerboxCategory: { id: "basic_block", name: _t("Basic Bloc"), sequence: 100 },
+    resources = {
+        powerboxCategory: withSequence(100, { id: "basic_block", name: _t("Basic Bloc") }),
         powerboxItems: [
             {
                 category: "basic_block",
                 name: _t("Signature"),
                 description: _t("Insert your signature"),
                 fontawesome: "fa-pencil-square-o",
-                action() {
-                    return p.insertSignature();
+                action: () => {
+                    return this.insertSignature();
                 },
             },
         ],
-    });
+    };
 
     async insertSignature() {
         const [currentUser] = await this.services.orm.read(

--- a/addons/html_editor/static/src/main/star_plugin.js
+++ b/addons/html_editor/static/src/main/star_plugin.js
@@ -9,16 +9,15 @@ import { _t } from "@web/core/l10n/translation";
 export class StarPlugin extends Plugin {
     static name = "star";
     static dependencies = ["dom"];
-    /** @type { (p: StarPlugin) => Record<string, any> } */
-    static resources = (p) => ({
+    resources = {
         powerboxItems: [
             {
                 name: _t("3 Stars"),
                 description: _t("Insert a rating over 3 stars"),
                 category: "widget",
                 fontawesome: "fa-star-o",
-                action() {
-                    p.addStars(3);
+                action: () => {
+                    this.addStars(3);
                 },
             },
             {
@@ -26,12 +25,12 @@ export class StarPlugin extends Plugin {
                 description: _t("Insert a rating over 5 stars"),
                 category: "widget",
                 fontawesome: "fa-star",
-                action() {
-                    p.addStars(5);
+                action: () => {
+                    this.addStars(5);
                 },
             },
         ],
-    });
+    };
 
     setup() {
         this.addDomListener(this.editable, "pointerdown", this.onMouseDown);

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -10,6 +10,7 @@ import {
 import { ancestors, closestElement, descendants, lastLeaf } from "@html_editor/utils/dom_traversal";
 import { parseHTML } from "@html_editor/utils/html";
 import { DIRECTIONS, leftPos, rightPos, nodeSize } from "@html_editor/utils/position";
+import { withSequence } from "@html_editor/utils/resource";
 import { findInSelection } from "@html_editor/utils/selection";
 import { getColumnIndex, getRowIndex } from "@html_editor/utils/table";
 
@@ -34,19 +35,18 @@ function isUnremovableTableComponent(element, root) {
 export class TablePlugin extends Plugin {
     static name = "table";
     static dependencies = ["dom", "history", "selection", "delete", "split", "color"];
-    /** @type { (p: TablePlugin) => Record<string, any> } */
-    static resources = (p) => ({
-        handle_tab: { callback: p.handleTab.bind(p), sequence: 20 },
-        handle_shift_tab: { callback: p.handleShiftTab.bind(p), sequence: 20 },
-        handle_delete_range: { callback: p.handleDeleteRange.bind(p) },
+    resources = {
+        handle_tab: withSequence(20, this.handleTab.bind(this)),
+        handle_shift_tab: withSequence(20, this.handleShiftTab.bind(this)),
+        handle_delete_range: this.handleDeleteRange.bind(this),
         isUnremovable: isUnremovableTableComponent,
         isUnsplittable: (element) =>
             element.tagName === "TABLE" || tableInnerComponents.has(element.tagName),
-        onSelectionChange: p.updateSelectionTable.bind(p),
-        colorApply: p.applyTableColor.bind(p),
-        modifyTraversedNodes: p.adjustTraversedNodes.bind(p),
+        onSelectionChange: this.updateSelectionTable.bind(this),
+        colorApply: this.applyTableColor.bind(this),
+        modifyTraversedNodes: this.adjustTraversedNodes.bind(this),
         considerNodeFullySelected: (node) => !!closestElement(node, ".o_selected_td"),
-    });
+    };
 
     setup() {
         this.addDomListener(this.editable, "mousedown", this.onMousedown);

--- a/addons/html_editor/static/src/main/table/table_ui_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_ui_plugin.js
@@ -12,16 +12,15 @@ import { TablePicker } from "./table_picker";
 export class TableUIPlugin extends Plugin {
     static name = "table_ui";
     static dependencies = ["overlay", "table"];
-    /** @type { (p: TableUIPlugin) => Record<string, any> } */
-    static resources = (p) => ({
+    resources = {
         powerboxItems: [
             {
                 name: _t("Table"),
                 description: _t("Insert a table"),
                 category: "structure",
                 fontawesome: "fa-table",
-                action(dispatch) {
-                    if (p.services.ui.isSmall) {
+                action: (dispatch) => {
+                    if (this.services.ui.isSmall) {
                         dispatch("INSERT_TABLE", { cols: 3, rows: 3 });
                     } else {
                         dispatch("OPEN_TABLE_PICKER");
@@ -29,7 +28,7 @@ export class TableUIPlugin extends Plugin {
                 },
             },
         ],
-    });
+    };
 
     setup() {
         /** @type {import("@html_editor/core/overlay_plugin").Overlay} */

--- a/addons/html_editor/static/src/main/tabulation_plugin.js
+++ b/addons/html_editor/static/src/main/tabulation_plugin.js
@@ -25,22 +25,16 @@ export class TabulationPlugin extends Plugin {
     static name = "tabulation";
     static dependencies = ["dom", "selection", "delete", "split"];
     static shared = ["indentBlocks", "outdentBlocks"];
-    /** @type { (p: TabulationPlugin) => Record<string, any> } */
-    static resources = (p) => ({
+    resources = {
         handle_tab: [],
         handle_shift_tab: [],
-        handle_delete_forward: { callback: p.handleDeleteForward.bind(p), sequence: 20 },
+        handle_delete_forward: this.handleDeleteForward.bind(this),
         shortcuts: [
             { hotkey: "tab", command: "TAB" },
             { hotkey: "shift+tab", command: "SHIFT_TAB" },
         ],
         isUnsplittable: isEditorTab, // avoid merge
-    });
-
-    setup() {
-        this.resources["handle_tab"].sort((a, b) => a.sequence - b.sequence);
-        this.resources["handle_shift_tab"].sort((a, b) => a.sequence - b.sequence);
-    }
+    };
 
     handleCommand(command, payload) {
         switch (command) {
@@ -65,7 +59,7 @@ export class TabulationPlugin extends Plugin {
     }
 
     handleTab() {
-        for (const { callback } of this.resources["handle_tab"]) {
+        for (const callback of this.getResource("handle_tab")) {
             if (callback()) {
                 return;
             }
@@ -82,7 +76,7 @@ export class TabulationPlugin extends Plugin {
     }
 
     handleShiftTab() {
-        for (const { callback } of this.resources["handle_shift_tab"]) {
+        for (const callback of this.getResource("handle_shift_tab")) {
             if (callback()) {
                 return;
             }

--- a/addons/html_editor/static/src/main/text_direction_plugin.js
+++ b/addons/html_editor/static/src/main/text_direction_plugin.js
@@ -7,8 +7,7 @@ import { isContentEditable, isTextNode } from "@html_editor/utils/dom_info";
 export class TextDirectionPlugin extends Plugin {
     static name = "text_direction";
     static dependencies = ["selection", "split", "format"];
-    /** @type { (p: TextDirectionPlugin) => Record<string, any> } */
-    static resources = (p) => ({
+    resources = {
         powerboxItems: [
             {
                 name: _t("Switch direction"),
@@ -20,7 +19,7 @@ export class TextDirectionPlugin extends Plugin {
                 },
             },
         ],
-    });
+    };
 
     setup() {
         if (this.config.direction) {

--- a/addons/html_editor/static/src/main/toolbar/toolbar.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar.js
@@ -16,7 +16,6 @@ export class Toolbar extends Component {
                         type: Object,
                         shape: {
                             id: String,
-                            sequence: Number,
                             namespace: { type: String, optional: true },
                             buttons: {
                                 type: Array,

--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -15,32 +15,31 @@ export class ToolbarPlugin extends Plugin {
     static name = "toolbar";
     static dependencies = ["overlay", "selection"];
     static shared = ["getToolbarInfo"];
-    /** @type { (p: ToolbarPlugin) => Record<string, any> } */
-    static resources = (p) => ({
-        onSelectionChange: p.handleSelectionChange.bind(p),
-    });
+    resources = {
+        onSelectionChange: this.handleSelectionChange.bind(this),
+    };
 
     setup() {
         const categoryIds = new Set();
-        for (const category of this.resources.toolbarCategory) {
+        for (const category of this.getResource("toolbarCategory")) {
             if (categoryIds.has(category.id)) {
                 throw new Error(`Duplicate toolbar category id: ${category.id}`);
             }
             categoryIds.add(category.id);
         }
-        this.categories = this.resources.toolbarCategory.sort((a, b) => a.sequence - b.sequence);
+        this.categories = this.getResource("toolbarCategory");
         this.buttonGroups = [];
         for (const category of this.categories) {
             this.buttonGroups.push({
                 ...category,
-                buttons: this.resources.toolbarItems.filter(
+                buttons: this.getResource("toolbarItems").filter(
                     (command) => command.category === category.id
                 ),
             });
         }
         this.buttonsDict = Object.assign(
             {},
-            ...this.resources.toolbarItems.map((button) => ({ [button.id]: button }))
+            ...this.getResource("toolbarItems").map((button) => ({ [button.id]: button }))
         );
         this.isMobileToolbar = hasTouch() && window.visualViewport;
 
@@ -219,7 +218,7 @@ export class ToolbarPlugin extends Plugin {
 
     updateNamespace() {
         const traversedNodes = this.getFilterTraverseNodes();
-        for (const namespace of this.resources.toolbarNamespace || []) {
+        for (const namespace of this.getResource('toolbarNamespace') || []) {
             if (namespace.isApplied(traversedNodes)) {
                 this.state.namespace = namespace.id;
                 return;

--- a/addons/html_editor/static/src/main/youtube_plugin.js
+++ b/addons/html_editor/static/src/main/youtube_plugin.js
@@ -10,12 +10,9 @@ export class YoutubePlugin extends Plugin {
     static name = "youtube";
     static dependencies = ["history", "powerbox", "link", "dom"];
     static shared = [];
-    /** @type { (p: YoutubePlugin) => Record<string, any> } */
-    static resources(p) {
-        return {
-            handle_paste_url: p.handlePasteUrl.bind(p),
-        };
-    }
+    resources = {
+        handle_paste_url: this.handlePasteUrl.bind(this),
+    };
     /**
      * @param {string} text
      * @param {string} url

--- a/addons/html_editor/static/src/others/collaboration/collaboration_odoo_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_odoo_plugin.js
@@ -40,18 +40,17 @@ export class CollaborationOdooPlugin extends Plugin {
     static name = "collaboration_odoo";
     static dependencies = ["history", "collaboration", "selection"];
     static shared = ["getPeerMetadata"];
-    /** @type { (p: CollaborationOdooPlugin) => Record<string, any> } */
-    static resources = (p) => ({
+    resources = {
         onSelectionChange: debounce(() => {
-            p.ptp?.notifyAllPeers(
+            this.ptp?.notifyAllPeers(
                 "oe_history_set_selection",
-                p.getCurrentCollaborativeSelection(),
+                this.getCurrentCollaborativeSelection(),
                 {
                     transport: "rtc",
                 }
             );
         }, 50),
-    });
+    };
 
     setup() {
         this.isDocumentStale = false;
@@ -270,7 +269,7 @@ export class CollaborationOdooPlugin extends Plugin {
                 },
             },
             onNotification: async (notification) => {
-                for (const cb of this.resources.handleCollaborationNotification || []) {
+                for (const cb of this.getResource("handleCollaborationNotification")) {
                     cb(notification);
                 }
                 let { fromPeerId, notificationName, notificationPayload } = notification;
@@ -362,7 +361,7 @@ export class CollaborationOdooPlugin extends Plugin {
      * @param {CollaborationSelection} selection
      */
     onExternalMultiselectionUpdate(selection) {
-        this.resources.collaborativeSelectionUpdate?.forEach((cb) => cb(selection));
+        this.getResource("collaborativeSelectionUpdate").forEach((cb) => cb(selection));
     }
 
     async requestPeer(peerId, requestName, requestPayload, params) {
@@ -379,7 +378,7 @@ export class CollaborationOdooPlugin extends Plugin {
             startTime: this.startCollaborationTime,
             peerName: user.name,
         };
-        for (const cb of this.resources.getCollaborationPeerMetadata || []) {
+        for (const cb of this.getResource("getCollaborationPeerMetadata")) {
             Object.assign(metadatas, cb());
         }
         return metadatas;

--- a/addons/html_editor/static/src/others/collaboration/collaboration_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_plugin.js
@@ -13,12 +13,11 @@ const HISTORY_SNAPSHOT_BUFFER_TIME = 1000 * 10;
 export class CollaborationPlugin extends Plugin {
     static name = "collaboration";
     static dependencies = ["history", "selection", "sanitize"];
-    /** @type { (p: CollaborationPlugin) => Record<string, any> } */
-    static resources = (p) => ({
-        set_attribute: p.setAttribute.bind(p),
-        process_history_step: p.processHistoryStep.bind(p),
-        is_reversible_step: p.isReversibleStep.bind(p),
-    });
+    resources = {
+        set_attribute: this.setAttribute.bind(this),
+        process_history_step: this.processHistoryStep.bind(this),
+        is_reversible_step: this.isReversibleStep.bind(this),
+    };
     static shared = [
         //
         "onExternalHistorySteps",
@@ -161,7 +160,7 @@ export class CollaborationPlugin extends Plugin {
             this.shared.rectifySelection(selectionData.editableSelection);
         }
 
-        this.resources.onExternalHistorySteps?.forEach((cb) => cb());
+        this.getResource("onExternalHistorySteps").forEach((cb) => cb());
 
         // todo: ensure that if the selection was not in the editable before the
         // reset, it remains where it was after applying the snapshot.
@@ -295,7 +294,7 @@ export class CollaborationPlugin extends Plugin {
         // this.dispatchEvent(new Event("resetFromSteps"));
     }
     postProcessExternalSteps() {
-        const postProcessExternalSteps = this.resources["post_process_external_steps"]
+        const postProcessExternalSteps = this.getResource("post_process_external_steps")
             ?.map((cb) => cb(this.editable))
             ?.filter(Boolean);
         if (postProcessExternalSteps?.length) {

--- a/addons/html_editor/static/src/others/collaboration/collaboration_selection_avatar_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_selection_avatar_plugin.js
@@ -21,16 +21,15 @@ export const AVATAR_SIZE = 25;
 export class CollaborationSelectionAvatarPlugin extends Plugin {
     static name = "collaboration_selection_avatar";
     static dependencies = ["history", "position", "local-overlay", "collaboration_odoo"];
-    /** @type { (p: CollaborationSelectionAvatarPlugin) => Record<string, any> } */
-    static resources = (p) => ({
-        handleCollaborationNotification: p.handleCollaborationNotification.bind(p),
-        getCollaborationPeerMetadata: () => ({ avatarUrl: p.avatarUrl }),
-        onExternalHistorySteps: p.refreshSelection.bind(p),
-        layoutGeometryChange: p.refreshSelection.bind(p),
-        setMovableElement: p.disableAvatarForElement.bind(p),
-        unsetMovableElement: p.enableAvatars.bind(p),
-        collaborativeSelectionUpdate: p.updateSelection.bind(p),
-    });
+    resources = {
+        handleCollaborationNotification: this.handleCollaborationNotification.bind(this),
+        getCollaborationPeerMetadata: () => ({ avatarUrl: this.avatarUrl }),
+        onExternalHistorySteps: this.refreshSelection.bind(this),
+        layoutGeometryChange: this.refreshSelection.bind(this),
+        setMovableElement: this.disableAvatarForElement.bind(this),
+        unsetMovableElement: this.enableAvatars.bind(this),
+        collaborativeSelectionUpdate: this.updateSelection.bind(this),
+    };
 
     /** @type {Map<string, SelectionInfo>} */
     selectionInfos = new Map();

--- a/addons/html_editor/static/src/others/collaboration/collaboration_selection_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_selection_plugin.js
@@ -19,13 +19,12 @@ export class CollaborationSelectionPlugin extends Plugin {
         "collaboration_odoo",
         "local-overlay",
     ];
-    /** @type { (p: CollaborationSelectionPlugin) => Record<string, any> } */
-    static resources = (p) => ({
-        handleCollaborationNotification: p.handleCollaborationNotification.bind(p),
-        getCollaborationPeerMetadata: () => ({ selectionColor: p.selectionColor }),
-        layoutGeometryChange: p.refreshSelection.bind(p),
-        collaborativeSelectionUpdate: p.updateSelection.bind(p),
-    });
+    resources = {
+        handleCollaborationNotification: this.handleCollaborationNotification.bind(this),
+        getCollaborationPeerMetadata: () => ({ selectionColor: this.selectionColor }),
+        layoutGeometryChange: this.refreshSelection.bind(this),
+        collaborativeSelectionUpdate: this.updateSelection.bind(this),
+    };
     selectionInfos = new Map();
 
     setup() {

--- a/addons/html_editor/static/src/others/dynamic_placeholder/dynamic_placeholder.js
+++ b/addons/html_editor/static/src/others/dynamic_placeholder/dynamic_placeholder.js
@@ -1,14 +1,14 @@
 import { Plugin } from "@html_editor/plugin";
 import { _t } from "@web/core/l10n/translation";
 import { DynamicPlaceholderPopover } from "@web/views/fields/dynamic_placeholder_popover";
+import { withSequence } from "@html_editor/utils/resource";
 
 export class DynamicPlaceholderPlugin extends Plugin {
     static name = "dynamic_placeholder";
     static dependencies = ["overlay", "selection", "history", "dom", "qweb"];
     static shared = ["updateDphDefaultModel"];
-    /** @type { (p: DynamicPlaceholderPlugin) => Record<string, any> } */
-    static resources = (p) => ({
-        powerboxCategory: { id: "marketing_tools", name: _t("Marketing Tools"), sequence: 60 },
+    resources = {
+        powerboxCategory: withSequence(60, { id: "marketing_tools", name: _t("Marketing Tools") }),
         powerboxItems: {
             name: _t("Dynamic Placeholder"),
             description: _t("Insert a field"),
@@ -18,7 +18,7 @@ export class DynamicPlaceholderPlugin extends Plugin {
                 dispatch("OPEN_DYNAMIC_PLACEHOLDER");
             },
         },
-    });
+    };
     setup() {
         this.defaultResModel = this.config.dynamicPlaceholderResModel;
 

--- a/addons/html_editor/static/src/others/embedded_component_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_component_plugin.js
@@ -9,14 +9,11 @@ import { memoize } from "@web/core/utils/functions";
 export class EmbeddedComponentPlugin extends Plugin {
     static name = "embedded_components";
     static dependencies = ["history", "protected_node"];
-    /** @type { (p: EmbeddedComponentPlugin) => Record<string, any> } */
-    static resources(p) {
-        return {
-            filter_descendants_to_serialize: p.filterDescendantsToSerialize.bind(p),
-            is_mutation_record_savable: p.isMutationRecordSavable.bind(p),
-            on_change_attribute: p.onChangeAttribute.bind(p),
-        };
-    }
+    resources = {
+        filter_descendants_to_serialize: this.filterDescendantsToSerialize.bind(this),
+        is_mutation_record_savable: this.isMutationRecordSavable.bind(this),
+        on_change_attribute: this.onChangeAttribute.bind(this),
+    };
 
     setup() {
         this.components = new Set();
@@ -109,7 +106,9 @@ export class EmbeddedComponentPlugin extends Plugin {
     }
 
     getEmbedding(host) {
-        return this.embeddedComponents(this.resources.embeddedComponents)[host.dataset.embedded];
+        return this.embeddedComponents(this.getResource("embeddedComponents"))[
+            host.dataset.embedded
+        ];
     }
 
     /**

--- a/addons/html_editor/static/src/others/embedded_components/plugins/excalidraw_plugin/excalidraw_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/excalidraw_plugin/excalidraw_plugin.js
@@ -6,7 +6,7 @@ import { ExcalidrawDialog } from "@html_editor/others/embedded_components/plugin
 export class ExcalidrawPlugin extends Plugin {
     static name = "excalidraw";
     static dependencies = ["embedded_components", "dom", "selection", "link"];
-    static resources = (p) => ({
+    resources = {
         powerboxItems: [
             {
                 category: "navigation",
@@ -15,11 +15,11 @@ export class ExcalidrawPlugin extends Plugin {
                 description: _t("Insert an Excalidraw Board"),
                 fontawesome: "fa-pencil-square-o",
                 action: () => {
-                    p.insertDrawingBoard();
+                    this.insertDrawingBoard();
                 },
             },
         ],
-    });
+    };
 
     insertDrawingBoard() {
         const selection = this.shared.getEditableSelection();

--- a/addons/html_editor/static/src/others/embedded_components/plugins/file_plugin/file_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/file_plugin/file_plugin.js
@@ -8,7 +8,7 @@ import { isBlock } from "@html_editor/utils/blocks";
 export class FilePlugin extends Plugin {
     static name = "file";
     static dependencies = ["embedded_components", "dom", "selection"];
-    static resources = (p) => ({
+    resources = {
         powerboxItems: [
             {
                 category: "media",
@@ -18,12 +18,12 @@ export class FilePlugin extends Plugin {
                 fontawesome: "fa-file",
                 isAvailable: (node) => {
                     return (
-                        !p.config.disableFile &&
+                        !this.config.disableFile &&
                         !!closestElement(node, "[data-embedded='clipboard']")
                     );
                 },
                 action: () => {
-                    p.openMediaDialog({
+                    this.openMediaDialog({
                         noVideos: true,
                         noImages: true,
                         noIcons: true,
@@ -32,7 +32,7 @@ export class FilePlugin extends Plugin {
                 },
             },
         ],
-    });
+    };
 
     handleCommand(command, payload) {
         switch (command) {

--- a/addons/html_editor/static/src/others/embedded_components/plugins/table_of_content_plugin/table_of_content_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/table_of_content_plugin/table_of_content_plugin.js
@@ -9,7 +9,7 @@ import {
 export class TableOfContentPlugin extends Plugin {
     static name = "tableOfContent";
     static dependencies = ["dom", "selection", "embedded_components", "link"];
-    static resources = (p) => ({
+    resources = {
         powerboxItems: [
             {
                 category: "navigation",
@@ -17,12 +17,12 @@ export class TableOfContentPlugin extends Plugin {
                 description: _t("Highlight the structure (headings) of this field"),
                 fontawesome: "fa-bookmark",
                 action: () => {
-                    p.insertTableOfContent();
+                    this.insertTableOfContent();
                 },
             },
         ],
         mutation_filtered_classes: ["o_embedded_toc_header_highlight"],
-    });
+    };
 
     setup() {
         this.manager = new TableOfContentManager({

--- a/addons/html_editor/static/src/others/embedded_components/plugins/video_plugin/video_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/video_plugin/video_plugin.js
@@ -6,7 +6,7 @@ import { renderToElement } from "@web/core/utils/render";
 export class VideoPlugin extends Plugin {
     static name = "video";
     static dependencies = ["embedded_components", "dom", "selection", "link"];
-    static resources = (p) => ({
+    resources = {
         powerboxItems: [
             {
                 category: "navigation",
@@ -15,13 +15,13 @@ export class VideoPlugin extends Plugin {
                 description: _t("Insert a Video"),
                 fontawesome: "fa-play",
                 action: () => {
-                    p.openVideoSelectorDialog((media) => {
-                        p.insertVideo(media);
+                    this.openVideoSelectorDialog((media) => {
+                        this.insertVideo(media);
                     });
                 },
             },
         ],
-    });
+    };
 
     /**
      * Inserts a video in the editor

--- a/addons/html_editor/static/src/others/qweb_plugin.js
+++ b/addons/html_editor/static/src/others/qweb_plugin.js
@@ -12,13 +12,12 @@ const isUnsplittableQWebElement = (element) =>
 export class QWebPlugin extends Plugin {
     static name = "qweb";
     static dependencies = ["overlay", "selection"];
-    /** @type { (p: QWebPlugin) => Record<string, any> } */
-    static resources = (p) => ({
-        onSelectionChange: p.onSelectionChange.bind(p),
-        is_mutation_record_savable: p.isMutationRecordSavable.bind(p),
+    resources = {
+        onSelectionChange: this.onSelectionChange.bind(this),
+        is_mutation_record_savable: this.isMutationRecordSavable.bind(this),
         isUnremovable: (element) => element.getAttribute("t-set") || element.getAttribute("t-call"),
         isUnsplittable: isUnsplittableQWebElement,
-    });
+    };
 
     setup() {
         this.editable.classList.add("odoo-editor-qweb");

--- a/addons/html_editor/static/src/plugin.js
+++ b/addons/html_editor/static/src/plugin.js
@@ -97,7 +97,10 @@ export class Plugin {
         this.shared = shared;
         this.dispatch = dispatch;
         this._cleanups = [];
-        this.resources = null; // set before start
+        /**
+         * The resources aggregated from all the plugins by the editor.
+         */
+        this._resources = null; // set before start
         this.isDestroyed = false;
     }
 
@@ -125,6 +128,13 @@ export class Plugin {
         };
         target.addEventListener(eventName, handler, capture);
         this._cleanups.push(() => target.removeEventListener(eventName, handler, capture));
+    }
+
+    /**
+     * @param {string} resourceId
+     */
+    getResource(resourceId) {
+        return this._resources[resourceId] || [];
     }
 
     destroy() {

--- a/addons/html_editor/static/src/utils/resource.js
+++ b/addons/html_editor/static/src/utils/resource.js
@@ -1,0 +1,8 @@
+export const resourceSequenceSymbol = Symbol("resourceSequence");
+
+export function withSequence(sequenceNumber, object) {
+    return {
+        [resourceSequenceSymbol]: sequenceNumber,
+        object,
+    };
+}

--- a/addons/html_editor/static/tests/collaboration.test.js
+++ b/addons/html_editor/static/tests/collaboration.test.js
@@ -688,9 +688,9 @@ describe("post process external steps", () => {
         };
         class ConfigPlugin extends Plugin {
             static name = "collab-test-config";
-            static resources = () => ({
+            resources = {
                 post_process_external_steps: postProcessExternalSteps,
-            });
+            };
         }
         await testMultiEditor({
             Plugins: [ConfigPlugin],

--- a/addons/html_editor/static/tests/data-oe/protected.test.js
+++ b/addons/html_editor/static/tests/data-oe/protected.test.js
@@ -553,9 +553,9 @@ test("don't protect a node under data-oe-protected='false' through delete and un
 test("protected plugin is robust against other plugins which can filter mutations", async () => {
     class FilterPlugin extends Plugin {
         static name = "filter_plugin";
-        static resources(p) {
-            return { is_mutation_record_savable: p.isMutationRecordSavable.bind(this) };
-        }
+        resources = {
+            is_mutation_record_savable: this.isMutationRecordSavable.bind(this),
+        };
         isMutationRecordSavable(record) {
             if (
                 record.type === "childList" &&

--- a/addons/html_editor/static/tests/format/font_size.test.js
+++ b/addons/html_editor/static/tests/format/font_size.test.js
@@ -156,9 +156,9 @@ test("should apply font size in unbreakable span with class", async () => {
 
 test("should apply font size in unbreakable span without class", async () => {
     class AddUnsplittableRulePlugin extends Plugin {
-        static resources = () => ({
+        resources = {
             isUnsplittable: (element) => element.getAttribute("t") === "unbreakable",
-        });
+        };
     }
     await testEditor({
         contentBefore: `<h1><span t="unbreakable">some [text]</span></h1>`,

--- a/addons/html_editor/static/tests/history.test.js
+++ b/addons/html_editor/static/tests/history.test.js
@@ -256,9 +256,9 @@ describe("step", () => {
 describe("prevent mutationFilteredClasses to be set from history", () => {
     class TestMutationFilteredClassesPlugin extends Plugin {
         static name = "testRenderClasses";
-        static resources = () => ({
+        resources = {
             mutation_filtered_classes: ["x"],
-        });
+        };
     }
     const Plugins = [...MAIN_PLUGINS, TestMutationFilteredClassesPlugin];
     test("should prevent mutationFilteredClasses to be added", async () => {
@@ -564,9 +564,9 @@ describe("destroy", () => {
             // Added history dependency so that this plugin is loaded after and unloaded before.
             static dependencies = ["history", "dom"];
             static name = "test";
-            static resources(p) {
-                return { is_mutation_record_savable: p.isMutationRecordSavable.bind(p) };
-            }
+            resources = {
+                is_mutation_record_savable: this.isMutationRecordSavable.bind(this),
+            };
             isMutationRecordSavable(record) {
                 if (
                     record.type === "childList" &&

--- a/addons/html_editor/static/tests/keyboard/shortcut.test.js
+++ b/addons/html_editor/static/tests/keyboard/shortcut.test.js
@@ -8,9 +8,9 @@ test("shortcut plugin allow registering shortcuts", async () => {
     let count = 0;
     class TestPlugin extends Plugin {
         static name = "test";
-        static resources = (p) => ({
+        resources = {
             shortcuts: [{ hotkey: "a", command: "TEST_CMD" }],
-        });
+        };
         handleCommand(command, payload) {
             if (command === "TEST_CMD") {
                 count++;
@@ -32,9 +32,9 @@ test.tags("iframe")("shortcut plugin allow registering shortcuts in iframe", asy
     let count = 0;
     class TestPlugin extends Plugin {
         static name = "test";
-        static resources = (p) => ({
+        resources = {
             shortcuts: [{ hotkey: "a", command: "TEST_CMD" }],
-        });
+        };
         handleCommand(command, payload) {
             if (command === "TEST_CMD") {
                 count++;

--- a/addons/html_editor/static/tests/misc.test.js
+++ b/addons/html_editor/static/tests/misc.test.js
@@ -4,6 +4,7 @@ import { expect, test } from "@odoo/hoot";
 import { click } from "@odoo/hoot-dom";
 import { setupEditor, testEditor } from "./_helpers/editor";
 import { getContent, setContent } from "./_helpers/selection";
+import { withSequence } from "@html_editor/utils/resource";
 
 test("can instantiate a Editor", async () => {
     const { el, editor } = await setupEditor("<p>hel[lo] world</p>", {});
@@ -107,7 +108,7 @@ test("can give resources in config", async () => {
         static name = "test";
 
         setup() {
-            expect(this.resources.some).toEqual(["value"]);
+            expect(this.getResource("some")).toEqual(["value"]);
         }
     }
 
@@ -115,6 +116,36 @@ test("can give resources in config", async () => {
         config: {
             Plugins: [...MAIN_PLUGINS, TestPlugin],
             resources: { some: ["value"] },
+        },
+    });
+});
+
+test("resource can have sequence", async () => {
+    expect.assertions(1);
+    class TestPlugin extends Plugin {
+        static name = "test";
+        resources = {
+            test_resource: [
+                { value: 2 },
+                withSequence(20, { value: 4 }),
+                withSequence(5, { value: 1 }),
+                { value: 3 },
+            ],
+        };
+
+        setup() {
+            expect(this.getResource("test_resource")).toEqual([
+                { value: 1 },
+                { value: 2 },
+                { value: 3 },
+                { value: 4 },
+            ]);
+        }
+    }
+
+    await setupEditor("<p></p>", {
+        config: {
+            Plugins: [...MAIN_PLUGINS, TestPlugin],
         },
     });
 });

--- a/addons/html_editor/static/tests/powerbox.test.js
+++ b/addons/html_editor/static/tests/powerbox.test.js
@@ -23,6 +23,7 @@ import { insertText, redo, undo } from "./_helpers/user_actions";
 import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { PowerboxPlugin } from "@html_editor/main/powerbox/powerbox_plugin";
 import { SearchPowerboxPlugin } from "@html_editor/main/powerbox/search_powerbox_plugin";
+import { withSequence } from "@html_editor/utils/resource";
 
 function commandNames() {
     return queryAllTexts(".o-we-command-name");
@@ -113,7 +114,7 @@ describe("search", () => {
     test("press 'backspace' should adapt adapt the search in the Powerbox", async () => {
         class TestPlugin extends Plugin {
             static name = "test";
-            static resources = () => ({
+            resources = {
                 powerboxCategory: { id: "test", name: "Test" },
                 powerboxItems: [
                     {
@@ -127,7 +128,7 @@ describe("search", () => {
                         category: "test",
                     },
                 ],
-            });
+            };
         }
         const { editor, el } = await setupEditor(`<p>[]</p>`, {
             config: { Plugins: [...MAIN_PLUGINS, TestPlugin] },
@@ -253,7 +254,7 @@ describe("search", () => {
         test("should search commands by optional keywords", async () => {
             class TestPlugin extends Plugin {
                 static name = "test";
-                static resources = () => ({
+                resources = {
                     powerboxCategory: { id: "test", name: "Test" },
                     powerboxItems: [
                         {
@@ -268,7 +269,7 @@ describe("search", () => {
                             category: "test",
                         },
                     ],
-                });
+                };
             }
             const { editor, el } = await setupEditor(`<p>[]</p>`, {
                 config: { Plugins: [...MAIN_PLUGINS, TestPlugin] },
@@ -300,7 +301,7 @@ describe("search", () => {
         test("match order: full match on keyword should come before partial matches on names or descriptions", async () => {
             class TestPlugin extends Plugin {
                 static name = "test";
-                static resources = () => ({
+                resources = {
                     powerboxCategory: { id: "test", name: "Test" },
                     powerboxItems: [
                         {
@@ -320,7 +321,7 @@ describe("search", () => {
                             searchKeywords: ["icon"],
                         },
                     ],
-                });
+                };
             }
             const { editor, el } = await setupEditor(`<p>[]</p>`, {
                 config: {
@@ -496,7 +497,7 @@ test("should toggle list on empty paragraph", async () => {
 
 class NoOpPlugin extends Plugin {
     static name = "no_op";
-    static resources = () => ({
+    resources = {
         powerboxCategory: { id: "no_op", name: "No-op" },
         powerboxItems: [
             {
@@ -509,7 +510,7 @@ class NoOpPlugin extends Plugin {
                 },
             },
         ],
-    });
+    };
 }
 
 test("should restore state before /command insertion when command is executed (1)", async () => {
@@ -722,14 +723,14 @@ test.todo("add plugins with the same powerboxCategory should crash", async () =>
         warn: (msg) => expect.step(msg),
     });
     class Plugin1 extends Plugin {
-        static resources = () => ({
-            powerboxCategory: { id: "test", name: "Test", sequence: 10 },
-        });
+        resources = {
+            powerboxCategory: withSequence(10, { id: "test", name: "Test" }),
+        };
     }
     class Plugin2 extends Plugin {
-        static resources = () => ({
-            powerboxCategory: { id: "test", name: "Test", sequence: 10 },
-        });
+        resources = {
+            powerboxCategory: withSequence(10, { id: "test", name: "Test" }),
+        };
     }
     await expect(
         setupEditor("<p>ab[]cd</p>", {

--- a/addons/html_editor/static/tests/preprocessing.test.js
+++ b/addons/html_editor/static/tests/preprocessing.test.js
@@ -29,9 +29,9 @@ const migrations = [
 
 class MigrationPlugin extends Plugin {
     static name = "knowledge_migrations_demo";
-    static resources = (p) => ({
-        preprocessDom: p.preprocessDom.bind(p),
-    });
+    resources = {
+        preprocessDom: this.preprocessDom.bind(this),
+    };
 
     preprocessDom(editable) {
         const elems = editable.querySelectorAll("[data-knowledge-version]");

--- a/addons/html_editor/static/tests/selection.test.js
+++ b/addons/html_editor/static/tests/selection.test.js
@@ -30,9 +30,9 @@ test("plugins should be notified when ranges are removed", async () => {
     let count = 0;
     class TestPlugin extends Plugin {
         static name = "test";
-        static resources = (p) => ({
+        resources = {
             onSelectionChange: () => count++,
-        });
+        };
     }
 
     const { el } = await setupEditor("<p>a[b]</p>", {
@@ -174,18 +174,18 @@ test("restore a selection when you are not in the editable shouldn't move the fo
     class TestPlugin extends Plugin {
         static name = "test";
         static dependencies = ["overlay"];
-        static resources = (p) => ({
+        resources = {
             powerboxItems: [
                 {
                     category: "widget",
                     name: "Test",
                     description: "Test",
-                    action() {
-                        p.showOverlay();
+                    action: () => {
+                        this.showOverlay();
                     },
                 },
             ],
-        });
+        };
 
         setup() {
             this.overlay = this.shared.createOverlay(TestInput);

--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/mention_plugin.js
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/mention_plugin.js
@@ -8,9 +8,9 @@ export class MentionPlugin extends Plugin {
     static name = "mention";
     static dependencies = ["overlay", "dom", "history", "selection"];
 
-    static resources = (p) => ({
-        onBeforeInput: { handler: p.onBeforeInput.bind(p) },
-    });
+    resources = {
+        onBeforeInput: this.onBeforeInput.bind(this),
+    };
 
     setup() {
         this.mentionList = this.shared.createOverlay(MentionList, {

--- a/addons/project/static/src/project_sharing/editor/project_sharing_media_plugin.js
+++ b/addons/project/static/src/project_sharing/editor/project_sharing_media_plugin.js
@@ -3,12 +3,12 @@ import { MediaPlugin } from "@html_editor/main/media/media_plugin";
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 
 export class ProjectSharingMediaPlugin extends MediaPlugin {
-    static resources = (p) => {
-        const resources = MediaPlugin.resources(p);
-        delete resources.toolbarCategory;
-        delete resources.toolbarItems;
-        return resources;
-    };
+    resources = {
+        ...this.resources,
+        toolbarItems: this.resources.toolbarItems.filter(
+            item => item.id !== "replace_image"
+        ),
+    }
     async createAttachment({ el, imageData, resId }) {
         const response = JSON.parse(
             await this.services.http.post(


### PR DESCRIPTION
This commit change the resource API for the plugins in 3 ways.

# 1) The disposal of resources

Instead of

```js
class MyPlugin extends Plugin {
    /** @type { (p: MyPlugin) => Record<string, any> } */
    static resources = (p) => ({
        my_handlers: p.handler.bind(p)
    })
}

```

We now have
```js
class MyPlugin extends Plugin {
    resources = {
        my_handlers: this.handler.bind(this)
    }
}
```

# 2) Resource getter
To access a specific resource within a plugin, instead of

```js
this.resources['my_handler']
```

We now have
```js
this.getResource('my_handler')
```

If no other plugin disposed the specified resource, the getter will return an empty array.

# 3) Sequences for all resources
This commit give the ability to specify a sequence for any resource item, removing the need for the consumer of the resource to have to setup it.

Instead of
```js
class MyPluginA extends Plugin {
    resources = {
        my_handlers: {handler: this.handler.bind(this), sequence: 100}
        my_data: {id: 'some-id', sequence: 100}
    }
}
class MyPluginB extends Plugin {
    constructor() {
        this.handlers = this.getResource('my_handlers')
            .sort((a, b) => a.sequence - b.sequence)
    }
    myMethod() {
        for (const {handler} of this.myHandlers) {
            handler();
        }
    }
}
```

We now have
```js
class MyPluginA extends Plugin {
    resources = {
        my_handlers: withSequence(100, this.handler.bind(this)),
        my_data: withSequence(100, {id: 'some-id'}),
    }
}
class MyPluginB extends Plugin {
    myMethod() {
        for (const handler of this.getResource('my_handlers')) {
            handler();
        }
    }
}
```





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
