### PR TITLE
[FIX] website: handle BCP 47 language codes to prevent SEO traceback

### DIFF
--- a/addons/website/static/src/components/dialog/seo.js
+++ b/addons/website/static/src/components/dialog/seo.js
@@ -1,5 +1,5 @@
 import { _t } from "@web/core/l10n/translation";
-import { pyToJsLocale } from "@web/core/l10n/utils";
+import { pyToJsLocale, jsToPyLocale } from "@web/core/l10n/utils";
 import { rpc } from "@web/core/network/rpc";
 import { useService, useAutofocus } from '@web/core/utils/hooks';
 import { MediaDialog } from '@web_editor/components/media_dialog/media_dialog';
@@ -154,7 +154,7 @@ class Keyword extends Component {
 
         onMounted(async () => {
             const suggestions = await rpc('/website/seo_suggest', {
-                lang: this.props.language,
+                lang: jsToPyLocale(this.props.language),
                 keywords: this.props.keyword,
             });
             const regex = new RegExp(WORD_SEPARATORS_REGEX + this.props.keyword + WORD_SEPARATORS_REGEX, 'gi');
@@ -216,6 +216,7 @@ class MetaKeywords extends Component {
 
         onWillStart(async () => {
             this.languages = await rpc('/website/get_languages');
+            this.languages = this.languages.map(([code, urlCode, name]) => [pyToJsLocale(code), urlCode, name]);
             this.state.language = this.getLanguage();
         });
     }


### PR DESCRIPTION
Steps to reproduce:

- Go to Website
- Open the menu Site > Optimize SEO
- Try to add some keyword
- Traceback occurs.

Since [1], language codes in the front-end now follow the BCP 47 format.
This commit ensures the proper application of jsToPyLocale and
pyToJsLocale conversions.

[1]: https://github.com/odoo/odoo/commit/42551616dcb563c39b915f2d510217a159668cb7

task-4210172