### PR TITLE
[FIX] snailmail_account: fix a write in a test on invoice for partner without email

### DIFF
--- a/addons/snailmail_account/tests/test_snailmail_on_invoice.py
+++ b/addons/snailmail_account/tests/test_snailmail_on_invoice.py
@@ -17,7 +17,7 @@ class TestSnailmailOnInvoice(TransactionCase):
         })
 
         partner_without_email.write({
-            'country_id': self.env.ref('base.us'),
+            'country_id': self.env.ref('base.us').id,
             'street': 'Test street',
             'zip': '12345',
             'city': 'testcity',


### PR DESCRIPTION
Since pr https://github.com/odoo/odoo/commit/9e769e1b11f2 there was a typo, causing tests to break because value of country_id was missing .id at the end. This commit fixes the issue.

