### PR TITLE
[FIX] stock: only select stock users when requesting a count

### DIFF
--- a/addons/stock/wizard/stock_request_count.py
+++ b/addons/stock/wizard/stock_request_count.py
@@ -13,7 +13,7 @@ class StockRequestCount(models.TransientModel):
         'Inventory Date', required=True,
         help="Choose a date to get the inventory at that date",
         default=fields.Datetime.now)
-    user_id = fields.Many2one('res.users', string="User")
+    user_id = fields.Many2one('res.users', string="User", domain=lambda self: [('groups_id', 'in', self.env.ref('stock.group_stock_user').id)])
     quant_ids = fields.Many2many('stock.quant')
     set_count = fields.Selection([('empty', 'Leave Empty'), ('set', 'Set Current Value')], default='empty', string='Count')
 


### PR DESCRIPTION
It is currently possible to select any user for a count request in the Inventory Adjustments view, even portal users.
This fix ensures only stock users are selected.

task 4207784

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
