### PR TITLE
[FIX] pos_restaurant: unable to transfer entire order

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -334,6 +334,7 @@ patch(PosStore.prototype, {
             this.addPendingOrder([order.id]);
         } else {
             const destinationOrder = this.getActiveOrdersOnTable(destinationTable)[0];
+            const linesToUpdate = [];
             for (const orphanLine of order.lines) {
                 const adoptingLine = destinationOrder.lines.find((l) =>
                     l.can_be_merged_with(orphanLine)
@@ -341,9 +342,12 @@ patch(PosStore.prototype, {
                 if (adoptingLine) {
                     adoptingLine.merge(orphanLine);
                 } else {
-                    orphanLine.update({ order_id: destinationOrder });
+                    linesToUpdate.push(orphanLine);
                 }
             }
+            linesToUpdate.forEach((orderline) => {
+                orderline.update({ order_id: destinationOrder });
+            });
             this.set_order(destinationOrder);
             this.addPendingOrder([destinationOrder.id]);
             await this.deleteOrders([order]);

--- a/addons/pos_restaurant/static/tests/tours/control_buttons_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/control_buttons_tour.js
@@ -26,11 +26,17 @@ registry.category("web_tour.tours").add("ControlButtonsTour", {
             FloorScreen.clickTable("4"),
             Chrome.activeTableOrOrderIs("4"),
             ProductScreen.addOrderline("Minute Maid", "3", "2", "6.0"),
+            // Extra line is added to test merging table.
+            // Merging this order to another should also include this extra line.
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            ProductScreen.selectedOrderlineHas("Coca-Cola", "1"),
+
             ProductScreen.clickControlButton("Transfer"),
             FloorScreen.clickTable("2"),
             Chrome.activeTableOrOrderIs("2"),
             Order.hasLine({ productName: "Water", quantity: "5" }),
             Order.hasLine({ productName: "Minute Maid", quantity: "3" }),
+            Order.hasLine({ productName: "Coca-Cola", quantity: "1" }),
 
             // Test SplitBillButton
             ProductScreen.clickControlButton("Split"),


### PR DESCRIPTION
Steps to reproduce :
---------------------------
- Install the pos_restaurant module.
- Place orders on two separate tables, e.g., Table A and Table B.
- Use the action button to transfer the order from Table A to Table B.

Issue :
---------
The last orderline of the table from where we transfer to another table is not
transfered to destination table when there is any orderline having different
product which is not present in any of the orderlines of the destination table.

Cause :
----------
The for loop on orderlines modifies the orderline reference during iteration,
causing the loop to skip some lines because the order.lines is altered
mid-iteration.

Fix :
------
Intead of updating within iteration we will update all lines after completion
of the iteration.
