### PR TITLE
[FIX] sale_loyalty: fix loyalty_data view on sale_order_form 

### DIFF
--- a/addons/sale_loyalty/static/src/views/fields/loyalty_total/loyalty_data_field.xml
+++ b/addons/sale_loyalty/static/src/views/fields/loyalty_total/loyalty_data_field.xml
@@ -4,7 +4,7 @@
     <t t-name="sale_loyalty.LoyaltyDataField">
         <table class="table" t-if="LoyaltyCardData">
             <tr class="border-bottom">
-                <td>Loyalty Card :</td>
+                <td><strong>Loyalty Card</strong></td>
             </tr>
             <tr class="border-none">
                 <td>Issued :</td>


### PR DESCRIPTION
prior this commit:
- The loyalty points table in sale order form view was inconsistent

post this commit:
- A small design fix to make it look more consistent with other labels
  and for better visual emphasis

related pr: https://github.com/odoo/odoo/pull/173476

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
