### PR TITLE
[FIX] calendar: more consistent sender for appointment

### DIFF
--- a/addons/calendar/models/calendar_attendee.py
+++ b/addons/calendar/models/calendar_attendee.py
@@ -196,8 +196,8 @@ class CalendarAttendee(models.Model):
                     attendee.ids,
                     compute_lang=True)[attendee.id]
                 mail_messages += attendee.event_id.with_context(no_document=True).sudo().message_notify(
-                    email_from=attendee.event_id.user_id.email_formatted or self.env.user.email_formatted,
-                    author_id=attendee.event_id.user_id.partner_id.id or self.env.user.partner_id.id,
+                    email_from=attendee.event_id._get_responsible().email_formatted or self.env.user.email_formatted,
+                    author_id=attendee.event_id._get_responsible().partner_id.id or self.env.user.partner_id.id,
                     body=body,
                     subject=subject,
                     notify_author=notify_author,

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -1050,6 +1050,11 @@ class CalendarEvent(models.Model):
         """Overridable getter to identify whether to send invitation/cancelation emails."""
         return False
 
+    def _get_responsible(self):
+        """Overridable getter to define who the notification emails should be sent as."""
+        self.ensure_one()
+        return self.user_id
+
     def _get_attendee_emails(self):
         """ Get comma-separated attendee email addresses. """
         self.ensure_one()


### PR DESCRIPTION
Currently there's no notion of "user who should be sending the notification mail"

It's added to let appointment fall back on the manager of the appointment instead of odoobot

task-4146850

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
