### PR TITLE
[FIX] point_of_sale: raise access denied for user role

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -491,6 +491,12 @@ msgid "Accept payments with an Adyen payment terminal"
 msgstr ""
 
 #. module: point_of_sale
+#. odoo-javascript
+#: code:addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.js:0
+msgid "Access Denied"
+msgstr ""
+
+#. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_config__access_token
 msgid "Access Token"
 msgstr ""
@@ -3395,6 +3401,14 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/point_of_sale/static/src/app/printer/pos_printer_service.js:0
 msgid "It is possible to print your tickets by making use of an IoT Box."
+msgstr ""
+
+#. module: point_of_sale
+#. odoo-javascript
+#: code:addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.js:0
+msgid ""
+"It seems like you don't have enough rights to create point of sale "
+"configurations."
 msgstr ""
 
 #. module: point_of_sale


### PR DESCRIPTION
We encounter an error when trying to open any POS category from the ``Dashboard``, if the Administrator is assigned the role of ``User`` for ``Point of Sale``

Steps to reproduce:
---
- Install the ``point_of_sale`` module(without demo)
- Change the right from ``Admin`` -> ``User`` in ``Point of Sale`` in Users
- Now go to ``Dashboard`` and try to open any category

Traceback:
---
```ParseError
while parsing /home/odoo/src/odoo/saas-17.4/addons/product/data/product_demo.xml:5, somewhere inside <record id="base.group_user" model="res.groups">
            <field name="implied_ids" eval="[(4, ref('product.group_product_variant'))]"/>
        </record>
```
This commit will fix the above error by displaying an ``Access Denied`` pop-up for users with the ``User`` role when attempting to open the POS category.

sentry-5717539295

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
