### PR TITLE
[FIX] packaging: fix lxml.html.clean split

### DIFF
--- a/debian/py3dist-overrides
+++ b/debian/py3dist-overrides
@@ -1,0 +1,1 @@
+lxml python3-lxml-html-clean | python3-lxml

--- a/setup/package.dfdebian
+++ b/setup/package.dfdebian
@@ -1,7 +1,9 @@
 # Please note that this Dockerfile is used for testing nightly builds and should
 # not be used to deploy Odoo
-FROM debian:bookworm
+FROM ubuntu:noble
 MAINTAINER Odoo S.A. <info@odoo.com>
+
+RUN userdel -r ubuntu
 
 RUN apt-get update && \
     apt-get install -y locales && \
@@ -35,6 +37,7 @@ RUN apt-get update -qq &&  \
         python3-jinja2 \
         python3-libsass \
         python3-lxml \
+        python3-lxml-html-clean \
         python3-ofxparse \
         python3-openpyxl \
         python3-passlib \


### PR DESCRIPTION
Since lxml.html.clean was moved to a separate package starting in lxml 5.2 the odoo Debian package was broken in Ubuntu 24.04.

A first fix was attempted in 318df32585b. While the package was properly built with this fix and was installable, but Odoo failed to start under Ubuntu. The bug flew under the radar because the simple test after the package build is done with a Docker based on Debian Bookworm.

In fact, the fix was not taken into account because the python packages defined in the debian/control are not really taken into account by dh_python3 that tries to compute the python dependencies.

With this commit, a py3dist-overrides file is used to overrides the package mapping between python packages and debian packages. The same pipe trick is used as in the previous fix to ensure that the package is installable in Ubuntu 24.04 (which provides python3-lxml-html) and in Debian Bookworm (which does not provide the python3-lxm-html).

Finally, the Docker image used for the build and the test is changed to use Ubuntu 24.04.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
