### PR TITLE
[FIX] web: StatusBarField arrow glitch on touch screen

### DIFF
--- a/addons/web/static/src/views/fields/statusbar/statusbar_field.scss
+++ b/addons/web/static/src/views/fields/statusbar/statusbar_field.scss
@@ -9,46 +9,105 @@
         align-self: stretch;
         align-items: stretch;
 
+        --o-statusbar-radius: 0.1rem;
+        --o-statusbar-border: #{$o-view-background-color};
+        --o-statusbar-background-active: #{map-get($-btn-secondary-design, active-background)};
+        --o-statusbar-border-active: #{map-get($-btn-secondary-design, active-border)};
+        --o-statusbar-background-hover: #{map-get($-btn-secondary-design, hover-background)};
+        --o-statusbar-caret-width: #{$o-statusbar-arrow-width};
+        --o-statusbar-border-width: #{$btn-border-width};
+        --o-statusbar-padding-x: calc(var(--o-statusbar-caret-width) * 1.25);
+        --o-statusbar-padding-y: calc(#{$btn-padding-y} + #{$btn-border-width});
+
+        --o-statusbar-point-top-left: 0 0;
+        --o-statusbar-point-top-right: calc(100% - var(--o-statusbar-caret-width)) 0;
+        --o-statusbar-point-middle-left: var(--o-statusbar-caret-width) 50%;
+        --o-statusbar-point-middle-right: 100% 50%;
+        --o-statusbar-point-bottom-left: 0 100%;
+        --o-statusbar-point-bottom-right: calc(100% - var(--o-statusbar-caret-width)) 100%;
+        --o-statusbar-point-inner-top-left: calc(var(--o-statusbar-border-width) * sqrt(2)) 0;
+        --o-statusbar-point-inner-top-right: calc(100% - var(--o-statusbar-caret-width) - var(--o-statusbar-border-width) * sqrt(2)) 0;
+        --o-statusbar-point-inner-middle-left: calc(var(--o-statusbar-caret-width) + var(--o-statusbar-border-width) * sqrt(2)) 50%;
+        --o-statusbar-point-inner-middle-right: calc(100% - var(--o-statusbar-border-width) * sqrt(2)) 50%;
+        --o-statusbar-point-inner-bottom-left: calc(var(--o-statusbar-border-width) * sqrt(2)) 100%;
+        --o-statusbar-point-inner-bottom-right: calc(100% - var(--o-statusbar-caret-width) - var(--o-statusbar-border-width) * sqrt(2)) 100%;
+
         > .o_arrow_button:not(.d-none) {
             position: relative;
-            padding-left: $o-statusbar-arrow-width * 1.5;
-            border-radius: 0;
-
+            padding: var(--o-statusbar-padding-y) calc(var(--o-statusbar-padding-x) * 1.375);
+            border: 0;
+            clip-path: polygon(
+                var(--o-statusbar-point-top-left),
+                var(--o-statusbar-point-top-right),
+                var(--o-statusbar-point-middle-right),
+                var(--o-statusbar-point-bottom-right),
+                var(--o-statusbar-point-bottom-left),
+                var(--o-statusbar-point-middle-left)
+            );
+            margin-left: calc(-1 * var(--o-statusbar-caret-width) - var(--o-statusbar-border-width) * sqrt(3));
+          
+            &.o_last {
+                --o-statusbar-point-middle-left: 0 50%;
+                padding-left: var(--o-statusbar-padding-x);
+                margin-left: 0;
+                border-top-left-radius: var(--o-statusbar-radius);
+                border-bottom-left-radius: var(--o-statusbar-radius);
+            }
+            
             &.o_first {
-                @include border-end-radius($border-radius);
-                padding-right: $o-horizontal-padding; // Compensate container padding
-                overflow: hidden; // to prevent scroll due to last arrow
+                --o-statusbar-point-top-right: 100% 0;
+                --o-statusbar-point-bottom-right: 100% 100%;
+                padding-right: var(--o-statusbar-padding-x);
+                border-top-right-radius: var(--o-statusbar-radius);
+                border-bottom-right-radius: var(--o-statusbar-radius);
                 flex-grow: 1;
             }
 
-            &.o_last {
-                @include border-start-radius($border-radius);
-                padding-left: $o-horizontal-padding;
+            &.dropdown-toggle::after {
+                content: normal;
+            }
+            
+            &::before {
+                content: "";
+                position: absolute;
+                inset: 0;
+                background-color: var(--o-statusbar-border);
+                clip-path: polygon(
+                    var(--o-statusbar-point-top-left),
+                    var(--o-statusbar-point-top-right),
+                    var(--o-statusbar-point-middle-right),
+                    var(--o-statusbar-point-bottom-right),
+                    var(--o-statusbar-point-bottom-left),
+                    var(--o-statusbar-point-middle-left),
+                    var(--o-statusbar-point-top-left),
+                    var(--o-statusbar-point-inner-top-left),
+                    var(--o-statusbar-point-inner-middle-left),
+                    var(--o-statusbar-point-inner-bottom-left),
+                    var(--o-statusbar-point-inner-bottom-right),
+                    var(--o-statusbar-point-inner-middle-right),
+                    var(--o-statusbar-point-inner-top-right),
+                    var(--o-statusbar-point-inner-top-left)
+                );
+            }
+            
+            &.o_last::before {
+                --o-statusbar-point-inner-top-left: var(--o-statusbar-point-top-left);
+                --o-statusbar-point-inner-middle-left: var(--o-statusbar-point-middle-left);
+                --o-statusbar-point-inner-bottom-left: var(--o-statusbar-point-bottom-left);
+                border-top-left-radius: var(--o-statusbar-radius);
+                border-bottom-left-radius: var(--o-statusbar-radius);
+            }
+            
+            &.o_first::before {
+                --o-statusbar-point-inner-top-right: var(--o-statusbar-point-top-right);
+                --o-statusbar-point-inner-middle-right: var(--o-statusbar-point-middle-right);
+                --o-statusbar-point-inner-bottom-right: var(--o-statusbar-point-bottom-right);
+                border-top-right-radius: var(--o-statusbar-radius);
+                border-bottom-right-radius: var(--o-statusbar-radius);
             }
 
-            &:not(.o_first),
-            &:not(.o_last) {
-                &:before, &:after {
-                    @include o-position-absolute(-$border-width, -$o-statusbar-arrow-width);
-                    display: block;
-
-                    border-top: floor($o-statusbar-height/2) solid transparent;
-                    border-bottom: ceil($o-statusbar-height/2) solid transparent;
-                    border-right: none;
-                    border-left: $o-statusbar-arrow-width solid map-get($-btn-secondary-design, background);
-                    -moz-transform: scale(0.9999); // Smooth the triangle on firefox
-                    content: " ";
-                    @include transition($btn-transition);
-                }
-
-                &:before {
-                    right: calc(-#{$o-statusbar-arrow-width} - #{$border-width});
-                    border-left-color: $o-view-background-color;
-                }
-
-                &:hover:after {
-                    border-left-color: map-get($-btn-secondary-design, hover-background);
-                }
+            &:hover, &:focus {
+                background-color: var(--o-statusbar-background-hover);
             }
 
             &:disabled {
@@ -61,19 +120,85 @@
                     }
                 }
             }
-
-            &.o_arrow_button_current:disabled, &:active:not(.o_first) {
-                background-color: map-get($-btn-secondary-design, active-background);
-                border-color: map-get($-btn-secondary-design, active-border);
-                color: map-get($-btn-secondary-design, active-color);
-
-                &:after {
-                    border-left-color: map-get($-btn-secondary-design, active-background);
+            
+            &.o_arrow_button_current:disabled, &:active:not(.o_last) {
+                z-index: 1;
+                background-color: var(--o-statusbar-background-active);
+                
+                &::before {
+                    --o-statusbar-point-inner-top-left: calc(var(--o-statusbar-border-width) * sqrt(3)) var(--o-statusbar-border-width);
+                    --o-statusbar-point-inner-top-right: calc(100% - var(--o-statusbar-caret-width) - var(--o-statusbar-border-width) / sqrt(2)) var(--o-statusbar-border-width);
+                    --o-statusbar-point-inner-bottom-left: calc(var(--o-statusbar-border-width) * sqrt(3)) calc(100% - var(--o-statusbar-border-width));
+                    --o-statusbar-point-inner-bottom-right: calc(100% - var(--o-statusbar-caret-width) - var(--o-statusbar-border-width) / sqrt(2)) calc(100% - var(--o-statusbar-border-width));
+                    background-color: var(--o-statusbar-border-active);
                 }
+            
+                &.o_last::before {
+                    --o-statusbar-point-inner-top-left: calc(var(--o-statusbar-border-width) * sqrt(2)) var(--o-statusbar-border-width);
+                    --o-statusbar-point-inner-middle-left: calc(var(--o-statusbar-border-width) * sqrt(2)) 50%;
+                    --o-statusbar-point-inner-bottom-left: calc(var(--o-statusbar-border-width) * sqrt(2)) calc(100% - var(--o-statusbar-border-width));
+                }
+            
+                &.o_first::before {
+                    --o-statusbar-point-inner-top-right: calc(100% - var(--o-statusbar-border-width) * sqrt(2)) var(--o-statusbar-border-width);
+                    --o-statusbar-point-inner-middle-right: calc(100% - var(--o-statusbar-border-width) * sqrt(2)) 50%;
+                    --o-statusbar-point-inner-bottom-right: calc(100% - var(--o-statusbar-border-width) * sqrt(2)) calc(100% - var(--o-statusbar-border-width));
+                }
+            }
 
-                &, & + .btn {
-                    &:before {
-                        border-left-color: map-get($-btn-secondary-design, active-border);
+            .o_rtl & {
+                --o-statusbar-point-top-left: var(--o-statusbar-caret-width) 0;
+                --o-statusbar-point-top-right: 100% 0;
+                --o-statusbar-point-middle-left: 0 50%;
+                --o-statusbar-point-middle-right: calc(100% - var(--o-statusbar-caret-width)) 50%;
+                --o-statusbar-point-bottom-left: var(--o-statusbar-caret-width) 100%;
+                --o-statusbar-point-bottom-right: 100% 100%;
+                --o-statusbar-point-inner-top-left: calc(var(--o-statusbar-caret-width) + var(--o-statusbar-border-width) * sqrt(2)) 0;
+                --o-statusbar-point-inner-top-right: calc(100% - var(--o-statusbar-border-width) * sqrt(2)) 0;
+                --o-statusbar-point-inner-middle-left: calc(var(--o-statusbar-border-width) * sqrt(2)) 50%;
+                --o-statusbar-point-inner-middle-right: calc(100% - var(--o-statusbar-caret-width) - var(--o-statusbar-border-width) * sqrt(2)) 50%;
+                --o-statusbar-point-inner-bottom-left: calc(var(--o-statusbar-caret-width) + var(--o-statusbar-border-width) * sqrt(2)) 100%;
+                --o-statusbar-point-inner-bottom-right: calc(100% - var(--o-statusbar-border-width) * sqrt(2)) 100%;
+          
+                &.o_last {
+                    --o-statusbar-point-middle-right: 100% 50%;
+                }
+                
+                &.o_first {
+                    --o-statusbar-point-top-left: 0 0;
+                    --o-statusbar-point-bottom-left: 0 100%;
+                }
+                
+                &.o_last::before {
+                    --o-statusbar-point-inner-top-right: var(--o-statusbar-point-top-right);
+                    --o-statusbar-point-inner-middle-right: var(--o-statusbar-point-middle-right);
+                    --o-statusbar-point-inner-bottom-right: var(--o-statusbar-point-bottom-right);
+                }
+                
+                &.o_first::before {
+                    --o-statusbar-point-inner-top-left: var(--o-statusbar-point-top-left);
+                    --o-statusbar-point-inner-middle-left: var(--o-statusbar-point-middle-left);
+                    --o-statusbar-point-inner-bottom-left: var(--o-statusbar-point-bottom-left);
+                }
+            
+                &.o_arrow_button_current:disabled, &:active:not(.o_last) {
+                    &::before {
+                        --o-statusbar-point-inner-top-left: calc(var(--o-statusbar-caret-width) + var(--o-statusbar-border-width) / sqrt(2)) var(--o-statusbar-border-width);
+                        --o-statusbar-point-inner-top-right: calc(100% - var(--o-statusbar-border-width) * sqrt(3)) var(--o-statusbar-border-width);
+                        --o-statusbar-point-inner-bottom-left: calc(var(--o-statusbar-caret-width) + var(--o-statusbar-border-width) / sqrt(2)) calc(100% - var(--o-statusbar-border-width));
+                        --o-statusbar-point-inner-bottom-right: calc(100% - var(--o-statusbar-border-width) * sqrt(3)) calc(100% - var(--o-statusbar-border-width));
+                    }
+                
+                    &.o_last::before {
+                        --o-statusbar-point-inner-top-right: calc(100% - var(--o-statusbar-border-width) * sqrt(2)) var(--o-statusbar-border-width);
+                        --o-statusbar-point-inner-middle-right: calc(100% - var(--o-statusbar-border-width) * sqrt(2)) 50%;
+                        --o-statusbar-point-inner-bottom-right: calc(100% - var(--o-statusbar-border-width) * sqrt(2)) calc(100% - var(--o-statusbar-border-width));
+                    }
+                
+                    &.o_first::before {
+                        --o-statusbar-point-inner-top-left: calc(var(--o-statusbar-border-width) * sqrt(2)) var(--o-statusbar-border-width);
+                        --o-statusbar-point-inner-middle-left: calc(var(--o-statusbar-border-width) * sqrt(2)) 50%;
+                        --o-statusbar-point-inner-bottom-left: calc(var(--o-statusbar-border-width) * sqrt(2)) calc(100% - var(--o-statusbar-border-width));
                     }
                 }
             }


### PR DESCRIPTION
On touchscreen, the interactive elements' padding is extended to make
them easier to target with fingers.

This commit fixes a glitch in the StatusBarField's arrow where the said
arrow doesn't touch the bottom of its element. Further more, it reworks
the shape to avoid having a small (but visible) gap between the "arrow"
part and the "label" one (in addition to weird background, appearing
border occasional glitches).

Steps to reproduce (on touchscreen):
- Open CRM app
- Open a lead (form view)
=> check the statusbar field arrow is "broken" at the bottom and a gap
between the arrow and the label

task-4212908


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
