### PR TITLE
[IMP] website: improve efficiency of the svg processing

### DIFF
--- a/addons/website/models/website_configurator_feature.py
+++ b/addons/website/models/website_configurator_feature.py
@@ -48,15 +48,12 @@ class WebsiteConfiguratorFeature(models.Model):
             'footer': '#FOOTER_COLOR',
         }
         color_mapping = {default_colors[color_key]: color_value for color_key, color_value in colors.items() if color_key in default_colors.keys()}
-        color_regex = '(?i)%s' % '|'.join('(%s)' % color for color in color_mapping.keys())
-        image_regex = '(?i)%s' % '|'.join('(%s)' % image for image in image_mapping.keys())
 
-        def subber_maker(mapping):
-            def subber(match):
-                key = match.group()
-                return mapping[key] if key in mapping else key
-            return subber
+        # Replace the default colors by the chosen ones
+        for default_color, chosen_color in color_mapping.items():
+            svg = svg.replace(default_color, chosen_color)
 
-        svg = re.sub(color_regex, subber_maker(color_mapping), svg)
-        svg = re.sub(image_regex, subber_maker(image_mapping), svg)
+        # Replace the default images by the one corresponding to the industry
+        for default_img, new_img in image_mapping.items():
+            svg = svg.replace(default_img, new_img)
         return svg


### PR DESCRIPTION
[IMP] website: improve efficiency of the svg processing

Since [1], the user has the possibility to load more templates than the three main ones. The problem is that, when loading extra templates, it may take some times for the `getRecommendedThemes()` method to receive the templates. The problem comes from the svg processing part and more specifically from the replacing of the default images and colors with the desired ones in the svgs. Before this commit, this was done thanks to regexes: the default colors and images were found by regexes and then replaced thanks to the `subber_maker()` method. In order to improve the efficiency, this commit removes the use of the regexes. Note that by doing so, the system is not case insensitive anymore which means that the colors used in the themes have to be hexadecimal in upper case in order to be correctly changed.

Some measurements have been made on a local machine in order to measure the efficiency gain; before this commit, the average time spent by the `_process_svg()` method when loading 27 themes was more or less 1.7 seconds and 1.68 seconds were needed for the two regex instructions. It means that 98.94% of the execution time is taken by the regex instruction. After this commit, the average time spent by the `_process_svg()` method when loading 27 themes is 0,0245 seconds and 0,0207 seconds is needed to replace the default colors and images by the wanted ones. This time, 83.07% of the execution time is dedicated to the color and image replacement.

[1]: https://github.com/odoo/odoo/commit/1181aaecc33422e6a3bf65ea71d4f8335cf22fe2

task-4207764
