### PR TITLE
[IMP] stock: simplify location form

### DIFF
--- a/addons/mrp_subcontracting/views/stock_location_views.xml
+++ b/addons/mrp_subcontracting/views/stock_location_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="stock.view_location_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='scrap_location']" position='after'>
-                <field name="is_subcontracting_location" groups="base.group_no_one" invisible="usage != 'internal'"/>
+                <field name="is_subcontracting_location" invisible="usage != 'internal'"/>
             </xpath>
         </field>
     </record>

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -78,7 +78,8 @@ class StockLocation(models.Model):
              "and a fallback is made on the parent locations if none is set here.\n\n"
              "FIFO: products/lots that were stocked first will be moved out first.\n"
              "LIFO: products/lots that were stocked last will be moved out first.\n"
-             "Closet location: products/lots closest to the target location will be moved out first.\n"
+             "Closest Location: products/lots closest to the target location will be moved out first.\n"
+             "Least Packages: products/lots that were stocked in package with least amount of qty will be moved out first.\n"
              "FEFO: products/lots with the closest removal date will be moved out first "
              "(the availability of this method depends on the \"Expiration Dates\" setting).")
     putaway_rule_ids = fields.One2many('stock.putaway.rule', 'location_in_id', 'Putaway Rules')

--- a/addons/stock_fleet/views/stock_location.xml
+++ b/addons/stock_fleet/views/stock_location.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="stock.view_location_form"/>
         <field name="arch" type="xml">
             <field name="scrap_location" position="after">
-                <field name="is_a_dock"/>
+                <field name="is_a_dock" invisible="usage not in ('view', 'internal')"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
In this commit:
====================
- The current location form includes fields that may confuse users, especially with virtual location types. By removing non-essential field like 'dock location' from various location types, we reduce complexity and make the form more intuitive.
- Additionally, 'Is a Subcontracting location' is moved to the normal mode to increase visibility for users, as it is a commonly used field.
- The tooltips have been corrected and clarified to improve user understanding.

task- 4149824
