### PR TITLE
[FIX] website: harmonize header buttons

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -2859,12 +2859,13 @@ input[value*="data-oe-translation-source-sha"] {
     border-right-width: 0;
 }
 
-// `nav-link` and `btn` don't have the same padding.
-// In some cases, we need to apply the padding of `btn` with the color of `nav-link`.
-// For example in "Sign In" button of `template_header_sidebar`.
-// Adding the `btn` class to `nav-link` doesn't work, as `nav-link` padding takes
-// the priority over `btn`. This class forces to keep the `btn` padding for
-// specific `nav-link`.
+// The `nav-link` and `btn` classes do not induce the same padding and border
+// radius. However, in some cases, we need to apply these properties of `btn`
+// with the color of `nav-link` (e.g. for the "Sign In" button of the "sidebar"
+// header). Adding the `btn` class to the `.nav-link` element does not work, as
+// `nav-link` padding takes the priority over the `btn` one. This class forces
+// to keep the wanted `btn` properties for specific `.nav-link` elements.
 .o_nav_link_btn {
+    border-radius: $btn-border-radius;
     padding: $btn-padding-y $btn-padding-x;
 }

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -423,7 +423,7 @@
                         </t>
                         <!-- Sign In -->
                         <t t-call="portal.placeholder_user_sign_in">
-                            <t t-set="_link_class" t-valuef="{{_additional_btn_color or 'nav-link o_nav_link_btn'}} w-100 border rounded text-center"/>
+                            <t t-set="_link_class" t-valuef="{{_additional_btn_color or 'nav-link o_nav_link_btn'}} w-100 border text-center"/>
                         </t>
                         <!-- User Dropdown -->
                         <t t-call="portal.user_dropdown">
@@ -523,7 +523,7 @@
                     </t>
                     <!-- Sign In -->
                     <t t-call="portal.placeholder_user_sign_in">
-                        <t t-set="_link_class" t-value="_additional_btn_color or 'nav-link border rounded px-3'"/>
+                        <t t-set="_link_class" t-value="_additional_btn_color or 'o_nav_link_btn nav-link border px-3'"/>
                     </t>
                     <!-- User Dropdown -->
                     <t t-call="portal.user_dropdown">
@@ -572,7 +572,7 @@
                 <ul class="o_header_hamburger_right_col navbar-nav flex-row gap-2 align-items-center ms-auto">
                     <!-- Sign In -->
                     <t t-call="portal.placeholder_user_sign_in">
-                        <t t-set="_link_class" t-valuef="o_navlink_background_hover btn rounded-circle text-reset"/>
+                        <t t-set="_link_class" t-valuef="o_navlink_background_hover btn text-reset"/>
                     </t>
                     <!-- User Dropdown -->
                     <t t-call="portal.user_dropdown">
@@ -797,20 +797,18 @@
                     <ul class="navbar-nav align-items-center gap-1 flex-wrap justify-content-end ms-auto">
                         <!-- Sign In -->
                         <t t-call="portal.placeholder_user_sign_in">
-                            <t t-set="_link_class" t-valuef="o_navlink_background btn rounded-circle text-reset"/>
+                            <t t-set="_link_class" t-valuef="o_navlink_background btn border-0 text-reset"/>
                         </t>
                         <!-- User Dropdown -->
                         <t t-call="portal.user_dropdown">
                             <t t-set="_icon" t-value="true"/>
                             <t t-set="_item_class" t-valuef="dropdown"/>
-                            <t t-set="_icon_class" t-valuef="fa-stack"/>
-                            <t t-set="_link_class" t-valuef="o_navlink_background btn d-flex align-items-center rounded-pill py-1 text-reset"/>
+                            <t t-set="_link_class" t-valuef="o_navlink_background btn d-flex align-items-center border-0 text-reset"/>
                             <t t-set="_dropdown_menu_class" t-valuef="dropdown-menu-end"/>
                         </t>
                         <!-- Language Selector -->
                         <t t-call="website.placeholder_header_language_selector">
