### PR TITLE
[FIX] stock: only select stock users when requesting a count

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -122,7 +122,8 @@ class StockQuant(models.Model):
     inventory_quantity_set = fields.Boolean(store=True, compute='_compute_inventory_quantity_set', readonly=False, default=False)
     is_outdated = fields.Boolean('Quantity has been moved since last count', compute='_compute_is_outdated')
     user_id = fields.Many2one(
-        'res.users', 'Assigned To', help="User assigned to do product count.")
+        'res.users', 'Assigned To', help="User assigned to do product count.",
+        domain=lambda self: [('groups_id', 'in', self.env.ref('stock.group_stock_user').id)])
 
     @api.depends('quantity', 'reserved_quantity')
     def _compute_available_quantity(self):

--- a/addons/stock/wizard/stock_request_count.py
+++ b/addons/stock/wizard/stock_request_count.py
@@ -12,7 +12,7 @@ class StockRequestCount(models.TransientModel):
         'Inventory Date', required=True,
         help="Choose a date to get the inventory at that date",
         default=fields.Datetime.now)
-    user_id = fields.Many2one('res.users', string="User")
+    user_id = fields.Many2one('res.users', string="User", domain=lambda self: [('groups_id', 'in', self.env.ref('stock.group_stock_user').id)])
     quant_ids = fields.Many2many('stock.quant')
     set_count = fields.Selection([('empty', 'Leave Empty'), ('set', 'Set Current Value')], default='empty', string='Count')
 


### PR DESCRIPTION
In the Inventory Adjustments view, it is currently possible to
select any user for a count request or assign any user to a
specific stock.quant, even portal users.
This fix ensures only stock users are selected.

task 4207784

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
