### PR TITLE
[FIX] website: disable "follow the tips" message temporarily

### DIFF
--- a/addons/website/static/src/components/website_loader/website_loader.js
+++ b/addons/website/static/src/components/website_loader/website_loader.js
@@ -124,7 +124,10 @@ export class WebsiteLoader extends Component {
             this.state.isVisible = true;
             for (const prop of [
                 "title",
-                "showTips",
+                // FIXME: website user/interactive tours are not properly
+                // working at the moment. This disables the "follow the tips"
+                // message in the website loader while waiting for a fix.
+                // "showTips",
                 "selectedFeatures",
                 "showWaitingMessages",
                 "bottomMessageTemplate",


### PR DESCRIPTION
Website user/interactive tours are not properly working at the moment. This disables the "follow the tips" message in the website loader while waiting for a fix.

Follow-up of https://github.com/odoo/odoo/pull/180471
Related to task-3084175
