### PR TITLE
[FIX] spreadsheet: support multi aggregators for same field

### DIFF
--- a/addons/spreadsheet/static/src/pivot/odoo_pivot.js
+++ b/addons/spreadsheet/static/src/pivot/odoo_pivot.js
@@ -351,7 +351,7 @@ export class OdooPivot {
             return { value: "" };
         }
         const measure = this.getMeasure(measureId);
-        const value = this.model.getPivotCellValue(measure.fieldName, domain);
+        const value = this.model.getPivotCellValue(measure, domain);
         let format;
         switch (measure.aggregator) {
             case "count":

--- a/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
+++ b/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
@@ -817,7 +817,7 @@ test("Adding a measure should trigger a reload", async () => {
     });
     setCellContent(model, "A1", '=PIVOT.VALUE(1, "probability:sum")');
     await animationFrame();
-    expect.verifySteps([["probability:sum"], "read_group"]);
+    expect.verifySteps([["probability_sum_id:sum(probability)"], "read_group"]);
     updatePivot(model, 1, {
         measures: [
             { id: "probability:sum", fieldName: "probability", aggregator: "sum" },
@@ -825,7 +825,10 @@ test("Adding a measure should trigger a reload", async () => {
         ],
     });
     await animationFrame();
-    expect.verifySteps([["probability:sum", "probability:avg"], "read_group"]);
+    expect.verifySteps([
+        ["probability_sum_id:sum(probability)", "probability_avg_id:avg(probability)"],
+        "read_group",
+    ]);
     updatePivot(model, 1, {
         measures: [
             { id: "probability:sum", fieldName: "probability", aggregator: "sum" },
@@ -834,7 +837,10 @@ test("Adding a measure should trigger a reload", async () => {
         ],
     });
     await animationFrame();
-    expect.verifySteps([["probability:sum", "probability:avg", "__count"], "read_group"]);
+    expect.verifySteps([
+        ["probability_sum_id:sum(probability)", "probability_avg_id:avg(probability)", "__count"],
+        "read_group",
+    ]);
 });
 
 test("Updating dimensions with undefined values does not trigger a new rpc", async () => {
@@ -1338,7 +1344,7 @@ test("can add a calculated measure", async function () {
         mockRPC: async function (route, { model, method, kwargs }) {
             if (model === "partner" && method === "read_group") {
                 expect.step("read_group");
-                expect(kwargs.fields).toEqual(["probability:avg"]);
+                expect(kwargs.fields).toEqual(["probability_avg_id:avg(probability)"]);
             }
         },
     });
@@ -1452,7 +1458,7 @@ test("can import a pivot with a calculated field", async function () {
         mockRPC: function (route, { model, method, kwargs }) {
             if (model === "partner" && method === "read_group") {
                 expect.step("read_group");
-                expect(kwargs.fields).toEqual(["probability:avg"]);
+                expect(kwargs.fields).toEqual(["probability_avg_id:avg(probability)"]);
             }
         },
     });
@@ -1549,7 +1555,7 @@ test("Data are fetched with the correct aggregator", async () => {
                 </pivot>`,
         mockRPC: async function (route, args) {
             if (args.method === "read_group") {
-                expect(args.kwargs.fields).toEqual(["probability:avg"]);
+                expect(args.kwargs.fields).toEqual(["probability_avg_id:avg(probability)"]);
                 expect.step("read_group");
             }
         },
@@ -1569,7 +1575,7 @@ test("changing measure aggregates", async () => {
             }
         },
     });
-    expect.verifySteps(["probability:avg"]);
+    expect.verifySteps(["probability_avg_id:avg(probability)"]);
     model.dispatch("UPDATE_PIVOT", {
         pivotId,
         pivot: {
@@ -1578,7 +1584,7 @@ test("changing measure aggregates", async () => {
         },
     });
     await animationFrame();
-    expect.verifySteps(["probability:sum"]);
+    expect.verifySteps(["probability_sum_id:sum(probability)"]);
     model.dispatch("UPDATE_PIVOT", {
         pivotId,
         pivot: {
@@ -1587,7 +1593,7 @@ test("changing measure aggregates", async () => {
         },
     });
     await animationFrame();
-    expect.verifySteps(["foo:sum"]);
+    expect.verifySteps(["foo_sum_id:sum(foo)"]);
 });
 
 test("many2one measures are aggregated with count_distinct by default", async () => {
@@ -1602,7 +1608,7 @@ test("many2one measures are aggregated with count_distinct by default", async ()
             }
         },
     });
-    expect.verifySteps(["probability:avg"]);
+    expect.verifySteps(["probability_avg_id:avg(probability)"]);
     model.dispatch("UPDATE_PIVOT", {
         pivotId,
         pivot: {

--- a/addons/spreadsheet/static/tests/pivots/model/pivot_positional_formula.test.js
+++ b/addons/spreadsheet/static/tests/pivots/model/pivot_positional_formula.test.js
@@ -123,7 +123,7 @@ test("sort first pivot column (ascending)", async () => {
                 model: "partner",
                 sortedColumn: {
                     groupId: [[], [1]],
-                    measure: "probability:avg",
+                    measure: "probability",
                     order: "asc",
                 },
             },


### PR DESCRIPTION
Steps to reproduce:
- Insert a pivot view in a spreadsheet
- Add two measures with the same field name and different aggregators => Only one aggregator is fetched

Before this commit, the Odoo pivot view in spreadsheet didn't support correctly the case where the same field was used multiple times in the measures section with different aggregators.

This commit fixes this issue by overriding the needed methods of the web pivot model (on which the spreadsheet pivot model is based on) to change the way the measurements are stored. Before, it was the fieldname of the measure, now it is an id, based on the fieldname, the aggregator and the type of the measure.

Task: 4207668

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
