### PR TITLE
[IMP] website: remove useless empty css versioning files and assets

### DIFF
--- a/addons/website/static/src/snippets/s_comparisons/001.scss
+++ b/addons/website/static/src/snippets/s_comparisons/001.scss
@@ -1,1 +1,0 @@
-.s_comparisons[data-vcss="001"] {}

--- a/addons/website/static/src/snippets/s_product_catalog/002.scss
+++ b/addons/website/static/src/snippets/s_product_catalog/002.scss
@@ -1,4 +1,0 @@
-// This file is empty because it is intended to trigger versioning.
-.s_product_catalog[data-vcss='002'] {
-
-}

--- a/addons/website/static/src/snippets/s_product_list/001.scss
+++ b/addons/website/static/src/snippets/s_product_list/001.scss
@@ -1,3 +1,0 @@
-// This file is empty because it is intended to trigger versioning.
-.s_product_list[data-vcss='001'] {
-}

--- a/addons/website/views/snippets/s_comparisons.xml
+++ b/addons/website/views/snippets/s_comparisons.xml
@@ -87,10 +87,4 @@
     <field name="active" eval="False"/>
 </record>
 
-<record id="website.s_comparisons_001_scss" model="ir.asset">
-    <field name="name">Comparisons 001 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_comparisons/001.scss</field>
-</record>
-
 </odoo>

--- a/addons/website/views/snippets/s_product_catalog.xml
+++ b/addons/website/views/snippets/s_product_catalog.xml
@@ -111,12 +111,6 @@
     </xpath>
 </template>
 
-<record id="website.s_product_catalog_002_scss" model="ir.asset">
-    <field name="name">Product catalog 002 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_product_catalog/002.scss</field>
-</record>
-
 <record id="website.s_product_catalog_001_scss" model="ir.asset">
     <field name="name">Product catalog 001 SCSS</field>
     <field name="bundle">web.assets_frontend</field>

--- a/addons/website/views/snippets/s_product_list.xml
+++ b/addons/website/views/snippets/s_product_list.xml
@@ -92,12 +92,6 @@
     <field name="path">website/static/src/snippets/s_product_list/000_variables.scss</field>
 </record>
 
-<record id="website.s_product_list_001_scss" model="ir.asset">
-    <field name="name">Product list 001 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_product_list/001.scss</field>
-</record>
-
 <record id="website.s_product_list_000_scss" model="ir.asset">
     <field name="name">Product list 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>


### PR DESCRIPTION
Introduced recently with [1], [2] and [3]. It is useless: if a snippet just stops having CSS... just stop having CSS. Disable the previous CSS as always and the `_disable_unused_snippets_assets` will work too provided that you do increase the `data-vcss` of the snippet.

[1]: https://github.com/odoo/odoo/commit/224ec4e62fd2822b679331187110a04a0187ec81
[2]: https://github.com/odoo/odoo/commit/1b361326f8f6c7e27c197ee2ca9496f556f9915c
[3]: https://github.com/odoo/odoo/commit/501e284e6ab52d304d50e6055a7718cba1b70256
