### PR TITLE
[FIX] mrp: not unreserve twice during mass production

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1928,15 +1928,6 @@ class MrpProduction(models.Model):
                         move = moves and moves.pop(0)
                         move_qty_to_reserve = move and move.product_qty or 0
 
-                # Unreserve the quantity removed from initial `stock.move.line` and
-                # not assigned to a move anymore. In case of a split smaller than initial
-                # quantity and fully reserved
-                if quantity and not move_line.move_id._should_bypass_reservation():
-                    self.env['stock.quant']._update_reserved_quantity(
-                        move_line.product_id, move_line.location_id, -quantity,
-                        lot_id=move_line.lot_id, package_id=move_line.package_id,
-                        owner_id=move_line.owner_id, strict=True)
-
             if move and move_qty_to_reserve != move.product_qty:
                 partially_assigned_moves.add(move.id)
 

--- a/addons/mrp/tests/test_smp.py
+++ b/addons/mrp/tests/test_smp.py
@@ -246,6 +246,56 @@ class TestMrpSerialMassProduce(TestMrpCommon):
         mo.procurement_group_id.mrp_production_ids.button_mark_done()
         self.assertEqual(mo.procurement_group_id.mrp_production_ids.mapped('state'), ['done', 'done'])
 
+    def test_mass_produce_with_tracked_product_3(self):
+        """
+        Check that the components are correclty reserved during mass
+        production of a tracked product.
+        """
+        warehouse = self.warehouse_1
+        warehouse.manufacture_steps = 'pbm'
+        mo = self.generate_mo(tracking_final='serial', qty_final=8, qty_base_1=1, qty_base_2=1, picking_type_id=warehouse.manu_type_id)[0]
+        comp1, comp2 = mo.move_raw_ids.mapped('product_id')
+        self.env['stock.quant']._update_available_quantity(comp1, mo.warehouse_id.lot_stock_id, 10)
+        self.env['stock.quant']._update_available_quantity(comp2, mo.warehouse_id.lot_stock_id, 10)
+        # delivery only partially comp2 to preproduction
+        picking = mo.picking_ids
+        move1, move2 = picking.move_ids
+        move1.quantity = 8.0
+        move2.quantity = 10.0
+        picking.move_ids.picked = True
+        picking.button_validate()
+        self.assertEqual(picking.state, 'done')
+        quant1 = move1.product_id.stock_quant_ids.filtered(lambda q: q.location_id == warehouse.pbm_loc_id)
+        self.assertRecordValues(quant1, [{'quantity': 8.0, 'reserved_quantity': 8.0}])
+        quant2 = move2.product_id.stock_quant_ids.filtered(lambda q: q.location_id == warehouse.pbm_loc_id)
+        self.assertRecordValues(quant2, [{'quantity': 10.0, 'reserved_quantity': 8.0}])
+        # Mass produce 3 serial numbers instead of 5 with no backorder
+        action = mo.action_serial_mass_produce_wizard()
+        wizard = Form(self.env['stock.assign.serial'].with_context(**action['context']))
+        wizard.next_serial_number = "sn#5"
+        wizard.next_serial_count = 3
+        action = wizard.save().generate_serial_numbers_production()
+        # Reload the wizard to apply generated serial numbers
+        wizard = Form(self.env['stock.assign.serial'].browse(action['res_id']))
+        wizard.save().no_backorder()
+        # Initial MO should have a backorder-sequenced name and be in to_close state
+        self.assertIn("-001", mo.name)
+        self.assertEqual(mo.state, "to_close")
+        # Each generated serial number should have its own mo
+        self.assertEqual(mo.procurement_group_id.mrp_production_ids.lot_producing_id.mapped('name'), ["sn#5", "sn#6", "sn#7"])
+        # Check the quants quantities between MO's validation
+        self.assertRecordValues(quant1, [{'quantity': 8.0, 'reserved_quantity': 3.0}])
+        self.assertRecordValues(quant2, [{'quantity': 10.0, 'reserved_quantity': 3.0}])
+        mo.button_mark_done()
+        self.assertRecordValues(quant1, [{'quantity': 7.0, 'reserved_quantity': 2.0}])
+        self.assertRecordValues(quant2, [{'quantity': 9.0, 'reserved_quantity': 2.0}])
+        other_mos = (mo.procurement_group_id.mrp_production_ids - mo)
+        other_mos.move_raw_ids.quantity = 1.0
+        other_mos.move_raw_ids.picked = True
+        other_mos.button_mark_done()
+        self.assertRecordValues(quant1, [{'quantity': 5.0, 'reserved_quantity': 0.0}])
+        self.assertRecordValues(quant2, [{'quantity': 7.0, 'reserved_quantity': 0.0}])
+
     def test_smp_produce_with_consumable_component(self):
         """Create a MO for a product tracked by serial number with a consumable component.
         Open the smp wizard, You should be able to generate all serial numbers.


### PR DESCRIPTION
### Steps to reproduce:

- Enable Multi-Step Routes
- Inventory > Configuration > Warehouse Management > Warehouses
- Change your warehouse settings to Manufacturing in 2 steps
- Create a product P tracked by serial number with a BOM: - 1 x COMP (a storable product with 10 units in stock)
- Create and confirm an MO for 10 units of P
- Validate the delivery from stock to pre-production
- Click on `Mass Produce` > `Generate` only 7 SN
- Click No back order (split and generate only 7 MO's)
#### > Looking at the quant of the product you see that 0 units are reserved in pre-production but 7 should be
- validate one of the 7 MO
#### > Looking at the quant of the product you see that -1 units are reserved in pre-production but 6 should be

### Cause of the issue:

By processing the "Mass produce" wizzard you will call the `_assign_serial_numbers` method and hence the `split_productions`: https://github.com/odoo/odoo/blob/af4055e2ccce399f94bc465e2dd529c9f14953e0/addons/mrp/wizard/stock_assign_serial_numbers.py#L65-L68 During this `split_productions` call, the quant reserved quantity will be updated by these lines:
https://github.com/odoo/odoo/blob/af4055e2ccce399f94bc465e2dd529c9f14953e0/addons/mrp/models/mrp_production.py#L1931-L1938 However, since the stock pocalypse, the quant is already updated once you write and change the quantity of the stock move line of the raw move of the inital MO because of these lines:
https://github.com/odoo/odoo/blob/af4055e2ccce399f94bc465e2dd529c9f14953e0/addons/stock/models/stock_move_line.py#L437-L439 Hence, the `stock.quant` reserved quantity will end up to be updated twice

opw-4145680
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
