### PR TITLE
[IMP] pos_event: attended status if badge printed

### DIFF
--- a/addons/pos_event/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/pos_event/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -9,6 +9,7 @@ patch(ReceiptScreen.prototype, {
         super.setup(...arguments);
 
         this.report = useService("report");
+        this.orm = useService("orm");
         this.doPrintEventFull = useTrackedAsync(() => this.printEventFull());
         this.doPrintEventBadge = useTrackedAsync(() => this.printEventBadge());
     },
@@ -48,6 +49,12 @@ patch(ReceiptScreen.prototype, {
                 "event.action_report_event_registration_badge_96x82",
                 smallBadgeRegistrations.map((reg) => reg.id)
             );
+        }
+
+        // Update the status to "attended" if we print the attendee badge
+        if (registrations.length > 0) {
+            const registrationIds = registrations.map((registration) => registration.id);
+            await this.orm.write("event.registration", registrationIds, { state: "done" });
         }
     },
 });


### PR DESCRIPTION
Before, when we were selling event tickets through pos_event the attendee weren't set as "attended" if we were printing their badges.

This PR makes it so that if the ticket is sold through pos_event and the attendee badge is printed, the attendee is automatically set as "attended" instead of the "registered" status as it was previously done


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
