### PR TITLE
[IMP] point_of_sale: pos remove tracking number from normal tickets

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -124,10 +124,7 @@ export class PosOrder extends Base {
             // FIXME: isn't there a better way to handle this date?
             shippingDate:
                 this.shipping_date && formatDate(DateTime.fromJSDate(new Date(this.shipping_date))),
-            headerData: {
-                ...headerData,
-                trackingNumber: this.tracking_number,
-            },
+            headerData: headerData,
             screenName: "ReceiptScreen",
         };
     }

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
@@ -3,7 +3,6 @@
     <t t-name="point_of_sale.ReceiptHeader">
         <img t-attf-src="/web/image?model=res.company&amp;id={{props.data.company.id}}&amp;field=logo" alt="Logo" class="pos-receipt-logo"/>
         <br/>
-        <h1 class="tracking-number text-center" style="font-size: 100px" t-if="props.data.trackingNumber and props.data.bigTrackingNumber" t-esc="props.data.trackingNumber" />
         <div class="d-flex flex-column align-items-center">
             <div class="pos-receipt-contact">
                 <!-- contact address -->
@@ -20,9 +19,6 @@
                 <div t-if="props.data.cashier" class="cashier">
                     <div>--------------------------------</div>
                     <div t-esc="props.data.cashier" />
-                </div>
-                <div t-if="props.data.trackingNumber and !props.data.bigTrackingNumber">
-                    <span class="tracking-number fs-1" t-esc="props.data.trackingNumber" />
                 </div>
             </div>
         </div>

--- a/addons/pos_restaurant/static/src/overrides/components/receipt_screen/order_receipt/order_receipt.xml
+++ b/addons/pos_restaurant/static/src/overrides/components/receipt_screen/order_receipt/order_receipt.xml
@@ -43,6 +43,14 @@
             <t t-if="props.data.table">Table <t t-esc="props.data.table" /></t>
             <t t-if="props.data.table and props.data.customer_count">, Guests: <t t-esc="props.data.customer_count" /></t>
         </xpath>
+        <xpath expr="//div[hasclass('pos-receipt-contact')]" position="before">
+            <h1 class="tracking-number text-center" style="font-size: 100px" t-if="props.data.trackingNumber and props.data.bigTrackingNumber" t-esc="props.data.trackingNumber" />
+        </xpath>
+        <xpath expr="//div[hasclass('pos-receipt-contact')]" position="after">
+            <div t-if="props.data.trackingNumber and !props.data.bigTrackingNumber">
+                <span class="tracking-number fs-1" t-esc="props.data.trackingNumber" />
+            </div>
+        </xpath>
     </t>
 
 </templates>

--- a/addons/pos_restaurant/static/src/overrides/models/pos_order.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_order.js
@@ -28,6 +28,10 @@ patch(PosOrder.prototype, {
             ...super.export_for_printing(...arguments),
             set_tip_after_payment: this.config.set_tip_after_payment,
             isRestaurant: this.config.module_pos_restaurant,
+            headerData: {
+                ...headerData,
+                trackingNumber: this.config.module_pos_restaurant ? this.tracking_number : null,
+            },
         };
     },
     setBooked(booked) {

--- a/addons/pos_self_order/static/src/overrides/components/receipt_header/receipt_header.xml
+++ b/addons/pos_self_order/static/src/overrides/components/receipt_header/receipt_header.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.ReceiptHeader" t-inherit="point_of_sale.ReceiptHeader" t-inherit-mode="extension">
-        <xpath expr="//h1[hasclass('tracking-number')]" position="after">
+        <xpath expr="//div[hasclass('pos-receipt-contact')]" position="before">
             <div t-if="props.data.pickingService" class="picking-service text-center pb-2">
                 <span t-if="props.data.pickingService == 'table'" >Service at Table</span>
                 <span t-else="">Pickup At Counter</span>


### PR DESCRIPTION
The tracking number was being displayed on regular tickets, which caused confusion when customers accessed the website via QR code to generate their invoice. This commit restricts the tracking number to be shown only on restaurant and/or kiosk (self-order) tickets where it is relevant, improving user experience and clarity.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
