### PR TITLE
[FIX] portal, *: make sure chatter bundle is loaded before ending the tour

### DIFF
--- a/addons/portal/static/src/chatter/frontend/portal_chatter_service.js
+++ b/addons/portal/static/src/chatter/frontend/portal_chatter_service.js
@@ -60,7 +60,6 @@ export class PortalChatterService {
                 dev: env.debug,
             }).mount(shadow);
         });
-        odoo.portalChatterReady.resolve(true);
         const thread = this.store.Thread.insert({ model: props.resModel, id: props.resId });
         Object.assign(thread, {
             access_token: chatterEl.getAttribute("data-token"),
@@ -77,6 +76,7 @@ export class PortalChatterService {
             { silent: true }
         );
         this.store.insert(data);
+        odoo.portalChatterReady.resolve(true);
     }
 }
 

--- a/addons/website_sale_slides/static/tests/tours/slides_course_member_invited_logged.js
+++ b/addons/website_sale_slides/static/tests/tours/slides_course_member_invited_logged.js
@@ -1,29 +1,42 @@
-/** @odoo-module **/
+import { registry } from "@web/core/registry";
 
-import { registry } from '@web/core/registry';
-
-
-registry.category('web_tour.tours').add('invited_on_payment_course_logged', {
+registry.category("web_tour.tours").add("invited_on_payment_course_logged", {
     test: true,
     steps: () => [
-{
-    trigger: 'a:contains("Add to Cart")',
-    content: 'Check that the course can be bought but not joined',
-    run: function () {
-        if (document.querySelector('.o_wslides_js_course_join_link')) {
-            console.error('The course should not be joinable before buying');
-        }
-    }
-}, {
-    trigger: '.o_wslides_slides_list_slide:contains("Home Gardening")',
-    content: 'Check that non-preview slides are not accessible',
-    run: function () {
-        if (this.anchor.querySelector(".o_wslides_js_slides_list_slide_link")) {
-            console.error('Invited attendee should not access non-preview slides');
-        }
-    }
-}, {
-    trigger: 'a:contains("Gardening: The Know-How")',
-    content: 'Check that preview slides are accessible',
-}
-]});
+        {
+            trigger: 'a:contains("Add to Cart")',
+            content: "Check that the course can be bought but not joined",
+            run: function () {
+                if (document.querySelector(".o_wslides_js_course_join_link")) {
+                    console.error("The course should not be joinable before buying");
+                }
+            },
+        },
+        // Chatter is lazy loading. Wait for it.
+        {
+            trigger: "a[id=review-tab]",
+            run: "click",
+        },
+        {
+            content: "Wait for the whole page to load",
+            trigger: "#chatterRoot:shadow .o-mail-Chatter",
+        },
+        {
+            trigger: "a[id=home-tab]",
+            run: "click",
+        },
+        {
+            trigger: '.o_wslides_slides_list_slide:contains("Home Gardening")',
+            content: "Check that non-preview slides are not accessible",
+            run: function () {
+                if (this.anchor.querySelector(".o_wslides_js_slides_list_slide_link")) {
+                    console.error("Invited attendee should not access non-preview slides");
+                }
+            },
+        },
+        {
+            trigger: 'a:contains("Gardening: The Know-How")',
+            content: "Check that preview slides are accessible",
+        },
+    ],
+});

--- a/addons/website_sale_slides/static/tests/tours/slides_course_member_invited_public.js
+++ b/addons/website_sale_slides/static/tests/tours/slides_course_member_invited_public.js
@@ -1,42 +1,60 @@
-/** @odoo-module **/
+import { registry } from "@web/core/registry";
 
