### PR TITLE
[IMP] account: seller price on vendor bills

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5015,7 +5015,7 @@ class AccountMove(models.Model):
         if any(move.move_type == "entry" for move in self):
             raise ValidationError(_("This action isn't available for this document."))
 
-        for move in self:
+        for move in self.with_context(prevent_price_compute=True):
             in_out, old_move_type = move.move_type.split('_')
             new_move_type = f"{in_out}_{'invoice' if old_move_type == 'refund' else 'refund'}"
             move.name = False

--- a/addons/account/tests/test_early_payment_discount.py
+++ b/addons/account/tests/test_early_payment_discount.py
@@ -639,7 +639,6 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
             with invoice.invoice_line_ids.new() as line_form:
                 line_form.product_id = self.product_a
                 line_form.price_unit = 121
-                line_form.quantity = 1
                 line_form.tax_ids.clear()
                 line_form.tax_ids.add(tax)
             self._assert_tax_totals_summary(invoice.tax_totals, {

--- a/addons/l10n_ar/tests/common.py
+++ b/addons/l10n_ar/tests/common.py
@@ -585,8 +585,8 @@ class TestAr(AccountTestInvoicingCommon):
                 for line in values['invoice_line_ids']:
                     with invoice_form.invoice_line_ids.new() as line_form:
                         line_form.product_id = line.get('product_id')
-                        line_form.price_unit = line.get('price_unit')
                         line_form.quantity = line.get('quantity')
+                        line_form.price_unit = line.get('price_unit')
                         if line.get('tax_ids'):
                             line_form.tax_ids = line.get('tax_ids')
                         line_form.name = 'xxxx'

--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -517,6 +517,11 @@ class AccountMoveLine(models.Model):
     purchase_line_id = fields.Many2one('purchase.order.line', 'Purchase Order Line', ondelete='set null', index='btree_not_null', copy=False)
     purchase_order_id = fields.Many2one('purchase.order', 'Purchase Order', related='purchase_line_id.order_id', readonly=True)
 
+    def _compute_price_unit(self):
+        # EXTEND account - prevent price computation when there are purchase order lines linked, unless the product or uom differs
+        lines_to_be_computed = self.filtered(lambda l: not l.purchase_line_id or l.purchase_line_id.product_uom != l.product_uom_id or l.purchase_line_id.product_id != l.product_id)
+        super(AccountMoveLine, lines_to_be_computed)._compute_price_unit()
+
     def _copy_data_extend_business_fields(self, values):
         # OVERRIDE to copy the 'purchase_line_id' field as well.
         super(AccountMoveLine, self)._copy_data_extend_business_fields(values)

--- a/addons/purchase_stock/tests/test_stockvaluation.py
+++ b/addons/purchase_stock/tests/test_stockvaluation.py
@@ -405,7 +405,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
         })
         rinv = self.env['account.move'].browse(credit_note_wizard.refund_moves()['res_id'])
         if qty is not None:
-            rinv.invoice_line_ids.quantity = qty
+            rinv.with_context(prevent_price_compute=True).invoice_line_ids.quantity = qty
         rinv.action_post()
         return rinv
 

--- a/addons/sale/models/account_move_line.py
+++ b/addons/sale/models/account_move_line.py
@@ -15,6 +15,11 @@ class AccountMoveLine(models.Model):
         'invoice_line_id', 'order_line_id',
         string='Sales Order Lines', readonly=True, copy=False)
 
+    def _compute_price_unit(self):
+        # EXTEND account - prevent price computation when there are sale order lines linked, unless the product/uom differs
+        lines_to_be_computed = self.filtered(lambda l: not l.sale_line_ids or l.sale_line_ids.product_uom != l.product_uom_id or l.sale_line_ids.product_id != l.product_id)
+        super(AccountMoveLine, lines_to_be_computed)._compute_price_unit()
+
     def _copy_data_extend_business_fields(self, values):
         # OVERRIDE to copy the 'sale_line_ids' field as well.
         super(AccountMoveLine, self)._copy_data_extend_business_fields(values)


### PR DESCRIPTION
When creating a vendor bill, the vendor prices defined on the product is not used. This is very evident when using the catalog option on the vendor bill. The price displayed is the seller's price, but the product's cost price is used instead. This commit gives preference to the vendor price.

No Task (18.0 Bug pad)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
