### PR TITLE
[FIX] stock: reserve on inter-company transit location

### DIFF
--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -401,7 +401,7 @@ class Location(models.Model):
 
     def should_bypass_reservation(self):
         self.ensure_one()
-        return self.usage in ('supplier', 'customer', 'inventory', 'production') or self.scrap_location or (self.usage == 'transit' and not self.company_id)
+        return self.usage in ('supplier', 'customer', 'inventory', 'production') or self.scrap_location
 
     def _check_access_putaway(self):
         return self


### PR DESCRIPTION
It used to be forbidden to reserve on inter-company transit, as this could raise issues with transfered lots that would belong to a company being processed in another company.

Since now lots can be made company-less for the purpose of being transferable between companies, it would make sense to enable the reservation again, and allow to draw from the inter-company location as if it was a normal transit location.

Task-4207078

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
