### PR TITLE
master-time-off-accruals-carry-over-validity-time-on-dashboard-akha

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -586,9 +586,9 @@ class HolidaysType(models.Model):
                         leave_type_data[1][key] = round(value, 2)
         return allocation_data
 
-    def _get_closest_expiring_leaves_date_and_count(self, allocations, remaining_leaves, target_date):
+    def _get_closest_expiring_leaves_date_and_count(self, allocations, allocation_data, target_date):
         # Get the expiration date and carryover date of all allocations and compute the closest expiration date
-        expiration_dates_per_allocation = defaultdict(lambda: {'expiration_date': fields.Date(), 'carryover_date': fields.Date()})
+        expiration_dates_per_allocation = defaultdict(lambda: {'expiration_date': fields.Date(), 'carryover_date': fields.Date(), 'carried_over_days_expiration_date': fields.Date()})
         expiration_dates = list()
         for allocation in allocations:
             expiration_date = allocation.date_to
@@ -598,30 +598,39 @@ class HolidaysType(models.Model):
             carryover_date = False
             if carryover_policy in ['maximum', 'lost']:
                 carryover_date = allocation._get_carryover_date(target_date)
-                # If carry over date == target date, then add 1 year to carry over date.
-                # Rational: for example if carry over date = 01/01 this year and target date = 01/01 this year,
-                # then any accrued days on 01/01 this year will have their carry over date 01/01 next year
-                # and not 01/01 this year.
-                if carryover_date == target_date:
-                    carryover_date += relativedelta(years=1)
 
-            expiration_dates.extend([expiration_date, carryover_date])
+            carried_over_days_expiration_date = allocation_data[allocation]['carried_over_days_expiration_date']
+
+            expiration_dates.extend([expiration_date, carryover_date, carried_over_days_expiration_date])
             expiration_dates_per_allocation[allocation]['expiration_date'] = expiration_date
             expiration_dates_per_allocation[allocation]['carryover_date'] = carryover_date
+            expiration_dates_per_allocation[allocation]['carried_over_days_expiration_date'] = carried_over_days_expiration_date
 
         expiration_dates = list(filter(lambda date: date is not False, expiration_dates))
         expiration_dates.sort()
         # Compute the number of expiring leaves
         for closest_expiration_date in expiration_dates:
+            # If closest_expiration_date == target date, then closest_expiration_date isn't the
+            # required expiration date.
+            # Rational: If an employee has 8 days 5 of which will expire on 01/01 this year, then
+            # on 01/01 this year the employee will have 3 days (because 5 days have just expired)
+            # and the expiration date of the 3 days will be different than 01/01 this year.
+            if closest_expiration_date == target_date:
+                continue
             expiring_leaves_count = 0
             for allocation in allocations:
                 expiration_date = expiration_dates_per_allocation[allocation]['expiration_date']
                 carryover_date = expiration_dates_per_allocation[allocation]['carryover_date']
+                carried_over_days_expiration_date = expiration_dates_per_allocation[allocation]['carried_over_days_expiration_date']
+
                 if expiration_date and expiration_date == closest_expiration_date:
-                    expiring_leaves_count += remaining_leaves[allocation]['virtual_remaining_leaves']
+                    expiring_leaves_count += allocation_data[allocation]['virtual_remaining_leaves']
                 elif carryover_date and carryover_date == closest_expiration_date:
                     accrual_plan_level = allocation._get_current_accrual_plan_level_id(target_date)[0]
-                    expiring_leaves_count += max(0, remaining_leaves[allocation]['virtual_remaining_leaves'] - accrual_plan_level.postpone_max_days)
+                    expiring_leaves_count += max(0, allocation_data[allocation]['virtual_remaining_leaves'] - accrual_plan_level.postpone_max_days)
+                elif carried_over_days_expiration_date and carried_over_days_expiration_date == closest_expiration_date:
+                    expiring_leaves_count += max(0, allocation_data[allocation]['expiring_carryover_days'] - allocation_data[allocation]['virtual_leaves_taken'])
+
             if expiring_leaves_count != 0:
                 return closest_expiration_date, expiring_leaves_count
 

