### PR TITLE
[IMP] mrp_workorder:  partial production

### DIFF
--- a/addons/mrp/tests/test_backorder.py
+++ b/addons/mrp/tests/test_backorder.py
@@ -937,7 +937,7 @@ class TestMrpWorkorderBackorder(TransactionCase):
         bo_1 = mo.procurement_group_id.mrp_production_ids - mo
         self.assertRecordValues(bo_1.workorder_ids, [
             {'state': 'cancel', 'qty_remaining': 0.0, 'workcenter_id': op_1.workcenter_id.id},
-            {'state': 'waiting', 'qty_remaining': 6.0, 'workcenter_id': op_2.workcenter_id.id},
+            {'state': 'ready', 'qty_remaining': 6.0, 'workcenter_id': op_2.workcenter_id.id},
         ])
         with Form(bo_1) as form_bo_1:
             form_bo_1.qty_producing = 2
@@ -951,7 +951,7 @@ class TestMrpWorkorderBackorder(TransactionCase):
         bo_2 = mo.procurement_group_id.mrp_production_ids - mo - bo_1
         self.assertRecordValues(bo_2.workorder_ids, [
             {'state': 'cancel', 'qty_remaining': 0.0, 'workcenter_id': op_1.workcenter_id.id},
-            {'state': 'waiting', 'qty_remaining': 4.0, 'workcenter_id': op_2.workcenter_id.id},
+            {'state': 'ready', 'qty_remaining': 4.0, 'workcenter_id': op_2.workcenter_id.id},
         ])
         op_6 = bo_2.workorder_ids.filtered(lambda wo: wo.state != 'cancel')
         with Form(bo_2) as form_bo_2:

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -3433,8 +3433,8 @@ class TestMrpOrder(TestMrpCommon):
         mo_backorder.button_plan()
 
         self.assertEqual(mo_backorder.workorder_ids[0].state, 'cancel')
-        self.assertEqual(mo_backorder.workorder_ids[1].state, 'waiting')
-        self.assertEqual(mo_backorder.workorder_ids[2].state, 'pending')
+        self.assertEqual(mo_backorder.workorder_ids[1].state, 'ready')
+        self.assertEqual(mo_backorder.workorder_ids[2].state, 'ready')
         self.assertFalse(mo_backorder.workorder_ids[0].date_start)
         self.assertEqual(mo_backorder.workorder_ids[1].date_start, datetime(2023, 3, 1, 12, 0))
         self.assertEqual(mo_backorder.workorder_ids[2].date_start, datetime(2023, 3, 1, 12, 45))

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -77,6 +77,8 @@
                 <field name="workcenter_id" readonly="state in ['cancel', 'done', 'progress']"/>
                 <field name="product_id" optional="show"/>
                 <field name="qty_remaining" optional="show" string="Quantity Remaining"/>
+                <field name="qty_produced" optional="hide" string="Quantity Produced" readonly="state in ['done', 'cancel'] or not production_availability"/>
+                <field name="qty_ready" optional="hide"/>
                 <field name="finished_lot_id" optional="hide" string="Lot/Serial"/>
                 <field name="date_start" optional="hide" readonly="state in ['progress', 'done', 'cancel']"/>
                 <field name="date_finished" optional="hide" readonly="state in ['progress', 'done', 'cancel']"/>
@@ -111,8 +113,8 @@
             <xpath expr="//list/field[@name='qty_remaining']" position="attributes">
                 <attribute name="column_invisible">parent.state == 'done'</attribute>
             </xpath>
-            <xpath expr="//list/field[@name='qty_remaining']" position="after">
-                <field name="qty_produced" optional="show" string="Quantity Produced" column_invisible="parent.state != 'done'"/>
+            <xpath expr="//list/field[@name='qty_ready']" position="attributes">
+                <attribute name="column_invisible">parent.state == 'done'</attribute>
             </xpath>
             <xpath expr="//field[@name='show_json_popover']" position='before'>
                 <button name="action_open_wizard" type="object" icon="fa-external-link" class="oe_edit_only" title="Open Work Order" context="{'default_workcenter_id': workcenter_id}"/>


### PR DESCRIPTION
Allow operators to register partial production on
work orders, thereby liberating work orders in the
queue before marking operations as done.
This will make it much more flexible for users and
also reduce the need for creating backorders, which
can be quite messy and difficult to understand.

Task 3504085
odoo/enterprise#70649