### PR TITLE
[REF] web: kanban: drop bold and display attrs support

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_compiler.js
+++ b/addons/web/static/src/views/kanban/kanban_compiler.js
@@ -128,22 +128,25 @@ export class KanbanCompiler extends ViewCompiler {
             }
         }
 
-        const { bold, display } = extractAttributes(el, ["bold", "display"]);
-        const classNames = [];
-        if (display === "right") {
-            classNames.push("float-end");
-        } else if (display === "full") {
-            classNames.push("o_text_block");
+        if (params.isLegacy) {
+            const { bold, display } = extractAttributes(el, ["bold", "display"]);
+            const classNames = [];
+            if (display === "right") {
+                classNames.push("floatend");
+            } else if (display === "full") {
+                classNames.push("o_text_block");
+            }
+            if (bold) {
+                classNames.push("o_text_bold");
+            }
+            if (classNames.length > 0) {
+                const clsFormatted = isSpan
+                    ? classNames.join(" ")
+                    : toStringExpression(classNames.join(" "));
+                compiled.setAttribute("class", clsFormatted);
+            }
         }
-        if (bold) {
-            classNames.push("o_text_bold");
-        }
-        if (classNames.length > 0) {
-            const clsFormatted = isSpan
-                ? classNames.join(" ")
-                : toStringExpression(classNames.join(" "));
-            compiled.setAttribute("class", clsFormatted);
-        }
+
         const attrs = {};
         for (const attr of el.attributes) {
             attrs[attr.name] = attr.value;

--- a/addons/web/static/src/views/kanban/kanban_record.js
+++ b/addons/web/static/src/views/kanban/kanban_record.js
@@ -205,10 +205,11 @@ export class KanbanRecord extends Component {
         this.dialog = useService("dialog");
         this.notification = useService("notification");
 
-        const { Compiler, templates } = this.props;
+        const { archInfo, Compiler, templates } = this.props;
         const ViewCompiler = Compiler || this.constructor.Compiler;
+        const isLegacy = archInfo.isLegacyArch;
 
-        this.templates = useViewCompiler(ViewCompiler, templates);
+        this.templates = useViewCompiler(ViewCompiler, templates, { isLegacy });
 
         this.menuTemplateName = this.props.archInfo.isLegacyArch
             ? this.constructor.LEGACY_KANBAN_MENU_ATTRIBUTE

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -442,24 +442,6 @@ test.tags("desktop")("Hide tooltip when user click inside a kanban headers item"
     expect(".o-tooltip").toHaveCount(0);
 });
 
-test("display full is supported on fields", async () => {
-    await mountView({
-        type: "kanban",
-        resModel: "partner",
-        arch: `
-        <kanban class="o_kanban_test">
-            <templates>
-                <t t-name="card">
-                    <field name="foo" display="full"/>
-                </t>
-            </templates>
-        </kanban>`,
-    });
-
-    expect(".o_kanban_record span.o_text_block").toHaveCount(4);
-    expect(queryFirst("span.o_text_block").textContent).toBe("yop");
-});
-
 test.tags("desktop")("basic grouped rendering", async () => {
     expect.assertions(16);
 

--- a/addons/web/static/tests/views/kanban/kanban_view_legacy.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view_legacy.test.js
@@ -196,7 +196,7 @@ beforeEach(() => {
     });
 });
 
-test("display full is supported on fields", async () => {
+test.debug("display full is supported on fields", async () => {
     await mountView({
         type: "kanban",
         resModel: "partner",


### PR DESCRIPTION
*in new API kanban views.

Those attributes were no longer used in standard views. Instead, we want to encourage the use of bootstrap utility classes (e.g. fw-bold). Note that we keep supporting them in legacy archs (those using "kanban-box"). The support of legacy archs will be dropped after v18.

Part of task~3992107

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