--- a/addons/hr_holidays/tests/test_expiring_leaves.py
+++ b/addons/hr_holidays/tests/test_expiring_leaves.py
@@ -23,6 +23,29 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
             'requires_allocation': 'yes',
             'allocation_validation_type': 'no_validation',
         })
+        cls.accrual_plan_with_accrual_validity = cls.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).sudo().create({
+            'name': 'Test Accrual Plan With Accrual Validity',
+            'carryover_date': 'other',
+            'carryover_day': 1,
+            'carryover_month': 'apr',
+            'level_ids': [
+                (0, 0, {
+                'start_count': 0,
+                'start_type': 'day',
+                'added_value': 3,
+                'added_value_type': 'day',
+                'frequency': 'yearly',
+                'yearly_day': 1,
+                'yearly_month': 'jan',
+                'cap_accrued_time': False,
+                'action_with_unused_accruals': 'maximum',
+                'postpone_max_days': 5,
+                'accrual_validity': True,
+                'accrual_validity_count': 3,
+                'accrual_validity_type': 'month',
+                })
+            ],
+        })
 
     @users('enguerran')
     def test_no_carried_over_leaves(self):
@@ -476,3 +499,144 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
         self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_expire'],
                     (target_date + relativedelta(month=10)).strftime('%m/%d/%Y'),
                     "The expiration date should be the expiration date of the second allocation because no days will expire on carryover date")
