### PR TITLE
[FIX] point_of_sale: handle adding products without archived variants

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -196,6 +196,9 @@ export class ProductProduct extends Base {
     }
 
     _isArchivedCombination(attributeValueIds) {
+        if (!this._archived_combinations) {
+            return false;
+        }
         for (const archivedCombination of this._archived_combinations) {
             const ptavCommon = archivedCombination.filter((ptav) =>
                 attributeValueIds.includes(ptav)


### PR DESCRIPTION
Before this commit, attempting to add a product to the cart that did not have an archived variant would result in an error.

opw-4212973

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
