### PR TITLE
[FIX] product: discount not set correctly if markup 0

### DIFF
--- a/addons/product/models/product_pricelist_item.py
+++ b/addons/product/models/product_pricelist_item.py
@@ -322,8 +322,7 @@ class PricelistItem(models.Model):
     @api.onchange('price_markup')
     def _onchange_price_markup(self):
         for item in self:
-            if item.price_markup:
-                item.price_discount = -item.price_markup
+            item.price_discount = -item.price_markup
 
     @api.onchange('product_id')
     def _onchange_product_id(self):


### PR DESCRIPTION
If markup is set to a value then reset to 0, the discount is not properly reset to 0.
This commit removes `if item.price_markup` as it was wrong.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
