### PR TITLE
[FIX] Analytic Distribution gets doubled on invoice

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1151,15 +1151,8 @@ class SaleOrderLine(models.Model):
         return res
 
     def _set_analytic_distribution(self, inv_line_vals, **optional_values):
-        analytic_account_id = self.order_id.analytic_account_id.id
         if self.analytic_distribution and not self.display_type:
             inv_line_vals['analytic_distribution'] = self.analytic_distribution
-        if analytic_account_id and not self.display_type:
-            analytic_account_id = str(analytic_account_id)
-            if 'analytic_distribution' in inv_line_vals:
-                inv_line_vals['analytic_distribution'][analytic_account_id] = inv_line_vals['analytic_distribution'].get(analytic_account_id, 0) + 100
-            else:
-                inv_line_vals['analytic_distribution'] = {analytic_account_id: 100}
 
     def _prepare_procurement_values(self, group_id=False):
         """ Prepare specific key for moves or other components that will be created from a stock rule

--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -93,6 +93,15 @@ class SaleOrderLine(models.Model):
                 del defaults["name"]
         return defaults
 
+    @api.depends('order_id.analytic_account_id')
+    def _compute_analytic_distribution(self):
+        super()._compute_analytic_distribution()
+        for line in self:
+            if line.display_type or line.analytic_distribution or not line.product_id:
+                continue
+            if line.order_id.analytic_account_id:
+                line.analytic_distribution = {line.order_id.analytic_account_id.id: 100}
+
     @api.depends('product_id.type')
     def _compute_product_updatable(self):
         super()._compute_product_updatable()


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

https://www.odoo.com/nl_NL/my/tasks/4210215

Current behavior before PR:

A Sale Order that contains the same Analytic Account both on the Sale Order AND on the Sale Order Line results in a 200% allocation on the related Invoice.

Desired behavior after PR is merged:

100% allocation on the related Invoice.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
