### PR TITLE
[FIX] pos_self_order: order traceback when offline

### DIFF
--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -337,6 +337,10 @@ export class SelfOrder extends Reactive {
         ); // Stripe, Adyen, Online
         const order = await this.sendDraftOrderToServer();
 
+        if (!order) {
+            return;
+        }
+
         // Stand number page will recall this function after the stand number is set
         if (
             service === "table" &&


### PR DESCRIPTION
Traceback is shown when making an order in kiosk because we try to proceed even if no order is created in the backend. In this fix, we return early in the `confirmOrder` procedure when no order is created (e.g. when offline).

The following is shown instead of the traceback:

![Screenshot 2024-09-25 at 13 17 42](https://github.com/user-attachments/assets/c87d241b-2878-444b-a2cf-96cf8ce5ba27)

