### PR TITLE
[FIX] sale: remove warnings on product type change

### DIFF
--- a/addons/sale/i18n/sale.pot
+++ b/addons/sale/i18n/sale.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 18.0\n"
+"Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-27 08:16+0000\n"
-"PO-Revision-Date: 2024-09-27 08:16+0000\n"
+"POT-Creation-Date: 2024-09-30 11:35+0000\n"
+"PO-Revision-Date: 2024-09-30 11:35+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -2783,11 +2783,6 @@ msgid "New Quotation"
 msgstr ""
 
 #. module: sale
-#: model:ir.model.fields,field_description:sale.field_sale_order__activity_calendar_event_id
-msgid "Next Activity Calendar Event"
-msgstr ""
-
-#. module: sale
 #: model:ir.model.fields,field_description:sale.field_sale_order__activity_date_deadline
 msgid "Next Activity Deadline"
 msgstr ""
@@ -4006,14 +4001,6 @@ msgid "Sales Warnings"
 msgstr ""
 
 #. module: sale
-#: model:ir.model.fields,help:sale.field_account_analytic_line__so_line
-msgid ""
-"Sales order item to which the time spent will be added in order to be "
-"invoiced to your customer. Remove the sales order item for the timesheet "
-"entry to be non-billable."
-msgstr ""
-
-#. module: sale
 #: model:ir.model.fields.selection,name:sale.selection__product_template__expense_policy__sales_price
 msgid "Sales price"
 msgstr ""
@@ -5063,8 +5050,6 @@ msgstr ""
 
 #. module: sale
 #. odoo-python
-#: code:addons/sale/models/product_product.py:0
-#: code:addons/sale/models/product_template.py:0
 #: code:addons/sale/models/sale_order_line.py:0
 #: code:addons/sale/wizard/res_config_settings.py:0
 #: model:ir.model.fields.selection,name:sale.selection__product_template__sale_line_warn__warning
@@ -5146,15 +5131,6 @@ msgstr ""
 #. odoo-python
 #: code:addons/sale/models/sale_order.py:0
 msgid "You cannot change the pricelist of a confirmed order !"
-msgstr ""
-
-#. module: sale
-#. odoo-python
-#: code:addons/sale/models/product_product.py:0
-#: code:addons/sale/models/product_template.py:0
-msgid ""
-"You cannot change the product's type because it is already used in sales "
-"orders."
 msgstr ""
 
 #. module: sale

--- a/addons/sale/models/product_product.py
+++ b/addons/sale/models/product_product.py
@@ -42,14 +42,6 @@ class ProductProduct(models.Model):
             product.sales_count = float_round(r.get(product.id, 0), precision_rounding=product.uom_id.rounding)
         return r
 
-    @api.onchange('type')
-    def _onchange_type(self):
-        if self._origin and self.sales_count > 0:
-            return {'warning': {
-                'title': _("Warning"),
-                'message': _("You cannot change the product's type because it is already used in sales orders.")
-            }}
-
     @api.depends_context('order_id')
     def _compute_product_is_in_sale_order(self):
         order_id = self.env.context.get('order_id')

--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -152,16 +152,6 @@ class ProductTemplate(models.Model):
         }
         return action
 
-    @api.onchange('type')
-    def _onchange_type(self):
-        res = super()._onchange_type()
-        if self._origin and self.sales_count > 0:
-            res['warning'] = {
-                'title': _("Warning"),
-                'message': _("You cannot change the product's type because it is already used in sales orders.")
-            }
-        return res
-
     @api.depends('type')
     def _compute_service_type(self):
         self.filtered(lambda t: t.type == 'consu' or not t.service_type).service_type = 'manual'


### PR DESCRIPTION
Before the commit:
Previously, when the product type of an item in a sales order was changed, a
warning would be displayed, but users were still allowed to make the change.
Although there are other checks in place to prevent changes to the product type
under certain conditions, the general warnings were unnecessary.

After the commit:
Now, there will be no general warning when changing a product's type.