### PR TITLE
[IMP] spreadsheet_dashboard: introduce sample dashboards 

### DIFF
--- a/addons/spreadsheet/static/src/scss/spreadsheet_dashboard.scss
+++ b/addons/spreadsheet/static/src/scss/spreadsheet_dashboard.scss
@@ -1,0 +1,3 @@
+.o-sample-dashboard .o-figure {
+    opacity: 0.4;
+}

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
@@ -2,7 +2,7 @@
 <templates>
     <div t-name="spreadsheet_dashboard.DashboardAction" class="o_action o_spreadsheet_dashboard_action o_field_highlight">
         <ControlPanel display="controlPanelDisplay">
-            <t t-set-slot="layout-actions">
+            <t t-set-slot="layout-actions" t-if="!state.activeDashboard?.isSample">
                 <t t-set="status" t-value="state.activeDashboard and state.activeDashboard.status"/>
                 <FilterValue
                     t-if="status === Status.Loaded"
@@ -13,7 +13,7 @@
                     t-key="filter.id"
                 />
             </t>
-            <t t-set-slot="control-panel-navigation-additional">
+            <t t-set-slot="control-panel-navigation-additional" t-if="!state.activeDashboard?.isSample">
                 <SpreadsheetShareButton t-key="activeDashboardId" model="state.activeDashboard?.model" onSpreadsheetShared.bind="shareSpreadsheet" togglerClass="'btn-light'"/>
             </t>
         </ControlPanel>
@@ -40,7 +40,7 @@
                 </div>
                 <t t-else="">
                     <MobileFigureContainer t-if="env.isSmall" spreadsheetModel="dashboard.model" t-key="dashboard.id"/>
