### PR TITLE
[FIX] hr_holidays: fix filter in pending allocation link

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -1294,7 +1294,7 @@ Attempting to double-book your time off won't magically make your vacation 2x be
     def open_pending_requests(self):
         user_employee = self.env.user.employee_id
         employee = self.env['hr.employee']._get_contextual_employee()
-        context = {'search_default_second_approval': True}
+        context = {'search_default_approve': True, 'search_default_second_approval': True}
         domain = []
         if employee != user_employee:
             view_name = 'hr_holidays.hr_leave_allocation_view_tree'


### PR DESCRIPTION
Steps:
- Install the hr_holidays module
- Click on the `Pending Requests` from dashboard

Description of the issue/feature this PR addresses: In the Time Off module, when clicking on Pending Requests, it opens the allocation with the only second approval filter.

Fix:
This PR resolves the issue by setting the default search filter to first approval along with second approval.

task-4208036

