### PR TITLE
[FIX] web_editor: fix rtl language in snippets modal

### DIFF
--- a/addons/web_editor/static/src/js/editor/add_snippet_dialog.js
+++ b/addons/web_editor/static/src/js/editor/add_snippet_dialog.js
@@ -9,6 +9,7 @@ import {
     Component,
     onMounted,
 } from "@odoo/owl";
+import { localization } from "@web/core/l10n/localization";
 
 export class RenameCustomSnippetDialog extends Component {
     static template = "web_editor.RenameCustomSnippetDialog";
@@ -39,6 +40,7 @@ export class AddSnippetDialog extends Component {
         snippets: Object,
         groupSelected: String,
         optionsSnippets: String,
+        frontendDirection: String,
         installModule: Function,
         addSnippet: Function,
         deleteCustomSnippet: Function,
@@ -71,6 +73,7 @@ export class AddSnippetDialog extends Component {
                 });
             }
             this.iframeDocument.documentElement.classList.add("o_add_snippets_preview");
+            this.iframeDocument.body.style.setProperty("direction", localization.direction);
             await this.insertStyle().then(() => {
                 this.iframeRef.el.classList.add("show");
             });
@@ -144,6 +147,7 @@ export class AddSnippetDialog extends Component {
         this.iframeDocument.body.innerHTML = "";
         const rowEl = document.createElement("div");
         rowEl.classList.add("row", "g-0", "o_snippets_preview_row");
+        rowEl.style.setProperty("direction", this.props.frontendDirection);
         const leftColEl = document.createElement("div");
         leftColEl.classList.add("col-lg-6");
         rowEl.appendChild(leftColEl);

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -5059,6 +5059,7 @@ class SnippetsMenu extends Component {
                     snippets: this.snippets,
                     groupSelected: groupSelected,
                     optionsSnippets: this.options.snippets,
+                    frontendDirection: this.options.direction,
                     installModule: (moduleID, snippetName) => {
                         resolve();
                         this._installModule(moduleID, snippetName);

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -2858,6 +2858,7 @@ we-select.o_grid we-toggler {
         scrollbar-gutter: stable both-edges;
     }
     .o_snippets_preview_row {
+        position: absolute; // Needed for RTL
         transform: scale(0.3);
         transform-origin: top left;
         width: 333%;


### PR DESCRIPTION
This commit adapts CSS code to correctly display the snippets modal for RTL languages.
The snippets modal was introduced in this commit [1].

[1]: https://github.com/odoo/odoo/commit/edf81c13d8f2f6d29a77d68cbfa0dc9216da3c2a

task-4072655