-                    <div t-else="" class="o_renderer">
+                    <div t-else="" class="o_renderer" t-att-class="{'o-sample-dashboard': dashboard.isSample}">
                         <SpreadsheetComponent
                             model="dashboard.model"
                             t-key="dashboard.id"/>

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_loader.js
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_loader.js
@@ -161,13 +161,14 @@ export class DashboardLoader {
         const dashboard = this._getDashboard(dashboardId);
         dashboard.status = Status.Loading;
         try {
-            const { snapshot, revisions, default_currency } = await this.orm.call(
+            const { snapshot, revisions, default_currency, is_sample } = await this.orm.call(
                 "spreadsheet.dashboard",
                 "get_readonly_dashboard",
                 [dashboardId]
             );
             dashboard.model = this._createSpreadsheetModel(snapshot, revisions, default_currency);
             dashboard.status = Status.Loaded;
+            dashboard.isSample = is_sample;
         } catch (error) {
             dashboard.error = error;
             dashboard.status = Status.Error;

--- a/addons/spreadsheet_dashboard_account/data/dashboards.xml
+++ b/addons/spreadsheet_dashboard_account/data/dashboards.xml
@@ -4,6 +4,8 @@
     <record id="dashboard_invoicing" model="spreadsheet.dashboard">
         <field name="name">Invoicing</field>
         <field name="spreadsheet_binary_data" type="base64" file="spreadsheet_dashboard_account/data/files/invoicing_dashboard.json"/>
+        <field name="main_data_model_ids" eval="[(4, ref('account.model_account_move'))]"/>
+        <field name="sample_dashboard_file_path">spreadsheet_dashboard_account/data/files/invoicing_sample_dashboard.json</field>
         <field name="dashboard_group_id" ref="spreadsheet_dashboard.spreadsheet_dashboard_group_finance"/>
         <field name="group_ids" eval="[Command.link(ref('account.group_account_readonly')), Command.link(ref('account.group_account_invoice'))]"/>
         <field name="sequence">20</field>

--- a/addons/spreadsheet_dashboard_account/data/files/invoicing_sample_dashboard.json
+++ b/addons/spreadsheet_dashboard_account/data/files/invoicing_sample_dashboard.json
@@ -1,0 +1,808 @@
+{
+    "version": 21,
+    "sheets": [
+        {
+            "id": "a7cd7db1-9407-4895-82f2-7657102c7688",
+            "name": "Dashboard",
+            "colNumber": 7,
+            "rowNumber": 62,
+            "rows": {
+                "6": {
+                    "size": 40
+                },
+                "22": {
+                    "size": 40
+                },
+                "23": {
+                    "size": 40
+                },
+                "24": {
+                    "size": 27
+                },
+                "25": {
+                    "size": 27
+                },
+                "26": {
+                    "size": 27
+                },
+                "27": {
+                    "size": 27
+                },
+                "28": {
+                    "size": 27
+                },
+                "29": {
+                    "size": 27
+                },
+                "30": {
+                    "size": 27
+                },
+                "31": {
+                    "size": 27
+                },
+                "32": {
+                    "size": 27
+                },
+                "33": {
+                    "size": 27
+                },
+                "35": {
+                    "size": 40
+                },
+                "36": {
+                    "size": 40
+                },
+                "37": {
+                    "size": 27
+                },
+                "38": {
+                    "size": 27
+                },
+                "39": {
+                    "size": 27
+                },
+                "40": {
+                    "size": 27
+                },
+                "41": {
+                    "size": 27
+                },
+                "42": {
+                    "size": 27
+                },
+                "43": {
+                    "size": 27
+                },
+                "44": {
+                    "size": 27
+                },
+                "45": {
+                    "size": 27
+                },
+                "46": {
+                    "size": 27
+                },
+                "48": {
+                    "size": 40
+                },
+                "49": {
+                    "size": 40
+                },
+                "50": {
+                    "size": 27
+                },
+                "51": {
+                    "size": 27
+                },
+                "52": {
+                    "size": 27
+                },
+                "53": {
+                    "size": 27
+                },
+                "54": {
+                    "size": 27
+                },
+                "55": {
+                    "size": 27
+                },
+                "56": {
+                    "size": 27
+                },
+                "57": {
+                    "size": 27
+                },
+                "58": {
+                    "size": 27
+                },
+                "59": {
+                    "size": 27
+                }
+            },
+            "cols": {
+                "0": {
+                    "size": 225
+                },
+                "1": {
+                    "size": 150
+                },
+                "2": {
+                    "size": 100
+                },
+                "3": {
+                    "size": 50
+                },
+                "4": {
+                    "size": 225
+                },
+                "5": {
+                    "size": 150
+                },
+                "6": {
+                    "size": 100
+                }
+            },
+            "merges": [
+                "D24:E24",
+                "D25:E25",
+                "D26:E26",
+                "D27:E27",
+                "D28:E28",
+                "D29:E29",
+                "D30:E30",
+                "D31:E31",
+                "D32:E32",
+                "D33:E33",
+                "D34:E34"
+            ],
+            "cells": {
+                "A7": {
+                    "content": "[Invoiced by Month](odoo://view/{\"viewType\":\"graph\",\"action\":{\"domain\":[\"&\",[\"state\",\"not in\",[\"draft\",\"cancel\"]],\"|\",[\"move_type\",\"=\",\"out_invoice\"],[\"move_type\",\"=\",\"out_refund\"]],\"context\":{\"group_by\":[\"invoice_date\"],\"graph_measure\":\"price_subtotal\",\"graph_mode\":\"line\",\"graph_groupbys\":[\"invoice_date:month\"]},\"modelName\":\"account.invoice.report\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Invoices Analysis\",\"positional\":true})"
+                },
+                "A23": {
+                    "content": "[Top Invoices](odoo://view/{\"viewType\":\"list\",\"action\":{\"domain\":[[\"move_type\",\"=\",\"out_invoice\"]],\"context\":{\"group_by\":[]},\"modelName\":\"account.move\",\"views\":[[false,\"list\"],[false,\"kanban\"],[false,\"form\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Invoices\"})"
+                },
+                "A24": {
+                    "content": "=_t(\"Reference\")"
+                },
+                "A36": {
+                    "content": "[Top Countries](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[\"&\",[\"state\",\"not in\",[\"draft\",\"cancel\"]],\"&\",[\"country_id\",\"!=\",false],[\"price_subtotal\",\">=\",0]],\"context\":{\"group_by\":[\"country_id\"],\"pivot_measures\":[\"price_subtotal\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"country_id\"]},\"modelName\":\"account.invoice.report\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"list\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Invoices Analysis\"})"
+                },
+                "A37": {
+                    "content": "=_t(\"Country\")"
+                },
+                "A49": {
+                    "content": "[Top Products](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[\"&\",[\"state\",\"not in\",[\"draft\",\"cancel\"]],\"&\",[\"product_id\",\"!=\",false],[\"price_subtotal\",\">=\",0]],\"context\":{\"group_by\":[\"product_id\"],\"pivot_measures\":[\"price_subtotal\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"product_id\"]},\"modelName\":\"account.invoice.report\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"list\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Invoices Analysis\"})"
+                },
+                "A50": {
+                    "content": "=_t(\"Product\")"
+                },
+                "B24": {
+                    "content": "=_t(\"Salesperson\")"
+                },
+                "B37": {
+                    "content": "=_t(\"Amount\")"
+                },
+                "B50": {
+                    "content": "=_t(\"Amount\")"
+                },
+                "C24": {
+                    "content": "=_t(\"Status\")"
+                },
+                "C37": {
+                    "content": "=_t(\"Ratio\")"
+                },
+                "C43": {
+                    "content": "=iferror(if(B43,B43/PIVOT.VALUE(2,\"price_subtotal\"),\"\"),\"\")"
+                },
+                "C44": {
+                    "content": "=iferror(if(B44,B44/PIVOT.VALUE(2,\"price_subtotal\"),\"\"),\"\")"
+                },
+                "C45": {
+                    "content": "=iferror(if(B45,B45/PIVOT.VALUE(2,\"price_subtotal\"),\"\"),\"\")"
+                },
+                "C46": {
+                    "content": "=iferror(if(B46,B46/PIVOT.VALUE(2,\"price_subtotal\"),\"\"),\"\")"
+                },
+                "C48": {
+                    "content": "=iferror(if(B48,B48/PIVOT.VALUE(2,\"price_subtotal\"),\"\"),\"\")"
+                },
+                "C50": {
+                    "content": "=_t(\"Ratio\")"
+                },
+                "C60": {
+                    "content": "=iferror(if(B60,B60/PIVOT.VALUE(3,\"price_subtotal\"),\"\"))"
+                },
+                "D24": {
+                    "content": "=_t(\"Customer\")"
+                },
+                "E36": {
+                    "content": "[Top Categories](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[\"&\",[\"state\",\"not in\",[\"draft\",\"cancel\"]],\"&\",[\"product_categ_id\",\"!=\",false],[\"price_subtotal\",\">=\",0]],\"context\":{\"group_by\":[\"product_categ_id\"],\"pivot_measures\":[\"price_subtotal\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"product_categ_id\"]},\"modelName\":\"account.invoice.report\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"list\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Invoices Analysis\"})"
+                },
+                "E37": {
+                    "content": "=_t(\"Top Categories\")"
+                },
+                "E49": {
+                    "content": "[Top Salespeople](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[\"&\",[\"state\",\"not in\",[\"draft\",\"cancel\"]],\"&\",[\"invoice_user_id\",\"!=\",false],[\"price_subtotal\",\">=\",0]],\"context\":{\"group_by\":[\"invoice_user_id\"],\"pivot_measures\":[\"price_subtotal\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"invoice_user_id\"]},\"modelName\":\"account.invoice.report\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"list\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Invoices Analysis\"})"
+                },
+                "E50": {
+                    "content": "=_t(\"Salesperson\")"
+                },
+                "F24": {
+                    "content": "=_t(\"Date\")"
+                },
+                "F37": {
+                    "content": "=_t(\"Amount\")"
+                },
+                "F50": {
+                    "content": "=_t(\"Amount\")"
+                },
+                "G24": {
+                    "content": "=_t(\"Amount\")"
+                },
+                "G37": {
+                    "content": "=_t(\"Ratio\")"
+                },
+                "G43": {
+                    "content": "=iferror(if(F43,F43/PIVOT.VALUE(1,\"price_subtotal\"),\"\"),\"\")"
+                },
+                "G44": {
+                    "content": "=iferror(if(F44,F44/PIVOT.VALUE(1,\"price_subtotal\"),\"\"),\"\")"
+                },
+                "G45": {
+                    "content": "=iferror(if(F45,F45/PIVOT.VALUE(1,\"price_subtotal\"),\"\"),\"\")"
+                },
+                "G46": {
+                    "content": "=iferror(if(F46,F46/PIVOT.VALUE(1,\"price_subtotal\"),\"\"),\"\")"
+                },
+                "G48": {
+                    "content": "=iferror(if(F48,F48/PIVOT.VALUE(1,\"price_subtotal\"),\"\"),\"\")"
+                },
+                "G50": {
+                    "content": "=_t(\"Ratio\")"
+                },
+                "G60": {
+                    "content": "=iferror(if(F60,F60/PIVOT.VALUE(4,\"price_subtotal\"),\"\"),\"\")"
+                }
+            },
+            "styles": {
+                "A7": 1,
+                "A23": 1,
+                "A36": 1,
+                "A49": 1,
+                "E36": 1,
+                "E49": 1,
+                "A37": 2,
+                "A50": 2,
+                "A24:D24": 2,
+                "E37": 2,
+                "E50": 2,
+                "B37:C37": 3,
+                "B50:C50": 3,
+                "F24:G24": 3,
+                "F37:G37": 3,
+                "F50:G50": 3,
+                "C43:C46": 4,
+                "C60": 4,
+                "G43:G46": 4,
+                "G60": 4
+            },
+            "formats": {},
+            "borders": {
+                "A36:C36": 1,
+                "A49:C49": 1,
+                "A7:G7": 1,
+                "A23:G23": 1,
+                "E36:G36": 1,
+                "E49:G49": 1,
+                "A37:C37": 2,
+                "A50:C50": 2,
+                "A8:G8": 2,
+                "A24:G24": 2,
+                "E37:G37": 2,
+                "E50:G50": 2,
+                "A25": 3,
+                "A38": 3,
+                "A51": 3,
+                "E25": 3,
+                "E38": 3,
+                "E51": 3,
+                "A26:A34": 4,
+                "A39:A47": 4,
+                "A52:A56": 4,
+                "A58:A60": 4,
+                "E26:E34": 4,
+                "E39:E47": 4,
+                "E52:E56": 4,
+                "E58:E60": 4,
+                "A48:C48": 5,
+                "A61:C61": 5,
+                "A35:G35": 5,
+                "E48:G48": 5,
+                "E61:G61": 5,
+                "A57:C57": 6,
+                "E57:G57": 6,
+                "B38": 7,
+                "B51": 7,
+                "B25:C25": 7,
+                "F25": 7,
+                "F38": 7,
+                "F51": 7,
+                "B39:B47": 8,
+                "B52:B56": 8,
+                "B58:B60": 8,
+                "B26:C34": 8,
+                "F26:F34": 8,
+                "F39:F47": 8,
+                "F52:F56": 8,
+                "F58:F60": 8,
+                "C38": 9,
+                "C51": 9,
+                "D25": 9,
+                "G25": 9,
+                "G38": 9,
+                "G51": 9,
+                "C39:C47": 10,
+                "C52:C56": 10,
+                "C58:C60": 10,
+                "D26:D34": 10,
+                "G26:G34": 10,
+                "G39:G47": 10,
+                "G52:G56": 10,
+                "G58:G60": 10
+            },
+            "conditionalFormats": [],
+            "figures": [
+                {
+                    "id": "1aeea7b2-900b-4067-b8ad-3e4772c54028",
+                    "x": 0,
+                    "y": 11,
+                    "width": 200,
+                    "height": 109,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "text",
+                        "title": {
+                            "text": "Invoiced",
+                            "color": "#434343",
+                            "bold": true
+                        },
+                        "type": "scorecard",
+                        "background": "#EFF6FF",
+                        "baseline": "Data!C11",
+                        "baselineDescr": "unpaid",
+                        "keyValue": "Data!C1",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "bdfb27d0-5902-4a2a-9b7e-514a6625578c",
+                    "x": 210,
+                    "y": 11,
+                    "width": 200,
+                    "height": 109,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "text",
+                        "title": {
+                            "text": "Average Invoice",
+                            "color": "#434343",
+                            "bold": true
+                        },
+                        "type": "scorecard",
+                        "background": "#EFF6FF",
+                        "baseline": "Data!C3",
+                        "baselineDescr": "Invoices",
+                        "keyValue": "Data!C2",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "b1673523-d139-47fb-b5ea-9e4f969aacb6",
+                    "x": 419,
+                    "y": 11,
+                    "width": 200,
+                    "height": 109,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "difference",
+                        "title": {
+                            "text": "DSO",
+                            "color": "#434343",
+                            "bold": true
+                        },
+                        "type": "scorecard",
+                        "background": "#FEF2F2",
+                        "baselineDescr": "in current year",
+                        "keyValue": "Data!C10",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "b181a834-363a-4f35-ac8d-b2edc3bb691a",
+                    "x": 0,
+                    "y": 178.0390625,
+                    "width": 1001,
+                    "height": 350,
+                    "tag": "chart",
+                    "data": {
+                        "type": "line",
+                        "dataSetsHaveTitle": false,
+                        "dataSets": [
+                            {
+                                "dataRange": "Data!C14:C20",
+                                "yAxisId": "y"
+                            }
+                        ],
+                        "legendPosition": "none",
+                        "labelRange": "Data!A14:A20",
+                        "title": {},
+                        "labelsAsText": true,
+                        "stacked": false,
+                        "aggregated": false,
+                        "cumulative": true,
+                        "fillArea": true
+                    }
+                }
+            ],
+            "tables": [],
+            "areGridLinesVisible": true,
+            "isVisible": true,
+            "headerGroups": {
+                "ROW": [],
+                "COL": []
+            },
+            "dataValidationRules": [],
+            "comments": {}
+        },
+        {
+            "id": "685cb5c3-4acb-45eb-8000-99e1af15b3ed",
+            "name": "Data",
+            "colNumber": 26,
+            "rowNumber": 107,
+            "rows": {},
+            "cols": {},
+            "merges": [],
+            "cells": {
+                "A1": {
+                    "content": "=_t(\"KPI - Income\")"
+                },
+                "A2": {
+                    "content": "=_t(\"KPI - Average Invoice\")"
+                },
+                "A3": {
+                    "content": "=_t(\"KPI - Invoice Count\")"
+                },
+                "A4": {
+                    "content": "=_t(\"Current year\")"
+                },
+                "A5": {
+                    "content": "=_t(\"Receivable\")"
+                },
+                "A6": {
+                    "content": "=_t(\"Income\")"
+                },
+                "A7": {
+                    "content": "=_t(\"COGS\")"
+                },
+                "A8": {
+                    "content": "=_t(\"Revenue\")"
+                },
+                "A9": {
+                    "content": "=_t(\"# days\")"
+                },
+                "A10": {
+                    "content": "=_t(\"KPI - DSO\")"
+                },
+                "A11": {
+                    "content": "=_t(\"KPI - Unpaid Invoices\")"
+                },
+                "A14": {
+                    "content": "=EDATE(TODAY(),B14)"
+                },
+                "A15": {
+                    "content": "=EDATE(TODAY(),B15)"
+                },
+                "A16": {
+                    "content": "=EDATE(TODAY(),B16)"
+                },
+                "A17": {
+                    "content": "=EDATE(TODAY(),B17)"
+                },
+                "A18": {
+                    "content": "=EDATE(TODAY(),B18)"
+                },
+                "A19": {
+                    "content": "=EDATE(TODAY(),B19)"
+                },
+                "A20": {
+                    "content": "=EDATE(TODAY(),B20)"
+                },
+                "B1": {
+                    "content": "42200"
+                },
+                "B2": {
+                    "content": "1789"
+                },
+                "B3": {
+                    "content": "32"
+                },
+                "B4": {
+                    "content": "=YEAR(TODAY())"
+                },
+                "B5": {
+                    "content": "7463.5"
+                },
+                "B6": {
+                    "content": "7169.7699999999895"
+                },
+                "B7": {
+                    "content": "0"
+                },
+                "B8": {
+                    "content": "=B6-B7"
+                },
+                "B9": {
+                    "content": "365"
+                },
+                "B10": {
+                    "content": "=ROUND(IFERROR(B5/B8*B9))"
+                },
+                "B11": {
+                    "content": "5783"
+                },
+                "B14": {
+                    "content": "6"
+                },
+                "B15": {
+                    "content": "5"
+                },
+                "B16": {
+                    "content": "4"
+                },
+                "B17": {
+                    "content": "3"
+                },
+                "B18": {
+                    "content": "2"
+                },
+                "B19": {
+                    "content": "1"
+                },
+                "B20": {
+                    "content": "0"
+                },
+                "C1": {
+                    "content": "=FORMAT.LARGE.NUMBER(B1)"
+                },
+                "C2": {
+                    "content": "=FORMAT.LARGE.NUMBER(B2)"
+                },
+                "C3": {
+                    "content": "=FORMAT.LARGE.NUMBER(B3)"
+                },
+                "C10": {
+                    "content": "=_t(\"380 days\")"
+                },
+                "C11": {
+                    "content": "=FORMAT.LARGE.NUMBER(B11)"
+                },
+                "C14": {
+                    "content": "27341"
+                },
+                "C15": {
+                    "content": "12263"
+                },
+                "C16": {
+                    "content": "25821"
+                },
+                "C17": {
+                    "content": "29033"
+                },
+                "C18": {
+                    "content": "21708"
+                },
+                "C19": {
+                    "content": "49252"
+                },
+                "C20": {
+                    "content": "15977"
+                }
+            },
+            "styles": {
+                "C1:C3": 5,
+                "C10:C11": 5
+            },
+            "formats": {
+                "A14:A20": 1,
+                "B5:B6": 2,
+                "B8": 2,
+                "B1:C2": 2,
+                "B11:C11": 2,
+                "C14:C20": 2,
+                "B3": 3,
+                "B10": 4
+            },
+            "borders": {},
+            "conditionalFormats": [],
+            "figures": [],
+            "tables": [],
+            "areGridLinesVisible": true,
+            "isVisible": true,
+            "headerGroups": {
+                "ROW": [],
+                "COL": []
+            },
+            "dataValidationRules": [],
+            "comments": {}
+        }
+    ],
+    "styles": {
+        "1": {
+            "textColor": "#01666b",
+            "bold": true,
+            "fontSize": 16
+        },
+        "2": {
+            "textColor": "#434343",
+            "bold": true,
+            "fontSize": 11
+        },
+        "3": {
+            "textColor": "#434343",
+            "bold": true,
+            "fontSize": 11,
+            "align": "center"
+        },
+        "4": {
+            "textColor": "#434343",
+            "verticalAlign": "middle"
+        },
+        "5": {
+            "fillColor": "#f8f9fa"
+        }
+    },
+    "formats": {
+        "1": "mmmm yyyy",
+        "2": "[$$]#,##0",
+        "3": "#,##0",
+        "4": "#,##0.00"
+    },
+    "borders": {
+        "1": {
+            "bottom": {
+                "style": "thin",
+                "color": "#CCCCCC"
+            }
+        },
+        "2": {
+            "top": {
+                "style": "thin",
+                "color": "#CCCCCC"
+            }
+        },
+        "3": {
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "4": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "5": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "6": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "7": {
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "8": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "9": {
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "10": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        }
+    },
+    "revisionId": "START_REVISION",
+    "uniqueFigureIds": true,
+    "settings": {
+        "locale": {
+            "name": "English (US)",
+            "code": "en_US",
+            "thousandsSeparator": ",",
+            "decimalSeparator": ".",
+            "dateFormat": "mm/dd/yyyy",
+            "timeFormat": "hh:mm:ss",
+            "formulaArgSeparator": ",",
+            "weekStart": 7
+        }
+    },
+    "pivots": {},
+    "pivotNextId": 8,
+    "customTableStyles": {},
+    "odooVersion": 12,
+    "globalFilters": [],
+    "lists": {},
+    "listNextId": 2
+}

--- a/addons/spreadsheet_dashboard_event_sale/data/dashboards.xml
+++ b/addons/spreadsheet_dashboard_event_sale/data/dashboards.xml
@@ -4,6 +4,8 @@
     <record id="spreadsheet_dashboard_events" model="spreadsheet.dashboard">
         <field name="name">Events</field>
         <field name="spreadsheet_binary_data" type="base64" file="spreadsheet_dashboard_event_sale/data/files/events_dashboard.json"/>
+        <field name="main_data_model_ids" eval="[(4, ref('event.model_event_event'))]"/>
+        <field name="sample_dashboard_file_path">spreadsheet_dashboard_event_sale/data/files/events_sample_dashboard.json</field>
         <field name="dashboard_group_id" ref="spreadsheet_dashboard.spreadsheet_dashboard_group_marketing"/>
         <field name="group_ids" eval="[Command.link(ref('event.group_event_manager'))]"/>
         <field name="sequence">60</field>

--- a/addons/spreadsheet_dashboard_event_sale/data/files/events_sample_dashboard.json
+++ b/addons/spreadsheet_dashboard_event_sale/data/files/events_sample_dashboard.json
@@ -1,0 +1,584 @@
+{
+    "version": 21,
+    "sheets": [
+        {
+            "id": "sheet1",
+            "name": "Dashboard",
+            "colNumber": 5,
+            "rowNumber": 49,
+            "rows": {
+                "6": {
+                    "size": 40
+                },
+                "22": {
+                    "size": 40
+                },
+                "23": {
+                    "size": 40
+                },
+                "24": {
+                    "size": 29
+                },
+                "25": {
+                    "size": 29
+                },
+                "26": {
+                    "size": 29
+                },
+                "27": {
+                    "size": 29
+                },
+                "28": {
+                    "size": 29
+                },
+                "29": {
+                    "size": 29
+                },
+                "30": {
+                    "size": 29
+                },
+                "31": {
+                    "size": 29
+                },
+                "32": {
+                    "size": 29
+                },
+                "33": {
+                    "size": 29
+                },
+                "35": {
+                    "size": 40
+                },
+                "36": {
+                    "size": 40
+                },
+                "37": {
+                    "size": 29
+                },
+                "38": {
+                    "size": 29
+                },
+                "39": {
+                    "size": 29
+                },
+                "40": {
+                    "size": 29
+                },
+                "41": {
+                    "size": 29
+                },
+                "42": {
+                    "size": 29
+                },
+                "43": {
+                    "size": 29
+                },
+                "44": {
+                    "size": 29
+                },
+                "45": {
+                    "size": 29
+                },
+                "46": {
+                    "size": 29
+                }
+            },
+            "cols": {
+                "0": {
+                    "size": 374
+                },
+                "1": {
+                    "size": 100
+                },
+                "2": {
+                    "size": 50
+                },
+                "3": {
+                    "size": 375
+                },
+                "4": {
+                    "size": 100
+                }
+            },
+            "merges": [],
+            "cells": {
+                "A7": {
+                    "content": "[Events Status](odoo://view/{\"viewType\":\"graph\",\"action\":{\"domain\":[],\"context\":{\"group_by\":[\"stage_id\"],\"graph_measure\":\"__count\",\"graph_mode\":\"bar\",\"graph_groupbys\":[\"stage_id\"]},\"modelName\":\"event.event\",\"views\":[[false,\"kanban\"],[false,\"calendar\"],[false,\"list\"],[false,\"form\"],[false,\"pivot\"],[false,\"graph\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Events\"})"
+                },
+                "A23": {
+                    "content": "[Top Venues](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[[\"address_id\",\"!=\",false]],\"context\":{\"group_by\":[\"address_id\"],\"pivot_measures\":[\"__count\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"address_id\"]},\"modelName\":\"event.event\",\"views\":[[false,\"kanban\"],[false,\"calendar\"],[false,\"list\"],[false,\"form\"],[false,\"pivot\"],[false,\"graph\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Events\"})"
+                },
+                "A24": {
+                    "content": "=_t(\"Venue\")"
+                },
+                "A36": {
+                    "content": "[Top Tags](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[[\"tag_ids\",\"!=\",false]],\"context\":{\"group_by\":[\"tag_ids\"],\"pivot_measures\":[\"__count\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"tag_ids\"]},\"modelName\":\"event.event\",\"views\":[[false,\"kanban\"],[false,\"calendar\"],[false,\"list\"],[false,\"form\"],[false,\"pivot\"],[false,\"graph\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Events\"})"
+                },
+                "A37": {
+                    "content": "=_t(\"Tag\")"
+                },
+                "B24": {
+                    "content": "=_t(\"Events\")"
+                },
+                "B37": {
+                    "content": "=_t(\"Events\")"
+                },
+                "D7": {
+                    "content": "[Registration Status](odoo://view/{\"viewType\":\"graph\",\"action\":{\"domain\":[],\"context\":{\"group_by\":[\"state\"],\"graph_measure\":\"__count\",\"graph_mode\":\"bar\",\"graph_groupbys\":[\"state\"]},\"modelName\":\"event.registration\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"kanban\"],[false,\"list\"],[false,\"form\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Attendees\"})"
+                },
+                "D23": {
+                    "content": "[Top Templates](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[[\"event_type_id\",\"!=\",false]],\"context\":{\"group_by\":[\"event_type_id\"],\"pivot_measures\":[\"__count\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"event_type_id\"]},\"modelName\":\"event.event\",\"views\":[[false,\"kanban\"],[false,\"calendar\"],[false,\"list\"],[false,\"form\"],[false,\"pivot\"],[false,\"graph\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Events\"})"
+                },
+                "D24": {
+                    "content": "=_t(\"Template\")"
+                },
+                "D36": {
+                    "content": "[Top Organizers](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[[\"organizer_id\",\"!=\",false]],\"context\":{\"group_by\":[\"organizer_id\"],\"pivot_measures\":[\"__count\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"organizer_id\"]},\"modelName\":\"event.event\",\"views\":[[false,\"kanban\"],[false,\"calendar\"],[false,\"list\"],[false,\"form\"],[false,\"pivot\"],[false,\"graph\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Events\"})"
+                },
+                "D37": {
+                    "content": "=_t(\"Organizer\")"
+                },
+                "E24": {
+                    "content": "=_t(\"Events\")"
+                },
+                "E37": {
+                    "content": "=_t(\"Events\")"
+                }
+            },
+            "styles": {
+                "A7": 1,
+                "A23": 1,
+                "A36": 1,
+                "D7": 1,
+                "D23": 1,
+                "D36": 1,
+                "A24": 2,
+                "A37": 2,
+                "D24": 2,
+                "D37": 2,
+                "B24": 3,
+                "B37": 3,
+                "E24": 3,
+                "E37": 3
+            },
+            "formats": {},
+            "borders": {
+                "A7:B7": 1,
+                "A23:B23": 1,
+                "A36:B36": 1,
+                "D7:E7": 1,
+                "D23:E23": 1,
+                "D36:E36": 1,
+                "A8:B8": 2,
+                "A24:B24": 2,
+                "A37:B37": 2,
+                "D8:E8": 2,
+                "D24:E24": 2,
+                "D37:E37": 2,
+                "A25": 3,
+                "A38": 3,
+                "D25": 3,
+                "D38": 3,
+                "A26:A34": 4,
+                "A39:A43": 4,
+                "A45:A47": 4,
+                "D26:D34": 4,
+                "D39:D43": 4,
+                "D45:D47": 4,
+                "A35:B35": 5,
+                "A48:B48": 5,
+                "D35:E35": 5,
+                "D48:E48": 5,
+                "A44:B44": 6,
+                "D44:E44": 6,
+                "B25": 7,
+                "B38": 7,
+                "E25": 7,
+                "E38": 7,
+                "B26:B34": 8,
+                "B39:B43": 8,
+                "B45:B47": 8,
+                "E26:E34": 8,
+                "E39:E43": 8,
+                "E45:E47": 8
+            },
+            "conditionalFormats": [],
+            "figures": [
+                {
+                    "id": "18361546-49c2-4212-88eb-b2ee50127d41",
+                    "x": 0,
+                    "y": 9,
+                    "width": 200,
+                    "height": 105,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "percentage",
+                        "title": {
+                            "text": "Events",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#EFF6FF",
+                        "baseline": "Data!E3",
+                        "baselineDescr": "since last period",
+                        "keyValue": "Data!D3",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "98d2b15d-9117-4ecf-9732-dc62df949dc1",
+                    "x": 210,
+                    "y": 9,
+                    "width": 200,
+                    "height": 105,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "percentage",
+                        "title": {
+                            "text": "Revenue",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#FFF7ED",
+                        "baseline": "Data!E4",
+                        "baselineDescr": "since last period",
+                        "keyValue": "Data!D4",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "6510bff8-7b28-42c6-af4b-c750bed2205c",
+                    "x": 420,
+                    "y": 9,
+                    "width": 200,
+                    "height": 105,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "percentage",
+                        "title": {
+                            "text": "Attendees",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#EFF6FF",
+                        "baseline": "Data!E2",
+                        "baselineDescr": "since last period",
+                        "keyValue": "Data!D2",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "9757f293-3703-437c-985c-208b91aaa8f1",
+                    "x": 0,
+                    "y": 188,
+                    "width": 472,
+                    "height": 335,
+                    "tag": "chart",
+                    "data": {
+                        "type": "bar",
+                        "dataSetsHaveTitle": false,
+                        "dataSets": [
+                            {
+                                "dataRange": "Data!B7:B8",
+                                "yAxisId": "y"
+                            }
+                        ],
+                        "legendPosition": "none",
+                        "labelRange": "Data!A7:A8",
+                        "title": {},
+                        "stacked": false,
+                        "aggregated": false
+                    }
+                },
+                {
+                    "id": "9b287910-b65f-4392-889a-52aafce81a3e",
+                    "x": 523,
+                    "y": 178,
+                    "width": 476,
+                    "height": 345,
+                    "tag": "chart",
+                    "data": {
+                        "type": "bar",
+                        "dataSetsHaveTitle": false,
+                        "dataSets": [
+                            {
+                                "dataRange": "Data!B11:B12",
+                                "yAxisId": "y"
+                            }
+                        ],
+                        "legendPosition": "none",
+                        "labelRange": "Data!A11:A12",
+                        "title": {},
+                        "stacked": false,
+                        "aggregated": false
+                    }
+                }
+            ],
+            "tables": [],
+            "areGridLinesVisible": true,
+            "isVisible": true,
+            "headerGroups": {
+                "ROW": [],
+                "COL": []
+            },
+            "dataValidationRules": [],
+            "comments": {}
+        },
+        {
+            "id": "3fad37db-0a40-46e9-bcc8-967eebf0bca4",
+            "name": "Data",
+            "colNumber": 26,
+            "rowNumber": 101,
+            "rows": {},
+            "cols": {},
+            "merges": [],
+            "cells": {
+                "A1": {
+                    "content": "=_t(\"KPI\")"
+                },
+                "A2": {
+                    "content": "=_t(\"Attendees\")"
+                },
+                "A3": {
+                    "content": "=_t(\"Events\")"
+                },
+                "A4": {
+                    "content": "=_t(\"Revenue\")"
+                },
+                "A7": {
+                    "content": "=_t(\"Booked\")"
+                },
+                "A8": {
+                    "content": "=_t(\"Ended\")"
+                },
+                "A11": {
+                    "content": "=_t(\"Attended\")"
+                },
+                "A12": {
+                    "content": "=_t(\"Registered\")"
+                },
+                "B1": {
+                    "content": "=_t(\"Current\")"
+                },
+                "B2": {
+                    "content": "478"
+                },
+                "B3": {
+                    "content": "56"
+                },
+                "B4": {
+                    "content": "15497"
+                },
+                "B7": {
+                    "content": "4656"
+                },
+                "B8": {
+                    "content": "435"
+                },
+                "B11": {
+                    "content": "134354"
+                },
+                "B12": {
+                    "content": "32345"
+                },
+                "C1": {
+                    "content": "=_t(\"Previous\")"
+                },
+                "C2": {
+                    "content": "344"
+                },
+                "C3": {
+                    "content": "43"
+                },
+                "C4": {
+                    "content": "11345"
+                },
+                "D1": {
+                    "content": "=_t(\"Current\")"
+                },
+                "D2": {
+                    "content": "=FORMAT.LARGE.NUMBER(B2)"
+                },
+                "D3": {
+                    "content": "=FORMAT.LARGE.NUMBER(B3)"
+                },
+                "D4": {
+                    "content": "=FORMAT.LARGE.NUMBER(B4)"
+                },
+                "E1": {
+                    "content": "=_t(\"Previous\")"
+                },
+                "E2": {
+                    "content": "=FORMAT.LARGE.NUMBER(C2)"
+                },
+                "E3": {
+                    "content": "=FORMAT.LARGE.NUMBER(C3)"
+                },
+                "E4": {
+                    "content": "=FORMAT.LARGE.NUMBER(C4)"
+                }
+            },
+            "styles": {
+                "A1:C1": 4,
+                "D1:E1": 5,
+                "D2:E4": 6
+            },
+            "formats": {
+                "B2:C3": 1,
+                "B4:E4": 2
+            },
+            "borders": {},
+            "conditionalFormats": [],
+            "figures": [],
+            "tables": [],
+            "areGridLinesVisible": true,
+            "isVisible": true,
+            "headerGroups": {
+                "ROW": [],
+                "COL": []
+            },
+            "dataValidationRules": [],
+            "comments": {}
+        }
+    ],
+    "styles": {
+        "1": {
+            "textColor": "#01666b",
+            "fontSize": 16,
+            "bold": true
+        },
+        "2": {
+            "textColor": "#434343",
+            "bold": true,
+            "fontSize": 11
+        },
+        "3": {
+            "textColor": "#434343",
+            "bold": true,
+            "fontSize": 11,
+            "align": "center"
+        },
+        "4": {
+            "bold": true
+        },
+        "5": {
+            "bold": true,
+            "fillColor": "#f2f2f2"
+        },
+        "6": {
+            "fillColor": "#f2f2f2"
+        }
+    },
+    "formats": {
+        "1": "0",
+        "2": "[$$]#,##0"
+    },
+    "borders": {
+        "1": {
+            "bottom": {
+                "style": "thin",
+                "color": "#CCCCCC"
+            }
+        },
+        "2": {
+            "top": {
+                "style": "thin",
+                "color": "#CCCCCC"
+            }
+        },
+        "3": {
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "4": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "5": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "6": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "7": {
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "8": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        }
+    },
+    "revisionId": "START_REVISION",
+    "uniqueFigureIds": true,
+    "settings": {
+        "locale": {
+            "name": "English (US)",
+            "code": "en_US",
+            "thousandsSeparator": ",",
+            "decimalSeparator": ".",
+            "dateFormat": "mm/dd/yyyy",
+            "timeFormat": "hh:mm:ss",
+            "formulaArgSeparator": ",",
+            "weekStart": 7
+        }
+    },
+    "pivots": {},
+    "pivotNextId": 11,
+    "customTableStyles": {},
+    "odooVersion": 12,
+    "globalFilters": [],
+    "lists": {},
+    "listNextId": 1
+}

--- a/addons/spreadsheet_dashboard_hr_expense/data/dashboards.xml
+++ b/addons/spreadsheet_dashboard_hr_expense/data/dashboards.xml
@@ -4,6 +4,8 @@
     <record id="spreadsheet_dashboard_expense" model="spreadsheet.dashboard">
         <field name="name">Expenses</field>
         <field name="spreadsheet_binary_data" type="base64" file="spreadsheet_dashboard_hr_expense/data/files/expense_dashboard.json"/>
+        <field name="main_data_model_ids" eval="[(4, ref('hr_expense.model_hr_expense'))]"/>
+        <field name="sample_dashboard_file_path">spreadsheet_dashboard_hr_expense/data/files/expense_sample_dashboard.json</field>
         <field name="dashboard_group_id" ref="spreadsheet_dashboard.spreadsheet_dashboard_group_finance"/>
         <field name="group_ids" eval="[Command.link(ref('hr_expense.group_hr_expense_manager'))]"/>
         <field name="sequence">40</field>

--- a/addons/spreadsheet_dashboard_hr_expense/data/files/expense_sample_dashboard.json
+++ b/addons/spreadsheet_dashboard_hr_expense/data/files/expense_sample_dashboard.json
@@ -1,0 +1,743 @@
+{
+    "version": 21,
+    "sheets": [
+        {
+            "id": "91067711-0fdf-451a-b1ec-9e8bdcff23f0",
+            "name": "Dashboard",
+            "colNumber": 7,
+            "rowNumber": 56,
+            "rows": {
+                "6": {
+                    "size": 40
+                },
+                "22": {
+                    "size": 40
+                },
+                "23": {
+                    "size": 40
+                },
+                "24": {
+                    "size": 30
+                },
+                "25": {
+                    "size": 30
+                },
+                "26": {
+                    "size": 30
+                },
+                "27": {
+                    "size": 30
+                },
+                "28": {
+                    "size": 30
+                },
+                "29": {
+                    "size": 30
+                },
+                "30": {
+                    "size": 30
+                },
+                "31": {
+                    "size": 30
+                },
+                "32": {
+                    "size": 30
+                },
+                "33": {
+                    "size": 30
+                },
+                "35": {
+                    "size": 40
+                },
+                "36": {
+                    "size": 40
+                },
+                "37": {
+                    "size": 30
+                },
+                "38": {
+                    "size": 30
+                },
+                "39": {
+                    "size": 30
+                },
+                "40": {
+                    "size": 30
+                },
+                "41": {
+                    "size": 30
+                },
+                "42": {
+                    "size": 30
+                },
+                "43": {
+                    "size": 30
+                },
+                "44": {
+                    "size": 30
+                },
+                "45": {
+                    "size": 30
+                },
+                "46": {
+                    "size": 30
+                }
+            },
+            "cols": {
+                "0": {
+                    "size": 276
+                },
+                "1": {
+                    "size": 95
+                },
+                "2": {
+                    "size": 100
+                },
+                "3": {
+                    "size": 50
+                },
+                "4": {
+                    "size": 295
+                },
+                "5": {
+                    "size": 85
+                },
+                "6": {
+                    "size": 100
+                }
+            },
+            "merges": [],
+            "cells": {
+                "A7": {
+                    "content": "[Expenses Analysis](odoo://view/{\"viewType\":\"graph\",\"action\":{\"domain\":[],\"context\":{\"group_by\":[\"date:month\",\"product_id\"],\"graph_measure\":\"total_amount\",\"graph_mode\":\"bar\",\"graph_groupbys\":[\"date:month\",\"product_id\"]},\"modelName\":\"hr.expense\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"list\"],[false,\"kanban\"],[false,\"form\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Expenses Analysis\",\"positional\":true})"
+                },
+                "A23": {
+                    "content": "[Top Expenses](odoo://view/{\"viewType\":\"list\",\"action\":{\"domain\":\"[]\",\"context\":{\"group_by\":[]},\"modelName\":\"hr.expense\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"list\"],[false,\"kanban\"],[false,\"form\"]]},\"threshold\":0,\"name\":\"Expenses Analysis\"})"
+                },
+                "A24": {
+                    "content": "=_t(\"Expense\")"
+                },
+                "A36": {
+                    "content": "[Top Reinvoiced Orders](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[[\"sale_order_id\",\"!=\",false]],\"context\":{\"group_by\":[\"sale_order_id\"],\"pivot_measures\":[\"__count\",\"total_amount\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"sale_order_id\"]},\"modelName\":\"hr.expense\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"list\"],[false,\"kanban\"],[false,\"form\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Expenses Analysis\"})"
+                },
+                "A37": {
+                    "content": "=_t(\"Order\")"
+                },
+                "B24": {
+                    "content": "=_t(\"Employee\")"
+                },
+                "B37": {
+                    "content": "=_t(\"# Expenses\")"
+                },
+                "C24": {
+                    "content": "=_t(\"Total\")"
+                },
+                "C37": {
+                    "content": "=_t(\"Total\")"
+                },
+                "E23": {
+                    "content": "[Top Categories](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[[\"product_id\",\"!=\",false]],\"context\":{\"group_by\":[\"product_id\"],\"pivot_measures\":[\"__count\",\"total_amount\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"product_id\"]},\"modelName\":\"hr.expense\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"list\"],[false,\"kanban\"],[false,\"form\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Expenses Analysis\"})"
+                },
+                "E24": {
+                    "content": "=_t(\"Category\")"
+                },
+                "E36": {
+                    "content": "[Top Employees](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[[\"product_id\",\"!=\",false]],\"context\":{\"group_by\":[\"product_id\"],\"pivot_measures\":[\"__count\",\"total_amount\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"product_id\"]},\"modelName\":\"hr.expense\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"list\"],[false,\"kanban\"],[false,\"form\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Expenses Analysis\"})"
+                },
+                "E37": {
+                    "content": "=_t(\"Employee\")"
+                },
+                "F24": {
+                    "content": "=_t(\"# Expenses\")"
+                },
+                "F37": {
+                    "content": "=_t(\"# Expenses\")"
+                },
+                "G24": {
+                    "content": "=_t(\"Total\")"
+                },
+                "G37": {
+                    "content": "=_t(\"Total\")"
+                }
+            },
+            "styles": {
+                "A7": 1,
+                "A23": 1,
+                "A36": 1,
+                "E23": 1,
+                "E36": 1,
+                "A37": 2,
+                "A24:B24": 2,
+                "E24": 2,
+                "E37": 2,
+                "C24": 3,
+                "B37:C37": 3,
+                "F24:G24": 3,
+                "F37:G37": 3
+            },
+            "formats": {},
+            "borders": {
+                "A23:C23": 1,
+                "A36:C36": 1,
+                "A7:G7": 1,
+                "E23:G23": 1,
+                "E36:G36": 1,
+                "A24:C24": 2,
+                "A37:C37": 2,
+                "A8:G8": 2,
+                "E24:G24": 2,
+                "E37:G37": 2,
+                "A25": 3,
+                "A38": 3,
+                "E25": 3,
+                "E38": 3,
+                "A26:A33": 4,
+                "A39:A46": 4,
+                "E26:E33": 4,
+                "E39:E46": 4,
+                "A34": 5,
+                "A47": 5,
+                "E34": 5,
+                "E47": 5,
+                "B25": 6,
+                "B38": 6,
+                "F25": 6,
+                "F38": 6,
+                "B26:B33": 7,
+                "B39:B46": 7,
+                "F26:F33": 7,
+                "F39:F46": 7,
+                "B34": 8,
+                "B47": 8,
+                "F34": 8,
+                "F47": 8,
+                "C25": 9,
+                "C38": 9,
+                "G25": 9,
+                "G38": 9,
+                "C26:C33": 10,
+                "C39:C46": 10,
+                "G26:G33": 10,
+                "G39:G46": 10,
+                "C34": 11,
+                "C47": 11,
+                "G34": 11,
+                "G47": 11
+            },
+            "conditionalFormats": [],
+            "figures": [
+                {
+                    "id": "34d7af0c-d66d-46f5-9b4f-91a8f26be506",
+                    "x": 0,
+                    "y": 12,
+                    "width": 200,
+                    "height": 106,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "difference",
+                        "title": {
+                            "text": "Expenses",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#EFF6FF",
+                        "keyValue": "Data!C1",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "64e233df-0643-4205-86c8-d051c45326a4",
+                    "x": 210,
+                    "y": 12,
+                    "width": 200,
+                    "height": 106,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "difference",
+                        "title": {
+                            "text": "To report",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#FFF7ED",
+                        "keyValue": "Data!C2",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "62c97109-f819-42a7-929d-e76a1204be62",
+                    "x": 420,
+                    "y": 12,
+                    "width": 200,
+                    "height": 106,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "difference",
+                        "title": {
+                            "text": "To validate",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#FFF7ED",
+                        "keyValue": "Data!C3",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "a84056d3-f845-4555-9bd9-3281b8b1c872",
+                    "x": 629,
+                    "y": 12,
+                    "width": 200,
+                    "height": 106,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "difference",
+                        "title": {
+                            "text": "To reimburse",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#FFF7ED",
+                        "keyValue": "Data!C4",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "3ce1b146-06b2-4a52-8a21-183d9b25af67",
+                    "x": 0,
+                    "y": 178,
+                    "width": 1002,
+                    "height": 348,
+                    "tag": "chart",
+                    "data": {
+                        "type": "bar",
+                        "dataSetsHaveTitle": true,
+                        "dataSets": [
+                            {
+                                "dataRange": "Data!B7:B14",
+                                "yAxisId": "y"
+                            },
+                            {
+                                "dataRange": "Data!C7:C14"
+                            },
+                            {
+                                "dataRange": "Data!D7:D14"
+                            },
+                            {
+                                "dataRange": "Data!E7:E14"
+                            }
+                        ],
+                        "legendPosition": "top",
+                        "labelRange": "Data!A7:A14",
+                        "title": {},
+                        "stacked": true,
+                        "aggregated": false,
+                        "horizontal": false
+                    }
+                }
+            ],
+            "tables": [],
+            "areGridLinesVisible": true,
+            "isVisible": true,
+            "headerGroups": {
+                "ROW": [],
+                "COL": []
+            },
+            "dataValidationRules": [],
+            "comments": {}
+        },
+        {
+            "id": "44bfb206-c15d-4314-a394-97690f1d5e8e",
+            "name": "Data",
+            "colNumber": 26,
+            "rowNumber": 98,
+            "rows": {},
+            "cols": {},
+            "merges": [],
+            "cells": {
+                "A1": {
+                    "content": "=_t(\"KPI - Expenses\")"
+                },
+                "A2": {
+                    "content": "=_t(\"KPI - To report\")"
+                },
+                "A3": {
+                    "content": "=_t(\"KPI - To validate\")"
+                },
+                "A4": {
+                    "content": "=_t(\"KPI - To reimburse\")"
+                },
+                "A8": {
+                    "content": "=EDATE(TODAY(),-F8)"
+                },
+                "A9": {
+                    "content": "=EDATE(TODAY(),-F9)"
+                },
+                "A10": {
+                    "content": "=EDATE(TODAY(),-F10)"
+                },
+                "A11": {
+                    "content": "=EDATE(TODAY(),-F11)"
+                },
+                "A12": {
+                    "content": "=EDATE(TODAY(),-F12)"
+                },
+                "A13": {
+                    "content": "=EDATE(TODAY(),-F13)"
+                },
+                "A14": {
+                    "content": "=EDATE(TODAY(),-F14)"
+                },
+                "B1": {
+                    "content": "34"
+                },
+                "B2": {
+                    "content": "8494.42"
+                },
+                "B3": {
+                    "content": "2878"
+                },
+                "B4": {
+                    "content": "=B2-B3"
+                },
+                "B7": {
+                    "content": "=_t(\"Expenses\")"
+                },
+                "B8": {
+                    "content": "351"
+                },
+                "B9": {
+                    "content": "1402"
+                },
+                "B10": {
+                    "content": "795"
+                },
+                "B11": {
+                    "content": "537"
+                },
+                "B12": {
+                    "content": "1269"
+                },
+                "B13": {
+                    "content": "496"
+                },
+                "B14": {
+                    "content": "1352"
+                },
+                "C1": {
+                    "content": "=FORMAT.LARGE.NUMBER(B1)"
+                },
+                "C2": {
+                    "content": "=FORMAT.LARGE.NUMBER(B2)"
+                },
+                "C3": {
+                    "content": "=FORMAT.LARGE.NUMBER(B3)"
+                },
+                "C4": {
+                    "content": "=FORMAT.LARGE.NUMBER(B4)"
+                },
+                "C7": {
+                    "content": "=_t(\"Mileage\")"
+                },
+                "C8": {
+                    "content": "1245"
+                },
+                "C9": {
+                    "content": "589"
+                },
+                "C10": {
+                    "content": "273"
+                },
+                "C11": {
+                    "content": "1254"
+                },
+                "C12": {
+                    "content": "1086"
+                },
+                "C13": {
+                    "content": "130"
+                },
+                "C14": {
+                    "content": "1388"
+                },
+                "D7": {
+                    "content": "=_t(\"Meals\")"
+                },
+                "D8": {
+                    "content": "1347"
+                },
+                "D9": {
+                    "content": "822"
+                },
+                "D10": {
+                    "content": "669"
+                },
+                "D11": {
+                    "content": "465"
+                },
+                "D12": {
+                    "content": "632"
+                },
+                "D13": {
+                    "content": "1378"
+                },
+                "D14": {
+                    "content": "298"
+                },
+                "E7": {
+                    "content": "=_t(\"Travel\")"
+                },
+                "E8": {
+                    "content": "1628"
+                },
+                "E9": {
+                    "content": "867"
+                },
+                "E10": {
+                    "content": "200"
+                },
+                "E11": {
+                    "content": "279"
+                },
+                "E12": {
+                    "content": "295"
+                },
+                "E13": {
+                    "content": "1142"
+                },
+                "E14": {
+                    "content": "1283"
+                },
+                "F8": {
+                    "content": "6"
+                },
+                "F9": {
+                    "content": "5"
+                },
+                "F10": {
+                    "content": "4"
+                },
+                "F11": {
+                    "content": "3"
+                },
+                "F12": {
+                    "content": "2"
+                },
+                "F13": {
+                    "content": "1"
+                },
+                "F14": {
+                    "content": "0"
+                }
+            },
+            "styles": {
+                "C1:C4": 4
+            },
+            "formats": {
+                "A8:A14": 1,
+                "B1": 2,
+                "B2:C4": 3,
+                "B8:E14": 3
+            },
+            "borders": {},
+            "conditionalFormats": [],
+            "figures": [],
+            "tables": [],
+            "areGridLinesVisible": true,
+            "isVisible": true,
+            "headerGroups": {
+                "ROW": [],
+                "COL": []
+            },
+            "dataValidationRules": [],
+            "comments": {}
+        }
+    ],
+    "styles": {
+        "1": {
+            "textColor": "#01666b",
+            "bold": true,
+            "fontSize": 16
+        },
+        "2": {
+            "textColor": "#434343",
+            "fontSize": 11,
+            "bold": true
+        },
+        "3": {
+            "textColor": "#434343",
+            "fontSize": 11,
+            "bold": true,
+            "align": "center"
+        },
+        "4": {
+            "fillColor": "#f8f9fa"
+        }
+    },
+    "formats": {
+        "1": "mmmm yyyy",
+        "2": "0",
+        "3": "[$$]#,##0"
+    },
+    "borders": {
+        "1": {
+            "bottom": {
+                "style": "thin",
+                "color": "#B7B7B7"
+            }
+        },
+        "2": {
+            "top": {
+                "style": "thin",
+                "color": "#B7B7B7"
+            }
+        },
+        "3": {
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "4": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "5": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "6": {
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "7": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "8": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "9": {
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "10": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "11": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        }
+    },
+    "revisionId": "START_REVISION",
+    "uniqueFigureIds": true,
+    "settings": {
+        "locale": {
+            "name": "English (US)",
+            "code": "en_US",
+            "thousandsSeparator": ",",
+            "decimalSeparator": ".",
+            "dateFormat": "mm/dd/yyyy",
+            "timeFormat": "hh:mm:ss",
+            "formulaArgSeparator": ",",
+            "weekStart": 7
+        }
+    },
+    "pivots": {},
+    "pivotNextId": 10,
+    "customTableStyles": {},
+    "odooVersion": 12,
+    "globalFilters": [],
+    "lists": {},
+    "listNextId": 2
+}

--- a/addons/spreadsheet_dashboard_im_livechat/data/dashboards.xml
+++ b/addons/spreadsheet_dashboard_im_livechat/data/dashboards.xml
@@ -4,6 +4,8 @@
     <record id="spreadsheet_dashboard_livechat" model="spreadsheet.dashboard">
         <field name="name">Live chat</field>
         <field name="spreadsheet_binary_data" type="base64" file="spreadsheet_dashboard_im_livechat/data/files/livechat_dashboard.json"/>
+        <field name="main_data_model_ids" eval="[(4, ref('im_livechat.model_im_livechat_report_channel'))]"/>
+        <field name="sample_dashboard_file_path">spreadsheet_dashboard_im_livechat/data/files/livechat_sample_dashboard.json</field>
         <field name="dashboard_group_id" ref="spreadsheet_dashboard.spreadsheet_dashboard_group_website"/>
         <field name="group_ids" eval="[Command.link(ref('im_livechat.im_livechat_group_manager'))]"/>
         <field name="sequence">100</field>

--- a/addons/spreadsheet_dashboard_im_livechat/data/files/livechat_sample_dashboard.json
+++ b/addons/spreadsheet_dashboard_im_livechat/data/files/livechat_sample_dashboard.json
@@ -1,0 +1,605 @@
+{
+    "version": 21,
+    "sheets": [
+        {
+            "id": "sheet1",
+            "name": "Dashboard",
+            "colNumber": 5,
+            "rowNumber": 35,
+            "rows": {
+                "6": {
+                    "size": 40
+                },
+                "22": {
+                    "size": 40
+                },
+                "23": {
+                    "size": 40
+                },
+                "24": {
+                    "size": 29
+                },
+                "25": {
+                    "size": 29
+                },
+                "26": {
+                    "size": 29
+                },
+                "27": {
+                    "size": 29
+                },
+                "28": {
+                    "size": 29
+                },
+                "29": {
+                    "size": 29
+                },
+                "30": {
+                    "size": 29
+                },
+                "31": {
+                    "size": 29
+                },
+                "32": {
+                    "size": 29
+                },
+                "33": {
+                    "size": 29
+                }
+            },
+            "cols": {
+                "0": {
+                    "size": 372
+                },
+                "1": {
+                    "size": 100
+                },
+                "2": {
+                    "size": 50
+                },
+                "3": {
+                    "size": 209
+                },
+                "4": {
+                    "size": 260
+                }
+            },
+            "merges": [],
+            "cells": {
+                "A7": {
+                    "content": "[Daily Sessions](odoo://view/{\"viewType\":\"graph\",\"action\":{\"domain\":[],\"context\":{\"group_by\":[\"start_date:day\"],\"graph_measure\":\"__count\",\"graph_mode\":\"bar\",\"graph_groupbys\":[\"start_date:day\"]},\"modelName\":\"im_livechat.report.channel\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Session per Day\"})"
+                },
+                "A23": {
+                    "content": "[Top Operators](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[],\"context\":{\"group_by\":[],\"pivot_measures\":[\"nbr_channel\",\"time_to_answer\",\"duration\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"partner_id\"]},\"modelName\":\"im_livechat.report.operator\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Operator Analysis\"})"
+                },
+                "A24": {
+                    "content": "=_t(\"Operator\")"
+                },
+                "B24": {
+                    "content": "=_t(\"Sessions\")"
+                },
+                "D7": {
+                    "content": "[Sessions by Operator](odoo://view/{\"viewType\":\"graph\",\"action\":{\"domain\":[],\"context\":{\"group_by\":[\"partner_id\"],\"graph_measure\":\"nbr_channel\",\"graph_mode\":\"bar\",\"graph_groupbys\":[\"partner_id\"]},\"modelName\":\"im_livechat.report.operator\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Operator Analysis\"})"
+                },
+                "D24": {
+                    "content": "=_t(\"Time to answer (seconds)\")"
+                },
+                "E24": {
+                    "content": "=_t(\"Average session (seconds)\")"
+                }
+            },
+            "styles": {
+                "A7": 1,
+                "A23": 1,
+                "D7": 1,
+                "A24": 2,
+                "B24": 3,
+                "D24:E24": 3
+            },
+            "formats": {},
+            "borders": {
+                "A7:B7": 1,
+                "D7:E7": 1,
+                "A23:E23": 1,
+                "A8:B8": 2,
+                "D8:E8": 2,
+                "A24:E24": 2,
+                "A25": 3,
+                "A26:A34": 4,
+                "A35:E35": 5,
+                "B25:D25": 6,
+                "B26:D34": 7,
+                "E25": 8,
+                "E26:E34": 9
+            },
+            "conditionalFormats": [],
+            "figures": [
+                {
+                    "id": "082454d7-d797-48a6-8db5-9182050a8c55",
+                    "x": 0,
+                    "y": 12,
+                    "width": 200,
+                    "height": 102,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "percentage",
+                        "title": {
+                            "text": "Sessions",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#EFF6FF",
+                        "baseline": "Data!E2",
+                        "baselineDescr": "since last period",
+                        "keyValue": "Data!D2",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "ced6ca85-c9d2-4804-9100-e1ca5fd290d1",
+                    "x": 213,
+                    "y": 12,
+                    "width": 200,
+                    "height": 102,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "percentage",
+                        "title": {
+                            "text": "Avg. Time to Answer",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#FEF2F2",
+                        "baseline": "Data!E3",
+                        "baselineDescr": "last period",
+                        "keyValue": "Data!D3",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "e0b92164-4451-4c0b-bd28-3bab46fd88de",
+                    "x": 426,
+                    "y": 12,
+                    "width": 200,
+                    "height": 102,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "percentage",
+                        "title": {
+                            "text": "Avg. Session Duration",
+                            "color": "#434343",
+                            "bold": true
+                        },
+                        "type": "scorecard",
+                        "background": "#FEF2F2",
+                        "baseline": "Data!E4",
+                        "baselineDescr": "last period",
+                        "keyValue": "Data!D4",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "5b8972f1-db5f-48dd-aeca-c0bc87c7155d",
+                    "x": 636,
+                    "y": 12,
+                    "width": 200,
+                    "height": 102,
+                    "tag": "chart",
+                    "data": {
+                        "background": "#EFF6FF",
+                        "sectionRule": {
+                            "colors": {
+                                "lowerColor": "#cc0000",
+                                "middleColor": "#f1c232",
+                                "upperColor": "#6aa84f"
+                            },
+                            "rangeMin": "0",
+                            "rangeMax": "5",
+                            "lowerInflectionPoint": {
+                                "type": "number",
+                                "value": "1"
+                            },
+                            "upperInflectionPoint": {
+                                "type": "number",
+                                "value": "3"
+                            }
+                        },
+                        "title": {
+                            "text": "Average Rating",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "gauge",
+                        "dataRange": "Data!D5"
+                    }
+                },
+                {
+                    "id": "d0e7d22f-834d-4d8e-88ee-ed66f743c812",
+                    "x": 522,
+                    "y": 178,
+                    "width": 469,
+                    "height": 345,
+                    "tag": "chart",
+                    "data": {
+                        "type": "bar",
+                        "dataSetsHaveTitle": false,
+                        "dataSets": [
+                            {
+                                "dataRange": "Data!B16:B18",
+                                "yAxisId": "y"
+                            }
+                        ],
+                        "legendPosition": "none",
+                        "labelRange": "Data!A16:A18",
+                        "title": {},
+                        "stacked": false,
+                        "aggregated": false
+                    }
+                },
+                {
+                    "id": "95bfac8a-184e-4f8e-b781-ead13c7dd6c1",
+                    "x": 0,
+                    "y": 178,
+                    "width": 474,
+                    "height": 345,
+                    "tag": "chart",
+                    "data": {
+                        "type": "bar",
+                        "dataSetsHaveTitle": false,
+                        "dataSets": [
+                            {
+                                "dataRange": "Data!C8:C13",
+                                "yAxisId": "y"
+                            }
+                        ],
+                        "legendPosition": "none",
+                        "labelRange": "Data!A8:A13",
+                        "title": {},
+                        "stacked": false,
+                        "aggregated": false
+                    }
+                }
+            ],
+            "tables": [],
+            "areGridLinesVisible": true,
+            "isVisible": true,
+            "headerGroups": {
+                "ROW": [],
+                "COL": []
+            },
+            "dataValidationRules": [],
+            "comments": {}
+        },
+        {
+            "id": "16705d67-20c0-466d-ac72-3b955432e0ba",
+            "name": "Data",
+            "colNumber": 26,
+            "rowNumber": 90,
+            "rows": {},
+            "cols": {},
+            "merges": [],
+            "cells": {
+                "A1": {
+                    "content": "=_t(\"KPI\")"
+                },
+                "A2": {
+                    "content": "=_t(\"Sessions\")"
+                },
+                "A3": {
+                    "content": "=_t(\"Avg. time to answer\")"
+                },
+                "A4": {
+                    "content": "=_t(\"Avg. session duration\")"
+                },
+                "A5": {
+                    "content": "=_t(\"Rating\")"
+                },
+                "A8": {
+                    "content": "=EDATE(TODAY(),-B8)"
+                },
+                "A9": {
+                    "content": "=EDATE(TODAY(),-B9)"
+                },
+                "A10": {
+                    "content": "=EDATE(TODAY(),-B10)"
+                },
+                "A11": {
+                    "content": "=EDATE(TODAY(),-B11)"
+                },
+                "A12": {
+                    "content": "=EDATE(TODAY(),-B12)"
+                },
+                "A13": {
+                    "content": "=EDATE(TODAY(),-B13)"
+                },
+                "A16": {
+                    "content": "=_t(\"Michael Bay\")"
+                },
+                "A17": {
+                    "content": "=_t(\"Emilia Stones\")"
+                },
+                "A18": {
+                    "content": "=_t(\"David Morenas\")"
+                },
+                "B1": {
+                    "content": "=_t(\"Current\")"
+                },
+                "B2": {
+                    "content": "382"
+                },
+                "B3": {
+                    "content": "10"
+                },
+                "B4": {
+                    "content": "47"
+                },
+                "B5": {
+                    "content": "4.6"
+                },
+                "B8": {
+                    "content": "5"
+                },
+                "B9": {
+                    "content": "4"
+                },
+                "B10": {
+                    "content": "3"
+                },
+                "B11": {
+                    "content": "2"
+                },
+                "B12": {
+                    "content": "1"
+                },
+                "B13": {
+                    "content": "0"
+                },
+                "B16": {
+                    "content": "45"
+                },
+                "B17": {
+                    "content": "234"
+                },
+                "B18": {
+                    "content": "99"
+                },
+                "C1": {
+                    "content": "=_t(\"Previous\")"
+                },
+                "C2": {
+                    "content": "297"
+                },
+                "C3": {
+                    "content": "13"
+                },
+                "C8": {
+                    "content": "=RANDBETWEEN(10,100)"
+                },
+                "C9": {
+                    "content": "=RANDBETWEEN(10,100)"
+                },
+                "C10": {
+                    "content": "=RANDBETWEEN(10,100)"
+                },
+                "C11": {
+                    "content": "=RANDBETWEEN(10,100)"
+                },
+                "C12": {
+                    "content": "=RANDBETWEEN(10,100)"
+                },
+                "C13": {
+                    "content": "=RANDBETWEEN(10,100)"
+                },
+                "D1": {
+                    "content": "=_t(\"Current\")"
+                },
+                "D2": {
+                    "content": "=FORMAT.LARGE.NUMBER(B2)"
+                },
+                "D3": {
+                    "content": "=CONCATENATE(ROUND(B3),\"min\")"
+                },
+                "D4": {
+                    "content": "=CONCATENATE(ROUND(B4),\"min\")"
+                },
+                "D5": {
+                    "content": "=B5"
+                },
+                "E1": {
+                    "content": "=_t(\"Previous\")"
+                },
+                "E2": {
+                    "content": "=FORMAT.LARGE.NUMBER(C2)"
+                },
+                "E3": {
+                    "content": "13"
+                },
+                "E4": {
+                    "content": "56"
+                }
+            },
+            "styles": {
+                "A1:E1": 4,
+                "D2:D5": 5,
+                "E2:E4": 5
+            },
+            "formats": {
+                "B5": 1,
+                "B2:C2": 1,
+                "B3:B4": 2,
+                "C3": 2,
+                "E3:E4": 3
+            },
+            "borders": {},
+            "conditionalFormats": [],
+            "figures": [],
+            "tables": [],
+            "areGridLinesVisible": true,
+            "isVisible": true,
+            "headerGroups": {
+                "ROW": [],
+                "COL": []
+            },
+            "dataValidationRules": [],
+            "comments": {}
+        }
+    ],
+    "styles": {
+        "1": {
+            "textColor": "#01666b",
+            "bold": true,
+            "fontSize": 16
+        },
+        "2": {
+            "textColor": "#434343",
+            "fontSize": 11,
+            "bold": true
+        },
+        "3": {
+            "textColor": "#434343",
+            "fontSize": 11,
+            "bold": true,
+            "align": "center"
+        },
+        "4": {
+            "bold": true
+        },
+        "5": {
+            "fillColor": "#f2f2f2"
+        }
+    },
+    "formats": {
+        "1": "0",
+        "2": "#,##0.00",
+        "3": "#,##0"
+    },
+    "borders": {
+        "1": {
+            "bottom": {
+                "style": "thin",
+                "color": "#CCCCCC"
+            }
+        },
+        "2": {
+            "top": {
+                "style": "thin",
+                "color": "#CCCCCC"
+            }
+        },
+        "3": {
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "4": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "5": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "6": {
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "7": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "8": {
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "9": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        }
+    },
+    "revisionId": "START_REVISION",
+    "uniqueFigureIds": true,
+    "settings": {
+        "locale": {
+            "name": "English (US)",
+            "code": "en_US",
+            "thousandsSeparator": ",",
+            "decimalSeparator": ".",
+            "dateFormat": "mm/dd/yyyy",
+            "timeFormat": "hh:mm:ss",
+            "formulaArgSeparator": ",",
+            "weekStart": 7
+        }
+    },
+    "pivots": {},
+    "pivotNextId": 6,
+    "customTableStyles": {},
+    "odooVersion": 12,
+    "globalFilters": [],
+    "lists": {},
+    "listNextId": 1
+}

--- a/addons/spreadsheet_dashboard_pos_hr/data/dashboards.xml
+++ b/addons/spreadsheet_dashboard_pos_hr/data/dashboards.xml
@@ -4,6 +4,8 @@
     <record id="spreadsheet_dashboard_pos" model="spreadsheet.dashboard">
         <field name="name">Point of Sale</field>
         <field name="spreadsheet_binary_data" type="base64" file="spreadsheet_dashboard_pos_hr/data/files/pos_dashboard.json"/>
+        <field name="main_data_model_ids" eval="[(4, ref('sale.model_sale_order'))]"/>
+        <field name="sample_dashboard_file_path">spreadsheet_dashboard_pos_hr/data/files/pos_sample_dashboard.json</field>
         <field name="dashboard_group_id" ref="spreadsheet_dashboard.spreadsheet_dashboard_group_sales"/>
         <field name="group_ids" eval="[Command.link(ref('point_of_sale.group_pos_manager'))]"/>
         <field name="sequence">300</field>

--- a/addons/spreadsheet_dashboard_pos_hr/data/files/pos_sample_dashboard.json
+++ b/addons/spreadsheet_dashboard_pos_hr/data/files/pos_sample_dashboard.json
@@ -1,0 +1,770 @@
+{
+    "version": 21,
+    "sheets": [
+        {
+            "id": "sheet1",
+            "name": "Dashboard",
+            "colNumber": 7,
+            "rowNumber": 63,
+            "rows": {
+                "6": {
+                    "size": 40
+                },
+                "23": {
+                    "size": 40
+                },
+                "24": {
+                    "size": 40
+                },
+                "25": {
+                    "size": 29
+                },
+                "26": {
+                    "size": 29
+                },
+                "27": {
+                    "size": 29
+                },
+                "28": {
+                    "size": 29
+                },
+                "29": {
+                    "size": 29
+                },
+                "30": {
+                    "size": 29
+                },
+                "31": {
+                    "size": 29
+                },
+                "32": {
+                    "size": 29
+                },
+                "33": {
+                    "size": 29
+                },
+                "34": {
+                    "size": 29
+                },
+                "36": {
+                    "size": 40
+                },
+                "37": {
+                    "size": 40
+                },
+                "38": {
+                    "size": 29
+                },
+                "39": {
+                    "size": 29
+                },
+                "40": {
+                    "size": 29
+                },
+                "41": {
+                    "size": 29
+                },
+                "42": {
+                    "size": 29
+                },
+                "43": {
+                    "size": 29
+                },
+                "44": {
+                    "size": 29
+                },
+                "45": {
+                    "size": 29
+                },
+                "46": {
+                    "size": 29
+                },
+                "47": {
+                    "size": 29
+                },
+                "49": {
+                    "size": 40
+                },
+                "50": {
+                    "size": 40
+                },
+                "51": {
+                    "size": 29
+                },
+                "52": {
+                    "size": 29
+                },
+                "53": {
+                    "size": 29
+                },
+                "54": {
+                    "size": 29
+                },
+                "55": {
+                    "size": 29
+                },
+                "56": {
+                    "size": 29
+                },
+                "57": {
+                    "size": 29
+                },
+                "58": {
+                    "size": 29
+                },
+                "59": {
+                    "size": 29
+                },
+                "60": {
+                    "size": 29
+                }
+            },
+            "cols": {
+                "0": {
+                    "size": 200
+                },
+                "1": {
+                    "size": 125
+                },
+                "2": {
+                    "size": 131
+                },
+                "3": {
+                    "size": 100
+                },
+                "4": {
+                    "size": 200
+                },
+                "5": {
+                    "size": 125
+                },
+                "6": {
+                    "size": 125
+                }
+            },
+            "merges": [
+                "A25:B25",
+                "A26:B26",
+                "A27:B27",
+                "A28:B28",
+                "A29:B29",
+                "A30:B30",
+                "A31:B31",
+                "A32:B32",
+                "A33:B33",
+                "A34:B34",
+                "A35:B35"
+            ],
+            "cells": {
+                "A7": {
+                    "content": "[Orders by Month](odoo://view/{\"viewType\":\"graph\",\"action\":{\"domain\":[],\"context\":{\"group_by\":[\"date:month\"],\"graph_measure\":\"__count\",\"graph_mode\":\"line\",\"graph_groupbys\":[\"date:month\"]},\"modelName\":\"report.pos.order\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Orders Analysis\"})"
+                },
+                "A24": {
+                    "content": "[Top Orders](odoo://view/{\"viewType\":\"list\",\"action\":{\"domain\":[],\"context\":{\"group_by\":[]},\"modelName\":\"pos.order\",\"views\":[[false,\"list\"],[false,\"form\"],[false,\"kanban\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Orders\"})"
+                },
+                "A25": {
+                    "content": "=_t(\"Sessions\")"
+                },
+                "A37": {
+                    "content": "[Top Sessions](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[],\"context\":{\"group_by\":[\"session_id\"],\"pivot_measures\":[\"order_id\",\"price_total\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"session_id\"]},\"modelName\":\"report.pos.order\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Orders Analysis\"})"
+                },
+                "A38": {
+                    "content": "=_t(\"Session\")"
+                },
+                "A50": {
+                    "content": "[Top Responsibles](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[[\"user_id\",\"!=\",false]],\"context\":{\"group_by\":[\"user_id\"],\"pivot_measures\":[\"order_id\",\"price_total\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"user_id\"]},\"modelName\":\"report.pos.order\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Orders Analysis\"})"
+                },
+                "A51": {
+                    "content": "=_t(\"Responsible\")"
+                },
+                "B38": {
+                    "content": "=_t(\"Orders\")"
+                },
+                "B51": {
+                    "content": "=_t(\"Orders\")"
+                },
+                "C25": {
+                    "content": "=_t(\"Date\")"
+                },
+                "C38": {
+                    "content": "=_t(\"Revenue\")"
+                },
+                "C51": {
+                    "content": "=_t(\"Revenue\")"
+                },
+                "D25": {
+                    "content": "=_t(\"Point of Sale\")"
+                },
+                "E25": {
+                    "content": "=_t(\"Employee\")"
+                },
+                "E37": {
+                    "content": "[Top Points of Sale](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[],\"context\":{\"group_by\":[\"config_id\"],\"pivot_measures\":[\"order_id\",\"price_total\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"config_id\"]},\"modelName\":\"report.pos.order\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Orders Analysis\"})"
+                },
+                "E38": {
+                    "content": "=_t(\"Point of Sale\")"
+                },
+                "E50": {
+                    "content": "[Top Products](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[[\"product_id\",\"!=\",false]],\"context\":{\"group_by\":[\"product_id\"],\"pivot_measures\":[\"order_id\",\"price_total\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"product_id\"]},\"modelName\":\"report.pos.order\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Orders Analysis\"})"
+                },
+                "E51": {
+                    "content": "=_t(\"Product\")"
+                },
+                "F25": {
+                    "content": "=_t(\"Customer\")"
+                },
+                "F38": {
+                    "content": "=_t(\"Orders\")"
+                },
+                "F51": {
+                    "content": "=_t(\"Orders\")"
+                },
+                "G25": {
+                    "content": "=_t(\"Total\")"
+                },
+                "G38": {
+                    "content": "=_t(\"Revenue\")"
+                },
+                "G51": {
+                    "content": "=_t(\"Revenue\")"
+                }
+            },
+            "styles": {
+                "A7": 1,
+                "A24": 1,
+                "A37": 1,
+                "A50": 1,
+                "E37": 1,
+                "E50": 1,
+                "A25": 2,
+                "A38": 2,
+                "A51": 2,
+                "E38": 2,
+                "E51": 2,
+                "C25:F25": 2,
+                "B38:C38": 3,
+                "B51:C51": 3,
+                "G25": 3,
+                "F38:G38": 3,
+                "F51:G51": 3
+            },
+            "formats": {},
+            "borders": {
+                "A37:C37": 1,
+                "A50:C50": 1,
+                "A7:G7": 1,
+                "A24:G24": 1,
+                "E37:G37": 1,
+                "E50:G50": 1,
+                "A38:C38": 2,
+                "A51:C51": 2,
+                "A8:G8": 2,
+                "A25:G25": 2,
+                "E38:G38": 2,
+                "E51:G51": 2,
+                "A26": 3,
+                "A27:A35": 4,
+                "A56:C56": 4,
+                "E56:G56": 4,
+                "A49:C49": 5,
+                "A62:C62": 5,
+                "A36:G36": 5,
+                "E49:G49": 5,
+                "E62:G62": 5,
+                "A39": 6,
+                "A52": 6,
+                "B26": 6,
+                "E39": 6,
+                "E52": 6,
+                "A40:A48": 7,
+                "A53:A55": 7,
+                "A57:A61": 7,
+                "B27:B35": 7,
+                "E40:E48": 7,
+                "E53:E55": 7,
+                "E57:E61": 7,
+                "B39": 8,
+                "B52": 8,
+                "C26:F26": 8,
+                "F39": 8,
+                "F52": 8,
+                "B40:B48": 9,
+                "B53:B55": 9,
+                "B57:B61": 9,
+                "C27:F35": 9,
+                "F40:F48": 9,
+                "F53:F55": 9,
+                "F57:F61": 9,
+                "C39": 10,
+                "C52": 10,
+                "G26": 10,
+                "G39": 10,
+                "G52": 10,
+                "C40:C48": 11,
+                "C53:C55": 11,
+                "C57:C61": 11,
+                "G27:G35": 11,
+                "G40:G48": 11,
+                "G53:G55": 11,
+                "G57:G61": 11
+            },
+            "conditionalFormats": [],
+            "figures": [
+                {
+                    "id": "cfee1ef1-ac54-4e9f-bdde-0162652de2cf",
+                    "x": 0,
+                    "y": 9,
+                    "width": 209,
+                    "height": 111,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "percentage",
+                        "title": {
+                            "text": "Orders",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#EFF6FF",
+                        "baseline": "Data!E2",
+                        "baselineDescr": "since last period",
+                        "keyValue": "Data!D2",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "d141cc35-0b60-4e91-b736-5c1453fea925",
+                    "x": 217,
+                    "y": 9,
+                    "width": 200,
+                    "height": 111,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "percentage",
+                        "title": {
+                            "text": "Revenue",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#EFF6FF",
+                        "baseline": "Data!E3",
+                        "baselineDescr": "since last period",
+                        "keyValue": "Data!D3",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "615fb94e-8098-456e-9f71-7799b82f04c4",
+                    "x": 426,
+                    "y": 9,
+                    "width": 197,
+                    "height": 111,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "percentage",
+                        "title": {
+                            "text": "Average order",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#EFF6FF",
+                        "baseline": "Data!E4",
+                        "baselineDescr": "since last period",
+                        "keyValue": "Data!D4",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "5143b90c-d735-4c43-a31c-db58bf917db8",
+                    "x": 0,
+                    "y": 178,
+                    "width": 1005,
+                    "height": 369,
+                    "tag": "chart",
+                    "data": {
+                        "type": "line",
+                        "dataSetsHaveTitle": false,
+                        "dataSets": [
+                            {
+                                "dataRange": "Data!C7:C16",
+                                "yAxisId": "y"
+                            }
+                        ],
+                        "legendPosition": "none",
+                        "labelRange": "Data!A7:A16",
+                        "title": {},
+                        "labelsAsText": true,
+                        "stacked": false,
+                        "aggregated": false,
+                        "cumulative": true,
+                        "fillArea": true
+                    }
+                }
+            ],
+            "tables": [],
+            "areGridLinesVisible": true,
+            "isVisible": true,
+            "headerGroups": {
+                "ROW": [],
+                "COL": []
+            },
+            "dataValidationRules": [],
+            "comments": {}
+        },
+        {
+            "id": "1497ba8c-9e7d-4aa4-8394-741da8110207",
+            "name": "Data",
+            "colNumber": 26,
+            "rowNumber": 101,
+            "rows": {},
+            "cols": {},
+            "merges": [],
+            "cells": {
+                "A1": {
+                    "content": "=_t(\"KPI\")"
+                },
+                "A2": {
+                    "content": "=_t(\"Orders\")"
+                },
+                "A3": {
+                    "content": "=_t(\"Revenue\")"
+                },
+                "A4": {
+                    "content": "=_t(\"Average order\")"
+                },
+                "A7": {
+                    "content": "=EDATE(TODAY(),-B7)"
+                },
+                "A8": {
+                    "content": "=EDATE(TODAY(),-B8)"
+                },
+                "A9": {
+                    "content": "=EDATE(TODAY(),-B9)"
+                },
+                "A10": {
+                    "content": "=EDATE(TODAY(),-B10)"
+                },
+                "A11": {
+                    "content": "=EDATE(TODAY(),-B11)"
+                },
+                "A12": {
+                    "content": "=EDATE(TODAY(),-B12)"
+                },
+                "A13": {
+                    "content": "=EDATE(TODAY(),-B13)"
+                },
+                "A14": {
+                    "content": "=EDATE(TODAY(),-B14)"
+                },
+                "A15": {
+                    "content": "=EDATE(TODAY(),-B15)"
+                },
+                "A16": {
+                    "content": "=EDATE(TODAY(),-B16)"
+                },
+                "B1": {
+                    "content": "=_t(\"Current\")"
+                },
+                "B2": {
+                    "content": "567"
+                },
+                "B3": {
+                    "content": "855890"
+                },
+                "B4": {
+                    "content": "=IFERROR(B3/B2)"
+                },
+                "B7": {
+                    "content": "9"
+                },
+                "B8": {
+                    "content": "8"
+                },
+                "B9": {
+                    "content": "7"
+                },
+                "B10": {
+                    "content": "6"
+                },
+                "B11": {
+                    "content": "5"
+                },
+                "B12": {
+                    "content": "4"
+                },
+                "B13": {
+                    "content": "3"
+                },
+                "B14": {
+                    "content": "2"
+                },
+                "B15": {
+                    "content": "1"
+                },
+                "B16": {
+                    "content": "0"
+                },
+                "C1": {
+                    "content": "=_t(\"Previous\")"
+                },
+                "C2": {
+                    "content": "342"
+                },
+                "C4": {
+                    "content": "789"
+                },
+                "C7": {
+                    "content": "2675"
+                },
+                "C8": {
+                    "content": "5508"
+                },
+                "C9": {
+                    "content": "5386"
+                },
+                "C10": {
+                    "content": "8463"
+                },
+                "C11": {
+                    "content": "2014"
+                },
+                "C12": {
+                    "content": "5490"
+                },
+                "C13": {
+                    "content": "6956"
+                },
+                "C14": {
+                    "content": "2282"
+                },
+                "C15": {
+                    "content": "9875"
+                },
+                "C16": {
+                    "content": "5508"
+                },
+                "D1": {
+                    "content": "=_t(\"Current\")"
+                },
+                "D2": {
+                    "content": "=FORMAT.LARGE.NUMBER(B2)"
+                },
+                "D3": {
+                    "content": "=FORMAT.LARGE.NUMBER(B3)"
+                },
+                "D4": {
+                    "content": "=FORMAT.LARGE.NUMBER(B4)"
+                },
+                "E1": {
+                    "content": "=_t(\"Previous\")"
+                },
+                "E2": {
+                    "content": "=FORMAT.LARGE.NUMBER(C2)"
+                },
+                "E3": {
+                    "content": "=B3 - 343545"
+                },
+                "E4": {
+                    "content": "=FORMAT.LARGE.NUMBER(C4)"
+                }
+            },
+            "styles": {
+                "A1:E1": 4,
+                "A2:E4": 5
+            },
+            "formats": {
+                "A7:A16": 1,
+                "B3:B4": 2,
+                "C4": 2,
+                "C7:C16": 2,
+                "D3:E4": 2
+            },
+            "borders": {},
+            "conditionalFormats": [],
+            "figures": [],
+            "tables": [],
+            "areGridLinesVisible": true,
+            "isVisible": true,
+            "headerGroups": {
+                "ROW": [],
+                "COL": []
+            },
+            "dataValidationRules": [],
+            "comments": {}
+        }
+    ],
+    "styles": {
+        "1": {
+            "textColor": "#01666b",
+            "fontSize": 16,
+            "bold": true
+        },
+        "2": {
+            "bold": true,
+            "textColor": "#434343",
+            "fontSize": 11
+        },
+        "3": {
+            "fontSize": 11,
+            "textColor": "#434343",
+            "bold": true,
+            "align": "center"
+        },
+        "4": {
+            "bold": true,
+            "fillColor": "#f2f2f2"
+        },
+        "5": {
+            "fillColor": "#f2f2f2"
+        }
+    },
+    "formats": {
+        "1": "mmmm yyyy",
+        "2": "[$$]#,##0"
+    },
+    "borders": {
+        "1": {
+            "bottom": {
+                "style": "thin",
+                "color": "#CCCCCC"
+            }
+        },
+        "2": {
+            "top": {
+                "style": "thin",
+                "color": "#CCCCCC"
+            }
+        },
+        "3": {
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "4": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "5": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "6": {
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "7": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "8": {
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "9": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "10": {
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "11": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        }
+    },
+    "revisionId": "START_REVISION",
+    "uniqueFigureIds": true,
+    "settings": {
+        "locale": {
+            "name": "English (US)",
+            "code": "en_US",
+            "thousandsSeparator": ",",
+            "decimalSeparator": ".",
+            "dateFormat": "mm/dd/yyyy",
+            "timeFormat": "hh:mm:ss",
+            "formulaArgSeparator": ",",
+            "weekStart": 7
+        }
+    },
+    "pivots": {},
+    "pivotNextId": 7,
+    "customTableStyles": {},
+    "odooVersion": 12,
+    "globalFilters": [],
+    "lists": {},
+    "listNextId": 2
+}

--- a/addons/spreadsheet_dashboard_pos_restaurant/data/dashboards.xml
+++ b/addons/spreadsheet_dashboard_pos_restaurant/data/dashboards.xml
@@ -4,6 +4,8 @@
     <record id="spreadsheet_dashboard_pos_restaurant" model="spreadsheet.dashboard">
         <field name="name">POS - Restaurant</field>
         <field name="spreadsheet_binary_data" type="base64" file="spreadsheet_dashboard_pos_restaurant/data/files/pos_restaurant_dashboard.json"/>
+        <field name="main_data_model_ids" eval="[(4, ref('point_of_sale.model_pos_order'))]"/>
+        <field name="sample_dashboard_file_path">spreadsheet_dashboard_pos_restaurant/data/files/pos_restaurant_sample_dashboard.json</field>
         <field name="dashboard_group_id" ref="spreadsheet_dashboard.spreadsheet_dashboard_group_sales"/>
         <field name="group_ids" eval="[Command.link(ref('point_of_sale.group_pos_manager'))]"/>
         <field name="sequence">350</field>

--- a/addons/spreadsheet_dashboard_pos_restaurant/data/files/pos_restaurant_sample_dashboard.json
+++ b/addons/spreadsheet_dashboard_pos_restaurant/data/files/pos_restaurant_sample_dashboard.json
@@ -1,0 +1,1409 @@
+{
+  "version": 21,
+  "sheets": [
+      {
+          "id": "c960176a-048b-4f9a-a326-3cc55c5fd1f2",
+          "name": "Dahsboard",
+          "colNumber": 11,
+          "rowNumber": 84,
+          "rows": {
+              "11": {
+                  "size": 36
+              },
+              "29": {
+                  "size": 41
+              },
+              "48": {
+                  "size": 39
+              },
+              "49": {
+                  "size": 36
+              },
+              "50": {
+                  "size": 26
+              },
+              "51": {
+                  "size": 26
+              },
+              "52": {
+                  "size": 26
+              },
+              "53": {
+                  "size": 26
+              },
+              "54": {
+                  "size": 26
+              },
+              "55": {
+                  "size": 26
+              },
+              "56": {
+                  "size": 26
+              },
+              "57": {
+                  "size": 26
+              },
+              "58": {
+                  "size": 26
+              },
+              "59": {
+                  "size": 26
+              },
+              "60": {
+                  "size": 26
+              },
+              "61": {
+                  "size": 26
+              },
+              "62": {
+                  "size": 26
+              },
+              "63": {
+                  "size": 26
+              },
+              "64": {
+                  "size": 26
+              },
+              "66": {
+                  "size": 39
+              },
+              "67": {
+                  "size": 34
+              },
+              "68": {
+                  "size": 26
+              },
+              "69": {
+                  "size": 26
+              },
+              "70": {
+                  "size": 26
+              },
+              "71": {
+                  "size": 26
+              },
+              "72": {
+                  "size": 26
+              },
+              "73": {
+                  "size": 26
+              },
+              "74": {
+                  "size": 26
+              },
+              "75": {
+                  "size": 26
+              },
+              "76": {
+                  "size": 26
+              },
+              "77": {
+                  "size": 26
+              },
+              "78": {
+                  "size": 26
+              },
+              "79": {
+                  "size": 26
+              },
+              "80": {
+                  "size": 26
+              },
+              "81": {
+                  "size": 26
+              },
+              "82": {
+                  "size": 26
+              }
+          },
+          "cols": {
+              "0": {
+                  "isHidden": true,
+                  "size": 40
+              },
+              "1": {
+                  "size": 288
+              },
+              "2": {
+                  "size": 99
+              },
+              "3": {
+                  "size": 76
+              },
+              "4": {
+                  "size": 65
+              },
+              "5": {
+                  "size": 27
+              },
+              "6": {
+                  "isHidden": true,
+                  "size": 41
+              },
+              "7": {
+                  "size": 217
+              },
+              "8": {
+                  "size": 92
+              },
+              "9": {
+                  "size": 80
+              },
+              "10": {
+                  "size": 84
+              }
+          },
+          "merges": [
+              "H68:I68",
+              "H69:I69",
+              "H70:I70",
+              "H71:I71",
+              "H72:I72",
+              "H73:I73",
+              "H74:I74",
+              "H75:I75",
+              "H76:I76",
+              "H77:I77",
+              "H78:I78"
+          ],
+          "cells": {
+              "A50": {
+                  "content": "#"
+              },
+              "A51": {
+                  "content": "1"
+              },
+              "A52": {
+                  "content": "2"
+              },
+              "A53": {
+                  "content": "3"
+              },
+              "A54": {
+                  "content": "4"
+              },
+              "A55": {
+                  "content": "5"
+              },
+              "A56": {
+                  "content": "6"
+              },
+              "A57": {
+                  "content": "7"
+              },
+              "A58": {
+                  "content": "8"
+              },
+              "A59": {
+                  "content": "9"
+              },
+              "A60": {
+                  "content": "10"
+              },
+              "A61": {
+                  "content": "11"
+              },
+              "A62": {
+                  "content": "12"
+              },
+              "A63": {
+                  "content": "13"
+              },
+              "A64": {
+                  "content": "14"
+              },
+              "A65": {
+                  "content": "15"
+              },
+              "A68": {
+                  "content": "#"
+              },
+              "A69": {
+                  "content": "1"
+              },
+              "A70": {
+                  "content": "2"
+              },
+              "A71": {
+                  "content": "3"
+              },
+              "A72": {
+                  "content": "4"
+              },
+              "A73": {
+                  "content": "5"
+              },
+              "A74": {
+                  "content": "6"
+              },
+              "A75": {
+                  "content": "7"
+              },
+              "A76": {
+                  "content": "8"
+              },
+              "A77": {
+                  "content": "9"
+              },
+              "A78": {
+                  "content": "10"
+              },
+              "A79": {
+                  "content": "11"
+              },
+              "A80": {
+                  "content": "12"
+              },
+              "A81": {
+                  "content": "13"
+              },
+              "A82": {
+                  "content": "14"
+              },
+              "A83": {
+                  "content": "15"
+              },
+              "B12": {
+                  "content": "=_t(\"Hourly Total Revenue\")"
+              },
+              "B30": {
+                  "content": "=_t(\"Daily Total Revenue\")"
+              },
+              "B49": {
+                  "content": "=_t(\"Top 15 Products per Margin\") "
+              },
+              "B50": {
+                  "content": "=_t(\"Product \")"
+              },
+              "B67": {
+                  "content": "=_t(\"Top 15 Tables per Revenue\")"
+              },
+              "B68": {
+                  "content": "=_t(\"Table\")"
+              },
+              "C50": {
+                  "content": "=_t(\"Quantity Sold\")"
+              },
+              "C68": {
+                  "content": "=_t(\"Orders\")"
+              },
+              "D50": {
+                  "content": "=_t(\"Revenue\")"
+              },
+              "D68": {
+                  "content": "=_t(\"Revenue\")"
+              },
+              "E50": {
+                  "content": "=_t(\"Margin\")"
+              },
+              "E68": {
+                  "content": "=_t(\"Tip\")"
+              },
+              "G50": {
+                  "content": "#"
+              },
+              "G51": {
+                  "content": "1"
+              },
+              "G52": {
+                  "content": "2"
+              },
+              "G53": {
+                  "content": "3"
+              },
+              "G54": {
+                  "content": "4"
+              },
+              "G55": {
+                  "content": "5"
+              },
+              "G56": {
+                  "content": "6"
+              },
+              "G57": {
+                  "content": "7"
+              },
+              "G58": {
+                  "content": "8"
+              },
+              "G59": {
+                  "content": "9"
+              },
+              "G60": {
+                  "content": "10"
+              },
+              "G61": {
+                  "content": "11"
+              },
+              "G62": {
+                  "content": "12"
+              },
+              "G63": {
+                  "content": "13"
+              },
+              "G64": {
+                  "content": "14"
+              },
+              "G65": {
+                  "content": "15"
+              },
+              "H49": {
+                  "content": "=_t(\"Top 15 Products per Category\")"
+              },
+              "H50": {
+                  "content": "=_t(\"Category \")"
+              },
+              "H67": {
+                  "content": "=_t(\"Top Responsibles\")"
+              },
+              "H68": {
+                  "content": "=_t(\"Responsible\")"
+              },
+              "I50": {
+                  "content": "=_t(\"Product \")"
+              },
+              "J50": {
+                  "content": "=_t(\"Quantity\")"
+              },
+              "J68": {
+                  "content": "=_t(\"Orders\")"
+              },
+              "K50": {
+                  "content": "=_t(\"Revenue \")"
+              },
+              "K68": {
+                  "content": "=_t(\"Revenue\")"
+              }
+          },
+          "styles": {
+              "A50": 1,
+              "A68": 1,
+              "G50": 1,
+              "A51:A65": 2,
+              "A69:A83": 2,
+              "E69:E83": 2,
+              "G51:G65": 2,
+              "B12": 3,
+              "B30": 3,
+              "B49": 3,
+              "B67": 3,
+              "H49": 3,
+              "B50": 4,
+              "B68": 4,
+              "H50": 4,
+              "H68": 4,
+              "C50:E50": 5,
+              "C68:E68": 5,
+              "I50:K50": 5,
+              "J68:K68": 5,
+              "H67": 6
+          },
+          "formats": {},
+          "borders": {
+              "B49:E49": 1,
+              "B67:E67": 1,
+              "B12:K12": 1,
+              "B30:K30": 1,
+              "H49:K49": 1,
+              "H67:K67": 1,
+              "B50:E50": 2,
+              "B68:E68": 2,
+              "B13:K13": 2,
+              "B31:K31": 2,
+              "H50:K50": 2,
+              "H68:K68": 2,
+              "B51": 3,
+              "B69": 3,
+              "H51": 3,
+              "I69": 3,
+              "B52:B64": 4,
+              "B70:B74": 4,
+              "B76:B82": 4,
+              "H52:H64": 4,
+              "I70:I74": 4,
+              "I76:I78": 4,
+              "B65": 5,
+              "B83": 5,
+              "H65": 5,
+              "B75:D75": 6,
+              "H70:H78": 6,
+              "I75:K75": 6,
+              "C69": 7,
+              "C51:D51": 7,
+              "I51:J51": 7,
+              "J69:K69": 7,
+              "C70:C74": 8,
+              "C76:C82": 8,
+              "C52:D64": 8,
+              "I52:J64": 8,
+              "J76:J78": 8,
+              "J70:K74": 8,
+              "K76:K77": 8,
+              "C83": 9,
+              "C65:D65": 9,
+              "I65:J65": 9,
+              "D69": 10,
+              "E51": 10,
+              "K51": 10,
+              "D70:D74": 11,
+              "D76:D82": 11,
+              "E52:E64": 11,
+              "K52:K64": 11,
+              "K78": 11,
+              "D83": 12,
+              "E65": 12,
+              "K65": 12,
+              "H69": 13,
+              "H79:K79": 14
+          },
+          "conditionalFormats": [],
+          "figures": [
+              {
+                  "id": "fdceb3b9-643f-4d30-a572-2d9b0b684f17",
+                  "x": 0,
+                  "y": 289,
+                  "width": 1027,
+                  "height": 391,
+                  "tag": "chart",
+                  "data": {
+                      "type": "combo",
+                      "dataSetsHaveTitle": true,
+                      "dataSets": [
+                          {
+                              "dataRange": "Data!B13:B37",
+                              "yAxisId": "y",
+                              "label": "Revenue"
+                          },
+                          {
+                              "dataRange": "Data!D14:D38",
+                              "label": "Average per order",
+                              "yAxisId": "y1",
+                              "trend": {
+                                  "type": "polynomial",
+                                  "order": 2,
+                                  "display": false
+                              }
+                          }
+                      ],
+                      "legendPosition": "top",
+                      "labelRange": "Data!A13:A37",
+                      "title": {
+                          "text": ""
+                      },
+                      "aggregated": false,
+                      "axesDesign": {
+                          "y": {
+                              "title": {
+                                  "text": "Total revenue"
+                              }
+                          },
+                          "y1": {
+                              "title": {
+                                  "text": "Average revenue per order"
+                              }
+                          }
+                      },
+                      "showValues": false
+                  }
+              },
+              {
+                  "id": "1ebdd3d0-8af0-4922-9223-2da0d6ec024c",
+                  "x": 0,
+                  "y": 721,
+                  "width": 1029,
+                  "height": 416,
+                  "tag": "chart",
+                  "data": {
+                      "type": "combo",
+                      "dataSetsHaveTitle": true,
+                      "dataSets": [
+                          {
+                              "dataRange": "Data!H13:H20",
+                              "yAxisId": "y"
+                          },
+                          {
+                              "dataRange": "Data!J13:J20",
+                              "yAxisId": "y1",
+                              "label": "Average per order"
+                          }
+                      ],
+                      "legendPosition": "top",
+                      "labelRange": "Data!G13:G20",
+                      "title": {
+                          "text": ""
+                      },
+                      "aggregated": false,
+                      "axesDesign": {
+                          "y": {
+                              "title": {
+                                  "text": "Total revenue"
+                              }
+                          },
+                          "y1": {
+                              "title": {
+                                  "text": "Average revenue per order"
+                              }
+                          }
+                      }
+                  }
+              },
+              {
+                  "id": "49b3e330-3a31-4d43-9930-c42f2805c0c3",
+                  "x": 620,
+                  "y": 10,
+                  "width": 200,
+                  "height": 108,
+                  "tag": "chart",
+                  "data": {
+                      "baselineColorDown": "#EA6175",
+                      "baselineColorUp": "#43C5B1",
+                      "baselineMode": "difference",
+                      "title": {
+                          "text": "#Orders",
+                          "bold": true,
+                          "color": "#434343"
+                      },
+                      "type": "scorecard",
+                      "background": "#EFF6FF",
+                      "keyValue": "Data!B2",
+                      "humanize": false
+                  }
+              },
+              {
+                  "id": "d96a0fa5-e91b-455c-8004-9f39eeb09ee2",
+                  "x": 0,
+                  "y": 127,
+                  "width": 200,
+                  "height": 108,
+                  "tag": "chart",
+                  "data": {
+                      "baselineColorDown": "#EA6175",
+                      "baselineColorUp": "#43C5B1",
+                      "baselineMode": "difference",
+                      "title": {
+                          "text": "Total revenue",
+                          "bold": true,
+                          "color": "#434343"
+                      },
+                      "type": "scorecard",
+                      "background": "#FFF7ED",
+                      "keyValue": "Data!B3",
+                      "humanize": false
+                  }
+              },
+              {
+                  "id": "6b97f89c-8416-43db-a32e-d0ab5cf9051e",
+                  "x": 0,
+                  "y": 10,
+                  "width": 200,
+                  "height": 108,
+                  "tag": "chart",
+                  "data": {
+                      "baselineColorDown": "#EA6175",
+                      "baselineColorUp": "#43C5B1",
+                      "baselineMode": "difference",
+                      "title": {
+                          "text": "Untaxed revenue",
+                          "bold": true,
+                          "color": "#434343"
+                      },
+                      "type": "scorecard",
+                      "background": "#FFF7ED",
+                      "keyValue": "Data!B4",
+                      "humanize": false
+                  }
+              },
+              {
+                  "id": "cd102569-7656-4986-bf87-6e87b3ea493a",
+                  "x": 207,
+                  "y": 10,
+                  "width": 200,
+                  "height": 108,
+                  "tag": "chart",
+                  "data": {
+                      "baselineColorDown": "#EA6175",
+                      "baselineColorUp": "#43C5B1",
+                      "baselineMode": "difference",
+                      "title": {
+                          "text": "Untaxed revenue per order",
+                          "bold": true,
+                          "color": "#434343"
+                      },
+                      "type": "scorecard",
+                      "background": "#FFF7ED",
+                      "keyValue": "Data!B5",
+                      "humanize": false
+                  }
+              },
+              {
+                  "id": "7b541ea8-8f93-44f4-9626-67073e540f16",
+                  "x": 414,
+                  "y": 10,
+                  "width": 200,
+                  "height": 108,
+                  "tag": "chart",
+                  "data": {
+                      "baselineColorDown": "#EA6175",
+                      "baselineColorUp": "#43C5B1",
+                      "baselineMode": "difference",
+                      "title": {
+                          "text": "Untaxed revenue per guest",
+                          "bold": true,
+                          "color": "#434343"
+                      },
+                      "type": "scorecard",
+                      "background": "#FFF7ED",
+                      "keyValue": "Data!B7",
+                      "humanize": false
+                  }
+              },
+              {
+                  "id": "150978db-0307-4a65-a70a-e3a634dcfd48",
+                  "x": 620,
+                  "y": 127,
+                  "width": 200,
+                  "height": 108,
+                  "tag": "chart",
+                  "data": {
+                      "baselineColorDown": "#EA6175",
+                      "baselineColorUp": "#43C5B1",
+                      "baselineMode": "difference",
+                      "title": {
+                          "text": "Discount Rate",
+                          "bold": true,
+                          "color": "#434343"
+                      },
+                      "type": "scorecard",
+                      "background": "#FEF2F2",
+                      "keyValue": "Data!B9",
+                      "humanize": false
+                  }
+              },
+              {
+                  "id": "77f395fa-f25d-4ba8-a99d-405a99ebeef7",
+                  "x": 207,
+                  "y": 127,
+                  "width": 200,
+                  "height": 108,
+                  "tag": "chart",
+                  "data": {
+                      "baselineColorDown": "#EA6175",
+                      "baselineColorUp": "#43C5B1",
+                      "baselineMode": "difference",
+                      "title": {
+                          "text": "Total revenue per order",
+                          "bold": true,
+                          "color": "#434343"
+                      },
+                      "type": "scorecard",
+                      "background": "#FFF7ED",
+                      "keyValue": "Data!B6",
+                      "humanize": false
+                  }
+              },
+              {
+                  "id": "87cda1aa-ba42-4865-8f56-912dd9e323a7",
+                  "x": 414,
+                  "y": 127,
+                  "width": 200,
+                  "height": 108,
+                  "tag": "chart",
+                  "data": {
+                      "baselineColorDown": "#EA6175",
+                      "baselineColorUp": "#43C5B1",
+                      "baselineMode": "difference",
+                      "title": {
+                          "text": "Total revenue per guest",
+                          "bold": true,
+                          "color": "#434343"
+                      },
+                      "type": "scorecard",
+                      "background": "#FFF7ED",
+                      "keyValue": "Data!B8",
+                      "humanize": false
+                  }
+              }
+          ],
+          "tables": [],
+          "areGridLinesVisible": true,
+          "isVisible": true,
+          "headerGroups": {
+              "ROW": [],
+              "COL": []
+          },
+          "dataValidationRules": [],
+          "comments": {}
+      },
+      {
+          "id": "5d9c050d-2ba4-49ea-992f-142a93cad05a",
+          "name": "Data",
+          "colNumber": 29,
+          "rowNumber": 113,
+          "rows": {},
+          "cols": {},
+          "merges": [],
+          "cells": {
+              "A1": {
+                  "content": "=_t(\"Measure\")"
+              },
+              "A2": {
+                  "content": "=_t(\"# Orders\")"
+              },
+              "A3": {
+                  "content": "=_t(\"Total revenue\")"
+              },
+              "A4": {
+                  "content": "=_t(\"Net revenue\")"
+              },
+              "A5": {
+                  "content": "=_t(\"Average untaxed revenue per order\")"
+              },
+              "A6": {
+                  "content": "=_t(\"Average total revenue per order\")"
+              },
+              "A7": {
+                  "content": "=_t(\"Average net revenue / sitting \")"
+              },
+              "A8": {
+                  "content": "=_t(\"Average total revenue / sitting\")"
+              },
+              "A9": {
+                  "content": "=_t(\"Average discount\")"
+              },
+              "A12": {
+                  "content": "=_t(\"Revenue per hour\")"
+              },
+              "A13": {
+                  "content": "=_t(\"Time\")"
+              },
+              "A14": {
+                  "content": "0"
+              },
+              "A15": {
+                  "content": "1"
+              },
+              "A16": {
+                  "content": "2"
+              },
+              "A17": {
+                  "content": "3"
+              },
+              "A18": {
+                  "content": "4"
+              },
+              "A19": {
+                  "content": "5"
+              },
+              "A20": {
+                  "content": "6"
+              },
+              "A21": {
+                  "content": "7"
+              },
+              "A22": {
+                  "content": "8"
+              },
+              "A23": {
+                  "content": "9"
+              },
+              "A24": {
+                  "content": "10"
+              },
+              "A25": {
+                  "content": "11"
+              },
+              "A26": {
+                  "content": "12"
+              },
+              "A27": {
+                  "content": "13"
+              },
+              "A28": {
+                  "content": "14"
+              },
+              "A29": {
+                  "content": "15"
+              },
+              "A30": {
+                  "content": "16"
+              },
+              "A31": {
+                  "content": "17"
+              },
+              "A32": {
+                  "content": "18"
+              },
+              "A33": {
+                  "content": "19"
+              },
+              "A34": {
+                  "content": "20"
+              },
+              "A35": {
+                  "content": "21"
+              },
+              "A36": {
+                  "content": "22"
+              },
+              "A37": {
+                  "content": "23"
+              },
+              "A38": {
+                  "content": "24"
+              },
+              "B1": {
+                  "content": "=_t(\"Always\")"
+              },
+              "B2": {
+                  "content": "897"
+              },
+              "B3": {
+                  "content": "454666"
+              },
+              "B4": {
+                  "content": "289756"
+              },
+              "B5": {
+                  "content": "12807"
+              },
+              "B6": {
+                  "content": "32149"
+              },
+              "B7": {
+                  "content": "43512"
+              },
+              "B8": {
+                  "content": "11946"
+              },
+              "B9": {
+                  "content": "18584"
+              },
+              "B13": {
+                  "content": "=_t(\"Revenue\")"
+              },
+              "B14": {
+                  "content": "39778"
+              },
+              "B15": {
+                  "content": "18736"
+              },
+              "B16": {
+                  "content": "33392"
+              },
+              "B17": {
+                  "content": "15876"
+              },
+              "B18": {
+                  "content": "37547"
+              },
+              "B19": {
+                  "content": "35778"
+              },
+              "B20": {
+                  "content": "42506"
+              },
+              "B21": {
+                  "content": "28653"
+              },
+              "B22": {
+                  "content": "47055"
+              },
+              "B23": {
+                  "content": "35883"
+              },
+              "B24": {
+                  "content": "47506"
+              },
+              "B25": {
+                  "content": "43113"
+              },
+              "B26": {
+                  "content": "26248"
+              },
+              "B27": {
+                  "content": "33474"
+              },
+              "B28": {
+                  "content": "44053"
+              },
+              "B29": {
+                  "content": "27609"
+              },
+              "B30": {
+                  "content": "19591"
+              },
+              "B31": {
+                  "content": "21330"
+              },
+              "B32": {
+                  "content": "11756"
+              },
+              "B33": {
+                  "content": "32755"
+              },
+              "B34": {
+                  "content": "28535"
+              },
+              "B35": {
+                  "content": "33462"
+              },
+              "B36": {
+                  "content": "18652"
+              },
+              "B37": {
+                  "content": "29928"
+              },
+              "B38": {
+                  "content": "12889"
+              },
+              "D13": {
+                  "content": "=_t(\"Average per table\")"
+              },
+              "D14": {
+                  "content": "108"
+              },
+              "D15": {
+                  "content": "241"
+              },
+              "D16": {
+                  "content": "227"
+              },
+              "D17": {
+                  "content": "242"
+              },
+              "D18": {
+                  "content": "170"
+              },
+              "D19": {
+                  "content": "124"
+              },
+              "D20": {
+                  "content": "264"
+              },
+              "D21": {
+                  "content": "252"
+              },
+              "D22": {
+                  "content": "269"
+              },
+              "D23": {
+                  "content": "95"
+              },
+              "D24": {
+                  "content": "254"
+              },
+              "D25": {
+                  "content": "86"
+              },
+              "D26": {
+                  "content": "215"
+              },
+              "D27": {
+                  "content": "200"
+              },
+              "D28": {
+                  "content": "69"
+              },
+              "D29": {
+                  "content": "212"
+              },
+              "D30": {
+                  "content": "315"
+              },
+              "D31": {
+                  "content": "204"
+              },
+              "D32": {
+                  "content": "119"
+              },
+              "D33": {
+                  "content": "267"
+              },
+              "D34": {
+                  "content": "60"
+              },
+              "D35": {
+                  "content": "142"
+              },
+              "D36": {
+                  "content": "316"
+              },
+              "D37": {
+                  "content": "73"
+              },
+              "D38": {
+                  "content": "282"
+              },
+              "F12": {
+                  "content": "=_t(\"Revenue per day\")"
+              },
+              "F13": {
+                  "content": "=_t(\"Time\")"
+              },
+              "F14": {
+                  "content": "1"
+              },
+              "F15": {
+                  "content": "2"
+              },
+              "F16": {
+                  "content": "3"
+              },
+              "F17": {
+                  "content": "4"
+              },
+              "F18": {
+                  "content": "5"
+              },
+              "F19": {
+                  "content": "6"
+              },
+              "F20": {
+                  "content": "7"
+              },
+              "G13": {
+                  "content": "=_t(\"Day of the week\")"
+              },
+              "G14": {
+                  "content": "=TODAY() - F14"
+              },
+              "G15": {
+                  "content": "=TODAY() - F15"
+              },
+              "G16": {
+                  "content": "=TODAY() - F16"
+              },
+              "G17": {
+                  "content": "=TODAY() - F17"
+              },
+              "G18": {
+                  "content": "=TODAY() - F18"
+              },
+              "G19": {
+                  "content": "=TODAY() - F19"
+              },
+              "G20": {
+                  "content": "=TODAY() - F20"
+              },
+              "H13": {
+                  "content": "=_t(\"Revenue\")"
+              },
+              "H14": {
+                  "content": "=RANDBETWEEN(1000,10000)"
+              },
+              "H15": {
+                  "content": "=RANDBETWEEN(1000,10000)"
+              },
+              "H16": {
+                  "content": "=RANDBETWEEN(1000,10000)"
+              },
+              "H17": {
+                  "content": "=RANDBETWEEN(1000,10000)"
+              },
+              "H18": {
+                  "content": "=RANDBETWEEN(1000,10000)"
+              },
+              "H19": {
+                  "content": "=RANDBETWEEN(1000,10000)"
+              },
+              "H20": {
+                  "content": "=RANDBETWEEN(1000,10000)"
+              },
+              "I13": {
+                  "content": "=_t(\"# Tables\")"
+              },
+              "J13": {
+                  "content": "=_t(\"Average per table\")"
+              },
+              "J14": {
+                  "content": "=RANDBETWEEN(50,200)"
+              },
+              "J15": {
+                  "content": "=RANDBETWEEN(50,200)"
+              },
+              "J16": {
+                  "content": "=RANDBETWEEN(50,200)"
+              },
+              "J17": {
+                  "content": "=RANDBETWEEN(50,200)"
+              },
+              "J18": {
+                  "content": "=RANDBETWEEN(50,200)"
+              },
+              "J19": {
+                  "content": "=RANDBETWEEN(50,200)"
+              },
+              "J20": {
+                  "content": "=RANDBETWEEN(50,200)"
+              }
+          },
+          "styles": {
+              "A1:B1": 7,
+              "A12": 8,
+              "F12": 8
+          },
+          "formats": {
+              "B3:B9": 1,
+              "B14:B38": 1,
+              "G14:G20": 2
+          },
+          "borders": {},
+          "conditionalFormats": [],
+          "figures": [],
+          "tables": [
+              {
+                  "range": "A13:D38",
+                  "type": "static",
+                  "config": {
+                      "hasFilters": false,
+                      "totalRow": false,
+                      "firstColumn": false,
+                      "lastColumn": false,
+                      "numberOfHeaders": 1,
+                      "bandedRows": false,
+                      "bandedColumns": false,
+                      "automaticAutofill": true,
+                      "styleId": "TableStyleMedium5"
+                  }
+              },
+              {
+                  "range": "F13:J20",
+                  "type": "static",
+                  "config": {
+                      "hasFilters": false,
+                      "totalRow": false,
+                      "firstColumn": false,
+                      "lastColumn": false,
+                      "numberOfHeaders": 1,
+                      "bandedRows": false,
+                      "bandedColumns": false,
+                      "automaticAutofill": true,
+                      "styleId": "TableStyleMedium5"
+                  }
+              }
+          ],
+          "areGridLinesVisible": true,
+          "isVisible": true,
+          "headerGroups": {
+              "ROW": [],
+              "COL": []
+          },
+          "dataValidationRules": [],
+          "comments": {}
+      }
+  ],
+  "styles": {
+      "1": {
+          "textColor": "#434343"
+      },
+      "2": {
+          "textColor": "#434343",
+          "verticalAlign": "middle"
+      },
+      "3": {
+          "fontSize": 16,
+          "textColor": "#01666B",
+          "bold": true
+      },
+      "4": {
+          "textColor": "#434343",
+          "bold": true,
+          "fontSize": 11
+      },
+      "5": {
+          "textColor": "#434343",
+          "bold": true,
+          "fontSize": 11,
+          "align": "center"
+      },
+      "6": {
+          "textColor": "#01666b",
+          "fontSize": 16,
+          "bold": true
+      },
+      "7": {
+          "fillColor": "#01666B",
+          "textColor": "#FFFFFF",
+          "bold": true
+      },
+      "8": {
+          "bold": true,
+          "textColor": "#01666B"
+      }
+  },
+  "formats": {
+      "1": "[$$]#,##0",
+      "2": "dddd d mmmm yyyy"
+  },
+  "borders": {
+      "1": {
+          "bottom": {
+              "style": "thin",
+              "color": "#CCCCCC"
+          }
+      },
+      "2": {
+          "top": {
+              "style": "thin",
+              "color": "#CCCCCC"
+          }
+      },
+      "3": {
+          "bottom": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          },
+          "right": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          }
+      },
+      "4": {
+          "top": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          },
+          "bottom": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          },
+          "right": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          }
+      },
+      "5": {
+          "top": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          },
+          "right": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          }
+      },
+      "6": {
+          "top": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          },
+          "bottom": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          }
+      },
+      "7": {
+          "bottom": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          },
+          "left": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          },
+          "right": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          }
+      },
+      "8": {
+          "top": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          },
+          "bottom": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          },
+          "left": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          },
+          "right": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          }
+      },
+      "9": {
+          "top": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          },
+          "left": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          },
+          "right": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          }
+      },
+      "10": {
+          "bottom": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          },
+          "left": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          }
+      },
+      "11": {
+          "top": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          },
+          "bottom": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          },
+          "left": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          }
+      },
+      "12": {
+          "top": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          },
+          "left": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          }
+      },
+      "13": {
+          "bottom": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          }
+      },
+      "14": {
+          "top": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          }
+      }
+  },
+  "revisionId": "START_REVISION",
+  "uniqueFigureIds": true,
+  "settings": {
+      "locale": {
+          "name": "English (US)",
+          "code": "en_US",
+          "thousandsSeparator": ",",
+          "decimalSeparator": ".",
+          "dateFormat": "mm/dd/yyyy",
+          "timeFormat": "hh:mm:ss",
+          "formulaArgSeparator": ",",
+          "weekStart": 7
+      }
+  },
+  "pivots": {},
+  "pivotNextId": 11,
+  "customTableStyles": {},
+  "odooVersion": 12,
+  "globalFilters": [],
+  "lists": {},
+  "listNextId": 1
+}

