### PR TITLE
[FIX] website_slides_survey: remove filter from certification search

### DIFF
--- a/addons/website_slides_survey/views/survey_survey_views.xml
+++ b/addons/website_slides_survey/views/survey_survey_views.xml
@@ -28,6 +28,7 @@
         <field name="mode">primary</field>
         <field name="arch" type="xml">
             <xpath expr='//filter[@name="certification"]' position="replace"/>
+            <xpath expr='//filter[@name="not_certification"]' position="replace"/>
         </field>
     </record>
 


### PR DESCRIPTION
Problem: Surveys can be filtered by whether or not they are also Certifications, based on the boolean field `certification` on the `survey.survey` record. There is a separate menu item to display Certifications only, which uses a Window Action domain filtering for this field being True.

In the inherited search view for Certifications, we already hide the filter for Certifications (since they are). But we still display the filter for non-Certifications, which is pointless given the domain.

Purpose: Hide the additional filter for `Is not a Certification` since it will never return results via the Certification views after the domain filters them out.

opw-4167285
