### PR TITLE
[FIX] point_of_sale: Fix symbols at close session popup

### DIFF
--- a/addons/point_of_sale/static/src/xml/Popups/ClosePosPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/ClosePosPopup.xml
@@ -43,20 +43,28 @@
                                     <tr t-foreach="defaultCashDetails.moves" t-as="move" t-key="move_index">
                                         <td>
                                             <div class="flex">
-                                                <div class="cash-sign" t-esc="move.amount &lt; 0 ? '-' : '+'"/>
                                                 <t t-esc="move.name"/>
                                             </div>
                                         </td>
-                                        <td t-esc="env.pos.format_currency(Math.abs(move.amount))"/>
+                                        <td>
+                                            <div style="width: 100%; text-align: right; padding-right: 5%;">
+                                                <div class="cash-sign" style="display: inline;" t-esc="move.amount &lt; 0 ? '-' : '+'"/>
+                                                <t t-esc="env.pos.format_currency(Math.abs(move.amount))"/>
+                                            </div>
+                                        </td>
                                     </tr>
                                     <tr t-if="defaultCashDetails.payment_amount">
                                         <td>
                                             <div class="flex">
-                                                <div class="cash-sign" t-esc="defaultCashDetails.payment_amount &lt; 0 ? '-' : '+'"/>
                                                 Payments in <t t-esc="defaultCashDetails.name"/>
                                             </div>
                                         </td>
-                                        <td t-esc="env.pos.format_currency(Math.abs(defaultCashDetails.payment_amount))"/>
+                                        <td>
+                                            <div style="width: 100%; text-align: right; padding-right: 5%;">
+                                                <div class="cash-sign" style="display: inline;" t-esc="defaultCashDetails.payment_amount &lt; 0 ? '-' : '+'"/>
+                                                <t t-esc="env.pos.format_currency(Math.abs(defaultCashDetails.payment_amount))"/>
+                                            </div>
+                                        </td>
                                     </tr>
                                 </tbody>
                             </t>


### PR DESCRIPTION
The close session popup shows negative and possitive symbols wrongly. With this modifications we use the symbol by default instead of calculate it.

Description of the issue/feature this PR addresses:

Modifies the displayed symbols at close session popup to make them look correctly

Current behavior before PR:

Before this modifications, when you specify negative and positive quantities i shows loke this:

![image](https://github.com/user-attachments/assets/e15480cf-9fd3-4ee6-abf0-d0846bb6bd3e)


Desired behavior after PR is merged:
After the PR is merged it will show the symbols properly

![image](https://github.com/user-attachments/assets/568a0b77-30c1-4139-a682-4ef9aaa763a3)


FL-556-3573
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
