### PR TITLE
[IMP] website_sale: notify user when email is already registered

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -72,7 +72,7 @@ class TableCompute(object):
             if index >= ppg and ((pos + 1.0) // ppr) > maxy:
                 break
 
-            if x == 1 and y == 1:   # simple heuristic for CPU optimization
+            if x == 1 and y == 1:  # simple heuristic for CPU optimization
                 minpos = pos // ppr
 
             for y2 in range(y):
@@ -144,7 +144,8 @@ class Website(main.Website):
     @http.route()
     def theme_customize_data(self, is_view_data, enable=None, disable=None, reset_view_arch=False):
         super().theme_customize_data(is_view_data, enable, disable, reset_view_arch)
-        if any(key in enable or key in disable for key in ['website_sale.products_list_view', 'website_sale.add_grid_or_list_option']):
+        if any(key in enable or key in disable for key in
+               ['website_sale.products_list_view', 'website_sale.add_grid_or_list_option']):
             request.session.pop('website_sale_shop_layout_mode', None)
 
     @http.route()
@@ -154,6 +155,7 @@ class Website(main.Website):
             'symbol': request.website.currency_id.symbol,
             'position': request.website.currency_id.position,
         }
+
 
 class WebsiteSale(payment_portal.PaymentPortal):
     _express_checkout_route = '/shop/express_checkout'
@@ -230,8 +232,8 @@ class WebsiteSale(payment_portal.PaymentPortal):
                 yield {'loc': loc}
 
     def _get_search_options(
-        self, category=None, attrib_values=None, tags=None, min_price=0.0, max_price=0.0,
-        conversion_rate=1, **post
+            self, category=None, attrib_values=None, tags=None, min_price=0.0, max_price=0.0,
+            conversion_rate=1, **post
     ):
         return {
             'displayDescription': True,
@@ -259,7 +261,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         return fuzzy_search_term, product_count, search_result
 
     def _shop_get_query_url_kwargs(
-        self, category, search, min_price, max_price, attrib=None, order=None, tags=None, **post
+            self, category, search, min_price, max_price, attrib=None, order=None, tags=None, **post
     ):
         return {
             'category': category,
@@ -334,14 +336,16 @@ class WebsiteSale(payment_portal.PaymentPortal):
                 post['tags'] = None
                 tags = {}
 
-        keep = QueryURL('/shop', **self._shop_get_query_url_kwargs(category and int(category), search, min_price, max_price, **post))
+        keep = QueryURL('/shop',
+                        **self._shop_get_query_url_kwargs(category and int(category), search, min_price, max_price,
+                                                          **post))
 
         now = datetime.timestamp(datetime.now())
         pricelist = website.pricelist_id
         if 'website_sale_pricelist_time' in request.session:
             # Check if we need to refresh the cached pricelist
             pricelist_save_time = request.session['website_sale_pricelist_time']
-            if pricelist_save_time < now - 60*60:
+            if pricelist_save_time < now - 60 * 60:
                 request.session.pop('website_sale_current_pl', None)
                 website.invalidate_recordset(['pricelist_id'])
                 pricelist = website.pricelist_id
@@ -374,7 +378,8 @@ class WebsiteSale(payment_portal.PaymentPortal):
             display_currency=website.currency_id,
             **post
         )
-        fuzzy_search_term, product_count, search_product = self._shop_lookup_products(attrib_set, options, post, search, website)
+        fuzzy_search_term, product_count, search_product = self._shop_lookup_products(attrib_set, options, post, search,
+                                                                                      website)
 
         filter_by_price_enabled = website.is_view_active('website_sale.filter_products_price')
         if filter_by_price_enabled:
@@ -515,8 +520,8 @@ class WebsiteSale(payment_portal.PaymentPortal):
             return request.redirect('/shop')
 
         if not document.shown_on_product_page or not (
-            document.res_id == product_template.id
-            and document.res_model == 'product.template'
+                document.res_id == product_template.id
+                and document.res_model == 'product.template'
         ):
             return request.redirect('/shop')
 
@@ -524,7 +529,8 @@ class WebsiteSale(payment_portal.PaymentPortal):
             document.ir_attachment_id,
         ).get_response(as_attachment=True)
 
