### PR TITLE
[FIX] web: issue with BarcodeVideoScanner

### DIFF
--- a/addons/web/static/src/core/barcode/barcode_video_scanner.js
+++ b/addons/web/static/src/core/barcode/barcode_video_scanner.js
@@ -21,6 +21,7 @@ export class BarcodeVideoScanner extends Component {
             validate: (fm) => ["environment", "left", "right", "user"].includes(fm),
         },
         close: { type: Function, optional: true },
+        onReady: { type: Function, optional: true },
         onResult: Function,
         onError: Function,
         delayBetweenScan: { type: Number, optional: true },
@@ -77,6 +78,12 @@ export class BarcodeVideoScanner extends Component {
                 this.props.onError(new Error(errorMessage));
                 return;
             }
+            if (!this.videoPreviewRef.el) {
+                this.cleanStreamAndTimeout();
+                const errorMessage = _t("Barcode Video Scanner could not be mounted properly.");
+                this.props.onError(new Error(errorMessage));
+                return;
+            }
             this.videoPreviewRef.el.srcObject = this.stream;
             await this.isVideoReady();
             const { height, width } = getComputedStyle(this.videoPreviewRef.el);
@@ -91,14 +98,16 @@ export class BarcodeVideoScanner extends Component {
             this.detectorTimeout = setTimeout(this.detectCode.bind(this), 100);
         });
 
-        onWillUnmount(() => {
-            clearTimeout(this.detectorTimeout);
-            this.detectorTimeout = null;
-            if (this.stream) {
-                this.stream.getTracks().forEach((track) => track.stop());
-                this.stream = null;
-            }
-        });
+        onWillUnmount(() => this.cleanStreamAndTimeout());
+    }
+
+    cleanStreamAndTimeout() {
+        clearTimeout(this.detectorTimeout);
+        this.detectorTimeout = null;
+        if (this.stream) {
+            this.stream.getTracks().forEach((track) => track.stop());
+            this.stream = null;
+        }
     }
 
     isZXingBarcodeDetector() {
@@ -116,6 +125,9 @@ export class BarcodeVideoScanner extends Component {
             await delay(10);
         }
         this.state.isReady = true;
+        if (this.props.onReady) {
+            this.props.onReady();
+        }
     }
 
     onResize(overlayInfo) {
@@ -157,7 +169,7 @@ export class BarcodeVideoScanner extends Component {
         } catch (err) {
             this.props.onError(err);
         }
-        if (!barcodeDetected || !this.props.delayBetweenScan) {
+        if (this.stream && (!barcodeDetected || !this.props.delayBetweenScan)) {
             this.detectorTimeout = setTimeout(this.detectCode.bind(this), 100);
         }
     }

--- a/addons/web/static/src/core/barcode/barcode_video_scanner.js
+++ b/addons/web/static/src/core/barcode/barcode_video_scanner.js
@@ -144,30 +144,31 @@ export class BarcodeVideoScanner extends Component {
      */
     async detectCode() {
         let barcodeDetected = false;
+        let codes = [];
         try {
-            const codes = await this.detector.detect(this.videoPreviewRef.el);
-            for (const code of codes) {
-                if (
-                    !this.isZXingBarcodeDetector() &&
-                    this.overlayInfo.x !== undefined &&
-                    this.overlayInfo.y !== undefined
-                ) {
-                    const { x, y, width, height } = this.adaptValuesWithRatio(code.boundingBox);
-                    if (
-                        x < this.overlayInfo.x ||
-                        x + width > this.overlayInfo.x + this.overlayInfo.width ||
-                        y < this.overlayInfo.y ||
-                        y + height > this.overlayInfo.y + this.overlayInfo.height
-                    ) {
-                        continue;
-                    }
-                }
-                barcodeDetected = true;
-                this.barcodeDetected(code.rawValue);
-                break;
-            }
+            codes = await this.detector.detect(this.videoPreviewRef.el);
         } catch (err) {
             this.props.onError(err);
+        }
+        for (const code of codes) {
+            if (
+                !this.isZXingBarcodeDetector() &&
+                this.overlayInfo.x !== undefined &&
+                this.overlayInfo.y !== undefined
+            ) {
+                const { x, y, width, height } = this.adaptValuesWithRatio(code.boundingBox);
+                if (
+                    x < this.overlayInfo.x ||
+                    x + width > this.overlayInfo.x + this.overlayInfo.width ||
+                    y < this.overlayInfo.y ||
+                    y + height > this.overlayInfo.y + this.overlayInfo.height
+                ) {
+                    continue;
+                }
+            }
+            barcodeDetected = true;
+            this.barcodeDetected(code.rawValue);
+            break;
         }
         if (this.stream && (!barcodeDetected || !this.props.delayBetweenScan)) {
             this.detectorTimeout = setTimeout(this.detectCode.bind(this), 100);

--- a/addons/web/static/tests/webclient/barcode/barcode_scanner.test.js
+++ b/addons/web/static/tests/webclient/barcode/barcode_scanner.test.js
@@ -104,3 +104,34 @@ test("Barcode scanner crop overlay", async () => {
         { x: 0, y: 0, width: 250, height: 250 },
     ]);
 });
+
+test("BarcodeVideoScanner onReady props", async () => {
+    function mockUserMedia() {
+        const canvas = document.createElement("canvas");
+        const ctx = canvas.getContext("2d");
+        const stream = canvas.captureStream();
+        canvas.width = 250;
+        canvas.height = 250;
+        ctx.strokeStyle = "black";
+        ctx.fillStyle = "white";
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        return stream;
+    }
+    // Simulate an environment with a camera/webcam.
+    patchWithCleanup(browser.navigator, {
+        mediaDevices: {
+            getUserMedia: mockUserMedia,
+        },
+    });
+    const resolvedOnReadyPromise = new Promise((resolve) => {
+        mountWithCleanup(BarcodeVideoScanner, {
+            props: {
+                facingMode: "environment",
+                onReady: () => resolve(true),
+                onResult: () => {},
+                onError: () => {},
+            },
+        });
+    });
+    expect(await resolvedOnReadyPromise).toBe(true);
+});


### PR DESCRIPTION
This commit changes two things:

1. Adds `onReady` props to be able to call a method when the video scanner is ready. In the Barcode app for example, this prop will let us to prevent to close the camera during its initialization.

2. Avoids to set a timeout for `detectCode` if there is no more stream. Without this change, it could happens something goes wrong when closing the camera video scanner and then, it will loop infinitly on `detectCode` because the timeout code part is outside of the try/catch and so it is called anyway everytime `detectCode` is run.

Enterprise PR: odoo/enterprise#70607