### PR TITLE
[FIX] account_peppol: Fix pylint undefined-variable / E0602

### DIFF
--- a/addons/account_peppol/models/res_company.py
+++ b/addons/account_peppol/models/res_company.py
@@ -19,7 +19,7 @@ def _cc_checker(country_code, code_type):
 
 
 def _re_sanitizer(expression):
-    return lambda endpoint: (res.group(0) if (res := re.search(expression, endpoint)) else endpoint)
+    return lambda endpoint: (res := re.search(expression, endpoint)) and res.group(0) or endpoint
 
 
 PEPPOL_ENDPOINT_RULES = {


### PR DESCRIPTION
AssertionError: pylint test failed: `Undefined variable 'res' (E0602) at odoo/addons/account_peppol/models/res_company.py:22`

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
