### PR TITLE
[FIX] point_of_sale: unable to settle demo orders in restaturent

### DIFF
--- a/addons/pos_restaurant/data/restaurant_session_floor.xml
+++ b/addons/pos_restaurant/data/restaurant_session_floor.xml
@@ -636,7 +636,8 @@
             <field name="price_unit">5.5</field>
             <field name="qty">1</field>
             <field name="order_id" ref="pos_open_order_5" />
-            <field name="full_product_name">Pizza 4 Formaggi</field>
+            <field name="full_product_name">Pasta 4 Formaggi</field>
+            <field name="uuid">00000000-0000-4000-000000000006</field>
         </record>
 
         <function model="pos.session" name="_set_last_order_preparation_change"


### PR DESCRIPTION
Steps to reproduce :
---------------------------
- Install the pos_restaurant module.
- Open any demo orders, let's say table 1
- Make the payment, then go to the receipt screen then the floor plan
- [ISSUE] Order is still there.
- In Table 6, can't even place the order

Cause :
---------
1. Demo orders case was not handled in the "sync_from_ui" method leading to this issue
2. Uuid was not given for the Table 6 order line, causing this misbehavior.

Fix :
------
1. Handled the case for demo orders in the "sync_from_ui" method
2. Provide uuid for table 6 order line at the time of creation

Task: 4212901