### PR TITLE
[FIX] website_sale_loyalty: test_gift_card_tour

### DIFF
--- a/addons/website_sale_loyalty/static/tests/tours/test_gift_card_tour.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_gift_card_tour.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { registry } from "@web/core/registry";
-import * as tourUtils from '@website_sale/js/tours/tour_utils';
+import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('shop_sale_gift_card', {
     test: true,
@@ -22,31 +22,28 @@ registry.category("web_tour.tours").add('shop_sale_gift_card', {
         },
         {
             content: 'check gift card line',
-            trigger: 'div>strong:contains("PAY WITH GIFT CARD")',
-            run: "click",
+            trigger: "#cart_products div>strong:contains(PAY WITH GIFT CARD)",
         },
         {
-            trigger: 'form[name="coupon_code"]',
-        },
-        {
-            content: 'insert gift card code',
+            content: "Insert promo",
             trigger: 'form[name="coupon_code"] input[name="promo"]',
             run: "edit 10PERCENT",
         },
         {
-            content: 'validate the gift card',
+            content: "Validate the promo",
             trigger: 'form[name="coupon_code"] .a-submit',
             run: "click",
         },
         {
-            content: 'check gift card amount',
-            trigger: '.oe_website_sale .oe_cart',
+            content: "Check promo",
+            trigger: "#cart_products div>strong:contains(10% on your order)",
+        },
+        {
+            content: "Click on Continue Shopping",
+            trigger: "div.card-body a:contains(Continue shopping)",
+            run: "click",
         },
         ...tourUtils.addToCart({productName: "TEST - Gift Card"}),
         tourUtils.goToCart({quantity: 2}),
-        {
-            content: 'check gift card amount',
-            trigger: '.oe_website_sale .oe_cart',
-        },
     ],
 });


### PR DESCRIPTION
In this commit, we fix the tour test_gift_card_tour by adding a step to continue shopping. We take advantage of this commit to remove unnecessary clicks.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
