### PR TITLE
[IMP] point_of_sale: add discard button in number_popup dialog

### DIFF
--- a/addons/point_of_sale/static/src/app/utils/input_popups/number_popup.js
+++ b/addons/point_of_sale/static/src/app/utils/input_popups/number_popup.js
@@ -45,4 +45,8 @@ export class NumberPopup extends Component {
         this.props.getPayload(this.state.buffer);
         this.props.close();
     }
+
+    cancel() {
+        this.props.close();
+    }
 }

--- a/addons/point_of_sale/static/src/app/utils/input_popups/number_popup.xml
+++ b/addons/point_of_sale/static/src/app/utils/input_popups/number_popup.xml
@@ -13,8 +13,11 @@
             <Numpad buttons="props.buttons" class="'p-1 rounded-3 bg-200'"/>
             <t t-set-slot="footer">
                 <div class="d-flex flex-grow-1 justify-content-center">
-                    <button t-att-disabled="!props.isValid(state.buffer)" class="btn btn-primary btn-lg lh-lg o-default-button" tabindex="1" t-on-click="confirm">
-                        <t t-esc = "props.confirmButtonLabel || 'Ok'" />
+                    <button t-att-disabled="!props.isValid(state.buffer)" class="btn btn-primary btn-lg lh-lg o-default-button me-2" tabindex="1" t-on-click="confirm">
+                        <t t-esc="props.confirmButtonLabel || 'Ok'" />
+                    </button>
+                    <button class="btn btn-secondary btn-lg lh-lg o-default-button" tabindex="1" t-on-click="cancel">
+                        <t t-esc="'Discard'" />
                     </button>
                 </div>
             </t>

--- a/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
@@ -45,7 +45,7 @@ patch(Navbar.prototype, {
                 ZERO,
                 { ...BACKSPACE, class: "o_colorlist_item_color_transparent_1" },
             ]),
-            confirmButtonLabel: _t("Jump to table"),
+            confirmButtonLabel: _t("Jump"),
             getPayload: async (table_number) => {
                 const find_table = (t) => t.table_number === parseInt(table_number);
                 const table =


### PR DESCRIPTION
In this commit:
===============
A discard button for the NumberPopup Dialogue is added in the footer.

Task- 4210911

