### PR TITLE
[FIX] account: reset to draft button

### DIFF
--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -146,7 +146,7 @@
                         <button name="action_reject" string="Reject" type="object" class="oe_highlight"
                                 invisible="state != 'in_process' or not is_sent" data-hotkey="q"/>
                         <button name="action_draft" string="Reset To Draft" type="object" class="btn btn-secondary"
-                                invisible="state in ('draft', 'in_process')"
+                                invisible="state in ('draft')"
                                 groups="account.group_account_invoice" data-hotkey="w"/>
                         <button name="action_cancel" string="Cancel" type="object"
                                 invisible="not id or not (state == 'draft' or (state == 'in_process' and is_sent))" data-hotkey="x"/>


### PR DESCRIPTION
This commit Restore "Reset to Draft" on Payments "In Process". Only Validated & Sent Payments can not be Reset to Draft.

task: 4213210




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
