### PR TITLE
[16.0][FIX] account: Avoid recomputation overwriting bank account

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -417,6 +417,9 @@ class AccountPayment(models.Model):
     def _compute_partner_bank_id(self):
         ''' The default partner_bank_id will be the first available on the partner. '''
         for pay in self:
+            # Avoid overwriting existing value
+            if pay.partner_bank_id and pay.partner_bank_id in pay.available_partner_bank_ids:
+                continue
             pay.partner_bank_id = pay.available_partner_bank_ids[:1]._origin
 
     @api.depends('partner_id', 'journal_id', 'destination_journal_id')


### PR DESCRIPTION
In case an extra dependency is added to the api.depends decorator of account.move._compute_journal_id, account.payment.partner_bank_id is going to be recomputed, potentially overwriting existing value.

Steps to reproduce:
1. Install a module adding a dependency to account.move._compute_journal_id
2. Create a vendor bill with a partner having more than one bank account
3. Register payment using another bank account than the first one

The created payment would then have its bank account recomputed.

By testing for an existing value in the compute function before assigning the first bank account of the partner, we ensure any manually defined value will not be overwritten through unwanted recomputation.


For context:
https://github.com/OCA/sale-workflow/pull/3321


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
