### PR TITLE
[FIX] account: no quick encoding on section/note

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1347,7 +1347,7 @@ class AccountMoveLine(models.Model):
     def default_get(self, fields_list):
         defaults = super().default_get(fields_list)
         quick_encode_suggestion = self.env.context.get('quick_encoding_vals')
-        if quick_encode_suggestion:
+        if quick_encode_suggestion and self.env.context.get('default_display_type') not in ('line_section', 'line_note'):
             defaults['account_id'] = quick_encode_suggestion['account_id']
             defaults['price_unit'] = quick_encode_suggestion['price_unit']
             defaults['tax_ids'] = [Command.set(quick_encode_suggestion['tax_ids'])]


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting
- Go to Accounting settings
- Set "Quick encoding" to "Customer Invoices and Vendor Bills"
- Create an invoice
- Set "Total (Tax inc.)" to any value
- Add a section and a note
- Check Journal Items

**Issue:**
A tax is set on the section and the note lines.

opw-4204583




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
