### PR TITLE
[FIX] web_editor: line decoration for gradient text color

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -105,6 +105,12 @@ function colorElement(element, color, mode) {
             element.style['background'] = '';
             element.style['background-image'] = color;
             element.classList.add('text-gradient');
+            element.querySelectorAll('u, s').forEach(lineDecorationTag => {
+                while (lineDecorationTag.firstChild) {
+                    lineDecorationTag.parentNode.insertBefore(lineDecorationTag.firstChild, lineDecorationTag);
+                }
+                lineDecorationTag.remove();
+              });
         } else {
             element.style['background-image'] = color;
         }

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -1232,6 +1232,12 @@ export const formatSelection = (editor, formatName, {applyStyle, formatProps} = 
         let currentNode = selectedTextNode;
         let parentNode = selectedTextNode.parentElement;
 
+        let closestFontNode = parentNode.closest("font");
+        if (closestFontNode?.classList.contains('text-gradient') 
+            && ((formatName == "underline") || (formatName == "strikeThrough"))) {
+            return;
+        }
+
         // Remove the format on all inline ancestors until a block or an element
         // with a class (in case the formating comes from the class).
         while (


### PR DESCRIPTION
Before this commit, it was possible to add line decoration to text even
when the text color was a gradient. However, the line decoration only
appears when the text was highlighted.

This commit removes the possibility to have line decoration and to set
the font color as to a gradient at the same time.

Steps to reproduce the bug:
- Add a snippet with text
- Add line decoration to the text (underline / strikethrough)
- Set the font color to a gradient
(The line decoration doesn't appear anymore unless highlighted)

task-3661369