### PR TITLE
[FIX] sale_loyalty: remove discount description when no taxes are applied

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -605,7 +605,7 @@ class SaleOrder(models.Model):
                     'Discount: %(desc)s%(tax_str)s',
                     desc=reward.description,
                     tax_str=tax_desc,
-                ),
+                ) if mapped_taxes else reward.description,
                 'price_unit': -(price * discount_factor),
                 'points_cost': 0,
                 'tax_id': [Command.clear()] + [Command.link(tax.id) for tax in mapped_taxes]


### PR DESCRIPTION
Issue:
- When applying a discount without taxes, a 'Discount:' label is shown in the description field, even though the product name already indicates the discount.

Fix:
- The 'Discount:' description is now suppressed when there are no taxes applied.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
