### PR TITLE
[FIX] stock: report rule table scss

### DIFF
--- a/addons/stock/static/src/scss/report_stock_rule.scss
+++ b/addons/stock/static/src/scss/report_stock_rule.scss
@@ -1,4 +1,13 @@
 .o_report_stock_rule{
+
+    .table > :not(:first-child) {
+        border-top: 2px solid currentColor;
+    }
+
+    .table {
+        border-color: #dee2e6;
+    }
+
     .o_report_stock_rule_rule {
         display: flex;
         flex-flow: row nowrap;


### PR DESCRIPTION
In the stock rule diagram, the table border color was not correct anymore.

before:
![image](https://github.com/user-attachments/assets/a415063c-fe4d-4111-8cb0-97f22f7e1646)

after:
![image](https://github.com/user-attachments/assets/513ba257-25b0-4bc5-931d-4636c50be39b)


task-id: 4207218

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