--- a/addons/spreadsheet_dashboard_sale/data/dashboards.xml
+++ b/addons/spreadsheet_dashboard_sale/data/dashboards.xml
@@ -4,6 +4,8 @@
     <record id="spreadsheet_dashboard_sales" model="spreadsheet.dashboard">
         <field name="name">Sales</field>
         <field name="spreadsheet_binary_data" type="base64" file="spreadsheet_dashboard_sale/data/files/sales_dashboard.json"/>
+        <field name="main_data_model_ids" eval="[(4, ref('sale.model_sale_order'))]"/>
+        <field name="sample_dashboard_file_path">spreadsheet_dashboard_sale/data/files/sales_sample_dashboard.json</field>
         <field name="dashboard_group_id" ref="spreadsheet_dashboard.spreadsheet_dashboard_group_sales"/>
         <field name="group_ids" eval="[Command.link(ref('sales_team.group_sale_manager'))]"/>
         <field name="sequence">100</field>
@@ -13,6 +15,8 @@
     <record id="spreadsheet_dashboard_product" model="spreadsheet.dashboard">
         <field name="name">Product</field>
         <field name="spreadsheet_binary_data" type="base64" file="spreadsheet_dashboard_sale/data/files/product_dashboard.json"/>
+        <field name="main_data_model_ids" eval="[(4, ref('sale.model_sale_order'))]"/>
+        <field name="sample_dashboard_file_path">spreadsheet_dashboard_sale/data/files/product_sample_dashboard.json</field>
         <field name="dashboard_group_id" ref="spreadsheet_dashboard.spreadsheet_dashboard_group_sales"/>
         <field name="group_ids" eval="[Command.link(ref('sales_team.group_sale_manager'))]"/>
         <field name="sequence">200</field>

