### PR TITLE
[FIX] website_*: fix step tours

### DIFF
--- a/addons/website/static/tests/tours/link_tools.js
+++ b/addons/website/static/tests/tours/link_tools.js
@@ -20,6 +20,7 @@ registerWebsitePreviewTour('link_tools', {
     test: true,
     url: '/',
     edition: true,
+    checkDelay: 150,
 }, () => [
     // 1. Create a new link from scratch.
     ...dragNDrop({

--- a/addons/website/static/tests/tours/rte.js
+++ b/addons/website/static/tests/tours/rte.js
@@ -13,6 +13,7 @@ registerWebsitePreviewTour('rte_translator', {
     test: true,
     url: '/',
     edition: true,
+    checkDelay: 150,
     wait_for: whenReady(),
 }, () => [
 ...goToTheme(),
@@ -71,15 +72,15 @@ registerWebsitePreviewTour('rte_translator', {
     run: "click",
 }, {
     content: "insert file name",
-    trigger: '.modal .modal-dialog .modal-body input[type="text"]',
-    run: "edit rte_translator.xml",
+    trigger: ".modal:not(.o_inactive_modal):contains(new page) .modal-body input[type=text]",
+    run: "edit rte_translator.xml && press Tab",
 },
 {
-    trigger: 'input[type="text"]:value(rte_translator.xml)',
+    trigger: '.modal:not(.o_inactive_modal):contains(new page) .modal-body input[type="text"]:value(rte_translator.xml)',
 },
 {
     content: "create file",
-    trigger: ".modal button.btn-primary:contains(create)",
+    trigger: ".modal:not(.o_inactive_modal):contains(new page) button.btn-primary:contains(create)",
     run: "click",
 }, {
     content: "click on the 'page manager' button",

--- a/addons/website/static/tests/tours/snippet_background_edition.js
+++ b/addons/website/static/tests/tours/snippet_background_edition.js
@@ -104,6 +104,7 @@ registerWebsitePreviewTour('snippet_background_edition', {
     url: '/',
     edition: true,
     test: true,
+    checkDelay: 150,
 },
 () => [
 ...dragNDrop(snippets[0]),

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -145,6 +145,7 @@ registerWebsitePreviewTour("website_form_editor_tour", {
     url: '/',
     edition: true,
     test: true,
+    checkDelay: 100,
 }, () => [
     // Drop a form builder snippet and configure it
     {
@@ -301,7 +302,7 @@ registerWebsitePreviewTour("website_form_editor_tour", {
     {
         content: "Change added Option label",
         trigger: 'we-list table input:eq(3)',
-        run: "edit Wiko Stairway",
+        run: "edit Wiko Stairway && press Tab",
     }, {
         content: "Check the resulting field",
         trigger: ":iframe .s_website_form_field.s_website_form_custom.s_website_form_required" +

--- a/addons/website_event_sale/static/tests/tours/website_event_sale_last_ticket.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale_last_ticket.js
@@ -1,41 +1,46 @@
 /** @odoo-module **/
 
 import { registry } from "@web/core/registry";
-import * as wsTourUtils from '@website_sale/js/tours/tour_utils';
+import * as wsTourUtils from "@website_sale/js/tours/tour_utils";
 
-registry.category("web_tour.tours").add('event_buy_last_ticket', {
+registry.category("web_tour.tours").add("event_buy_last_ticket", {
     test: true,
-    url: '/event',
-    steps: () => [{
+    url: "/event",
+    checkDelay: 150,
+    steps: () => [
+    {
         content: "Open the Last ticket test event page",
         trigger: '.o_wevent_events_list a:contains("Last ticket test")',
         run: "click",
     },
     {
-        content: "Open Registration Page",
-        trigger: '.btn-primary:contains("Register")',
+        content: "Open Registration Modal",
+        trigger: ".btn-primary:contains(Register)",
         run: "click",
     },
     {
-        content: "Open the register modal",
-        trigger: 'button:contains("Register")',
-        run: "click",
+        content: "Check the modal Tickets is opened",
+        trigger: "body:has(.modal:contains(Tickets))",
     },
     {
         trigger: '#wrap:not(:has(a[href*="/event"]:contains("Last ticket test")))',
     },
     {
         content: "Select 2 units of `VIP` ticket type",
-        trigger: 'select:eq(0)',
+        trigger: ".modal select:eq(0)",
         run: "select 2",
     },
     {
-        trigger: "select:eq(0):has(option:contains(2):selected)",
+        trigger: ".modal select:eq(0):has(option:contains(2):selected)",
     },
     {
         content: "Click on `Order Now` button",
-        trigger: '.a-submit:contains("Register")',
+        trigger: ".modal .modal-footer button.btn-primary.a-submit:contains(Register)",
         run: "click",
+    },
+    {
+        content: "Check the modal Attendees is opened",
+        trigger: "body:has(.modal:contains(Attendees):contains(Ticket #1):contains(Ticket #2))",
     },
     {
         content: "Fill attendees details",
@@ -54,7 +59,7 @@ registry.category("web_tour.tours").add('event_buy_last_ticket', {
     },
     {
         content: "Validate attendees details",
-        trigger: "button[type=submit]:contains(Go to Payment)",
+        trigger: ".modal button[type=submit]:contains(Go to Payment)",
         run: "click",
     },
     ...wsTourUtils.fillAdressForm({
@@ -66,4 +71,5 @@ registry.category("web_tour.tours").add('event_buy_last_ticket', {
         zip: "123",
     }),
     ...wsTourUtils.payWithTransfer(true),
-]});
+    ],
+});

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
@@ -5,6 +5,7 @@ const messagesContain = (text) => `.o-livechat-root:shadow .o-mail-Message:conta
 
 registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
     test: true,
+    checkDelay: 50,
     steps: () => [
         {
             trigger: messagesContain("Hello! I'm a bot!"),

--- a/addons/website_sale/static/tests/tours/website_sale_cart_notification.js
+++ b/addons/website_sale/static/tests/tours/website_sale_cart_notification.js
@@ -3,42 +3,39 @@
 import { registry } from "@web/core/registry";
 import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
-registry.category("web_tour.tours").add('website_sale_cart_notification', {
+registry.category("web_tour.tours").add("website_sale_cart_notification", {
     test: true,
-    url: '/shop',
+    url: "/shop",
+    checkDelay: 150,
     steps: () => [
-        ...tourUtils.addToCart({productName: 'website_sale_cart_notification_product_1'}),
+        ...tourUtils.addToCart({ productName: "website_sale_cart_notification_product_1" }),
         {
             content: "check that 1 website_sale_cart_notification_product_1 was added",
             trigger: '.toast-body span:contains("1 x website_sale_cart_notification_product_1")',
-            run: "click",
         },
         {
             content: "check the price of 1 website_sale_cart_notification_product_1",
             trigger: '.toast-body div:contains("$ 1,000.00")',
-            run: "click",
         },
         {
             content: "close the notification",
-            trigger: '.toast-header button.btn-close',
+            trigger: ".toast-header button.btn-close",
             run: "click",
         },
         {
             content: "check that the notification is closed",
-            trigger: 'div.position-absolute.w-100.h-100.top-0.pe-none',
-            run: () => {
-                if (
-                    document.querySelectorAll("div.position-absolute.w-100.h-100.top-0.pe-none div")
-                        .length !== 1
-                ) {
-                    console.error('The cart notification is not closed!');
+            trigger: "div.position-absolute.w-100.h-100.top-0.pe-none",
+            run() {
+                if (this.anchor.querySelectorAll("div").length !== 1) {
+                    console.error("The cart notification is not closed!");
                 }
             },
         },
-        ...tourUtils.searchProduct('website_sale_cart_notification_product_2'),
+        ...tourUtils.searchProduct("website_sale_cart_notification_product_2"),
         {
             content: "select website_sale_cart_notification_product_2",
-            trigger: '.oe_product_cart:first a:contains("website_sale_cart_notification_product_2")',
+            trigger:
+                '.oe_product_cart:first a:contains("website_sale_cart_notification_product_2")',
             run: "click",
         },
         {
@@ -50,9 +47,6 @@ registry.category("web_tour.tours").add('website_sale_cart_notification', {
             run: "edit 3",
         },
         {
-            trigger: "#product_detail",
-        },
-        {
             content: "click on add to cart",
             trigger: '#product_detail form[action^="/shop/cart/update"] #add_to_cart',
             run: "click",
@@ -60,17 +54,14 @@ registry.category("web_tour.tours").add('website_sale_cart_notification', {
         {
             content: "check that 3 website_sale_cart_notification_product_2 was added",
             trigger: '.toast-body span:contains("3 x website_sale_cart_notification_product_2")',
-            run: "click",
         },
         {
             content: "check that the novariants/custom attributes are displayed.",
             trigger: '.toast-body span.text-muted.small:contains("Size: S")',
-            run: "click",
         },
         {
             content: "check the price of 1 website_sale_cart_notification_product_2",
             trigger: '.toast-body div:contains("$ 15,000.00")',
-            run: "click",
         },
         {
             content: "Go To Cart",
@@ -78,12 +69,12 @@ registry.category("web_tour.tours").add('website_sale_cart_notification', {
             run: "click",
         },
         tourUtils.assertCartContains({
-            productName: 'website_sale_cart_notification_product_1',
+            productName: "website_sale_cart_notification_product_1",
             backend: false,
         }),
         tourUtils.assertCartContains({
-            productName: 'website_sale_cart_notification_product_2',
+            productName: "website_sale_cart_notification_product_2",
             backend: false,
         }),
-    ]
+    ],
 });

--- a/addons/website_sale_loyalty/static/tests/tours/test_apply_discount_code.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_apply_discount_code.js
@@ -1,69 +1,68 @@
 /** @odoo-module **/
 
 import { registry } from "@web/core/registry";
-import * as tourUtils from '@website_sale/js/tours/tour_utils';
+import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
-registry.category("web_tour.tours").add('apply_discount_code_program_multi_rewards', {
+registry.category("web_tour.tours").add("apply_discount_code_program_multi_rewards", {
     test: true,
-    url: '/shop?search=Super%20Chair',
+    checkDelay: 150,
+    url: "/shop?search=Super%20Chair",
     steps: () => [
         {
             trigger: ".oe_search_found",
         },
         {
-            content: 'select Super Chair',
-            trigger: '.oe_product_cart a:contains("Super Chair")',
+            content: "select Super Chair",
+            trigger: ".oe_product_cart a:contains(Super Chair)",
             run: "click",
         },
         {
-            content: 'Add Super Chair into cart',
-            trigger: 'a:contains(Add to cart)',
+            content: "Add Super Chair into cart",
+            trigger: "a:contains(Add to cart)",
             run: "click",
         },
         tourUtils.goToCart(),
         {
-            trigger: 'form[name="coupon_code"]',
+            trigger: "h3:contains(order overview)",
         },
         {
-            content: 'insert discount code',
+            content: "insert discount code",
             trigger: 'form[name="coupon_code"] input[name="promo"]',
             run: "edit 12345",
         },
         {
-            content: 'validate the promo code',
-            trigger: 'form[name="coupon_code"] .a-submit',
+            content: "validate the promo code",
+            trigger: 'form[name="coupon_code"] .a-submit:contains(apply)',
             run: "click",
         },
         {
-            content: 'check reward',
-            trigger: '.alert:contains("10% on Super Chair")',
+            content: "check reward",
+            trigger: ".alert:contains(10% on Super Chair)",
         },
         {
-            content: 'claim reward',
-            trigger: '.alert:contains("10% on Super Chair") .btn:contains("Claim")',
+            content: "claim reward",
+            trigger: ".alert:contains(10% on Super Chair) .btn:contains(Claim)",
             run: "click",
         },
         {
-            content: 'check claimed reward',
-            trigger: 'div>strong:contains("10% on Super Chair")',
+            content: "check claimed reward",
+            trigger:
+                "#cart_products.js_cart_lines .o_cart_product strong:contains(10% on Super Chair)",
         },
         // Try to reapply the same promo code
         {
-            trigger: 'form[name="coupon_code"]',
-        },
-        {
-            content: 'insert discount code',
+            content: "insert discount code",
             trigger: 'form[name="coupon_code"] input[name="promo"]',
             run: "edit 12345",
         },
         {
-            content: 'validate the promo code',
-            trigger: 'form[name="coupon_code"] .a-submit',
+            content: "validate the promo code",
+            trigger: 'form[name="coupon_code"] .a-submit:contains(apply)',
             run: "click",
         },
         {
-            content: 'check refused message',
-            trigger: '.alert-danger:contains("This promo code is already applied")',
+            content: "check refused message",
+            trigger: ".alert-danger:contains(This promo code is already applied)",
         },
     ],
 });


### PR DESCRIPTION
In this commit, we impose a checkDelay on the tours of 150ms (the default checkDelay is 750ms). This makes the tours execute faster. We take advantage of this commit to remove unnecessary actions (like clicks when it is simply a matter of checking that the element is in the DOM). We add verification steps to ensure that the tour executes correctly and waits for mutations before continuing the tour.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
