### PR TITLE
[FIX] web: avoid blurring editor on drag

### DIFF
--- a/addons/web/static/src/core/utils/draggable_hook_builder.js
+++ b/addons/web/static/src/core/utils/draggable_hook_builder.js
@@ -662,8 +662,13 @@ export function makeDraggableHook(hookParams) {
                 // https://bugzilla.mozilla.org/show_bug.cgi?id=1352061
                 // https://bugzilla.mozilla.org/show_bug.cgi?id=339293
                 safePrevent(ev);
-                if (document.activeElement && !document.activeElement.contains(ev.target)) {
-                    document.activeElement.blur();
+                const eventDocument = ev.target.ownerDocument || ("activeElement" in ev.target && ev.target);
+                if (
+                    eventDocument &&
+                    eventDocument.activeElement &&
+                    !eventDocument.activeElement.contains(ev.target)
+                ) {
+                    eventDocument.activeElement.blur();
                 }
 
                 const { currentTarget, pointerId, target } = ev;


### PR DESCRIPTION
- Go to mass mailing
- Try to drag an element inside the editor
- Drag immediately stops

[1] fixes an issue with inputs and drag and drop by force blurring the active element of the main document.

If the activeElement of the main document is the window of the iframe itself this leads to the editor saving its changes. Which includes clearing the draggable that triggered the event. This renders the draggable unusable.

We now blur the active element of the document where the target is located.

1: ef97eaf9876bcf1712d4a6bfb91307875b0034ac

task-4210331

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
