### PR TITLE
[FIX] website: fix wrong `g-col-*` class within `s_numbers_grid`

### DIFF
--- a/addons/website/views/snippets/s_numbers_grid.xml
+++ b/addons/website/views/snippets/s_numbers_grid.xml
@@ -5,35 +5,35 @@
     <section class="s_numbers_grid o_cc o_cc2 pt56 pb56">
         <div class="container">
             <div class="row o_grid_mode" data-row-count="6" style="gap: 8px;">
-                <div class="o_grid_item g-col-md-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 1 / 1 / 4 / 4; z-index: 1; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                <div class="o_grid_item g-col-lg-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 1 / 1 / 4 / 4; z-index: 1; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
                     <p>Revenue Growth</p>
                     <span class="display-5">54%</span>
                 </div>
-                <div class="o_grid_item g-col-md-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 1 / 4 / 4 / 7;; z-index: 2; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                <div class="o_grid_item g-col-lg-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 1 / 4 / 4 / 7;; z-index: 2; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
                     <p>Projects deployed</p>
                     <span class="display-5">+225</span>
                 </div>
-                <div class="o_grid_item g-col-md-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 1 / 7 / 4 / 10; z-index: 3; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                <div class="o_grid_item g-col-lg-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 1 / 7 / 4 / 10; z-index: 3; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
                     <p>Expected revenue</p>
                     <span class="display-5">$50M</span>
                 </div>
-                <div class="o_grid_item g-col-md-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 1 / 10 / 4 / 13; z-index: 4; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                <div class="o_grid_item g-col-lg-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 1 / 10 / 4 / 13; z-index: 4; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
                     <p>Online Members</p>
                     <span class="display-5">235,403</span>
                 </div>
-                <div class="o_grid_item g-col-md-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 4 / 1 / 7 / 4; z-index: 5; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                <div class="o_grid_item g-col-lg-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 4 / 1 / 7 / 4; z-index: 5; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
                     <p>Customer Retention</p>
                     <span class="display-5">85%</span>
                 </div>
-                <div class="o_grid_item g-col-md-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 4 / 4 / 7 / 7; z-index: 6; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                <div class="o_grid_item g-col-lg-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 4 / 4 / 7 / 7; z-index: 6; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
                     <p>Inventory turnover</p>
                     <span class="display-5">4x</span>
                 </div>
-                <div class="o_grid_item g-col-md-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 4 / 7 / 7 / 10; z-index: 7; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                <div class="o_grid_item g-col-lg-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 4 / 7 / 7 / 10; z-index: 7; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
                     <p>Website visitors</p>
                     <span class="display-5">100,000</span>
                 </div>
-                <div class="o_grid_item g-col-md-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 4 / 10 / 7 / 13; z-index: 8; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                <div class="o_grid_item g-col-lg-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 4 / 10 / 7 / 13; z-index: 8; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
                     <p>Transactions</p>
                     <span class="display-5">45,958</span>
                 </div>


### PR DESCRIPTION
This PR aims to fix an issue about the wrong grid classes on the `s_numbers_grid` snippet.

Prior to this PR, the snippet was using `g-col-md` classes, which is creating conflicts with the handles of the snippet at some breakpoint.

In fact, the classes should match the `col-*` ones and be `g-col-lg-*`.

This PR replaces the old `g-col-*` with the right one.

task-4187041

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
