### PR TITLE
[FIX] survey: overlap images on user side result page

### DIFF
--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -427,7 +427,7 @@
             <!-- Directly use field or route if the user doesn't have access rights -->
             <div t-if="not env.user.has_group('survey.group_survey_user')"
                 class="o_survey_choice_img d-flex my-3 justify-content-center">
-                <img t-att-src="'/survey/get_question_image/%s/%s/%s/%s' % (survey.access_token, answer.access_token, question.id, label.id)"/>
+                <img t-att-src="'/survey/get_question_image/%s/%s/%s/%s' % (survey.access_token, answer.access_token, question.id, label.id)" class="mw-100 h-auto"/>
             </div>
             <div t-else=""  t-field="label.value_image"
                 class="o_survey_choice_img d-flex my-3 justify-content-center"


### PR DESCRIPTION
Steps to reproduce:
1. Create a live session for a 'Quiz about your company' survey
2. Add images to your answers
2. Complete it with one user
3. Review your answer in the last
4. The images are getting overlap

Technical Reason:
on the user-side results page, images that were not properly handled were displayed at their default size.

After this commit:
it should be perfectly aligned.

Task-4208130