-    @http.route(['/shop/product/<model("product.template"):product>'], type='http', auth="public", website=True, sitemap=False)
+    @http.route(['/shop/product/<model("product.template"):product>'], type='http', auth="public", website=True,
+                sitemap=False)
     def old_product(self, product, category='', search='', **kwargs):
         # Compatibility pre-v14
         return request.redirect(_build_url_w_params("/shop/%s" % slug(product), request.params), code=301)
@@ -542,12 +548,14 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
         image_ids = request.env["ir.attachment"].browse(i['id'] for i in images)
         image_create_data = [Command.create({
-                    'name': image.name,                          # Images uploaded from url do not have any datas. This recovers them manually
-                    'image_1920': image.datas if image.datas else request.env['ir.qweb.field.image'].load_remote_url(image.url),
-                }) for image in image_ids]
+            'name': image.name,  # Images uploaded from url do not have any datas. This recovers them manually
+            'image_1920': image.datas if image.datas else request.env['ir.qweb.field.image'].load_remote_url(image.url),
+        }) for image in image_ids]
 
-        product_product = request.env['product.product'].browse(int(product_product_id)) if product_product_id else False
-        product_template = request.env['product.template'].browse(int(product_template_id)) if product_template_id else False
+        product_product = request.env['product.product'].browse(
+            int(product_product_id)) if product_product_id else False
+        product_template = request.env['product.template'].browse(
+            int(product_template_id)) if product_template_id else False
 
         if product_product and not product_template:
             product_template = product_product.product_tmpl_id
@@ -574,8 +582,10 @@ class WebsiteSale(payment_portal.PaymentPortal):
         if not request.env.user.has_group('website.group_website_restricted_editor'):
             raise NotFound()
 
-        product_product = request.env['product.product'].browse(int(product_product_id)) if product_product_id else False
-        product_template = request.env['product.template'].browse(int(product_template_id)) if product_template_id else False
+        product_product = request.env['product.product'].browse(
+            int(product_product_id)) if product_product_id else False
+        product_template = request.env['product.template'].browse(
+            int(product_template_id)) if product_template_id else False
 
         if product_product and not product_template:
             product_template = product_product.product_tmpl_id
