### PR TITLE
[FIX] account: Add dependency to compute is_being_sent based on send_and_print_values

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -659,7 +659,8 @@ class AccountMove(models.Model):
                 move.invoice_user_id = move.invoice_user_id or self.env.user
             else:
                 move.invoice_user_id = False
-
+    
+    @api.depends('send_and_print_values')
     def _compute_is_being_sent(self):
         for move in self:
             move.is_being_sent = bool(move.send_and_print_values)


### PR DESCRIPTION

Description of the issue/feature this PR addresses:
The unit test "test_invoice_multi" from account fails when the account_accountant module is installed. 

Current behavior before PR:
1. Install account_accountant
2. Running the unit test test_invoice_multi and the you will see that causes a failure.

Desired behavior after PR is merged:
The unit test test_invoice_multi passes successfully, even with the account_accountant module installed.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
