### PR TITLE
Saas-17.4-time-off-approve-multiple-allocation-broken-akha

### DIFF
--- a/addons/hr_holidays/i18n/hr_holidays.pot
+++ b/addons/hr_holidays/i18n/hr_holidays.pot
@@ -946,7 +946,7 @@ msgstr ""
 #. module: hr_holidays
 #. odoo-python
 #: code:addons/hr_holidays/models/hr_leave_allocation.py:0
-msgid "Allocation must be confirmed (\"To Approve\") in order to approve it."
+msgid "Allocation must be confirmed (\"To Approve\") or validated once (\"Second Approval\") in order to approve it."
 msgstr ""
 
 #. module: hr_holidays

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -645,26 +645,6 @@ class HolidaysAllocation(models.Model):
     # Business methods
     ####################################################
 
-    def action_validate(self):
-        if any(allocation.state not in ['confirm', 'validate1'] and allocation.validation_type != 'no_validation' for allocation in self):
-            raise UserError(_('Allocation must be "To Approve" or "Second Approval" in order to validate it.'))
-
-        to_validate = self.filtered(lambda alloc: alloc.state == 'confirm' and alloc.validation_type != 'both')
-        to_second_validate = self.filtered(lambda alloc: alloc.state == 'validate1' and alloc.validation_type == 'both')
-        if to_validate:
-            to_validate.write({
-                'state': 'validate',
-                'approver_id': self.env.user.employee_id.id
-            })
-            to_validate.activity_update()
-        if to_second_validate:
-            to_second_validate.write({
-                'state': 'validate',
-                'second_approver_id': self.env.user.employee_id.id
-            })
-            to_second_validate.activity_update()
-        return True
-
     def action_set_to_confirm(self):
         if any(allocation.state != 'refuse' for allocation in self):
             raise UserError(_('Allocation state must be "Refused" in order to be reset to "To Approve".'))
@@ -677,18 +657,32 @@ class HolidaysAllocation(models.Model):
         return True
 
     def action_approve(self):
-        # if allocation_validation_type == 'both': this method is the first approval
-        # if allocation_validation_type != 'both': this method calls action_validate() below
+        self._action_approve()
+        return True
 
-        if any(allocation.state != 'confirm' for allocation in self):
-            raise UserError(_('Allocation must be confirmed ("To Approve") in order to approve it.'))
+    def action_validate(self):
+        # We don't know all the places in all the apps where `action_validate` is called.
+        # Hence, `action_validate` is kept and not removed.
+        self._action_approve()
+        return True
+
+    def _action_approve(self):
+
+        if any(allocation.state not in ['confirm', 'validate1'] and allocation.validation_type != 'no_validation' for allocation in self):
+            raise UserError(_('Allocation must be confirmed "To Approve" or validated once "Second Approval" in order to approve it.'))
 
         current_employee = self.env.user.employee_id
-        self.filtered(lambda alloc: alloc.validation_type == 'both').write({'state': 'validate1', 'approver_id': current_employee.id})
+        # If a time-off type had validation_type = 'both' and after first validation the validation_type was changed to be != both,
+        # then it should be considered as a single_validate_allocation.
+        single_validate_allocs = self.filtered(lambda alloc: alloc.state == 'confirm' and alloc.validation_type != 'both')
+        first_validate_allocs = self.filtered(lambda alloc: alloc.state == 'confirm' and alloc.validation_type == 'both')
+        second_validate_allocs = self.filtered(lambda alloc: alloc.state == 'validate1')
 
-        self.filtered(lambda alloc: alloc.validation_type != 'both').action_validate()
+        single_validate_allocs.write({'state': 'validate', 'approver_id': current_employee.id})
+        first_validate_allocs.write({'state': 'validate1', 'approver_id': current_employee.id})
+        second_validate_allocs.write({'state': 'validate', 'second_approver_id': current_employee.id})
+
         self.activity_update()
-        return True
 
     def action_refuse(self):
         current_employee = self.env.user.employee_id


### PR DESCRIPTION
**Fix a bug that prevented approving allocation requests that required multiple approvers**

**Steps to reproduce**

1. Create a new time off type and set `approval` to `By employee's approver and time off officer`.
2. Create a new allocation:
    * Use the time off type created above.
    * Set the number of days to 20.
3. Save the created allocation.
4. Go to `Management -> Allocations`.
5. Select the created allocation and press on the actions cog.
6. Press on `Approve Allocations`.
7. The allocation state doesn't change to `second approval`.

The action `Approve Allocations` doesn't take into account the allocations that are in the first stage of approval.

task-4207884