### PR TITLE
[IMP] web,*: kanban: reduce footer font size

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -395,7 +395,7 @@
                             <field name="name" class="fw-bold fs-5"/>
                             <field name="contact_name"/>
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
-                            <footer class="pt-1 mt-0 fs-6">
+                            <footer class="pt-1 mt-0">
                                 <div class="d-flex mt-auto">
                                     <field name="priority" widget="priority" class="me-2"/>
                                     <field name="activity_ids" widget="kanban_activity"/>
@@ -549,7 +549,7 @@
                             <field name="partner_id" class="text-truncate" />
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                             <field name="lead_properties" widget="properties"/>
-                            <footer class="fs-6 pt-1">
+                            <footer class="pt-1">
                                 <div class="d-flex mt-auto align-items-center">
                                     <field name="priority" widget="priority" groups="base.group_user" class="me-2"/>
                                     <field name="activity_ids" widget="kanban_activity"/>

--- a/addons/event_booth/views/event_booth_views.xml
+++ b/addons/event_booth/views/event_booth_views.xml
@@ -100,7 +100,7 @@
                 <templates>
                     <t t-name="card">
                         <field class="fw-bold fs-5" name="name"/>
-                        <footer class="p-0 fs-6">
+                        <footer class="p-0">
                             <field name="booth_category_id"/>
                             <field class="ms-auto" name="activity_ids" widget="kanban_activity"/>
                         </footer>

--- a/addons/fleet/views/fleet_vehicle_cost_views.xml
+++ b/addons/fleet/views/fleet_vehicle_cost_views.xml
@@ -283,7 +283,7 @@
                             <field class="float-end" name="date"/>
                         </div>
                         <field class="text-truncate" name="vendor_id"/>
-                        <footer class="fs-6 pt-0">
+                        <footer class="pt-0">
                             <field name="amount" widget="monetary" options="{'currency_field': 'currency_id'}"/>
                             <field name="activity_ids" widget="kanban_activity" class="ms-auto"/>
                         </footer>

--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -150,13 +150,13 @@
                                     <i class="fa fa-fw me-2 fa-envelope text-primary" title="Email"/>
                                     <field name="work_email"/>
                                 </div>
-                                <div t-if="record.work_phone.raw_value">
-                                    <i class="fa fa-fw me-2 fa-phone text-primary" title="Phone"/>
-                                    <field name="work_phone"/>
+                                <div class="d-flex">
+                                    <div t-if="record.work_phone.raw_value">
+                                        <i class="fa fa-fw me-2 fa-phone text-primary" title="Phone"/>
+                                        <field name="work_phone"/>
+                                    </div>
+                                    <field name="user_id" widget="many2one_avatar_user" readonly="1" class="ms-auto"/>
                                 </div>
-                                <footer class="fs-6 position-absolute bottom-0 end-0">
-                                    <field name="user_id" widget="many2one_avatar_user" readonly="1" class="mb-2 ms-auto me-2"/>
-                                </footer>
                             </main>
                         </t>
                     </templates>

--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -344,7 +344,7 @@
                         <field name="job_id" invisible="context.get('search_default_job_id', False)"/>
                         <field name="categ_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                         <field name="applicant_properties" widget="properties"/>
-                        <footer class="fs-6">
+                        <footer>
                             <field name="priority" widget="priority"/>
                             <field class="ms-1 align-items-center" name="activity_ids" widget="kanban_activity"/>
                             <div class="d-flex ms-auto align-items-center">

--- a/addons/hr_recruitment/views/hr_candidate_views.xml
+++ b/addons/hr_recruitment/views/hr_candidate_views.xml
@@ -132,7 +132,7 @@
                         <field t-else="" class="fw-bold fs-5" name="partner_id"/>
                         <field name="categ_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                         <field name="candidate_properties" widget="properties"/>
-                        <footer class="fs-6">
+                        <footer>
                             <field name="priority" widget="priority"/>
                             <field class="ms-1 align-items-center" name="activity_ids" widget="kanban_activity"/>
                             <div class="d-flex ms-auto align-items-center">

--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -308,7 +308,7 @@
                                     <span class="text-truncate" t-att-title="record.name.value"><field name="name" class="fst-italic"/></span>
                                 </div>
                             </div>
-                            <footer class="mt-0 pt-0 fs-6">
+                            <footer class="mt-0 pt-0">
                                 <div class="d-flex ms-auto">
                                     <strong><field name="unit_amount" widget="timesheet_duration_uom" decoration-danger="unit_amount &gt; 24" decoration-muted="unit_amount == 0" class="ms-1"/></strong>
                                 </div>

