### PR TITLE
[FIX] stock: disable drag & drop in operations kanban view

### DIFF
--- a/addons/stock/views/stock_picking_type_views.xml
+++ b/addons/stock/views/stock_picking_type_views.xml
@@ -175,7 +175,7 @@
         <field name="name">stock.picking.type.kanban</field>
         <field name="model">stock.picking.type</field>
         <field name="arch" type="xml">
-            <kanban highlight_color="color" class="o_stock_kanban" js_class="stock_dashboard_kanban" create="0" group_create="false" can_open="0">
+            <kanban highlight_color="color" class="o_stock_kanban" js_class="stock_dashboard_kanban" records_draggable="0" create="0" group_create="false" can_open="0">
                 <field name="color"/>
                 <field name="code" readonly="1"/>
                 <field name="count_move_ready"/>


### PR DESCRIPTION
In a multi-warehouse environment, dragging and dropping operations card by mistagein "group by" view can lead to many issues. Therefore, this PR disables this feature.

task-4207673


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
