### PR TITLE
[FIX] web: resequence with NULL values

### DIFF
--- a/addons/web/static/src/model/relational_model/dynamic_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_list.js
@@ -339,13 +339,9 @@ export class DynamicList extends DataPoint {
             let lastSequence = (asc ? -1 : 1) * Infinity;
             for (let index = 0; index < originalList.length; index++) {
                 const sequence = getSequence(originalList[index]);
-                if (
-                    ((index < firstIndex || index >= lastIndex) &&
-                        ((asc && lastSequence >= sequence) ||
-                            (!asc && lastSequence <= sequence))) ||
-                    (index >= firstIndex && index < lastIndex && lastSequence === sequence)
-                ) {
+                if ((asc && lastSequence >= sequence) || (!asc && lastSequence <= sequence)) {
                     reorderAll = true;
+                    break;
                 }
                 lastSequence = sequence;
             }

--- a/addons/web/static/src/model/relational_model/static_list.js
+++ b/addons/web/static/src/model/relational_model/static_list.js
@@ -975,12 +975,9 @@ export class StaticList extends DataPoint {
         let lastSequence = (asc ? -1 : 1) * Infinity;
         for (let index = 0; index < records.length; index++) {
             const sequence = getSequence(records[index]);
-            if (
-                ((index < firstIndex || index >= lastIndex) &&
-                    ((asc && lastSequence >= sequence) || (!asc && lastSequence <= sequence))) ||
-                (index >= firstIndex && index < lastIndex && lastSequence === sequence)
-            ) {
+            if ((asc && lastSequence >= sequence) || (!asc && lastSequence <= sequence)) {
                 reorderAll = true;
+                break;
             }
             lastSequence = sequence;
         }

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -11484,6 +11484,163 @@ QUnit.module("Views", (hooks) => {
         );
     });
 
+    QUnit.test("resequence with NULL values", async function (assert) {
+        const mockedActionService = {
+            start() {
+                return {
+                    doActionButton(params) {
+                        if (params.name === "reload") {
+                            params.onClose();
+                        } else {
+                            throw makeServerError();
+                        }
+                    },
+                };
+            },
+        };
+        serviceRegistry.add("action", mockedActionService, { force: true });
+
+        serverData.models = {
+            // we want the data to be minimal to have a minimal test
+            foo: {
+                fields: { int_field: { string: "int_field", type: "integer", sortable: true } },
+                records: [
+                    { id: 1, int_field: 1 },
+                    { id: 2 },
+                    { id: 3, int_field: 3 },
+                    { id: 4, int_field: 2 },
+                ],
+            },
+        };
+        await makeView({
+            type: "list",
+            resModel: "foo",
+            serverData,
+            arch: `
+                <tree default_order="int_field">
+                    <field name="int_field" widget="handle"/>
+                    <field name="id"/>
+                    <button name="reload" class="reload" string="Confirm" type="object"/>
+                </tree>`,
+            async mockRPC(route, args, performRPC) {
+                if (args.method === "web_search_read") {
+                    const res = await performRPC(route, args);
+                    const serverRecords = Object.fromEntries(
+                        Object.values(serverData.models.foo.records).map((e) => [e.id, e])
+                    );
+                    // when sorted, NULL values are last
+                    const getServerValue = (record) =>
+                        serverRecords[record.id].int_field === false
+                            ? Number.MAX_SAFE_INTEGER
+                            : serverRecords[record.id].int_field;
+
+                    res.records.sort((a, b) => getServerValue(a) - getServerValue(b));
+                    return res;
+                }
+            },
+        });
+        assert.deepEqual(
+            Array.from(document.querySelectorAll(".o_field_cell[name=id]")).map(
+                (e) => e.textContent
+            ),
+            ["1", "4", "3", "2"],
+            "2 should be the last one because NULL is sorted last in python"
+        );
+
+        // drag and drop the fourth line in third position
+        await dragAndDrop("tbody tr:nth-child(4) .o_handle_cell", "tbody tr:nth-child(3)");
+        assert.deepEqual(
+            Array.from(document.querySelectorAll(".o_field_cell[name=id]")).map(
+                (e) => e.textContent
+            ),
+            ["1", "4", "2", "3"]
+        );
+
+        await click(target.querySelector("button.reload"));
+        assert.deepEqual(
+            Array.from(document.querySelectorAll(".o_field_cell[name=id]")).map(
+                (e) => e.textContent
+            ),
+            ["1", "4", "2", "3"],
+            "The order should be kept"
+        );
+    });
+
+    QUnit.test("resequence with only NULL values", async function (assert) {
+        const mockedActionService = {
+            start() {
+                return {
+                    doActionButton(params) {
+                        if (params.name === "reload") {
+                            params.onClose();
+                        } else {
+                            throw makeServerError();
+                        }
+                    },
+                };
+            },
+        };
+        serviceRegistry.add("action", mockedActionService, { force: true });
+
+        serverData.models = {
+            // we want the data to be minimal to have a minimal test
+            foo: {
+                fields: { int_field: { string: "int_field", type: "integer", sortable: true } },
+                records: [{ id: 1 }, { id: 2 }, { id: 3 }],
+            },
+        };
+        await makeView({
+            type: "list",
+            resModel: "foo",
+            serverData,
+            arch: `
+                <tree default_order="int_field">
+                    <field name="int_field" widget="handle"/>
+                    <field name="id"/>
+                    <button name="reload" class="reload" string="Confirm" type="object"/>
+                </tree>`,
+            async mockRPC(route, args, performRPC) {
+                if (args.method === "web_search_read") {
+                    const res = await performRPC(route, args);
+                    const serverRecords = Object.fromEntries(
+                        Object.values(serverData.models.foo.records).map((e) => [e.id, e])
+                    );
+                    // when sorted, NULL values are last
+                    const getServerValue = (record) =>
+                        serverRecords[record.id].int_field === false
+                            ? Number.MAX_SAFE_INTEGER
+                            : serverRecords[record.id].int_field;
+
+                    res.records.sort((a, b) => getServerValue(a) - getServerValue(b));
+                    return res;
+                }
+            },
+        });
+        assert.deepEqual(
+            Array.from(document.querySelectorAll(".o_field_cell[name=id]")).map(
+                (e) => e.textContent
+            ),
+            ["1", "2", "3"]
+        );
+
+        // drag and drop the third line in second position
+        await dragAndDrop("tbody tr:nth-child(3) .o_handle_cell", "tbody tr:nth-child(2)");
+        assert.deepEqual(
+            Array.from(document.querySelectorAll(".o_field_cell[name=id]")).map(
+                (e) => e.textContent
+            ),
+            ["1", "3", "2"]
+        );
+
+        await click(target.querySelector("button.reload"));
+        assert.deepEqual(
+            Array.from(document.querySelectorAll(".o_field_cell[name=id]")).map(
+                (e) => e.textContent
+            ),
+            ["1", "3", "2"]
+        );
+    });
+
     QUnit.test("editable list with handle widget", async function (assert) {
         assert.expect(12);
 


### PR DESCRIPTION
Steps to reproduce
==================

1) Create a Bill of Materials
2) Select a product
3) Add an operation
4) Save
5) Click on the Show Instructions button
6) Create three instructions [A, B, C]
7) Go back to the instructions list
8) The order is [A, B, C]
9) Swap the last two instructions (move the third one before the second one)
10) The order should now be [A, C, B]
11) Create a new instruction D
12) Go back to the instructions list
13) The order should be [A, C, B, D]
14) Move the fourth one one slot up
15) The order should be [A, C, D, B]
16) Go back to the BOM
17) Click again on the Show Instructions button
18) The order has now changed and is [A, D, C, B]