--- a/addons/im_livechat/views/discuss_channel_views.xml
+++ b/addons/im_livechat/views/discuss_channel_views.xml
@@ -55,7 +55,7 @@
                                 </div>
                                 <field name="rating_last_image" string="Rating" widget="image" options='{"size": [40, 40]}' class="ms-auto"/>
                             </div>
-                            <footer class="fs-6 pt-0">
+                            <footer class="pt-0">
                                 <t t-if="record.country_id.raw_value">
                                     <span class="fw-bold">Country: </span><field string="Country" name="country_id"/>
                                 </t>

--- a/addons/lunch/views/lunch_product_views.xml
+++ b/addons/lunch/views/lunch_product_views.xml
@@ -124,7 +124,7 @@
                                 </div>
                             </div>
                             <field name="supplier_id" />
-                            <footer class="fs-6 pt-0 mt-0">
+                            <footer class="pt-0 mt-0">
                                 <field name="description" class="text-muted"/>
                             </footer>
                         </main>
@@ -157,7 +157,7 @@
                                 <field name="price" widget="monetary" class="fw-bold ms-auto"/>
                             </div>
                             <field name="supplier_id" />
-                            <footer class="fs-6 pt-0 mt-0">
+                            <footer class="pt-0 mt-0">
                                 <field name="description" class="text-muted"/>
                             </footer>
                         </main>

--- a/addons/mail/views/mail_activity_plan_views.xml
+++ b/addons/mail/views/mail_activity_plan_views.xml
@@ -96,7 +96,7 @@
                                                     <field name="delay_count"/> <field name="delay_unit"/>
                                                     (<field name="delay_from"/>)
                                                 </div>
-                                                <footer class="p-0 fs-6">
+                                                <footer class="p-0">
                                                     <field name="responsible_type"/>
                                                     <field class="ms-auto" name="responsible_id" widget="many2one_avatar_user" readonly="1"/>
                                                 </footer>

--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -170,7 +170,7 @@
                         <span name="owner_user_id" t-if="record.owner_user_id.raw_value">Requested by: <field name="owner_user_id"/></span>
                         <span t-if="record.equipment_id.raw_value"><field name="equipment_id"/><span t-if="record.category_id.raw_value"> (<field name="category_id"/>)</span></span>
                         <field name="schedule_date"/>
-                        <footer class="fs-6">
+                        <footer>
                             <div class="d-flex">
                                 <field name="priority" widget="priority"/>
                                 <field name="activity_ids" widget="kanban_activity" class="ms-3"/>
@@ -473,7 +473,7 @@
                             <span t-if="record.model.raw_value" class="fw-bold small"> (<field name="model"/>)</span>
                         </div>
                         <field t-if="record.serial_no.raw_value" name="serial_no"/>
-                        <footer class="fs-6">
+                        <footer>
                             <div class="badge text-bg-danger" t-if="record.maintenance_open_count.raw_value">
                                 <field name="maintenance_open_count" /> Request
                             </div>

--- a/addons/marketing_card/views/card_campaign_views.xml
+++ b/addons/marketing_card/views/card_campaign_views.xml
@@ -158,7 +158,7 @@
                     <t t-name="card" class="o_marketing_card_campaign_kanban">
                         <field name="name" class="fw-bolder fs-5"/>
                         <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" class="mt-2"/>
-                        <footer class="fs-6 pt-0">
+                        <footer class="pt-0">
                             <div>
                                 <a type="object" name="action_view_cards_shared" href="#" class="me-1">
                                     <span class="badge rounded-pill">

--- a/addons/mass_mailing/views/mailing_contact_views.xml
+++ b/addons/mass_mailing/views/mailing_contact_views.xml
@@ -79,7 +79,7 @@
                             </div>
                         </div>
                         <field name="tag_ids"/>
-                        <footer class="fs-6 pt-1">
+                        <footer class="pt-1">
                             <field name="email" class="fw-bolder"/>
                             <field name="company_name" class="ms-auto"/>
                         </footer>

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -421,7 +421,7 @@
                                 <field name='mailing_model_id' invisible="mailing_on_mailing_list"/>
                                 <span invisible="not mailing_on_mailing_list">Mailing Contact</span>
                             </div>
-                            <footer class="fs-6 pt-0">
+                            <footer class="pt-0">
                                 <div>
                                     <span invisible="not sent_date" t-attf-title="Sent on #{record.sent_date.value}">
                                         <span class="fa fa-paper-plane me-2 small my-auto" aria-label="Sent date"/>

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -206,7 +206,7 @@
                                 <field name="product_tmpl_id" class="fw-medium fs-5"/>
                                 <span class="float-end badge rounded-pill"><field name="product_qty"/> <field name="product_uom_id" class="small"/></span>
                             </div>
