### PR TITLE
[FIX] website_sale_loyalty: hide claim button when no rewards

### DIFF
--- a/addons/website_sale_loyalty/static/src/js/portal_loyalty_card.xml
+++ b/addons/website_sale_loyalty/static/src/js/portal_loyalty_card.xml
@@ -16,7 +16,7 @@
                     <span class="text-primary" t-out="reward.points"/>
                 </div>
             </div>
-            <div class="d-flex justify-content-center">
+            <div t-if="props.rewards.length > 0" class="d-flex justify-content-center">
                 <a
                     t-if="props.program.program_type == 'loyalty'"
                     type="button"


### PR DESCRIPTION
Before the commit:
The button label remained as 'Claim' even when there were no rewards, which
seemed inconsistent.

After this commit:
The button gets hidden when no rewards are available.