### PR TITLE
[FIX] web,base: makes sure python_method and action_id is not both set

### DIFF
--- a/addons/web/static/src/search/control_panel/control_panel.js
+++ b/addons/web/static/src/search/control_panel/control_panel.js
@@ -445,25 +445,32 @@ export class ControlPanel extends Component {
         }
         const userId = newActionIsShared ? false : user.userId;
 
-        const extractValues = ({ parent_action_id, action_id, parent_res_model }) => ({
+        const {
+            parent_action_id,
+            action_id,
+            parent_res_model,
+            python_method,
+            domain,
+            context,
+            groups_ids,
+        } = currentEmbeddedAction;
+        const values = {
             parent_action_id: parent_action_id[0],
-            action_id: action_id[0] || this.env.config.actionId,
             parent_res_model,
             parent_res_id: this.env.searchModel.globalContext.active_id,
             user_id: userId,
             is_deletable: true,
             default_view_mode: this.env.config.viewType,
-        });
-        const { parent_action_id, action_id, python_method, domain, context, groups_ids } =
-            currentEmbeddedAction;
-        const values = {
-            ...extractValues(currentEmbeddedAction),
-            python_method,
             domain,
             context,
             groups_ids,
             name: newActionName,
         };
+        if (python_method) {
+            values.python_method = python_method;
+        } else {
+            values.action_id = action_id[0] || this.env.config.actionId;
+        }
         const embeddedActionId = await this.orm.create("ir.embedded.actions", [values]);
         const description = `${newActionName}`;
         this.env.searchModel.createNewFavorite({

--- a/odoo/addons/base/models/ir_embedded_actions.py
+++ b/odoo/addons/base/models/ir_embedded_actions.py
@@ -51,6 +51,12 @@ class IrEmbeddedActions(models.Model):
         for vals in vals_list:
             if "name" not in vals:
                 vals["name"] = self.env["ir.actions.actions"].browse(vals["action_id"]).name
+            if "python_method" in vals and "action_id" in vals:
+                if vals.get("python_method"):
+                    # then remove the action_id since the action surely given by the python method.
+                    del vals["action_id"]
+                else:  # remove python_method in the vals since the vals is falsy.
+                    del vals["python_method"]
         return super().create(vals_list)
 
     # The record is deletable if it hasn't been created from a xml record (i.e. is not a default embedded action)

--- a/odoo/addons/base/tests/test_ir_embedded_actions.py
+++ b/odoo/addons/base/tests/test_ir_embedded_actions.py
@@ -121,3 +121,25 @@ class TestEmbeddedActionsBase(TransactionCaseWithUserDemo):
         self.assertEqual(len(res), 3, "There should be 3 embedded records linked to the parent action")
         self.assertTrue(self.embedded_action_1.id in res and self.embedded_action_2.id in res and embedded_action_custo.id in res, "The correct embedded actions\
                         should be in embedded_actions")
+
+    def test_create_embedded_action_with_action_and_python_method(self):
+        embedded_action1, embedded_action2 = self.env['ir.embedded.actions'].create([
+            {
+                'name': 'EmbeddedActionCustom',
+                'action_id': self.action_2.id,
+                'parent_action_id': self.parent_action.id,
+                'parent_res_model': 'res.partner',
+                'python_method': "action_python_method",
+            },
+            {
+                'name': 'EmbeddedActionCustom2',
+                'action_id': self.action_2.id,
+                'python_method': "",
+                'parent_action_id': self.parent_action.id,
+                'parent_res_model': 'res.partner',
+            }
+        ])
+        self.assertEqual(embedded_action1.python_method, "action_python_method")
+        self.assertFalse(embedded_action1.action_id)
+        self.assertEqual(embedded_action2.action_id, self.env['ir.actions.actions'].browse(self.action_2.id))
+        self.assertFalse(embedded_action2.python_method)


### PR DESCRIPTION
Before this commit, when the user tries to duplicate a embedded action containing the field `python_method` set, the `action_id` should not given otherwise an error will be raised because the `check_only_one_action_defined` constraint will not be respected because we will have 2 actions to call for a same embedded action.

This commit makes sure the `action_id` field is not set if `python_method` is given.

task-4191101