### PR TITLE
[FIX] google_calendar: prevent error when set a meeting for all day

### DIFF
--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -70,7 +70,7 @@ class GoogleSync(models.AbstractModel):
 
         result = super().write(vals)
         for record in self.filtered('need_sync'):
-            if record.google_id:
+            if record.id and record.google_id:
                 record.with_user(record._get_event_user())._google_patch(google_service, record.google_id, record._google_values(), timeout=3)
 
         return result


### PR DESCRIPTION
Currently, An error is generated when set a meeting for all day, and the record has not been saved yet.

Steps to reproduce:

- Install a 'google_calendar' module.
- Open a setting, And synchronize odoo calendar with Google Calendar [1].Add Client ID and  Client Secret in Google Calendar section.
- Open Calendar, Click on 'Google' to synchronize the calendar with Google Calendar.
- Create a new meeting, Add a 'Meeting Subject' and save it.
- Active the 'All day' boolean. An error occurs in the backend.

```TypeError: Object of type NewId is not JSON serializable```

An error occurs when the system tries to dumps Python Dictionary values to JSON, but dictionary values contain  'NewId' object like <NewId origin=116>.

Link [1]: https://www.odoo.com/documentation/saas-17.4/applications/productivity/calendar/google.html

To handle this issue, add a condition to ensure that synchronization happens with Google Calendar only after the edited record has been successfully saved.

Sentry-5857711296

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
