### PR TITLE
[FIX] website: fix `s_empowerment` snippet width

### DIFF
--- a/addons/website/views/snippets/s_empowerment.xml
+++ b/addons/website/views/snippets/s_empowerment.xml
@@ -3,7 +3,7 @@
 
 <template id="s_empowerment" name="Empowerment">
     <section class="s_empowerment pt24 pb24">
-        <div class="container-fluid">
+        <div class="container">
             <div class="row o_grid_mode" data-row-count="12">
                 <div class="o_grid_item g-height-12 g-col-lg-7 col-lg-7" style="grid-area: 1 / 1 / 13 / 8; --grid-item-padding-x: 24px;">
                     <span class="s_cta_badge d-inline-block my-3 border rounded py-2 px-3 o_cc o_cc1 o_animable" data-snippet="s_cta_badge" data-name="CTA Badge" style="border-radius: 32px !important;">


### PR DESCRIPTION
This commit aims to fix a width issue within the `s_empowerment` snippet.

Prior to this commit, the `container` of the snippet was set to `fluid`. While this was fine at a `1440px` width device, it looked off at a larger one.

This commit changes that class from `container-fluid` to `container` to ensure the best visual result at all size.

task-4211212

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
