### PR TITLE
[FIX] auth_oauth: raise the Badrequest if the dbname doesn't available in kw

### DIFF
--- a/addons/auth_oauth/controllers/main.py
+++ b/addons/auth_oauth/controllers/main.py
@@ -122,12 +122,12 @@ class OAuthController(http.Controller):
     @http.route('/auth_oauth/signin', type='http', auth='none')
     @fragment_to_query_string
     def signin(self, **kw):
-        state = json.loads(kw['state'])
+        state = json.loads(kw.get('state', '{}'))
 
         # make sure request.session.db and state['d'] are the same,
         # update the session and retry the request otherwise
-        dbname = state['d']
-        if not http.db_filter([dbname]):
+        dbname = state.get('d')
+        if not dbname or not http.db_filter([dbname]):
             return BadRequest()
         ensure_db(db=dbname)
 


### PR DESCRIPTION


Currently, an exception is generated when the user tries to sign in with oauth and `kw` is empty.

Stack Trace:
```
KeyError: 'state'
  File "odoo/http.py", line 2383, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1913, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1976, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1943, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2100, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 227, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 757, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/auth_oauth/controllers/main.py", line 47, in wrapper
    return func(self, *a, **kw)
  File "addons/auth_oauth/controllers/main.py", line 125, in signin
    state = json.loads(kw['state'])
```

This commit will fix the above issue by adapting the case with an empty `kw` by raising `BadRequest()` when `dbname` was not found due to an empty `kw`.

sentry-5831561955

