### PR TITLE
[FIX] pos_hr: fix wrong variable access

### DIFF
--- a/addons/pos_hr/static/src/app/select_cashier_mixin.js
+++ b/addons/pos_hr/static/src/app/select_cashier_mixin.js
@@ -117,7 +117,7 @@ export function useCashierSelector({ exclusive, onScan } = { onScan: () => {}, e
                 return;
             }
         } else if (pinMatchEmployees.length === 1) {
-            employee = pinMatchEmployees[0].item;
+            employee = pinMatchEmployees[0];
         }
 
         if (!pin && employee && employee._pin) {


### PR DESCRIPTION
Item does not exist anymore on the employee list in the select cashier mixin.

Adapt the code to use the correct variable name.


