### PR TITLE
[IMP] mail: reduce size of mention suggestion

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -100,6 +100,7 @@ export class Composer extends Component {
         this.ref = useRef("textarea");
         this.fakeTextarea = useRef("fakeTextarea");
         this.emojiButton = useRef("emoji-button");
+        this.inputContainerRef = useRef("input-container");
         this.state = useState({
             active: true,
         });
@@ -326,7 +327,7 @@ export class Composer extends Component {
 
     get navigableListProps() {
         const props = {
-            anchorRef: this.ref.el,
+            anchorRef: this.inputContainerRef.el,
             position: this.env.inChatter ? "bottom-fit" : "top-fit",
             onSelect: (ev, option) => {
                 this.suggestion.insert(option);

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -40,6 +40,7 @@
                         'rounded-3 align-self-stretch' : extended,
                         'flex-column': extended or props.composer.message,
                     }"
+                    t-ref="input-container"
                 >
                     <div class="position-relative flex-grow-1">
                         <t t-set="inputClasses" t-value="'o-mail-Composer-inputStyle form-control border-0 rounded-3'"/>

--- a/addons/mail/static/src/core/common/navigable_list.xml
+++ b/addons/mail/static/src/core/common/navigable_list.xml
@@ -15,14 +15,14 @@
                     t-on-click="(ev) => this.selectOption(ev, option_index)"
                 >
                     <hr class="my-2" t-if="option.group != lastGroup and option_index != 0"/>
-                    <a role="button" class="d-flex align-items-center w-100 py-2 px-4" t-att-class="{ 'o-mail-NavigableList-active bg-300': state.activeIndex === option_index }">
+                    <a role="button" class="d-flex align-items-center w-100 px-3 py-1 small" t-att-class="{ 'o-mail-NavigableList-active bg-300': state.activeIndex === option_index }">
                         <t t-if="option.optionTemplate" t-call="{{ option.optionTemplate }}"/>
                         <t t-elif="props.optionTemplate" t-call="{{ props.optionTemplate }}"/>
                         <t t-else="" t-esc="option.label"/>
                     </a>
                     <t t-set="lastGroup" t-value="option.group"/>
                 </div>
-                <span t-if="props.hint" class="text-muted fst-italic form-text align-self-end m-0 me-1" t-esc="props.hint"/>
+                <span t-if="props.hint" class="text-muted fst-italic form-text align-self-end m-0 me-1 smaller" t-esc="props.hint"/>
             </div>
         </div>
     </t>


### PR DESCRIPTION
Spacing was too big, and also size of suggestion list items were as big as any other content. As a result, this was too distracting compared to actual content like message list.

This commit make suggestion items smaller and also reduces spacing around suggestion items. This make suggestion less likely to truncate, so more content of suggestion is visible.

Also suggestion list takes whole width of composer, instead of just the inner textarea.

<img width="1178" alt="Screenshot 2024-09-23 at 13 52 45" src="https://github.com/user-attachments/assets/a806e83d-7662-4f63-8361-f6bf4ed09dbc">