-                            <t t-set="_txt_class" t-valuef="small"/>
-                            <t t-set="_btn_class" t-valuef="o_navlink_background btn rounded-pill py-1 text-reset"/>
+                            <t t-set="_btn_class" t-valuef="o_navlink_background btn text-reset"/>
                             <t t-set="_flag_class" t-valuef="m-2"/>
                             <t t-set="_dropdown_menu_class" t-valuef="dropdown-menu-end"/>
                         </t>
@@ -1081,7 +1079,7 @@
                             </t>
                             <!-- Sign In -->
                             <t t-call="portal.placeholder_user_sign_in">
-                                <t t-set="_link_class" t-valuef="{{_additional_btn_color or 'nav-link'}} ms-2 rounded border px-3"/>
+                                <t t-set="_link_class" t-valuef="{{_additional_btn_color or 'nav-link o_nav_link_btn'}} ms-2 border px-3"/>
                             </t>
                             <!-- User Dropdown -->
                             <t t-call="portal.user_dropdown">
@@ -1392,7 +1390,7 @@
                             </t>
                             <!-- Sign In -->
                             <t t-call="portal.placeholder_user_sign_in">
-                                <t t-set="_link_class" t-valuef="{{_additional_btn_color or 'nav-link o_nav_link_btn'}} w-100 border rounded text-center"/>
+                                <t t-set="_link_class" t-valuef="{{_additional_btn_color or 'nav-link o_nav_link_btn'}} w-100 border text-center"/>
                             </t>
                             <!-- User Dropdown -->
                             <t t-call="portal.user_dropdown">
@@ -1499,7 +1497,7 @@
                         </t>
                         <!-- Sign In -->
                         <t t-call="portal.placeholder_user_sign_in">
-                            <t t-set="_link_class" t-valuef="{{_additional_btn_color or 'nav-link'}} border rounded-pill px-3"/>
+                            <t t-set="_link_class" t-valuef="{{_additional_btn_color or 'nav-link o_nav_link_btn'}} border px-3"/>
                         </t>
                         <!-- User Dropdown -->
                         <t t-call="portal.user_dropdown">


### PR DESCRIPTION
### Adapt button border-radius
**Mobile, Default, Hamburger, Vertical, Two sales, Sidebar, Rounded box**:
This PR adapts the button border radius to match the border radius defined in the Web Editor.

### "Vertical" template: harmonize button height
Prior to this PR, the user dropdown, the language selector and the sign in button were inconsistent due to their different heights. This PR adapts them to harmonize their size.

task-4207675

---

Adapt button border-radius
| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/64a5fa69-7fb5-46d3-93db-53fb4a1546af) | ![Capture d’écran 2024-09-24 à 14 06 25](https://github.com/user-attachments/assets/296a66d6-5936-46f0-96ce-d7e9ae84951c) |
| ![image](https://github.com/user-attachments/assets/fd755c61-d739-4b43-9879-b849934a5dc5) | ![Capture d’écran 2024-09-24 à 14 07 06](https://github.com/user-attachments/assets/aa85440f-78b8-48c7-8582-11e782d54272) |


"Vertical" template: harmonize button height
| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/8712b245-da09-448b-b1c2-0dbb0dbdbee7) | <img width="356" alt="Capture d’écran 2024-09-24 à 14 09 06" src="https://github.com/user-attachments/assets/7dac7b1a-3c14-4425-9a67-00b86f00dfc9"> |
| ![image](https://github.com/user-attachments/assets/549e5177-9aaf-4a7e-b8c4-253bb39005b8) | <img width="378" alt="Capture d’écran 2024-09-24 à 14 09 40" src="https://github.com/user-attachments/assets/8eaa323a-4f5c-4709-9824-c49f1dd92b3b"> |









---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
