### PR TITLE
[FIX] website: deleting search should not refresh

### DIFF
--- a/addons/website/static/src/snippets/s_searchbar/000.js
+++ b/addons/website/static/src/snippets/s_searchbar/000.js
@@ -307,11 +307,6 @@ publicWidget.registry.searchBar = publicWidget.Widget.extend({
         } else { // clear button clicked
             this._render(); // remove existing suggestions
             ev.preventDefault();
-            if (!this.wasEmpty) {
-                this.limit = 0; // prevent autocomplete
-                const form = this.$('.o_search_order_by').parents('form');
-                form.submit();
-            }
         }
     },
 });


### PR DESCRIPTION
Before this commit, clicking on the "x" button on the searchbar would
refresh the page and remove the result immediatly. The user might want
to keep the result if he does not do another search.

This commit avoids refreshing the page when removing the input content.

Steps to reproduce the bug:
- Click on the search button in the navbar
- Search "tree"
- Press enter
(You are redirected to /website/search)
- Click on the "x" button to delete the input content
(The page refresh)

task-3570756