### PR TITLE
[FIX] odoo: add missing display_name(search)

### DIFF
--- a/addons/mail/models/mail_alias.py
+++ b/addons/mail/models/mail_alias.py
@@ -32,6 +32,7 @@ class Alias(models.Model):
     _name = 'mail.alias'
     _description = "Email Aliases"
     _rec_name = 'alias_name'
+    _rec_names_search = ['alias_name', 'alias_domain']
     _order = 'alias_model_id, alias_name'
 
     # email definition
@@ -39,7 +40,7 @@ class Alias(models.Model):
         'Alias Name', copy=False,
         help="The name of the email alias, e.g. 'jobs' if you want to catch emails for <jobs@example.odoo.com>")
     alias_full_name = fields.Char('Alias Email', compute='_compute_alias_full_name', store=True, index='btree_not_null')
-    display_name = fields.Char(string='Display Name', compute='_compute_display_name')
+    display_name = fields.Char(string='Display Name', compute='_compute_display_name', search='_search_display_name')
     alias_domain_id = fields.Many2one(
         'mail.alias.domain', string='Alias Domain', ondelete='restrict',
         default=lambda self: self.env.company.alias_domain_id)

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -287,7 +287,10 @@ class Task(models.Model):
     repeat_until = fields.Date(string="End Date", compute='_compute_repeat', compute_sudo=True, readonly=False)
 
     # Quick creation shortcuts
-    display_name = fields.Char(compute='_compute_display_name', inverse='_inverse_display_name',
+    display_name = fields.Char(
+        compute='_compute_display_name',
+        inverse='_inverse_display_name',
+        search='_search_display_name',
         help="""Use these keywords in the title to set new tasks:\n
             #tags Set tags on the task
             @user Assign the task to a user

--- a/addons/website_hr_recruitment/models/hr_department.py
+++ b/addons/website_hr_recruitment/models/hr_department.py
@@ -8,4 +8,4 @@ class Department(models.Model):
     _inherit = 'hr.department'
 
     # Get department name using superuser, because model is not accessible for portal users
-    display_name = fields.Char(compute='_compute_display_name', compute_sudo=True)
+    display_name = fields.Char(compute='_compute_display_name', search='_search_display_name', compute_sudo=True)


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/181529, we cannot search on display name for some models that define themselves the field without specifying the search method.

The `display_name` field is defined (including its compute method) only when the model does not define it yet. Existing declarations were missing a `search` declaration.

odoo/enterprise#70746

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
