### PR TITLE
[FIX] website: handle language variants in SEO suggestions API request

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -664,7 +664,38 @@ class Website(Home):
 
     @http.route(['/website/seo_suggest'], type='json', auth="user", website=True)
     def seo_suggest(self, keywords=None, lang=None):
-        language = lang.split("_")
+        """
+        Suggests search keywords based on a given input using Google's
+        autocomplete API.
+
+        This method takes in a `keywords` string and an optional `lang`
+        parameter that defines the language and geographical region for
+        tailoring search suggestions. It sends a request to Google's
+        autocomplete service and returns the search suggestions in JSON format.
+
+        :param str keywords: the keyword string for which suggestions
+            are needed.
+        :param str lang: a string representing the language and geographical
+            location, formatted as:
+            - `language_territory@modifier`, where:
+                - `language`: 2-letter ISO language code (e.g., "en" for
+                  English).
+                - `territory`: Optional, 2-letter country code (e.g., "US" for
+                  United States).
+                - `modifier`: Optional, generally script variant (e.g.,
+                  "latin").
+            If `lang` is not provided or does not match the expected format, the
+            default language is set to English (`en`) and the territory to the
+            United States (`US`).
+
+        :returns: JSON list of strings
+            A list of suggested keywords returned by Google's autocomplete
+            service. If no suggestions are found or if there's an error (e.g.,
+            connection issues), an empty list is returned.
+        """
+        pattern = r'^([a-zA-Z]+)(?:_(\w+))?(?:@(\w+))?$'
+        match = re.match(pattern, lang)
+        language = [match.group(1), match.group(2) or ''] if match else ['en', 'US']
         url = "http://google.com/complete/search"
         try:
             req = requests.get(url, params={

--- a/addons/website/tests/test_controllers.py
+++ b/addons/website/tests/test_controllers.py
@@ -5,7 +5,9 @@ import json
 
 from werkzeug.urls import url_encode
 
+from unittest.mock import patch, Mock
 from odoo import tests
+from odoo.addons.website.controllers.main import Website
 from odoo.tools import mute_logger, submap
 
 
@@ -112,3 +114,62 @@ class TestControllers(tests.HttpCase):
                 404,
                 "Public user shouldn't access record fields with a `groups` even if published"
             )
+
+    @patch('requests.get')
+    def test_05_seo_suggest_language_regex(self, mock_get):
+        """
+        Test the seo_suggest method to verify it properly handles different
+        language inputs, sends correct parameters ('hl' for host language and
+        'gl' for geolocation) to the Google API, and returns the expected
+        suggestions. The test checks a variety of cases including:
+        - Regional language codes (e.g., 'en_US', 'fr_FR')
+        - Basic language codes (e.g., 'es', 'sr')
+        - Language codes with script modifier (e.g., 'sr_RS@latin',
+          'zh_CN@pinyin')
+        - Empty string input to handle default case
+        """
+
+        # Mocking the response from Google API to simulate what would be
+        # returned by the seo_suggest method.
+        mock_response = Mock()
+        mock_response.content = '''<?xml version="1.0"?>
+        <toplevel>
+            <CompleteSuggestion>
+                <suggestion data="test suggestion"/>
+            </CompleteSuggestion>
+        </toplevel>'''
+        mock_get.return_value = mock_response
+
+        # Test cases with different language inputs and expected hl and gl
+        # values.
+        test_cases = [
+            ('en_US', ['en', 'US']),         # US English
+            ('fr_FR', ['fr', 'FR']),         # French in France
+            ('es', ['es', '']),              # Spanish without country code
+            ('sr_RS@latin', ['sr', 'RS']),   # Serbian with script in Serbia
+            ('zh_CN@pinyin', ['zh', 'CN']),  # Chinese with pinyin script in China
+            ('sr@latin', ['sr', '']),        # Serbian with script but no country
+            ('', ['en', 'US'])               # Default case (empty lang. input)
+        ]
+
+        for lang_input, expected_output in test_cases:
+            # subTest creates an isolated context for each test case, allowing
+            # failures to be reported separately.
+            with self.subTest(lang=lang_input):
+                result = Website.seo_suggest(self, keywords="test", lang=lang_input)
+
+                # Extract the parameters that were passed in the mock
+                # requests.get call.
+                called_params = mock_get.call_args[1]['params']
+
+                # Verify that the 'hl' parameter (host language) matches the
+                # expected output
+                self.assertEqual(called_params['hl'], expected_output[0])
+
+                # Verify that the 'gl' parameter (geolocation) matches the
+                # expected output
+                self.assertEqual(called_params['gl'], expected_output[1])
+
+                # Verify that the returned result contains the expected
+                # suggestion "test suggestion"
+                self.assertIn('test suggestion', result)


### PR DESCRIPTION
Steps to reproduce:

- Install serbian (latin) language
- Add a keyword in serbian via SEO optimize menu
- Traceback occurs

This fix ensures that language variants, such as "sr@latin", are properly handled when making requests to the Google Autocomplete API for SEO suggestions.
A test has been added.

task-4210707