### PR TITLE
[IMP] account: Ease adding companies to accounts

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -3091,6 +3091,12 @@ msgid "Bank & Cash"
 msgstr ""
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_move.py:0
+msgid "Bank & Cash accounts cannot be shared between companies."
+msgstr ""
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_account_journal__bank_account_id
 #: model_terms:ir.ui.view,arch_db:account.view_account_journal_form
 msgid "Bank Account"

--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -1490,6 +1490,13 @@ msgstr ""
 #. odoo-python
 #: code:addons/account/models/account_account.py:0
 msgid ""
+"Account %(account)s will be split in %(num_accounts)s, one for each company:\n"
+msgstr ""
+
+#. module: account
+#. odoo-python
+#: code:addons/account/models/account_account.py:0
+msgid ""
 "Account %s cannot be unmerged as it already belongs to a single company. The"
 " unmerge operation only splits an account based on its companies."
 msgstr ""
@@ -2771,7 +2778,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account/models/account_account.py:0
 msgid ""
-"Are you sure? This will split the account into one account per company:"
+"Are you sure? This will perform the following operations:\n"
 msgstr ""
 
 #. module: account
@@ -17459,12 +17466,6 @@ msgid ""
 "You have to configure the 'Exchange Gain or Loss Journal' in your company "
 "settings, to manage automatically the booking of accounting entries related "
 "to differences between exchange rates."
-msgstr ""
-
-#. module: account
-#. odoo-python
-#: code:addons/account/models/account_account.py:0
-msgid "You must select a single account to un-merge."
 msgstr ""
 
 #. module: account

--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -106,6 +106,9 @@ class AccountAccount(models.Model):
     company_ids = fields.Many2many('res.company', string='Companies', required=True, readonly=False,
         default=lambda self: self.env.company)
     code_mapping_ids = fields.One2many(comodel_name='account.code.mapping', inverse_name='account_id')