-                            <footer class="fs-6 pt-1">
+                            <footer class="pt-1">
                                 <field name="code"/>
                             </footer>
                         </t>

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -576,7 +576,7 @@
                                 <field name="product_qty" class="ms-auto"/>
                                 <field name="product_uom_id" class="small ms-1"/>
                             </div>
-                            <footer class="fs-6 text-muted">
+                            <footer class="text-muted">
                                 <div class="d-flex">
                                     <field name="name" class="me-1"/>
                                     <field name="date_start" widget="datetime" options="{'show_time': false}"/>

--- a/addons/point_of_sale/views/pos_session_view.xml
+++ b/addons/point_of_sale/views/pos_session_view.xml
@@ -109,7 +109,7 @@
                                     'opened': 'success', 'closing_control': 'warning', 'closed': 'warning'}}" class="ms-auto"/>
                         </div>
                         <field name="name" />
-                        <footer class="fs-6 pt-1">
+                        <footer class="pt-1">
                             <field name="start_at" />
                             <field name="user_id" widget="many2one_avatar_user" readonly="state != 'opening_control'" class="ms-auto"/>
                         </footer>

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -464,7 +464,7 @@
                                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                                 </div>
                             </div>
-                            <footer class="fs-6 mt-auto pt-0 ms-1">
+                            <footer class="mt-auto pt-0 ms-1">
                                 <div class="d-flex align-items-center">
                                     <div class="o_project_kanban_boxes d-flex align-items-baseline">
                                         <a class="o_project_kanban_box me-1" name="action_view_tasks" type="object">

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -692,7 +692,7 @@
                             <field name="task_properties" widget="properties"/>
                             <field name="displayed_image_id" widget="attachment_image"/>
                         </div>
-                        <footer t-if="!selection_mode" class="fs-6 pt-1">
+                        <footer t-if="!selection_mode" class="pt-1">
                             <div class="d-flex align-items-center gap-1" t-att-class="['1_done', '1_canceled'].includes(record.state.raw_value) ? 'opacity-50' : ''">
                                 <field name="priority" widget="priority" style="margin-right: 5px;"/>
                                 <field name="activity_ids" widget="kanban_activity" style="margin-right: 2px"/>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -486,7 +486,7 @@
                                 <field name="partner_id" class="fw-bolder fs-5"/>
                                 <field name="amount_total" widget="monetary" class="fw-bolder ms-auto"/>
                             </div>
-                            <footer class="fs-6 pt-0">
+                            <footer class="pt-0">
                                 <div class="d-flex">
                                     <field name="name" class="me-1"/> <field name="date_order" options="{'show_time': false}"/>
                                     <field name="activity_ids" widget="kanban_activity" class="ms-1"/>

--- a/addons/purchase_requisition/views/purchase_requisition_views.xml
+++ b/addons/purchase_requisition/views/purchase_requisition_views.xml
@@ -150,7 +150,7 @@
                             <field name="state" widget="label_selection" options="{'classes': {'draft': 'default', 'done': 'success', 'close': 'danger'}}" readonly="1" class="ms-auto"/>
                         </div>
                         <field name="requisition_type" class="text-muted"/>
-                        <footer class="fs-6">
+                        <footer>
                             <field name="vendor_id"/>
                             <field name="user_id" widget="many2one_avatar_user" class="ms-auto"/>
                         </footer>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -79,7 +79,7 @@
                             <field name="partner_id" class="fw-bolder fs-5" />
                             <field name="amount_total" widget="monetary" class="fw-bolder ms-auto"/>
                         </div>
-                        <footer class="fs-6">
+                        <footer>
                             <div class="d-flex text-muted">
                                 <field name="name"/>
                                 <field name="date_order" class="ms-1"/>

--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -11,7 +11,7 @@
                             <field name="name" class="fw-bold fs-5 mb-1"/>
                             <span class="badge rounded-pill ms-auto mt-1"><strong>Min qty:</strong><field name="product_min_qty"/></span>
                         </div>
-                        <footer class="fs-6 pt-0">
+                        <footer class="pt-0">
                             <field name="product_id"/>
                             <span class="badge rounded-pill ms-auto"><strong>Max qty:</strong><field name="product_max_qty"/></span>
                         </footer>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -46,7 +46,7 @@
                                 <field name="state" widget="label_selection" options="{'classes': {'draft': 'default', 'cancel': 'danger', 'waiting': 'warning', 'confirmed': 'warning', 'done': 'success'}}" class="ms-auto"/>
                             </div>
                             <field name="picking_properties" widget="properties"/>
-                            <footer class="fs-6 pt-0">
+                            <footer class="pt-0">
                                 <div class="d-flex">
                                     <field name="partner_id"/>
                                     <field name="activity_ids" widget="kanban_activity"/>

