### PR TITLE
[FIX] loyalty: default points in point update wizard

### DIFF
--- a/addons/loyalty/wizard/loyalty_card_update_balance_views.xml
+++ b/addons/loyalty/wizard/loyalty_card_update_balance_views.xml
@@ -9,6 +9,7 @@
                 <sheet>
                     <h3>You are about to change the balance of the card</h3>
                     <group>
+                        <field name="card_id" invisible="1"/>
                         <field name="old_balance"/>
                         <field name="new_balance"/>
                         <field name="description" placeholder="Example: Gift for customer"/>


### PR DESCRIPTION
Issue:
-The old balance field in loyalty card point update wizard is not set by default

Fix:
-Added `card_id` in form view 

