### PR TITLE
[FIX] mail: active sub-thread in sidebar when category is collapsed

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -34,6 +34,7 @@
             <DiscussSidebarChannel t-foreach="filteredThreads(category.threads)" t-as="thread" t-key="thread.localId" thread="thread"/>
         </t>
         <DiscussSidebarChannel t-elif="store.discuss.thread?.in(category.threads)" thread="store.discuss.thread"/>
+        <DiscussSidebarChannel t-elif="store.discuss.thread?.parent_channel_id?.in(category.threads)" thread="store.discuss.thread.parent_channel_id" />
     </t>
 
     <t t-name="mail.DiscussSidebarCategory">
@@ -101,9 +102,10 @@
                 </Dropdown>
                 <t t-else="" t-call="mail.DiscussSidebarChannel.main"/>
                 <t t-set="subChannels" t-value="env.filteredThreads?.(thread.sub_channel_ids) ?? []"/>
+                <t t-set="isCategoryOpen" t-value="thread.discussAppCategory.open" />
                 <ul t-if="subChannels.length > 0" class="list-unstyled position-relative flex-grow-1" t-att-class="{ 'my-1 d-flex flex-column gap-1': store.discuss.isSidebarCompact, 'mt-1 mb-0': !store.discuss.isSidebarCompact }">
                     <t t-foreach="subChannels" t-as="sub" t-key="sub.localId">
-                        <DiscussSidebarSubchannel thread="sub" isFirst="sub_first"/>
+                        <DiscussSidebarSubchannel t-if="isCategoryOpen or sub.eq(store.discuss.thread)" thread="sub" isFirst="sub_first or !isCategoryOpen"/>
                     </t>
                 </ul>
             </t>

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -64,6 +64,22 @@ test("toggling category button does not hide active category items", async () =>
     await contains(".o-mail-DiscussSidebarChannel.o-active");
 });
 
+test("toggling category button does not hide active sub thread", async () => {
+    const pyEnv = await startServer();
+    const mainChannelId = pyEnv["discuss.channel"].create({ name: "Main Channel" });
+    const subChannelId = pyEnv["discuss.channel"].create({
+        name: "Sub Channel",
+        parent_channel_id: mainChannelId,
+    });
+    await start();
+    await openDiscuss(subChannelId);
+    await contains(".o-mail-DiscussSidebar-item", { text: "Main Channel" });
+    await contains(".o-mail-DiscussSidebar-item", { text: "Sub Channel" });
+    await click(".o-mail-DiscussSidebar button", { text: "Channels" });
+    await contains(".o-mail-DiscussSidebar-item", { text: "Main Channel" });
+    await contains(".o-mail-DiscussSidebar-item", { text: "Sub Channel" });
+});
+
 test("Closing a category sends the updated user setting to the server.", async () => {
     onRpc("/web/dataset/call_kw/res.users.settings/set_res_users_settings", async (request) => {
         const { params } = await request.json();


### PR DESCRIPTION
**Current behavior before PR:**

When a category containing an active sub-thread is collapsed, the sidebar does not display the sub-thread.

**Desired behavior after PR is merged:**

The sidebar correctly displays the active sub-thread, even if the category is collapsed.

![Ideas-Suggestions_Before](https://github.com/user-attachments/assets/d4737533-0ae2-4325-b8a9-8aac70ed0f63)  ![Ideas   Suggestions](https://github.com/user-attachments/assets/a89b48a9-a9e3-4e25-92dc-0ab042a9809e)   


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
