### PR TITLE
[FIX] account,account_peppol: Print & Send - fix no options traceback

### DIFF
--- a/addons/account/models/account_move_send.py
+++ b/addons/account/models/account_move_send.py
@@ -599,7 +599,7 @@ class AccountMoveSend(models.AbstractModel):
         assert custom_settings['pdf_report'].is_invoice_report if custom_settings.get('pdf_report') else True
         assert all(
             sending_method in dict(self.env['res.partner']._fields['invoice_sending_method'].selection)
-            for sending_method in custom_settings['sending_methods']
+            for sending_method in custom_settings.get('sending_methods', [])
         ) if 'sending_methods' in custom_settings else True
 
     @api.model

--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -999,3 +999,11 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
         self.assertTrue(pdf_report)
         invoice.invoice_pdf_report_id.unlink()
         self.assertTrue(invoice.is_move_sent)
+
+    def test_no_sending_method_selected(self):
+        invoice = self.init_invoice("out_invoice", amounts=[1000], post=True)
+        self.assertFalse(invoice.invoice_pdf_report_id)
+        wizard = self.create_send_and_print(invoice, sending_methods=[])
+        wizard.action_send_and_print()
+        self.assertTrue(invoice.is_move_sent)
+        self.assertTrue(invoice.invoice_pdf_report_id)

--- a/addons/account_peppol/wizard/account_move_send_wizard.py
+++ b/addons/account_peppol/wizard/account_move_send_wizard.py
@@ -8,7 +8,7 @@ class AccountMoveSendWizard(models.TransientModel):
     def action_send_and_print(self, allow_fallback_pdf=False):
         # EXTENDS 'account'
         self.ensure_one()
-        if 'peppol' in self.sending_methods:
+        if self.sending_methods and 'peppol' in self.sending_methods:
             if registration_action := self._do_peppol_pre_send(self.move_id):
                 return registration_action
         return super().action_send_and_print(allow_fallback_pdf=allow_fallback_pdf)


### PR DESCRIPTION
When you Print & Send with no sending method selected a tracebacks happens.
It should generate the invoice documents and do nothing more.

task-no
