### PR TITLE
[FIX] account: Show amount_total_signed instead of amount_total

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -544,7 +544,7 @@
                                 </div>
                                 <div class="row">
                                     <div class="col-6">
-                                        <span><field name="amount_total" widget='monetary'/></span>
+                                        <span><field name="amount_total_in_currency_signed" widget='monetary'/></span>
                                         <span><field name="currency_id" invisible="1"/></span>
                                     </div>
                                     <div class="col-6">


### PR DESCRIPTION
Before these changes, the total price of the invoices was displayed in the kanban view without considering whether it was an outgoing or incoming payment. This can cause confusion for the user when charging customers.

![image](https://github.com/user-attachments/assets/4d31596e-d1f6-4469-a477-aefbb8b83aea)

After these changes, the total is displayed with the symbol so that users can easily differentiate the type of invoice, just as it is done in the tree views.

![image](https://github.com/user-attachments/assets/541faed5-0f3a-4b0e-8311-c776faa65eff)

cc @Tecnativa TT50987

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
