### PR TITLE
[IMP] website: remove card image width option

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -1412,6 +1412,17 @@ options.registry.ReplaceMedia.include({
     },
 });
 
+options.registry.ImageTools.include({
+    async _computeWidgetVisibility(widgetName, params) {
+        if (params.optionsPossibleValues.selectStyle
+                && params.cssProperty === 'width'
+                && this.$target[0].classList.contains('o_card_img')) {
+            return false;
+        }
+        return this._super(...arguments);
+    },
+});
+
 options.registry.BackgroundVideo = options.Class.extend({
 
     //--------------------------------------------------------------------------
@@ -2479,7 +2490,7 @@ options.registry.collapse = options.Class.extend({
 
         const accordionId = setUniqueId(accordionEl, "myCollapse");
         accordionContentEl.dataset.bsParent = "#" + accordionId;
-        
+
         const contentId = setUniqueId(accordionContentEl, "myCollapseTab");
         accordionBtnEl.dataset.bsTarget = "#" + contentId;
         accordionBtnEl.setAttribute("aria-controls", contentId);


### PR DESCRIPTION
Commit [1] introduced new options for cards and more. Image integration into cards and related options were added.

Image have a "width" option (25-50-100%)... which actually does not make much sense when it concern card images. This has always been the case but [1] made it more visible and created new ways for that option to be weird when used on card images. Time to hide it in that case.

[1]: https://github.com/odoo/odoo/commit/dd40e1e8d9026d189dc17134c85331711f50a470

task-4208444