--- a/addons/spreadsheet_dashboard_sale/data/files/product_sample_dashboard.json
+++ b/addons/spreadsheet_dashboard_sale/data/files/product_sample_dashboard.json
@@ -1,0 +1,740 @@
+{
+    "version": 21,
+    "sheets": [
+        {
+            "id": "sheet1",
+            "name": "Dashboard",
+            "colNumber": 7,
+            "rowNumber": 60,
+            "rows": {
+                "6": {
+                    "size": 40
+                },
+                "26": {
+                    "size": 40
+                },
+                "46": {
+                    "size": 40
+                },
+                "47": {
+                    "size": 40
+                },
+                "48": {
+                    "size": 29
+                },
+                "49": {
+                    "size": 29
+                },
+                "50": {
+                    "size": 29
+                },
+                "51": {
+                    "size": 29
+                },
+                "52": {
+                    "size": 29
+                },
+                "53": {
+                    "size": 29
+                },
+                "54": {
+                    "size": 29
+                },
+                "55": {
+                    "size": 29
+                },
+                "56": {
+                    "size": 29
+                },
+                "57": {
+                    "size": 29
+                }
+            },
+            "cols": {
+                "0": {
+                    "size": 275
+                },
+                "1": {
+                    "size": 100
+                },
+                "2": {
+                    "size": 100
+                },
+                "3": {
+                    "size": 50
+                },
+                "4": {
+                    "size": 275
+                },
+                "5": {
+                    "size": 100
+                },
+                "6": {
+                    "size": 100
+                }
+            },
+            "merges": [],
+            "cells": {
+                "A7": {
+                    "content": "[Best Sellers by Revenue](odoo://view/{\"viewType\":\"graph\",\"action\":{\"domain\":[[\"state\", \"not in\", [\"draft\", \"sent\", \"cancel\"]]],\"context\":{\"group_by\":[\"product_id\"],\"graph_measure\":\"price_subtotal\",\"graph_mode\":\"bar\",\"graph_groupbys\":[\"product_id\"]},\"modelName\":\"sale.report\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Best Sellers by Revenue\"})"
+                },
+                "A27": {
+                    "content": "[Best Sellers by Units Sold](odoo://view/{\"viewType\":\"graph\",\"action\":{\"domain\":[[\"state\", \"not in\", [\"draft\", \"sent\", \"cancel\"]]],\"context\":{\"group_by\":[\"product_id\"],\"graph_measure\":\"__count\",\"graph_mode\":\"bar\",\"graph_groupbys\":[\"product_id\"]},\"modelName\":\"sale.report\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Sales Analysis\"})"
+                },
+                "A47": {
+                    "content": "[Best Selling Products](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[[\"state\", \"not in\", [\"draft\", \"sent\", \"cancel\"]]],\"context\":{\"group_by\":[\"product_id\"],\"pivot_measures\":[\"__count\",\"price_subtotal\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"product_id\"]},\"modelName\":\"sale.report\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Sales Analysis\"})"
+                },
+                "A48": {
+                    "content": "=_t(\"Product\")"
+                },
+                "B48": {
+                    "content": "=_t(\"Units\")"
+                },
+                "C48": {
+                    "content": "=_t(\"Revenue\")"
+                },
+                "E47": {
+                    "content": "[Best Selling Categories](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[[\"state\", \"not in\", [\"draft\", \"sent\", \"cancel\"]]],\"context\":{\"group_by\":[\"categ_id\"],\"pivot_measures\":[\"__count\",\"price_subtotal\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"categ_id\"]},\"modelName\":\"sale.report\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Sales Analysis\"})"
+                },
+                "E48": {
+                    "content": "=_t(\"Category\")"
+                },
+                "F48": {
+                    "content": "=_t(\"Units\")"
+                },
+                "G48": {
+                    "content": "=_t(\"Revenue\")"
+                }
+            },
+            "styles": {
+                "A7": 1,
+                "A27": 1,
+                "A47": 1,
+                "E47": 1,
+                "A48": 2,
+                "E48": 2,
+                "B48:C48": 3,
+                "F48:G48": 3
+            },
+            "formats": {},
+            "borders": {
+                "A47:C47": 1,
+                "A7:G7": 1,
+                "A27:G27": 1,
+                "E47:G47": 1,
+                "A48:C48": 2,
+                "A8:G8": 2,
+                "A28:G28": 2,
+                "E48:G48": 2,
+                "A49": 3,
+                "E49": 3,
+                "A50:A52": 4,
+                "A54:A58": 4,
+                "E50:E52": 4,
+                "E54:E58": 4,
+                "A53:C53": 5,
+                "E53:G53": 5,
+                "A59:C59": 6,
+                "E59:G59": 6,
+                "B49": 7,
+                "F49": 7,
+                "B50:B52": 8,
+                "B54:B58": 8,
+                "F50:F52": 8,
+                "F54:F58": 8,
+                "C49": 9,
+                "G49": 9,
+                "C50:C52": 10,
+                "C54:C58": 10,
+                "G50:G52": 10,
+                "G54:G58": 10
+            },
+            "conditionalFormats": [],
+            "figures": [
+                {
+                    "id": "5f383918-4073-4f19-9cc9-603216c953ad",
+                    "x": 0,
+                    "y": 12,
+                    "width": 450,
+                    "height": 108,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "text",
+                        "title": {
+                            "text": "Best Seller",
+                            "color": "#434343",
+                            "bold": true
+                        },
+                        "type": "scorecard",
+                        "background": "#FEF2F2",
+                        "baseline": "Data!C2",
+                        "baselineDescr": "sold",
+                        "keyValue": "Data!B2",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "ec57f69b-f2b1-4dfc-990c-91ab61b526bf",
+                    "x": 459,
+                    "y": 12,
+                    "width": 450,
+                    "height": 108,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "text",
+                        "title": {
+                            "text": "Best Category",
+                            "color": "#434343",
+                            "bold": true
+                        },
+                        "type": "scorecard",
+                        "background": "#FEF2F2",
+                        "baseline": "Data!C3",
+                        "baselineDescr": "sold",
+                        "keyValue": "Data!B3",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "d710386b-9584-44aa-a5ec-5bbc9e4312d1",
+                    "x": 0,
+                    "y": 178.05078125,
+                    "width": 1000,
+                    "height": 438,
+                    "tag": "chart",
+                    "data": {
+                        "type": "bar",
+                        "dataSetsHaveTitle": false,
+                        "dataSets": [
+                            {
+                                "dataRange": "Data!B7:B26",
+                                "yAxisId": "y"
+                            }
+                        ],
+                        "legendPosition": "none",
+                        "labelRange": "Data!A7:A26",
+                        "title": {},
+                        "stacked": false,
+                        "aggregated": false
+                    }
+                },
+                {
+                    "id": "66891187-fb5e-4190-b115-c15e37a0df97",
+                    "x": 0,
+                    "y": 655,
+                    "width": 1000,
+                    "height": 437,
+                    "tag": "chart",
+                    "data": {
+                        "type": "bar",
+                        "dataSetsHaveTitle": false,
+                        "dataSets": [
+                            {
+                                "dataRange": "Data!B29:B48",
+                                "yAxisId": "y"
+                            }
+                        ],
+                        "legendPosition": "none",
+                        "labelRange": "Data!A29:A48",
+                        "title": {},
+                        "stacked": false,
+                        "aggregated": false
+                    }
+                }
+            ],
+            "tables": [],
+            "areGridLinesVisible": true,
+            "isVisible": true,
+            "headerGroups": {
+                "ROW": [],
+                "COL": []
+            },
+            "dataValidationRules": [],
+            "comments": {}
+        },
+        {
+            "id": "a83a78f2-b124-4d6f-9726-125e62a32b8d",
+            "name": "Data",
+            "colNumber": 23,
+            "rowNumber": 88,
+            "rows": {},
+            "cols": {},
+            "merges": [],
+            "cells": {
+                "A1": {
+                    "content": "=_t(\"KPI\")"
+                },
+                "A2": {
+                    "content": "=_t(\"Best selling product\")"
+                },
+                "A3": {
+                    "content": "=_t(\"Best selling category\")"
+                },
+                "A7": {
+                    "content": "=_t(\"TitanForge Gaming Chair\")"
+                },
+                "A8": {
+                    "content": "=_t(\"GlideSync Wireless Mouse\")"
+                },
+                "A9": {
+                    "content": "=_t(\"PulseFit Smartband\")"
+                },
+                "A10": {
+                    "content": "=_t(\"CrystalWave Smart Mirror\")"
+                },
+                "A11": {
+                    "content": "=_t(\"NovaTech Power Bank\")"
+                },
+                "A12": {
+                    "content": "=_t(\"UltraBeam Projector\")"
+                },
+                "A13": {
+                    "content": "=_t(\"VeloCharge Electric Bike\")"
+                },
+                "A14": {
+                    "content": "=_t(\"QuantumSound Earbuds\")"
+                },
+                "A15": {
+                    "content": "=_t(\"BreezePure Air Filter\")"
+                },
+                "A16": {
+                    "content": "=_t(\"FlexiDesk Standing Desk\")"
+                },
+                "A17": {
+                    "content": "=_t(\"AeroTrack Fitness Watch\")"
+                },
+                "A18": {
+                    "content": "=_t(\"AeroMax Travel Pillow\")"
+                },
+                "A19": {
+                    "content": "=_t(\"PureSonic Bluetooth Speaker\")"
+                },
+                "A20": {
+                    "content": "=_t(\"HydroLux Water Bottle\")"
+                },
+                "A21": {
+                    "content": "=_t(\"OmniClean Robot Vacuum\")"
+                },
+                "A22": {
+                    "content": "=_t(\"SolarSwift Charger\")"
+                },
+                "A23": {
+                    "content": "=_t(\"HyperChill Mini Fridge\")"
+                },
+                "A24": {
+                    "content": "=_t(\"FlexiGrip Yoga Mat\")"
+                },
+                "A25": {
+                    "content": "=_t(\"SnapGrip Camera Mount\")"
+                },
+                "A26": {
+                    "content": "=_t(\"EcoBlade Kitchen Knife\")"
+                },
+                "A29": {
+                    "content": "=_t(\"GlideSync Wireless Mouse\")"
+                },
+                "A30": {
+                    "content": "=_t(\"TitanForge Gaming Chair\")"
+                },
+                "A31": {
+                    "content": "=_t(\"PulseFit Smartband\")"
+                },
+                "A32": {
+                    "content": "=_t(\"CrystalWave Smart Mirror\")"
+                },
+                "A33": {
+                    "content": "=_t(\"NovaTech Power Bank\")"
+                },
+                "A34": {
+                    "content": "=_t(\"UltraBeam Projector\")"
+                },
+                "A35": {
+                    "content": "=_t(\"VeloCharge Electric Bike\")"
+                },
+                "A36": {
+                    "content": "=_t(\"QuantumSound Earbuds\")"
+                },
+                "A37": {
+                    "content": "=_t(\"BreezePure Air Filter\")"
+                },
+                "A38": {
+                    "content": "=_t(\"FlexiDesk Standing Desk\")"
+                },
+                "A39": {
+                    "content": "=_t(\"AeroTrack Fitness Watch\")"
+                },
+                "A40": {
+                    "content": "=_t(\"AeroMax Travel Pillow\")"
+                },
+                "A41": {
+                    "content": "=_t(\"PureSonic Bluetooth Speaker\")"
+                },
+                "A42": {
+                    "content": "=_t(\"HydroLux Water Bottle\")"
+                },
+                "A43": {
+                    "content": "=_t(\"OmniClean Robot Vacuum\")"
+                },
+                "A44": {
+                    "content": "=_t(\"SolarSwift Charger\")"
+                },
+                "A45": {
+                    "content": "=_t(\"HyperChill Mini Fridge\")"
+                },
+                "A46": {
+                    "content": "=_t(\"FlexiGrip Yoga Mat\")"
+                },
+                "A47": {
+                    "content": "=_t(\"SnapGrip Camera Mount\")"
+                },
+                "A48": {
+                    "content": "=_t(\"EcoBlade Kitchen Knife\")"
+                },
+                "B1": {
+                    "content": "=_t(\"Name\")"
+                },
+                "B2": {
+                    "content": "=_t(\"GlideSync Wireless Mouse\")"
+                },
+                "B3": {
+                    "content": "=_t(\"TitanForge Gaming Chair\")"
+                },
+                "B7": {
+                    "content": "150000"
+                },
+                "B8": {
+                    "content": "145000"
+                },
+                "B9": {
+                    "content": "140000"
+                },
+                "B10": {
+                    "content": "138000"
+                },
+                "B11": {
+                    "content": "125000"
+                },
+                "B12": {
+                    "content": "125000"
+                },
+                "B13": {
+                    "content": "118000"
+                },
+                "B14": {
+                    "content": "110000"
+                },
+                "B15": {
+                    "content": "95000"
+                },
+                "B16": {
+                    "content": "98000"
+                },
+                "B17": {
+                    "content": "85500"
+                },
+                "B18": {
+                    "content": "85000"
+                },
+                "B19": {
+                    "content": "74000"
+                },
+                "B20": {
+                    "content": "65000"
+                },
+                "B21": {
+                    "content": "60000"
+                },
+                "B22": {
+                    "content": "45000"
+                },
+                "B23": {
+                    "content": "30000"
+                },
+                "B24": {
+                    "content": "25000"
+                },
+                "B25": {
+                    "content": "15500"
+                },
+                "B26": {
+                    "content": "7500"
+                },
+                "B29": {
+                    "content": "500"
+                },
+                "B30": {
+                    "content": "475"
+                },
+                "B31": {
+                    "content": "460"
+                },
+                "B32": {
+                    "content": "445"
+                },
+                "B33": {
+                    "content": "420"
+                },
+                "B34": {
+                    "content": "410"
+                },
+                "B35": {
+                    "content": "390"
+                },
+                "B36": {
+                    "content": "365"
+                },
+                "B37": {
+                    "content": "350"
+                },
+                "B38": {
+                    "content": "330"
+                },
+                "B39": {
+                    "content": "315"
+                },
+                "B40": {
+                    "content": "290"
+                },
+                "B41": {
+                    "content": "270"
+                },
+                "B42": {
+                    "content": "250"
+                },
+                "B43": {
+                    "content": "225"
+                },
+                "B44": {
+                    "content": "195"
+                },
+                "B45": {
+                    "content": "150"
+                },
+                "B46": {
+                    "content": "120"
+                },
+                "B47": {
+                    "content": "95"
+                },
+                "B48": {
+                    "content": "60"
+                },
+                "C1": {
+                    "content": "=_t(\"Units\")"
+                },
+                "C2": {
+                    "content": "500"
+                },
+                "C3": {
+                    "content": "475"
+                },
+                "D1": {
+                    "content": "=_t(\"Revenue\")"
+                },
+                "D2": {
+                    "content": "110000"
+                },
+                "D3": {
+                    "content": "311155"
+                }
+            },
+            "styles": {},
+            "formats": {
+                "B7:B26": 1,
+                "D2:D3": 1
+            },
+            "borders": {},
+            "conditionalFormats": [],
+            "figures": [
+                {
+                    "id": "7283c8f8-6ecc-4537-90c3-2a8fd8c3a431",
+                    "x": 660,
+                    "y": 376.5,
+                    "width": 536,
+                    "height": 335,
+                    "tag": "chart",
+                    "data": {
+                        "type": "bar",
+                        "dataSetsHaveTitle": false,
+                        "dataSets": [
+                            {
+                                "dataRange": "B29:B48",
+                                "yAxisId": "y"
+                            }
+                        ],
+                        "legendPosition": "none",
+                        "labelRange": "A29:A48",
+                        "title": {},
+                        "stacked": false,
+                        "aggregated": false
+                    }
+                }
+            ],
+            "tables": [],
+            "areGridLinesVisible": true,
+            "isVisible": true,
+            "headerGroups": {
+                "ROW": [],
+                "COL": []
+            },
+            "dataValidationRules": [],
+            "comments": {}
+        }
+    ],
+    "styles": {
+        "1": {
+            "textColor": "#01666b",
+            "bold": true,
+            "fontSize": 16
+        },
+        "2": {
+            "textColor": "#434343",
+            "fontSize": 11,
+            "bold": true
+        },
+        "3": {
+            "textColor": "#434343",
+            "fontSize": 11,
+            "bold": true,
+            "align": "center"
+        }
+    },
+    "formats": {
+        "1": "[$$]#,##0"
+    },
+    "borders": {
+        "1": {
+            "bottom": {
+                "style": "thin",
+                "color": "#CCCCCC"
+            }
+        },
+        "2": {
+            "top": {
+                "style": "thin",
+                "color": "#CCCCCC"
+            }
+        },
+        "3": {
+            "bottom": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            }
+        },
+        "4": {
+            "top": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            }
+        },
+        "5": {
+            "top": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            }
+        },
+        "6": {
+            "top": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            }
+        },
+        "7": {
+            "bottom": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            }
+        },
+        "8": {
+            "top": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            }
+        },
+        "9": {
+            "bottom": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            }
+        },
+        "10": {
+            "top": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            }
+        }
+    },
+    "revisionId": "START_REVISION",
+    "uniqueFigureIds": true,
+    "settings": {
+        "locale": {
+            "name": "English (US)",
+            "code": "en_US",
+            "thousandsSeparator": ",",
+            "decimalSeparator": ".",
+            "dateFormat": "mm/dd/yyyy",
+            "timeFormat": "hh:mm:ss",
+            "formulaArgSeparator": ",",
+            "weekStart": 7
+        }
+    },
+    "pivots": {},
+    "pivotNextId": 3,
+    "customTableStyles": {},
+    "odooVersion": 12,
+    "globalFilters": [],
+    "lists": {},
+    "listNextId": 1
+}

