### PR TITLE
[FIX] website: reorganize price list snippets

### DIFF
--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -152,20 +152,11 @@
                 <t t-snippet="website.s_cta_box" string="Box Call to Action" group="content">
                     <keywords>CTA, button, btn, action, engagement, link, offer, appeal, call to action, prompt, interact, trigger</keywords>
                 </t>
-                <t t-snippet="website.s_pricelist_boxed" string="Pricelist Boxed" group="content">
-                    <keywords>menu, pricing, shop, table, cart, product, cost, charges, fees, tarifs, prices, expenses</keywords>
-                </t>
                 <t t-snippet="website.s_striped" string="Striped section" group="content">
                     <keywords>hero, jumbotron, headline, header, intro, home, content, picture, photo, illustration, media, visual, article, combination, trendy, pattern, design</keywords>
                 </t>
                 <t t-snippet="website.s_cta_card" string="Card Call to Action" group="content">
                     <keywords>CTA, button, btn, action, engagement, link, offer, appeal, call to action, prompt, interact, trigger, items, checklists, entries, sequences, bullets, points, list, group, benefits, features, advantages</keywords>
-                </t>
-                <t t-snippet="website.s_pricelist_cafe" string="Pricelist cafe" group="content">
-                    <keywords>menu, pricing, shop, table, cart, product, cost, charges, fees, tarifs, prices, expenses, columns</keywords>
-                </t>
-                <t t-snippet="website.s_product_catalog" string="Pricelist" group="content">
-                    <keywords>menu, pricing</keywords>
                 </t>
                 <t t-snippet="website.s_searchbar" string="Search" t-forbid-sanitize="form" group="content"/>
                 <t t-snippet="website.s_color_blocks_2" string="Big Boxes" group="content">
@@ -299,6 +290,15 @@
                 <t t-snippet="website.s_table_of_content" string="Table of Content" group="text"/>
                 <t t-snippet="website.s_faq_horizontal" string="Topics List" group="text">
                     <keywords>questions, answers, common answers, common questions, faq, help, support, information, knowledge, guide, troubleshooting, assistance, QA, terms of services</keywords>
+                </t>
+                <t t-snippet="website.s_product_catalog" string="Pricelist" group="text">
+                    <keywords>menu, pricing</keywords>
+                </t>
+                <t t-snippet="website.s_pricelist_cafe" string="Pricelist cafe" group="text">
+                    <keywords>menu, pricing, shop, table, cart, product, cost, charges, fees, tarifs, prices, expenses, columns</keywords>
+                </t>
+                <t t-snippet="website.s_pricelist_boxed" string="Pricelist Boxed" group="text">
+                    <keywords>menu, pricing, shop, table, cart, product, cost, charges, fees, tarifs, prices, expenses</keywords>
                 </t>
 
                 <!-- Contact & Forms group -->


### PR DESCRIPTION
This commit moves the price list snippets to a more appropriate category: Text

task-4212916

Requires:
- https://github.com/odoo/design-themes/pull/942


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
