### PR TITLE
[FIX] pos_restaurant: fix table linking in ios chrome

### DIFF
--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
@@ -89,6 +89,7 @@
                     t-attf-class="floor-map position-relative w-100 h-100 {{ pos.isEditMode ? 'floor-grid' : ''}}"
                     t-ref="floor-map-ref"
                     t-attf-style="
+                        -webkit-touch-callout: none;
                         height: {{state.floorHeight}} !important;
                         width: {{state.floorWidth}} !important;
                         {{ activeFloor?.floor_background_image and !isKanban ?


### PR DESCRIPTION
Table linking in chrome on ios does not work if the floorplan has a bg image. When the user tries to drag a table, the context menu appears, which prevents the table dragging from taking place.

This is because of a mistake in commit 894d7c25b7dd216ac6df1fd8ebedffccd20ef64e, where a line was removed.

Task: 4196350





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