--- a/addons/spreadsheet_dashboard_sale/data/files/sales_sample_dashboard.json
+++ b/addons/spreadsheet_dashboard_sale/data/files/sales_sample_dashboard.json
@@ -1,0 +1,1168 @@
+{
+    "version": 21,
+    "sheets": [
+        {
+            "id": "sheet1",
+            "name": "Dashboard",
+            "colNumber": 7,
+            "rowNumber": 86,
+            "rows": {
+                "5": {
+                    "size": 40
+                },
+                "21": {
+                    "size": 40
+                },
+                "22": {
+                    "size": 29
+                },
+                "23": {
+                    "size": 29
+                },
+                "24": {
+                    "size": 29
+                },
+                "25": {
+                    "size": 29
+                },
+                "26": {
+                    "size": 29
+                },
+                "27": {
+                    "size": 29
+                },
+                "28": {
+                    "size": 29
+                },
+                "29": {
+                    "size": 29
+                },
+                "30": {
+                    "size": 29
+                },
+                "31": {
+                    "size": 29
+                },
+                "32": {
+                    "size": 29
+                },
+                "33": {
+                    "size": 23
+                },
+                "34": {
+                    "size": 43
+                },
+                "35": {
+                    "size": 35
+                },
+                "36": {
+                    "size": 28
+                },
+                "37": {
+                    "size": 28
+                },
+                "38": {
+                    "size": 28
+                },
+                "39": {
+                    "size": 28
+                },
+                "40": {
+                    "size": 28
+                },
+                "41": {
+                    "size": 28
+                },
+                "42": {
+                    "size": 28
+                },
+                "43": {
+                    "size": 28
+                },
+                "44": {
+                    "size": 28
+                },
+                "45": {
+                    "size": 28
+                },
+                "47": {
+                    "size": 40
+                },
+                "48": {
+                    "size": 40
+                },
+                "49": {
+                    "size": 28
+                },
+                "50": {
+                    "size": 28
+                },
+                "51": {
+                    "size": 28
+                },
+                "52": {
+                    "size": 28
+                },
+                "53": {
+                    "size": 28
+                },
+                "54": {
+                    "size": 28
+                },
+                "55": {
+                    "size": 28
+                },
+                "56": {
+                    "size": 28
+                },
+                "57": {
+                    "size": 28
+                },
+                "58": {
+                    "size": 28
+                },
+                "60": {
+                    "size": 40
+                },
+                "61": {
+                    "size": 40
+                },
+                "62": {
+                    "size": 28
+                },
+                "63": {
+                    "size": 28
+                },
+                "64": {
+                    "size": 28
+                },
+                "65": {
+                    "size": 28
+                },
+                "66": {
+                    "size": 28
+                },
+                "67": {
+                    "size": 28
+                },
+                "68": {
+                    "size": 28
+                },
+                "69": {
+                    "size": 28
+                },
+                "70": {
+                    "size": 28
+                },
+                "71": {
+                    "size": 28
+                },
+                "73": {
+                    "size": 40
+                },
+                "74": {
+                    "size": 40
+                },
+                "75": {
+                    "size": 28
+                },
+                "76": {
+                    "size": 28
+                },
+                "77": {
+                    "size": 28
+                },
+                "78": {
+                    "size": 28
+                },
+                "79": {
+                    "size": 28
+                },
+                "80": {
+                    "size": 28
+                },
+                "81": {
+                    "size": 28
+                },
+                "82": {
+                    "size": 28
+                },
+                "83": {
+                    "size": 28
+                },
+                "84": {
+                    "size": 28
+                },
+                "85": {
+                    "size": 28
+                }
+            },
+            "cols": {
+                "0": {
+                    "size": 349
+                },
+                "1": {
+                    "size": 95
+                },
+                "2": {
+                    "size": 80
+                },
+                "3": {
+                    "size": 50
+                },
+                "4": {
+                    "size": 323
+                },
+                "5": {
+                    "size": 100
+                },
+                "6": {
+                    "size": 100
+                }
+            },
+            "merges": [],
+            "cells": {
+                "A6": {
+                    "content": "[Monthly Sales](odoo://view/{\"viewType\":\"graph\",\"action\":{\"domain\":[[\"state\",\"not in\",[\"draft\",\"cancel\",\"sent\"]]],\"context\":{\"group_by\":[\"date:month\"],\"graph_measure\":\"price_subtotal\",\"graph_mode\":\"line\",\"graph_groupbys\":[\"date:month\"]},\"modelName\":\"sale.report\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Sales Analysis\"})"
+                },
+                "A22": {
+                    "content": "[Top Quotations](odoo://view/{\"viewType\":\"list\",\"action\":{\"domain\":[[\"state\",\"in\",[\"draft\",\"sent\"]]],\"context\":{\"group_by\":[]},\"modelName\":\"sale.order\",\"views\":[[false,\"list\"],[false,\"kanban\"],[false,\"form\"],[false,\"calendar\"],[false,\"pivot\"],[false,\"graph\"],[false,\"activity\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Quotations\"})"
+                },
+                "A23": {
+                    "content": "=_t(\"Customer\")"
+                },
+                "A35": {
+                    "content": "[Top Countries](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[[\"country_id\",\"!=\",false],[\"state\",\"not in\",[\"draft\",\"sent\",\"cancel\"]]],\"context\":{\"group_by\":[\"country_id\"],\"pivot_measures\":[\"order_reference\",\"price_subtotal\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"country_id\"]},\"modelName\":\"sale.report\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Sales Analysis\"})"
+                },
+                "A36": {
+                    "content": "=_t(\"Country\")"
+                },
+                "A48": {
+                    "content": "[Top Customers](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[[\"partner_id\",\"!=\",false],[\"state\",\"not in\",[\"draft\",\"sent\",\"cancel\"]]],\"context\":{\"group_by\":[\"partner_id\"],\"pivot_measures\":[\"order_reference\",\"price_subtotal\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"partner_id\"]},\"modelName\":\"sale.report\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Sales Analysis\"})"
+                },
+                "A49": {
+                    "content": "=_t(\"Customer\")"
+                },
+                "A61": {
+                    "content": "[Top Sales Teams](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[[\"team_id\",\"!=\",false],[\"state\",\"not in\",[\"draft\",\"sent\",\"cancel\"]]],\"context\":{\"group_by\":[\"team_id\"],\"pivot_measures\":[\"order_reference\",\"price_subtotal\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"team_id\"]},\"modelName\":\"sale.report\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Sales Analysis\"})"
+                },
+                "A62": {
+                    "content": "=_t(\"Sales Team\")"
+                },
+                "A74": {
+                    "content": "[Top Sources](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[[\"source_id\",\"!=\",false],[\"state\",\"not in\",[\"draft\",\"sent\",\"cancel\"]]],\"context\":{\"group_by\":[\"source_id\"],\"pivot_measures\":[\"order_reference\",\"price_subtotal\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"source_id\"]},\"modelName\":\"sale.report\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Sales Analysis\"})"
+                },
+                "A75": {
+                    "content": "=_t(\"Source\")"
+                },
+                "B23": {
+                    "content": "=_t(\"Salesperson\")"
+                },
+                "B36": {
+                    "content": "=_t(\"Orders\")"
+                },
+                "B49": {
+                    "content": "=_t(\"Orders\")"
+                },
+                "B62": {
+                    "content": "=_t(\"Orders\")"
+                },
+                "B75": {
+                    "content": "=_t(\"Orders\")"
+                },
+                "C23": {
+                    "content": "=_t(\"Revenue\")"
+                },
+                "C36": {
+                    "content": "=_t(\"Revenue\")"
+                },
+                "C49": {
+                    "content": "=_t(\"Revenue\")"
+                },
+                "C62": {
+                    "content": "=_t(\"Revenue\")"
+                },
+                "C75": {
+                    "content": "=_t(\"Revenue\")"
+                },
+                "E22": {
+                    "content": "[Top Sales Orders](odoo://view/{\"viewType\":\"list\",\"action\":{\"domain\":[[\"state\",\"not in\",[\"draft\",\"sent\",\"cancel\"]]],\"context\":{\"group_by\":[]},\"modelName\":\"sale.order\",\"views\":[[false,\"list\"],[false,\"kanban\"],[false,\"form\"],[false,\"calendar\"],[false,\"pivot\"],[false,\"graph\"],[false,\"activity\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Sales Orders\"})"
+                },
+                "E23": {
+                    "content": "=_t(\"Customer\")"
+                },
+                "E35": {
+                    "content": "[Top Products](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[[\"product_tmpl_id\",\"!=\",false],[\"state\",\"not in\",[\"draft\",\"sent\",\"cancel\"]]],\"context\":{\"group_by\":[\"product_id\"],\"pivot_measures\":[\"order_reference\",\"price_subtotal\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"product_id\"]},\"modelName\":\"sale.report\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Sales Analysis\"})"
+                },
+                "E36": {
+                    "content": "=_t(\"Product\")"
+                },
+                "E48": {
+                    "content": "[Top Categories](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[[\"categ_id\",\"!=\",false],[\"state\",\"not in\",[\"draft\",\"sent\",\"cancel\"]]],\"context\":{\"group_by\":[\"categ_id\"],\"pivot_measures\":[\"order_reference\",\"price_subtotal\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"categ_id\"]},\"modelName\":\"sale.report\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Sales Analysis\"})"
+                },
+                "E49": {
+                    "content": "=_t(\"Category\")"
+                },
+                "E61": {
+                    "content": "[Top Salespeople](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[[\"user_id\",\"!=\",false],[\"state\",\"not in\",[\"draft\",\"sent\",\"cancel\"]]],\"context\":{\"group_by\":[\"user_id\"],\"pivot_measures\":[\"order_reference\",\"price_subtotal\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"user_id\"]},\"modelName\":\"sale.report\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Sales Analysis\"})"
+                },
+                "E62": {
+                    "content": "=_t(\"Salesperson\")"
+                },
+                "E74": {
+                    "content": "[Top Mediums](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[[\"medium_id\",\"!=\",false],[\"state\",\"not in\",[\"draft\",\"sent\",\"cancel\"]]],\"context\":{\"group_by\":[\"medium_id\"],\"pivot_measures\":[\"order_reference\",\"price_subtotal\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"medium_id\"]},\"modelName\":\"sale.report\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Sales Analysis\"})"
+                },
+                "E75": {
+                    "content": "=_t(\"Medium\")"
+                },
+                "F23": {
+                    "content": "=_t(\"Salesperson\")"
+                },
+                "F36": {
+                    "content": "=_t(\"Orders\")"
+                },
+                "F49": {
+                    "content": "=_t(\"Orders\")"
+                },
+                "F62": {
+                    "content": "=_t(\"Orders\")"
+                },
+                "F75": {
+                    "content": "=_t(\"Orders\")"
+                },
+                "G23": {
+                    "content": "=_t(\"Revenue\")"
+                },
+                "G36": {
+                    "content": "=_t(\"Revenue\")"
+                },
+                "G49": {
+                    "content": "=_t(\"Revenue\")"
+                },
+                "G62": {
+                    "content": "=_t(\"Revenue\")"
+                },
+                "G75": {
+                    "content": "=_t(\"Revenue\")"
+                }
+            },
+            "styles": {
+                "A6": 1,
+                "A22": 1,
+                "A35": 1,
+                "A48": 1,
+                "A61": 1,
+                "A74": 1,
+                "E22": 1,
+                "E35": 1,
+                "E48": 1,
+                "E61": 1,
+                "E74": 1,
+                "A23:B23": 2,
+                "E23:F23": 2,
+                "A36": 3,
+                "A49": 3,
+                "A62": 3,
+                "A75": 3,
+                "C36": 3,
+                "C75": 3,
+                "E36": 3,
+                "E49": 3,
+                "E62": 3,
+                "E75": 3,
+                "B36": 4,
+                "B75": 4,
+                "B49:C49": 4,
+                "B62:C62": 4,
+                "F36:G36": 4,
+                "F49:G49": 4,
+                "F62:G62": 4,
+                "F75:G75": 4,
+                "C23": 5,
+                "G23": 5
+            },
+            "formats": {},
+            "borders": {
+                "A22:C22": 1,
+                "A35:C35": 1,
+                "A48:C48": 1,
+                "A61:C61": 1,
+                "A74:C74": 1,
+                "A6:G6": 1,
+                "E22:G22": 1,
+                "E35:G35": 1,
+                "E48:G48": 1,
+                "E61:G61": 1,
+                "E74:G74": 1,
+                "B62": 2,
+                "B75": 2,
+                "E23:F23": 2,
+                "F49": 2,
+                "F62": 2,
+                "F75": 2,
+                "A7:G7": 2,
+                "A23:B23": 3,
+                "A24:B24": 4,
+                "A25:B32": 5,
+                "A37:C46": 5,
+                "A50:C59": 5,
+                "A64:C72": 5,
+                "A77:C77": 5,
+                "A79:C85": 5,
+                "E25:G33": 5,
+                "E37:G46": 5,
+                "E51:G59": 5,
+                "E64:G72": 5,
+                "E77:G77": 5,
+                "E79:G85": 5,
+                "A33:B33": 6,
+                "A34:C34": 7,
+                "A36": 8,
+                "A47:C47": 9,
+                "A60:C60": 9,
+                "A73:C73": 9,
+                "A86:C86": 9,
+                "E34:G34": 9,
+                "E47:G47": 9,
+                "E60:G60": 9,
+                "E73:G73": 9,
+                "E86:G86": 9,
+                "A49": 10,
+                "E36": 10,
+                "A62": 11,
+                "A75": 11,
+                "E49": 11,
+                "E62": 11,
+                "E75": 11,
+                "A63:C63": 12,
+                "A76:C76": 12,
+                "E24:G24": 12,
+                "E50:G50": 12,
+                "E63:G63": 12,
+                "E76:G76": 12,
+                "A78:C78": 13,
+                "E78:G78": 13,
+                "B36": 14,
+                "B49": 14,
+                "F36": 14,
+                "C23": 15,
+                "C24": 16,
+                "C25:C32": 17,
+                "C33": 18,
+                "C36": 19,
+                "C49": 20,
+                "G36": 20,
+                "C62": 21,
+                "C75": 21,
+                "G23": 21,
+                "G49": 21,
+                "G62": 21,
+                "G75": 21,
+                "D23": 22,
+                "D24:D33": 23,
+                "D36": 23,
+                "D37:D46": 24,
+                "D49:D59": 24,
+                "D62:D72": 24,
+                "D75:D77": 24,
+                "D79:D85": 24
+            },
+            "conditionalFormats": [],
+            "figures": [
+                {
+                    "id": "51823220-f22b-4359-8711-579a249c91bb",
+                    "x": 0,
+                    "y": 11,
+                    "width": 213,
+                    "height": 101,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "percentage",
+                        "title": {
+                            "text": "Quotations",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#EFF6FF",
+                        "baseline": "Data!E4",
+                        "baselineDescr": "since last period",
+                        "keyValue": "Data!D4",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "9a38934c-b454-4a4b-88aa-17d1b80dbf5f",
+                    "x": 223,
+                    "y": 11,
+                    "width": 211,
+                    "height": 101,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "percentage",
+                        "title": {
+                            "text": "Orders",
+                            "color": "#434343",
+                            "bold": true
+                        },
+                        "type": "scorecard",
+                        "background": "#EFF6FF",
+                        "baseline": "Data!E5",
+                        "baselineDescr": "since last period",
+                        "keyValue": "Data!D5",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "67858d0e-b5ba-4a3c-bf9e-c0fceaeedf65",
+                    "x": 444,
+                    "y": 11,
+                    "width": 218,
+                    "height": 101,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "percentage",
+                        "title": {
+                            "text": "Revenue",
+                            "color": "#434343",
+                            "bold": true
+                        },
+                        "type": "scorecard",
+                        "background": "#FFF7ED",
+                        "baseline": "Data!E7",
+                        "baselineDescr": "since last period",
+                        "keyValue": "Data!D7",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "d43375c1-73a6-42a2-8dbd-0f13c285824f",
+                    "x": 672,
+                    "y": 11,
+                    "width": 213,
+                    "height": 101,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "percentage",
+                        "title": {
+                            "text": "Average Order",
+                            "color": "#434343",
+                            "bold": true
+                        },
+                        "type": "scorecard",
+                        "background": "#FFF7ED",
+                        "baseline": "Data!E8",
+                        "baselineDescr": "since last period",
+                        "keyValue": "Data!D8",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "3ceb14f0-2a13-4691-817e-ff15c643b2bf",
+                    "x": 0,
+                    "y": 156,
+                    "width": 1093,
+                    "height": 343,
+                    "tag": "chart",
+                    "data": {
+                        "type": "line",
+                        "dataSetsHaveTitle": false,
+                        "dataSets": [
+                            {
+                                "dataRange": "Data!C11:C16",
+                                "yAxisId": "y"
+                            }
+                        ],
+                        "legendPosition": "none",
+                        "labelRange": "Data!A11:A16",
+                        "title": {},
+                        "labelsAsText": true,
+                        "stacked": false,
+                        "aggregated": false,
+                        "cumulative": true,
+                        "fillArea": true
+                    }
+                }
+            ],
+            "tables": [],
+            "areGridLinesVisible": true,
+            "isVisible": true,
+            "headerGroups": {
+                "ROW": [],
+                "COL": []
+            },
+            "dataValidationRules": [],
+            "comments": {}
+        },
+        {
+            "id": "eae01f9c-c461-4489-ade4-957ef2459d40",
+            "name": "Data",
+            "colNumber": 26,
+            "rowNumber": 103,
+            "rows": {},
+            "cols": {},
+            "merges": [],
+            "cells": {
+                "A1": {
+                    "content": "=_t(\"KPI\")"
+                },
+                "A2": {
+                    "content": "=_t(\"Draft quotations\")"
+                },
+                "A3": {
+                    "content": "=_t(\"Quotations sent\")"
+                },
+                "A4": {
+                    "content": "=_t(\"Total quotations\")"
+                },
+                "A5": {
+                    "content": "=_t(\"Orders\")"
+                },
+                "A6": {
+                    "content": "=_t(\"Total orders\")"
+                },
+                "A7": {
+                    "content": "=_t(\"Revenue\")"
+                },
+                "A8": {
+                    "content": "=_t(\"Average order amount\")"
+                },
+                "A11": {
+                    "content": "=EDATE(TODAY(), -B11)"
+                },
+                "A12": {
+                    "content": "=EDATE(TODAY(), -B12)"
+                },
+                "A13": {
+                    "content": "=EDATE(TODAY(), -B13)"
+                },
+                "A14": {
+                    "content": "=EDATE(TODAY(), -B14)"
+                },
+                "A15": {
+                    "content": "=EDATE(TODAY(), -B15)"
+                },
+                "A16": {
+                    "content": "=EDATE(TODAY(), -B16)"
+                },
+                "B1": {
+                    "content": "=_t(\"Current\")"
+                },
+                "B2": {
+                    "content": "13"
+                },
+                "B3": {
+                    "content": "15"
+                },
+                "B4": {
+                    "content": "189"
+                },
+                "B5": {
+                    "content": "456"
+                },
+                "B6": {
+                    "content": "72"
+                },
+                "B7": {
+                    "content": "491617.3"
+                },
+                "B8": {
+                    "content": "=IFERROR(B7/B6)"
+                },
+                "B11": {
+                    "content": "6"
+                },
+                "B12": {
+                    "content": "5"
+                },
+                "B13": {
+                    "content": "4"
+                },
+                "B14": {
+                    "content": "3"
+                },
+                "B15": {
+                    "content": "2"
+                },
+                "B16": {
+                    "content": "1"
+                },
+                "C1": {
+                    "content": "=_t(\"Previous\")"
+                },
+                "C2": {
+                    "content": "25"
+                },
+                "C3": {
+                    "content": "25"
+                },
+                "C4": {
+                    "content": "123"
+                },
+                "C5": {
+                    "content": "345"
+                },
+                "C6": {
+                    "content": "25"
+                },
+                "C7": {
+                    "content": "350000"
+                },
+                "C8": {
+                    "content": "=IFERROR(C7/C6)"
+                },
+                "C11": {
+                    "content": "77913"
+                },
+                "C12": {
+                    "content": "763749"
+                },
+                "C13": {
+                    "content": "130466"
+                },
+                "C14": {
+                    "content": "218483"
+                },
+                "C15": {
+                    "content": "563073"
+                },
+                "C16": {
+                    "content": "183723"
+                },
+                "D1": {
+                    "content": "=_t(\"Current\")"
+                },
+                "D2": {
+                    "content": "=B2"
+                },
+                "D3": {
+                    "content": "15"
+                },
+                "D4": {
+                    "content": "=B4"
+                },
+                "D5": {
+                    "content": "=B5"
+                },
+                "D6": {
+                    "content": "=FORMAT.LARGE.NUMBER(B6)"
+                },
+                "D7": {
+                    "content": "=FORMAT.LARGE.NUMBER(B7)"
+                },
+                "D8": {
+                    "content": "=FORMAT.LARGE.NUMBER(B8)"
+                },
+                "E1": {
+                    "content": "=_t(\"Previous\")"
+                },
+                "E2": {
+                    "content": "25"
+                },
+                "E3": {
+                    "content": "25"
+                },
+                "E4": {
+                    "content": "123"
+                },
+                "E5": {
+                    "content": "345"
+                },
+                "E6": {
+                    "content": "25"
+                },
+                "E7": {
+                    "content": "=C7"
+                },
+                "E8": {
+                    "content": "=C8"
+                }
+            },
+            "styles": {
+                "A1:E1": 6,
+                "D2:E8": 7
+            },
+            "formats": {
+                "A11:A16": 1,
+                "C11:C16": 2,
+                "B7:E8": 2
+            },
+            "borders": {},
+            "conditionalFormats": [],
+            "figures": [],
+            "tables": [],
+            "areGridLinesVisible": true,
+            "isVisible": true,
+            "headerGroups": {
+                "ROW": [],
+                "COL": []
+            },
+            "dataValidationRules": [],
+            "comments": {}
+        }
+    ],
+    "styles": {
+        "1": {
+            "textColor": "#01666b",
+            "bold": true,
+            "fontSize": 16
+        },
+        "2": {
+            "fontSize": 11,
+            "textColor": "#434343",
+            "verticalAlign": "middle",
+            "bold": true
+        },
+        "3": {
+            "bold": true,
+            "fontSize": 11,
+            "textColor": "#434343"
+        },
+        "4": {
+            "bold": true,
+            "fontSize": 11,
+            "textColor": "#434343",
+            "align": "center"
+        },
+        "5": {
+            "align": "center",
+            "fontSize": 11,
+            "textColor": "#434343",
+            "verticalAlign": "middle",
+            "bold": true
+        },
+        "6": {
+            "bold": true
+        },
+        "7": {
+            "fillColor": "#f2f2f2"
+        }
+    },
+    "formats": {
+        "1": "mmmm yyyy",
+        "2": "[$$]#,##0"
+    },
+    "borders": {
+        "1": {
+            "bottom": {
+                "style": "thin",
+                "color": "#CCCCCC"
+            }
+        },
+        "2": {
+            "top": {
+                "style": "thin",
+                "color": "#CCCCCC"
+            }
+        },
+        "3": {
+            "top": {
+                "style": "thin",
+                "color": "#CCCCCC"
+            },
+            "bottom": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            }
+        },
+        "4": {
+            "top": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "5": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "6": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "7": {
+            "top": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            }
+        },
+        "8": {
+            "top": {
+                "style": "thin",
+                "color": "#CCCCCC"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            }
+        },
+        "9": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "10": {
+            "top": {
+                "style": "thin",
+                "color": "#CCCCCC"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "11": {
+            "top": {
+                "style": "thin",
+                "color": "#CCCCCC"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "12": {
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "13": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "14": {
+            "top": {
+                "style": "thin",
+                "color": "#CCCCCC"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "15": {
+            "top": {
+                "style": "thin",
+                "color": "#CCCCCC"
+            },
+            "bottom": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            }
+        },
+        "16": {
+            "top": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            }
+        },
+        "17": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            }
+        },
+        "18": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            }
+        },
+        "19": {
+            "top": {
+                "style": "thin",
+                "color": "#CCCCCC"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            }
+        },
+        "20": {
+            "top": {
+                "style": "thin",
+                "color": "#CCCCCC"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "21": {
+            "top": {
+                "style": "thin",
+                "color": "#CCCCCC"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "22": {
+            "left": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            }
+        },
+        "23": {
+            "left": {
+                "style": "thin",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "24": {
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        }
+    },
+    "revisionId": "START_REVISION",
+    "uniqueFigureIds": true,
+    "settings": {
+        "locale": {
+            "name": "English (US)",
+            "code": "en_US",
+            "thousandsSeparator": ",",
+            "decimalSeparator": ".",
+            "dateFormat": "mm/dd/yyyy",
+            "timeFormat": "hh:mm:ss",
+            "formulaArgSeparator": ",",
+            "weekStart": 7
+        }
+    },
+    "pivots": {},
+    "pivotNextId": 13,
+    "customTableStyles": {},
+    "odooVersion": 12,
+    "globalFilters": [],
+    "lists": {},
+    "listNextId": 3
+}

--- a/addons/spreadsheet_dashboard_sale_timesheet/data/dashboards.xml
+++ b/addons/spreadsheet_dashboard_sale_timesheet/data/dashboards.xml
@@ -4,6 +4,8 @@
     <record id="spreadsheet_dashboard_timesheet" model="spreadsheet.dashboard">
         <field name="name">Timesheets</field>
         <field name="spreadsheet_binary_data" type="base64" file="spreadsheet_dashboard_sale_timesheet/data/files/timesheet_dashboard.json"/>
+        <field name="main_data_model_ids" eval="[(4, ref('analytic.model_account_analytic_line')), (4, ref('project.model_project_project')), (4, ref('sale.model_sale_order'))]"/>
+        <field name="sample_dashboard_file_path">spreadsheet_dashboard_sale_timesheet/data/files/timesheet_sample_dashboard.json</field>
         <field name="dashboard_group_id" ref="spreadsheet_dashboard.spreadsheet_dashboard_group_project"/>
         <field name="group_ids" eval="[Command.link(ref('hr_timesheet.group_hr_timesheet_approver'))]"/>
         <field name="sequence">200</field>

--- a/addons/spreadsheet_dashboard_sale_timesheet/data/files/timesheet_sample_dashboard.json
+++ b/addons/spreadsheet_dashboard_sale_timesheet/data/files/timesheet_sample_dashboard.json
@@ -1,0 +1,713 @@
+{
+  "version": 21,
+  "sheets": [
+      {
+          "id": "sheet1",
+          "name": "Dashboard",
+          "colNumber": 9,
+          "rowNumber": 48,
+          "rows": {
+              "6": {
+                  "size": 40
+              },
+              "22": {
+                  "size": 40
+              },
+              "23": {
+                  "size": 40
+              },
+              "24": {
+                  "size": 31
+              },
+              "25": {
+                  "size": 31
+              },
+              "26": {
+                  "size": 31
+              },
+              "27": {
+                  "size": 31
+              },
+              "28": {
+                  "size": 31
+              },
+              "29": {
+                  "size": 31
+              },
+              "30": {
+                  "size": 31
+              },
+              "31": {
+                  "size": 31
+              },
+              "32": {
+                  "size": 31
+              },
+              "33": {
+                  "size": 31
+              },
+              "35": {
+                  "size": 40
+              },
+              "36": {
+                  "size": 40
+              },
+              "37": {
+                  "size": 31
+              },
+              "38": {
+                  "size": 31
+              },
+              "39": {
+                  "size": 31
+              },
+              "40": {
+                  "size": 31
+              },
+              "41": {
+                  "size": 31
+              },
+              "42": {
+                  "size": 31
+              },
+              "43": {
+                  "size": 31
+              },
+              "44": {
+                  "size": 31
+              },
+              "45": {
+                  "size": 31
+              },
+              "46": {
+                  "size": 31
+              }
+          },
+          "cols": {
+              "0": {
+                  "size": 175
+              },
+              "1": {
+                  "size": 100
+              },
+              "2": {
+                  "size": 100
+              },
+              "3": {
+                  "size": 100
+              },
+              "4": {
+                  "size": 50
+              },
+              "5": {
+                  "size": 175
+              },
+              "6": {
+                  "size": 100
+              },
+              "7": {
+                  "size": 100
+              },
+              "8": {
+                  "size": 100
+              }
+          },
+          "merges": [],
+          "cells": {
+              "A7": {
+                  "content": "[Time Billed by Week](odoo://view/{\"viewType\":\"graph\",\"action\":{\"domain\":[[\"project_id\",\"!=\",false]],\"context\":{\"group_by\":[\"date:week\"],\"graph_measure\":\"billable_time\",\"graph_mode\":\"line\",\"graph_groupbys\":[\"date:week\"]},\"modelName\":\"timesheets.analysis.report\",\"views\":[[false,\"pivot\"],[false,\"graph\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Timesheets by Billing Type\"})"
+              },
+              "A23": {
+                  "content": "[Top Projects](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[\"&\",[\"project_id\",\"!=\",false],[\"project_id\",\"!=\",false]],\"context\":{\"group_by\":[\"project_id\"],\"pivot_measures\":[\"unit_amount\",\"billable_time\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"project_id\"]},\"modelName\":\"timesheets.analysis.report\",\"views\":[[false,\"pivot\"],[false,\"graph\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Top Projects\"})"
+              },
+              "A24": {
+                  "content": "=_t(\"Project\")"
+              },
+              "A36": {
+                  "content": "[Top Departments](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[\"&\",[\"project_id\",\"!=\",false],[\"department_id\",\"!=\",false]],\"context\":{\"group_by\":[\"department_id\"],\"pivot_measures\":[\"unit_amount\",\"billable_time\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"department_id\"]},\"modelName\":\"timesheets.analysis.report\",\"views\":[[false,\"pivot\"],[false,\"graph\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Top Departments\"})"
+              },
+              "A37": {
+                  "content": "=_t(\"Department\")"
+              },
+              "B24": {
+                  "content": "=_t(\"Hours spent\")"
+              },
+              "B37": {
+                  "content": "=_t(\"Hours spent\")"
+              },
+              "C24": {
+                  "content": "=_t(\"Hours billed\")"
+              },
+              "C37": {
+                  "content": "=_t(\"Hours billed\")"
+              },
+              "D24": {
+                  "content": "=_t(\"Billable rate\")"
+              },
+              "D34": {
+                  "content": "=IFERROR(C34/B34)"
+              },
+              "D37": {
+                  "content": "=_t(\"Billable rate\")"
+              },
+              "F23": {
+                  "content": "[Top Tasks](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[\"&\",[\"project_id\",\"!=\",false],[\"task_id\",\"!=\",false]],\"context\":{\"group_by\":[\"task_id\"],\"pivot_measures\":[\"unit_amount\",\"billable_time\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"task_id\"]},\"modelName\":\"timesheets.analysis.report\",\"views\":[[false,\"pivot\"],[false,\"graph\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Top Tasks\"})"
+              },
+              "F24": {
+                  "content": "=_t(\"Task\")"
+              },
+              "F36": {
+                  "content": "[Top Employees](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[\"&\",[\"project_id\",\"!=\",false],[\"employee_id\",\"!=\",false]],\"context\":{\"group_by\":[\"employee_id\"],\"pivot_measures\":[\"unit_amount\",\"billable_time\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"employee_id\"]},\"modelName\":\"timesheets.analysis.report\",\"views\":[[false,\"pivot\"],[false,\"graph\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Top Employees\"})"
+              },
+              "F37": {
+                  "content": "=_t(\"Employee\")"
+              },
+              "G24": {
+                  "content": "=_t(\"Hours spent\")"
+              },
+              "G37": {
+                  "content": "=_t(\"Hours spent\")"
+              },
+              "H24": {
+                  "content": "=_t(\"Hours billed\")"
+              },
+              "H37": {
+                  "content": "=_t(\"Hours billed\")"
+              },
+              "I24": {
+                  "content": "=_t(\"Billable rate\")"
+              },
+              "I34": {
+                  "content": "=IFERROR(H34/G34)"
+              },
+              "I37": {
+                  "content": "=_t(\"Billable rate\")"
+              }
+          },
+          "styles": {
+              "A7": 1,
+              "A23": 1,
+              "A36": 1,
+              "F23": 1,
+              "F36": 1,
+              "A24": 2,
+              "A37": 2,
+              "F24": 2,
+              "F37": 2,
+              "A34:D34": 3,
+              "I34": 3,
+              "B24:D24": 4,
+              "B37:D37": 4,
+              "G24:I24": 4,
+              "G37:I37": 4
+          },
+          "formats": {
+              "D34": 1,
+              "I34": 2
+          },
+          "borders": {
+              "A23:D23": 1,
+              "A36:D36": 1,
+              "A7:I7": 1,
+              "F23:I23": 1,
+              "F36:I36": 1,
+              "A24:D24": 2,
+              "A37:D37": 2,
+              "A8:I8": 2,
+              "F24:I24": 2,
+              "F37:I37": 2,
+              "A25": 3,
+              "A38": 3,
+              "F25": 3,
+              "F38": 3,
+              "A26:A34": 4,
+              "A39:A40": 4,
+              "A42:A47": 4,
+              "F26:F34": 4,
+              "F39:F40": 4,
+              "F42:F47": 4,
+              "A35:D35": 5,
+              "A48:D48": 5,
+              "F35:I35": 5,
+              "F48:I48": 5,
+              "A41:D41": 6,
+              "F41:I41": 6,
+              "B25:C25": 7,
+              "B38:C38": 7,
+              "G25:H25": 7,
+              "G38:H38": 7,
+              "B26:C34": 8,
+              "B39:C40": 8,
+              "B42:C47": 8,
+              "G26:H34": 8,
+              "G39:H40": 8,
+              "G42:H47": 8,
+              "D25": 9,
+              "D38": 9,
+              "I25": 9,
+              "I38": 9,
+              "D26:D34": 10,
+              "D39:D40": 10,
+              "D42:D47": 10,
+              "I26:I34": 10,
+              "I39:I40": 10,
+              "I42:I47": 10
+          },
+          "conditionalFormats": [],
+          "figures": [
+              {
+                  "id": "14907ee1-177b-4dda-97d7-223b1b00abe5",
+                  "x": 0,
+                  "y": 9,
+                  "width": 200,
+                  "height": 109,
+                  "tag": "chart",
+                  "data": {
+                      "baselineColorDown": "#DC6965",
+                      "baselineColorUp": "#00A04A",
+                      "baselineMode": "percentage",
+                      "title": {
+                          "text": "Billable Hours",
+                          "bold": true,
+                          "color": "#434343"
+                      },
+                      "type": "scorecard",
+                      "background": "#FEF2F2",
+                      "baseline": "Data!E5",
+                      "baselineDescr": "since last period",
+                      "keyValue": "Data!D5",
+                      "humanize": false
+                  }
+              },
+              {
+                  "id": "c484c691-bb4a-4a9d-8a25-8464162ee96a",
+                  "x": 210,
+                  "y": 9,
+                  "width": 200,
+                  "height": 109,
+                  "tag": "chart",
+                  "data": {
+                      "baselineColorDown": "#DC6965",
+                      "baselineColorUp": "#00A04A",
+                      "baselineMode": "percentage",
+                      "title": {
+                          "text": "Non-billable Hours",
+                          "bold": true,
+                          "color": "#434343"
+                      },
+                      "type": "scorecard",
+                      "background": "#FEF2F2",
+                      "baseline": "Data!E6",
+                      "baselineDescr": "since last period",
+                      "keyValue": "Data!D6",
+                      "humanize": false
+                  }
+              },
+              {
+                  "id": "0b033641-2a0f-4db7-893d-f14fbb320b94",
+                  "x": 420,
+                  "y": 9,
+                  "width": 200,
+                  "height": 109,
+                  "tag": "chart",
+                  "data": {
+                      "baselineColorDown": "#DC6965",
+                      "baselineColorUp": "#00A04A",
+                      "baselineMode": "text",
+                      "title": {
+                          "text": "Billable Rate",
+                          "bold": true,
+                          "color": "#434343"
+                      },
+                      "type": "scorecard",
+                      "background": "#ECFDF5",
+                      "baseline": "Data!E8",
+                      "baselineDescr": "last period",
+                      "keyValue": "Data!D8",
+                      "humanize": false
+                  }
+              },
+              {
+                  "id": "97fc8891-3062-4bac-86f7-7bf737aade07",
+                  "x": 0,
+                  "y": 178,
+                  "width": 1001,
+                  "height": 344,
+                  "tag": "chart",
+                  "data": {
+                      "type": "line",
+                      "dataSetsHaveTitle": false,
+                      "dataSets": [
+                          {
+                              "dataRange": "Data!B11:B16",
+                              "yAxisId": "y"
+                          }
+                      ],
+                      "legendPosition": "none",
+                      "labelRange": "Data!A11:A16",
+                      "title": {},
+                      "labelsAsText": true,
+                      "stacked": false,
+                      "aggregated": false,
+                      "cumulative": true,
+                      "fillArea": true
+                  }
+              }
+          ],
+          "tables": [],
+          "areGridLinesVisible": true,
+          "isVisible": true,
+          "headerGroups": {
+              "ROW": [],
+              "COL": []
+          },
+          "dataValidationRules": [],
+          "comments": {}
+      },
+      {
+          "id": "7802fc6d-c96b-452f-86d8-1c69816bebdc",
+          "name": "Data",
+          "colNumber": 26,
+          "rowNumber": 100,
+          "rows": {},
+          "cols": {},
+          "merges": [],
+          "cells": {
+              "A1": {
+                  "content": "=_t(\"KPI\")"
+              },
+              "A2": {
+                  "content": "=_t(\"Billed fixed price\")"
+              },
+              "A3": {
+                  "content": "=_t(\"Billed manually\")"
+              },
+              "A4": {
+                  "content": "=_t(\"Billed timesheets\")"
+              },
+              "A5": {
+                  "content": "=_t(\"Billable hours\")"
+              },
+              "A6": {
+                  "content": "=_t(\"Non-billable hours\")"
+              },
+              "A7": {
+                  "content": "=_t(\"Grand total\")"
+              },
+              "A8": {
+                  "content": "=_t(\"Billable rate\")"
+              },
+              "A11": {
+                  "content": "=EDATE(TODAY(),0-15)"
+              },
+              "A12": {
+                  "content": "=EDATE(TODAY(),0-12)"
+              },
+              "A13": {
+                  "content": "=EDATE(TODAY(),0-9)"
+              },
+              "A14": {
+                  "content": "=EDATE(TODAY(),0-6)"
+              },
+              "A15": {
+                  "content": "=EDATE(TODAY(),0-3)"
+              },
+              "A16": {
+                  "content": "=EDATE(TODAY(),0)"
+              },
+              "B1": {
+                  "content": "=_t(\"Current\")"
+              },
+              "B2": {
+                  "content": "43.5"
+              },
+              "B3": {
+                  "content": "31"
+              },
+              "B4": {
+                  "content": "5"
+              },
+              "B5": {
+                  "content": "=597"
+              },
+              "B6": {
+                  "content": "167"
+              },
+              "B7": {
+                  "content": "104.5"
+              },
+              "B8": {
+                  "content": "0.79"
+              },
+              "B11": {
+                  "content": "=RANDBETWEEN(0,200)"
+              },
+              "B12": {
+                  "content": "=RANDBETWEEN(0,200)"
+              },
+              "B13": {
+                  "content": "=RANDBETWEEN(0,200)"
+              },
+              "B14": {
+                  "content": "=RANDBETWEEN(0,200)"
+              },
+              "B15": {
+                  "content": "=RANDBETWEEN(0,200)"
+              },
+              "B16": {
+                  "content": "=RANDBETWEEN(0,200)"
+              },
+              "C1": {
+                  "content": "=_t(\"Previous\")"
+              },
+              "C5": {
+                  "content": "467"
+              },
+              "C6": {
+                  "content": "234"
+              },
+              "C7": {
+                  "content": "2"
+              },
+              "C8": {
+                  "content": "0.67"
+              },
+              "D1": {
+                  "content": "=_t(\"Current\")"
+              },
+              "D2": {
+                  "content": "=FORMAT.LARGE.NUMBER(B2)"
+              },
+              "D3": {
+                  "content": "=FORMAT.LARGE.NUMBER(B3)"
+              },
+              "D4": {
+                  "content": "=FORMAT.LARGE.NUMBER(B4)"
+              },
+              "D5": {
+                  "content": "=FORMAT.LARGE.NUMBER(B5)"
+              },
+              "D6": {
+                  "content": "=FORMAT.LARGE.NUMBER(B6)"
+              },
+              "D7": {
+                  "content": "=FORMAT.LARGE.NUMBER(B7)"
+              },
+              "D8": {
+                  "content": "=B8"
+              },
+              "E1": {
+                  "content": "=_t(\"Previous\")"
+              },
+              "E2": {
+                  "content": "=FORMAT.LARGE.NUMBER(C2)"
+              },
+              "E3": {
+                  "content": "=FORMAT.LARGE.NUMBER(C3)"
+              },
+              "E4": {
+                  "content": "=FORMAT.LARGE.NUMBER(C4)"
+              },
+              "E5": {
+                  "content": "=FORMAT.LARGE.NUMBER(C5)"
+              },
+              "E6": {
+                  "content": "=FORMAT.LARGE.NUMBER(C6)"
+              },
+              "E7": {
+                  "content": "=FORMAT.LARGE.NUMBER(C7)"
+              },
+              "E8": {
+                  "content": "=C8"
+              }
+          },
+          "styles": {
+              "A1:E1": 5,
+              "A2:E8": 6
+          },
+          "formats": {
+              "D8:E8": 1,
+              "A11:A16": 3,
+              "B2:B4": 4,
+              "B6:C7": 4
+          },
+          "borders": {},
+          "conditionalFormats": [],
+          "figures": [],
+          "tables": [],
+          "areGridLinesVisible": true,
+          "isVisible": true,
+          "headerGroups": {
+              "ROW": [],
+              "COL": []
+          },
+          "dataValidationRules": [],
+          "comments": {}
+      }
+  ],
+  "styles": {
+      "1": {
+          "textColor": "#01666b",
+          "bold": true,
+          "fontSize": 16
+      },
+      "2": {
+          "textColor": "#434343",
+          "fontSize": 11,
+          "bold": true
+      },
+      "3": {
+          "textColor": "#434343",
+          "verticalAlign": "middle"
+      },
+      "4": {
+          "textColor": "#434343",
+          "fontSize": 11,
+          "bold": true,
+          "align": "center"
+      },
+      "5": {
+          "bold": true
+      },
+      "6": {
+          "fillColor": "#f2f2f2"
+      }
+  },
+  "formats": {
+      "1": "0%",
+      "2": "0.00%",
+      "3": "qq yyyy",
+      "4": "#,##0.00"
+  },
+  "borders": {
+      "1": {
+          "bottom": {
+              "style": "thin",
+              "color": "#CCCCCC"
+          }
+      },
+      "2": {
+          "top": {
+              "style": "thin",
+              "color": "#CCCCCC"
+          }
+      },
+      "3": {
+          "bottom": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          },
+          "right": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          }
+      },
+      "4": {
+          "top": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          },
+          "bottom": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          },
+          "right": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          }
+      },
+      "5": {
+          "top": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          }
+      },
+      "6": {
+          "top": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          },
+          "bottom": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          }
+      },
+      "7": {
+          "bottom": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          },
+          "left": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          },
+          "right": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          }
+      },
+      "8": {
+          "top": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          },
+          "bottom": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          },
+          "left": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          },
+          "right": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          }
+      },
+      "9": {
+          "bottom": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          },
+          "left": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          }
+      },
+      "10": {
+          "top": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          },
+          "bottom": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          },
+          "left": {
+              "style": "thick",
+              "color": "#FFFFFF"
+          }
+      }
+  },
+  "revisionId": "START_REVISION",
+  "uniqueFigureIds": true,
+  "settings": {
+      "locale": {
+          "name": "English (US)",
+          "code": "en_US",
+          "thousandsSeparator": ",",
+          "decimalSeparator": ".",
+          "dateFormat": "mm/dd/yyyy",
+          "timeFormat": "hh:mm:ss",
+          "formulaArgSeparator": ",",
+          "weekStart": 7
+      }
+  },
+  "pivots": {},
+  "pivotNextId": 7,
+  "customTableStyles": {},
+  "odooVersion": 12,
+  "globalFilters": [],
+  "lists": {},
+  "listNextId": 1
+}

