### PR TITLE
[FIX] web: avoid saving on visibility change for x2many fields and settings

### DIFF
--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -14,7 +14,7 @@ import {
 } from "@web/core/utils/hooks";
 import { createElement, parseXML } from "@web/core/utils/xml";
 import { FormArchParser } from "@web/views/form/form_arch_parser";
-import { loadSubViews } from "@web/views/form/form_controller";
+import { loadSubViews, useFormViewInDialog } from "@web/views/form/form_controller";
 import { FormRenderer } from "@web/views/form/form_renderer";
 import { extractFieldsFromArchInfo, useRecordObserver } from "@web/model/relational_model/utils";
 import { computeViewClassName, isNull } from "@web/views/utils";
@@ -593,6 +593,7 @@ export class X2ManyFieldDialog extends Component {
                 () => [this.record.isInEdition]
             );
         }
+        useFormViewInDialog();
     }
 
     async beforeExecuteActionButton(clickParams) {

--- a/addons/web/static/src/webclient/actions/action_hook.js
+++ b/addons/web/static/src/webclient/actions/action_hook.js
@@ -60,7 +60,18 @@ export function useSetupAction(params = {}) {
         __getOrderBy__,
     } = component.env;
 
-    const { beforeUnload, beforeLeave, getGlobalState, getLocalState, rootRef } = params;
+    const {
+        beforeVisibilityChange,
+        beforeUnload,
+        beforeLeave,
+        getGlobalState,
+        getLocalState,
+        rootRef,
+    } = params;
+
+    if (beforeVisibilityChange) {
+        useExternalListener(document, "visibilitychange", beforeVisibilityChange);
+    }
 
     if (beforeUnload) {
         useExternalListener(window, "beforeunload", beforeUnload);

--- a/addons/web/static/src/webclient/settings_form_view/settings_form_controller.js
+++ b/addons/web/static/src/webclient/settings_form_view/settings_form_controller.js
@@ -99,6 +99,9 @@ export class SettingsFormController extends formView.Controller {
     //This is needed to avoid the auto save when unload
     beforeUnload() {}
 
+    //This is needed to avoid the auto save when visibility change
+    beforeVisibilityChange() {}
+
     async save() {
         await this.env.onClickViewButton({
             clickParams: {

--- a/addons/web/static/tests/_framework/view_test_helpers.js
+++ b/addons/web/static/tests/_framework/view_test_helpers.js
@@ -1,6 +1,6 @@
 import { after, expect, getFixture } from "@odoo/hoot";
 import { click, formatXml, queryAll, queryAllTexts } from "@odoo/hoot-dom";
-import { animationFrame, Deferred } from "@odoo/hoot-mock";
+import { animationFrame, Deferred, tick } from "@odoo/hoot-mock";
 import { Component, onMounted, useSubEnv, xml } from "@odoo/owl";
 import { Dialog } from "@web/core/dialog/dialog";
 import { MainComponentsContainer } from "@web/core/main_components_container";
@@ -282,4 +282,19 @@ export function parseViewProps(params) {
 export async function selectFieldDropdownItem(fieldName, itemContent, options) {
     await clickFieldDropdown(fieldName, options);
     await clickFieldDropdownItem(fieldName, itemContent);
+}
+
+/**
+ * Emulates the behaviour when we hide the tab in the browser.
+ */
+export async function hideTab() {
+    const prop = Object.getOwnPropertyDescriptor(Document.prototype, "visibilityState");
+    Object.defineProperty(document, "visibilityState", {
+        value: "hidden",
+        configurable: true,
+        writable: true,
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+    await tick();
+    Object.defineProperty(document, "visibilityState", prop);
 }

--- a/addons/web/static/tests/web_test_helpers.js
+++ b/addons/web/static/tests/web_test_helpers.js
@@ -140,6 +140,7 @@ export {
     mountViewInDialog,
     parseViewProps,
     selectFieldDropdownItem,
+    hideTab,
 } from "./_framework/view_test_helpers";
 export { useTestClientAction } from "./_framework/webclient_test_helpers";
 


### PR DESCRIPTION
- one2many field:
 * On a dirty form view with an one2many filed;
 * Click the one2many field;
 * Open load more;
 * Create a new record;
 * Change the visibility (change tab on the browser).

 Before this commit, the form view will save and close the load more and
 the new record dialog.

- many2many field:
 * On a new record form view with a many2many field;
 * Click the `add` button on the kanban of the many2many field;
 * Complete the dialog form view;
 * Change the visibility;
 * Save the dialog form view.

 Before this commit, because when changing the visibility, the
 background form view will save the new record, and the dialog form view
 (the one opened when clicking the button `add`) will lose the
 references to it's parent record.

- settings:
 * Open the settings view;
 * Made a change on a setting;
 * Change visibility.

 Before this commit, the settings will be saved without calling the
 `execute` function. Furthermore, settings should never be saved if it's
 not an implicit action from the user.

The autosave feature really doesn't make sense in any of these cases.

opw-[4141005](https://www.odoo.com/web#id=4141005&view_type=form&model=project.task)
opw-[4143092](https://www.odoo.com/web#id=4143092&view_type=form&model=project.task)
opw-[4177698](https://www.odoo.com/web#id=4177698&view_type=form&model=project.task)
opw-[4151462](https://www.odoo.com/web#id=4151462&view_type=form&model=project.task)
