### PR TITLE
[FIX] pos_hr: fix employee cash in/out modal

### DIFF
--- a/addons/pos_hr/models/pos_session.py
+++ b/addons/pos_hr/models/pos_session.py
@@ -78,5 +78,6 @@ class PosSession(models.Model):
 
     def _prepare_account_bank_statement_line_vals(self, session, sign, amount, reason, extras):
         vals = super()._prepare_account_bank_statement_line_vals(session, sign, amount, reason, extras)
-        vals['employee_id'] = extras['employee_id']
+        if extras.get('employee_id'):
+            vals['employee_id'] = extras['employee_id']
         return vals

--- a/addons/pos_hr/static/src/overrides/components/navbar/cash_move_popup/cash_move_popup.js
+++ b/addons/pos_hr/static/src/overrides/components/navbar/cash_move_popup/cash_move_popup.js
@@ -4,9 +4,10 @@ import { patch } from "@web/core/utils/patch";
 patch(CashMovePopup.prototype, {
     _prepare_try_cash_in_out_payload() {
         const result = super._prepare_try_cash_in_out_payload(...arguments);
-        const employee_id = this.pos.get_cashier().id;
-        // replace the extras with an object containing "employee_id"
-        result[result.length - 1] = { ...result[result.length - 1], employee_id };
+        if (this.pos.config.module_pos_hr) {
+            const employee_id = this.pos.get_cashier().id;
+            result[result.length - 1] = { ...result[result.length - 1], employee_id };
+        }
         return result;
     },
 });


### PR DESCRIPTION
Adding condition before adding employee_id information in the cash move values. If pos_hr module is not installed, then employee_id will be an user_id instead of an employee_id

