### PR TITLE
[FIX] tools: `populate` fixes

### DIFF
--- a/odoo/cli/populate.py
+++ b/odoo/cli/populate.py
@@ -38,6 +38,7 @@ class Populate(Command):
                          dest='separator',
                          help="Single character separator for char/text fields.",
                          default=DEFAULT_SEPARATOR)
+        parser.add_option_group(group)
         opt = odoo.tools.config.parse_config(cmdargs, setup_logging=True)
 
         # deduplicate models if necessary, and keep the last corresponding


### PR DESCRIPTION
## [FIX] tools: variate `company_dependent` dates

Following de302c2d36305c0d7562572a30587641eabfe914, `company_dependent` fields
are stored as `jsonb` now, so the variation of dates needs to take that into account.


## [FIX] tools: allow populate for less priviledged `pg_roles`

When running the `populate` with a `pg_roles` that doesn't have admin access
or the group `session_replication_role` (only since PG15), the routine
crashes with an Insufficient exception when trying to drop the Fkey
constriants.
This context manager was initially added to speed up batch insertion by 10x,
but we are adding a generic catch to ignore said optimisation when privileges
are insufficient.


## [FIX] cli: show --help for populate CLI

Group options were added with the respective `help` section for each
arg, but the group was never added to the CLI arg parser.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