+    # Ensure `code_mapping_ids` is written before `company_ids` so we don't trigger the `_ensure_code_is_unique`
+    # constraint when writing multiple code mappings and multiple companies in the same call to `write`.
+    code_mapping_ids.write_sequence = 19
     tag_ids = fields.Many2many(
         comodel_name='account.account.tag',
         relation='account_account_account_tag',

--- a/addons/account/models/account_code_mapping.py
+++ b/addons/account/models/account_code_mapping.py
@@ -36,7 +36,7 @@ class AccountCodeMapping(models.Model):
             case [('account_id', 'in', account_ids)]:
                 self_ids = {
                     f'{account_id},{company.id}'
-                    for company in self.env.companies
+                    for company in self.env.user.company_ids
                     for account_id in account_ids
                 }
                 return self.browse(sorted(self_ids))._as_query()

--- a/addons/account/models/account_code_mapping.py
+++ b/addons/account/models/account_code_mapping.py
@@ -1,8 +1,12 @@
-from odoo import fields, models
+from odoo import fields, models, api
 from odoo.tools import Query
 
 
 class AccountCodeMapping(models.Model):
+    # This model is used purely for UI, to display the account codes for each company.
+    # It is not stored in DB. Instead, records are only populated in cache by the
+    # `_search` override when accessing the One2many on `account.account`.
+
     _name = 'account.code.mapping'
     _description = "Mapping of account codes per company"
     _auto = False
@@ -11,16 +15,19 @@ class AccountCodeMapping(models.Model):
     account_id = fields.Many2one(
         comodel_name='account.account',
         string="Account",
-        compute='_compute_self',
+        store=False,
+        # suppress warning about field not being searchable (due to being used in depends);
+        # searching is actually implemented in the `_search` override.
+        search=True,
     )
     company_id = fields.Many2one(
         comodel_name='res.company',
         string="Company",
-        compute='_compute_self',
+        store=False,
     )
     code = fields.Char(
         string="Code",
-        compute='_compute_self',
+        compute='_compute_code',
         inverse='_inverse_code',
     )
 
@@ -30,30 +37,34 @@ class AccountCodeMapping(models.Model):
         return super().browse(ids)
 
     def _search(self, domain, offset=0, limit=None, order=None) -> Query:
+        # This method will populate this model's records in cache when the `code_mapping_ids`
+        # One2many on `account_account` is accessed. Any existing records that correspond to the
+        # search domain will be returned, and additional ones will be created in cache as needed.
         match domain:
-            case [('id', 'in', ids)]:
-                return self.browse(sorted(ids))._as_query()
             case [('account_id', 'in', account_ids)]:
-                self_ids = {
-                    f'{account_id},{company.id}'
-                    for company in self.env.user.company_ids
+                companies = self.env.user.company_ids
+                existing_code_mappings = self.env.cache.get_records(self, self._fields['account_id']).filtered(
+                    lambda m: m.account_id.id in account_ids and m.company_id in companies
+                )
+                keys = {(m.account_id.id, m.company_id.id) for m in existing_code_mappings}
+                missing_keys = [
+                    (account_id, company_id)
                     for account_id in account_ids
-                }
-                return self.browse(sorted(self_ids))._as_query()
+                    for company_id in companies.ids
+                    if (account_id, company_id) not in keys
+                ]
+                max_existing_id = max(existing_code_mappings.ids, default=0)
+                new_code_mappings = self.browse(range(max_existing_id + 1, max_existing_id + len(missing_keys) + 1))
+
+                self.env.cache.update(new_code_mappings, self._fields['account_id'], [account_id for account_id, _ in missing_keys])
+                self.env.cache.update(new_code_mappings, self._fields['company_id'], [company_id for _, company_id in missing_keys])
+
+                mappings = existing_code_mappings | new_code_mappings
+                return mappings.sorted(lambda m: (m.account_id.id, m.company_id.sequence, m.company_id.name))._as_query()
         raise NotImplementedError
 
-    def _compute_self(self):
-        for record in self:
-            (account_id, company_id) = record._origin.id.split(',')
-            # If record is a NewId, then record.account_id and record.company_id should be too
-            # in order to behave correctly in onchange.
-            if isinstance(record.id, models.NewId):
-                record.account_id = models.NewId(int(account_id))
-                record.company_id = models.NewId(int(company_id))
-            else:
-                record.account_id = int(account_id)
-                record.company_id = int(company_id)
-        # Do this in a separate loop, so that prefetching can happen if needed
+    @api.depends('account_id.code')
+    def _compute_code(self):
         for record in self:
             account = record.account_id.with_company(record.company_id._origin)
             record.code = account.code

--- a/addons/account/tests/test_account_account.py
+++ b/addons/account/tests/test_account_account.py
@@ -52,13 +52,13 @@ class TestAccountAccount(TestAccountMergeCommon):
         })
         self.assertRecordValues(account, [{'code': '180011', 'company_ids': [company_1.id, company_2.id]}])
 
