### PR TITLE
[FIX] html_editor: drag and drop from the table shouldn't traceback

### DIFF
--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -377,10 +377,12 @@ export class DomPlugin extends Plugin {
             // Correct the position if it happens to be in the editable root.
             lastPosition = getDeepestPosition(...lastPosition);
         }
-        this.shared.setSelection(
-            { anchorNode: lastPosition[0], anchorOffset: lastPosition[1] },
-            { normalize: false }
-        );
+        if (lastPosition[0] !== null) {
+            this.shared.setSelection(
+                { anchorNode: lastPosition[0], anchorOffset: lastPosition[1] },
+                { normalize: false }
+            );
+        }
         return firstInsertedNodes.concat(insertedNodes).concat(lastInsertedNodes);
     }
 
@@ -388,7 +390,7 @@ export class DomPlugin extends Plugin {
         if (node === this.editable) {
             return true;
         }
-        return node.hasAttribute("contenteditable");
+        return node && node.hasAttribute("contenteditable");
     }
 
     copyAttributes(source, target) {

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -3612,6 +3612,24 @@ describe("onDrop", () => {
             `<p>ab<img class="img-fluid" data-file-name="image.png" src="${base64Image}">[]c</p>`
         );
     });
+    test("should not cause a traceback when add br from htmlTransferItem, which is possible when dragging table cells", async () => {
+        const { el } = await setupEditor("<p>[]<br></p>");
+        const pElement = el.firstChild;
+        const textNode = pElement.firstChild;
+
+        patchWithCleanup(document, {
+            caretPositionFromPoint: () => ({ offsetNode: textNode, offset: 0 }),
+        });
+
+        const dropData = new DataTransfer();
+        dropData.setData("text/html", '<br class="Apple-interchange-newline">');
+        dispatch(pElement, "drop", { dataTransfer: dropData });
+        await tick();
+
+        expect(getContent(el)).toBe(
+            `<p><br></p><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`
+        );
+    });
 });
 
 function dataURItoBlob(dataURI) {


### PR DESCRIPTION
Before this commit: in a table, select last two cells of first row and drag drop it to a p element out of the table, a traceback is raised

After this commit: the traceback is fixed, the added test only simulate the to be pasted content when drag and drop the selected cells




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
