### PR TITLE
[FIX] sale: hide invoicing policy when product type is combo

### DIFF
--- a/addons/pos_sale/views/product_views.xml
+++ b/addons/pos_sale/views/product_views.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
+    <!-- TODO: remove this view in master -->
     <record id="product_template_form_view" model="ir.ui.view">
         <field name="name">product.template.form.inherit</field>
         <field name="model">product.template</field>

--- a/addons/sale/views/product_views.xml
+++ b/addons/sale/views/product_views.xml
@@ -14,7 +14,11 @@
                 <field name="visible_expense_policy" invisible="1"/>
             </field>
             <field name="type" position="after">
-                <field name="invoice_policy" required="1" invisible="not sale_ok"/>
+                <field
+                    name="invoice_policy"
+                    required="1"
+                    invisible="not sale_ok or type == 'combo'"
+                />
             </field>
             <field name="service_tracking" position="attributes">
                 <attribute name="invisible" add="not sale_ok" separator="or"/>


### PR DESCRIPTION
Issue:
- The invoicing policy field is displayed for all product types, including combo products.

Fix:
- Hide invoicing policy field for products of type 'combo'.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
