### PR TITLE
[FIX] project : Stop counting subtasks for project kanban view

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -56,7 +56,7 @@ class Project(models.Model):
         project_and_state_counts = self.env['project.task'].with_context(
             active_test=any(project.active for project in self)
         )._read_group(
-            [('project_id', 'in', self.ids)],
+            [('project_id', 'in', self.ids), ('display_in_project', '=', True)],
             ['project_id', 'state'],
             ['__count'],
         )


### PR DESCRIPTION
### Steps to reproduce:
	- Create a project
	- Create a task in this project and add a subtask for this task
	- Navigate to the kanban view for projects
	- Notice that the count of tasks shows 2 but you will just see only one task when clicking on this project

### Current behavior before PR:
This is happening because when calculating the count of tasks we are just considering the tasks that has that project_id without checking anything else.

https://github.com/odoo/odoo/blob/17.0/addons/project/models/project_project.py#L56:L62

But when showing the tasks we are just showing the main tasks not the sub-tasks.

### Desired behavior after PR is merged:
We are now checking if this task should be displayed or not and if it won't be displayed we don't count it.

This is a backport of [commit](https://github.com/odoo/odoo/pull/160476/commits/1fc1f6f54ebadcda1ef090e1f73a05be85373c03)

opw-4201309