### PR TITLE
[REV] web: switch /web/tests routes

### DIFF
--- a/addons/web/controllers/webclient.py
+++ b/addons/web/controllers/webclient.py
@@ -97,15 +97,15 @@ class WebClient(http.Controller):
     def version_info(self):
         return odoo.service.common.exp_version()
 
-    @http.route('/web/tests', type='http', auth='user', readonly=True)
+    @http.route('/web/tests/next', type='http', auth='user', readonly=True)
     def unit_tests_suite(self, mod=None, **kwargs):
         return request.render('web.unit_tests_suite')
 
-    @http.route('/web/tests/legacy', type='http', auth='user', readonly=True)
+    @http.route('/web/tests', type='http', auth='user', readonly=True)
     def test_suite(self, mod=None, **kwargs):
         return request.render('web.qunit_suite')
 
-    @http.route('/web/tests/legacy/mobile', type='http', auth="none")
+    @http.route('/web/tests/mobile', type='http', auth="none")
     def test_mobile_suite(self, mod=None, **kwargs):
         return request.render('web.qunit_mobile_suite')
 

--- a/addons/web/static/src/core/debug/debug_providers.js
+++ b/addons/web/static/src/core/debug/debug_providers.js
@@ -27,10 +27,24 @@ commandProviderRegistry.add("debug", {
             });
             result.push({
                 action() {
+                    browser.open("/web/tests/next?debug=assets");
+                },
+                category: "debug",
+                name: _t("Run unit tests"),
+            });
+            result.push({
+                action() {
                     browser.open("/web/tests?debug=assets");
                 },
                 category: "debug",
-                name: _t("Run Unit Tests"),
+                name: _t("Run QUnit tests (legacy)"),
+            });
+            result.push({
+                action() {
+                    browser.open("/web/tests/mobile?debug=assets");
+                },
+                category: "debug",
+                name: _t("Run QUnit mobile tests (legacy)"),
             });
         } else {
             const debugKey = "debug";

--- a/addons/web/static/src/webclient/debug/debug_items.js
+++ b/addons/web/static/src/webclient/debug/debug_items.js
@@ -3,14 +3,36 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { SelectCreateDialog } from "@web/views/view_dialogs/select_create_dialog";
 
-function runUnitTestsItem() {
-    const href = "/web/tests?debug=assets";
+function runHootItem() {
+    const href = "/web/tests/next?debug=assets";
     return {
         type: "item",
-        description: _t("Run Unit Tests"),
+        description: _t("Run unit tests"),
         href,
         callback: () => browser.open(href),
         sequence: 10,
+    };
+}
+
+function runJSTestsItem() {
+    const href = "/web/tests?debug=assets";
+    return {
+        type: "item",
+        description: _t("Run QUnit tests (legacy)"),
+        href,
+        callback: () => browser.open(href),
+        sequence: 20,
+    };
+}
+
+function runJSTestsMobileItem() {
+    const href = "/web/tests/mobile?debug=assets";
+    return {
+        type: "item",
+        description: _t("Run QUnit mobile tests (legacy)"),
+        href,
+        callback: () => browser.open(href),
+        sequence: 30,
     };
 }
 
@@ -62,6 +84,8 @@ function globalSeparator() {
 registry
     .category("debug")
     .category("default")
-    .add("runUnitTestsItem", runUnitTestsItem)
+    .add("runHootItem", runHootItem)
+    .add("runJSTestsItem", runJSTestsItem)
+    .add("runJSTestsMobileItem", runJSTestsMobileItem)
     .add("globalSeparator", globalSeparator)
     .add("openViewItem", openViewItem);

--- a/addons/web/tests/test_js.py
+++ b/addons/web/tests/test_js.py
@@ -36,7 +36,7 @@ class WebSuite(odoo.tests.HttpCase):
     @odoo.tests.no_retry
     def test_unit_desktop(self):
         # Unit tests suite (desktop)
-        self.browser_js('/web/tests?headless&loglevel=2&preset=desktop&timeout=15000', "", "", login='admin', timeout=1800, success_signal="[HOOT] test suite succeeded", error_checker=unit_test_error_checker)
+        self.browser_js('/web/tests/next?headless&loglevel=2&preset=desktop&timeout=15000', "", "", login='admin', timeout=1800, success_signal="[HOOT] test suite succeeded", error_checker=unit_test_error_checker)
 
     @odoo.tests.no_retry
     def test_hoot(self):
@@ -46,7 +46,7 @@ class WebSuite(odoo.tests.HttpCase):
     @odoo.tests.no_retry
     def test_qunit_desktop(self):
         # ! DEPRECATED
-        self.browser_js('/web/tests/legacy?mod=web', "", "", login='admin', timeout=1800, success_signal="QUnit test suite done.", error_checker=qunit_error_checker)
+        self.browser_js('/web/tests?mod=web', "", "", login='admin', timeout=1800, success_signal="QUnit test suite done.", error_checker=qunit_error_checker)
 
     def test_check_suite(self):
         self._check_forbidden_statements('web.assets_unit_tests')
@@ -100,8 +100,8 @@ class MobileWebSuite(odoo.tests.HttpCase):
     @odoo.tests.no_retry
     def test_unit_mobile(self):
         # Unit tests suite (mobile)
-        self.browser_js('/web/tests?headless&loglevel=2&preset=mobile&tag=-headless&timeout=15000', "", "", login='admin', timeout=1800, success_signal="[HOOT] test suite succeeded", error_checker=unit_test_error_checker)
+        self.browser_js('/web/tests/next?headless&loglevel=2&preset=mobile&tag=-headless&timeout=15000', "", "", login='admin', timeout=1800, success_signal="[HOOT] test suite succeeded", error_checker=unit_test_error_checker)
 
     def test_qunit_mobile(self):
         # ! DEPRECATED
-        self.browser_js('/web/tests/legacy/mobile?mod=web', "", "", login='admin', timeout=1800, success_signal="QUnit test suite done.", error_checker=qunit_error_checker)
+        self.browser_js('/web/tests/mobile?mod=web', "", "", login='admin', timeout=1800, success_signal="QUnit test suite done.", error_checker=qunit_error_checker)


### PR DESCRIPTION
Test routes were not meant to be changed in stable (17.2 and 17.4).

This reverts commit d9035ae6b4a506044da4a499f112c3ac1f0e0b5d.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
