### PR TITLE
[FIX] web_editor: chatgpt prompt hitting twice

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_prompt_dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_prompt_dialog.js
@@ -49,7 +49,9 @@ export class ChatGPTPromptDialog extends ChatGPTDialog {
     onTextareaKeydown(ev) {
         if (ev.key === 'Enter' && !ev.shiftKey) {
             ev.stopImmediatePropagation();
-            this.submitPrompt(ev);
+            if (this.state.prompt.trim().length) {
+                this.submitPrompt(ev);
+            }
         }
     }
     submitPrompt(ev) {

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_prompt_dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_prompt_dialog.js
@@ -48,6 +48,7 @@ export class ChatGPTPromptDialog extends ChatGPTDialog {
 
     onTextareaKeydown(ev) {
         if (ev.key === 'Enter' && !ev.shiftKey) {
+            ev.stopImmediatePropagation();
             this.submitPrompt(ev);
         }
     }

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_prompt_dialog.xml
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_prompt_dialog.xml
@@ -71,7 +71,7 @@
                         t-model="state.prompt" required="required"></textarea>
                 </div>
                 <div class="border-start-0 rounded-0 rounded-end-3 align-self-center ms-2 me-3">
-                    <button class="btn" t-att-class="state.prompt.length ? 'btn-success' : 'disabled'" t-on-click="submitPrompt">
+                    <button class="btn" t-att-class="state.prompt.trim().length ? 'btn-success' : 'disabled'" t-on-click="submitPrompt">
                         <i class="fa fa-paper-plane"></i>
                     </button>
                 </div>


### PR DESCRIPTION
**Behaviour before PR:**

- In chatgpt prompt dialog, `submitPrompt` method gets called twice when user presses `ctrl + enter` after writing something. As result chatgpt responds twice with same content. This happens because in `dialog.js` a hotkey service is active on `ctrl + enter` which is responsible to trigger a click event on submit button of dialog and `submitPrompt` gets called second time.
- Moreover, if text-area is empty and user hits `enter` then an empty prompt is sent to chatGPT resulting in a meaningless response.

**Behaviour after PR:**

- Now, `submitPrompt` method gets called once on `ctrl + enter.`
- If text-area is empty then pressing `enter` will not submit prompt.

task-4207108



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
