### PR TITLE
[FIX] stock_dropshipping: wrong vendor selected

### DIFF
--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -60,7 +60,7 @@ class StockRule(models.Model):
                 supplier = procurement.values['orderpoint_id'].supplier_id
             else:
                 supplier = procurement.product_id.with_company(procurement.company_id.id)._select_seller(
-                    partner_id=procurement.values.get("supplierinfo_name") or (procurement.values.get("group_id") and procurement.values.get("group_id").partner_id),
+                    partner_id=self._get_partner_id(procurement.values, rule),
                     quantity=procurement.product_qty,
                     date=max(procurement_date_planned.date(), fields.Date.today()),
                     uom_id=procurement.product_uom)
@@ -331,3 +331,6 @@ class StockRule(models.Model):
         if self.location_dest_id.usage == "supplier":
             res['purchase_line_id'], res['partner_id'] = move_to_copy._get_purchase_line_and_partner_from_chain()
         return res
+
+    def _get_partner_id(self, values, rule):
+        return values.get("supplierinfo_name") or (values.get("group_id") and values.get("group_id").partner_id)

--- a/addons/stock_dropshipping/models/stock.py
+++ b/addons/stock_dropshipping/models/stock.py
@@ -15,6 +15,12 @@ class StockRule(models.Model):
         """
         return procurement.values.get('sale_line_id'), super(StockRule, self)._get_procurements_to_merge_groupby(procurement)
 
+    def _get_partner_id(self, values, rule):
+        route = self.env.ref('stock_dropshipping.route_drop_shipping', raise_if_not_found=False)
+        if route and rule.route_id == route:
+            return False
+        return super()._get_partner_id(values, rule)
+
 
 class ProcurementGroup(models.Model):
     _inherit = "procurement.group"


### PR DESCRIPTION
Steps to reproduce:
- Create a product with 2 vendors:
	- First one: quantity 10, delay 10, price 5
	- Second one: quantity 5, delay 5, price 10
- Select the dropship route on the product
- Create an SO with that product (quantity 5) and confirm it
- Go on the purchase order created

Bug:
The vendor selected is not the correct one (it selects the first one, so the price should be 0, and the delay should be incorrect as well)

Fix:
In https://github.com/odoo/odoo/commit/a35be7b0dd52a5a02b6811cb95ad3189483b7327, the partner passed to _select_seller will always have a value, but an incorrect one for dropshipping routes. The problem resides in https://github.com/odoo/odoo/blob/c04fe54bf45509660ea94a9d7d431c74f1c6023b/addons/product/models/product_product.py#L656. The partner_id is the SO buyer, and it's not possible to have the vendor == to the buyer. It thus default the vendor to the first known vendor which is incorrect.

task-id: 4207060

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
