### PR TITLE
[FIX] hr_attendance: update current date dynamically in kiosk view

### DIFF
--- a/addons/hr_attendance/static/src/components/card_layout/card_layout.js
+++ b/addons/hr_attendance/static/src/components/card_layout/card_layout.js
@@ -16,16 +16,9 @@ export class CardLayout extends Component {
     };
 
     setup() {
-        const now = DateTime.now();
-        this.state = useState({
-            dayOfWeek: now.toFormat("cccc"), // 'Wednesday'
-            date: now.toLocaleString({ ...DateTime.DATE_FULL, weekday: undefined }),
-            time: this.getCurrentTime(),
-        });
+        this.state = useState(this.getDateTime());
         this.timeInterval = setInterval(() => {
-            this.state.time = this.getCurrentTime();
-            this.state.date = now.toLocaleString({ ...DateTime.DATE_FULL, weekday: undefined });
-            this.state.dayOfWeek = now.toFormat("cccc");
+            Object.assign(this.state, this.getDateTime());
         }, 1000);
         this.companyImageUrl = url("/web/binary/company_logo", {
             company: this.props.companyId,
@@ -35,7 +28,15 @@ export class CardLayout extends Component {
         });
     }
 
-    getCurrentTime() {
-        return DateTime.now().toLocaleString(DateTime.TIME_SIMPLE);
+    getDateTime() {
+        const now = DateTime.now();
+        return {
+            dayOfWeek: now.toFormat("cccc"),
+            date: now.toLocaleString({
+                ...DateTime.DATE_FULL,
+                weekday: undefined,
+            }),
+            time: now.toLocaleString(DateTime.TIME_SIMPLE),
+        };
     }
 }


### PR DESCRIPTION
Problem:
The current date in the kiosk view remains static, as `now` is initialized when the component is rendered and does not update. The date should dynamically refresh by calling `DateTime.now()` at regular intervals.

Steps to reproduce:
- Open the attendance kiosk view.
- Wait until the next day.
- The displayed date does not update automatically.

opw-4199136

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
