### PR TITLE
[IMP] html_editor: apply color and font-size to list item marker

### DIFF
--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -447,6 +447,9 @@ export class DomPlugin extends Plugin {
                 if (extraClass) {
                     newEl.classList.add(extraClass);
                 }
+                if (block.nodeName === "LI") {
+                    this.delegateTo("set_tag_overrides", block, newEl);
+                }
             } else {
                 // eg do not change a <div> into a h1: insert the h1
                 // into it instead.

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -121,6 +121,7 @@ function getUnselectedEdgeNodes(selection) {
  * @property { SelectionPlugin['modifySelection'] } modifySelection
  * @property { SelectionPlugin['preserveSelection'] } preserveSelection
  * @property { SelectionPlugin['rectifySelection'] } rectifySelection
+ * @property { SelectionPlugin['isNodeContentsFullySelected'] } isNodeContentsFullySelected
  * @property { SelectionPlugin['resetActiveSelection'] } resetActiveSelection
  * @property { SelectionPlugin['resetSelection'] } resetSelection
  * @property { SelectionPlugin['setCursorEnd'] } setCursorEnd
@@ -144,6 +145,7 @@ export class SelectionPlugin extends Plugin {
         "getTraversedBlocks",
         "modifySelection",
         "rectifySelection",
+        "isNodeContentsFullySelected",
         // todo: ideally, this should not be shared
         "resetActiveSelection",
         "focusEditable",
@@ -572,6 +574,20 @@ export class SelectionPlugin extends Plugin {
             // Default rule
             (range.isPointInRange(node, 0) && range.isPointInRange(node, nodeSize(node)));
         return this.getTraversedNodes().filter(isNodeFullySelected);
+    }
+
+    isNodeContentsFullySelected(node) {
+        const selection = this.getEditableSelection();
+        const range = new Range();
+        range.setStart(selection.startContainer, selection.startOffset);
+        range.setEnd(selection.endContainer, selection.endOffset);
+
+        const firstLeafNode = firstLeaf(node);
+        const lastLeafNode = lastLeaf(node);
+        return (
+            range.isPointInRange(firstLeafNode, 0) &&
+            range.isPointInRange(lastLeafNode, nodeSize(lastLeafNode))
+        );
     }
 
     /**

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -208,10 +208,17 @@ export class ColorPlugin extends Plugin {
             }
         }
 
-        const selectedNodes =
-            mode === "backgroundColor"
-                ? selectionNodes.filter((node) => !closestElement(node, "table.o_selected_table"))
-                : selectionNodes;
+        const hexColor = rgbToHex(color).toLowerCase();
+        const selectedNodes = selectionNodes.filter((node) => {
+            if (mode === "backgroundColor") {
+                return !closestElement(node, "table.o_selected_table");
+            }
+            const li = closestElement(node, "li");
+            if (li && color && this.dependencies.selection.isNodeContentsFullySelected(li)) {
+                return rgbToHex(li.style.color).toLowerCase() !== hexColor;
+            }
+            return true;
+        });
 
         const selectedFieldNodes = new Set(
             this.dependencies.selection
@@ -220,8 +227,8 @@ export class ColorPlugin extends Plugin {
                 .filter(Boolean)
         );
 
-        const getFonts = (selectedNodes) => {
-            return selectedNodes.flatMap((node) => {
+        const getFonts = (selectedNodes) =>
+            selectedNodes.flatMap((node) => {
                 let font = closestElement(node, "font") || closestElement(node, "span");
                 const children = font && descendants(font);
                 if (
@@ -278,7 +285,6 @@ export class ColorPlugin extends Plugin {
                 }
                 return font;
             });
-        };
 
         for (const fieldNode of selectedFieldNodes) {
             this.colorElement(fieldNode, color, mode);
@@ -295,6 +301,10 @@ export class ColorPlugin extends Plugin {
         // Color the selected <font>s and remove uncolored fonts.
         const fontsSet = new Set(fonts);
         for (const font of fontsSet) {
+            const closestLI = closestElement(font, "li");
+            if (font && color === "" && closestLI?.style.color) {
+                color = "initial";
+            }
             this.colorElement(font, color, mode);
             if (
                 !hasColor(font, "color") &&

--- a/addons/html_editor/static/src/main/hint.scss
+++ b/addons/html_editor/static/src/main/hint.scss
@@ -5,12 +5,12 @@
         content: attr(placeholder);
         position: absolute;
         top: 0;
-        left: 0;
+        left: var(--placeholder-left, 0);
         display: block;
         color: inherit;
         opacity: 0.4;
         pointer-events: none;
         text-align: inherit;
-        width: 100%;
+        width: calc(100% - var(--placeholder-left, 0));
     }
 }

--- a/addons/html_editor/static/src/main/hint_plugin.js
+++ b/addons/html_editor/static/src/main/hint_plugin.js
@@ -86,6 +86,7 @@ export class HintPlugin extends Plugin {
     }
 
     makeHint(el, text) {
+        this.dispatchTo("make_hint_handlers", el);
         el.setAttribute("placeholder", text);
         el.classList.add("o-we-hint");
     }
@@ -93,6 +94,7 @@ export class HintPlugin extends Plugin {
     removeHint(el) {
         el.removeAttribute("placeholder");
         removeClass(el, "o-we-hint");
+        this.getResource("system_style_properties").forEach((n) => el.style.removeProperty(n));
         if (this.hint === el) {
             this.hint = null;
         }

--- a/addons/html_editor/static/src/main/list/utils.js
+++ b/addons/html_editor/static/src/main/list/utils.js
@@ -14,7 +14,12 @@ export function insertListAfter(document, afterNode, mode, content = []) {
     list.append(
         ...content.map((c) => {
             const li = document.createElement("LI");
-            li.append(...[].concat(c));
+            if (c.length === 1 && c[0].tagName === "FONT" && c[0].style.color) {
+                li.style.color = c[0].style.color;
+                li.append(...c[0].childNodes);
+            } else {
+                li.append(...[].concat(c));
+            }
             return li;
         })
     );

--- a/addons/html_editor/static/src/main/list/utils.js
+++ b/addons/html_editor/static/src/main/list/utils.js
@@ -1,3 +1,5 @@
+import { getFontSizeOrClass } from "@html_editor/utils/formatting";
+
 export function createList(document, mode) {
     const node = document.createElement(mode === "OL" ? "OL" : "UL");
     if (mode === "CL") {
@@ -14,8 +16,21 @@ export function insertListAfter(document, afterNode, mode, content = []) {
     list.append(
         ...content.map((c) => {
             const li = document.createElement("LI");
+            let fontSizeStyle;
             if (c.length === 1 && c[0].tagName === "FONT" && c[0].style.color) {
                 li.style.color = c[0].style.color;
+                li.append(...c[0].childNodes);
+            } else if (
+                c.length === 1 &&
+                c[0].tagName === "SPAN" &&
+                (fontSizeStyle = getFontSizeOrClass(c[0]))
+            ) {
+                if (fontSizeStyle.type === "font-size") {
+                    li.style.fontSize = fontSizeStyle.value;
+                } else if (fontSizeStyle.type === "class") {
+                    li.classList.add(fontSizeStyle.value);
+                }
+                li.style.listStylePosition = "inside";
                 li.append(...c[0].childNodes);
             } else {
                 li.append(...[].concat(c));

--- a/addons/html_editor/static/src/utils/color.js
+++ b/addons/html_editor/static/src/utils/color.js
@@ -164,6 +164,7 @@ export function hasColor(element, mode) {
     return (
         (style[mode] &&
             style[mode] !== "inherit" &&
+            style[mode] !== "initial" &&
             (!parent || style[mode] !== parent.style[mode])) ||
         (classRegex.test(element.className) &&
             (!parent || getComputedStyle(element)[mode] !== getComputedStyle(parent)[mode]))

--- a/addons/html_editor/static/src/utils/formatting.js
+++ b/addons/html_editor/static/src/utils/formatting.js
@@ -236,3 +236,19 @@ export function getFontSizeDisplayValue(sel, document) {
     const pxValue = convertNumericToUnit(remValue, "rem", "px", htmlStyle);
     return pxValue || parseFloat(getComputedStyle(closestStartContainerEl).fontSize);
 }
+
+export function getFontSizeOrClass(node) {
+    if (!node) {
+        return null;
+    }
+
+    if (node.style.fontSize) {
+        return { type: "font-size", value: node.style.fontSize };
+    }
+
+    const fontSizeClass = FONT_SIZE_CLASSES.find((cls) => node.classList.contains(cls));
+    if (fontSizeClass) {
+        return { type: "class", value: fontSizeClass };
+    }
+    return null;
+}

--- a/addons/html_editor/static/tests/list/color_list.test.js
+++ b/addons/html_editor/static/tests/list/color_list.test.js
@@ -1,0 +1,200 @@
+import { testEditor } from "../_helpers/editor";
+import { test } from "@odoo/hoot";
+import {
+    setColor,
+    splitBlock,
+    toggleOrderedList,
+    toggleUnorderedList,
+} from "../_helpers/user_actions";
+import { execCommand } from "../_helpers/userCommands";
+
+test("should apply color to completely selected list item", async () => {
+    await testEditor({
+        contentBefore: "<ol><li>[abc]</li><li>def</li></ol>",
+        stepFunction: setColor("rgb(255, 0, 0)", "color"),
+        contentAfter: '<ol><li style="color: rgb(255, 0, 0);">[abc]</li><li>def</li></ol>',
+    });
+});
+
+test("should apply color to completely selected multiple list items", async () => {
+    await testEditor({
+        contentBefore: "<ul><li>[abc</li><li>def]</li></ul>",
+        stepFunction: setColor("rgb(255, 0, 0)", "color"),
+        contentAfter:
+            '<ul><li style="color: rgb(255, 0, 0);">[abc</li><li style="color: rgb(255, 0, 0);">def]</li></ul>',
+    });
+});
+
+test("should apply color to completely selected and partially selected list items", async () => {
+    await testEditor({
+        contentBefore: "<ol><li>[abc</li><li>def</li><li>gh]i</li></ol>",
+        stepFunction: setColor("rgb(255, 0, 0)", "color"),
+        contentAfter:
+            '<ol><li style="color: rgb(255, 0, 0);">[abc</li><li style="color: rgb(255, 0, 0);">def</li><li><font style="color: rgb(255, 0, 0);">gh]</font>i</li></ol>',
+    });
+});
+
+test("should apply color to completely selected list items and paragraph tag", async () => {
+    await testEditor({
+        contentBefore: "<ul><li>[abc</li><li>def</li></ul><p>ghi]</p>",
+        stepFunction: setColor("rgb(255, 0, 0", "color"),
+        contentAfter:
+            '<ul><li style="color: rgb(255, 0, 0);">[abc</li><li style="color: rgb(255, 0, 0);">def</li></ul><p><font style="color: rgb(255, 0, 0);">ghi]</font></p>',
+    });
+});
+
+test("should carry list item color to new list item", async () => {
+    await testEditor({
+        contentBefore: '<ol><li>abc</li><li style="color: rgb(255, 0, 0);">def[]</li></ol>',
+        stepFunction: splitBlock,
+        contentAfter:
+            '<ol><li>abc</li><li style="color: rgb(255, 0, 0);">def</li><li style="color: rgb(255, 0, 0);">[]<br></li></ol>',
+    });
+});
+
+test("should carry list item color to new list item (2)", async () => {
+    await testEditor({
+        contentBefore: '<ul><li style="color: rgb(255, 0, 0);">[]abc</li><li>def</li></ul>',
+        stepFunction: splitBlock,
+        contentAfter:
+            '<ul><li style="color: rgb(255, 0, 0);"><br></li><li style="color: rgb(255, 0, 0);">[]abc</li><li>def</li></ul>',
+    });
+});
+
+test("should carry color of paragraph to list item", async () => {
+    await testEditor({
+        contentBefore: '<p><font style="color: rgb(255, 0, 0);">[]abc</font></p>',
+        stepFunction: toggleUnorderedList,
+        contentAfter: '<ul><li style="color: rgb(255, 0, 0);">[]abc</li></ul>',
+    });
+});
+
+test("should carry color of paragraph to list item (2)", async () => {
+    await testEditor({
+        contentBefore:
+            '<ol><li style="color: rgb(255, 0, 0);">abc</li></ol><p><font style="color: rgb(0, 0, 255);">[]def</font></p><ol><li>ghi</li></ol>',
+        stepFunction: toggleOrderedList,
+        contentAfter:
+            '<ol><li style="color: rgb(255, 0, 0);">abc</li><li style="color: rgb(0, 0, 255);">[]def</li><li>ghi</li></ol>',
+    });
+});
+
+test("should carry color of paragraph to list item (3)", async () => {
+    await testEditor({
+        contentBefore:
+            '<ul><li style="color: rgb(255, 0, 0);">abc</li></ul><p>[]def</p><ul><li style="color: rgb(255, 0, 0);">ghi</li></ul>',
+        stepFunction: toggleUnorderedList,
+        contentAfter:
+            '<ul><li style="color: rgb(255, 0, 0);">abc</li><li>[]def</li><li style="color: rgb(255, 0, 0);">ghi</li></ul>',
+    });
+});
+
+test("should carry color of list item to paragraph", async () => {
+    await testEditor({
+        contentBefore: '<ol><li style="color: rgb(255, 0, 0);">[]abc</li><li>def</li></ol>',
+        stepFunction: toggleOrderedList,
+        contentAfter:
+            '<p><font style="color: rgb(255, 0, 0);">[]abc</font></p><ol><li>def</li></ol>',
+    });
+});
+
+test("should carry color of list item to paragraph (2)", async () => {
+    await testEditor({
+        contentBefore:
+            '<ul><li style="color: rgb(255, 0, 0);">abc</li><li style="color: rgb(0, 0, 255);">[]def</li><li>ghi</li></ul>',
+        stepFunction: toggleUnorderedList,
+        contentAfter:
+            '<ul><li style="color: rgb(255, 0, 0);">abc</li></ul><p><font style="color: rgb(0, 0, 255);">[]def</font></p><ul><li>ghi</li></ul>',
+    });
+});
+
+test("should carry color of list item to paragraph (3)", async () => {
+    await testEditor({
+        contentBefore:
+            '<ol><li style="color: rgb(255, 0, 0);">abc</li><li>[]def</li><li>ghi</li></ol>',
+        stepFunction: toggleOrderedList,
+        contentAfter:
+            '<ol><li style="color: rgb(255, 0, 0);">abc</li></ol><p>[]def</p><ol><li>ghi</li></ol>',
+    });
+});
+
+test("should carry color of list item to paragraph (4)", async () => {
+    await testEditor({
+        contentBefore:
+            '<ol><li style="color: rgb(255, 0, 0);">abc<font style="color: rgb(0, 255, 0)">def</font>ghi[]</li></ol>',
+        stepFunction: toggleOrderedList,
+        contentAfter:
+            '<p><font style="color: rgb(255, 0, 0);">abc<font style="color: rgb(0, 255, 0)">def</font>ghi[]</font></p>',
+    });
+});
+
+test("should keep list item color on toggling list twice", async () => {
+    await testEditor({
+        contentBefore:
+            '<ol><li style="color: rgb(255, 0, 0);">[abc</li><li style="color: rgb(0, 0, 255);">def]</li></ol>',
+        stepFunction: (editor) => {
+            toggleOrderedList(editor);
+            toggleOrderedList(editor);
+        },
+        contentAfter:
+            '<ol><li style="color: rgb(255, 0, 0);">[abc</li><li style="color: rgb(0, 0, 255);">def]</li></ol>',
+    });
+});
+
+test("remove color from list item", async () => {
+    await testEditor({
+        contentBefore:
+            '<ul><li style="color: rgb(255, 0, 0);">abc</li><li style="color: rgb(255, 0, 0);">[ghi]</li></ul>',
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter: '<ul><li style="color: rgb(255, 0, 0);">abc</li><li>[ghi]</li></ul>',
+    });
+});
+
+test("should remove color from partially selected list item", async () => {
+    await testEditor({
+        contentBefore: '<ol><li style="color: rgb(255, 0, 0);">ab[cd]ef</li></ol>',
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter:
+            '<ol><li style="color: rgb(255, 0, 0);">ab<font style="color: initial;">[cd]</font>ef</li></ol>',
+    });
+});
+
+test("should change color of a list item", async () => {
+    await testEditor({
+        contentBefore:
+            '<ul><li style="color: rgb(255, 0, 0);">[abc]</li><li style="color: rgb(255, 0, 0);">ghi</li></ul>',
+        stepFunction: setColor("rgb(0, 0, 255)", "color"),
+        contentAfter:
+            '<ul><li style="color: rgb(0, 0, 255);">[abc]</li><li style="color: rgb(255, 0, 0);">ghi</li></ul>',
+    });
+});
+
+test("should change color of a list item (2)", async () => {
+    await testEditor({
+        contentBefore:
+            '<ol><li style="color: rgb(255, 0, 0);">[abc</li><li style="color: rgb(255, 0, 0);">ghi]</li></ol>',
+        stepFunction: setColor("rgb(0, 0, 255)", "color"),
+        contentAfter:
+            '<ol><li style="color: rgb(0, 0, 255);">[abc</li><li style="color: rgb(0, 0, 255);">ghi]</li></ol>',
+    });
+});
+
+test("should change color of subpart of a list item", async () => {
+    await testEditor({
+        contentBefore:
+            '<ol><li style="color: rgb(255, 0, 0);">a[b]c</li><li style="color: rgb(255, 0, 0);">ghi</li></ol>',
+        stepFunction: setColor("rgb(0, 0, 255)", "color"),
+        contentAfter:
+            '<ol><li style="color: rgb(255, 0, 0);">a<font style="color: rgb(0, 0, 255);">[b]</font>c</li><li style="color: rgb(255, 0, 0);">ghi</li></ol>',
+    });
+});
+
+test("should change color of subpart of a list item (2)", async () => {
+    await testEditor({
+        contentBefore:
+            '<ol><li style="color: rgb(255, 0, 0);">a[bc</li><li style="color: rgb(255, 0, 0);">gh]i</li></ol>',
+        stepFunction: setColor("rgb(0, 0, 255)", "color"),
+        contentAfter:
+            '<ol><li style="color: rgb(255, 0, 0);">a<font style="color: rgb(0, 0, 255);">[bc</font></li><li style="color: rgb(255, 0, 0);"><font style="color: rgb(0, 0, 255);">gh]</font>i</li></ol>',
+    });
+});

--- a/addons/html_editor/static/tests/list/list_font_size.test.js
+++ b/addons/html_editor/static/tests/list/list_font_size.test.js
@@ -1,0 +1,207 @@
+import { testEditor } from "../_helpers/editor";
+import { test } from "@odoo/hoot";
+import {
+    setFontSize,
+    splitBlock,
+    toggleOrderedList,
+    toggleUnorderedList,
+} from "../_helpers/user_actions";
+import { execCommand } from "../_helpers/userCommands";
+
+test("should apply font-size to completely selected list item", async () => {
+    await testEditor({
+        contentBefore: "<ol><li>[abc]</li><li>def</li></ol>",
+        stepFunction: setFontSize("56px"),
+        contentAfter:
+            '<ol><li style="font-size: 56px; list-style-position: inside;">[abc]</li><li>def</li></ol>',
+    });
+});
+
+test("should apply font-size to completely selected multiple list items", async () => {
+    await testEditor({
+        contentBefore: "<ul><li>[abc</li><li>def]</li></ul>",
+        stepFunction: (editor) =>
+            execCommand(editor, "formatFontSizeClassName", { className: "h2-fs" }),
+        contentAfter:
+            '<ul><li class="h2-fs" style="list-style-position: inside;">[abc</li><li class="h2-fs" style="list-style-position: inside;">def]</li></ul>',
+    });
+});
+
+test("should apply font-size to completely selected and partially selected list items", async () => {
+    await testEditor({
+        contentBefore: "<ol><li>[abc</li><li>def</li><li>gh]i</li></ol>",
+        stepFunction: setFontSize("18px"),
+        contentAfter:
+            '<ol><li style="font-size: 18px; list-style-position: inside;">[abc</li><li style="font-size: 18px; list-style-position: inside;">def</li><li><span style="font-size: 18px;">gh]</span>i</li></ol>',
+    });
+});
+
+test("should apply font-size to completely selected list items and paragraph tag", async () => {
+    await testEditor({
+        contentBefore: "<ul><li>[abc</li><li>def</li></ul><p>ghi]</p>",
+        stepFunction: (editor) =>
+            execCommand(editor, "formatFontSizeClassName", { className: "display-3-fs" }),
+        contentAfter:
+            '<ul><li class="display-3-fs" style="list-style-position: inside;">[abc</li><li class="display-3-fs" style="list-style-position: inside;">def</li></ul><p><span class="display-3-fs">ghi]</span></p>',
+    });
+});
+
+test("should carry list item font-size to new list item", async () => {
+    await testEditor({
+        contentBefore:
+            '<ol><li>abc</li><li style="font-size: 18px; list-style-position: inside;">def[]</li></ol>',
+        stepFunction: splitBlock,
+        contentAfter:
+            '<ol><li>abc</li><li style="font-size: 18px; list-style-position: inside;">def</li><li style="font-size: 18px; list-style-position: inside;">[]<br></li></ol>',
+    });
+});
+
+test("should carry list item font-size to new list item (2)", async () => {
+    await testEditor({
+        contentBefore:
+            '<ul><li class="display-3-fs" style="list-style-position: inside;">[]abc</li><li>def</li></ul>',
+        stepFunction: splitBlock,
+        contentAfter:
+            '<ul><li class="display-3-fs" style="list-style-position: inside;"><br></li><li class="display-3-fs" style="list-style-position: inside;">[]abc</li><li>def</li></ul>',
+    });
+});
+
+test("should carry font-size of paragraph to list item", async () => {
+    await testEditor({
+        contentBefore:
+            '<p><span style="font-size: 18px; list-style-position: inside;">[]abc</span></p>',
+        stepFunction: toggleUnorderedList,
+        contentAfter:
+            '<ul><li style="font-size: 18px; list-style-position: inside;">[]abc</li></ul>',
+    });
+});
+
+test("should carry font-size of paragraph to list item (2)", async () => {
+    await testEditor({
+        contentBefore:
+            '<ol><li class="h3-fs" style="list-style-position: inside;">abc</li></ol><p><span class="display-3-fs" style="list-style-position: inside;">[]def</span></p><ol><li>ghi</li></ol>',
+        stepFunction: toggleOrderedList,
+        contentAfter:
+            '<ol><li class="h3-fs" style="list-style-position: inside;">abc</li><li class="display-3-fs" style="list-style-position: inside;">[]def</li><li>ghi</li></ol>',
+    });
+});
+
+test("should carry font-size of paragraph to list item (3)", async () => {
+    await testEditor({
+        contentBefore:
+            '<ul><li style="font-size: 18px; list-style-position: inside;">abc</li></ul><p>[]def</p><ul><li style="font-size: 18px; list-style-position: inside;">ghi</li></ul>',
+        stepFunction: toggleUnorderedList,
+        contentAfter:
+            '<ul><li style="font-size: 18px; list-style-position: inside;">abc</li><li>[]def</li><li style="font-size: 18px; list-style-position: inside;">ghi</li></ul>',
+    });
+});
+
+test("should carry font-size of list item to paragraph", async () => {
+    await testEditor({
+        contentBefore:
+            '<ol><li style="font-size: 18px; list-style-position: inside;">[]abc</li><li>def</li></ol>',
+        stepFunction: toggleOrderedList,
+        contentAfter: '<p><span style="font-size: 18px;">[]abc</span></p><ol><li>def</li></ol>',
+    });
+});
+
+test("should carry font-size of list item to paragraph (2)", async () => {
+    await testEditor({
+        contentBefore:
+            '<ul><li class="display-3-fs" style="list-style-position: inside;">abc</li><li class="display-3-fs" style="list-style-position: inside;">[]def</li><li>ghi</li></ul>',
+        stepFunction: toggleUnorderedList,
+        contentAfter:
+            '<ul><li class="display-3-fs" style="list-style-position: inside;">abc</li></ul><p><span class="display-3-fs">[]def</span></p><ul><li>ghi</li></ul>',
+    });
+});
+
+test("should carry font-size of list item to paragraph (3)", async () => {
+    await testEditor({
+        contentBefore:
+            '<ol><li style="font-size: 18px; list-style-position: inside;">abc</li><li>[]def</li><li>ghi</li></ol>',
+        stepFunction: toggleOrderedList,
+        contentAfter:
+            '<ol><li style="font-size: 18px; list-style-position: inside;">abc</li></ol><p>[]def</p><ol><li>ghi</li></ol>',
+    });
+});
+
+test("should carry font-size of list item to paragraph (4)", async () => {
+    await testEditor({
+        contentBefore:
+            '<ol><li style="font-size: 18px; list-style-position: inside;">abc<span style="font-size: 32px;">def</span>ghi[]</li></ol>',
+        stepFunction: toggleOrderedList,
+        contentAfter:
+            '<p><span style="font-size: 18px;">abc<span style="font-size: 32px;">def</span>ghi[]</span></p>',
+    });
+});
+
+test("should keep list item font-size on toggling list twice", async () => {
+    await testEditor({
+        contentBefore:
+            '<ol><li style="font-size: 18px; list-style-position: inside;">[abc</li><li style="font-size: 32px; list-style-position: inside;">def]</li></ol>',
+        stepFunction: (editor) => {
+            toggleOrderedList(editor);
+            toggleOrderedList(editor);
+        },
+        contentAfter:
+            '<ol><li style="font-size: 18px; list-style-position: inside;">[abc</li><li style="font-size: 32px; list-style-position: inside;">def]</li></ol>',
+    });
+});
+
+test("should change font-size of a list item", async () => {
+    await testEditor({
+        contentBefore:
+            '<ul><li style="font-size: 18px; list-style-position: inside;">[abc]</li><li style="font-size: 18px; list-style-position: inside;">ghi</li></ul>',
+        stepFunction: setFontSize("32px"),
+        contentAfter:
+            '<ul><li style="font-size: 32px; list-style-position: inside;">[abc]</li><li style="font-size: 18px; list-style-position: inside;">ghi</li></ul>',
+    });
+});
+
+test("should change font-size of a list item (2)", async () => {
+    await testEditor({
+        contentBefore:
+            '<ol><li style="font-size: 18px; list-style-position: inside;">[abc</li><li style="font-size: 18px; list-style-position: inside;">ghi]</li></ol>',
+        stepFunction: setFontSize("32px"),
+        contentAfter:
+            '<ol><li style="font-size: 32px; list-style-position: inside;">[abc</li><li style="font-size: 32px; list-style-position: inside;">ghi]</li></ol>',
+    });
+});
+
+test("should change font-size of subpart of a list item", async () => {
+    await testEditor({
+        contentBefore:
+            '<ol><li style="font-size: 18px; list-style-position: inside;">a[b]c</li><li style="font-size: 18px; list-style-position: inside;">ghi</li></ol>',
+        stepFunction: setFontSize("32px"),
+        contentAfter:
+            '<ol><li style="font-size: 18px; list-style-position: inside;">a<span style="font-size: 32px;">[b]</span>c</li><li style="font-size: 18px; list-style-position: inside;">ghi</li></ol>',
+    });
+});
+
+test("should change font-size of subpart of a list item (2)", async () => {
+    await testEditor({
+        contentBefore:
+            '<ol><li style="font-size: 18px; list-style-position: inside;">a[bc</li><li style="font-size: 18px; list-style-position: inside;">gh]i</li></ol>',
+        stepFunction: setFontSize("32px"),
+        contentAfter:
+            '<ol><li style="font-size: 18px; list-style-position: inside;">a<span style="font-size: 32px;">[bc</span></li><li style="font-size: 18px; list-style-position: inside;"><span style="font-size: 32px;">gh]</span>i</li></ol>',
+    });
+});
+
+test("should remove font-size style on converting the text to a block tag", async () => {
+    await testEditor({
+        contentBefore:
+            '<ul><li style="font-size: 32px; list-style-position: inside;">a[]bc</li></ul>',
+        stepFunction: (editor) => editor.shared.dom.setTag({ tagName: "H1" }),
+        contentAfter: '<ul><li><h1><span style="font-size: 32px;">a[]bc</span></h1></li></ul>',
+    });
+});
+
+test("should remove font-size class on converting the text to a block tag", async () => {
+    await testEditor({
+        contentBefore:
+            '<ul><li class="display-3-fs" style="list-style-position: inside;">a[]bc</li></ul>',
+        stepFunction: (editor) => editor.shared.dom.setTag({ tagName: "H1" }),
+        contentAfter: '<ul><li><h1><span class="display-3-fs">a[]bc</span></h1></li></ul>',
+    });
+});


### PR DESCRIPTION
Description of the issue this PR addresses:

Current behavior before PR:

It was not possible to apply color and font-size to list item markers.

Desired behavior after PR is merged:

This commit ensures that if a list item is selected completely, applying color and font-size to it will apply them to the list item itself making sure the list item marker are also gets styled.

Note:
I. The color and font-size is applied to marker only when the entire list item is selected, not if list item is only partially selected.
II. The font-size property will not apply to the marker also if the list item contains block elements (eg. H1, H2, H3, ...etc), as applying font-size to list item sets `list-style-position: inside` which moves block elements to next line.

task-3281223

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
