### PR TITLE
Multiple fixes for return picking

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -124,7 +124,7 @@ class StockPicking(models.Model):
             # Creates new SO line only when pickings linked to a sale order and
             # for moves with qty. done and not already linked to a SO line.
             if not sale_order \
-                or (move.location_dest_id.usage != 'customer' and not move.to_refund) \
+                or (move.location_dest_id.usage != 'customer' and not (move.location_id.usage == 'customer' and move.to_refund)) \
                 or move.sale_line_id \
                 or not move.picked:
                 continue

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -12,6 +12,15 @@ from odoo import Command
 @tagged('post_install', '-at_install')
 class TestSaleStock(TestSaleStockCommon, ValuationReconciliationTestCommon):
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.new_product = cls.env['product.product'].create({
+            'name': 'new_product',
+            'type': 'consu',
+            'is_storable': True,
+        })
+
     def _get_new_sale_order(self, amount=10.0, product=False):
         """ Creates and returns a sale order with one default order line.
 
@@ -1231,15 +1240,10 @@ class TestSaleStock(TestSaleStockCommon, ValuationReconciliationTestCommon):
         picking.move_ids.write({'quantity': 10, 'picked': True})
         picking.button_validate()
 
-        new_product = self.env['product.product'].create({
-            'name': 'new_product',
-            'type': 'consu',
-            'is_storable': True,
-        })
         return_picking_form = Form(self.env['stock.return.picking']
             .with_context(active_id=picking.id, active_model='stock.picking'))
         with return_picking_form.product_return_moves.new() as line:
-            line.product_id = new_product
+            line.product_id = self.new_product
             line.quantity = 2
         return_wizard = return_picking_form.save()
         return_wizard.product_return_moves[0].quantity = 2
@@ -1248,16 +1252,46 @@ class TestSaleStock(TestSaleStockCommon, ValuationReconciliationTestCommon):
         return_picking = self.env['stock.picking'].browse(res['res_id'])
         self.assertTrue(return_picking)
         self.assertEqual(len(return_picking.move_ids), 2)
-        new_product_moves = self.env['stock.move'].search([('product_id', '=', new_product.id)])
+        new_product_moves = self.env['stock.move'].search([('product_id', '=', self.new_product.id)])
         self.assertEqual(len(new_product_moves), 1, 'The new product should not create extra procurement')
-        sol = self.env['sale.order.line'].search([('product_id', '=', new_product.id)])
+        sol = self.env['sale.order.line'].search([('product_id', '=', self.new_product.id)])
         self.assertFalse(sol)
         return_picking.button_validate()
-        sol = self.env['sale.order.line'].search([('product_id', '=', new_product.id)])
+        sol = self.env['sale.order.line'].search([('product_id', '=', self.new_product.id)])
         self.assertTrue(sol)
         self.assertEqual(sol.product_uom_qty, 0)
         self.assertEqual(sol.qty_delivered, -2)
         self.assertEqual(sol.order_id, sale_order)
+
+    def test_return_multisteps_receipt(self):
+        """test extra product returned are added to the sale order only once in 3 steps receipt"""
+
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        warehouse.reception_steps = 'three_steps'
+        sale_order = self._get_new_sale_order()
+        sale_order.action_confirm()
+        picking = sale_order.picking_ids
+        picking.move_ids.write({'quantity': 10, 'picked': True})
+        picking.button_validate()
+
+        return_picking_form = Form(self.env['stock.return.picking']
+            .with_context(active_id=picking.id, active_model='stock.picking'))
+        with return_picking_form.product_return_moves.new() as line:
+            line.product_id = self.new_product
+            line.quantity = 2
+        return_wizard = return_picking_form.save()
+        res = return_wizard.action_create_returns()
+        return_picking = self.env['stock.picking'].browse(res['res_id'])
+        self.assertEqual(return_picking.location_id, picking.location_dest_id)
+        self.assertEqual(return_picking.location_dest_id, warehouse.in_type_id.default_location_dest_id)
+        return_picking.button_validate()
+        next_pick = return_picking.move_ids.move_dest_ids.picking_id
+        next_pick.button_validate()
+        next_pick = next_pick.move_ids.move_dest_ids.picking_id
+        next_pick.button_validate()
+        sol = self.env['sale.order.line'].search([('product_id', '=', self.new_product.id)])
+        self.assertEqual(len(sol), 1)
+        self.assertEqual(sol.qty_delivered, -2)
 
     def test_return_with_mto_and_multisteps(self):
         """

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -1248,6 +1248,8 @@ class TestSaleStock(TestSaleStockCommon, ValuationReconciliationTestCommon):
         return_picking = self.env['stock.picking'].browse(res['res_id'])
         self.assertTrue(return_picking)
         self.assertEqual(len(return_picking.move_ids), 2)
