### PR TITLE
[FIX] web_editor: remove dialog previews when replacing outdated snippet

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -9349,6 +9349,8 @@ registry.VersionControl = SnippetOptionWidget.extend({
                 newBlockEl = snippet.baseBody.cloneNode(true);
             },
         });
+        // Removing the eventual dialog previews.
+        newBlockEl.querySelectorAll(".s_dialog_preview").forEach(previewEl => previewEl.remove());
         // Replacing the block.
         this.options.wysiwyg.odooEditor.historyPauseSteps();
         this.$target[0].classList.add("d-none"); // Hiding the block to replace it smoothly.


### PR DESCRIPTION
Since commit [1], the snippets are dropped by using a snippets dialog. In order for dynamic elements to be visible in the modal, fake previews are used. They are then removed once the snippet is dropped. These previews can be recognized by their `s_dialog_preview` class.

When a snippet is deprecated, a message is displayed in the right panel, informing that it is outdated and allowing to therefore replace it by its new version. However, in the case where the new version would have a dialog preview in it, this preview would not be removed.

This commit handles the dialog previews removal when replacing an outdated snippet.

[1]: https://github.com/odoo/odoo/commit/edf81c13d8f2f6d29a77d68cbfa0dc9216da3c2a

task-4185274