### PR TITLE
[FIX] website: fix some `s_text_cover` issues

### DIFF
--- a/addons/website/views/snippets/s_text_cover.xml
+++ b/addons/website/views/snippets/s_text_cover.xml
@@ -5,12 +5,12 @@
     <section class="s_text_cover o_colored_level o_cc o_cc3">
         <div class="container-fluid">
             <div class="row o_grid_mode" data-row-count="11">
-                <div class="o_grid_item g-height-10 g-col-lg-5 col-lg-6 o_cc o_cc1 pt48 pb48" style="z-index: 1; grid-area: 2 / 3 / 11 / 8; --grid-item-padding-x: 24px; --grid-item-padding-y: 24px;">
+                <div class="o_grid_item g-height-9 g-col-lg-5 col-lg-5 o_cc o_cc1" style="z-index: 1; grid-area: 2 / 3 / 11 / 8; --grid-item-padding-x: 24px; --grid-item-padding-y: 24px;">
                     <h1 class="display-3">Sell Online. <br/>Easily.</h1>
                     <p class="lead"><br/>Sell online easily with a user-friendly platform that streamlines all the steps, including setup, inventory management, and payment processing.<br/></p>
                     <a t-att-href="cta_btn_href" class="btn btn-lg btn-primary"><t t-esc="cta_btn_text">Contact us</t></a>
                 </div>
-                <div class="o_grid_item g-height-12 g-col-lg-6 col-lg-6 o_cc o_cc1 pt48 pb48 oe_img_bg o_not_editable d-none d-md-block" style="grid-area: 1 / 7 / 12 / 13; --grid-item-padding-x: 0px; --grid-item-padding-y: 0px; background-image: url('/web/image/website.s_text_cover_default_image');"/>
+                <div class="o_grid_item g-height-11 g-col-lg-6 col-lg-6 o_cc o_cc1 oe_img_bg o_not_editable d-none d-lg-block o_snippet_mobile_invisible" style="grid-area: 1 / 7 / 12 / 13; --grid-item-padding-x: 0px; --grid-item-padding-y: 0px; background-image: url('/web/image/website.s_text_cover_default_image');"/>
             </div>
         </div>
     </section>


### PR DESCRIPTION
This commit fixes the `s_text_cover` snippet template to:
- remove the padding `pt pb` classes, as they are useless in grid mode,
- fix the `g-height-*` classes, as they were not matching the number of rows and it is needed to resize smoothly,
- fix a `col-lg-*` class as it needs to match with the grid one,
- fix the mobile visibility classes: the mobile breakpoint is at `LG` and it was missing the `o_snippet_mobile_invisible` class.

task-3665300