### PR TITLE
WIP: search display_name

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -275,11 +275,6 @@ class MetaModel(api.Meta):
                     field.__set_name__(self, name)
 
             add('id', fields.Id(automatic=True))
-            add_default('display_name', fields.Char(
-                string='Display Name', automatic=True,
-                compute='_compute_display_name',
-                search='_search_display_name',
-            ))
 
             if attrs.get('_log_access', self._auto):
                 add_default('create_uid', fields.Many2one(
@@ -7264,6 +7259,12 @@ class Model(AbstractModel):
     _register = False           # not visible in ORM registry, meant to be python-inherited only
     _abstract = False           # not abstract
     _transient = False          # not transient
+
+    display_name = fields.Char(
+        string='Display Name', automatic=True,
+        compute='_compute_display_name',
+        search='_search_display_name',
+    )
 
 
 class TransientModel(Model):


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/174967, use name_search on task doesn't work correctly:
"Non-stored field project.task.display_name cannot be searched"
Which makes any many2one toward it unsearchable.

The field display_name is only added when no display_name are set on the model. It means that every model 'overriding' display_name should also included `search='_search_display_name'`.

Two solution:
- add `display_name` has a normal field to be extended as usual. (import nightmare to fix)
- just add  `search='_search_display_name'` on every model taht have display_name =field...