-import { registry } from '@web/core/registry';
-
-
-registry.category('web_tour.tours').add('invited_on_payment_course_public', {
+registry.category("web_tour.tours").add("invited_on_payment_course_public", {
     test: true,
     steps: () => [
-{
-    trigger: '.o_wslides_identification_banner a:contains("Log in")',
-    content: 'Check that there is an identification banner',
-}, {
-    trigger: '.o_wslides_js_course_join a:contains("Log in")',
-    run: function () {
-        if (document.querySelector('.o_wslides_js_course_join #add_to_cart')) {
-            console.error('The course should not be buyable before logging in');
-        }
-    }
-}, {
-    trigger: '.o_wslides_slides_list_slide:contains("Gardening: The Know-How")',
-    run: function () {
-        if (this.anchor.querySelector(".o_wslides_js_slides_list_slide_link")) {
-            console.error('Invited attendee should not access slides, even previews');
-        }
-    }
-}, {
-    trigger: 'a:contains("Log in")',
-    run: "click",
-}, {
-    trigger: 'input[id="password"]',
-    run: "edit portal",
-}, {
-    trigger: 'button:contains("Log in")',
-    run: "click",
-}, {
-    trigger: 'a:contains("Gardening: The Know-How")',
-    content: 'Check that preview slides are now accessible',
-}, {
-    trigger: '.o_wslides_js_course_join:contains("Add to Cart")',
-    content: 'Check that the course can now be bought',
-}
-]});
+        {
+            trigger: '.o_wslides_identification_banner a:contains("Log in")',
+            content: "Check that there is an identification banner",
+        },
+        {
+            trigger: '.o_wslides_js_course_join a:contains("Log in")',
+            run: function () {
+                if (document.querySelector(".o_wslides_js_course_join #add_to_cart")) {
+                    console.error("The course should not be buyable before logging in");
+                }
+            },
+        },
+        {
+            trigger: '.o_wslides_slides_list_slide:contains("Gardening: The Know-How")',
+            run: function () {
+                if (this.anchor.querySelector(".o_wslides_js_slides_list_slide_link")) {
+                    console.error("Invited attendee should not access slides, even previews");
+                }
+            },
+        },
+        {
+            trigger: 'a:contains("Log in")',
+            run: "click",
+        },
+        {
+            trigger: 'input[id="password"]',
+            run: "edit portal",
+        },
+        {
+            trigger: 'button:contains("Log in")',
+            run: "click",
+        },
+        {
+            trigger: 'a:contains("Gardening: The Know-How")',
+            content: "Check that preview slides are now accessible",
+        },
+        // Chatter is lazy loading. Wait for it.
+        {
+            trigger: "a[id=review-tab]",
+            run: "click",
+        },
+        {
+            content: "Wait for the whole page to load",
+            trigger: "#chatterRoot:shadow .o-mail-Chatter",
+        },
+        {
+            trigger: "a[id=home-tab]",
+            run: "click",
+        },
+        {
+            trigger: '.o_wslides_js_course_join:contains("Add to Cart")',
+            content: "Check that the course can now be bought",
+        },
+    ],
+});

--- a/addons/website_slides/static/tests/tours/slide_portal_chatter_bunddle.js
+++ b/addons/website_slides/static/tests/tours/slide_portal_chatter_bunddle.js
@@ -1,0 +1,32 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("portal_chatter_bundle", {
+    test: true,
+    steps: () => [
+        {
+            trigger: 'a:contains("Gardening: The Know-How")',
+            content: "Check that the previews are accessible",
+        },
+        {
+            trigger: "a[id=review-tab]",
+            run: "click",
+        },
+        {
+            content: "Wait for the whole page to load",
+            trigger: "#chatterRoot:shadow .o-mail-Chatter",
+            run: () => {
+                odoo.portalChatterReady.then(() => {
+                    const { missing, failed, unloaded } = odoo.loader.findErrors();
+                    if ([missing, failed, unloaded].some((arr) => arr.length)) {
+                        console.error(
+                            "Couldn't load all JS modules.",
+                            JSON.stringify({ missing, failed, unloaded })
+                        );
+                    } else {
+                        console.log("test successful");
+                    }
+                });
+            },
+        },
+    ],
+});

--- a/addons/website_slides/static/tests/tours/slides_course_member.js
+++ b/addons/website_slides/static/tests/tours/slides_course_member.js
@@ -1,5 +1,3 @@
-/** @odoo-module **/
-
 import { registry } from "@web/core/registry";
 
 /**
@@ -11,132 +9,163 @@ import { registry } from "@web/core/registry";
  * they use fullscreen player to complete the course;
  * they rate the course;
  */
