### PR TITLE
[IMP] account: audit exceptions on move level and without setting

### DIFF
--- a/addons/account/models/account_lock_exception.py
+++ b/addons/account/models/account_lock_exception.py
@@ -277,52 +277,50 @@ class AccountLockException(models.Model):
     def _get_audit_trail_during_exception_domain(self):
         self.ensure_one()
 
-        domain = [
-            ('model', '=', 'account.move'),
-            ('account_audit_log_activated', '=', True),
-            ('message_type', '=', 'notification'),
-            ('account_audit_log_move_id.company_id', 'child_of', self.company_id.id),  # WORKAROUND: record_company_id is not set for bills
+        common_message_domain = [
             ('date', '>=', self.create_date),
         ]
-
         if self.user_id:
-            domain.append(('create_uid', '=', self.user_id.id))
+            common_message_domain.append(('create_uid', '=', self.user_id.id))
         if self.end_datetime:
-            domain.append(('date', '<=', self.end_datetime))
+            common_message_domain.append(('date', '<=', self.end_datetime))
 
-        # Add a restriction on the accounting date to avoid unnecessary entries
+        # Add restrictions on the accounting date to avoid unnecessary entries
         min_date = self.lock_date
         max_date = self.company_lock_date
         move_date_domain = []
         tracking_old_datetime_domain = []
         tracking_new_datetime_domain = []
         if min_date:
-            move_date_domain.append([('account_audit_log_move_id.date', '>=', min_date)])
+            move_date_domain.append([('date', '>=', min_date)])
             tracking_old_datetime_domain.append([('tracking_value_ids.old_value_datetime', '>=', min_date)])
             tracking_new_datetime_domain.append([('tracking_value_ids.new_value_datetime', '>=', min_date)])
         if max_date:
-            move_date_domain.append([('account_audit_log_move_id.date', '<=', max_date)])
+            move_date_domain.append([('date', '<=', max_date)])
             tracking_old_datetime_domain.append([('tracking_value_ids.old_value_datetime', '<=', max_date)])
             tracking_new_datetime_domain.append([('tracking_value_ids.new_value_datetime', '<=', max_date)])
-        domain.extend([
+
+        return [
+            ('company_id', 'child_of', self.company_id.id),
+            ('audit_trail_message_ids', 'any', common_message_domain),
             '|',
-                *expression.AND(move_date_domain),
-                '&',
+                # The date was changed from or to a value inside the excepted period
+                ('audit_trail_message_ids', 'any', [
                     ('tracking_value_ids.field_id', '=', self.env['ir.model.fields']._get('account.move', 'date').id),
                     '|',
                         *expression.AND(tracking_old_datetime_domain),
                         *expression.AND(tracking_new_datetime_domain),
-        ])
-
-        return domain
+                ]),
+                # The date of the move is inside the excepted period and sth. was changed on the move
+                *expression.AND(move_date_domain),
+        ]
 
     def action_show_audit_trail_during_exception(self):
         self.ensure_one()
         return {
-            'name': _("Audit Trail during the Exception"),
+            'name': _("Journal Items"),
             'type': 'ir.actions.act_window',
-            'res_model': 'mail.message',
-            'views': [(self.env.ref('account.view_message_tree_audit_log').id, 'list'), (False, 'form')],
-            'search_view_id': [self.env.ref('account.view_message_tree_audit_log_search').id],
-            'domain': self._get_audit_trail_during_exception_domain(),
-        }
+            'res_model': 'account.move.line',
+            'view_mode': 'list,form',
+            'domain': [('move_id', 'any', self._get_audit_trail_during_exception_domain())],
+       }

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -291,6 +291,15 @@ class AccountMove(models.Model):
     country_code = fields.Char(related='company_id.account_fiscal_country_id.code', readonly=True)
     company_price_include = fields.Selection(related='company_id.account_price_include', readonly=True)
     attachment_ids = fields.One2many('ir.attachment', 'res_id', domain=[('res_model', '=', 'account.move')], string='Attachments')
+    audit_trail_message_ids = fields.One2many(
+        'mail.message',
+        'res_id',
+        domain=[
+            ('model', '=', 'account.move'),
+            ('message_type', '=', 'notification'),
+        ],
+        string='Audit Trail Messages',
+    )
 
     # === Hash Fields === #
     restrict_mode_hash_table = fields.Boolean(related='journal_id.restrict_mode_hash_table')

--- a/addons/account/views/account_lock_exception_views.xml
+++ b/addons/account/views/account_lock_exception_views.xml
@@ -19,7 +19,7 @@
                                     type="object" icon="fa-bars">
                                 <div class="o_stat_info">
                                     <span class="o_stat_text">
-                                        Audit Trail
+                                        Audit
                                     </span>
                                 </div>
                             </button>


### PR DESCRIPTION
On the exception form view is a button to audit the exception.
Clicking displays the audit trail messages and only does so when the
audit trail is activated in the settings.

After this commit
  * We only show (all) the lines of the affected moves instead of the individual messages
  * Exceptions can be audited when the audit trail setting is not activated
