### PR TITLE
[FIX] website_slides: prevent traceback on duplicating multiple records

### DIFF
--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -739,12 +739,11 @@ class Channel(models.Model):
     def copy_data(self, default=None):
         default = dict(default or {})
         vals_list = super().copy_data(default=default)
-        if 'name' not in default:
-            for channel, vals in zip(self, vals_list):
+        for channel, vals in zip(self, vals_list):
+            if 'name' not in default:
                 vals['name'] = f"{channel.name} ({_('copy')})"
-
-        if 'enroll' not in default and self.visibility == "members":
-            vals['enroll'] = 'invite'
+            if 'enroll' not in default and channel.visibility == "members":
+                vals['enroll'] = 'invite'
         return vals_list
 
     def write(self, vals):

--- a/addons/website_slides/tests/test_slide_channel.py
+++ b/addons/website_slides/tests/test_slide_channel.py
@@ -403,3 +403,16 @@ class TestSequencing(slides_common.SlidesCase):
 
         copied_channel = channel.copy()
         self.assertEqual(copied_channel.enroll, 'invite', "Copied channel should have the same enroll field value")
+
+    @users('user_officer')
+    def test_duplicate_courses(self):
+        channel1 = self.env['slide.channel'].create({
+            'name': 'Test Course 1',
+        })
+        channel2 = self.env['slide.channel'].create({
+            'name': 'Test Course 2',
+        })
+
+        copied_value = (channel1 + channel2).copy()
+        self.assertEqual(copied_value[0].name, 'Test Course 1 (copy)')
+        self.assertEqual(copied_value[1].name, 'Test Course 2 (copy)')


### PR DESCRIPTION
Steps to reproduce:
1. Go to e-learning
2. Switch to list view
3. Select multiple courses
4. Duplicate them

Technical Reason:
In the 'copy_data' method, there was an incorrect indentation in the loop, and one condition needed to be placed inside the loop.

After this Commit:
No traceback will occur on duplicating multiple courses.

Task-4211075