### PR TITLE
[IMP] sale: rename reporting menus

### DIFF
--- a/addons/sale/i18n/sale.pot
+++ b/addons/sale/i18n/sale.pot
@@ -3707,7 +3707,7 @@ msgstr ""
 
 #. module: sale
 #: model:ir.actions.act_window,name:sale.action_order_report_customers
-msgid "Sales Analysis Per Customers"
+msgid "Sales Analysis By Customers"
 msgstr ""
 
 #. module: sale
@@ -3717,7 +3717,7 @@ msgstr ""
 
 #. module: sale
 #: model:ir.actions.act_window,name:sale.action_order_report_products
-msgid "Sales Analysis Products"
+msgid "Sales Analysis By Products"
 msgstr ""
 
 #. module: sale

--- a/addons/sale/report/sale_report_views.xml
+++ b/addons/sale/report/sale_report_views.xml
@@ -144,7 +144,7 @@
     </record>
 
     <record id="action_order_report_products" model="ir.actions.act_window">
-        <field name="name">Sales Analysis Products</field>
+        <field name="name">Sales Analysis By Products</field>
         <field name="res_model">sale.report</field>
         <field name="view_mode">graph,pivot</field>
         <field name="view_id" ref="sale_report_graph_pie"/>
@@ -154,7 +154,7 @@
     </record>
 
     <record id="action_order_report_customers" model="ir.actions.act_window">
-        <field name="name">Sales Analysis Per Customers</field>
+        <field name="name">Sales Analysis By Customers</field>
         <field name="res_model">sale.report</field>
         <field name="view_mode">graph,pivot</field>
         <field name="view_id" ref="sale_report_graph_bar"/>


### PR DESCRIPTION
This commit rename reporting menus to have consistent name with other reporting menus in sales.

task-4209879
