### PR TITLE
[FIX] account: install l10n_fr for monaco companies

### DIFF
--- a/addons/account/__init__.py
+++ b/addons/account/__init__.py
@@ -44,6 +44,8 @@ def _auto_install_l10n(env):
         elif country_code == 'DE':
             module_list.append('l10n_de_skr03')
             module_list.append('l10n_de_skr04')
+        elif country_code == 'MC':
+            module_list.append('l10n_fr')
         else:
             if env['ir.module.module'].search([('name', '=', 'l10n_' + country_code.lower())]):
                 module_list.append('l10n_' + country_code.lower())


### PR DESCRIPTION
Monaco is sharing the same CoA as France, therefore
we should use l10n_fr when installing account
with a company from Monaco.

opw-4197369
