### PR TITLE
[FIX] spreadsheet_account: Fix ODOO.BALANCE offset computation

### DIFF
--- a/addons/spreadsheet_account/static/src/accounting_datasource.js
+++ b/addons/spreadsheet_account/static/src/accounting_datasource.js
@@ -2,6 +2,7 @@
 import { camelToSnakeObject, toServerDateString } from "@spreadsheet/helpers/helpers";
 import { _t } from "@web/core/l10n/translation";
 import { sprintf } from "@web/core/utils/strings";
+import { deepCopy } from "@web/core/utils/objects";
 
 import { ServerData } from "@spreadsheet/data_sources/server_data";
 
@@ -81,6 +82,7 @@ export class AccountingDataSource {
      * @returns {{ debit: number, credit: number }}
      */
     _fetchAccountData(codes, dateRange, offset, companyId, includeUnposted) {
+        dateRange = deepCopy(dateRange);
         dateRange.year += offset;
         // Excel dates start at 1899-12-30, we should not support date ranges
         // that do not cover dates prior to it.

--- a/addons/spreadsheet_account/static/tests/model/accounting_tests.js
+++ b/addons/spreadsheet_account/static/tests/model/accounting_tests.js
@@ -141,7 +141,6 @@ QUnit.module("spreadsheet_account > Accounting", { beforeEach }, () => {
                         assert.step(JSON.stringify(blob));
                     }
                 }
-                return [];
             },
         });
         setCellContent(model, "A1", `=ODOO.BALANCE("100", "2022")`);
@@ -153,6 +152,7 @@ QUnit.module("spreadsheet_account > Accounting", { beforeEach }, () => {
         setCellContent(model, "A7", `=ODOO.DEBIT("5", "05/04/2021", 1)`);
         setCellContent(model, "A8", `=ODOO.BALANCE("5", "2022",,,FALSE)`);
         setCellContent(model, "A9", `=ODOO.BALANCE("100", "05/05/2022",,,TRUE)`);
+        setCellContent(model, "A10", `=ODOO.BALANCE(33,2021,-2)`);
         await waitForDataSourcesLoaded(model);
 
         assert.verifySteps([
@@ -218,6 +218,14 @@ QUnit.module("spreadsheet_account > Accounting", { beforeEach }, () => {
                     codes: ["100"],
                     companyId: null,
                     includeUnposted: true,
+                })
+            ),
+            JSON.stringify(
+                camelToSnakeObject({
+                    dateRange: parseAccountingDate("2019"),
+                    codes: ["33"],
+                    companyId: null,
+                    includeUnposted: false,
                 })
             ),
         ]);


### PR DESCRIPTION
The computation of ODOO.BALANCE with year offsets was wrong as we would apply the offset once to query the debit data and TWICE when querying the credit data, making the computation of the delta completely meaningless.

Task-4207414

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
