### PR TITLE
[FIX] sales: computing sales team in invoice

### DIFF
--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -29,15 +29,17 @@ class AccountMove(models.Model):
             downpayment_lines.unlink()
         return res
 
-    @api.depends('invoice_user_id')
+    @api.depends('invoice_user_id', 'partner_id')
     def _compute_team_id(self):
         sale_moves = self.filtered(lambda move: move.is_sale_document(include_receipts=True))
-        for ((user_id, company_id), moves) in groupby(
+        for ((user_id, company_id, partner_team_id), moves) in groupby(
             sale_moves,
-            key=lambda m: (m.invoice_user_id.id, m.company_id.id)
+            key=lambda m: (m.invoice_user_id.id, m.company_id.id, m.partner_id.team_id.id)
         ):
+            default_team_id = self.env.context.get('default_team_id', False) or partner_team_id
             self.concat(*moves).team_id = self.env['crm.team'].with_context(
-                allowed_company_ids=[company_id]
+                allowed_company_ids=[company_id],
+                default_team_id=default_team_id
             )._get_default_team_id(
                 user_id=user_id,
             )


### PR DESCRIPTION
Versions
16.0+

Description of the issue/feature this PR addresses:

The issue occurs when selecting a partner in an invoice, the sales team is not correctly computed. The problem arises because the default_team_id is not passed as a parameter to the context when the partner is selected, which works correctly in sales orders but fails in invoices.

Current behavior before PR:

When modifying the partner_id in an invoice, the sales team is not recomputed, leading to incorrect or missing sales team assignment.

Desired behavior after PR is merged:

After this PR is merged, modifying the partner_id on an invoice will correctly recompute the sales team by passing the default_team_id in the context, ensuring consistent behavior between invoices and sales orders.

I will now provide a short video demonstrating the error. This issue is replicable if none of the sales teams have any members assigned.
https://drive.google.com/file/d/15mUpXvdlVpGZXW976PK7EVYH6X4sm2CJ/view?usp=sharing

PR of v16 https://github.com/odoo/odoo/pull/180961