### PR TITLE
[FIX] account: wrong waiting and late count on dashboard

### DIFF
--- a/addons/account/tests/test_account_journal_dashboard.py
+++ b/addons/account/tests/test_account_journal_dashboard.py
@@ -213,12 +213,12 @@ class TestAccountJournalDashboard(TestAccountJournalDashboardCommon):
 
         self._create_test_vendor_bills(journal)
         dashboard_data = journal._get_journal_dashboard_data_batched()[journal.id]
-        # Expected behavior is to have six amls waiting for payment for a total amount of 4440$
-        # three of which would be late for a total amount of 140$
-        self.assertEqual(6, dashboard_data['number_waiting'])
+        # Expected behavior is to have three moves waiting for payment for a total amount of 4440$ one of which would be late
+        # for a total amount of 40$ (second move has one of three lines late but that's not enough to make the move late)
+        self.assertEqual(3, dashboard_data['number_waiting'])
         self.assertEqual(format_amount(self.env, 4440, company_currency), dashboard_data['sum_waiting'])
-        self.assertEqual(3, dashboard_data['number_late'])
-        self.assertEqual(format_amount(self.env, 140, company_currency), dashboard_data['sum_late'])
+        self.assertEqual(1, dashboard_data['number_late'])
+        self.assertEqual(format_amount(self.env, 40, company_currency), dashboard_data['sum_late'])
 
     def test_gap_in_sequence_warning(self):
         journal = self.company_data['default_journal_sale']

--- a/addons/account/tests/test_account_journal_dashboard_common.py
+++ b/addons/account/tests/test_account_journal_dashboard_common.py
@@ -49,8 +49,8 @@ class TestAccountJournalDashboardCommon(AccountTestInvoicingCommon):
                 'tax_ids': [],
             })]
         }).action_post()
-        # This bill has two amls of 10$. Both are waiting for payment and due in 16 and 46 days.
-        # number_waiting += 2, sum_waiting += -4000$, number_late += 0, sum_late += 0$
+        # This bill has two residual amls. One of 1000$ and one of 3000$. Both are waiting for payment and due in 16 and 46 days.
+        # number_waiting += 1, sum_waiting += -4000$, number_late += 0, sum_late += 0$
 
         self.env['account.move'].create({
             'move_type': 'in_invoice',
@@ -67,8 +67,9 @@ class TestAccountJournalDashboardCommon(AccountTestInvoicingCommon):
                 'tax_ids': [],
             })]
         }).action_post()
-        # This bill has two amls of 100$. One which is late and due 14 days prior and one which is waiting for payment and due in 15 days.
-        # number_waiting += 2, sum_waiting += -400$, number_late += 1, sum_late += -100$
+        # This bill has two residual amls. One of 100$ and one of 300$. One is late and due 14 days prior and one which is waiting for payment and due in 15 days.
+        # Even though one entry is late, the entire move isn't considered late since all entries are not.
+        # number_waiting += 1, sum_waiting += -400$, number_late += 0, sum_late += 0$
 
         self.env['account.move'].create({
             'move_type': 'in_invoice',
@@ -85,8 +86,8 @@ class TestAccountJournalDashboardCommon(AccountTestInvoicingCommon):
                 'tax_ids': [],
             })]
         }).action_post()
-        # This bill has two amls of 1000$. Both of them are late and due 45 and 15 days prior.
-        # number_waiting += 2, sum_waiting += -40$, number_late += 2, sum_late += -40$
+        # This bill has two residual amls. One of 10$ and one of 30$. Both of them are late and due 45 and 15 days prior.
+        # number_waiting += 1, sum_waiting += -40$, number_late += 1, sum_late += -40$
 
     def assertDashboardPurchaseSaleData(self, journal, number_draft, sum_draft, number_waiting, sum_waiting, number_late, sum_late, currency, **kwargs):
         expected_values = {


### PR DESCRIPTION
Description of the issue this commit addresses:

Since recently, the <[X] To Pay> and <[X] Late> buttons don't send the user to an account.move.line model view anymore but to an account.move model one but when that change was made, the computation of the number of items on the dashboard was not changed so it was still counting the amount of account.move. line there was in the account.move items that were shown in the view resulting in wrong totals.

---

Steps to reproduce:

1. Install account
2. Create new Vendor Bill with a split payment term ("30% now, Balance 60 Days" for example) on today's date for Bill Date.
3. Go to the dashboard, click the <[X] To Pay> button.
4. the amount of moves in the view that is opened with the button is one above the value of "X" in the button.

This is due to using a split payment term that creates two installment for a single vendor bill hence counting one more aml than there are moves.

---

Desired behavior after this commit is merged:

The right amount of To Pay and Late moves is shown at all times.

---

Enterprise PR: https://github.com/odoo/enterprise/pull/70725
No task

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
