### PR TITLE
[IMP] hr_holidays: Update employee's time off balance expiry computation

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -6,7 +6,6 @@ from datetime import datetime, date, time
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, _
-from odoo.addons.resource.models.utils import HOURS_PER_DAY
 from odoo.addons.hr_holidays.models.hr_leave import get_employee_from_context
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.tools.float_utils import float_round
@@ -659,6 +658,7 @@ class HolidaysAllocation(models.Model):
             if not allocation.lastcall:
                 if not current_level:
                     allocation.lastcall = today
+                    allocation.actual_lastcall = allocation.lastcall
                     continue
                 allocation.lastcall = max(
                     current_level._get_previous_date(today),

--- a/addons/hr_holidays/tests/test_expiring_leaves.py
+++ b/addons/hr_holidays/tests/test_expiring_leaves.py
@@ -23,6 +23,29 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
             'requires_allocation': 'yes',
             'allocation_validation_type': 'no_validation',
         })
+        cls.accrual_plan_with_accrual_validity = cls.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).sudo().create({
+            'name': 'Test Accrual Plan With Accrual Validity',
+            'carryover_date': 'other',
+            'carryover_day': 1,
+            'carryover_month': 'apr',
+            'level_ids': [
+                (0, 0, {
+                'start_count': 0,
+                'start_type': 'day',
+                'added_value': 3,
+                'added_value_type': 'day',
+                'frequency': 'yearly',
+                'yearly_day': 1,
+                'yearly_month': 'jan',
+                'cap_accrued_time': False,
+                'action_with_unused_accruals': 'maximum',
+                'postpone_max_days': 5,
+                'accrual_validity': True,
+                'accrual_validity_count': 3,
+                'accrual_validity_type': 'month',
+                })
+            ],
+        })
 
     @users('enguerran')
     def test_no_carried_over_leaves(self):
@@ -640,9 +663,141 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
 
         # Days between the target date and the expiration date (accrual_plan's carryover date)
         working_days_equivalent_needed = (allocation._get_carryover_date(target_date) - target_date).days + 1
-    
+
         # Assert the closest allocation duration (number of working days equivalent (8 hours/day) remaining before the allocation expires)
         self.assertEqual(round(allocation_data[logged_in_emp][0][1]['closest_allocation_duration']), working_days_equivalent_needed,
                             "The closest allocation duration should be the number of working days equivalent (24 hours/day) remaining before the allocation expires")
