### PR TITLE
[FIX] hr_presence: fix traceback in employee list view

### DIFF
--- a/addons/hr_presence/models/hr_employee.py
+++ b/addons/hr_presence/models/hr_employee.py
@@ -110,13 +110,25 @@ class Employee(models.AbstractModel):
         return super().write(vals)
 
     def action_open_leave_request(self):
-        self.ensure_one()
+        if len(self) == 1:
+            model = 'hr.leave'
+            context = {'default_employee_id': self.id}
+        else:
+            model = 'hr.leave.generate.multi.wizard'
+            context = {
+                'default_employee_ids': self.ids,
+                'default_date_from': fields.Date.today(),
+                'default_date_to': fields.Date.today(),
+                'default_name': _('Unplanned Absence'),
+            }
+
         return {
-            "type": "ir.actions.act_window",
-            "res_model": "hr.leave",
-            "views": [[False, "form"]],
-            "view_mode": 'form',
-            "context": {'default_employee_id': self.id},
+            'type': 'ir.actions.act_window',
+            'res_model': model,
+            'views': [[False, 'form']],
+            'view_mode': 'form',
+            'context': context,
+            'target': 'new',
         }
 
     # --------------------------------------------------


### PR DESCRIPTION
Steps:
- Install the hr_presence module
- open employee list view
- Click on the `Create a Time Off` from Presence Control Menu

Description of the issue/feature this PR addresses: In the HR module, When selecting multiple employees from the list view and clicking `Create a Time Off` in the Presence Control menu, a traceback error occurs.

Cause:
The error is caused by opening the hr.leave form view, which contains the employee_id field that allows the selection of only one employee. Since multiple employees are selected, a singleton error is triggered.

Fix:
This PR resolves the issue by updating the wizard of the model `hr.leave.generate.multi.wizard`, enabling the creation of time off for multiple employees.

task-4207392
