### PR TITLE
[FIX] html_editor: undeterministic image transformation test

### DIFF
--- a/addons/html_editor/static/tests/image.test.js
+++ b/addons/html_editor/static/tests/image.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { click, queryOne, waitFor } from "@odoo/hoot-dom";
+import { click, queryOne, waitFor, waitUntil } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { setupEditor } from "./_helpers/editor";
 import { contains } from "@web/../tests/web_test_helpers";
@@ -299,7 +299,7 @@ test("Image transformation dissapear when selection change", async () => {
         `<img class="img-fluid test-image" src="/web/static/img/logo.png">
         <p> [Hello] world </p> `
     );
-    await animationFrame();
+    await waitUntil(() => !document.querySelector(".transfo-container"));
     transfoContainers = document.querySelectorAll(".transfo-container");
     expect(transfoContainers.length).toBe(0);
     // Remove the transfoContainer element if not destroyed by the selection change


### PR DESCRIPTION
Before this commit, the
`@html_editor/image/Image transformation dissapear when selection change` test was failing unpredictably.

This commit fix it.