-        
-                         
+
+    @users('enguerran')
+    def test_carried_over_days_expiration_date(self):
+        """
+        This test case aims to assert that carried_over_days_expiration_date is taken into account when the
+        expiration date is computed.
+        - First accrual plan:
+            - Carryover date : 1st of April.
+            - Has 1 level:
+                - Accrues 3 days yearly on the 1st of January.
+                - Carryover with a maximum of 5 days.
+        - Second accrual plan:
+            Has the same definition as the one above except that carried over days are valid for 3 months.
+        - Note: the following dates are in format dd/mm/YYYY
+        - Define 2 allocations:
+            - Both allocations will start on 01/01/2023.
+            - One allocation uses the first accrual plan and the other uses the second accrual plan.
+            - Both allocations accrue 3 days yearly.
+            - The first allocation expires on the 1st of October.
+            - The second allocation doesn't expire.
+        - On 01/01/2024, both allocations will accrue 3 days for the employee.
+        - If target date is 01/04/2024, then the expiration date should be 01/7/2024 because on 01/04/2024, 3 days will carryover for
+          the second allocation and these 3 days will expire in 3 months.
+        """
+        accrual_plan_without_accrual_validity = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).sudo().create({
+            'name': 'Test Accrual Plan',
+            'carryover_date': 'other',
+            'carryover_day': 1,
+            'carryover_month': 'apr',
+            'level_ids': [
+                (0, 0, {
+                'start_count': 0,
+                'start_type': 'day',
+                'added_value': 3,
+                'added_value_type': 'day',
+                'frequency': 'yearly',
+                'yearly_day': 1,
+                'yearly_month': 'jan',
+                'cap_accrued_time': False,
+                'action_with_unused_accruals': 'maximum',
+                'postpone_max_days': 5,
+                })
+            ],
+        })
+
+        logged_in_emp = self.env.user.employee_id
+        with freeze_time("2023-1-1"):
+            # Allocation 1
+            self.env['hr.leave.allocation'].sudo().create({
+                'date_from': '2023-1-1',
+                'date_to': '2024-10-1',
+                'allocation_type': 'accrual',
+                'accrual_plan_id': accrual_plan_without_accrual_validity.id,
+                'holiday_status_id': self.leave_type.id,
+                'employee_id': logged_in_emp.id,
+                'number_of_days': 0,
+            })
+            # Allocation 2
+            self.env['hr.leave.allocation'].sudo().create({
+                'date_from': '2023-1-1',
+                'allocation_type': 'accrual',
+                'accrual_plan_id': self.accrual_plan_with_accrual_validity.id,
+                'holiday_status_id': self.leave_type.id,
+                'employee_id': logged_in_emp.id,
+                'number_of_days': 0,
+            })
+
+        with freeze_time("2024-4-1"):
+            self.env['hr.leave.allocation'].with_user(self.user_hruser)._update_accrual()
+
+        target_date = date(2024, 4, 1)
+        allocation_data = self.leave_type.get_allocation_data(logged_in_emp, target_date)
+        # Assert the date of expiration
+        self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_expire'],
+                    (target_date + relativedelta(month=7)).strftime('%m/%d/%Y'),
+                    "The expiration date should be the carried over days expiration date of allocation 3")
+
+        # Assert the number of expiring leaves
+        self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_remaining'], 3)
+
+    @users('enguerran')
+    def test_carried_over_days_expiration_date_2(self):
+        """
+        This tess case aims to assert that the number of expiring leaves on carried_over_days_expiration_date is
+        computed properly
+        - Define an accrual plan:
+            - Carryover date : 1st of April.
+            - Has 1 level:
+                - Accrues 3 days yearly on the 1st of January.
+                - Carryover with a maximum of 5 days.
+                - Carried over days are valid for 3 months.
+        - Note: the following dates are in format dd/mm/YYYY
+        - Define an allocation:
+            - The allocation will start on 01/01/2023.
+            - The allocation uses the accrual plan defined above.
+            - The allocation expires on the 1st of October.
+        - On 01/01/2024, 3 days are accrued.
+        - If target date is 01/05/2024, then the expiration date should be 01/7/2024.
+        - On 01/04/2024, 3 days will carryover.
+        - The employee taked 2 days as time off.
+        - The number of expiring days on 01/07/2024 is 1 day.
+        """
+
+        logged_in_emp = self.env.user.employee_id
+        with freeze_time("2023-1-1"):
+            self.env['hr.leave.allocation'].sudo().create({
+                'date_from': '2023-1-1',
+                'allocation_type': 'accrual',
+                'accrual_plan_id': self.accrual_plan_with_accrual_validity.id,
+                'holiday_status_id': self.leave_type.id,
+                'employee_id': logged_in_emp.id,
+                'number_of_days': 0,
+            })
+
+        with freeze_time("2024-4-1"):
+            self.env['hr.leave.allocation'].with_user(self.user_hruser)._update_accrual()
+            leave = self.env['hr.leave'].create({
+                'name': 'leave',
+                'employee_id': logged_in_emp.id,
+                'holiday_status_id': self.leave_type.id,
+                'request_date_from': '2024-04-03',
+                'request_date_to': '2024-04-04',
+            })
+            leave.sudo().action_validate()
+
+        target_date = date(2024, 5, 1)
+        allocation_data = self.leave_type.get_allocation_data(logged_in_emp, target_date)
+        # Assert the date of expiration
+        self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_expire'],
+                    (target_date + relativedelta(month=7)).strftime('%m/%d/%Y'),
+                    "The expiration date should be the carried over days expiration date of allocation 3")
+
+        # Assert the number of expiring leaves
+        self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_remaining'], 1)


### PR DESCRIPTION
In the Time Off app dashboard, employees can view whether some of their unused time off days are set to expire and the exact expiration date.

At the accrual plan level, a validity period can be defined for carried-over days, after which they expire. However, the expiration date of these carried-over days hasn't been considered when calculating the employee's expiring balance.

Steps to reproduce:  
1. Create a new accrual plan.  
2. Define a new accrual plan level.  
3. Configure the level to accrue 10 days annually.  
4. Set the carryover validity to 2 months.  
5. Keep all other settings as default.  
6. Create a new allocation.  
7. Apply the previously defined accrual plan.  
8. Set the start date to 01/01/20xx (where xx is the previous year).  
9. Confirm the employee's balance is now 10 days.  
10. Navigate to the dashboard.  
11. Set the date to 01/01/(20xx + 2), corresponding to the carryover date.  
12. Notice that no expiration date is displayed on the dashboard.  
13. The expiration date should be displayed as 01/03/(20xx + 2).

This update addresses the issue by incorporating the expiration dates of carried-over days into the calculation.

task-4207987