### PR TITLE
[FIX] base: prevent address truncation in PDF documents

### DIFF
--- a/odoo/addons/base/views/ir_qweb_widget_templates.xml
+++ b/odoo/addons/base/views/ir_qweb_widget_templates.xml
@@ -26,7 +26,7 @@
 
             <div t-if="address and 'address' in fields" t-attf-class="d-flex align-items-baseline gap-1">
                 <i t-if="not options.get('no_marker')" class="fa fa-map-marker fa-fw" role="img" aria-label="Address" title="Address"/>
-                <span class="w-100 lh-sm text-truncate d-block" itemprop="streetAddress" t-esc="address"/>
+                <span class="w-100 lh-sm text-break d-block" itemprop="streetAddress" t-esc="address"/>
             </div>
             <div t-if="city and 'city' in fields" t-attf-class="d-flex align-items-baseline gap-1">
                 <i t-if="not options.get('no_marker')" class="fa fa-map-marker fa-fw" role="img" aria-label="Address" title="Address"/>


### PR DESCRIPTION
Problem:
When printing a Sales Order for a partner with a long address, the address is truncated in the generated PDF.

Steps to reproduce:
- Create a partner with a long address.
- Create a Sales Order for that partner.
- Print the Sales Order.
- In the generated PDF, the partner's address is truncated.

opw-4201101

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
