### PR TITLE
[FIX] website_sale_mondialrelay: adapt to new checkout

### DIFF
--- a/addons/website_sale/static/src/js/checkout.js
+++ b/addons/website_sale/static/src/js/checkout.js
@@ -22,6 +22,7 @@ publicWidget.registry.WebsiteSaleCheckout = publicWidget.Widget.extend({
     async start() {
         this.mainButton = document.querySelector('a[name="website_sale_main_button"]');
         this.use_delivery_as_billing_toggle = document.querySelector('#use_delivery_as_billing');
+        this.billingContainer = this.el.querySelector('#billing_container');
         await this._prepareDeliveryMethods();
     },
 
@@ -36,7 +37,7 @@ publicWidget.registry.WebsiteSaleCheckout = publicWidget.Widget.extend({
      */
     async _changeAddress(ev) {
         const newAddress = ev.currentTarget;
-        if (newAddress.dataset.isSelected) { // If the card is already selected.
+        if (newAddress.classList.contains('bg-primary')) { // If the card is already selected.
             return;
         }
         const addressType = newAddress.dataset.addressType;
@@ -87,14 +88,13 @@ publicWidget.registry.WebsiteSaleCheckout = publicWidget.Widget.extend({
         }
 
         // Toggle the billing address row.
-        const billingContainer = this.el.querySelector('#billing_container');
         if (useDeliveryAsBilling) {
-            billingContainer.classList.add('d-none');  // Hide the billing address row.
+            this.billingContainer.classList.add('d-none');  // Hide the billing address row.
             const selectedDeliveryAddress = this._getSelectedAddress('delivery');
             await this._selectMatchingBillingAddress(selectedDeliveryAddress.dataset.partnerId);
         } else {
             this._disableMainButton();
-            billingContainer.classList.remove('d-none');  // Show the billing address row.
+            this.billingContainer.classList.remove('d-none');  // Show the billing address row.
         }
 
         this._enableMainButton();  // Try to enable the main button.

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -506,7 +506,7 @@ div#payment_method {
     }
 }
 
-.js_change_delivery, .js_change_billing {
+.js_change_address {
     cursor: pointer;
 }
 

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2249,7 +2249,7 @@
             <h4 class="text-uppercase small fs-6 fw-bold mt-3">Billing address</h4>
             <t t-set="has_delivery" t-value="order._has_deliverable_products()"/>
             <div t-if="has_delivery" class="form-check form-switch mt-2 mb-3">
-                <label>
+                <label id="use_delivery_as_billing_label">
                     <input
                         type="checkbox"
                         id="use_delivery_as_billing"
@@ -2310,9 +2310,12 @@
     <!-- Card view of addresses. Called in `website_sale.checkout`. -->
     <template id="address_kanban" name="Kanban address">
         <t t-set="address_type" t-value="is_invoice and 'billing' or 'delivery'"/>
-        <div t-attf-class="card position-relative h-100 #{selected and 'bg-primary border border-primary' or is_invoice and 'js_change_billing' or 'js_change_delivery'}"
-             t-att-data-address-type="address_type"
-             t-att-data-partner-id="contact.id">
+        <div
+            name="address_card"
+            t-attf-class="card position-relative h-100 #{selected and 'bg-primary border border-primary' or 'js_change_address'}"
+            t-att-data-address-type="address_type"
+            t-att-data-partner-id="contact.id"
+        >
             <div class="card-body d-flex flex-column align-items-start">
                 <t t-esc="contact" t-options="dict(widget='contact', fields=['name', 'address'], no_marker=True)"/>
                 <t t-if="contact._can_be_edited_by_current_customer(website_sale_order, address_type)">

--- a/addons/website_sale_mondialrelay/__manifest__.py
+++ b/addons/website_sale_mondialrelay/__manifest__.py
@@ -11,6 +11,7 @@ This module allow your customer to choose a Point Relais® and use it as shippin
     'depends': ['website_sale', 'delivery_mondialrelay'],
     'data': [
         'views/delivery_carrier_views.xml',
+        'views/delivery_form_templates.xml',
         'views/res_config_settings_views.xml',
         'views/templates.xml',
     ],

--- a/addons/website_sale_mondialrelay/views/delivery_form_templates.xml
+++ b/addons/website_sale_mondialrelay/views/delivery_form_templates.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="mondialrelay_delivery_method" inherit_id="website_sale.delivery_method">
+        <input name="o_delivery_radio" position="attributes">
+            <attribute name="t-att-data-is-mondialrelay">dm.is_mondialrelay</attribute>
+        </input>
+        <label class="o_delivery_carrier_label" position="after">
+            <small t-if="dm.is_mondialrelay" class="text-muted my-auto">
+                Click to choose a pickup point
+            </small>
+        </label>
+    </template>
+
+</odoo>

--- a/addons/website_sale_mondialrelay/views/templates.xml
+++ b/addons/website_sale_mondialrelay/views/templates.xml
@@ -1,17 +1,31 @@
 <odoo>
 
-    <template id="website_sale_mondialrelay_address_on_payment" inherit_id="website_sale.address_on_payment">
-        <xpath expr="//span[@t-out='order.partner_shipping_id']" position="before">
-            <t t-if="order.partner_shipping_id.is_mondialrelay" >
-                <img src="/website_sale_mondialrelay/static/src/img/logo.png" title="Mondial Relay" height="20px" />
-            </t>
-        </xpath>
+    <template
+        id="website_sale_mondialrelay_billing_address_row"
+        inherit_id="website_sale.billing_address_row"
+    >
+        <label id="use_delivery_as_billing_label" position="attributes">
+            <attribute name="title">Unavailable with Mondial Relay</attribute>
+            <attribute name="data-bs-toggle">tooltip</attribute>
+            <attribute name="data-bs-trigger">hover focus</attribute>
+        </label>
     </template>
 
     <template id="website_sale_mondialrelay_address_kanban" inherit_id="website_sale.address_kanban">
         <xpath expr="//t[@t-esc='contact']" position="before">
             <t t-if="contact.is_mondialrelay">
                 <img class="float-end" title="Mondial Relay" height="20px" src="/website_sale_mondialrelay/static/src/img/logo.png" />
+            </t>
+        </xpath>
+        <div name="address_card" position="attributes">
+            <attribute name="t-att-data-is-mondialrelay">contact.is_mondialrelay</attribute>
+        </div>
+    </template>
+
+    <template id="website_sale_mondialrelay_address_on_payment" inherit_id="website_sale.address_on_payment">
+        <xpath expr="//span[@t-out='order.partner_shipping_id']" position="before">
+            <t t-if="order.partner_shipping_id.is_mondialrelay" >
+                <img src="/website_sale_mondialrelay/static/src/img/logo.png" title="Mondial Relay" height="20px" />
             </t>
         </xpath>
     </template>


### PR DESCRIPTION
It was possible to use delivery as billing address even if delivery address was a modialrelay one. That caused a traceback as it is not allowed to change modialrelay address. This commit will prevent these cases.
