### PR TITLE
[IMP] product: improve ptav update confirmation msg

### DIFF
--- a/addons/product/wizard/update_product_attribute_value.py
+++ b/addons/product/wizard/update_product_attribute_value.py
@@ -25,7 +25,7 @@ class UpdateProductAttributeValue(models.TransientModel):
         for wizard in self:
             if wizard.mode == 'add':
                 wizard.message = _(
-                    "You are about to add \"%(attribute_value)s\" to %(product_count)s products.",
+                    "You are about to add the value \"%(attribute_value)s\" to %(product_count)s products.",
                     attribute_value=wizard.attribute_value_id.name,
                     product_count=wizard.product_count,
                 )


### PR DESCRIPTION
This commit update confirmation msg of ptav wizard to update product attributes message to add what it'll add to product instead just attribute name

**Before**:
`You are about to add "Black" to 10 products`

**After**:
`You are about to add the value "Black" to 10 product`
