### PR TITLE
[FIX] website: maintain offset on field edit

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -215,6 +215,12 @@ const FormEditor = options.Class.extend({
         template.content.querySelectorAll("[data-name]").forEach(el => {
             el.dataset.name = this._getQuotesEncodedName(el.dataset.name);
         });
+        // TODO remove this part in master and add offset classes in xml
+        template.content.querySelectorAll('.s_website_form_field').forEach(el => {
+            if (field.formatInfo.offset) {
+                el.classList.add(field.formatInfo.offset);
+            };
+        });
         return template.content.firstElementChild;
     },
 });
@@ -278,6 +284,7 @@ const FieldEditor = FormEditor.extend({
             labelWidth: this.$target[0].querySelector('.s_website_form_label').style.width,
             multiPosition: multipleInput && multipleInput.dataset.display || 'horizontal',
             col: [...this.$target[0].classList].filter(el => el.match(/^col-/g)).join(' '),
+            offset: [...this.$target[0].classList].filter(el => el.match(/^offset-/g)).join(' '),
             requiredMark: requiredMark,
             optionalMark: optionalMark,
             mark: mark && mark.textContent,

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -210,6 +210,14 @@
             content: "Form has a model name",
             trigger: 'iframe section.s_website_form form[data-model_name="mail.mail"]',
         }, {
+            content: "Set the offset and width of the Phone Number field",
+            trigger: 'iframe input[name="phone"]',
+            run: function () {
+                const fieldEl = this.$anchor[0].closest('.s_website_form_field');
+                fieldEl.classList.add('offset-lg-3');
+                fieldEl.classList.add('col-lg-9');
+            },
+        }, {
             content: 'Edit the Phone Number field',
             trigger: 'iframe input[name="phone"]',
         }, {
@@ -545,6 +553,19 @@
         {
             content: 'Verify that phone field is still auto-fillable',
             trigger: 'iframe .s_website_form_field input[data-fill-with="phone"]:propValue("+1 555-555-5555")',
+        },
+        {
+            content: "Check that the offset and width of the Phone Number field are still correct",
+            trigger: 'iframe .s_website_form_field input[data-fill-with="phone"]',
+            run: function () {
+                const fieldEl = this.$anchor[0].closest('.s_website_form_field');
+                if (!fieldEl.classList.contains('offset-lg-3')) {
+                    return;
+                }
+                if (!fieldEl.classList.contains('col-lg-9')) {
+                    return;
+                }
+            },
         },
         // Check that the resulting form behavior is correct.
         {


### PR DESCRIPTION
Before this commit, changing display parameters of a field (label
position, description, etc.) would remove the offset already added. It
would require to add them again if a change was made on the display,
even if the mouse just hovered the buttons.

This commit solves the issue.

Steps to reproduce the bug:
- Add a form snippet
- Add an offset to a field
- In the snippet customization, hover over the label position
(The offset was removed for good)

task-3675509