### PR TITLE
[FIX] hr_gamification: Correct badge count on smart button

### DIFF
--- a/addons/hr_gamification/models/gamification.py
+++ b/addons/hr_gamification/models/gamification.py
@@ -32,6 +32,7 @@ class GamificationBadge(models.Model):
     _inherit = 'gamification.badge'
 
     granted_users_count = fields.Integer(compute="_compute_granted_users_count")
+    granted_employees_count = fields.Integer(compute="_compute_granted_employees_count")
 
     @api.depends('owner_ids.user_id')
     def _compute_granted_users_count(self):
@@ -40,12 +41,19 @@ class GamificationBadge(models.Model):
                 ('badge_id', '=', badge.id),
             ])
 
-    def get_granted_employees(self):
-        employee_ids = self.mapped('owner_ids.employee_id').ids
+    @api.depends('owner_ids.employee_id')
+    def _compute_granted_employees_count(self):
+        for badge in self:
+            badge.granted_employees_count = self.env['gamification.badge.user'].search_count([
+                ('badge_id', '=', badge.id),
+            ])
+
+    def get_granted_users(self):
+        user_ids = self.mapped('owner_ids.user_id').ids
         return {
             'type': 'ir.actions.act_window',
-            'name': 'Granted Employees',
+            'name': 'Granted Users',
             'view_mode': 'kanban,tree,form',
-            'res_model': 'hr.employee.public',
-            'domain': [('id', 'in', employee_ids)]
+            'res_model': 'res.users',
+            'domain': [('id', 'in', user_ids)]
         }

--- a/addons/hr_gamification/models/gamification.py
+++ b/addons/hr_gamification/models/gamification.py
@@ -27,17 +27,17 @@ class GamificationBadgeUser(models.Model):
             'res_id': self.badge_id.id,
         }
 
+
 class GamificationBadge(models.Model):
     _inherit = 'gamification.badge'
 
-    granted_employees_count = fields.Integer(compute="_compute_granted_employees_count")
+    granted_users_count = fields.Integer(compute="_compute_granted_users_count")
 
-    @api.depends('owner_ids.employee_id')
-    def _compute_granted_employees_count(self):
+    @api.depends('owner_ids.user_id')
+    def _compute_granted_users_count(self):
         for badge in self:
-            badge.granted_employees_count = self.env['gamification.badge.user'].search_count([
+            badge.granted_users_count = self.env['gamification.badge.user'].search_count([
                 ('badge_id', '=', badge.id),
-                ('employee_id', '!=', False)
             ])
 
     def get_granted_employees(self):

--- a/addons/hr_gamification/views/gamification_views.xml
+++ b/addons/hr_gamification/views/gamification_views.xml
@@ -7,7 +7,7 @@
             <field name="inherit_id" ref="gamification.badge_form_view"/>
             <field name="arch" type="xml">
                 <div name="button_box" position="inside">
-                    <button class="oe_stat_button" type="object" name="get_granted_employees" invisible="granted_count == 0" icon="fa-user">
+                    <button class="oe_stat_button" type="object" name="get_granted_users" invisible="granted_count == 0" icon="fa-user">
                         <field name="granted_users_count" string="Granted" widget="statinfo"/>
                     </button>
                 </div>

--- a/addons/hr_gamification/views/gamification_views.xml
+++ b/addons/hr_gamification/views/gamification_views.xml
@@ -8,7 +8,7 @@
             <field name="arch" type="xml">
                 <div name="button_box" position="inside">
                     <button class="oe_stat_button" type="object" name="get_granted_employees" invisible="granted_count == 0" icon="fa-user">
-                        <field name="granted_employees_count" string="Granted" widget="statinfo"/>
+                        <field name="granted_users_count" string="Granted" widget="statinfo"/>
                     </button>
                 </div>
             </field>

--- a/addons/hr_gamification/wizard/gamification_badge_user_wizard.py
+++ b/addons/hr_gamification/wizard/gamification_badge_user_wizard.py
@@ -28,6 +28,6 @@ class GamificationBadgeUserWizard(models.TransientModel):
         return self.env['gamification.badge.user'].create(values)._send_badge()
 
     @api.depends('user_id')
-    def _compute_eployee_id(self):
+    def _compute_employee_id(self):
         for wizard in self:
             wizard.employee_id = wizard.user_id.employee_id

--- a/addons/hr_gamification/wizard/gamification_badge_user_wizard.py
+++ b/addons/hr_gamification/wizard/gamification_badge_user_wizard.py
@@ -8,9 +8,10 @@ from odoo.exceptions import UserError, AccessError
 class GamificationBadgeUserWizard(models.TransientModel):
     _inherit = 'gamification.badge.user.wizard'
 
-    employee_id = fields.Many2one('hr.employee', string='Employee', required=False)
-    user_id = fields.Many2one('res.users', string='User', compute='_compute_user_id',
-        store=True, readonly=False, compute_sudo=True)
+    employee_id = fields.Many2one('hr.employee', string='Employee', required=False,
+        compute='_compute_eployee_id', store=True)
+    user_id = fields.Many2one('res.users', string='User',
+        store=True, readonly=False)
 
     def action_grant_badge(self):
         """Wizard action for sending a badge to a chosen employee"""
@@ -26,7 +27,7 @@ class GamificationBadgeUserWizard(models.TransientModel):
 
         return self.env['gamification.badge.user'].create(values)._send_badge()
 
-    @api.depends('employee_id')
-    def _compute_user_id(self):
+    @api.depends('user_id')
+    def _compute_eployee_id(self):
         for wizard in self:
-            wizard.user_id = wizard.employee_id.user_id
+            wizard.employee_id = wizard.user_id.employee_id


### PR DESCRIPTION
The issue occurs when granting a badge to a user. The smart button always shows zero (0) badges granted, regardless of how many users have received the badge. This happens because the smart button displays the count of employees granted the badge, but `employee_id` is always `False` as a result counting how many `employee_id` granted this badge is always 0. `employee_id` it wasn't calculated. instead `user_id` was calculated from `employee_id`, but I think it was done by mistake.

I added the `_compute_granted_user_count()` function to count how many `users` have been granted the badge. This ensures the smart button now displays the correct number of users  and employees who received the badge. But I left the _compute_granted_user_count() function even while we don't needed it any more, just in case of someone who didn't update.

When clicking the smart button, now it lists all users that grant this budge, rather than listing only employees who grant it.

And the  `employee_id` is now computed, ensuring it is no longer `False` when the user is an employee.

**Steps to reproduce the issue:**
1: Install Employees
2: Install HR Gamification (not an app)
3: open Employees --> Configurations --> Challenges --> Budges
4: click on of those budges 
5: grant a budge to an employee
6: check the smart button it still shows that 0 employees were granted this budge
7: click on it and it wont list the employees who granted the budge

opw-4165187