-registry.category("web_tour.tours").add('course_member', {
-    url: '/slides',
+registry.category("web_tour.tours").add("course_member", {
+    url: "/slides",
     test: true,
     steps: () => [
-// eLearning: go on free course and join it
-{
-    trigger: 'a:contains("Basics of Gardening - Test")',
-    run: "click",
-}, {
-    trigger: 'a:contains("Join this Course")',
-    run: "click",
-}, {
-    // check membership
-    trigger: '.o_wslides_js_course_join:contains("You\'re enrolled")',
-}, {
-    trigger: 'a:contains("Gardening: The Know-How")',
-    run: "click",
-},
-// eLearning: follow course by cliking on first lesson and going to fullscreen player
-{
-    trigger: '.o_wslides_fs_slide_name:contains("Home Gardening")',
-    run: 'click',
-},
-// eLearning: share the first slide
-{
-    trigger: '.o_wslides_fs_share',
-    run: "click",
-}, {
-    trigger: '.o_wslides_js_share_email input',
-    run: "edit friend@example.com",
-}, {
-    trigger: '.o_wslides_js_share_email button',
-    run: "click",
-}, {
-    // check email has been sent
-    trigger: '.o_wslides_js_share_email:contains("Sharing is caring")',
-}, {
-    trigger: '.modal-footer button:contains("Close")',
-    run: "click",
-},
-// eLeaning: course completion
-{
-    trigger: '.o_wslides_fs_sidebar_header',
-    run: "press ArrowLeft",
-},
-{
-    trigger: ".o_wslides_fs_sidebar_list_item.active:contains(Gardening: The Know-How)",
-},
-{
-    trigger: '.o_wslides_progress_percentage:contains("40")',
-    run: "press ArrowRight",
-},
-{
-    trigger: ".o_wslides_fs_sidebar_list_item.active:contains(Home Gardening)",
-},
-{
-    // check progression
-    trigger: '.o_wslides_progress_percentage:contains("40")',
-    run: "press ArrowRight",
-},
-{
-    trigger: ".o_wslides_fs_sidebar_list_item.active:contains(Mighty Carrots)",
-},
-{
-    // check progression
-    trigger: '.o_wslides_progress_percentage:contains("60")',
-},
-{
-    trigger: '.o_wslides_fs_slide_name:contains("How to Grow and Harvest The Best Strawberries | Basics")',
-    run: 'click',
-}, {
-    // check that video slide is marked as 'done'
-    trigger: '.o_wslides_fs_sidebar_section_slides li:contains("How to Grow and Harvest The Best Strawberries | Basics") .o_wslides_slide_completed',
-}, {
-    // check progression
-    trigger: '.o_wslides_progress_percentage:contains("80")',
-},
-// eLearning: last slide is a quiz, complete it
-{
-    trigger: '.o_wslides_fs_slide_name:contains("Test your knowledge")',
-    run: 'click',
-}, {
-    trigger: '.o_wslides_js_lesson_quiz_question:first .list-group a:first',
-    run: "click",
-}, {
-    trigger: '.o_wslides_js_lesson_quiz_question:last .list-group a:first',
-    run: "click",
-}, {
-    trigger: '.o_wslides_js_lesson_quiz_submit',
-    run: "click",
-}, {
-    // check that we have a properly motivational message to motivate us!
-    trigger: '.o_wslides_quiz_modal_rank_motivational > div > div:contains("Reach the next rank and gain a very nice mug!")',
-    run: "click",
-}, {
-    trigger: 'a:contains("End course")',
-    run: "click",
-},
-// eLearning: ending course redirect to /slides, course is completed now
-{
-    // check that the course is marked as completed
-    trigger: 'div:contains("Basics of Gardening") span:contains("Completed")',
-},
-// eLearning: go back on course and rate it (new rate or update it, both should work)
-{
-    trigger: 'a:contains("Basics of Gardening")',
-    run: "click",
-},
-{
-    trigger: 'button[data-bs-target="#ratingpopupcomposer"]',
-    run: "click",
-},
-{
-    trigger: ".modal .modal-body i.fa.fa-star:eq(2)",
-    run: 'click',
-},
-{
-    trigger: ".modal .modal-body textarea",
-    run: "edit This is a great course. Top !",
-},
-{
-    trigger: ".modal button:contains(review)",
-    run: "click",
-},
-{
-    trigger: 'a[id="review-tab"]',
-    run: "click",
-},
-]});
+        // eLearning: go on free course and join it
+        {
+            trigger: 'a:contains("Basics of Gardening - Test")',
+            run: "click",
+        },
+        // Chatter is lazy loading. Wait for it.
+        {
+            trigger: "a[id=review-tab]",
+            run: "click",
+        },
+        {
+            content: "Wait for the whole page to load",
+            trigger: "#chatterRoot:shadow .o-mail-Chatter",
+        },
+        {
+            trigger: "a[id=home-tab]",
+            run: "click",
+        },
+        {
+            trigger: 'a:contains("Join this Course")',
+            run: "click",
+        },
+        {
+            // check membership
+            trigger: '.o_wslides_js_course_join:contains("You\'re enrolled")',
+        },
+        {
+            trigger: 'a:contains("Gardening: The Know-How")',
+            run: "click",
+        },
+        // eLearning: follow course by cliking on first lesson and going to fullscreen player
+        {
+            trigger: '.o_wslides_fs_slide_name:contains("Home Gardening")',
+            run: "click",
+        },
+        // eLearning: share the first slide
+        {
+            trigger: ".o_wslides_fs_share",
+            run: "click",
+        },
+        {
+            trigger: ".o_wslides_js_share_email input",
+            run: "edit friend@example.com",
+        },
+        {
+            trigger: ".o_wslides_js_share_email button",
+            run: "click",
+        },
+        {
+            // check email has been sent
+            trigger: '.o_wslides_js_share_email:contains("Sharing is caring")',
+        },
+        {
+            trigger: '.modal-footer button:contains("Close")',
+            run: "click",
+        },
+        // eLeaning: course completion
+        {
+            trigger: ".o_wslides_fs_sidebar_header",
+            run: "press ArrowLeft",
+        },
+        {
+            trigger: ".o_wslides_fs_sidebar_list_item.active:contains(Gardening: The Know-How)",
+        },
+        {
+            trigger: '.o_wslides_progress_percentage:contains("40")',
+            run: "press ArrowRight",
+        },
+        {
+            trigger: ".o_wslides_fs_sidebar_list_item.active:contains(Home Gardening)",
+        },
+        {
+            // check progression
+            trigger: '.o_wslides_progress_percentage:contains("40")',
+            run: "press ArrowRight",
+        },
+        {
+            trigger: ".o_wslides_fs_sidebar_list_item.active:contains(Mighty Carrots)",
+        },
+        {
+            // check progression
+            trigger: '.o_wslides_progress_percentage:contains("60")',
+        },
+        {
+            trigger:
+                '.o_wslides_fs_slide_name:contains("How to Grow and Harvest The Best Strawberries | Basics")',
+            run: "click",
+        },
+        {
+            // check that video slide is marked as 'done'
+            trigger:
+                '.o_wslides_fs_sidebar_section_slides li:contains("How to Grow and Harvest The Best Strawberries | Basics") .o_wslides_slide_completed',
+        },
+        {
+            // check progression
+            trigger: '.o_wslides_progress_percentage:contains("80")',
+        },
+        // eLearning: last slide is a quiz, complete it
+        {
+            trigger: '.o_wslides_fs_slide_name:contains("Test your knowledge")',
+            run: "click",
+        },
+        {
+            trigger: ".o_wslides_js_lesson_quiz_question:first .list-group a:first",
+            run: "click",
+        },
+        {
+            trigger: ".o_wslides_js_lesson_quiz_question:last .list-group a:first",
+            run: "click",
+        },
+        {
+            trigger: ".o_wslides_js_lesson_quiz_submit",
+            run: "click",
+        },
+        {
+            // check that we have a properly motivational message to motivate us!
+            trigger:
+                '.o_wslides_quiz_modal_rank_motivational > div > div:contains("Reach the next rank and gain a very nice mug!")',
+            run: "click",
+        },
+        {
+            trigger: 'a:contains("End course")',
+            run: "click",
+        },
+        // eLearning: ending course redirect to /slides, course is completed now
+        {
+            // check that the course is marked as completed
+            trigger: 'div:contains("Basics of Gardening") span:contains("Completed")',
+        },
+        // eLearning: go back on course and rate it (new rate or update it, both should work)
+        {
+            trigger: 'a:contains("Basics of Gardening")',
+            run: "click",
+        },
+        {
+            trigger: 'button[data-bs-target="#ratingpopupcomposer"]',
+            run: "click",
+        },
+        {
+            trigger: ".modal .modal-body i.fa.fa-star:eq(2)",
+            run: "click",
+        },
+        {
+            trigger: ".modal .modal-body textarea",
+            run: "edit This is a great course. Top !",
+        },
+        {
+            trigger: ".modal button:contains(review)",
+            run: "click",
+        },
+        {
+            trigger: 'a[id="review-tab"]',
+            run: "click",
+        },
+    ],
+});

