### PR TITLE
[PERF] point_of_sale: optimize product addition to cart

### DIFF
--- a/addons/point_of_sale/static/src/app/models/data_service_options.js
+++ b/addons/point_of_sale/static/src/app/models/data_service_options.js
@@ -31,8 +31,8 @@ export class DataServiceOptions {
                 name: "product.product",
                 key: "id",
                 condition: (record) => {
-                    return record.models["pos.order.line"].find(
-                        (l) => l.product_id?.id === record.id
+                    return record["<-pos.order.line.product_id"].find(
+                        (l) => !(l.order_id?.finalized && typeof l.order_id.id === "number")
                     );
                 },
             },


### PR DESCRIPTION
Before this commit, adding a product to the cart became progressively slower after creating several orders in the PoS, especially when a high number of products were loaded. This performance issue was due to the search operation across all order lines for each product, which became increasingly inefficient with a large number of loaded products and created orders. To address this, "<-pos.order.line.product_id" is now utilized to directly find the corresponding order line, significantly reducing the time complexity and improving the responsiveness of product addition to the cart.

opw-4209134

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
