### PR TITLE
Fix inconsistent computation of accrued days.

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -853,6 +853,8 @@ class HolidaysAllocation(models.Model):
         self.number_of_hours_display = 0.0
         self.number_of_days = 0.0
         self.already_accrued = False
+        self.carried_over_days_expiration_date = False
+        self.expiring_carryover_days = 0
         date_to = min(self.date_to, date.today()) if self.date_to else False
         self._process_accrual_plans(date_to)
 


### PR DESCRIPTION
Steps to Reproduce:

Create an accrual allocation:
  - Carryover date on allocation start date.
  - Has 1 level:
    * Start 0 days after allocation start date.
    * Accrues 1 day monthly on 1st day of the month.
    * Carryover policy all accrued time carried over.
    * Carryover validity 1 month.
    * Leave other options as is.
  - Leave other options as is.

Create an allocation:
  - Allocation type: accrual allocation.
  - Accrual plan: use the one defined above.
  - The following dates are in mm/dd/YYYY
  - Set allocation start date 08/01/2023.
    Number of days becomes 2 days (as expected).
  - Set allocation start date 09/01/2023.
    Number of day becomes 12 days (as expected).
  - Set allocation start date 08/01/2023.
    Number of days becomes 13 days (wrong).

The issue is that the expiration date of carried over days and the number of expiring days aren't reset when the start date of the allocation changes.

The fix is to reset these values when the start date of the allocation changes.

task-4208024