### PR TITLE
[IMP] web: customizable classes for the `remaining_days` field

### DIFF
--- a/addons/web/static/src/views/fields/remaining_days/remaining_days_field.js
+++ b/addons/web/static/src/views/fields/remaining_days/remaining_days_field.js
@@ -1,5 +1,8 @@
+
 import { Component } from "@odoo/owl";
+import { evaluateExpr } from "@web/core/py_js/py";
 import { formatDate, formatDateTime } from "@web/core/l10n/dates";
+import { getClassNameFromDecoration } from "@web/views/utils";
 import { localization } from "@web/core/l10n/localization";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
@@ -11,7 +14,18 @@ const { DateTime } = luxon;
 export class RemainingDaysField extends Component {
     static components = { DateTimeField };
 
-    static props = standardFieldProps;
+    static props = {
+        ...standardFieldProps,
+        classes: { type: Object, optional: true },
+    };
+
+    static defaultProps = {
+        classes: {
+            'bf': 'days <= 0',
+            'danger': 'days < 0',
+            'warning': 'days == 0',
+        },
+    };
 
     static template = "web.RemainingDaysField";
 
@@ -53,12 +67,39 @@ export class RemainingDaysField extends Component {
             ? formatDateTime(record.data[name], { format: localization.dateFormat })
             : formatDate(record.data[name]);
     }
+
+    get classNames() {
+        if (this.diffDays === null) {
+            return null;
+        }
+        if (!this.props.record.isActive) {
+            return null;
+        }
+        const classNames = {};
+        const evalContext = {days: this.diffDays, record: this.props.record.evalContext};
+        for (const decoration in this.props.classes) {
+            const value = evaluateExpr(this.props.classes[decoration], evalContext);
+            classNames[getClassNameFromDecoration(decoration)] = value;
+        }
+        return classNames;
+    }
+
+    get dateTimeFieldProps() {
+        return Object.fromEntries(
+            Object.entries(this.props).filter(([key]) => standardFieldProps[key])
+        );
+    }
 }
 
 export const remainingDaysField = {
     component: RemainingDaysField,
     displayName: _t("Remaining Days"),
     supportedTypes: ["date", "datetime"],
+    extractProps: ({ options }) => {
+        return {
+            classes: options.classes,
+        };
+    },
 };
 
 registry.category("fields").add("remaining_days", remainingDaysField);

--- a/addons/web/static/src/views/fields/remaining_days/remaining_days_field.xml
+++ b/addons/web/static/src/views/fields/remaining_days/remaining_days_field.xml
@@ -2,21 +2,15 @@
 <templates xml:space="preserve">
     <t t-name="web.RemainingDaysField">
         <t t-if="props.readonly">
-            <t t-set="days" t-value="diffDays" />
-            <t t-set="formatted" t-value="formattedValue" />
             <div
-                t-att-class="{
-                    'fw-bold': days !== null and days lte 0 and props.record.isActive,
-                    'text-danger': days !== null and days lt 0 and props.record.isActive,
-                    'text-warning': days !== null and days === 0 and props.record.isActive,
-                }"
-                t-att-title="formatted"
+                t-att-class="classNames"
+                t-att-title="formattedValue"
             >
                 <t t-esc="diffString"/>
             </div>
         </t>
         <t t-else="">
-            <DateTimeField t-props="props" />
+            <DateTimeField t-props="dateTimeFieldProps" />
         </t>
     </t>
 </templates>

--- a/addons/web/static/tests/views/fields/remaining_days_field.test.js
+++ b/addons/web/static/tests/views/fields/remaining_days_field.test.js
@@ -386,3 +386,49 @@ test("RemainingDaysField on a datetime field in list view in UTC-8", async () =>
         "2 days ago",
     ]);
 });
+
+test("RemainingDaysField with custom decoration classes", async () => {
+    mockDate("2017-10-08 15:35:11");
+
+    Partner._records = [
+        { id: 1, date: "2017-10-08" }, // today
+        { id: 2, date: "2017-10-09" }, // tomorrow
+        { id: 3, date: "2017-10-07" }, // yesterday
+        { id: 4, date: "2017-10-10" }, // + 2 days
+        { id: 5, date: "2017-10-05" }, // - 3 days
+        { id: 6, date: "2018-02-08" }, // + 4 months (diff >= 100 days)
+        { id: 7, date: "2017-06-08" }, // - 4 months (diff >= 100 days)
+        { id: 8, date: false },
+    ];
+
+    await mountView({
+        type: "list",
+        resModel: "partner",
+        arch: /* xml */ `
+                <list>
+                    <field
+                        name="date"
+                        widget="remaining_days"
+                        options="{
+                            'classes': {
+                                'muted': 'days &lt; -30',
+                                'danger': 'days &lt; 0',
+                                'success': 'days == 0',
+                                'warning': 'days &gt; 30',
+                                'info': 'days &gt;= 2'
+                            }
+                        }"
+                    />
+                </list>`,
+    });
+
+    const cells = queryAll(".o_data_cell div div");
+    expect(cells[0]).toHaveClass("text-success");
+    expect(cells[1]).not.toHaveAttribute("class");
+    expect(cells[2]).toHaveClass("text-danger");
+    expect(cells[3]).toHaveClass("text-info");
+    expect(cells[4]).toHaveClass("text-danger");
+    expect(cells[5]).toHaveClass("text-warning");
+    expect(cells[6]).toHaveClass("text-muted");
+    expect(cells[7]).not.toHaveAttribute("class");
+});


### PR DESCRIPTION
This commit adds the ability to customize the classes of the `remaining_days` field through the `classes` option.

Usage:

```xml
<field
    name="fname"
    widget="remaining_days"
    options="{'classes': {'success': 'days &gt;= 10'}"
/>
```


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
