### PR TITLE
[FIX] product: raise user when editing purchase uom

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -398,7 +398,7 @@ class ProductTemplate(models.Model):
     @api.onchange('uom_po_id')
     def _onchange_uom(self):
         if self.uom_id and self.uom_po_id and self.uom_id.category_id != self.uom_po_id.category_id:
-            self.uom_po_id = self.uom_id
+            raise UserError(_("You can only select a purchase unit of measure from the same category as the product's unit of measure."))
 
     @api.onchange('type')
     def _onchange_type(self):


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a product “P1”: - UoM: unit

- Go to the purchase tab and update the PO UoM to gram

Problem:
The PO UoM is updated to unit instead of raising an user error to the client to infom him what is the problem.

The PO UoM is updated because the UoM gram is not in the same category as the UoM unit.

opw-4203851