### PR TITLE
[FIX] point_of_sale: fix order deletion

### DIFF
--- a/addons/point_of_sale/static/src/app/models/data_service.js
+++ b/addons/point_of_sale/static/src/app/models/data_service.js
@@ -559,13 +559,15 @@ export class PosData extends Reactive {
             .map(([idx, values]) => values)
             .flat();
 
+        // Delete all children records before main record
         this.indexedDB.delete(recordModel, [record.uuid]);
-        const result = record.delete();
         for (const item of recordsToDelete) {
             this.indexedDB.delete(item.model.modelName, [item.uuid]);
             item.delete();
         }
 
+        // Delete the main record
+        const result = record.delete();
         return result;
     }
 

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -583,9 +583,9 @@ class TestUi(TestPointOfSaleHttpCommon):
         n_paid = self.env['pos.order'].search_count([('state', '=', 'paid')])
         self.assertEqual(n_invoiced, 1, 'There should be 1 invoiced order.')
         self.assertEqual(n_paid, 2, 'There should be 2 paid order.')
-        last_order = self.env['pos.order'].search([])[-1]
-        self.assertEqual(last_order.lines[0].price_subtotal, 12.0)
-        self.assertEqual(last_order.lines[0].price_subtotal_incl, 12.0)
+        last_order = self.env['pos.order'].search([], limit=1, order="id desc")
+        self.assertEqual(last_order.lines[0].price_subtotal, 30.0)
+        self.assertEqual(last_order.lines[0].price_subtotal_incl, 30.0)
 
     def test_04_product_configurator(self):
         # Making one attribute inactive to verify that it doesn't show


### PR DESCRIPTION
Before when deleting an order, we removed the order and after related records. This caused an error when trying to remove the order because the related records try to access the order.

Now we remove the related records first and then the order.

