### PR TITLE
[FIX] mrp: not auto-assign raw move for unavailable components

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -8,6 +8,7 @@ import re
 
 from ast import literal_eval
 from collections import defaultdict
+from datetime import datetime
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, _, Command
@@ -1226,6 +1227,8 @@ class MrpProduction(models.Model):
                 continue
 
             new_qty = float_round((self.qty_producing - self.qty_produced) * move.unit_factor, precision_rounding=move.product_uom.rounding)
+            if move.manual_consumption and (float_compare(move.forecast_availability, 0, precision_rounding=move.product_uom.rounding) < 0) or move.forecast_expected_date and move.forecast_expected_date >= datetime.today():
+                new_qty = min(new_qty, move.product_qty_available)
             move._set_quantity_done(new_qty)
             if not move.manual_consumption:
                 move.picked = True

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -1245,6 +1245,8 @@ class TestMrpOrder(TestMrpCommon):
             'product_id': p2.id,
             'company_id': self.env.company.id,
         })
+        self.env['stock.quant']._update_available_quantity(p1, mo1.warehouse_id.lot_stock_id, 2.0)
+        self.env['stock.quant']._update_available_quantity(p2, mo1.warehouse_id.lot_stock_id, 2.0)
         mo_form = Form(mo1)
         mo_form.qty_producing = 1
         mo1 = mo_form.save()
@@ -1341,6 +1343,8 @@ class TestMrpOrder(TestMrpCommon):
             'product_id': p2.id,
             'company_id': self.env.company.id,
         })
+        self.env['stock.quant']._update_available_quantity(p1, mo1.warehouse_id.lot_stock_id, 2.0)
+        self.env['stock.quant']._update_available_quantity(p2, mo1.warehouse_id.lot_stock_id, 2.0)
         mo_form = Form(mo1)
         mo_form.qty_producing = 1
         mo1 = mo_form.save()

--- a/addons/mrp/tests/test_traceability.py
+++ b/addons/mrp/tests/test_traceability.py
@@ -188,6 +188,8 @@ class TestTraceability(TestMrpCommon):
         mo_form.bom_id = bom_1
         mo_form.product_qty = 2
         mo = mo_form.save()
+        self.env['stock.quant']._update_available_quantity(product_1, mo.warehouse_id.lot_stock_id, 2.0)
+        self.env['stock.quant']._update_available_quantity(product_2, mo.warehouse_id.lot_stock_id, 2.0)
         mo.action_confirm()
 
         mo_form = Form(mo)

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -478,7 +478,8 @@ Please change the quantity done or the rounding precision of your unit of measur
             for location, mvs in moves_per_location.items():
                 forecast_info = mvs._get_forecast_availability_outgoing(warehouse, location)
                 for move in mvs:
-                    move.forecast_availability, move.forecast_expected_date = forecast_info[move]
+                    # since the forecast_info are not computed for New records we set it from the _origin
+                    move.forecast_availability, move.forecast_expected_date = forecast_info[move._origin]
 
     def _set_date_deadline(self, new_deadline):
         # Handle the propagation of `date_deadline` fields (up and down stream - only update by up/downstream documents)


### PR DESCRIPTION
### Steps to reproduce:

- Create BOM consuming a storable component COMP that is not in stock
- Set the bom line consumption to manual
- Create and confirm a Manufacturing order using that BOM
- Set the qty producing of the MO to the max and save or start an operation (result in the same qty producing change)

#### > The component is automatically reserved on the move raw.

### Cause of the issue:

Changing the `qty_producing` of the MO will trigger a call of the `_set_qty_producing` method. During this call and since the raw move is not flagged as `should_bypass_set_qty_producing` its quantity will be set and the reservation of the corresponding quatity will be made: https://github.com/odoo/odoo/blob/c04fe54bf45509660ea94a9d7d431c74f1c6023b/addons/mrp/models/mrp_production.py#L1219-L1231 Since the move raw is therefore `assigned`, the forecast will be recomputed to be available:
https://github.com/odoo/odoo/blob/c04fe54bf45509660ea94a9d7d431c74f1c6023b/addons/stock/models/stock_move.py#L456-L464

opw-4190253
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
