### PR TITLE
[FIX] mail: composer placeholder text for subchannels

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -212,7 +212,13 @@ export class Composer extends Component {
         }
         if (this.thread) {
             if (this.thread.channel_type === "channel") {
-                return _t("Message #%(thread name)s…", { "thread name": this.thread.displayName });
+                const threadName = this.thread.displayName;
+                if (this.thread.parent_channel_id) {
+                    return _t(`Message "%(subChannelName)s"`, {
+                        subChannelName: threadName,
+                    });
+                }
+                return _t("Message #%(threadName)s…", { threadName });
             }
             return _t("Message %(thread name)s…", { "thread name": this.thread.displayName });
         }

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -78,6 +78,20 @@ test("composer text input placeholder should contain channel name when thread do
     await contains("textarea.o-mail-Composer-input[placeholder='Message #General…']");
 });
 
+test("composer input placeholder in channel thread", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "General",
+    });
+    const subchannelID = pyEnv["discuss.channel"].create({
+        name: "ThreadFromGeneral",
+        parent_channel_id: channelId,
+    });
+    await start();
+    await openDiscuss(subchannelID);
+    await contains(`.o-mail-Composer-input[placeholder='Message "ThreadFromGeneral"']`);
+});
+
 test("add an emoji", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "swamp-safari" });


### PR DESCRIPTION
Purpose of this commit:
Adjust the placeholder text for subchannels, as it previously included the '#' symbol, which typically denotes a channel rather than a thread

Before
![image](https://github.com/user-attachments/assets/1b61e8ff-f3ff-4aca-9c38-7690aacd214c)

After
![image](https://github.com/user-attachments/assets/a361991b-9cde-4c11-9bec-b42c1272aec7)