+
+    @users('enguerran')
+    def test_carried_over_days_expiration_date(self):
+        """
+        This tess case aims to assert that carried_over_days_expiration_date is taken into account when the
+        expiration date is computed.
+
+        - First accrual plan:
+            - Carryover date : 1st of April.
+            - Has 1 level:
+                - Accrues 3 days yearly on the 1st of January.
+                - Carryover with a maximum of 5 days.
+
+        - Second accrual plan:
+            Has the same definition as the one above except that carried over days are valid for 3 months.
+
+        - Note: the following dates are in format dd/mm/YYYY
+        - Define 2 allocations:
+            - Both allocations will start on 01/01/2023.
+            - One allocation uses the first accrual plan and the other uses the second accrual plan.
+            - Both allocations accrue 3 days yearly.
+            - The first allocation expires on the 1st of October.
+            - The second allocation doesn't expire.
+
+        - On 01/01/2024, both allocations will accrue 3 days for the employee.
+        - If target date is 01/04/2024, then the expiration date should be 01/7/2024 because on 01/04/2024, 3 days will carryover for
+          the second allocation and these 3 days will expire in 3 months.
+        """
+        accrual_plan_without_accrual_validity = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).sudo().create({
+            'name': 'Test Accrual Plan',
+            'carryover_date': 'other',
+            'carryover_day': 1,
+            'carryover_month': 'apr',
+            'level_ids': [
+                (0, 0, {
+                'start_count': 0,
+                'start_type': 'day',
+                'added_value': 3,
+                'added_value_type': 'day',
+                'frequency': 'yearly',
+                'yearly_day': 1,
+                'yearly_month': 'jan',
+                'cap_accrued_time': False,
+                'action_with_unused_accruals': 'maximum',
+                'postpone_max_days': 5,
+                })
+            ],
+        })
+
+        logged_in_emp = self.env.user.employee_id
+        with freeze_time("2023-1-1"):
+            # Allocation 1
+            self.env['hr.leave.allocation'].sudo().create({
+                'date_from': '2023-1-1',
+                'date_to': '2024-10-1',
+                'allocation_type': 'accrual',
+                'accrual_plan_id': accrual_plan_without_accrual_validity.id,
+                'holiday_status_id': self.leave_type.id,
+                'employee_id': logged_in_emp.id,
+                'number_of_days': 0,
+            })
+            # Allocation 2
+            self.env['hr.leave.allocation'].sudo().create({
+                'date_from': '2023-1-1',
+                'allocation_type': 'accrual',
+                'accrual_plan_id': self.accrual_plan_with_accrual_validity.id,
+                'holiday_status_id': self.leave_type.id,
+                'employee_id': logged_in_emp.id,
+                'number_of_days': 0,
+            })
+
+        with freeze_time("2024-4-1"):
+            self.env['hr.leave.allocation'].sudo()._update_accrual()
+
+        target_date = date(2024, 4, 1)
+        allocation_data = self.leave_type.get_allocation_data(logged_in_emp, target_date)
+        # Assert the date of expiration
+        self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_expire'],
+                    (target_date + relativedelta(month=7)).strftime('%m/%d/%Y'),
+                    "The expiration date should be the carried over days expiration date of allocation 3")
+
+        # Assert the number of expiring leaves
+        self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_remaining'], 3)
+
+    @users('enguerran')
+    def test_carried_over_days_expiration_date_2(self):
+        """
+        This tess case aims to assert that the number of expiring leaves on carried_over_days_expiration_date is
+        computed properly
+
+        - Define an accrual plan:
+            - Carryover date : 1st of April.
+            - Has 1 level:
+                - Accrues 3 days yearly on the 1st of January.
+                - Carryover with a maximum of 5 days.
+                - Carried over days are valid for 3 months.
+
+        - Note: the following dates are in format dd/mm/YYYY
+        - Define an allocation:
+            - The allocation will start on 01/01/2023.
+            - The allocation uses the accrual plan defined above.
+            - The allocation expires on the 1st of October.
+
+        - On 01/01/2024, 3 days are accrued.
+        - If target date is 01/05/2024, then the expiration date should be 01/7/2024.
+        - On 01/04/2024, 3 days will carryover.
+        - The employee took 2 days as time off.
+        - The number of expiring days on 01/07/2024 is 1 day.
+        """
+
+        logged_in_emp = self.env.user.employee_id
+        with freeze_time("2023-1-1"):
+            self.env['hr.leave.allocation'].sudo().create({
+                'date_from': '2023-1-1',
+                'allocation_type': 'accrual',
+                'accrual_plan_id': self.accrual_plan_with_accrual_validity.id,
+                'holiday_status_id': self.leave_type.id,
+                'employee_id': logged_in_emp.id,
+                'number_of_days': 0,
+            })
+
+        with freeze_time("2024-4-1"):
+            self.env['hr.leave.allocation'].sudo()._update_accrual()
+            leave = self.env['hr.leave'].create({
+                'name': 'leave',
+                'employee_id': logged_in_emp.id,
+                'holiday_status_id': self.leave_type.id,
+                'request_date_from': '2024-04-03',
+                'request_date_to': '2024-04-04',
+            })
+            leave.sudo().action_validate()
+
+        target_date = date(2024, 5, 1)
+        allocation_data = self.leave_type.get_allocation_data(logged_in_emp, target_date)
+        # Assert the date of expiration
+        self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_expire'],
+                    (target_date + relativedelta(month=7)).strftime('%m/%d/%Y'),
+                    "The expiration date should be the carried over days expiration date of allocation 3")
+
+        # Assert the number of expiring leaves
+        self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_remaining'], 1)


### PR DESCRIPTION
**Update employee's time off balance expiry computation**

In the Time Off app dashboard, employees can view whether some of their unused time off days are set to expire and the exact expiration date.

At the accrual plan level, a validity period can be defined for carried-over days, after which they expire. However, the expiration date of these carried-over days hasn't been considered when calculating the employee's expiring balance.

This update addresses the issue by incorporating the expiration dates of carried-over days into the calculation.

task-4207987