### PR TITLE
[IMP] account: let user use next_payment_date on wizard

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -3355,6 +3355,11 @@ msgid "Before"
 msgstr ""
 
 #. module: account
+#: model:ir.model.fields.selection,name:account.selection__account_payment_register__installments_mode__before_date
+msgid "Before Next Payment Date"
+msgstr ""
+
+#. module: account
 #. odoo-python
 #: code:addons/account/wizard/account_merge_wizard.py:0
 msgid "Belongs to the same company as %s."
@@ -15826,6 +15831,12 @@ msgstr ""
 #: model:ir.model.fields,help:account.field_res_partner__debit
 #: model:ir.model.fields,help:account.field_res_users__debit
 msgid "Total amount you have to pay to this vendor."
+msgstr ""
+
+#. module: account
+#. odoo-python
+#: code:addons/account/wizard/account_payment_register.py:0
+msgid "Total for the installments before %(date)s."
 msgstr ""
 
 #. module: account

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1915,11 +1915,9 @@ class AccountMove(models.Model):
             move.next_payment_date = min([line.payment_date for line in move.line_ids.filtered(lambda l: l.payment_date and not l.reconciled)], default=False)
 
     def _search_next_payment_date(self, operator, value):
-        lines_before_date = self.env['account.move.line'].search([
-            ('reconciled', '=', False),
-            ('payment_date', operator, value)
-        ])
-        return [('line_ids', 'in', lines_before_date.ids)]
+        if operator not in ('=', '<', '<='):
+            raise UserError(self.env._('Operation not supported'))
+        return [('line_ids', 'any', [('reconciled', '=', False), ('payment_date', operator, value)])]
 
     # -------------------------------------------------------------------------
     # SEARCH METHODS

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -3121,7 +3121,7 @@ class AccountMoveLine(models.Model):
     # INSTALLMENTS
     # -------------------------------------------------------------------------
 
-    def _get_installments_data(self, payment_currency=None, payment_date=None):
+    def _get_installments_data(self, payment_currency=None, payment_date=None, next_payment_date=None):
         move = self.move_id
         move.ensure_one()
 
@@ -3168,7 +3168,9 @@ class AccountMoveLine(models.Model):
             # In case of overdue, all of them are sum as a default amount to be paid.
             # The next installment is added for the difference.
             if line.display_type == 'payment_term':
-                if (line.date_maturity or line.date) < payment_date:
+                if next_payment_date and (line.date_maturity or line.date) <= next_payment_date:
+                    current_installment_mode = 'before_date'
+                elif (line.date_maturity or line.date) < payment_date:
                     # Collect all overdue installments.
                     first_installment_mode = current_installment_mode = 'overdue'
                 elif not first_installment_mode:


### PR DESCRIPTION
The idea is that if a user uses a filter on "Next Payment Date", 
when he pays, he would expect to pay everything that he needs until this date.

For instance, imagine a bill with 3 installments.
One that was at the end of last month, one for the end of this week and one in 2 months.
You want to pay everything for the end of the week, and make the payment today.
Currently, the only way to do so would be to change the payment date (to make them overdue), but that's not the same thing.

To solve this, we rely on the context to know if it was in the search domain, and then pay everything up to this date.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
