### PR TITLE
[FIX] project_{purchase,sale_expense}: number of purchase orders is incorrect and other analytics issues

### DIFF
--- a/addons/project_hr_expense/models/hr_expense.py
+++ b/addons/project_hr_expense/models/hr_expense.py
@@ -20,5 +20,5 @@ class HrExpense(models.Model):
             analytic_distribution = self.env['project.project'].browse(project_id)._get_analytic_distribution()
             if analytic_distribution:
                 for vals in vals_list:
-                    vals['analytic_distribution'] = analytic_distribution
+                    vals['analytic_distribution'] = vals.get('analytic_distribution', analytic_distribution)
         return super().create(vals_list)

--- a/addons/project_purchase/models/purchase_order_line.py
+++ b/addons/project_purchase/models/purchase_order_line.py
@@ -11,7 +11,7 @@ class PurchaseOrderLine(models.Model):
         super()._compute_analytic_distribution()
         ProjectProject = self.env['project.project']
         for line in self:
-            if line.display_type:
+            if line.display_type or line.analytic_distribution:
                 continue
             project_id = line._context.get('project_id')
             project = ProjectProject.browse(project_id) if project_id else line.order_id.project_id

--- a/addons/project_purchase/tests/__init__.py
+++ b/addons/project_purchase/tests/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_project_profitability
+from . import test_project_purchase

--- a/addons/project_purchase/tests/test_project_purchase.py
+++ b/addons/project_purchase/tests/test_project_purchase.py
@@ -1,0 +1,54 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import Command
+
+from odoo.addons.project_purchase.tests.test_project_profitability import TestProjectPurchaseProfitability
+
+
+class TestProjectPurchase(TestProjectPurchaseProfitability):
+
+    def test_compute_purchase_orders_count(self):
+        project1 = self.env['project.project'].create({'name': 'Project'})
+        project1.account_id = self.analytic_account  # Project with analytics
+        order_line_values = {
+            'analytic_distribution': {self.analytic_account.id: 100},
+            'product_id': self.product_order.id,
+            'product_qty': 1,
+            'price_unit': self.product_order.standard_price,
+            'currency_id': self.env.company.currency_id.id,
+        }
+        self.env['purchase.order'].create([
+            {
+                'name': 'Purchase Order 1',
+                'partner_id': self.partner_a.id,
+                'order_line': [Command.create(order_line_values)],
+            },
+            {
+                'name': 'Purchase Order 2',
+                'partner_id': self.partner_a.id,
+                'project_id': project1.id,
+            },
+            {
+                'name': 'Purchase Order 3',
+                'partner_id': self.partner_a.id,
+                'project_id': project1.id,
+                'order_line': [Command.create(order_line_values)],
+            },
+        ])
+        self.assertEqual(project1.purchase_orders_count, 3, 'The number of purchase orders linked to project1 should be equal to 3.')
+
+        project2 = self.env['project.project'].create({'name': 'Project'})
+        project2.account_id = False  # Project without analytics
+        self.env['purchase.order'].create([
+            {
+                'name': 'Purchase Order 4',
+                'partner_id': self.partner_a.id,
+                'project_id': project2.id,
+            },
+            {
+                'name': 'Purchase Order 5',
+                'partner_id': self.partner_a.id,
+                'project_id': project2.id,
+            },
+        ])
+        self.assertEqual(project2.purchase_orders_count, 2, 'The number of purchase orders linked to project2 should be equal to 2.')

--- a/addons/project_sale_expense/models/hr_expense.py
+++ b/addons/project_sale_expense/models/hr_expense.py
@@ -1,16 +1,16 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models
+from odoo import api, models
 
 
 class Expense(models.Model):
     _inherit = "hr.expense"
 
+    @api.depends('sale_order_id')
     def _compute_analytic_distribution(self):
         super()._compute_analytic_distribution()
-        for expense in self:
-            if not expense.sale_order_id:
-                continue
-            analytic_distribution = expense.sale_order_id.project_id._get_analytic_distribution()
-            if analytic_distribution:
-                expense.analytic_distribution = analytic_distribution
+        if not self.env.context.get('project_id'):
+            for expense in self:
+                if not self.sale_order_id:
+                    continue
+                expense.analytic_distribution = expense.sale_order_id.project_id._get_analytic_distribution()


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. From the Purchase app, create a purchase order (don't link it to any project with the project field)
2. Add a line on the PO with a distribution
3. On the line, add the project's analytic account
4. Go to the Project > Top bar > Purchase Orders > The new purchase order is not there

Fix:
-------------------
We should take into account the purchase orders whose lines have an analytic distribution corresponding to the project. We will do a second _read_group() call for that purpose.

- Others fixes: - Still in Purchase app, when changing the project_id of the PO, it changes the analytic distribution of all PO lines (including PO lines with non-empty distribution). To be consistent with SO and SO lines, it should only affect PO lines that do not have their analytic distribution set.

    - In Expenses app, when changing the 'Customer to Reinvoice' field of an expense, it should automatically fill in the analytic distribution of the expense with the account
    of the project of the sale order linked to the 'Customer to Reinvoice'. The problem is that it does not systematically change the analytic distribution if such account exists.

    - When creating an expense from the top bar action, and changing the distribution of the expense (the percentage for instance), it does not get saved on saving the record.

task-4191106
version-18.0

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
