### PR TITLE
[FIX] mrp: manual consumption BOM line with operations

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -727,7 +727,7 @@ class StockMove(models.Model):
 
     @api.model
     def _determine_is_manual_consumption(self, bom_line):
-        return bom_line and bom_line.manual_consumption
+        return bom_line and (bom_line.manual_consumption or bom_line.operation_id)
 
     def _get_relevant_state_among_moves(self):
         res = super()._get_relevant_state_among_moves()


### PR DESCRIPTION
When an operation is added to a BOM line, it will be treated as a manual consumption component.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
