### PR TITLE
[IMP] hr_work_entry_contract: work entry type settings

### DIFF
--- a/addons/hr_work_entry_contract/data/hr_work_entry_data.xml
+++ b/addons/hr_work_entry_contract/data/hr_work_entry_data.xml
@@ -7,47 +7,42 @@
             <field name="name">Generic Time Off</field>
             <field name="code">LEAVE100</field>
             <field name="color">3</field>
-            <field name="is_leave">True</field>
+            <field name="is_work">False</field>
         </record>
 
         <record id="work_entry_type_compensatory" model="hr.work.entry.type">
             <field name="name">Compensatory Time Off</field>
             <field name="code">LEAVE105</field>
             <field name="color">3</field>
-            <field name="is_leave">True</field>
+            <field name="is_work">False</field>
         </record>
 
         <record id="work_entry_type_home_working" model="hr.work.entry.type">
             <field name="name">Home Working</field>
             <field name="code">WORK110</field>
             <field name="color">2</field>
-            <field name="is_leave">True</field>
+            <field name="is_work">False</field>
         </record>
 
         <record id="work_entry_type_unpaid_leave" model="hr.work.entry.type">
             <field name="name">Unpaid</field>
             <field name="color">5</field>
             <field name="code">LEAVE90</field>
-            <field name="is_leave">True</field>
+            <field name="is_work">False</field>
         </record>
 
         <record id="work_entry_type_sick_leave" model="hr.work.entry.type">
             <field name="name">Sick Time Off</field>
             <field name="code">LEAVE110</field>
-            <field name="is_leave">True</field>
+            <field name="is_work">False</field>
             <field name="color">5</field>
         </record>
 
          <record id="work_entry_type_legal_leave" model="hr.work.entry.type">
             <field name="name">Paid Time Off</field>
             <field name="code">LEAVE120</field>
-            <field name="is_leave">True</field>
+            <field name="is_work">False</field>
             <field name="color">5</field>
         </record>
-
-        <record id="hr_work_entry.work_entry_type_attendance" model="hr.work.entry.type">
-            <field name="is_leave">False</field>
-        </record>
-
     </data>
 </odoo>

--- a/addons/hr_work_entry_contract/data/hr_work_entry_demo.xml
+++ b/addons/hr_work_entry_contract/data/hr_work_entry_demo.xml
@@ -11,7 +11,7 @@
         <record id="work_entry_type_long_leave" model="hr.work.entry.type">
             <field name="name">Long Term Time Off</field>
             <field name="code">LEAVE200</field>
-            <field name="is_leave">True</field>
+            <field name="is_work">False</field>
             <field name="color">4</field>
         </record>
 

--- a/addons/hr_work_entry_contract/models/hr_work_entry.py
+++ b/addons/hr_work_entry_contract/models/hr_work_entry.py
@@ -50,7 +50,7 @@ class HrWorkEntry(models.Model):
             """)
 
     def _get_duration_is_valid(self):
-        return self.work_entry_type_id and self.work_entry_type_id.is_leave
+        return self.work_entry_type_id and not self.work_entry_type_id.is_work
 
     @api.onchange('employee_id', 'date_start', 'date_stop')
     def _onchange_contract_id(self):
@@ -146,7 +146,7 @@ class HrWorkEntry(models.Model):
         return res or outside_calendar
 
     def _get_leaves_entries_outside_schedule(self):
-        return self.filtered(lambda w: w.work_entry_type_id.is_leave and w.state not in ('validated', 'cancelled'))
+        return self.filtered(lambda w: not w.work_entry_type_id.is_work and w.state not in ('validated', 'cancelled'))
 
     def _mark_leaves_outside_schedule(self):
         """
@@ -184,5 +184,5 @@ class HrWorkEntryType(models.Model):
     _inherit = 'hr.work.entry.type'
     _description = 'HR Work Entry Type'
 
