### PR TITLE
[FIX] account: payment method display name

### DIFF
--- a/addons/account/models/account_payment_method.py
+++ b/addons/account/models/account_payment_method.py
@@ -127,8 +127,11 @@ class AccountPaymentMethodLine(models.Model):
     available_payment_method_ids = fields.Many2many(related='journal_id.available_payment_method_ids')
 
     @api.depends('journal_id')
+    @api.depends_context('hide_payment_journal_id')
     def _compute_display_name(self):
         for method in self:
+            if self.env.context.get('hide_payment_journal_id'):
+                return super()._compute_display_name()
             method.display_name = f"{method.name} ({method.journal_id.name})"
 
     @api.depends('payment_method_id.name')

--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -19,7 +19,7 @@
                     <field name="name"/>
                     <field name="journal_id"/>
                     <field name="company_id" optional="hide" groups="base.group_multi_company"/>
-                    <field name="payment_method_line_id"/>
+                    <field name="payment_method_line_id" context="{'hide_payment_journal_id': 1}"/>
                     <field name="partner_id" string="Customer"/>
                     <field name="amount_signed" string="Amount in Currency" optional="hide" groups="!base.group_multi_currency"/>
                     <field name="amount_signed" string="Amount in Currency" optional="show" groups="base.group_multi_currency"/>
@@ -276,7 +276,9 @@
                                 <field name="journal_id"
                                        domain="[('id', 'in', available_journal_ids)]"
                                        readonly="state != 'draft'"/>
-                                <field name="payment_method_line_id" options="{'no_create': True, 'no_open': True}"
+                                <field name="payment_method_line_id"
+                                       context="{'hide_payment_journal_id': 1}"
+                                       options="{'no_create': True, 'no_open': True}"
                                        required="1"
                                        readonly="state != 'draft'"/>
 

--- a/addons/account/wizard/account_payment_register_views.xml
+++ b/addons/account/wizard/account_payment_register_views.xml
@@ -58,6 +58,7 @@
                         <group name="group1">
                             <field name="journal_id" options="{'no_open': True, 'no_create': True}" required="1"/>
                             <field name="payment_method_line_id"
+                                   context="{'hide_payment_journal_id': 1}"
                                    required="1"  options="{'no_create': True, 'no_open': True}"/>
                             <field name="partner_bank_id"
                                    invisible="not show_partner_bank_account or not can_edit_wizard or (can_group_payments and not group_payment)"


### PR DESCRIPTION
In this pr: https://github.com/odoo/odoo/pull/174537 we have change the display name of the payment method line by adding the name of the journal. But it has changed every view where the payment method line are available. Since we want to have the journal on the groupby of some view, we added a context key to be added when we want to hide the journal.

no task id

enterprise: https://github.com/odoo/enterprise/pull/70622




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
