### PR TITLE
[FIX] web: revert "Data" debug item change

### DIFF
--- a/addons/web/static/tests/core/debug/debug_manager.test.js
+++ b/addons/web/static/tests/core/debug/debug_manager.test.js
@@ -513,7 +513,10 @@ describe.tags("desktop")("DebugMenu", () => {
         });
         await contains(".o_debug_manager button").click();
         await contains(".dropdown-menu .dropdown-item:contains(/^Data/)").click();
-        expect(browser.location.pathname).toBe("/json/m-custom/1");
+        expect(".modal").toHaveCount(1);
+        expect(".modal-body pre").toHaveText(
+            '{\n "create_date": "2019-03-11 09:30:00",\n "display_name": "custom1",\n "id": 1,\n "name": "custom1",\n "write_date": "2019-03-11 09:30:00"\n}'
+        );
     });
 
     test("view metadata: basic rendering", async () => {


### PR DESCRIPTION
In the PR [1], the behavior of the "View Raw Record Data" debug item changed. It opened the /json route of the current view and it was also available in multi record views (list, kanban, etc.).

This commit reverts this behavior change but keeps the renaming.

task-4055746

[1]: https://github.com/odoo/odoo/pull/180141