### PR TITLE
[FIX] hr_recruitement{_skills}: No error on create employee from cdt

### DIFF
--- a/addons/hr_recruitment/models/hr_candidate.py
+++ b/addons/hr_recruitment/models/hr_candidate.py
@@ -340,7 +340,7 @@ class HrCandidate(models.Model):
             })
 
         action = self.env['ir.actions.act_window']._for_xml_id('hr.open_view_employee_list')
-        employee = self.env['hr.employee'].create(self._get_employee_create_vals())
+        employee = self.env['hr.employee'].with_context(creating_employee=True).create(self._get_employee_create_vals())
         action['res_id'] = employee.id
         return action
 

--- a/addons/hr_recruitment_skills/models/hr_candidate.py
+++ b/addons/hr_recruitment_skills/models/hr_candidate.py
@@ -35,6 +35,9 @@ class HrCandidate(models.Model):
             candidate.skill_ids = candidate.candidate_skill_ids.skill_id
 
     def _update_employee_from_candidate(self):
+        if self.env.context.get('creating_employee'):
+            return super()._update_employee_from_candidate()
+
         vals_list = []
         for candidate in self:
             existing_skills = candidate.employee_id.employee_skill_ids.skill_id


### PR DESCRIPTION
Steps
---
* Create a candidate
* Give them a skill
* *Create Employee*
* => Traceback -> "Two levels for the same skill is not allowed"

Cause
---
* on `hr.employee.skill` we have a unique constraint on the skill employee pair
* but when creating an employee we would attempt to create the skills twice, once through regular create and once from the override of `_update_employee_from_candidate` call in the write