-        # Test that you can create an account with multiple codes and companies if you specify `code_by_company`.
+        # Test that you can create an account with multiple codes and companies if you specify the codes in `code_mapping_ids`
         account_2 = self.env['account.account'].create({
-            'code_by_company': {
-                company_1.id: '180021',
-                company_2.id: '180022',
-                company_3.id: '180023',
-            },
+            'code_mapping_ids': [
+                Command.create({'company_id': company_1.id, 'code': '180021'}),
+                Command.create({'company_id': company_2.id, 'code': '180022'}),
+                Command.create({'company_id': company_3.id, 'code': '180023'}),
+            ],
             'name': 'My second account',
             'account_type': 'asset_current',
             'company_ids': [Command.set([company_1.id, company_2.id, company_3.id])],
@@ -673,7 +673,7 @@ class TestAccountAccount(TestAccountMergeCommon):
         self.assertEqual(self.env['account.chart.template'].with_company(company_2).ref('test_account_2'), new_account)
 
     def test_account_code_mapping(self):
-        company_3 = self.env['res.company'].create({'name': 'Test Company 3'})
+        company_3 = self.env['res.company'].create({'name': 'company_3'})
         account = self.env['account.account'].create({
             'code': 'test1',
             'name': 'Test Account',
@@ -704,6 +704,48 @@ class TestAccountAccount(TestAccountMergeCommon):
             account_form.company_ids.add(self.company_data_2['company'])
             account_form.company_ids.add(company_3)
 
+        self.assertRecordValues(account.with_company(self.company_data_2['company'].id), [{'code': 'test2'}])
+        self.assertRecordValues(account.with_company(company_3.id), [{'code': 'test3'}])
+
+    def test_account_code_mapping_create(self):
+        """ Similar as above, except test that you can create an account while specifying multiple codes in the code mapping tab. """
+
+        company_3 = self.env['res.company'].create({'name': 'company_3'})
+
+        AccountAccount = self.env['account.account'].with_context(
+            {'allowed_company_ids': [self.company_data['company'].id, self.company_data_2['company'].id, company_3.id]}
+        )
+
+        with Form(AccountAccount) as account_form:
+            expected_code_mapping_vals_list = [
+                {'company_id': self.company_data['company'].id, 'code': False},
+                {'company_id': self.company_data_2['company'].id, 'code': False},
+                {'company_id': company_3.id, 'code': False},
+            ]
+            actual_code_mapping_vals_list = account_form.code_mapping_ids._records
+
+            for expected_code_mapping_vals, actual_code_mapping_vals in zip(expected_code_mapping_vals_list, actual_code_mapping_vals_list):
+                for key, expected_val in expected_code_mapping_vals.items():
+                    self.assertEqual(actual_code_mapping_vals[key], expected_val)
+
+            account_form.name = "My Test Account"
+            account_form.code = 'test1'
+            with account_form.code_mapping_ids.edit(1) as code_mapping_form:
+                code_mapping_form.code = 'test2'
+            with account_form.code_mapping_ids.edit(2) as code_mapping_form:
+                code_mapping_form.code = 'test3'
+
+            # Test that writing codes and companies at the same time doesn't trigger the constraint
+            # that the code must be set for each company in company_ids
+            account_form.company_ids.add(self.company_data_2['company'])
+            account_form.company_ids.add(company_3)
+
+        account = account_form.record
+
+        self.assertRecordValues(account, [{
+            'company_ids': [self.company_data['company'].id, self.company_data_2['company'].id, company_3.id],
+            'code': 'test1'
+        }])
         self.assertRecordValues(account.with_company(self.company_data_2['company'].id), [{'code': 'test2'}])
         self.assertRecordValues(account.with_company(company_3.id), [{'code': 'test3'}])
 

--- a/addons/account/views/account_account_views.xml
+++ b/addons/account/views/account_account_views.xml
@@ -194,8 +194,8 @@
             <field name="binding_view_types">form,list</field>
             <field name="state">code</field>
             <field name="code">
-if record:
-    action = record.action_unmerge()
+if records:
+    action = records.action_unmerge()
             </field>
         </record>
     </data>

--- a/addons/account/views/account_account_views.xml
+++ b/addons/account/views/account_account_views.xml
@@ -74,7 +74,7 @@
                                     </group>
                                 </group>
                             </page>
-                            <page name="mapping" string="Mapping" groups="base.group_multi_company">
+                            <page name="mapping" string="Mapping" groups="base.group_multi_company" invisible="not display_mapping_tab">
                                 <field name="code_mapping_ids" nolabel="1">
                                     <list editable="bottom">
                                         <field name="company_id"/>
@@ -107,7 +107,7 @@
                     <field name="tag_ids" domain="[('applicability', '=', 'accounts')]" optional="hide" widget="many2many_tags"/>
                     <field name="allowed_journal_ids" optional="hide" widget="many2many_tags"/>
                     <field name="currency_id" options="{'no_create': True}" groups="base.group_multi_currency"/>
-                    <field name="company_ids" widget="many2many_tags" options="{'no_create': True}" groups="base.group_multi_company"/>
+                    <field name="company_ids" widget="many2many_tags" readonly="True" groups="base.group_multi_company"/>
                 </list>
             </field>
         </record>


### PR DESCRIPTION
- We provide a default value for the account code/company mapping at the initial onchange, meaning the user can create an account with multiple companies and codes from the start.
- We make the mapping visible for all of the user's companies. We make it invisible if the user only has access to one company.
- We make the `companies` field read-only in the accounts list view.
- We don't prevent the user from unmerging accounts if they have access to all the account's companies, even if all the companies aren't selected in the company selector.
- We let users unmerge several accounts that are selected in the CoA list view.

task-4191362