@@ -602,9 +612,9 @@ class WebsiteSale(payment_portal.PaymentPortal):
         :return: None
         """
         if (
-            not request.env.user.has_group('website.group_website_restricted_editor')
-            or image_res_model not in ['product.product', 'product.template', 'product.image']
-            or move not in ['first', 'left', 'right', 'last']
+                not request.env.user.has_group('website.group_website_restricted_editor')
+                or image_res_model not in ['product.product', 'product.template', 'product.image']
+                or move not in ['first', 'left', 'right', 'last']
         ):
             raise NotFound()
 
@@ -719,7 +729,8 @@ class WebsiteSale(payment_portal.PaymentPortal):
             'view_track': view_track,
         }
 
-    @http.route(['/shop/change_pricelist/<model("product.pricelist"):pricelist>'], type='http', auth="public", website=True, sitemap=False)
+    @http.route(['/shop/change_pricelist/<model("product.pricelist"):pricelist>'], type='http', auth="public",
+                website=True, sitemap=False)
     def pricelist_change(self, pricelist, **post):
         website = request.env['website'].get_current_website()
         redirect_url = request.httprequest.referrer
@@ -735,14 +746,18 @@ class WebsiteSale(payment_portal.PaymentPortal):
                     try:
                         min_price = float(min_price)
                         args['min_price'] = min_price and str(
-                            previous_price_list.currency_id._convert(min_price, pricelist.currency_id, request.website.company_id, fields.Date.today(), round=False)
+                            previous_price_list.currency_id._convert(min_price, pricelist.currency_id,
+                                                                     request.website.company_id, fields.Date.today(),
+                                                                     round=False)
                         )
                     except (ValueError, TypeError):
                         pass
                     try:
                         max_price = float(max_price)
                         args['max_price'] = max_price and str(
-                            previous_price_list.currency_id._convert(max_price, pricelist.currency_id, request.website.company_id, fields.Date.today(), round=False)
+                            previous_price_list.currency_id._convert(max_price, pricelist.currency_id,
+                                                                     request.website.company_id, fields.Date.today(),
+                                                                     round=False)
                         )
                     except (ValueError, TypeError):
                         pass
@@ -805,13 +820,15 @@ class WebsiteSale(payment_portal.PaymentPortal):
                 raise NotFound()
             if abandoned_order.state != 'draft':  # abandoned cart already finished
                 values.update({'abandoned_proceed': True})
-            elif revive == 'squash' or (revive == 'merge' and not request.session.get('sale_order_id')):  # restore old cart or merge with unexistant
+            elif revive == 'squash' or (revive == 'merge' and not request.session.get(
+                    'sale_order_id')):  # restore old cart or merge with unexistant
                 request.session['sale_order_id'] = abandoned_order.id
                 return request.redirect('/shop/cart')
             elif revive == 'merge':
                 abandoned_order.order_line.write({'order_id': request.session['sale_order_id']})
                 abandoned_order.action_cancel()
-            elif abandoned_order.id != request.session.get('sale_order_id'):  # abandoned cart found, user have to choose what to do
+            elif abandoned_order.id != request.session.get(
+                    'sale_order_id'):  # abandoned cart found, user have to choose what to do
                 values.update({'access_token': abandoned_order.access_token})
 
         values.update({
@@ -829,9 +846,9 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
     @http.route(['/shop/cart/update'], type='http', auth="public", methods=['POST'], website=True)
     def cart_update(
-        self, product_id, add_qty=1, set_qty=0,
-        product_custom_attribute_values=None, no_variant_attribute_values=None,
-        express=False, **kwargs
+            self, product_id, add_qty=1, set_qty=0,
+            product_custom_attribute_values=None, no_variant_attribute_values=None,
+            express=False, **kwargs
     ):
         """This route is called when adding a product to cart (no options)."""
         sale_order = request.website.sale_get_order(force_create=True)
@@ -863,8 +880,8 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
     @http.route(['/shop/cart/update_json'], type='json', auth="public", methods=['POST'], website=True, csrf=False)
     def cart_update_json(
-        self, product_id, line_id=None, add_qty=None, set_qty=None, display=True,
-        product_custom_attribute_values=None, no_variant_attribute_values=None, **kw
+            self, product_id, line_id=None, add_qty=None, set_qty=None, display=True,
+            product_custom_attribute_values=None, no_variant_attribute_values=None, **kw
     ):
         """
         This route is called :
