### PR TITLE
[FIX] account: fix traceback when removing lock date with exception

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -535,7 +535,8 @@ class ResCompany(models.Model):
                     )
                 if exception:
                     # The search domain of the exception ensures `exception[soft_lock_date_field] < company[soft_lock_date_field]`
-                    soft_lock_date = max(soft_lock_date, exception[soft_lock_date_field])
+                    # or `exception[soft_lock_date_field] is False`
+                    soft_lock_date = max(soft_lock_date, exception[soft_lock_date_field] or date.min)
                 else:
                     soft_lock_date = max(soft_lock_date, company[soft_lock_date_field])
         return soft_lock_date


### PR DESCRIPTION
In commit d8bf86fec7b9a0a3f6e0aef2c4c124bc81bfb898 we allowed removing lock dates with an exception.
But when computing the user lock date based on (parent) company lock dates and user exceptions (`_get_user_lock_date`) we still assume that it is not possible.

This is fixed in this commit.

Reproduce traceback
  1. Set Sale Lock Date to 2024/08/31
  2. Remove Sale Lock Date with an exception for me forever
  3. Create an invoice and try to set the invoice date to a date
     before 2024/08/31