### PR TITLE
[FIX] {purchase{,_stock},stock_account}: more accurate price unit calc

### DIFF
--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -438,8 +438,7 @@ class PurchaseOrderLine(models.Model):
             price_unit = price_unit * (1 - self.discount / 100)
         if self.taxes_id:
             qty = self.product_qty or 1
-            price_unit_prec = self.env['decimal.precision'].precision_get('Product Price')
-            price_unit = self.taxes_id.with_context(round=False).compute_all(price_unit, currency=self.order_id.currency_id, quantity=qty, product=self.product_id)['total_void']
+            price_unit = self.taxes_id.with_context(round=False, round_base=False).compute_all(price_unit, currency=self.order_id.currency_id, quantity=qty, product=self.product_id)['total_void']
             price_unit = price_unit / qty
         if self.product_uom.id != self.product_id.uom_id.id:
             price_unit *= self.product_uom.factor / self.product_id.uom_id.factor

--- a/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
+++ b/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
@@ -514,3 +514,37 @@ class TestValuationReconciliation(ValuationReconciliationTestCommon):
 
         picking2 = purchase_order2.picking_ids[0]
         self.assertEqual(picking2.state, 'done')
+
+    @freeze_time('2000-05-05')
+    def test_currency_exchange_journal_items(self):
+        """ Prices modified by discounts and currency exchanges should still yield accurate price
+        units when calculated by valuation mechanisms.
+        """
+        self.env.company.currency_id = self.env.ref('base.IQD').id
+        self.test_product_order.standard_price = 500
+        self.stock_account_product_categ.property_cost_method = 'average'
+        self.env['res.currency.rate'].create({
+            'name': '2000-05-05',
+            'company_rate': .00756,
+            'currency_id': self.env.ref('base.USD').id,
+            'company_id': self.env.company.id,
+        })
+
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'currency_id': self.env.ref('base.USD').id,
+            'order_line': [(0, 0, {
+                'product_id': self.test_product_order.id,
+                'product_uom_qty': 13,
+                'discount': 1,
+            })],
+        })
+        purchase_order.button_confirm()
+        purchase_order.picking_ids.move_ids.quantity = 13
+        purchase_order.picking_ids.button_validate()
+        pre_bill_remaining_value = purchase_order.picking_ids.move_ids.stock_valuation_layer_ids.remaining_value
+        purchase_order.action_create_invoice()
+        purchase_order.invoice_ids.invoice_date = '2000-05-05'
+        purchase_order.invoice_ids.action_post()
+        post_bill_remaining_value = purchase_order.picking_ids.move_ids.stock_valuation_layer_ids.remaining_value
+        self.assertEqual(post_bill_remaining_value, pre_bill_remaining_value)

--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -271,7 +271,8 @@ class AccountMoveLine(models.Model):
         if float_is_zero(self.quantity, precision_rounding=self.product_uom_id.rounding):
             return self.price_unit
 
-        price_unit = self.price_subtotal / self.quantity
+        price_unit = self.price_unit * (1 - self.discount / 100) if self.discount else\
+                     self.price_subtotal / self.quantity
         return -price_unit if self.move_id.move_type == 'in_refund' else price_unit
 
     def _get_stock_valuation_layers(self, move):


### PR DESCRIPTION
**Current behavior:**
With a non-standard-costing, stored product appears in a purchase order with a discount and requiring a currency exchange, the price unit may be calculated in an inaccurate fashion.

**Expected behavior:**
The price_unit should be accurate.

**Steps to reproduce:**
1. Enable another currency, set an exchange rate on it that is very small (like < 0.01)

2. Enable automatic valuation, create a product with both average costing method and real time valuation on its category, give it some initial cost e.g., 500

3. Create a new purchase order, add a line like: - product_id: from step 2 - quantity: 13 - discount: 1%

4. Set the currency on the purchase order to be the one from step 1, so it is different from the active company's

5. Confirm the purchase order and validate the receipt, look at the SVL generated and note its remaining value

6. Create a bill for the purchase order, post the invoice, then look at the SVL's remaining value again -> it changed

**Cause of the issue:**
The price unit being converted between currencies and rounded causes some discrepancy with the final value, also the calculation for gross price unit on AML model is somewhat primitive.

**Fix:**
Stop rounding base and update the formula used when calculating gross price unit.

opw-4103167