### PR TITLE
[FIX] spreadsheet_dashboard: Graphs in Mobile view aren't showed correctly

### DIFF
--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/mobile_figure_container/mobile_figure_container.js
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/mobile_figure_container/mobile_figure_container.js
@@ -22,7 +22,6 @@ export class MobileFigureContainer extends Component {
             .map((figure) => ({
                 ...figure,
                 width: window.innerWidth,
-                height: 300,
             }));
     }
 

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/mobile_figure_container/mobile_figure_container.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/mobile_figure_container/mobile_figure_container.xml
@@ -4,11 +4,13 @@
         <t t-if="!figures.length">
             Only chart figures are displayed in small screens but this dashboard doesn't contain any
         </t>
-        <t
+        <div
             t-foreach="figures" t-as="figure"
-            t-component="getFigureComponent(figure)"
-            figure="figure"
-            t-key="figure.id"/>
+            t-key="figure.id"
+            t-attf-style="min-height: #{figure.height}px;"
+        >
+            <t t-component="getFigureComponent(figure)" figure="figure"/>
+        </div>
     </t>
 </templates>
 


### PR DESCRIPTION
When we display more than one chart in the mobile view, the height of the elements is being adjusted to fill 100%, which in some cases causes a size that makes it impossible to view the chart.

![image](https://github.com/user-attachments/assets/68ff7a94-dc92-484b-a96f-f843c00f6449)

To solve this, we have added a div that will encompass the chart and set a minimum height as defined in the spreadsheets, ensuring that the elements are always displayed correctly.

![image](https://github.com/user-attachments/assets/ed1fa34a-7d23-4853-b449-dcc0f95c78bd)

cc @Tecnativa TT50972

ping @chienandalu  @pedrobaeza 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