--- a/addons/stock_fleet/views/stock_picking_batch.xml
+++ b/addons/stock_fleet/views/stock_picking_batch.xml
@@ -110,7 +110,7 @@
         <field name="arch" type="xml">
             <data>
                 <xpath expr="//footer" position="replace">
-                    <footer class="fs-6 pt-0">
+                    <footer class="pt-0">
                         <field name="dock_id"/>
                         <div>
                             <field name="state" widget="state_selection" class="float-start pt-1 me-1"/>

--- a/addons/stock_picking_batch/views/stock_picking_batch_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_batch_views.xml
@@ -160,7 +160,7 @@
                             <field name="state" widget="label_selection" class="ms-auto"/>
                         </div>
                         <field name="description" class="fw-bold mb-2"/>
-                        <footer class="fs-6 pt-0">
+                        <footer class="pt-0">
                             <field name="picking_type_id" readonly="state != 'draft'"/>
                             <div class="d-flex">
                                 <field name="scheduled_date" readonly="state in ['cancel', 'done']"/>

--- a/addons/survey/views/survey_user_views.xml
+++ b/addons/survey/views/survey_user_views.xml
@@ -140,7 +140,7 @@
                 <templates>
                     <t t-name="card">
                         <field name="survey_id" class="fw-bold fs-5 mb-1"/>
-                        <footer class="fs-6 pt-0">
+                        <footer class="pt-0">
                             <field name="create_date"/>
                             <field name="state" widget="label_selection" options="{'classes': {'new': 'default', 'done': 'success', 'in_progress':'warning'}}" class="ms-auto"/>
                         </footer>

--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -203,7 +203,7 @@
             column-gap: var(--Card-Footer-gap, #{map-get($spacers, 2)});
             margin-top: auto;
             padding-top: var(--KanbanRecord-padding-v);
-            font-size: var(--Card-Footer-font-size, 1rem);
+            font-size: var(--Card-Footer-font-size, .875rem);
         }
 
         aside {

--- a/addons/website_event_track/views/event_track_views.xml
+++ b/addons/website_event_track/views/event_track_views.xml
@@ -48,7 +48,7 @@
                         <field name="name" class="fw-medium fs-5"/>
                         <div t-if="duration" class="d-flex"><field name="duration" widget="float_time"/>hours</div>
                         <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
-                        <footer class="fs-6 pt-0">
+                        <footer class="pt-0">
                             <div class="d-flex align-items-center">
                                 <field name="priority" widget="priority"/>
                                 <field name="activity_ids" widget="kanban_activity" class="ms-1"/>

--- a/addons/website_sale/views/website_pages_views.xml
+++ b/addons/website_sale/views/website_pages_views.xml
@@ -60,7 +60,7 @@
                 </div>
             </xpath>
             <xpath expr="//aside" position="after">
-                <footer class="justify-content-end flex-grow-1 fs-6">
+                <footer class="justify-content-end flex-grow-1">
                     <field name="is_published" widget="boolean_toggle"/>
                     <span t-if="record.is_published.raw_value">Published</span>
                     <span t-else="">Not Published</span>

--- a/addons/website_slides/views/slide_channel_partner_views.xml
+++ b/addons/website_slides/views/slide_channel_partner_views.xml
@@ -69,7 +69,7 @@
                         <t t-name="card">
                             <field name="channel_id" class="fw-bolder fs-5"/>
                             <field name="partner_id"/>
-                            <footer class="fs-6 mt-2">
+                            <footer class="mt-2">
                                 <field name="completion" widget="progressbar"/>
                                 <field name="channel_user_id" widget="many2one_avatar_user" class="ms-auto"/>
                             </footer>

--- a/addons/website_slides/views/slide_slide_views.xml
+++ b/addons/website_slides/views/slide_slide_views.xml
@@ -220,7 +220,7 @@
                                 <field name="name" class="fw-bolder fs-5"/>
                                 <field name="channel_id" class="text-mutex"/>
                                 <field name="tag_ids" widget="many2many_tags" class="mb-2"/>
-                                <footer class="mt-auto d-flex justify-content-between align-items-end fs-6 pt-0">
+                                <footer class="mt-auto d-flex justify-content-between align-items-end pt-0">
                                     <span>
                                         <t t-if="record.slide_category.raw_value == 'infographic'">
                                             <i class="fa fa-file-image-o me-2" aria-label="Infographic" role="img" title="Infographic"/>


### PR DESCRIPTION
Before this commit, the default font size for kanban footers was 1rem. A lot of kanban views overruled it by using classname `fs-6`. This commit changes the default font-size to .875rem (which is `fs-6`) which allows to remove the classname from a lot of archs.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
