### PR TITLE
[FIX] point_of_sale: ensure unsynced paid orders sync after restart

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -88,6 +88,9 @@ export class PosOrder extends Base {
         return this.state !== "draft";
     }
 
+    get isUnsyncedPaid() {
+        return this.finalized && typeof this.id === "string";
+    }
     getEmailItems() {
         return [_t("the receipt")].concat(this.is_to_invoice() ? [_t("the invoice")] : []);
     }

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -490,6 +490,15 @@ export class PosStore extends Reactive {
     }
 
     async afterProcessServerData() {
+        // Adding the not synced paid orders to the pending orders
+        const paidUnsyncedOrderIds = this.models["pos.order"]
+            .filter((order) => order.isUnsyncedPaid)
+            .map((order) => order.id);
+
+        if (paidUnsyncedOrderIds.length > 0) {
+            this.addPendingOrder(paidUnsyncedOrderIds);
+        }
+
         const openOrders = this.data.models["pos.order"].filter((order) => !order.finalized);
 
         if (!this.config.module_pos_restaurant) {


### PR DESCRIPTION
Before this commit, orders created in offline mode would not sync upon restarting the session once back online.

opw-4213314

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
