### PR TITLE
[FIX] mail: remove extra search icon in chatter search panel

### DIFF
--- a/addons/mail/static/src/core/common/search_messages_panel.xml
+++ b/addons/mail/static/src/core/common/search_messages_panel.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.SearchMessagesPanel">
-        <ActionPanel title="env.inChatter ? undefined : title" minWidth="200" initialWidth="400" icon="'oi oi-search'">
+        <ActionPanel title="env.inChatter ? undefined : title" minWidth="200" initialWidth="400" icon="env.inChatter ? false : 'oi oi-search'">
             <div class="d-flex py-2">
                 <div class="input-group">
                     <div class="o_searchview form-control d-flex align-items-center bg-view p-0" role="search" aria-autocomplete="list">

--- a/addons/mail/static/src/discuss/core/common/action_panel.js
+++ b/addons/mail/static/src/discuss/core/common/action_panel.js
@@ -11,14 +11,7 @@ import { useService } from "@web/core/utils/hooks";
 export class ActionPanel extends Component {
     static template = "mail.ActionPanel";
     static components = { ResizablePanel };
-    static props = {
-        icon: { type: String, optional: true },
-        title: { type: String, optional: true },
-        resizable: { type: Boolean, optional: true },
-        slots: { type: Object, optional: true },
-        initialWidth: { type: Number, optional: true },
-        minWidth: { type: Number, optional: true },
-    };
+    static props = ["icon?", "title?", "resizable?", "slots?", "initialWidth?", "minWidth?"];
     static defaultProps = { resizable: true };
 
     setup() {


### PR DESCRIPTION
**Current behavior before PR:**

On clicking the search button on chatter. Extra search icon appears above the search bar

**Desired behavior after PR is merged:**

now after clicking search button on chatter extra icon is removed.

task-4206791

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr