### PR TITLE
[FIX] hw_drivers: increase nginx request size

### DIFF
--- a/addons/point_of_sale/tools/posbox/overwrite_after_init/etc/nginx/nginx.conf
+++ b/addons/point_of_sale/tools/posbox/overwrite_after_init/etc/nginx/nginx.conf
@@ -1,0 +1,50 @@
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+error_log /var/log/nginx/error.log;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+	worker_connections 768;
+}
+
+http {
+
+	##
+	# Basic Settings
+	##
+
+	sendfile on;
+	tcp_nopush on;
+	types_hash_max_size 2048;
+	client_max_body_size 10M;
+
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
+
+	##
+	# SSL Settings
+	##
+
+	ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3; # Dropping SSLv3, ref: POODLE
+	ssl_prefer_server_ciphers on;
+
+	##
+	# Logging Settings
+	##
+
+	access_log /var/log/nginx/access.log;
+
+	##
+	# Gzip Settings
+	##
+
+	gzip on;
+
+	##
+	# Virtual Host Configs
+	##
+
+	include /etc/nginx/conf.d/*.conf;
+	include /etc/nginx/sites-enabled/*;
+}


### PR DESCRIPTION
Currently the IoT Box accepts maximum the default nginx size of 1MB per request. This can be an issue when sending over heavy files to print. This PR increases the limit to 10MB and backports the PR #157733 in v17.0 as this version will be the base for our new image

