### PR TITLE
[FIX] mail: create thread from message does not show <p>

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
@@ -85,9 +85,9 @@ patch(Thread.prototype, {
         return super.notifyOnLeave && !this.parent_channel_id;
     },
     /**
-     * @param {*} param0
+     * @param {Object} [param0={}]
      * @param {import("models").Message} [param0.initialMessage]
-     * @param {string} [param0.searchTerm]
+     * @param {string} [param0.name]
      */
     async createSubChannel({ initialMessage, name } = {}) {
         const { data, sub_channel } = await rpc("/discuss/channel/sub_channel/create", {
@@ -95,7 +95,7 @@ patch(Thread.prototype, {
             from_message_id: initialMessage?.id,
             name,
         });
-        this.store.insert(data);
+        this.store.insert(data, { html: true });
         this.store.Thread.get(sub_channel).open();
     },
     /**

--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -158,6 +158,18 @@ export function onRpcBefore(route, callback) {
     }
 }
 
+/**
+ * Register a callback to be executed just before end of an RPC request being processed.
+ * Useful to do all server processing but delay the response received by web client.
+ *
+ * @param {string} route the route to put callback just before returning response.
+ * @param {Function} callback - The function to execute just before the end of RPC call.
+ */
+export function onRpcAfter(route, callback) {
+    const handler = registry.category("mock_rpc").get(route);
+    patchWithCleanup(handler, { after: callback });
+}
+
 let archs = {};
 export function registerArchs(newArchs) {
     archs = newArchs;

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -12,6 +12,7 @@ import { serializeDateTime, today } from "@web/core/l10n/dates";
 import { ensureArray } from "@web/core/utils/arrays";
 import { uniqueId } from "@web/core/utils/functions";
 import { DEFAULT_MAIL_SEARCH_ID, DEFAULT_MAIL_VIEW_ID } from "./constants";
+import { convertBrToLineBreak } from "@mail/utils/common/format";
 
 const { DateTime } = luxon;
 
@@ -582,7 +583,9 @@ export class DiscussChannel extends models.ServerModel {
                 channel_type: "channel",
                 group_public_id: self.group_public_id,
                 from_message_id: message?.id,
-                name: message ? message.body.substring(0, 30) : name || "New Thread",
+                name: message
+                    ? convertBrToLineBreak(message.body).substring(0, 30)
+                    : name || "New Thread",
                 parent_channel_id: self.id,
             })
         );


### PR DESCRIPTION
Before this commit, creating a thread from a message was sometimes showing the html tags of the message in text content.

Steps to reproduce:
- Open general channel
- Post a message
- Set "slow 4g" network performance
- Create a thread from the message => It opens the sub channel with the message, but the
   message and thread name title shows HTML tags like `<p>`

This happens due to missing of `store.insert({ html: true })`, which this commit fixes.

Task-4207900

Before
![Sep-24-2024 19-24-16](https://github.com/user-attachments/assets/83cca087-14bf-470f-ae5b-c77020008698)
After
![Sep-24-2024 19-26-04](https://github.com/user-attachments/assets/ad7a0157-026e-4432-a16e-2e2cd1fe712a)