-    is_leave = fields.Boolean(
-        default=False, string="Time Off", help="Allow the work entry type to be linked with time off types.")
+    is_work = fields.Boolean(default=True, string="Working Time",
+        help="If checked, the work entry is counted as work time in the working schedule")

--- a/addons/hr_work_entry_contract/models/resource_calendar.py
+++ b/addons/hr_work_entry_contract/models/resource_calendar.py
@@ -6,10 +6,10 @@ from odoo import api, models
 class ResourceCalendar(models.Model):
     _inherit = 'resource.calendar'
 
-    # Override the method to add 'attendance_ids.work_entry_type_id.is_leave' to the dependencies
-    @api.depends('attendance_ids.work_entry_type_id.is_leave')
+    # Override the method to add 'attendance_ids.work_entry_type_id.is_work' to the dependencies
+    @api.depends('attendance_ids.work_entry_type_id.is_work')
     def _compute_hours_per_week(self):
         super()._compute_hours_per_week()
 
     def _get_global_attendances(self):
-        return super()._get_global_attendances().filtered(lambda a: not a.work_entry_type_id.is_leave)
+        return super()._get_global_attendances().filtered(lambda a: not a.work_entry_type_id or a.work_entry_type_id.is_work)

--- a/addons/hr_work_entry_contract/models/resource_calendar_attendance.py
+++ b/addons/hr_work_entry_contract/models/resource_calendar_attendance.py
@@ -7,4 +7,4 @@ class ResourceCalendarAttendance(models.Model):
     _inherit = 'resource.calendar.attendance'
 
     def _is_work_period(self):
-        return not self.work_entry_type_id.is_leave and super()._is_work_period()
+        return not self.work_entry_type_id or self.work_entry_type_id.is_work and super()._is_work_period()

--- a/addons/hr_work_entry_contract/tests/common.py
+++ b/addons/hr_work_entry_contract/tests/common.py
@@ -39,19 +39,18 @@ class TestWorkEntryBase(TransactionCase):
 
         cls.work_entry_type = cls.env['hr.work.entry.type'].create({
             'name': 'Extra attendance',
-            'is_leave': False,
             'code': 'WORKTEST200',
         })
 
         cls.work_entry_type_unpaid = cls.env['hr.work.entry.type'].create({
             'name': 'Unpaid Time Off',
-            'is_leave': True,
+            'is_work': False,
             'code': 'LEAVETEST300',
         })
 
         cls.work_entry_type_leave = cls.env['hr.work.entry.type'].create({
             'name': 'Time Off',
-            'is_leave': True,
+            'is_work': False,
             'code': 'LEAVETEST100'
         })
 

