### PR TITLE
Master e-commerce description format adaptation

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1324,7 +1324,7 @@
                                     </t>
                                 </a>
                             </t>
-                            <div t-field="product.description_ecommerce" class="oe_structure"
+                            <div t-field="product.description_ecommerce"
                                 placeholder="A detailed, formatted description to promote your product on this page. Use '/' to discover more features."/>
                             <form t-if="product._is_add_to_cart_possible()" action="/shop/cart/update" method="POST">
                                 <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()" t-nocache="The csrf token must always be up to date."/>


### PR DESCRIPTION
Steps to reproduce:
- Open the product page.
- Add an eCommerce description from the frontend and try to edit it using the web editor.

Cause:
The format of the eCommerce description cannot be changed from the frontend.

Fix:
Removed the "oe_structure" class to allow formatting changes from the frontend web editor.

With this fix, users can now modify and format the eCommerce description \ directly from the frontend.
