### PR TITLE
[FIX] l10n_es_pos: fix crash when l10n_es_edi_facturae is not installed

### DIFF
--- a/addons/l10n_es_pos/models/account_move.py
+++ b/addons/l10n_es_pos/models/account_move.py
@@ -12,6 +12,10 @@ class AccountMove(models.Model):
                 move.l10n_es_is_simplified = move.pos_order_ids[0].is_l10n_es_simplified_invoice
 
     def _generate_pdf_and_send_invoice(self, template, force_synchronous=True, allow_fallback_pdf=True, bypass_download=False, **kwargs):
-        if self.company_id.country_code == "ES" and not self.company_id.l10n_es_edi_facturae_certificate_id:
+        if (
+            self.company_id.country_code == "ES"
+            and 'l10n_es_edi_facturae_certificate_id' in self.company_id._fields
+            and not self.company_id.l10n_es_edi_facturae_certificate_id
+        ):
             kwargs['l10n_es_edi_facturae_checkbox_xml'] = False
         return super()._generate_pdf_and_send_invoice(template, force_synchronous, allow_fallback_pdf, bypass_download, **kwargs)


### PR DESCRIPTION
The `l10n_es_edi_facturae` module is auto-installed with Spanish localization, but is not a direct dependency of the `l10n_es_pos` module. And in case it (`l10n_es_edi_facturae`) is manually uninstalled, trying to generate an invoice will crash with:

AttributeError: 'res.company' object has no attribute 'l10n_es_edi_facturae_certificate_id'

This commit ensure the field is present before trying to use it.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
