### PR TITLE
[FIX] hr_attendance: archived employee in gantt

### DIFF
--- a/addons/hr_attendance/__manifest__.py
+++ b/addons/hr_attendance/__manifest__.py
@@ -36,7 +36,13 @@ actions(Check in/Check out) performed by them.
         'web.assets_backend': [
             'hr_attendance/static/src/**/*.js',
             'hr_attendance/static/src/**/*.xml',
-            'hr_attendance/static/src/scss/views/*.scss'
+            'hr_attendance/static/src/scss/views/*.scss',
+            ('remove', 'hr_attendance/static/src/views/attendance_graph_view.js'),
+            ('remove', 'hr_attendance/static/src/views/attendance_pivot_view.js'),
+        ],
+        'web.assets_backend_lazy': [
+            'hr_attendance/static/src/views/attendance_graph_view.js',
+            'hr_attendance/static/src/views/attendance_pivot_view.js',
         ],
         'web.qunit_suite_tests': [
             'hr_attendance/static/tests/hr_attendance_mock_server.js',

--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -655,7 +655,10 @@ class HrAttendance(models.Model):
     def _read_group_employee_id(self, resources, domain):
         user_domain = self.env.context.get('user_domain')
         if not user_domain:
-            return self.env['hr.employee'].search([('company_id', 'in', self.env.context.get('allowed_company_ids', []))])
+            return self.env['hr.employee'].search([
+                ('company_id', 'in', self.env.context.get('allowed_company_ids', [])),
+                ('active', '=', True),
+            ])
         else:
             employee_name_domain = []
             for leaf in user_domain:

--- a/addons/hr_attendance/static/src/views/attendance_graph_view.js
+++ b/addons/hr_attendance/static/src/views/attendance_graph_view.js
@@ -1,0 +1,23 @@
+import { registry } from "@web/core/registry";
+import { graphView } from "@web/views/graph/graph_view";
+import { GraphModel } from "@web/views/graph/graph_model";
+
+
+export class AttendanceGraphModel extends GraphModel {
+
+    /** @override **/
+    async load(searchParams) {
+        const activeDomainParam = searchParams.domain.some((index) => Array.isArray(index) && index[0] == "employee_id.active")
+        if (!activeDomainParam) {
+            searchParams.domain.push(["employee_id.active", "=", true]);
+        }
+        return super.load(searchParams);
+    }
+}
+
+const attendanceGraphView = {
+    ...graphView,
+    Model: AttendanceGraphModel,
+};
+
+registry.category("views").add("attendance_graph_view", attendanceGraphView);

--- a/addons/hr_attendance/static/src/views/attendance_list_view.js
+++ b/addons/hr_attendance/static/src/views/attendance_list_view.js
@@ -18,9 +18,31 @@ export class AttendanceListRenderer extends ListRenderer {
     }
 };
 
+export class AttendanceListModel extends listView.Model {
+
+    /**
+    * @override
+    * Add the calendar view's selected attendees to the list view's domain.
+    */
+    async load(params = {}) {
+        const activeDomainParam = params.domain.some((index) => Array.isArray(index) && index[0] == "employee_id.active")
+        if (!activeDomainParam) {
+            params.domain.push(["employee_id.active", "=", true]);
+        }
+        return super.load(params);
+    }
+}
+
 export const attendanceListView = {
     ...listView,
     Renderer: AttendanceListRenderer,
+    Model: AttendanceListModel,
+};
+
+export const attendanceManagerListView = {
+    ...listView,
+    Model: AttendanceListModel,
 };
 
 registry.category("views").add("attendance_list_view", attendanceListView);
+registry.category("views").add("attendance_manager_list_view", attendanceManagerListView);

--- a/addons/hr_attendance/static/src/views/attendance_pivot_view.js
+++ b/addons/hr_attendance/static/src/views/attendance_pivot_view.js
@@ -1,0 +1,23 @@
+import { registry } from "@web/core/registry";
+import { pivotView } from "@web/views/pivot/pivot_view";
+import { PivotModel } from "@web/views/pivot/pivot_model";
+
+
+export class AttendancePivotModel extends PivotModel {
+
+    /** @override **/
+    async load(searchParams) {
+        const activeDomainParam = searchParams.domain.some((index) => Array.isArray(index) && index[0] == "employee_id.active")
+        if (!activeDomainParam) {
+            searchParams.domain.push(["employee_id.active", "=", true]);
+        }
+        return super.load(searchParams);
+    }
+}
+
+const attendancePivotView = {
+    ...pivotView,
+    Model: AttendancePivotModel,
+};
+
+registry.category("views").add("attendance_pivot_view", attendancePivotView);

--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -187,7 +187,7 @@
         <field name="name">hr.attendance.graph</field>
         <field name="model">hr.attendance</field>
         <field name="arch" type="xml">
-            <graph string="Worked Hours" type="line" stacked="0" sample="1">
+            <graph string="Worked Hours" type="line" stacked="0" sample="1" js_class="attendance_graph_view">
                 <field name="employee_id" type="row"/>
                 <field name="check_in" interval="week" type="col"/>
                 <field name="overtime_hours" widget="float_time"/>
@@ -200,7 +200,7 @@
         <field name="name">hr.attendance.pivot</field>
         <field name="model">hr.attendance</field>
         <field name="arch" type="xml">
-            <pivot string="Worked Hours">
+            <pivot string="Worked Hours" js_class="attendance_pivot_view">
                 <field name="employee_id" type="row"/>
                 <field name="check_in" type="col" interval="month"/>
                 <field name="worked_hours" type="measure" widget="float_time"/>
@@ -229,6 +229,11 @@
                         domain="[('out_mode', '=', 'auto_check_out')]"/>
                 <separator/>
                 <filter string="Date" name="check_in_filter" date="check_in"/>
+                <separator/>
+                <filter
+                    string="Archived Employees"
+                    name="archivedemployees"
+                    domain="[('employee_id.active', '=', False)]"/>
                 <filter string="Last 3 Months" invisible="1" name="last_three_months" domain="[(
                     'check_in','&gt;=', (
                         context_today() + datetime.timedelta(days=-90)
@@ -311,6 +316,11 @@
                 <filter string="To Approve" name="to_approve" domain="[('overtime_status','=', 'to_approve')]"/>
                 <filter string="Approved" name="approved" domain="[('overtime_status','=', 'approved')]"/>
                 <filter string="Refused" name="refused" domain="[('overtime_status','=', 'refused')]"/>
+                <separator/>
+                <filter
+                    string="Archived Employees"
+                    name="archivedemployees"
+                    domain="[('employee_id.active', '=', False)]"/>
                 <group string="Group By">
                     <filter string="Employee" name="employee" context="{'group_by': 'employee_id'}"/>
                 </group>
@@ -322,7 +332,7 @@
         <field name="name">hr.attendance.list</field>
         <field name="model">hr.attendance</field>
         <field name="arch" type="xml">
-            <list string="Employee attendances" create="0">
+            <list string="Employee attendances" create="0" js_class="attendance_manager_list_view">
                 <header>
                     <button class="btn-secondary" string="Approve" name="action_approve_overtime" type="object"/>
                     <button class="btn-secondary" string="Refuse" name="action_refuse_overtime" type="object"/>


### PR DESCRIPTION
With this task, by default archived employees will not be displayed. If the user want to see them, he can select archived employees or write their name in the searchbar.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
