### PR TITLE
[FIX] html_editor: do not add empty line to separator element

### DIFF
--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -525,7 +525,12 @@ export function isEmptyBlock(blockEl) {
  * @returns {boolean}
  */
 export function isShrunkBlock(blockEl) {
-    return isEmptyBlock(blockEl) && !blockEl.querySelector("br") && blockEl.nodeName !== "IMG";
+    return (
+        isEmptyBlock(blockEl) &&
+        !blockEl.querySelector("br") &&
+        blockEl.nodeName !== "IMG" &&
+        blockEl.nodeName !== "HR"
+    );
 }
 
 export function isEditorTab(node) {

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -485,6 +485,14 @@ describe("Selection collapsed", () => {
                 contentAfter: `<div contenteditable="false"><div contenteditable="true"><p>abc[]def</p></div></div>`,
             });
         });
+        test("should not add empty line to a seperator", async () => {
+            const { editor, el } = await setupEditor(
+                `<hr contenteditable="false"><p>abc</p><p><br>[]</p>`
+            );
+            deleteBackward(editor);
+            expect("br").toHaveCount(0);
+            expect(getContent(el)).toBe(`<hr contenteditable="false"><p>abc[]</p>`);
+        });
     });
 
     describe("Line breaks", () => {


### PR DESCRIPTION
Before this commit: delete an empty line under a separator and some text adds a br element to the separator

After this commit: the br won't be added to hr element because it already has a visible height




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
