### PR TITLE
[FIX] sale_project: set the project manager in project created from SO

### DIFF
--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -187,7 +187,7 @@ class SaleOrderLine(models.Model):
             'active': True,
             'company_id': self.company_id.id,
             'allow_billable': True,
-            'user_id': False,
+            'user_id': self.product_id.project_template_id.user_id.id,
         }
 
     def _timesheet_create_project(self):


### PR DESCRIPTION
Previously, when SO confirmed the default project manager remain unset. This commit adapts the functionality of setting the project manager if the template is included otherwise the manager remains unset.

task-3953729

