### PR TITLE
[FIX] html_editor: drag and drop from the table shouldn't traceback

### DIFF
--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -490,10 +490,13 @@ export class TablePlugin extends Plugin {
     onMousedown(ev) {
         this._currentMouseState = ev.type;
         this._lastMousedownPosition = [ev.x, ev.y];
+        this.deselectTable();
         if (this.isPointerInsideCell(ev)) {
             this.editable.addEventListener("mousemove", this.onMousemove);
+            const currentSelection = this.shared.getEditableSelection();
+            // disable dragging on table
+            this.shared.setCursorStart(currentSelection.anchorNode);
         }
-        this.deselectTable();
     }
 
     onMouseup(ev) {

--- a/addons/html_editor/static/tests/mouse/click.test.js
+++ b/addons/html_editor/static/tests/mouse/click.test.js
@@ -1,6 +1,6 @@
 import { expect, test } from "@odoo/hoot";
 import { setupEditor, testEditor } from "../_helpers/editor";
-import { pointerDown, pointerUp } from "@odoo/hoot-dom";
+import { pointerDown, pointerUp, waitUntil } from "@odoo/hoot-dom";
 import { tick } from "@odoo/hoot-mock";
 import { leftPos, rightPos } from "@html_editor/utils/position";
 import { getContent, setSelection } from "../_helpers/selection";
@@ -100,3 +100,17 @@ test("should insert a paragraph before the table, then one after it", async () =
         `<p><br></p><table></table><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`
     );
 });
+
+test.tags("desktop")(
+    "should have collapsed selection when mouse down on a table cell",
+    async () => {
+        const { el } = await setupEditor(
+            `<table class="table table-bordered o_table"><tbody><tr><td><p><br></p></td><td><p><br>[</p></td><td><p>]<br></p></td></tr></tbody></table>`
+        );
+        const lastCell = el.querySelector("td:last-child");
+        pointerDown(lastCell);
+        await waitUntil(() => !document.querySelector(".o-we-toolbar"));
+        const selection = document.getSelection();
+        expect(selection.isCollapsed).toBe(true);
+    }
+);


### PR DESCRIPTION
Before this commit: in a table, select last two cells of first row and
drag drop it to a p element out of the table, a traceback is raised

After this commit: the dragging on the table cells is disabled



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