--- a/addons/website_slides/static/tests/tours/slides_course_member_invited_logged.js
+++ b/addons/website_slides/static/tests/tours/slides_course_member_invited_logged.js
@@ -1,30 +1,45 @@
-/** @odoo-module **/
+import { registry } from "@web/core/registry";
 
-import { registry } from '@web/core/registry';
-
-
-registry.category('web_tour.tours').add('invite_check_channel_preview_as_logged', {
+registry.category("web_tour.tours").add("invite_check_channel_preview_as_logged", {
     test: true,
     steps: () => [
-{
-    trigger: 'a:contains("Gardening: The Know-How")',
-    content: 'Check that the previews are accessible',
-}, {
-    trigger: '.o_wslides_slides_list_slide:contains("Home Gardening")',
-    content: 'Check that other slides are not accessible',
-    run: function () {
-        if (this.anchor.querySelector(".o_wslides_js_slides_list_slide_link")) {
-            console.error('Invited attendee should not see non-preview slides');
-        }
-    }
-}, {
-    trigger: 'a:contains("Join this Course")',
-    run: "click",
-}, {
-    trigger: '.o_wslides_js_course_join:contains("You\'re enrolled")',
-    content: 'Check that user is enrolled',
-}, {
-    trigger: '.o_wslides_js_slides_list_slide_link:contains("Home Gardening")',
-    content: 'Check that slides are now accessible',
-},
-]});
+        {
+            trigger: 'a:contains("Gardening: The Know-How")',
+            content: "Check that the previews are accessible",
+        },
+        {
+            trigger: '.o_wslides_slides_list_slide:contains("Home Gardening")',
+            content: "Check that other slides are not accessible",
+            run: function () {
+                if (this.anchor.querySelector(".o_wslides_js_slides_list_slide_link")) {
+                    console.error("Invited attendee should not see non-preview slides");
+                }
+            },
+        },
+        {
+            trigger: 'a:contains("Join this Course")',
+            run: "click",
+        },
+        {
+            trigger: '.o_wslides_js_course_join:contains("You\'re enrolled")',
+            content: "Check that user is enrolled",
+        },
+        // Chatter is lazy loading. Wait for it.
+        {
+            trigger: "a[id=review-tab]",
+            run: "click",
+        },
+        {
+            content: "Wait for the whole page to load",
+            trigger: "#chatterRoot:shadow .o-mail-Chatter",
+        },
+        {
+            trigger: "a[id=home-tab]",
+            run: "click",
+        },
+        {
+            trigger: '.o_wslides_js_slides_list_slide_link:contains("Home Gardening")',
+            content: "Check that slides are now accessible",
+        },
+    ],
+});

