### PR TITLE
[FIX] product_margin: prevent error when applying Group by on product margins

### DIFF
--- a/addons/product_margin/models/product_product.py
+++ b/addons/product_margin/models/product_product.py
@@ -89,6 +89,8 @@ class ProductProduct(models.Model):
         return res
 
     def _compute_product_margin_fields_values(self, field_names=None):
+        if not self.ids:
+            return self.browse()
         if field_names is None:
             field_names = []
         date_from = self.env.context.get('date_from', time.strftime('%Y-01-01'))


### PR DESCRIPTION
When there is no product in the database and user applies Group By
on product margins, a traceback will appear.

Steps to reproduce the error:
- Create a database without demo data
- Install ```Accounting``` module
- Go to Accounting > Configuration > Settings > Enable Margin Analysis
- Go to Accounting > Reporting > Product Margins > Click on Open Margins >
  Group By > Select any Group

Traceback:
```
SyntaxError: syntax error at or near ")"
LINE 35:                 WHERE l.product_id IN ()
                                                ^

  File "odoo/http.py", line 2383, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1913, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1976, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1943, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2187, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 227, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 757, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 35, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 459, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/web/models/models.py", line 242, in web_read_group
    groups = self._web_read_group(domain, fields, groupby, limit, offset, orderby, lazy)
  File "addons/web/models/models.py", line 268, in _web_read_group
    groups = self.read_group(domain, fields, groupby, offset=offset, limit=limit,
  File "odoo/models.py", line 2775, in read_group
    rows = self._read_group(domain, annotated_groupby.values(), annotated_aggregates.values(), offset=offset, limit=limit, order=orderby)
  File "addons/product_margin/models/product_product.py", line 77, in _read_group
    all_records._compute_product_margin_fields_values()
  File "addons/product_margin/models/product_product.py", line 149, in _compute_product_margin_fields_values
    self.env.cr.execute(sqlstr, (tuple(self.ids), states, payment_states, invoice_types, date_from, date_to, company_id))
  File "odoo/sql_db.py", line 347, in execute
    res = self._obj.execute(query, params)
```

https://github.com/odoo/odoo/blob/b548452b78c2e5231730f673b263ba92ce036d3b/addons/product_margin/models/product_product.py#L142-L152
Here, when there is no product in the database,
So, ```self.ids``` will be [].
So it will lead to the above traceback.

sentry-5860443914

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
