### PR TITLE
[FIX] mrp: Fix Manufacture from BoM

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -826,7 +826,8 @@ class MrpProduction(models.Model):
 
     @api.onchange('qty_producing', 'lot_producing_id')
     def _onchange_producing(self):
-        self._set_qty_producing(False)
+        if 'default_bom_id' not in self.env.context:
+            self._set_qty_producing(False)
 
     @api.onchange('lot_producing_id')
     def _onchange_lot_producing(self):


### PR DESCRIPTION
The Manufacture button added in the BoM Overview prepares a new manufacturing order using the bom.
However for serial products this has a drawback of changing the state to 'in progress'. This is not the case when creating a new manufacturing order and then selecting the same bom.
The origin is within '_onchange_producing / _set_qty_producing' and the way the record is initialized:
- from 'Manufacturing orders / New' all fields have their default values
- from 'BoM Overview / Manufacture' the bom_id and related fields are set.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
