### PR TITLE
[FIX] product: allow changing priority in form view

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -49,7 +49,7 @@
                         <label for="name" string="Product Name"/>
                         <h1>
                             <div class="d-flex">
-                                <field name="is_favorite" widget="boolean_favorite" class="me-3" nolabel="1" readonly="1"/>
+                                <field name="is_favorite" widget="boolean_favorite" class="me-3" nolabel="1"/>
                                 <field class="text-break" name="name" options="{'line_breaks': False}" widget="text" placeholder="e.g. Cheese Burger"/>
                             </div>
                         </h1>


### PR DESCRIPTION
readonly was added to product template in commit 0d75323600a14dd8964b0b3d29d69aa0fde3ee45 When it should've just been on product.product, so users were no longer able to set as favorite from form view.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
