### PR TITLE
[FIX] project: task description generation

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -2540,7 +2540,12 @@ class Task(models.Model):
                     ('partner_id', '=', False), email_domain, ('stage_id.fold', '=', False)
                 ]).write({'partner_id': new_partner[0].id})
         # use the sanitized body of the email from the message thread to populate the task's description
-        if not self.description and message.subtype_id == self._creation_subtype() and self.partner_id == message.author_id:
+        if (
+           not self.description
+           and message.subtype_id == self._creation_subtype()
+           and self.partner_id == message.author_id
+           and msg_vals['message_type'] == 'email'
+        ):
             self.description = message.body
         return super(Task, self)._message_post_after_hook(message, msg_vals)
 

--- a/addons/project/tests/test_project_flow.py
+++ b/addons/project/tests/test_project_flow.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from markupsafe import Markup
+
 from .test_project_base import TestProjectCommon
 from odoo import Command
 from odoo.tools import mute_logger
@@ -123,6 +125,13 @@ class TestProjectFlow(TestProjectCommon, MailCommon):
         self.assertEqual(task.name, 'Super Frog', 'project_task: name should be the email subject')
         self.assertEqual(task.project_id, self.project_goats, 'project_task: incorrect project')
         self.assertEqual(task.stage_id.sequence, 1, "project_task: should have a stage with sequence=1")
+        self.assertEqual(
+            task.description,
+            Markup(
+                '<pre>Hello,\n\nThis email should create a new entry in your module. Please check that it\neffectively works.\n\nThanks,\n<span data-o-mail-quote="1">\n--\nRaoul Boitempoils\nIntegrator at Agrolait</span></pre>\n'
+            ),
+            'The task description should be the email content.',
+        )
 
     def test_subtask_process(self):
         """


### PR DESCRIPTION
The task description of a task generated after receiving an email from an email alias should be the body of the email (from the message thread). We differentiate this case from the case where the task is generated in another way (e.g. manually or triggered by another module), in which we should not populate the task description.

related-https://github.com/odoo/odoo/pull/108360

task-4207145
version-16.0

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