Cause of the issue
==================

The quality.point model has no default value for the sequence field.
Instructions are created from a form view -> There is no context as to
which sequence we should choose the be the last one.
We pass no value for the sequence field when creating a record -> NULL
is what's actually saved in the database.
When the webclient reads the records, it receives 0 instead of NULL for
the sequence value.

Here are the ordered values by sequence at step 8:

```
+------+----------+
| name | sequence |
|------+----------|
| A    | <null>   |
| B    | <null>   |
| C    | <null>   |
+------+----------+
```

Step 9:
The webclient reorders [A, C, B] with no offset

Step 10:
```
+------+----------+
| name | sequence |
|------+----------|
| A    | 0        |
| C    | 1        |
| B    | 2        |
+------+----------+
```

Step 13:
```
+------+----------+
| name | sequence |
|------+----------|
| A    | 0        |
| C    | 1        |
| B    | 2        |
| D    | <null>   |
+------+----------+
```

Step 14:
The webclient reorders [D, B] with no offset

Step 15:
```
+------+----------+
| name | sequence |
|------+----------|
| A    | 0        |
| D    | 0        |
| B    | 1        |
| C    | 1        |
+------+----------+
```

Currently these are the cases where we reorder every record:

- If the sections outside the edited range are not sorted
- If we are inside the modified range and adjacent records have the same
  sequence

Since the webclient has no idea if a value is null or not,
we don't reorder every record in step 14

Solution
========

Since there is no easy way to guess if a record has a NULL value,
we reorder every record if the initial list is not strictly ordered.

Limitations
===========

This doesn't properly handle cases were there are multiple pages,
or if there is a domain applied.

This is already the case without NULLs.

Alternate solutions
===================

Return the record from the server ordered as if NULL was equal to 0
-------------------------------------------------------------------

A lot of usecases actually depends on this behaviour and we can't change
that.

Set a default on the field
--------------------------

We can't choose a default value that would always result in new records
being the latest one. With Int.MAX, we can't resequence as this simply
increments the existing sequence.
This doesn't handle existing records having a NULL value.

A new field type fields.Sequence()
----------------------------------

This can't be done in stable and we would need to migrate existing data

opw-4032273