### PR TITLE
[FIX] web_editor: prevent drop in hidden mega menu while scrolling

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -3542,8 +3542,12 @@ var SnippetsMenu = Widget.extend({
                         // Some drop zones might have been disabled.
                         $el = $el.filter($dropZones);
                         if ($el.length) {
-                            $el.after($toInsert);
-                            dropped = true;
+                            // Prevent snippet from being dropped in an element not displayed.
+                            const display = $el[0].style.display;
+                            if (display && display != "none") {
+                                $el.after($toInsert);
+                                dropped = true;
+                            }
                         }
                     }
 


### PR DESCRIPTION
Steps to reproduce:

- Create a mega menu, enter edit mode.
- Add enough snippets to enable scrolling.
- Scroll to the top, open the mega menu.
- Drag an alert snippet, scroll down, and the menu closes.
- Drop the snippet, it ends up in the closed menu.

Fix: prevent dropping snippets into hidden elements, cancel the drop.

task-3644791