### PR TITLE
[FIX] web_editor: don't allow nested comments

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -1438,8 +1438,15 @@ function _createColumnGrid() {
  * @param {string} content
  * @returns {Comment}
  */
-function _createMso(content='') {
-    return document.createComment(`[if mso]>${content}<![endif]`)
+function _createMso(content = "") {
+    // We remove commets having opposite condition fron the one we will insert
+    // We remove comment tags having the same condition
+    const showRegex = /<!--\[if\s+mso\]>([\s\S]*?)<!\[endif\]-->/g;
+    const hideRegex = /<!--\[if\s+!mso\]>([\s\S]*?)<!\[endif\]-->/g;
+    let contentToInsert = content;
+    contentToInsert = contentToInsert.replace(showRegex, (matchedContent, group) => group);
+    contentToInsert = contentToInsert.replace(hideRegex, "");
+    return document.createComment(`[if mso]>${contentToInsert}<![endif]`);
 }
 /**
  * Return a table element, with its default styles and attributes, as well as
@@ -1759,4 +1766,5 @@ export default {
     normalizeColors: normalizeColors,
     normalizeRem: normalizeRem,
     toInline: toInline,
+    createMso: _createMso,
 };

--- a/addons/web_editor/static/tests/convert_inline_tests.js
+++ b/addons/web_editor/static/tests/convert_inline_tests.js
@@ -1066,6 +1066,20 @@ QUnit.module('convert_inline', {}, function () {
 
         $styleSheet.remove();
     });
+
+    QUnit.test('Create mso properly', async function (assert) {
+        assert.strictEqual(convertInline.createMso('<div>abcde</div>').nodeValue,
+            '[if mso]><div>abcde</div><![endif]',
+            "Should wrap the content in mso condition");
+
+        assert.strictEqual(convertInline.createMso('<div>ef<!--[if mso]><div>abcd</div><![endif]-->gh</div>').nodeValue,
+            '[if mso]><div>ef<div>abcd</div>gh</div><![endif]',
+            "Should wrap the content inside one mso condition");
+
+        assert.strictEqual(convertInline.createMso('<div>ef<!--[if !mso]><div>abcd</div><![endif]-->gh</div>').nodeValue,
+            '[if mso]><div>efgh</div><![endif]',
+            "Should remove nested mso hide condition");
+    });
 });
 
 });


### PR DESCRIPTION
Issue:
======
Extra button in the sent email.

Steps to reproduce the issue:
=============================
- Create a new mailing
- Start from scratch
- Drop cover template
- Add a link inside it
- Test send the email
- There is an extra link in the sent email.

Origin of the issue:
====================
In the case when the button is inside the cover template we end up with
something like this `<!--mso condition ab <!-- another condition cd
endif--> ef endif-->` but in reality comments can't be nested so the
first comment will close at the ending of the second comment so we will
end up with the content `ef` being displayed.

Solution:
=========
Since the two conditions are opposites, we remove completely the content
of the nested comment if it has oppisite condition otherwise we just
remove the comment tags since they will be replaced with the upper
comment

opw-4149948