@@ -972,7 +989,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         return {
             'currency_id': order.currency_id.id,
             'lines': [
-                { # For the cart_notification
+                {  # For the cart_notification
                     'id': line.id,
                     'image_url': order.website_id.image_url(line.product_id, 'image_128'),
                     'quantity': line._get_displayed_quantity(),
@@ -1119,7 +1136,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         _update_mode, address_mode = mode
         if address_mode == 'shipping':
             required_fields += self._get_mandatory_fields_shipping(country_id)
-        else: # 'billing'
+        else:  # 'billing'
             required_fields += self._get_mandatory_fields_billing(country_id)
             if all_form_values.get('use_same'):
                 # If the billing address is also used as shipping one, the phone is required as well
@@ -1138,6 +1155,19 @@ class WebsiteSale(payment_portal.PaymentPortal):
         if data.get('email') and not tools.single_email_re.match(data.get('email')):
             error["email"] = 'error'
             error_message.append(_('Invalid Email! Please enter a valid email address.'))
+
+        is_public_user = request.website.is_public_user()
+        email_change = data.get('email')
+        existing_email = request.env['res.users'].sudo().search([('login', '=', email_change)], limit=1)
+
+        # Prevent a public user from creating an order with an internal or portal user's email
+        if is_public_user and existing_email:
+            error.update({
+                'email': 'error'
+            })
+
+            error_message.append(_("Another user is already registered using this email address. "
+                                   "Please Sign in."))
 
         # vat validation
         Partner = request.env['res.partner']
@@ -1202,7 +1232,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             if k in authorized_fields and v is not None:
                 new_values[k] = v
             else:  # DEBUG ONLY
-                if k not in ('field_required', 'partner_id', 'callback', 'submitted'): # classic case
+                if k not in ('field_required', 'partner_id', 'callback', 'submitted'):  # classic case
                     _logger.debug("website_sale postprocess: %s value has been dropped (empty or not writable)" % k)
 
         if request.website.specific_user_account:
@@ -1287,7 +1317,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
                     values = Partner.browse(partner_id)
             elif partner_id == -1:
                 mode = ('new', kw.get('mode') or 'shipping')
-            else: # no mode - refresh without post?
+            else:  # no mode - refresh without post?
                 return request.redirect('/shop/checkout')
 
         # IF POSTED
@@ -1318,9 +1348,9 @@ class WebsiteSale(payment_portal.PaymentPortal):
                         if kw.get('use_same'):
                             update_values['partner_shipping_id'] = partner_id
                         elif (
-                            order._is_public_order()
-                            and not kw.get('callback')
-                            and not order.only_services
+                                order._is_public_order()
+                                and not kw.get('callback')
+                                and not order.only_services
                         ):
                             # Now that the billing is set, if shipping is necessary
                             # request the customer to fill the shipping address
@@ -1381,7 +1411,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
     )
     def process_express_checkout(
             self, billing_address, shipping_address=None, shipping_option=None, **kwargs
-        ):
+    ):
         """ Records the partner information on the order when using express checkout flow.
 
         Depending on whether the partner is registered and logged in, either creates a new partner
@@ -1426,7 +1456,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         request.session['sale_last_order_id'] = order_sudo.id
 
         if shipping_address:
-            #in order to not override shippig address, it's checked separately from shipping option
+            # in order to not override shippig address, it's checked separately from shipping option
             self._include_country_and_state_in_address(shipping_address)
 
             if order_sudo.partner_shipping_id.name.endswith(order_sudo.name):
@@ -1439,7 +1469,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
                     partner_id=order_sudo.partner_shipping_id.id,
                 )
             elif any(
-                shipping_address[k] != order_sudo.partner_shipping_id[k] for k in shipping_address
+                    shipping_address[k] != order_sudo.partner_shipping_id[k] for k in shipping_address
             ):
                 # The sale order's shipping partner's address is different from the one received. If
                 # all the sale order's child partners' address differs from the one received, we
@@ -1555,7 +1585,8 @@ class WebsiteSale(payment_portal.PaymentPortal):
             else:
                 def_country_id = request.website.user_id.sudo().country_id
 
-        country = 'country_id' in values and values['country_id'] != '' and request.env['res.country'].browse(int(values['country_id']))
+        country = 'country_id' in values and values['country_id'] != '' and request.env['res.country'].browse(
+            int(values['country_id']))
         country = country and country.exists() or def_country_id
 
         res = {
@@ -1605,21 +1636,21 @@ class WebsiteSale(payment_portal.PaymentPortal):
             ('type', 'in', ('invoice', 'delivery', 'other')),
         ])
         if (
-            partner_sudo != order_sudo.partner_id
-            and partner_sudo != order_sudo.partner_id.commercial_partner_id
-            and partner_sudo.id not in children
+                partner_sudo != order_sudo.partner_id
+                and partner_sudo != order_sudo.partner_id.commercial_partner_id
+                and partner_sudo.id not in children
         ):
             raise Forbidden()
 
         fpos_before = order_sudo.fiscal_position_id
         if (
-            mode == 'billing'
-            and partner_sudo != order_sudo.partner_invoice_id
+                mode == 'billing'
+                and partner_sudo != order_sudo.partner_invoice_id
         ):
             order_sudo.partner_invoice_id = partner_id
         elif (
-            mode == 'shipping'
-            and partner_sudo != order_sudo.partner_shipping_id
+                mode == 'shipping'
+                and partner_sudo != order_sudo.partner_shipping_id
         ):
             order_sudo.partner_shipping_id = partner_id
             if order_sudo.carrier_id:
@@ -1754,7 +1785,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             errors.append((
                 _('Sorry, we are unable to ship your order'),
                 _('No shipping method is available for your current order and shipping address. '
-                   'Please contact us for more information.'),
+                  'Please contact us for more information.'),
             ))
         return errors
 
@@ -1872,7 +1903,8 @@ class WebsiteSale(payment_portal.PaymentPortal):
     def print_saleorder(self, **kwargs):
         sale_order_id = request.session.get('sale_last_order_id')
         if sale_order_id:
-            pdf, _ = request.env['ir.actions.report'].sudo()._render_qweb_pdf('sale.action_report_saleorder', [sale_order_id])
+            pdf, _ = request.env['ir.actions.report'].sudo()._render_qweb_pdf('sale.action_report_saleorder',
+                                                                              [sale_order_id])
             pdfhttpheaders = [('Content-Type', 'application/pdf'), ('Content-Length', u'%s' % len(pdf))]
             return request.make_response(pdf, headers=pdfhttpheaders)
         else:
@@ -1962,7 +1994,8 @@ class WebsiteSale(payment_portal.PaymentPortal):
             tracking_cart_dict['shipping'] = delivery_line.price_unit
         return tracking_cart_dict
 
-    @http.route(['/shop/country_infos/<model("res.country"):country>'], type='json', auth="public", methods=['POST'], website=True)
+    @http.route(['/shop/country_infos/<model("res.country"):country>'], type='json', auth="public", methods=['POST'],
+                website=True)
     def country_infos(self, country, mode, **kw):
         return dict(
             fields=country.get_address_fields(),
@@ -1986,7 +2019,8 @@ class WebsiteSale(payment_portal.PaymentPortal):
     def products_recently_viewed_delete(self, product_id, **kwargs):
         visitor_sudo = request.env['website.visitor']._get_visitor_from_request()
         if visitor_sudo:
-            request.env['website.track'].sudo().search([('visitor_id', '=', visitor_sudo.id), ('product_id', '=', product_id)]).unlink()
+            request.env['website.track'].sudo().search(
+                [('visitor_id', '=', visitor_sudo.id), ('product_id', '=', product_id)]).unlink()
         return {}
 
 
@@ -2034,7 +2068,8 @@ class PaymentPortal(payment_portal.PaymentPortal):
         if not kwargs.get('amount'):
             kwargs['amount'] = order_sudo.amount_total
 
-        if tools.float_compare(kwargs['amount'], order_sudo.amount_total, precision_rounding=order_sudo.currency_id.rounding):
+        if tools.float_compare(kwargs['amount'], order_sudo.amount_total,
+                               precision_rounding=order_sudo.currency_id.rounding):
             raise ValidationError(_("The cart has been updated. Please refresh the page."))
 
         tx_sudo = self._create_transaction(
@@ -2090,12 +2125,12 @@ class CustomerPortal(sale_portal.CustomerPortal):
                 'product_id': line.product_id.id,
                 'combination': combination.ids,
                 'no_variant_attribute_values': [
-                    { # Same input format as provided by product configurator
+                    {  # Same input format as provided by product configurator
                         'value': ptav.id,
                     } for ptav in line.product_no_variant_attribute_value_ids
                 ],
                 'product_custom_attribute_values': [
-                    { # Same input format as provided by product configurator
+                    {  # Same input format as provided by product configurator
                         'custom_product_template_attribute_value_id': pcav.custom_product_template_attribute_value_id.id,
                         'custom_value': pcav.custom_value,
                     } for pcav in line.product_custom_attribute_value_ids


### PR DESCRIPTION
Currently, during the checkout process, if a public user enters an email that is already associated with an existing user, Odoo creates a new contact instead of associating the order with the existing account. This leads to duplicate contacts and confusion when the user tries to register later with the same email.

This improvement ensures that during checkout, if the provided email is already linked to a registered account, the user will be notified to log in instead of creating a new contact. This enhances the user experience by preventing duplicate accounts and guiding the user to the correct workflow.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