--- a/addons/hr_work_entry_contract/tests/test_work_entry.py
+++ b/addons/hr_work_entry_contract/tests/test_work_entry.py
@@ -277,8 +277,8 @@ class TestWorkEntry(TestWorkEntryBase):
         })
 
         entry_type_1, entry_type_2 = self.env['hr.work.entry.type'].create([
-            {'name': 'Work type 1', 'is_leave': False, 'code': 'ENTRY_TYPE1'},
-            {'name': 'Work type 2', 'is_leave': False, 'code': 'ENTRY_TYPE2'},
+            {'name': 'Work type 1', 'code': 'ENTRY_TYPE1'},
+            {'name': 'Work type 2', 'code': 'ENTRY_TYPE2'},
         ])
 
         self.env['resource.calendar.attendance'].create([

--- a/addons/hr_work_entry_contract/views/hr_work_entry_views.xml
+++ b/addons/hr_work_entry_contract/views/hr_work_entry_views.xml
@@ -25,16 +25,4 @@
             </xpath>
         </field>
     </record>
-
-    <record id="hr_work_entry_contract_type_view_form_inherit" model="ir.ui.view">
-        <field name="name">hr.work.entry.type.contract.view.form.inherit</field>
-        <field name="model">hr.work.entry.type</field>
-        <field name="inherit_id" ref="hr_work_entry.hr_work_entry_type_view_form"/>
-        <field name="arch" type="xml">
-            <group name="time_off" position="inside">
-                <field name="is_leave"/>
-            </group>
-        </field>
-    </record>
-
 </odoo>

--- a/addons/hr_work_entry_holidays/models/hr_work_entry.py
+++ b/addons/hr_work_entry_holidays/models/hr_work_entry.py
@@ -22,7 +22,7 @@ class HrWorkEntry(models.Model):
 
     def _reset_conflicting_state(self):
         super()._reset_conflicting_state()
-        attendances = self.filtered(lambda w: w.work_entry_type_id and not w.work_entry_type_id.is_leave)
+        attendances = self.filtered(lambda w: w.work_entry_type_id and w.work_entry_type_id.is_work)
         attendances.write({'leave_id': False})
 
     def action_approve_leave(self):

--- a/addons/hr_work_entry_holidays/tests/test_leave.py
+++ b/addons/hr_work_entry_holidays/tests/test_leave.py
@@ -46,7 +46,7 @@ class TestWorkEntryLeave(TestWorkEntryHolidaysBase):
         self.assertFalse(work_entry_1.leave_id, "It should not be linked to the leave")
 
         leave_work_entry = self.env['hr.work.entry'].search([('leave_id', '=', leave.id)]) - work_entry_1
-        self.assertTrue(leave_work_entry.work_entry_type_id.is_leave, "It should have created a leave work entry")
+        self.assertFalse(leave_work_entry.work_entry_type_id.is_work, "It should have created a leave work entry")
         self.assertEqual(leave_work_entry[:1].state, 'conflict', "The leave work entry should conflict")
 
     def test_validate_leave_without_overlap(self):
@@ -60,7 +60,7 @@ class TestWorkEntryLeave(TestWorkEntryHolidaysBase):
         self.assertFalse(work_entry[:1].active, "It should have been archived")
 
         leave_work_entry = self.env['hr.work.entry'].search([('leave_id', '=', leave.id)])
-        self.assertTrue(leave_work_entry.work_entry_type_id.is_leave, "It should have created a leave work entry")
+        self.assertFalse(leave_work_entry.work_entry_type_id.is_work, "It should have created a leave work entry")
         self.assertNotEqual(leave_work_entry[:1].state, 'conflict', "The leave work entry should not conflict")
 
     def test_refuse_leave(self):
@@ -175,8 +175,8 @@ class TestWorkEntryLeave(TestWorkEntryHolidaysBase):
 
     def test_split_leaves_by_entry_type(self):
         entry_type_paid, entry_type_unpaid = self.env['hr.work.entry.type'].create([
-            {'name': 'Paid leave', 'code': 'PAID', 'is_leave': True},
-            {'name': 'Unpaid leave', 'code': 'UNPAID', 'is_leave': True},
+            {'name': 'Paid leave', 'code': 'PAID', 'is_work': False},
+            {'name': 'Unpaid leave', 'code': 'UNPAID', 'is_work': False},
         ])
 
         leave_type_paid, leave_type_unpaid = self.env['hr.leave.type'].create([{

--- a/addons/hr_work_entry_holidays/tests/test_work_entry.py
+++ b/addons/hr_work_entry_holidays/tests/test_work_entry.py
@@ -155,7 +155,7 @@ class TestWorkeEntryHolidaysWorkEntry(TestWorkEntryHolidaysBase):
         date_to = datetime(2023, 2, 28, 23, 59, 59)
         work_entry_type_holiday = self.env['hr.work.entry.type'].create({
             'name': 'Public Holiday',
-            'is_leave': True,
+            'is_work': False,
             'code': 'LEAVETEST500'
         })
         self.env['resource.calendar.leaves'].create({


### PR DESCRIPTION
In this PR,
The `is_leave` field is set to True as the default and its place in the form view under the Unpaid section has been changed.
Removed the link Payroll Tips & tricks on Note page

Task-4199423