--- a/addons/website_slides/static/tests/tours/slides_course_member_invited_public.js
+++ b/addons/website_slides/static/tests/tours/slides_course_member_invited_public.js
@@ -1,41 +1,60 @@
-/** @odoo-module **/
+import { registry } from "@web/core/registry";
 
-import { registry } from '@web/core/registry';
-
-
-registry.category('web_tour.tours').add('invite_check_channel_preview_as_public', {
+registry.category("web_tour.tours").add("invite_check_channel_preview_as_public", {
     test: true,
     steps: () => [
-{
-    trigger: '.o_wslides_identification_banner',
-    content: 'Check that there is an identification banner',
-}, {
-    trigger: '.o_wslides_slides_list_slide:contains("Gardening: The Know-How")',
-    run: function () {
-        if (this.anchor.querySelector(".o_wslides_js_slides_list_slide_link")) {
-            console.error('The preview should not allow the public user to browse slides');
-        }
-    }
-}, {
-    trigger: 'a:contains("Join this Course")',
-    run: "click",
-}, {
-    trigger: 'a:contains("login")',
-    run: "click",
-}, {
-    trigger: 'input[id="password"]',
-    run: "edit portal",
-}, {
-    trigger: 'button:contains("Log in")',
-    run: "click",
-}, {
-    trigger: 'a:contains("Join this Course")',
-    run: "click",
-}, {
-    trigger: '.o_wslides_js_course_join:contains("You\'re enrolled")',
-    content: 'Check that user is enrolled',
-}, {
-    trigger: '.o_wslides_js_slides_list_slide_link:contains("Gardening: The Know-How")',
-    content: 'Check that slides are now accessible',
-}
-]});
+        {
+            trigger: ".o_wslides_identification_banner",
+            content: "Check that there is an identification banner",
+        },
+        {
+            trigger: '.o_wslides_slides_list_slide:contains("Gardening: The Know-How")',
+            run: function () {
+                if (this.anchor.querySelector(".o_wslides_js_slides_list_slide_link")) {
+                    console.error("The preview should not allow the public user to browse slides");
+                }
+            },
+        },
+        {
+            trigger: 'a:contains("Join this Course")',
+            run: "click",
+        },
+        {
+            trigger: 'a:contains("login")',
+            run: "click",
+        },
+        {
+            trigger: 'input[id="password"]',
+            run: "edit portal",
+        },
+        {
+            trigger: 'button:contains("Log in")',
+            run: "click",
+        },
+        // Chatter is lazy loading. Wait for it.
+        {
+            trigger: "a[id=review-tab]",
+            run: "click",
+        },
+        {
+            content: "Wait for the whole page to load",
+            trigger: "#chatterRoot:shadow .o-mail-Chatter",
+        },
+        {
+            trigger: "a[id=home-tab]",
+            run: "click",
+        },
+        {
+            trigger: 'a:contains("Join this Course")',
+            run: "click",
+        },
+        {
+            trigger: '.o_wslides_js_course_join:contains("You\'re enrolled")',
+            content: "Check that user is enrolled",
+        },
+        {
+            trigger: '.o_wslides_js_slides_list_slide_link:contains("Gardening: The Know-How")',
+            content: "Check that slides are now accessible",
+        },
+    ],
+});

