### PR TITLE
[FIX] html_editor: column hint only show once at the first p node

### DIFF
--- a/addons/html_editor/static/src/main/column_plugin.js
+++ b/addons/html_editor/static/src/main/column_plugin.js
@@ -81,7 +81,7 @@ export class ColumnPlugin extends Plugin {
         hints: [
             {
                 selector: `.odoo-editor-editable .o_text_columns div[class^='col-'],
-                            .odoo-editor-editable .o_text_columns p:first-child`,
+                            .odoo-editor-editable .o_text_columns div[class^='col-']>p:first-child`,
                 text: _t("Empty column"),
             },
         ],

--- a/addons/html_editor/static/tests/columnize.test.js
+++ b/addons/html_editor/static/tests/columnize.test.js
@@ -37,6 +37,23 @@ describe("2 columns", () => {
         });
     });
 
+    test("should display the normal hint when cursor is in an empty cell of an empty table in one of the columns", async () => {
+        await testEditor({
+            /* eslint-disable */
+            contentBefore:
+                columnsContainer(
+                    column(6, `<table><tbody><tr><td><p>[]<br></p></td><td><p><br></p></td></tr></tbody></table>`) +
+                    column(6, "<p><br></p>")
+                ),
+            contentAfterEdit:
+                columnsContainer(
+                    column(6, `<table><tbody><tr><td><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p></td><td><p><br></p></td></tr></tbody></table>`) +
+                    column(6, `<p><br></p>`)
+                ),
+            /* eslint-enable */
+        });
+    });
+
     test("should do nothing", async () => {
         await testEditor({
             contentBefore: columnsContainer(


### PR DESCRIPTION
Before this commit: creating a table in an empty column, all the table cells have the column hint

After this commit: only the first p node under the col div has the column hint



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
