### PR TITLE
[FIX] website: fix multiple buttons rendering within snippets

### DIFF
--- a/addons/website/views/snippets/s_closer_look.xml
+++ b/addons/website/views/snippets/s_closer_look.xml
@@ -7,8 +7,8 @@
             <h1 class="display-3" style="text-align: center;">Take a closer look</h1>
             <p class="lead" style="text-align: center;">Write one or two paragraphs describing your product, services or a specific feature.<br/> To be successful your content needs to be useful to your readers.</p>
             <p style="text-align: center;">
-                <a t-att-href="cta_btn_href" class="btn btn-primary">Start Now</a>
-                <a t-att-href="cta_btn_href" class="btn btn-outline-primary"><t t-out="cta_btn_text">Contact us</t></a>
+                <a t-att-href="cta_btn_href" class="btn btn-primary mb-2">Start Now</a>
+                <a t-att-href="cta_btn_href" class="btn btn-outline-primary mb-2"><t t-out="cta_btn_text">Contact us</t></a>
             </p>
             <p>
                 <br/>

--- a/addons/website/views/snippets/s_cover.xml
+++ b/addons/website/views/snippets/s_cover.xml
@@ -9,8 +9,8 @@
             <h1 class="display-3" style="text-align: center;">Your journey starts here</h1>
             <p class="lead" style="text-align: center;">Write one or two paragraphs describing your product, services or a specific feature.<br/> To be successful your content needs to be useful to your readers.</p>
             <p style="text-align: center;">
-                <a t-att-href="cta_btn_href" class="btn btn-secondary"><t t-esc="cta_btn_text">Discover more</t></a>
-                <a t-att-href="cta_btn_href" class="btn btn-outline-secondary"><t t-esc="cta_btn_text">Contact us</t></a>
+                <a t-att-href="cta_btn_href" class="btn btn-secondary mb-2"><t t-esc="cta_btn_text">Discover more</t></a>
+                <a t-att-href="cta_btn_href" class="btn btn-outline-secondary mb-2"><t t-esc="cta_btn_text">Contact us</t></a>
             </p>
         </div>
     </section>

--- a/addons/website/views/snippets/s_discovery.xml
+++ b/addons/website/views/snippets/s_discovery.xml
@@ -10,8 +10,8 @@
             <h1 class="display-2" style="text-align: center;">Discover our solutions</h1>
             <p class="lead" style="text-align: center;">Write one or two paragraphs describing your product, services or a specific feature.<br/> To be successful your content needs to be useful to your readers.<br/><br/></p>
             <p style="text-align: center;">
-                <a t-att-href="cta_btn_href" class="btn btn-primary"><t t-out="cta_btn_text">Our store</t></a>
-                <a t-att-href="cta_btn_href" class="btn btn-secondary"><t t-out="cta_btn_text">Contact us</t></a>
+                <a t-att-href="cta_btn_href" class="btn btn-primary mb-2"><t t-out="cta_btn_text">Our store</t></a>
+                <a t-att-href="cta_btn_href" class="btn btn-secondary mb-2"><t t-out="cta_btn_text">Contact us</t></a>
             </p>
         </div>
     </section>

--- a/addons/website/views/snippets/s_empowerment.xml
+++ b/addons/website/views/snippets/s_empowerment.xml
@@ -12,8 +12,8 @@
                     <h1 class="display-4">Empowering Your Success<br/>with Every Solution.</h1>
                     <p class="lead"><br/>Delivering tailored, innovative tools to help you overcome challenges and<br/> achieve your goals, ensuring your journey is fully supported.<br/><br/></p>
                     <p>
-                        <a href="#" class="btn btn-primary">Get started</a>
-                        <a href="#" class="btn btn-secondary">Learn more</a>
+                        <a href="#" class="btn btn-primary mb-2">Get started</a>
+                        <a href="#" class="btn btn-secondary mb-2">Learn more</a>
                     </p>
                 </div>
                 <div class="o_grid_item o_grid_item_image g-height-12 g-col-lg-5 col-lg-5 o_snippet_mobile_invisible d-none d-lg-block" style="grid-area: 1 / 8 / 13 / 13; --grid-item-padding-x: 24px; --grid-item-padding-y: 0px;">


### PR DESCRIPTION
This commit introduces a fix for the snippets that include at least two
buttons in their layout.

Prior to this commit, the buttons were simply defined within the `<p>`
tag, due to a lack of testing corner case scenarios. This implementation
was actually wrong, because as soon as you add `n+1` button within the
editor, it'll apply a `mb-2` on each button to space them correctly on
smaller devices.

To fix this issue, we simply replicate the behaviour of the editor by
adding the class on the snippets that match this scenario.

task-4210852
part of task-4077427

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
