### PR TITLE
[FIX] pos_restaurant: table marked as full after booking

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -319,7 +319,7 @@ patch(PosStore.prototype, {
         );
     },
     tableHasOrders(table) {
-        return this.getActiveOrdersOnTable(table).length > 0;
+        return Boolean(table.getOrder());
     },
     async transferOrder(destinationTable) {
         const order = this.models["pos.order"].getBy("uuid", this.orderToTransferUuid);
@@ -349,7 +349,9 @@ patch(PosStore.prototype, {
                 }
             }
             this.set_order(destinationOrder);
-            this.addPendingOrder([destinationOrder.id]);
+            if (destinationOrder?.id) {
+                this.addPendingOrder([destinationOrder.id]);
+            }
             await this.deleteOrders([order]);
         }
         await this.setTable(destinationTable);


### PR DESCRIPTION
Before this commit:
===
- After booking a table and returning to the floor plan, the table was not marked as full.

After this commit:
===
- After booking a table and returning to the floor plan, the table is now correctly marked as full.

Task-4210770
