### PR TITLE
[REF] website_event_sale: event_buy_last_ticket tour

### DIFF
--- a/addons/website_event_sale/static/tests/tours/website_event_sale_last_ticket.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale_last_ticket.js
@@ -1,69 +1,90 @@
 /** @odoo-module **/
 
 import { registry } from "@web/core/registry";
-import * as wsTourUtils from '@website_sale/js/tours/tour_utils';
+import * as wsTourUtils from "@website_sale/js/tours/tour_utils";
 
-registry.category("web_tour.tours").add('event_buy_last_ticket', {
+registry.category("web_tour.tours").add("event_buy_last_ticket", {
     test: true,
-    url: '/event',
-    steps: () => [{
-        content: "Open the Last ticket test event page",
-        trigger: '.o_wevent_events_list a:contains("Last ticket test")',
-        run: "click",
-    },
-    {
-        content: "Open Registration Page",
-        trigger: '.btn-primary:contains("Register")',
-        run: "click",
-    },
-    {
-        content: "Open the register modal",
-        trigger: 'button:contains("Register")',
-        run: "click",
-    },
-    {
-        trigger: '#wrap:not(:has(a[href*="/event"]:contains("Last ticket test")))',
-    },
-    {
-        content: "Select 2 units of `VIP` ticket type",
-        trigger: 'select:eq(0)',
-        run: "select 2",
-    },
-    {
-        trigger: "select:eq(0):has(option:contains(2):selected)",
-    },
-    {
-        content: "Click on `Order Now` button",
-        trigger: '.a-submit:contains("Register")',
-        run: "click",
-    },
-    {
-        content: "Fill attendees details",
-        trigger: 'form[id="attendee_registration"] .btn[type=submit]',
-        run: function () {
-            document.querySelector("input[name*='1-name']").value = "Att1";
-            document.querySelector("input[name*='1-phone']").value = "111 111";
-            document.querySelector("input[name*='1-email']").value = "att1@example.com";
-            document.querySelector("input[name*='2-name']").value = "Att2";
-            document.querySelector("input[name*='2-phone']").value = "222 222";
-            document.querySelector("input[name*='2-email']").value = "att2@example.com";
+    url: "/event",
+    checkDelay: 100,
+    steps: () => [
+        {
+            content: "Open the Last ticket test event page",
+            trigger: '.o_wevent_events_list a:contains("Last ticket test")',
+            run: "click",
         },
-    },
-    {
-        trigger: "input[name*='1-name'], input[name*='2-name']",
-    },
-    {
-        content: "Validate attendees details",
-        trigger: "button[type=submit]:contains(Go to Payment)",
-        run: "click",
-    },
-    ...wsTourUtils.fillAdressForm({
-        name: "test1",
-        phone: "111 111",
-        email: "test@example.com",
-        street: "street test 1",
-        city: "testCity",
-        zip: "123",
-    }),
-    ...wsTourUtils.payWithTransfer(true),
-]});
+        {
+            content: "Open Registration Modal",
+            trigger: ".btn-primary:contains(Register)",
+            run: "click",
+        },
+        {
+            content: "Check the modal Tickets is opened",
+            trigger: "body:has(.modal:contains(Tickets))",
+        },
+        {
+            trigger: '#wrap:not(:has(a[href*="/event"]:contains("Last ticket test")))',
+        },
+        {
+            content: "Select 2 units of `VIP` ticket type",
+            trigger: ".modal select:eq(0)",
+            run: "select 2",
+        },
+        {
+            trigger: ".modal select:eq(0):has(option:contains(2):selected)",
+        },
+        {
+            content: "Click on `Order Now` button",
+            trigger: ".modal .modal-footer button.btn-primary.a-submit:contains(Register)",
+            run: "click",
+        },
+        {
+            content: "Check the modal Attendees is opened",
+            trigger: "body:has(.modal:contains(Attendees):contains(Ticket #1):contains(Ticket #2))",
+        },
+        {
+            content: "Fill name of attendee 1",
+            trigger: ".modal input[name*='1-name']",
+            run: "edit Att1",
+        },
+        {
+            content: "Fill phone of attendee 1",
+            trigger: ".modal input[name*='1-phone']",
+            run: "edit 111-111",
+        },
+        {
+            content: "Fill email of attendee 1",
+            trigger: ".modal input[name*='1-email']",
+            run: "edit att1@example.com",
+        },
+        {
+            content: "Fill name of attendee 2",
+            trigger: ".modal input[name*='2-name']",
+            run: "edit Att2",
+        },
+        {
+            content: "Fill phone of attendee 2",
+            trigger: ".modal input[name*='2-phone']",
+            run: "edit 222-222",
+        },
+        {
+            content: "Fill email of attendee 2",
+            trigger: ".modal input[name*='2-email']",
+            run: "edit att2@example.com",
+        },
+        {
+            content: "Validate attendees details",
+            trigger: ".modal button[type=submit]:contains(Go to Payment)",
+            run: "click",
+        },
+        ...wsTourUtils.fillAdressForm({
+            name: "test1",
+            phone: "111 111",
+            email: "test@example.com",
+            street: "street test 1",
+            city: "testCity",
+            zip: "123",
+        }),
+        ...wsTourUtils.payWithTransfer(true),
+    ],
+});


### PR DESCRIPTION
We split the run that defines the input values ​​into several steps in order to use helpers instead of setting the input value explicitly (without using javascript events). This better simulates the interactions that the user makes with the DOM.
We take advantage of this commit to force the checkDelay to 100ms (by default it is at 750ms) which allows the trick to run faster. We take advantage of this commit to linter the file.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
