### PR TITLE
[FIX] point_of_sale: Ensure order exists before reading state in refund

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
@@ -214,8 +214,13 @@ odoo.define('point_of_sale.TicketScreen', function (require) {
 
             const invoicedOrderIds = new Set(
                 allToRefundDetails
-                    .filter(detail => this._state.syncedOrders.cache[detail.orderline.orderBackendId].state === "invoiced")
-                    .map(detail => detail.orderline.orderBackendId)
+                    .filter(
+                        (detail) =>
+                            this._state.syncedOrders.cache[detail.orderline.orderBackendId] &&
+                            this._state.syncedOrders.cache[detail.orderline.orderBackendId].state ===
+                            "invoiced"
+                    )
+                    .map((detail) => detail.orderline.orderBackendId)
             );
 
             if (invoicedOrderIds.size > 1) {


### PR DESCRIPTION
Prior to this commit, there were scenarios where sync orders did not contain an order, leading to a failure when reading its state. This commit introduces a check to ensure the order exists in sync before its state is read, thereby preventing this error.

backport of `https://github.com/odoo/odoo/pull/162943`

opw-4190381


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
