### PR TITLE
[FIX] website: fix the card of the `s_cta_card` snippet

### DIFF
--- a/addons/website/views/snippets/s_cta_card.xml
+++ b/addons/website/views/snippets/s_cta_card.xml
@@ -11,7 +11,7 @@
                     <p class="lead">Join us and make your company a better place.</p>
                 </div>
                 <div class="col-lg-4">
-                    <div class="s_card card o_cc o_cc1 mx-auto shadow" data-name="Card" style="border-width: 0; max-width: 50%" data-vcss="001">
+                    <div class="s_card card o_cc o_cc1 mx-auto shadow" data-snippet="s_card" data-name="Card" data-vxml="001" style="border-width: 0px !important; max-width: 50%">
                         <div class="card-body p-4">
                             <h5 class="card-title">What you will get</h5>
                             <br/>


### PR DESCRIPTION
In commit [1], the new `s_cta_card` snippet has been added. It uses the `s_card` inner snippet.

This commit fixes the card:
- add the missing `data-snippet` attribute,
- fix the versioning: indeed, it was using `data-vcss` while the inner snippet in fact uses `data-vxml`. This caused the card background colors to be washed out, instead of being the real selected color.
- fix the `border-width` style: it was missing the `px` unit and the `!important` that would be added if we used the option to set it.

[1]: https://github.com/odoo/odoo/commit/4b88c63a96e84f5a603eea35fee3a395fbb4aae3

Related to task-4094392