### PR TITLE
[FIX] {sale_,}stock: see delivered quantities for interco sales

### DIFF
--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -291,11 +291,11 @@ class SaleOrderLine(models.Model):
             moves = moves.filtered(lambda r: fields.Date.context_today(r, r.date) <= self._context['accrual_entry_date'])
 
         for move in moves:
-            if (strict and move.location_dest_id.usage == "customer") or \
-               (not strict and move.rule_id.id in triggering_rule_ids and (move.location_final_id or move.location_dest_id).usage == "customer"):
+            if (strict and move.location_dest_id._is_outgoing()) or \
+               (not strict and move.rule_id.id in triggering_rule_ids and (move.location_final_id or move.location_dest_id)._is_outgoing()):
                 if not move.origin_returned_move_id or (move.origin_returned_move_id and move.to_refund):
                     outgoing_moves |= move
-            elif move.location_id.usage == "customer" and move.to_refund:
+            elif move.location_id._is_outgoing() and move.to_refund:
                 incoming_moves |= move
 
         return outgoing_moves, incoming_moves

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -452,6 +452,14 @@ class Location(models.Model):
         self.ensure_one()
         return other_location.parent_path in self.parent_path
 
+    def _is_outgoing(self):
+        self.ensure_one()
+        if self.usage == 'customer':
+            return True
+        # Can also be True if location is inter-company transit
+        inter_comp_location = self.env.ref('stock.stock_location_inter_company', raise_if_not_found=False)
+        return self._child_of(inter_comp_location)
+
     def _get_weight(self, excluded_sml_ids=False):
         """Returns a dictionary with the net and forecasted weight of the location.
         param excluded_sml_ids: set of stock.move.line ids to exclude from the computation


### PR DESCRIPTION
Currently, we only check delivered quantities in a Sale Order based on the `usage` of the destination location of the related delivery. This means that in the case of Inter-company transactions, we won't consider them as deliveries, as its delivery location will be 'Inter-Company Transit', which itself is a 'transit' location.

Test in odoo/enterprise#70663

Task-4207132

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
