### PR TITLE
[FIX] account,account_peppol: wrong raise, missing with_company

### DIFF
--- a/addons/account/models/account_move_send.py
+++ b/addons/account/models/account_move_send.py
@@ -94,7 +94,7 @@ class AccountMoveSend(models.AbstractModel):
         alerts = {}
         if partners_without_mail := moves.filtered(lambda m: 'email' in moves_data[m]['sending_methods'] and not m.partner_id.email).partner_id:
             alerts['account_missing_email'] = {
-                'level': 'danger' if len(partners_without_mail) == 1 else 'warning',
+                'level': 'danger' if len(moves) == 1 else 'warning',
                 'message': _("Partner(s) should have an email address."),
                 'action_text': _("View Partner(s)"),
                 'action': partners_without_mail._get_records_action(name=_("Check Partner(s) Email(s)")),


### PR DESCRIPTION
COMMIT 1:
[FIX] account: fix email raising in multi

The email warning should be "danger" and raised only if there is only
one move. If there is multiple invoices, we are sending in batch and should
try to send other invoices anyway.

task-no

COMMIT 2:
FIX] account_peppol: batch peppol failing with correct configuration

Steps to reproduce:
1. Have two companies: one valid for peppol, the other one not (use one
belgian and the default US for example.
2. Create two invoices with the valid BE company, for a partner that is valid
on Peppol. Note that this partner is not valid for US company, since it is
not configured to use Peppol.
3. Try to send the invoices in batch: they fail to send with an error
message saying that the partner is not correctly configured for Peppol.

Problem:
The check of the validity was dependent of self.env.company, which shouldn't
be the case since the processing can happen from cron (which it is in this
case of batch sending). It should be agnostic crom the current
environment company.

Solution:
The peppol verification state is company dependent, it should be retrieved
with a `with_company`.

task-no