--- a/addons/spreadsheet_dashboard_stock_account/data/dashboards.xml
+++ b/addons/spreadsheet_dashboard_stock_account/data/dashboards.xml
@@ -4,6 +4,8 @@
     <record id="spreadsheet_dashboard_warehouse_metrics" model="spreadsheet.dashboard">
         <field name="name">Warehouse Metrics</field>
         <field name="spreadsheet_binary_data" type="base64" file="spreadsheet_dashboard_stock_account/data/files/warehouse_metrics_dashboard.json"/>
+        <field name="main_data_model_ids" eval="[(4, ref('stock.model_stock_quant'))]"/>
+        <field name="sample_dashboard_file_path">spreadsheet_dashboard_stock_account/data/files/warehouse_metrics_sample_dashboard.json</field>
         <field name="dashboard_group_id" ref="spreadsheet_dashboard.spreadsheet_dashboard_group_logistics"/>
         <field name="group_ids" eval="[Command.link(ref('stock.group_stock_manager'))]"/>
         <field name="sequence">300</field>

--- a/addons/spreadsheet_dashboard_stock_account/data/files/warehouse_metrics_sample_dashboard.json
+++ b/addons/spreadsheet_dashboard_stock_account/data/files/warehouse_metrics_sample_dashboard.json
@@ -1,0 +1,1029 @@
+{
+    "version": 22,
+    "sheets": [
+        {
+            "id": "sheet1",
+            "name": "Dashboard",
+            "colNumber": 8,
+            "rowNumber": 72,
+            "rows": {
+                "6": {
+                    "size": 38
+                },
+                "22": {
+                    "size": 40
+                },
+                "23": {
+                    "size": 21
+                },
+                "24": {
+                    "size": 21
+                },
+                "25": {
+                    "size": 21
+                },
+                "26": {
+                    "size": 21
+                },
+                "27": {
+                    "size": 21
+                },
+                "28": {
+                    "size": 21
+                },
+                "29": {
+                    "size": 21
+                },
+                "30": {
+                    "size": 21
+                },
+                "31": {
+                    "size": 21
+                },
+                "32": {
+                    "size": 21
+                },
+                "33": {
+                    "size": 21
+                },
+                "34": {
+                    "size": 21
+                },
+                "35": {
+                    "size": 21
+                },
+                "36": {
+                    "size": 21
+                },
+                "37": {
+                    "size": 21
+                },
+                "38": {
+                    "size": 21
+                },
+                "39": {
+                    "size": 21
+                },
+                "40": {
+                    "size": 41
+                },
+                "41": {
+                    "size": 21
+                },
+                "42": {
+                    "size": 21
+                },
+                "43": {
+                    "size": 21
+                },
+                "44": {
+                    "size": 21
+                },
+                "45": {
+                    "size": 21
+                },
+                "46": {
+                    "size": 21
+                },
+                "47": {
+                    "size": 21
+                },
+                "48": {
+                    "size": 21
+                },
+                "49": {
+                    "size": 21
+                },
+                "50": {
+                    "size": 21
+                },
+                "51": {
+                    "size": 21
+                },
+                "52": {
+                    "size": 21
+                },
+                "53": {
+                    "size": 21
+                },
+                "54": {
+                    "size": 21
+                },
+                "55": {
+                    "size": 21
+                },
+                "56": {
+                    "size": 21
+                },
+                "57": {
+                    "size": 36
+                },
+                "58": {
+                    "size": 38
+                },
+                "59": {
+                    "size": 27
+                },
+                "60": {
+                    "size": 27
+                },
+                "61": {
+                    "size": 27
+                },
+                "62": {
+                    "size": 27
+                },
+                "63": {
+                    "size": 27
+                },
+                "64": {
+                    "size": 27
+                },
+                "65": {
+                    "size": 27
+                },
+                "66": {
+                    "size": 27
+                },
+                "67": {
+                    "size": 27
+                },
+                "68": {
+                    "size": 27
+                },
+                "69": {
+                    "size": 21
+                },
+                "70": {
+                    "size": 21
+                },
+                "71": {
+                    "size": 21
+                }
+            },
+            "cols": {
+                "0": {
+                    "size": 332
+                },
+                "1": {
+                    "size": 100
+                },
+                "2": {
+                    "size": 69
+                },
+                "3": {
+                    "size": 40
+                },
+                "4": {
+                    "size": 50
+                },
+                "5": {
+                    "size": 275
+                },
+                "6": {
+                    "size": 100
+                },
+                "7": {
+                    "size": 95
+                }
+            },
+            "merges": [],
+            "cells": {
+                "A7": {
+                    "content": "=_t(\"Available and reserved stock qty (top locations)\")"
+                },
+                "A23": {
+                    "content": "=_t(\"Available and reserved stock qty (top propducts)\")"
+                },
+                "A41": {
+                    "content": "=_t(\"Ageing stock qty by category and creation date\")"
+                },
+                "A58": {
+                    "content": "=_t(\"Top 10 products with negative stock\")"
+                },
+                "A59": {
+                    "content": "=_t(\"Products\")"
+                },
+                "E7": {
+                    "content": "=_t(\"Available and reserved stock value (top locations)\")"
+                },
+                "E23": {
+                    "content": "=_t(\"Available and reserved stock value (top propducts)\")"
+                },
+                "E41": {
+                    "content": "=_t(\"Ageing stock value by product and creation date\")"
+                }
+            },
+            "styles": {
+                "A7": 1,
+                "A23": 1,
+                "A41": 1,
+                "A58": 1,
+                "E7": 1,
+                "E23": 1,
+                "E41": 1,
+                "A59": 2
+            },
+            "formats": {},
+            "borders": {
+                "A7:C7": 1,
+                "A23:C23": 1,
+                "A41:C41": 1,
+                "A58:C58": 1,
+                "E7:H7": 1,
+                "E23:H23": 1,
+                "E41:H41": 1,
+                "A8:C8": 2,
+                "A24:C24": 2,
+                "A42:C42": 2,
+                "A59:C59": 2,
+                "E8:H8": 2,
+                "E24:H24": 2,
+                "E42:H42": 2
+            },
+            "conditionalFormats": [],
+            "figures": [
+                {
+                    "id": "833374d1-d09f-4a4e-bb09-2831ceee5465",
+                    "x": 246,
+                    "y": 9,
+                    "width": 237,
+                    "height": 108,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#E06666",
+                        "baselineColorUp": "#6AA84F",
+                        "baselineMode": "text",
+                        "title": {
+                            "text": "Share reserved stock Value",
+                            "align": "left",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#ECFDF5",
+                        "baseline": "Data!E4",
+                        "keyValue": "Data!B4",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "de7010e1-2cdc-4e19-a1de-1c7fd4795bf4",
+                    "x": 0,
+                    "y": 9,
+                    "width": 237,
+                    "height": 108,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#E06666",
+                        "baselineColorUp": "#6AA84F",
+                        "baselineMode": "text",
+                        "title": {
+                            "text": "Share reserved stock Qty",
+                            "align": "left",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#ECFDF5",
+                        "baseline": "Data!E3",
+                        "keyValue": "Data!B3",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "639d221d-d74d-4762-984e-9debac4f5a82",
+                    "x": 492,
+                    "y": 9,
+                    "width": 237,
+                    "height": 108,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#E06666",
+                        "baselineColorUp": "#6AA84F",
+                        "baselineMode": "difference",
+                        "title": {
+                            "text": "Lines with negative stock",
+                            "bold": true,
+                            "align": "left",
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#EFF6FF",
+                        "keyValue": "Data!B5",
+                        "humanize": true
+                    }
+                },
+                {
+                    "id": "c6b5d23a-bd70-4c85-b5d8-174914e392cf",
+                    "x": 0,
+                    "y": 176,
+                    "width": 501,
+                    "height": 344,
+                    "tag": "chart",
+                    "data": {
+                        "type": "bar",
+                        "dataSetsHaveTitle": true,
+                        "dataSets": [
+                            {
+                                "dataRange": "Data!B11:B17",
+                                "yAxisId": "y"
+                            },
+                            {
+                                "dataRange": "Data!C11:C17"
+                            }
+                        ],
+                        "legendPosition": "top",
+                        "labelRange": "Data!A11:A17",
+                        "title": {},
+                        "stacked": true,
+                        "aggregated": false,
+                        "horizontal": false
+                    }
+                },
+                {
+                    "id": "0583c3a5-77a3-40e9-a8ae-a80c4923cdd8",
+                    "x": 540,
+                    "y": 176,
+                    "width": 481,
+                    "height": 344,
+                    "tag": "chart",
+                    "data": {
+                        "type": "bar",
+                        "dataSetsHaveTitle": true,
+                        "dataSets": [
+                            {
+                                "dataRange": "Data!B20:B25",
+                                "yAxisId": "y"
+                            },
+                            {
+                                "dataRange": "Data!C20:C25"
+                            }
+                        ],
+                        "legendPosition": "top",
+                        "labelRange": "Data!A20:A25",
+                        "title": {},
+                        "stacked": true,
+                        "aggregated": false,
+                        "horizontal": false
+                    }
+                },
+                {
+                    "id": "19195543-e12e-40e4-b404-e1d27d0629a9",
+                    "x": 0,
+                    "y": 561,
+                    "width": 501,
+                    "height": 358,
+                    "tag": "chart",
+                    "data": {
+                        "type": "bar",
+                        "dataSetsHaveTitle": true,
+                        "dataSets": [
+                            {
+                                "dataRange": "Data!B28:B36",
+                                "yAxisId": "y"
+                            },
+                            {
+                                "dataRange": "Data!C28:C36"
+                            }
+                        ],
+                        "legendPosition": "top",
+                        "labelRange": "Data!A28:A36",
+                        "title": {},
+                        "stacked": true,
+                        "aggregated": false,
+                        "horizontal": false
+                    }
+                },
+                {
+                    "id": "4abd0d9a-4754-4197-bf1d-8580e5676f31",
+                    "x": 541,
+                    "y": 561,
+                    "width": 480,
+                    "height": 356,
+                    "tag": "chart",
+                    "data": {
+                        "type": "bar",
+                        "dataSetsHaveTitle": true,
+                        "dataSets": [
+                            {
+                                "dataRange": "Data!B39:B47",
+                                "yAxisId": "y"
+                            },
+                            {
+                                "dataRange": "Data!C39:C47"
+                            }
+                        ],
+                        "legendPosition": "top",
+                        "labelRange": "Data!A39:A47",
+                        "title": {},
+                        "stacked": true,
+                        "aggregated": false,
+                        "horizontal": false
+                    }
+                },
+                {
+                    "id": "8ed2d718-6948-4dc5-aa0a-034c5ec345d1",
+                    "x": 0,
+                    "y": 959,
+                    "width": 503,
+                    "height": 335,
+                    "tag": "chart",
+                    "data": {
+                        "type": "bar",
+                        "dataSetsHaveTitle": false,
+                        "dataSets": [
+                            {
+                                "dataRange": "Data!B50:B52",
+                                "yAxisId": "y"
+                            },
+                            {
+                                "dataRange": "Data!C50:C52"
+                            },
+                            {
+                                "dataRange": "Data!D50:D52"
+                            },
+                            {
+                                "dataRange": "Data!E50:E52"
+                            },
+                            {
+                                "dataRange": "Data!F50:F52"
+                            }
+                        ],
+                        "legendPosition": "none",
+                        "labelRange": "Data!A50:A52",
+                        "title": {},
+                        "stacked": true,
+                        "aggregated": false,
+                        "horizontal": false
+                    }
+                },
+                {
+                    "id": "fdbb3758-85b5-4d59-b8bf-621b65e0c7b6",
+                    "x": 540,
+                    "y": 959,
+                    "width": 481,
+                    "height": 335,
+                    "tag": "chart",
+                    "data": {
+                        "type": "bar",
+                        "dataSetsHaveTitle": false,
+                        "dataSets": [
+                            {
+                                "dataRange": "Data!B50:B52",
+                                "yAxisId": "y"
+                            },
+                            {
+                                "dataRange": "Data!C50:C52"
+                            },
+                            {
+                                "dataRange": "Data!D50:D52"
+                            },
+                            {
+                                "dataRange": "Data!E50:E52"
+                            },
+                            {
+                                "dataRange": "Data!F50:F52"
+                            }
+                        ],
+                        "legendPosition": "none",
+                        "labelRange": "Data!A50:A52",
+                        "title": {},
+                        "stacked": true,
+                        "aggregated": false,
+                        "horizontal": false
+                    }
+                }
+            ],
+            "tables": [],
+            "areGridLinesVisible": true,
+            "isVisible": true,
+            "headerGroups": {
+                "ROW": [],
+                "COL": []
+            },
+            "dataValidationRules": [],
+            "comments": {}
+        },
+        {
+            "id": "fb6d5d91-04cf-4c22-953a-a00c4e8f19e4",
+            "name": "Data",
+            "colNumber": 22,
+            "rowNumber": 82,
+            "rows": {},
+            "cols": {},
+            "merges": [],
+            "cells": {
+                "A1": {
+                    "content": "=_t(\"KPI\")"
+                },
+                "A2": {
+                    "content": "=_t(\"Total inventory value\")"
+                },
+                "A3": {
+                    "content": "=_t(\"Share of reserved stock qty\")"
+                },
+                "A4": {
+                    "content": "=_t(\"Share of reserved stock Value\")"
+                },
+                "A5": {
+                    "content": "=_t(\"Count of products with negative stock\")"
+                },
+                "A12": {
+                    "content": "=_t(\"WH/Stock\")"
+                },
+                "A13": {
+                    "content": "=_t(\"WH/Output\")"
+                },
+                "A14": {
+                    "content": "=_t(\"Pre-production\")"
+                },
+                "A15": {
+                    "content": "=_t(\"Post-production\")"
+                },
+                "A16": {
+                    "content": "=_t(\"WH/Stock/Shelf 10\")"
+                },
+                "A21": {
+                    "content": "=_t(\"WH/Stock\")"
+                },
+                "A22": {
+                    "content": "=_t(\"WH/Output\")"
+                },
+                "A23": {
+                    "content": "=_t(\"Pre-production\")"
+                },
+                "A24": {
+                    "content": "=_t(\"Post-production\")"
+                },
+                "A25": {
+                    "content": "=_t(\"WH/Stock/Shelf 10\")"
+                },
+                "A29": {
+                    "content": "=_t(\"Electric standing desk\")"
+                },
+                "A30": {
+                    "content": "=_t(\"Smart air purifier\")"
+                },
+                "A31": {
+                    "content": "=_t(\"Waterproof hiking backpack\")"
+                },
+                "A32": {
+                    "content": "=_t(\"Solar-powered phone charger\")"
+                },
+                "A33": {
+                    "content": "=_t(\"3D printing pen\")"
+                },
+                "A34": {
+                    "content": "=_t(\"Compact espresso machine\")"
+                },
+                "A35": {
+                    "content": "=_t(\"Bluetooth-enabled LED light strip\")"
+                },
+                "A36": {
+                    "content": "=_t(\"Ergonomic office chair\")"
+                },
+                "A40": {
+                    "content": "=_t(\"Electric standing desk\")"
+                },
+                "A41": {
+                    "content": "=_t(\"Smart air purifier\")"
+                },
+                "A42": {
+                    "content": "=_t(\"Waterproof hiking backpack\")"
+                },
+                "A43": {
+                    "content": "=_t(\"Solar-powered phone charger\")"
+                },
+                "A44": {
+                    "content": "=_t(\"3D printing pen\")"
+                },
+                "A45": {
+                    "content": "=_t(\"Compact espresso machine\")"
+                },
+                "A46": {
+                    "content": "=_t(\"Bluetooth-enabled LED light strip\")"
+                },
+                "A47": {
+                    "content": "=_t(\"Ergonomic office chair\")"
+                },
+                "A50": {
+                    "content": "=EDATE(TODAY(),-6)"
+                },
+                "A51": {
+                    "content": "=EDATE(TODAY(),-3)"
+                },
+                "A52": {
+                    "content": "=EDATE(TODAY(),0)"
+                },
+                "A55": {
+                    "content": "=EDATE(TODAY(),-6)"
+                },
+                "A56": {
+                    "content": "=EDATE(TODAY(),-3)"
+                },
+                "A57": {
+                    "content": "=EDATE(TODAY(),0)"
+                },
+                "B2": {
+                    "content": "188071"
+                },
+                "B3": {
+                    "content": "0.2408405172413793"
+                },
+                "B4": {
+                    "content": "0.4064262964518719"
+                },
+                "B5": {
+                    "content": "6"
+                },
+                "B11": {
+                    "content": "=_t(\"Available Quantity\")"
+                },
+                "B12": {
+                    "content": "3377"
+                },
+                "B13": {
+                    "content": "598"
+                },
+                "B14": {
+                    "content": "3826"
+                },
+                "B15": {
+                    "content": "2772"
+                },
+                "B16": {
+                    "content": "3455"
+                },
+                "B20": {
+                    "content": "=_t(\"Available Value\")"
+                },
+                "B21": {
+                    "content": "34189"
+                },
+                "B22": {
+                    "content": "31472"
+                },
+                "B23": {
+                    "content": "48745"
+                },
+                "B24": {
+                    "content": "41379"
+                },
+                "B25": {
+                    "content": "29347"
+                },
+                "B28": {
+                    "content": "=_t(\"Available Quantity\")"
+                },
+                "B29": {
+                    "content": "55"
+                },
+                "B30": {
+                    "content": "43"
+                },
+                "B31": {
+                    "content": "32"
+                },
+                "B32": {
+                    "content": "57"
+                },
+                "B33": {
+                    "content": "71"
+                },
+                "B34": {
+                    "content": "20"
+                },
+                "B35": {
+                    "content": "33"
+                },
+                "B36": {
+                    "content": "11"
+                },
+                "B39": {
+                    "content": "=_t(\"Available Value\")"
+                },
+                "B40": {
+                    "content": "1986"
+                },
+                "B41": {
+                    "content": "6388"
+                },
+                "B42": {
+                    "content": "7098"
+                },
+                "B43": {
+                    "content": "5878"
+                },
+                "B44": {
+                    "content": "7870"
+                },
+                "B45": {
+                    "content": "3064"
+                },
+                "B46": {
+                    "content": "5372"
+                },
+                "B47": {
+                    "content": "5213"
+                },
+                "B50": {
+                    "content": "483"
+                },
+                "B51": {
+                    "content": "108"
+                },
+                "B52": {
+                    "content": "236"
+                },
+                "B55": {
+                    "content": "88"
+                },
+                "B56": {
+                    "content": "403"
+                },
+                "B57": {
+                    "content": "119"
+                },
+                "C1": {
+                    "content": "=_t(\"Reserved\")"
+                },
+                "C3": {
+                    "content": "447"
+                },
+                "C4": {
+                    "content": "76437"
+                },
+                "C11": {
+                    "content": "=_t(\"Reserved Quantity\")"
+                },
+                "C12": {
+                    "content": "4483"
+                },
+                "C13": {
+                    "content": "4782"
+                },
+                "C14": {
+                    "content": "4603"
+                },
+                "C15": {
+                    "content": "2226"
+                },
+                "C16": {
+                    "content": "1345"
+                },
+                "C20": {
+                    "content": "=_t(\"Reserved Value\")"
+                },
+                "C21": {
+                    "content": "44891"
+                },
+                "C22": {
+                    "content": "48745"
+                },
+                "C23": {
+                    "content": "29347"
+                },
+                "C24": {
+                    "content": "38686"
+                },
+                "C25": {
+                    "content": "48745"
+                },
+                "C28": {
+                    "content": "=_t(\"Reserved Quantity\")"
+                },
+                "C29": {
+                    "content": "69"
+                },
+                "C30": {
+                    "content": "15"
+                },
+                "C31": {
+                    "content": "55"
+                },
+                "C32": {
+                    "content": "72"
+                },
+                "C33": {
+                    "content": "62"
+                },
+                "C34": {
+                    "content": "40"
+                },
+                "C35": {
+                    "content": "38"
+                },
+                "C36": {
+                    "content": "30"
+                },
+                "C39": {
+                    "content": "=_t(\"Reserved Value\")"
+                },
+                "C40": {
+                    "content": "2313"
+                },
+                "C41": {
+                    "content": "3376"
+                },
+                "C42": {
+                    "content": "1124"
+                },
+                "C43": {
+                    "content": "4626"
+                },
+                "C44": {
+                    "content": "4886"
+                },
+                "C45": {
+                    "content": "7053"
+                },
+                "C46": {
+                    "content": "4888"
+                },
+                "C47": {
+                    "content": "6652"
+                },
+                "C50": {
+                    "content": "337"
+                },
+                "C51": {
+                    "content": "285"
+                },
+                "C52": {
+                    "content": "275"
+                },
+                "C55": {
+                    "content": "119"
+                },
+                "C56": {
+                    "content": "54"
+                },
+                "C57": {
+                    "content": "310"
+                },
+                "D1": {
+                    "content": "=_t(\"Total\")"
+                },
+                "D3": {
+                    "content": "1856"
+                },
+                "D4": {
+                    "content": "188071"
+                },
+                "D50": {
+                    "content": "333"
+                },
+                "D51": {
+                    "content": "215"
+                },
+                "D52": {
+                    "content": "358"
+                },
+                "D55": {
+                    "content": "91"
+                },
+                "D56": {
+                    "content": "439"
+                },
+                "D57": {
+                    "content": "319"
+                },
+                "E3": {
+                    "content": "=_t(\"447 out of 1,856\")"
+                },
+                "E4": {
+                    "content": "=_t(\"76,437 out of 188,071\")"
+                },
+                "E50": {
+                    "content": "213"
+                },
+                "E51": {
+                    "content": "247"
+                },
+                "E52": {
+                    "content": "378"
+                },
+                "E55": {
+                    "content": "97"
+                },
+                "E56": {
+                    "content": "235"
+                },
+                "E57": {
+                    "content": "227"
+                },
+                "F50": {
+                    "content": "331"
+                },
+                "F51": {
+                    "content": "373"
+                },
+                "F52": {
+                    "content": "356"
+                },
+                "F55": {
+                    "content": "67"
+                },
+                "F56": {
+                    "content": "60"
+                },
+                "F57": {
+                    "content": "135"
+                }
+            },
+            "styles": {
+                "A1": 3,
+                "C1:D1": 3,
+                "A2:A5": 4,
+                "B1": 4
+            },
+            "formats": {
+                "A50:A52": 1,
+                "A55:A57": 1,
+                "B2": 2,
+                "D4": 2,
+                "B3:B4": 3,
+                "B5": 4,
+                "C3:D3": 4,
+                "B21:C25": 5,
+                "B40:C47": 5,
+                "C4": 6
+            },
+            "borders": {},
+            "conditionalFormats": [],
+            "figures": [],
+            "tables": [],
+            "areGridLinesVisible": true,
+            "isVisible": true,
+            "headerGroups": {
+                "ROW": [],
+                "COL": []
+            },
+            "dataValidationRules": [],
+            "comments": {}
+        }
+    ],
+    "styles": {
+        "1": {
+            "fontSize": 16,
+            "textColor": "#01666B",
+            "bold": true
+        },
+        "2": {
+            "textColor": "#434343",
+            "bold": true,
+            "fontSize": 11
+        },
+        "3": {
+            "bold": true,
+            "fillColor": "#E6F2F3"
+        },
+        "4": {
+            "fillColor": "#E6F2F3"
+        }
+    },
+    "formats": {
+        "1": "qq yyyy",
+        "2": "[$$]#,##0,[$k]",
+        "3": "0.00%",
+        "4": "#,##0.00",
+        "5": "[$$]#,##0",
+        "6": "[$$]#,##0[$]"
+    },
+    "borders": {
+        "1": {
+            "bottom": {
+                "style": "thin",
+                "color": "#CCCCCC"
+            }
+        },
+        "2": {
+            "top": {
+                "style": "thin",
+                "color": "#CCCCCC"
+            }
+        }
+    },
+    "revisionId": "START_REVISION",
+    "uniqueFigureIds": true,
+    "settings": {
+        "locale": {
+            "name": "English (US)",
+            "code": "en_US",
+            "thousandsSeparator": ",",
+            "decimalSeparator": ".",
+            "dateFormat": "mm/dd/yyyy",
+            "timeFormat": "hh:mm:ss",
+            "formulaArgSeparator": ",",
+            "weekStart": 7
+        }
+    },
+    "pivots": {},
+    "pivotNextId": 25,
+    "customTableStyles": {},
+    "odooVersion": 12,
+    "globalFilters": [],
+    "lists": {},
+    "listNextId": 3
+}

--- a/addons/spreadsheet_dashboard_website_sale/data/dashboards.xml
+++ b/addons/spreadsheet_dashboard_website_sale/data/dashboards.xml
@@ -4,6 +4,8 @@
     <record id="spreadsheet_dashboard_ecommerce" model="spreadsheet.dashboard">
         <field name="name">eCommerce</field>
         <field name="spreadsheet_binary_data" type="base64" file="spreadsheet_dashboard_website_sale/data/files/ecommerce_dashboard.json"/>
+        <field name="main_data_model_ids" eval="[(4, ref('sale.model_sale_order'))]"/>
+        <field name="sample_dashboard_file_path">spreadsheet_dashboard_website_sale/data/files/ecommerce_sample_dashboard.json</field>
         <field name="dashboard_group_id" ref="spreadsheet_dashboard.spreadsheet_dashboard_group_website"/>
         <field name="group_ids" eval="[Command.link(ref('sales_team.group_sale_manager'))]"/>
         <field name="sequence">200</field>

--- a/addons/spreadsheet_dashboard_website_sale/data/files/ecommerce_sample_dashboard.json
+++ b/addons/spreadsheet_dashboard_website_sale/data/files/ecommerce_sample_dashboard.json
@@ -1,0 +1,596 @@
+{
+    "version": 21,
+    "sheets": [
+        {
+            "id": "sheet1",
+            "name": "Dashboard",
+            "colNumber": 7,
+            "rowNumber": 41,
+            "rows": {
+                "5": {
+                    "size": 48
+                },
+                "21": {
+                    "size": 44
+                },
+                "22": {
+                    "size": 35
+                },
+                "23": {
+                    "size": 34
+                },
+                "24": {
+                    "size": 34
+                },
+                "25": {
+                    "size": 34
+                },
+                "26": {
+                    "size": 34
+                },
+                "27": {
+                    "size": 34
+                },
+                "28": {
+                    "size": 34
+                },
+                "29": {
+                    "size": 34
+                },
+                "30": {
+                    "size": 34
+                },
+                "31": {
+                    "size": 34
+                }
+            },
+            "cols": {
+                "0": {
+                    "size": 259
+                },
+                "1": {
+                    "size": 112
+                },
+                "2": {
+                    "size": 112
+                },
+                "3": {
+                    "size": 46
+                },
+                "4": {
+                    "size": 257
+                },
+                "5": {
+                    "size": 112
+                },
+                "6": {
+                    "size": 112
+                }
+            },
+            "merges": [],
+            "cells": {
+                "A6": {
+                    "content": "[Monthly Sales](odoo://view/{\"viewType\":\"graph\",\"action\":{\"domain\":[[\"state\",\"not in\",[\"draft\",\"cancel\",\"sent\"]]],\"context\":{\"group_by\":[],\"graph_measure\":\"price_subtotal\",\"graph_mode\":\"line\",\"graph_groupbys\":[\"date:day\"],\"graph_order\":null,\"graph_stacked\":true,\"graph_cumulated\":false},\"modelName\":\"sale.report\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Sales Analysis\"})"
+                },
+                "A22": {
+                    "content": "[Top Products](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[\"&\",[\"website_id\",\"!=\",false],[\"state\",\"in\",[\"sale\",\"done\"]]],\"context\":{\"group_by\":[],\"pivot_measures\":[\"order_reference\",\"price_total\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"product_id\"]},\"modelName\":\"sale.report\",\"views\":[[false,\"pivot\"],[false,\"graph\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Online Sales Analysis\"})"
+                },
+                "A23": {
+                    "content": "=_t(\"Products\")"
+                },
+                "B23": {
+                    "content": "=_t(\"Units\")"
+                },
+                "C23": {
+                    "content": "=_t(\"Revenue\")"
+                },
+                "E22": {
+                    "content": "[Top Categories](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[[\"state\",\"not in\",[\"draft\",\"cancel\",\"sent\"]]],\"context\":{\"group_by\":[],\"pivot_measures\":[\"order_reference\",\"price_subtotal\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"categ_id\"]},\"modelName\":\"sale.report\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Sales Analysis\"})"
+                },
+                "E23": {
+                    "content": "=_t(\"Categories\")"
+                },
+                "F23": {
+                    "content": "=_t(\"Units\")"
+                },
+                "G23": {
+                    "content": "=_t(\"Revenue\")"
+                }
+            },
+            "styles": {
+                "A6": 1,
+                "A22": 1,
+                "E22": 1,
+                "A23": 2,
+                "E23": 2,
+                "B23:C23": 3,
+                "F23:G23": 3
+            },
+            "formats": {},
+            "borders": {
+                "A22:C22": 1,
+                "A6:G6": 1,
+                "E22:G22": 1,
+                "A23:C23": 2,
+                "A7:G7": 2,
+                "E23:G23": 2,
+                "A24": 3,
+                "E24": 3,
+                "A25:A32": 4,
+                "E25:E32": 4,
+                "A33:C33": 5,
+                "E33:G33": 5,
+                "B24": 6,
+                "F24": 6,
+                "B25:B32": 7,
+                "F25:F32": 7,
+                "C24": 8,
+                "G24": 8,
+                "C25:C32": 9,
+                "G25:G32": 9
+            },
+            "conditionalFormats": [],
+            "figures": [
+                {
+                    "id": "a761d77e-17d1-4d7a-ac85-5494c07dd360",
+                    "x": 0,
+                    "y": 9,
+                    "width": 209,
+                    "height": 106,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "percentage",
+                        "title": {
+                            "text": "Carts",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#EFF6FF",
+                        "baseline": "Data!E2",
+                        "baselineDescr": "since last period",
+                        "keyValue": "Data!D2",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "7db1cb48-a155-4984-b8dd-de155db2b65f",
+                    "x": 220,
+                    "y": 9,
+                    "width": 209,
+                    "height": 106,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "percentage",
+                        "title": {
+                            "text": "Orders",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#EFF6FF",
+                        "baseline": "Data!E3",
+                        "baselineDescr": "since last period",
+                        "keyValue": "Data!D3",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "1bfef494-7090-4263-8e07-83f14f43c0e7",
+                    "x": 441,
+                    "y": 9,
+                    "width": 209,
+                    "height": 106,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "percentage",
+                        "title": {
+                            "text": "Abandoned Carts",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#EFF6FF",
+                        "baseline": "Data!E4",
+                        "baselineDescr": "since last period",
+                        "keyValue": "Data!D4",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "79d91c01-7aeb-4845-aa82-5a41895b74af",
+                    "x": 661,
+                    "y": 9,
+                    "width": 209,
+                    "height": 106,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "percentage",
+                        "title": {
+                            "text": "Total Revenue",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#FFF7ED",
+                        "baseline": "Data!E5",
+                        "baselineDescr": "since last period",
+                        "keyValue": "Data!D5",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "7792afad-3707-4c60-ae72-10f9c9bf1363",
+                    "x": 0,
+                    "y": 162.61328125,
+                    "width": 1010,
+                    "height": 346,
+                    "tag": "chart",
+                    "data": {
+                        "type": "line",
+                        "dataSetsHaveTitle": false,
+                        "dataSets": [
+                            {
+                                "dataRange": "Data!C8:C15",
+                                "yAxisId": "y"
+                            }
+                        ],
+                        "legendPosition": "none",
+                        "labelRange": "Data!A8:A15",
+                        "title": {},
+                        "labelsAsText": true,
+                        "stacked": false,
+                        "aggregated": false,
+                        "cumulative": true,
+                        "fillArea": true
+                    }
+                }
+            ],
+            "tables": [],
+            "areGridLinesVisible": true,
+            "isVisible": true,
+            "headerGroups": {
+                "ROW": [],
+                "COL": []
+            },
+            "dataValidationRules": [],
+            "comments": {}
+        },
+        {
+            "id": "795f40fb-7598-4275-b0a8-549499781f22",
+            "name": "Data",
+            "colNumber": 26,
+            "rowNumber": 100,
+            "rows": {},
+            "cols": {},
+            "merges": [],
+            "cells": {
+                "A1": {
+                    "content": "=_t(\"KPI\")"
+                },
+                "A2": {
+                    "content": "=_t(\"Carts\")"
+                },
+                "A3": {
+                    "content": "=_t(\"Orders\")"
+                },
+                "A4": {
+                    "content": "=_t(\"Abandoned Carts\")"
+                },
+                "A5": {
+                    "content": "=_t(\"Revenue\")"
+                },
+                "A8": {
+                    "content": "=EDATE(TODAY(),-B8)"
+                },
+                "A9": {
+                    "content": "=EDATE(TODAY(),-B9)"
+                },
+                "A10": {
+                    "content": "=EDATE(TODAY(),-B10)"
+                },
+                "A11": {
+                    "content": "=EDATE(TODAY(),-B11)"
+                },
+                "A12": {
+                    "content": "=EDATE(TODAY(),-B12)"
+                },
+                "A13": {
+                    "content": "=EDATE(TODAY(),-B13)"
+                },
+                "A14": {
+                    "content": "=EDATE(TODAY(),-B14)"
+                },
+                "A15": {
+                    "content": "=EDATE(TODAY(),-B15)"
+                },
+                "B1": {
+                    "content": "=_t(\"Current\")"
+                },
+                "B2": {
+                    "content": "5786"
+                },
+                "B3": {
+                    "content": "3982"
+                },
+                "B4": {
+                    "content": "=B2-B3"
+                },
+                "B5": {
+                    "content": "59568"
+                },
+                "B8": {
+                    "content": "7"
+                },
+                "B9": {
+                    "content": "6"
+                },
+                "B10": {
+                    "content": "5"
+                },
+                "B11": {
+                    "content": "4"
+                },
+                "B12": {
+                    "content": "3"
+                },
+                "B13": {
+                    "content": "2"
+                },
+                "B14": {
+                    "content": "1"
+                },
+                "B15": {
+                    "content": "0"
+                },
+                "C1": {
+                    "content": "=_t(\"Previous\")"
+                },
+                "C2": {
+                    "content": "4578"
+                },
+                "C3": {
+                    "content": "2545"
+                },
+                "C4": {
+                    "content": "=C2-C3"
+                },
+                "C5": {
+                    "content": "49802"
+                },
+                "C8": {
+                    "content": "156470"
+                },
+                "C9": {
+                    "content": "85155"
+                },
+                "C10": {
+                    "content": "59117"
+                },
+                "C11": {
+                    "content": "156863"
+                },
+                "C12": {
+                    "content": "110368"
+                },
+                "C13": {
+                    "content": "90088"
+                },
+                "C14": {
+                    "content": "165450"
+                },
+                "C15": {
+                    "content": "389601"
+                },
+                "D1": {
+                    "content": "=_t(\"Current\")"
+                },
+                "D2": {
+                    "content": "=FORMAT.LARGE.NUMBER(B2)"
+                },
+                "D3": {
+                    "content": "=FORMAT.LARGE.NUMBER(B3)"
+                },
+                "D4": {
+                    "content": "=FORMAT.LARGE.NUMBER(B4)"
+                },
+                "D5": {
+                    "content": "=FORMAT.LARGE.NUMBER(B5)"
+                },
+                "E1": {
+                    "content": "=_t(\"Previous\")"
+                },
+                "E2": {
+                    "content": "=FORMAT.LARGE.NUMBER(C2)"
+                },
+                "E3": {
+                    "content": "=FORMAT.LARGE.NUMBER(C3)"
+                },
+                "E4": {
+                    "content": "=FORMAT.LARGE.NUMBER(C4)"
+                },
+                "E5": {
+                    "content": "=FORMAT.LARGE.NUMBER(C5)"
+                }
+            },
+            "styles": {
+                "A1:E1": 4,
+                "D2:E5": 5
+            },
+            "formats": {
+                "A8:A15": 1,
+                "C8:C15": 2,
+                "B3:E3": 2,
+                "B5:E5": 2
+            },
+            "borders": {},
+            "conditionalFormats": [],
+            "figures": [],
+            "tables": [],
+            "areGridLinesVisible": true,
+            "isVisible": true,
+            "headerGroups": {
+                "ROW": [],
+                "COL": []
+            },
+            "dataValidationRules": [],
+            "comments": {}
+        }
+    ],
+    "styles": {
+        "1": {
+            "fontSize": 16,
+            "bold": true
+        },
+        "2": {
+            "textColor": "#434343",
+            "bold": true,
+            "fontSize": 11
+        },
+        "3": {
+            "textColor": "#434343",
+            "bold": true,
+            "fontSize": 11,
+            "align": "center"
+        },
+        "4": {
+            "bold": true
+        },
+        "5": {
+            "fillColor": "#EFEFEF"
+        }
+    },
+    "formats": {
+        "1": "mmmm yyyy",
+        "2": "[$$]#,##0"
+    },
+    "borders": {
+        "1": {
+            "bottom": {
+                "style": "thin",
+                "color": "#CCCCCC"
+            }
+        },
+        "2": {
+            "top": {
+                "style": "thin",
+                "color": "#CCCCCC"
+            }
+        },
+        "3": {
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "4": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "5": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "6": {
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "7": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "right": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "8": {
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "9": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            },
+            "left": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        }
+    },
+    "revisionId": "START_REVISION",
+    "uniqueFigureIds": true,
+    "settings": {
+        "locale": {
+            "name": "English (US)",
+            "code": "en_US",
+            "thousandsSeparator": ",",
+            "decimalSeparator": ".",
+            "dateFormat": "mm/dd/yyyy",
+            "timeFormat": "hh:mm:ss",
+            "formulaArgSeparator": ",",
+            "weekStart": 7
+        }
+    },
+    "pivots": {},
+    "pivotNextId": 9,
+    "customTableStyles": {},
+    "odooVersion": 12,
+    "globalFilters": [],
+    "lists": {},
+    "listNextId": 1
+}

--- a/addons/spreadsheet_dashboard_website_sale_slides/data/dashboards.xml
+++ b/addons/spreadsheet_dashboard_website_sale_slides/data/dashboards.xml
@@ -4,6 +4,8 @@
     <record id="spreadsheet_dashboard_elearning" model="spreadsheet.dashboard">
         <field name="name">eLearning</field>
         <field name="spreadsheet_binary_data" type="base64" file="spreadsheet_dashboard_website_sale_slides/data/files/elearning_dashboard.json"/>
+        <field name="main_data_model_ids" eval="[(4, ref('sale.model_sale_order'))]"/>
+        <field name="sample_dashboard_file_path">spreadsheet_dashboard_website_sale_slides/data/files/elearning_sample_dashboard.json</field>
         <field name="dashboard_group_id" ref="spreadsheet_dashboard.spreadsheet_dashboard_group_website"/>
         <field name="group_ids" eval="[Command.link(ref('website_slides.group_website_slides_manager'))]"/>
         <field name="sequence">200</field>

--- a/addons/spreadsheet_dashboard_website_sale_slides/data/files/elearning_sample_dashboard.json
+++ b/addons/spreadsheet_dashboard_website_sale_slides/data/files/elearning_sample_dashboard.json
@@ -1,0 +1,675 @@
+{
+    "version": 21,
+    "sheets": [
+        {
+            "id": "sheet1",
+            "name": "Dashboard",
+            "colNumber": 11,
+            "rowNumber": 42,
+            "rows": {
+                "6": {
+                    "size": 40
+                },
+                "22": {
+                    "size": 40
+                }
+            },
+            "cols": {
+                "0": {
+                    "size": 100
+                },
+                "1": {
+                    "size": 100
+                },
+                "2": {
+                    "size": 100
+                },
+                "3": {
+                    "size": 100
+                },
+                "4": {
+                    "size": 75
+                },
+                "5": {
+                    "size": 50
+                },
+                "6": {
+                    "size": 100
+                },
+                "7": {
+                    "size": 100
+                },
+                "8": {
+                    "size": 100
+                },
+                "9": {
+                    "size": 100
+                },
+                "10": {
+                    "size": 75
+                }
+            },
+            "merges": [],
+            "cells": {
+                "A7": {
+                    "content": "[Revenues](odoo://view/{\"viewType\":\"graph\",\"action\":{\"domain\":[[\"product_id.channel_ids\",\"!=\",false]],\"context\":{\"group_by\":[\"date:month\"],\"graph_measure\":\"price_subtotal\",\"graph_mode\":\"line\",\"graph_groupbys\":[\"date:month\"]},\"modelName\":\"sale.report\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"eLearning Revenues\"})"
+                },
+                "A23": {
+                    "content": "[Attendees by Course](odoo://view/{\"viewType\":\"graph\",\"action\":{\"domain\":[],\"context\":{\"group_by\":[\"channel_id\"],\"graph_measure\":\"__count\",\"graph_mode\":\"bar\",\"graph_groupbys\":[\"channel_id\"]},\"modelName\":\"slide.channel.partner\",\"views\":[[false,\"list\"],[false,\"form\"],[false,\"kanban\"],[false,\"pivot\"],[false,\"graph\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Attendees by Course\"})"
+                },
+                "G23": {
+                    "content": "[Views by Course](odoo://view/{\"viewType\":\"graph\",\"action\":{\"domain\":[[\"is_category\",\"=\",false]],\"context\":{\"group_by\":[\"channel_id\",\"slide_category\"],\"graph_measure\":\"total_views\",\"graph_mode\":\"bar\",\"graph_groupbys\":[\"channel_id\",\"slide_category\"]},\"modelName\":\"slide.slide\",\"views\":[[false,\"graph\"],[false,\"list\"],[false,\"form\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Views by Course\"})"
+                }
+            },
+            "styles": {
+                "A7": 1,
+                "A23": 1,
+                "G23": 1
+            },
+            "formats": {},
+            "borders": {
+                "A23:E23": 1,
+                "A7:K7": 1,
+                "G23:K23": 1,
+                "A24:E24": 2,
+                "A8:K8": 2,
+                "G24:K24": 2
+            },
+            "conditionalFormats": [],
+            "figures": [
+                {
+                    "id": "cc154c8b-08a2-4878-b245-37ea92d373c8",
+                    "x": 0,
+                    "y": 12,
+                    "width": 192,
+                    "height": 104,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "difference",
+                        "title": {
+                            "text": "Courses",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#EFF6FF",
+                        "keyValue": "Data!D2",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "1a2f0ccc-460d-405a-aa89-a3f39a771104",
+                    "x": 202,
+                    "y": 12,
+                    "width": 192,
+                    "height": 104,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "difference",
+                        "title": {
+                            "text": "Content",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#EFF6FF",
+                        "keyValue": "Data!D3",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "1f39216f-cebd-4884-8cfb-27d94e5c2e22",
+                    "x": 606,
+                    "y": 12,
+                    "width": 192,
+                    "height": 104,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "percentage",
+                        "title": {
+                            "text": "Attendees",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#EFF6FF",
+                        "baseline": "Data!E4",
+                        "baselineDescr": "since last period",
+                        "keyValue": "Data!D4",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "165a7593-a6b6-4c5d-8758-d9b09572fa30",
+                    "x": 808,
+                    "y": 12,
+                    "width": 192,
+                    "height": 104,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "percentage",
+                        "title": {
+                            "text": "Revenue",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#FFF7ED",
+                        "baseline": "Data!E6",
+                        "baselineDescr": "since last period",
+                        "keyValue": "Data!D6",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "bbd06704-ff49-496b-90dc-e1616f65d613",
+                    "x": 404,
+                    "y": 12,
+                    "width": 192,
+                    "height": 104,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "difference",
+                        "title": {
+                            "text": "Rating",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#EFF6FF",
+                        "keyValue": "Data!D5",
+                        "humanize": false
+                    }
+                },
+                {
+                    "id": "569091e3-1b9b-43b7-8f79-26fed8c39a4d",
+                    "x": 0,
+                    "y": 178,
+                    "width": 1000,
+                    "height": 345,
+                    "tag": "chart",
+                    "data": {
+                        "type": "line",
+                        "dataSetsHaveTitle": false,
+                        "dataSets": [
+                            {
+                                "dataRange": "Data!C9:C16",
+                                "yAxisId": "y"
+                            }
+                        ],
+                        "legendPosition": "none",
+                        "labelRange": "Data!A9:A16",
+                        "title": {},
+                        "labelsAsText": true,
+                        "stacked": false,
+                        "aggregated": false,
+                        "cumulative": true,
+                        "fillArea": true
+                    }
+                },
+                {
+                    "id": "fbf2d9af-f4ca-4c52-8f24-076dd9f873b9",
+                    "x": 0,
+                    "y": 563,
+                    "width": 477,
+                    "height": 392,
+                    "tag": "chart",
+                    "data": {
+                        "type": "bar",
+                        "dataSetsHaveTitle": false,
+                        "dataSets": [
+                            {
+                                "dataRange": "Data!B20:B24",
+                                "yAxisId": "y"
+                            }
+                        ],
+                        "legendPosition": "none",
+                        "labelRange": "Data!A20:A24",
+                        "title": {},
+                        "stacked": false,
+                        "aggregated": false
+                    }
+                },
+                {
+                    "id": "491d9161-1056-4615-90a7-33b13cb778b5",
+                    "x": 525,
+                    "y": 563,
+                    "width": 475,
+                    "height": 391,
+                    "tag": "chart",
+                    "data": {
+                        "type": "bar",
+                        "dataSetsHaveTitle": true,
+                        "dataSets": [
+                            {
+                                "dataRange": "Data!B27:B32",
+                                "yAxisId": "y"
+                            },
+                            {
+                                "dataRange": "Data!C27:C32"
+                            },
+                            {
+                                "dataRange": "Data!D27:D32"
+                            },
+                            {
+                                "dataRange": "Data!E27:E32"
+                            },
+                            {
+                                "dataRange": "Data!F27:F32"
+                            }
+                        ],
+                        "legendPosition": "top",
+                        "labelRange": "Data!A27:A32",
+                        "title": {},
+                        "stacked": true,
+                        "aggregated": false,
+                        "horizontal": false
+                    }
+                }
+            ],
+            "tables": [],
+            "areGridLinesVisible": true,
+            "isVisible": true,
+            "headerGroups": {
+                "ROW": [],
+                "COL": []
+            },
+            "dataValidationRules": [],
+            "comments": {}
+        },
+        {
+            "id": "7c4d0b0e-26a0-410c-b37f-b7e0c2c819c8",
+            "name": "Data",
+            "colNumber": 26,
+            "rowNumber": 96,
+            "rows": {},
+            "cols": {},
+            "merges": [],
+            "cells": {
+                "A2": {
+                    "content": "=_t(\"Courses\")"
+                },
+                "A3": {
+                    "content": "=_t(\"Content\")"
+                },
+                "A4": {
+                    "content": "=_t(\"Attendees\")"
+                },
+                "A5": {
+                    "content": "=_t(\"Rating\")"
+                },
+                "A6": {
+                    "content": "=_t(\"Revenue\")"
+                },
+                "A9": {
+                    "content": "=EDATE(TODAY(),-B9)"
+                },
+                "A10": {
+                    "content": "=EDATE(TODAY(),-B10)"
+                },
+                "A11": {
+                    "content": "=EDATE(TODAY(),-B11)"
+                },
+                "A12": {
+                    "content": "=EDATE(TODAY(),-B12)"
+                },
+                "A13": {
+                    "content": "=EDATE(TODAY(),-B13)"
+                },
+                "A14": {
+                    "content": "=EDATE(TODAY(),-B14)"
+                },
+                "A15": {
+                    "content": "=EDATE(TODAY(),-B15)"
+                },
+                "A16": {
+                    "content": "=EDATE(TODAY(),-B16)"
+                },
+                "A19": {
+                    "content": "=_t(\"Attendees by course\")"
+                },
+                "A20": {
+                    "content": "=_t(\"Introduction to AI\")"
+                },
+                "A21": {
+                    "content": "=_t(\"Python for Beginners\")"
+                },
+                "A22": {
+                    "content": "=_t(\"Data Science 101\")"
+                },
+                "A23": {
+                    "content": "=_t(\"AWS Cloud Essentials\")"
+                },
+                "A24": {
+                    "content": "=_t(\"Machine Learning Basics\")"
+                },
+                "A27": {
+                    "content": "=_t(\"Views by course\")"
+                },
+                "A28": {
+                    "content": "=_t(\"Introduction to AI\")"
+                },
+                "A29": {
+                    "content": "=_t(\"Python for Beginners\")"
+                },
+                "A30": {
+                    "content": "=_t(\"Data Science 101\")"
+                },
+                "A31": {
+                    "content": "=_t(\"AWS Cloud Essentials\")"
+                },
+                "A32": {
+                    "content": "=_t(\"Machine Learning Basics\")"
+                },
+                "B1": {
+                    "content": "=_t(\"Current\")"
+                },
+                "B2": {
+                    "content": "35"
+                },
+                "B3": {
+                    "content": "145"
+                },
+                "B4": {
+                    "content": "3562"
+                },
+                "B5": {
+                    "content": "4.2"
+                },
+                "B6": {
+                    "content": "17478"
+                },
+                "B9": {
+                    "content": "7"
+                },
+                "B10": {
+                    "content": "6"
+                },
+                "B11": {
+                    "content": "5"
+                },
+                "B12": {
+                    "content": "4"
+                },
+                "B13": {
+                    "content": "3"
+                },
+                "B14": {
+                    "content": "2"
+                },
+                "B15": {
+                    "content": "1"
+                },
+                "B16": {
+                    "content": "0"
+                },
+                "B20": {
+                    "content": "120"
+                },
+                "B21": {
+                    "content": "85"
+                },
+                "B22": {
+                    "content": "95"
+                },
+                "B23": {
+                    "content": "67"
+                },
+                "B24": {
+                    "content": "100"
+                },
+                "B27": {
+                    "content": "=_t(\"Article\")"
+                },
+                "B28": {
+                    "content": "85"
+                },
+                "B29": {
+                    "content": "55"
+                },
+                "B30": {
+                    "content": "76"
+                },
+                "B31": {
+                    "content": "70"
+                },
+                "B32": {
+                    "content": "83"
+                },
+                "C1": {
+                    "content": "=_t(\"Previous\")"
+                },
+                "C2": {
+                    "content": "20"
+                },
+                "C3": {
+                    "content": "123"
+                },
+                "C4": {
+                    "content": "2987"
+                },
+                "C6": {
+                    "content": "11456"
+                },
+                "C9": {
+                    "content": "147574"
+                },
+                "C10": {
+                    "content": "234217"
+                },
+                "C11": {
+                    "content": "455646"
+                },
+                "C12": {
+                    "content": "184701"
+                },
+                "C13": {
+                    "content": "128578"
+                },
+                "C14": {
+                    "content": "177586"
+                },
+                "C15": {
+                    "content": "70810"
+                },
+                "C16": {
+                    "content": "455098"
+                },
+                "C27": {
+                    "content": "=_t(\"Document\")"
+                },
+                "C28": {
+                    "content": "92"
+                },
+                "C29": {
+                    "content": "94"
+                },
+                "C30": {
+                    "content": "52"
+                },
+                "C31": {
+                    "content": "53"
+                },
+                "C32": {
+                    "content": "65"
+                },
+                "D1": {
+                    "content": "=_t(\"Current\")"
+                },
+                "D2": {
+                    "content": "=FORMAT.LARGE.NUMBER(B2)"
+                },
+                "D3": {
+                    "content": "=FORMAT.LARGE.NUMBER(B3)"
+                },
+                "D4": {
+                    "content": "=FORMAT.LARGE.NUMBER(B4)"
+                },
+                "D5": {
+                    "content": "=CONCATENATE(B5,\"/5\")"
+                },
+                "D6": {
+                    "content": "=FORMAT.LARGE.NUMBER(B6)"
+                },
+                "D27": {
+                    "content": "=_t(\"Image\")"
+                },
+                "D28": {
+                    "content": "101"
+                },
+                "D29": {
+                    "content": "77"
+                },
+                "D30": {
+                    "content": "109"
+                },
+                "D31": {
+                    "content": "75"
+                },
+                "D32": {
+                    "content": "76"
+                },
+                "E1": {
+                    "content": "=_t(\"Previous\")"
+                },
+                "E4": {
+                    "content": "=FORMAT.LARGE.NUMBER(C4)"
+                },
+                "E6": {
+                    "content": "=FORMAT.LARGE.NUMBER(C6)"
+                },
+                "E27": {
+                    "content": "=_t(\"Video\")"
+                },
+                "E28": {
+                    "content": "78"
+                },
+                "E29": {
+                    "content": "97"
+                },
+                "E30": {
+                    "content": "116"
+                },
+                "E31": {
+                    "content": "91"
+                },
+                "E32": {
+                    "content": "68"
+                },
+                "F27": {
+                    "content": "=_t(\"Quiz\")"
+                },
+                "F28": {
+                    "content": "79"
+                },
+                "F29": {
+                    "content": "76"
+                },
+                "F30": {
+                    "content": "87"
+                },
+                "F31": {
+                    "content": "117"
+                },
+                "F32": {
+                    "content": "51"
+                }
+            },
+            "styles": {
+                "B1:E1": 2,
+                "D2:D4": 3,
+                "E4": 3,
+                "D6:E6": 3,
+                "D5": 4
+            },
+            "formats": {
+                "A9:A16": 1,
+                "B2:B4": 2,
+                "C4": 2,
+                "B5": 3,
+                "C9:C16": 4,
+                "B6:E6": 4
+            },
+            "borders": {},
+            "conditionalFormats": [],
+            "figures": [],
+            "tables": [],
+            "areGridLinesVisible": true,
+            "isVisible": true,
+            "headerGroups": {
+                "ROW": [],
+                "COL": []
+            },
+            "dataValidationRules": [],
+            "comments": {}
+        }
+    ],
+    "styles": {
+        "1": {
+            "textColor": "#01666b",
+            "bold": true,
+            "fontSize": 16
+        },
+        "2": {
+            "bold": true
+        },
+        "3": {
+            "fillColor": "#f2f2f2"
+        },
+        "4": {
+            "fillColor": "#f2f2f2",
+            "align": "right"
+        }
+    },
+    "formats": {
+        "1": "mmmm yyyy",
+        "2": "0",
+        "3": "#,##0",
+        "4": "[$$]#,##0"
+    },
+    "borders": {
+        "1": {
+            "bottom": {
+                "style": "thin",
+                "color": "#CCCCCC"
+            }
+        },
+        "2": {
+            "top": {
+                "style": "thin",
+                "color": "#CCCCCC"
+            }
+        }
+    },
+    "revisionId": "START_REVISION",
+    "uniqueFigureIds": true,
+    "settings": {
+        "locale": {
+            "name": "English (US)",
+            "code": "en_US",
+            "thousandsSeparator": ",",
+            "decimalSeparator": ".",
+            "dateFormat": "mm/dd/yyyy",
+            "timeFormat": "hh:mm:ss",
+            "formulaArgSeparator": ",",
+            "weekStart": 7
+        }
+    },
+    "pivots": {},
+    "pivotNextId": 12,
+    "customTableStyles": {},
+    "odooVersion": 12,
+    "globalFilters": [],
+    "lists": {},
+    "listNextId": 1
+}

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -1103,16 +1103,17 @@ def extract_spreadsheet_terms(fileobj, keywords, comment_tags, options):
                 if markdown_link:
                     terms.append(markdown_link[1])
         for figure in sheet['figures']:
-            title = figure['data']['title']
-            if isinstance(title, str):
-                terms.append(title)
-            elif 'text' in title:
-                terms.append(title['text'])
-            if 'axesDesign' in figure['data']:
-                for axes in figure['data']['axesDesign'].values():
-                    terms.append(axes.get('title', {}).get('text', ''))
-            if 'baselineDescr' in figure['data']:
-                terms.append(figure['data']['baselineDescr'])
+            if figure['tag'] == 'chart':
+                title = figure['data']['title']
+                if isinstance(title, str):
+                    terms.append(title)
+                elif 'text' in title:
+                    terms.append(title['text'])
+                if 'axesDesign' in figure['data']:
+                    for axes in figure['data']['axesDesign'].values():
+                        terms.append(axes.get('title', {}).get('text', ''))
+                if 'baselineDescr' in figure['data']:
+                    terms.append(figure['data']['baselineDescr'])
     pivots = data.get('pivots', {}).values()
     lists = data.get('lists', {}).values()
     for data_source in itertools.chain(lists, pivots):


### PR DESCRIPTION
Currently, users with an fresh empty database will only see empty
dashboards. They will go through a list of empty tables and charts without any
data and probably miss the potential of the dashboard app.

For a proper onboarding experience, they should be greeted with a sample
dashboard to give them a better idea of the dashboard look and use.

Technically, we store sample json files to be used when the
main model (the model that is used the most in the dashboard) has no records.

task-3947773

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
