### PR TITLE
[FIX] web_editor: enable the use of "|" in form field

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -563,7 +563,11 @@ const UserValueWidget = publicWidget.Widget.extend({
                 this._triggerWidgetsValues.push(...dataValue.split(/\s*,\s*/g));
             } else if (validMethodNames.includes(key)) {
                 this._methodsNames.push(key);
-                this._methodsParams.optionsPossibleValues[key] = dataValue.split(/\s*\|\s*/g);
+                if (this._methodsParams.noSplit) {
+                    this._methodsParams.optionsPossibleValues[key] = [dataValue];
+                } else {
+                    this._methodsParams.optionsPossibleValues[key] = dataValue.split(/\s*\|\s*/g);
+                }
             } else {
                 this._methodsParams[key] = dataValue;
             }

--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -1496,6 +1496,7 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
                     && inputEl.name !== this.$target[0].querySelector(".s_website_form_input")?.name
                     && !existingDependencyNames.includes(inputEl.name) && !this._findCircular(el)) {
                 const button = document.createElement('we-button');
+                button.dataset.noSplit = true;
                 button.textContent = el.querySelector('.s_website_form_label_content').textContent;
                 button.dataset.setVisibilityDependency = inputEl.name;
                 selectDependencyEl.append(button);


### PR DESCRIPTION
Before this commit, after selecting a field containing the char "|"
for conditional display, the field on which the condition is set will
never appear again.

This commit enable the use of any characters in form fields

Steps to reproduce the bug:
- Add a form
- Add two fields (A and B)
- Rename the field A with a string that contains "|"
- Set the field B visibility to "Visible only if"
- Set the field A as the visibility condition for field B
(field B visible only if field A contains 'hello', for example)
- Save the changes
- Complete the field A according to the visibility condition
(The second field does not appear)

task-3893749