--- a/addons/website_slides/tests/test_load_chatter_bundle.py
+++ b/addons/website_slides/tests/test_load_chatter_bundle.py
@@ -7,25 +7,4 @@ from odoo.addons.website_slides.tests.test_ui_wslides import TestUiMemberInvited
 @tests.tagged("-at_install", "post_install")
 class TestPortalChatterLoadBundle(TestUiMemberInvited):
     def test_load_modules(self):
-        self.channel.visibility = "members"
-        check_js_modules = """
-                    odoo.portalChatterReady.then(() => {
-                        const { missing, failed, unloaded } = odoo.loader.findErrors();
-                        if ([missing, failed, unloaded].some(arr => arr.length)) {
-                            console.error("Couldn't load all JS modules.", JSON.stringify({ missing, failed, unloaded }));
-                        } else {
-                            console.log("test successful");
-                        }
-                        Object.assign(console, {
-                            log: () => {},
-                            error: () => {},
-                            warn: () => {},
-                        });
-                    })
-                """
-        self.browser_js(
-            self.portal_invite_url,
-            code=check_js_modules,
-            ready="odoo.portalChatterReady",
-            login="portal",
-        )
+        self.start_tour(self.portal_invite_url, "portal_chatter_bundle", login="portal")


### PR DESCRIPTION
Since PR #138233, portal chatter is lazy loaded in the frontend. Some tour tests
 could terminate before the bundle was loaded, resulting in a random Uncaught
 promise error. This commit ensures that the bundle is loaded first.