+        new_product_moves = self.env['stock.move'].search([('product_id', '=', new_product.id)])
+        self.assertEqual(len(new_product_moves), 1, 'The new product should not create extra procurement')
         sol = self.env['sale.order.line'].search([('product_id', '=', new_product.id)])
         self.assertFalse(sol)
         return_picking.button_validate()

--- a/addons/stock/wizard/stock_picking_return.py
+++ b/addons/stock/wizard/stock_picking_return.py
@@ -189,6 +189,8 @@ class ReturnPicking(models.TransientModel):
 
         proc_list = []
         for line in self.product_return_moves:
+            if not line.move_id:
+                continue
             proc_values = {
                 'group_id': self.picking_id.group_id,
                 'sale_line_id': line.move_id.sale_line_id.id,

--- a/addons/stock/wizard/stock_picking_return.py
+++ b/addons/stock/wizard/stock_picking_return.py
@@ -192,7 +192,7 @@ class ReturnPicking(models.TransientModel):
             proc_values = {
                 'group_id': self.picking_id.group_id,
                 'sale_line_id': line.move_id.sale_line_id.id,
-                'date_planned': line.move_id.date,
+                'date_planned': line.move_id.date or fields.Datetime.now(),
                 'warehouse_id': self.picking_id.picking_type_id.warehouse_id,
                 'partner_id': self.picking_id.partner_id.id,
                 'location_final_id': line.move_id.location_final_id or self.picking_id.location_dest_id,

--- a/addons/stock/wizard/stock_picking_return.py
+++ b/addons/stock/wizard/stock_picking_return.py
@@ -162,7 +162,8 @@ class ReturnPicking(models.TransientModel):
         )
         returned_lines = False
         for return_line in self.product_return_moves:
-            returned_lines = return_line._process_line(new_picking)
+            if return_line._process_line(new_picking):
+                returned_lines = True
         if not returned_lines:
             raise UserError(_("Please specify at least one non-zero quantity."))
 

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -57,10 +57,10 @@ class StockMove(models.Model):
             if self.product_id.lot_valuated:
                 layers_by_lot = layers.grouped('lot_id')
                 prices = {}
-                for lot, stock_layers in layers_by_lot:
+                for lot, stock_layers in layers_by_lot.items():
                     qty = sum(stock_layers.mapped("quantity"))
                     val = sum(stock_layers.mapped("value"))
-                    prices[lot] = val / qty if not float_is_zero(qty, precision_rounding=lot.uom_id.rounding) else 0
+                    prices[lot] = val / qty if not float_is_zero(qty, precision_rounding=self.product_id.uom_id.rounding) else 0
             else:
                 quantity = sum(layers.mapped("quantity"))
                 prices = {self.env['stock.lot']: sum(layers.mapped("value")) / quantity if not float_is_zero(quantity, precision_rounding=layers.uom_id.rounding) else 0}


### PR DESCRIPTION
This commit unpack the keys and values of `layers_by_lot` correctly + use the uom of the product's move not the lot

Task :4210510

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
