### PR TITLE
[IMP] web: open link in new tab with ctrl+click

### DIFF
--- a/addons/mail/static/src/views/web/activity/activity_record.js
+++ b/addons/mail/static/src/views/web/activity/activity_record.js
@@ -5,6 +5,7 @@ import { Component } from "@odoo/owl";
 import { evaluateBooleanExpr } from "@web/core/py_js/py";
 import { user } from "@web/core/user";
 import { Field } from "@web/views/fields/field";
+import { useMiddleClick } from "@web/core/utils/middle_click";
 import {
     getFormattedRecord,
     getImageSrcFromRecordInfo,
@@ -33,6 +34,12 @@ export class ActivityRecord extends Component {
         const { templateDocs } = this.props.archInfo;
         const templates = useViewCompiler(ActivityCompiler, templateDocs);
         this.recordTemplate = templates["activity-box"];
+
+        useMiddleClick({
+            clickParams: {
+                record: this.props.record,
+            },
+        });
     }
 
     getRenderingContext() {

--- a/addons/mail/static/src/views/web/activity/activity_record.xml
+++ b/addons/mail/static/src/views/web/activity/activity_record.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.ActivityRecord">
-    <td class="o_activity_record p-2 cursor-pointer" t-on-click="() => this.props.openRecord(this.props.record)">
+    <td class="o_activity_record p-2 cursor-pointer" t-on-click="() => this.props.openRecord(this.props.record)" t-ref="middleclick">
         <t t-call="{{ recordTemplate }}" t-call-context="this.getRenderingContext()"/>
     </td>
 </t>

--- a/addons/stock/static/src/views/picking_form/stock_move_one2many.xml
+++ b/addons/stock/static/src/views/picking_form/stock_move_one2many.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="stock.MovesListRenderer.RecordRow" t-inherit-mode="primary" t-inherit="web.ListRenderer.RecordRow">
-        <xpath expr="//tr/t[1]" position="inside">
+        <xpath expr="//t[@t-component='constructor.recordRowComponent']/t[1]" position="inside">
             <t t-if="column.type === 'opendetailsop'">
                 <td class="o_data_cell cursor-pointer o_list_button">
                     <t t-if="record.resModel === 'stock.move' &amp;&amp; record.data?.show_details_visible">

--- a/addons/web/static/src/core/utils/middle_click.js
+++ b/addons/web/static/src/core/utils/middle_click.js
@@ -1,0 +1,82 @@
+import { useEffect, useRef } from "@odoo/owl";
+import { router, stateToUrl } from "@web/core/browser/router";
+
+const EXCLUDED_TAGS = ["A", "IMG"];
+
+export function useMiddleClick({ refName, clickParams }) {
+    const ref = useRef(refName || "middleclick");
+    let _onCtrlClick;
+    if (clickParams) {
+        if (clickParams.onCtrlClick) {
+            _onCtrlClick = clickParams.onCtrlClick;
+        } else if (clickParams.record) {
+            _onCtrlClick = () => {
+                const actionStack = [
+                    ...router.current.actionStack,
+                    {
+                        action: clickParams.record.action,
+                        model: clickParams.record.resModel,
+                        resId: clickParams.record.resId,
+                    },
+                ];
+                const href = stateToUrl({
+                    actionStack,
+                });
+                window.open(href);
+            };
+        }
+    }
+    const handleClick = (ev) => {
+        if (
+            !ev.target.classList.contains("middle_clickable") &&
+            EXCLUDED_TAGS.find((tag) => ev.target.closest(`${tag}`))
+        ) {
+            // keep the default browser behavior if the click on the element is not explicitly handled by the hook
+            // e.g. <a> tag in an element middle clickable
+            return;
+        }
+        if ((ev.ctrlKey && ev.button === 0) || ev.button === 1) {
+            if (_onCtrlClick) {
+                _onCtrlClick(ev);
+                ev.preventDefault();
+                ev.stopPropagation();
+            }
+        }
+    };
+    const styleControlPressed = (ev) => {
+        if (ev.key === "Control") {
+            document.body.classList.add("ctrl_key_pressed");
+        }
+    };
+    const styleControlUp = (ev) => {
+        if (ev.key === "Control") {
+            resetStyleAndRouter();
+        }
+    };
+    const resetStyleAndRouter = () => {
+        document.body.classList.remove("ctrl_key_pressed");
+    };
+    useEffect(
+        () => {
+            if (ref.el) {
+                const el = ref.el;
+                el.classList.add("middle_clickable");
+                el.addEventListener("auxclick", handleClick, { capture: true });
+                el.addEventListener("click", handleClick, { capture: true });
+                window.addEventListener("keydown", styleControlPressed);
+                window.addEventListener("keyup", styleControlUp);
+                // we must do a reset when the page loses focus while the key is still pressed
+                window.addEventListener("blur", resetStyleAndRouter);
+                return () => {
+                    el.removeEventListener("auxclick", handleClick);
+                    el.removeEventListener("click", handleClick);
+                    window.removeEventListener("keydown", styleControlPressed);
+                    window.removeEventListener("keyup", styleControlUp);
+                    window.removeEventListener("blur", resetStyleAndRouter);
+                    resetStyleAndRouter();
+                };
+            }
+        },
+        () => [ref.el]
+    );
+}

--- a/addons/web/static/src/views/fields/many2one/many2one_field.js
+++ b/addons/web/static/src/views/fields/many2one/many2one_field.js
@@ -6,6 +6,7 @@ import { _t } from "@web/core/l10n/translation";
 import { evaluateBooleanExpr } from "@web/core/py_js/py";
 import { registry } from "@web/core/registry";
 import { useChildRef, useOwnedDialogs, useService } from "@web/core/utils/hooks";
+import { useMiddleClick } from "@web/core/utils/middle_click";
 import { escape, sprintf } from "@web/core/utils/strings";
 import { Many2XAutocomplete, useOpenMany2XRecord } from "@web/views/fields/relational_utils";
 import * as BarcodeScanner from "@web/core/barcode/barcode_dialog";
@@ -104,6 +105,11 @@ export class Many2OneField extends Component {
         this.notification = useService("notification");
         this.autocompleteContainerRef = useChildRef();
         this.addDialog = useOwnedDialogs();
+        useMiddleClick({
+            clickParams: {
+                record: this.props.record,
+            },
+        });
 
         this.focusInput = () => {
             this.autocompleteContainerRef.el.querySelector("input").focus();

--- a/addons/web/static/src/views/fields/many2one/many2one_field.xml
+++ b/addons/web/static/src/views/fields/many2one/many2one_field.xml
@@ -52,6 +52,7 @@
                         aria-label="Internal link"
                         data-tooltip="Internal link"
                         t-on-click="onExternalBtnClick"
+                        t-ref="middleclick"
                     />
                 </t>
                 <button

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -7,6 +7,7 @@ import { Pager } from "@web/core/pager/pager";
 import { evaluateBooleanExpr } from "@web/core/py_js/py";
 import { registry } from "@web/core/registry";
 import { useBus, useService } from "@web/core/utils/hooks";
+import { useMiddleClick } from "@web/core/utils/middle_click";
 import { useSortable } from "@web/core/utils/sortable_owl";
 import { getTabableElements } from "@web/core/utils/ui";
 import { Field, getPropertyFieldInfo } from "@web/views/fields/field";
@@ -96,7 +97,29 @@ export class ListRenderer extends Component {
         this.groupByButtons = this.props.archInfo.groupBy.buttons;
         useExternalListener(document, "click", this.onGlobalClick.bind(this));
         this.tableRef = useRef("table");
-
+        useMiddleClick({
+            clickParams: {
+                onCtrlClick: (ev) => {
+                    const recordRowId = ev.target.closest(".o_data_row")?.dataset.id;
+                    const record =
+                        recordRowId && this.props.list.records.find((r) => r.id === recordRowId);
+                    if (
+                        !record ||
+                        record.isNew ||
+                        record.isInEdition ||
+                        this.props.archInfo.noOpen
+                    ) {
+                        // if record.isNew => do nothing
+                        // if record.readonly => openRecord
+                        // if record is editable => do nothing except handling "View" click
+                        return;
+                    }
+                    // todo tells the action service to open in new window
+                    this.props.openRecord(record);
+                },
+            },
+            refName: "table",
+        });
         this.longTouchTimer = null;
         this.touchStartMs = 0;
 

--- a/addons/web/static/tests/core/utils/middle_click.test.js
+++ b/addons/web/static/tests/core/utils/middle_click.test.js
@@ -1,0 +1,43 @@
+import { expect, test } from "@odoo/hoot";
+import { keyDown } from "@odoo/hoot-dom";
+import { Component, xml } from "@odoo/owl";
+import { contains, mountWithCleanup } from "@web/../tests/web_test_helpers";
+
+import { useMiddleClick } from "@web/core/utils/middle_click";
+
+test("ctrl+click behavior on specified element", async () => {
+    class MiddleClick extends Component {
+        static props = ["*"];
+        static template = xml`
+            <div class="root">
+                <h2>Wonderful Component</h2>
+                <button t-ref="recordRef" class="btn btn-primary" t-on-click="onClick">Click me!</button>
+            </div>
+        `;
+
+        setup() {
+            useMiddleClick({
+                clickParams: {
+                    onCtrlClick: () => {
+                        expect.step("ctrl+click");
+                    },
+                },
+                refName: "recordRef",
+            });
+        }
+
+        onClick() {
+            expect.step("click");
+        }
+    }
+
+    await mountWithCleanup(MiddleClick);
+
+    expect.verifySteps([]);
+    await contains(".btn").click();
+    expect.verifySteps(["click"]);
+    await keyDown("Control");
+    expect(document.body).toHaveClass("ctrl_key_pressed");
+    await contains(".btn").click();
+    expect.verifySteps(["ctrl+click"]);
+});


### PR DESCRIPTION
This commit introduces the ability to open record in new tabs by pressing ctrl key and then clicking on the record, or by using the middle click on a mouse.

This behavior only applies on elements that don't have a native experience handled by the browser (e.g. images/ urls).

task-4031939
