### PR TITLE
[FIX] account: use domestic fp when domestic vat in EU

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -250,11 +250,17 @@ class AccountFiscalPosition(models.Model):
 
         # First search only matching VAT positions
         vat_required = bool(partner.vat)
-        fp = self._get_fpos_by_region(delivery.country_id.id, delivery.state_id.id, delivery.zip, vat_required)
+        vat_not_matching_country_for_domestic_eu = (
+            intra_eu and vat_exclusion and delivery.country_id != company.country_id
+        )
+        fpos_country_id = company.country_id.id if vat_not_matching_country_for_domestic_eu else delivery.country_id.id
+        fpos_state_id = False if vat_not_matching_country_for_domestic_eu else delivery.state_id.id
+        fpos_zip = False if vat_not_matching_country_for_domestic_eu else delivery.zip
+        fp = self._get_fpos_by_region(fpos_country_id, fpos_state_id, fpos_zip, vat_required)
 
         # Then if VAT required found no match, try positions that do not require it
         if not fp and vat_required:
-            fp = self._get_fpos_by_region(delivery.country_id.id, delivery.state_id.id, delivery.zip, False)
+            fp = self._get_fpos_by_region(fpos_country_id, fpos_state_id, fpos_zip, False)
 
         return fp or self.env['account.fiscal.position']
 

--- a/addons/account/tests/test_fiscal_position.py
+++ b/addons/account/tests/test_fiscal_position.py
@@ -215,6 +215,11 @@ class TestFiscalPosition(common.TransactionCase):
             'name': 'US NO VAT',
             'country_id': self.us.id,
         })
+        partner_nl_be_vat = self.env['res.partner'].create({
+            'name': 'NL BE VAT',
+            'vat': 'BE0477472701',
+            'country_id': self.nl.id,
+        })
 
         # Case : 1
         # Billing (VAT/country) : BE/BE
@@ -268,6 +273,14 @@ class TestFiscalPosition(common.TransactionCase):
         self.assertEqual(
             self.env['account.fiscal.position'].get_fiscal_position(partner_us_no_vat.id, partner_us_no_vat.id),
             fp_eu_extra
+        )
+
+        # Case : 7
+        # Billing (VAT/country): BE/NL
+        # Delivery (VAT/country): BE/NL
+        self.assertEqual(
+            self.env['account.fiscal.position'].get_fiscal_position(partner_nl_be_vat.id, partner_nl_be_vat),
+            fp_be_nat
         )
 
     def test_fiscal_position_constraint(self):


### PR DESCRIPTION
Currently the fiscal position gets determined based on the country of the customer. However, in the EU we should take into account the country of the VAT number, since that determines the fiscal country.

Say you are a Belgian company and you have a customer with a Belgian VAT number, but the address in the Netherlands, the current logic would define that the fiscal position is "intra-community", since the countries differ.

This commit changes the check for the EU to take into account the fiscal country of the customer based on his VAT number (if there is one).

[task-4185132](https://www.odoo.com/odoo/all-tasks/4185132)