### PR TITLE
[FIX] mrp: button alignment in work order line

### DIFF
--- a/addons/mrp/static/src/views/mrp_workorder_one2many.xml
+++ b/addons/mrp/static/src/views/mrp_workorder_one2many.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-inherit="web.ListRenderer" t-inherit-mode="extension">
+        <xpath expr="//table" position="attributes">
+            <attribute name="t-att-class">
+                {'w-auto': this.props.list.resModel == 'mrp.workorder' or (this.props.nestedKeyOptionalFieldsData and this.props.nestedKeyOptionalFieldsData.field == 'workorder_ids')}
+            </attribute>
+        </xpath>
+    </t>
+</templates>


### PR DESCRIPTION
With this Commit :
----------------------------------

- Adjusted the list view template to resolve the misalignment of the 'Done' button when clicking the 'Start' button on the work order line.

- I have modified the associated class to ensure proper alignment.
