### PR TITLE
[FIX] calendar: hide week numbers in mobile view

### DIFF
--- a/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.xml
+++ b/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.xml
@@ -43,5 +43,8 @@
                 </t>
             </div>
         </xpath>
+        <xpath expr="//t[@t-elif]//span[hasclass('o_current_week')]" position="attributes">
+            <attribute name="t-if" add="!env.isSmall" separator="and"/>
+        </xpath>
     </t>
 </templates>

--- a/addons/web/static/src/views/calendar/calendar_controller.xml
+++ b/addons/web/static/src/views/calendar/calendar_controller.xml
@@ -48,7 +48,7 @@
                                 <t t-esc="currentMonth"/>
                             </t>
                             <t t-elif="model.meta.scale === 'week'">
-                                <t t-esc="weekHeader"/> <span t-if="model.meta.scale === 'week'" class="badge bg-100 rounded px-1 ms-1">Week <t t-esc="currentWeek"/></span>
+                                <t t-esc="weekHeader"/> <span t-if="model.meta.scale === 'week'" class="o_current_week badge bg-100 rounded px-1 ms-1">Week <t t-esc="currentWeek"/></span>
                             </t>
                             <t t-else="">
                                 <t t-esc="dayHeader" />


### PR DESCRIPTION
Before this PR: Week numbers were shown in the calendar view, but they were truncated on mobile screens.

After this PR: Week numbers are no longer displayed in the calendar view on mobile devices, resulting in a cleaner and more readable layout for mobile users.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
