### PR TITLE
[FIX] website: restore ability to use the form snippet as an inner one

### DIFF
--- a/addons/web_editor/models/ir_qweb_fields.py
+++ b/addons/web_editor/models/ir_qweb_fields.py
@@ -57,10 +57,17 @@ class IrQWeb(models.AbstractModel):
                 sub_call = el.get('t-call')
                 if sub_call:
                     el.set('t-options', f"{{'snippet-key': '{snippet_key}', 'snippet-sub-call-key': '{sub_call}'}}")
-                # If it already has a data-snippet it is a saved or an inherited snippet.
-                # Do not override it.
-                elif 'data-snippet' not in el.attrib:
-                    el.attrib['data-snippet'] = snippet_key.split('.', 1)[-1]
+                else:
+                    # If it already has a data-snippet it is a saved or an
+                    # inherited snippet. Do not override it.
+                    if 'data-snippet' not in el.attrib:
+                        el.attrib['data-snippet'] = snippet_key.split('.', 1)[-1]
+
+                    # If it already has a data-name it is a saved or an
+                    # inherited snippet. Do not override it.
+                    snippet_name = compile_context.get('snippet-name')
+                    if snippet_name and 'data-name' not in el.attrib:
+                        el.attrib['data-name'] = snippet_name
 
         return super()._compile_node(el, compile_context, indent)
 
@@ -101,8 +108,9 @@ class IrQWeb(models.AbstractModel):
 
     def _compile_directive_snippet_call(self, el, compile_context, indent):
         key = el.attrib.pop('t-snippet-call')
+        snippet_name = el.attrib.pop('string', None)
         el.set('t-call', key)
-        el.set('t-options', f"{{'snippet-key': {key!r}}}")
+        el.set('t-options', f"{{'snippet-key': {key!r}, 'snippet-name': {snippet_name!r}}}")
         return self._compile_node(el, compile_context, indent)
 
     def _compile_directive_install(self, el, compile_context, indent):

--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -144,6 +144,7 @@
         'views/snippets/s_embed_code.xml',
         'views/snippets/s_website_controller_page_listing_layout.xml',
         'views/snippets/s_website_form.xml',
+        'views/snippets/s_title_form.xml',
         'views/snippets/s_searchbar.xml',
         'views/snippets/s_button.xml',
         'views/snippets/s_freegrid.xml',

--- a/addons/website/views/new_page_template_templates.xml
+++ b/addons/website/views/new_page_template_templates.xml
@@ -196,7 +196,7 @@ overridden by modules), because:
     </xpath>
     <xpath expr="//h2" position="replace" mode="inner">Our Services</xpath>
     <xpath expr="//h2" position="after">
-        <t t-snippet-call="website.s_searchbar_input"/>
+        <t t-snippet-call="website.s_searchbar_input" string="Search Input"/>
     </xpath>
 </template>
 
@@ -455,8 +455,8 @@ overridden by modules), because:
         <p class="lead">Experienced fullstack developer.</p>
     </xpath>
     <xpath expr="//p" position="after">
-        <t t-snippet-call="website.s_social_media"/>
-        <t t-snippet-call="website.s_hr"/>
+        <t t-snippet-call="website.s_social_media" string="Social"/>
+        <t t-snippet-call="website.s_hr" string="Separator"/>
     </xpath>
 </template>
 
@@ -573,13 +573,13 @@ overridden by modules), because:
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_colored_level o_cc o_cc1" separator=" "/>
     </xpath>
-</template> 
+</template>
 
 <template id="new_page_template_basic_s_quotes_carousel" inherit_id="website.new_page_template_s_quotes_carousel" primary="True">
     <xpath expr="//section" position="attributes">
         <attribute name="class" remove="o_colored_level o_cc o_cc1" separator=" "/>
     </xpath>
-</template> 
+</template>
 
 <!-- s_references -->
 

--- a/addons/website/views/snippets/s_searchbar.xml
+++ b/addons/website/views/snippets/s_searchbar.xml
@@ -20,7 +20,7 @@
                 <div class="col-lg-8 offset-lg-2">
                     <h2>Search on our website</h2>
                     <p>You will get results from blog posts, products, etc</p>
-                    <t t-snippet-call="website.s_searchbar_input"/>
+                    <t t-snippet-call="website.s_searchbar_input" string="Search Input"/>
                 </div>
             </div>
         </div>

--- a/addons/website/views/snippets/s_title_form.xml
+++ b/addons/website/views/snippets/s_title_form.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_title_form" name="Title - Form">
+    <section class="s_title_form o_cc o_cc2 pt64 pb48">
+        <div class="o_container_small">
+            <h2 class="text-center">Let's Connect</h2>
+            <p class="text-center lead">Get in touch with your customers to provide them with better service. You can modify the form fields to gather more precise information.</p>
+            <t t-snippet-call="website.s_website_form" string="Form"/>
+        </div>
+    </section>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -2,15 +2,9 @@
 <odoo>
 
 <template id="s_website_form" name="Form">
-    <section class="s_website_form o_cc o_cc2 pt64 pb64" data-vcss="001" data-snippet="s_website_form">
-        <div class="o_container_small">
+    <section class="s_website_form pt16 pb16" data-vcss="001" data-snippet="s_website_form">
+        <div class="container-fluid">
             <form action="/website/form/" method="post" enctype="multipart/form-data" class="o_mark_required" data-mark="*" data-pre-fill="true" data-model_name="mail.mail" data-success-mode="redirect" data-success-page="/contactus-thank-you">
-                <div class="row text-center">
-                    <div class="col-12 pb16">
-                        <h2>Let's Connect</h2>
-                        <p class="lead">Get in touch with your customers to provide them with better service. You can modify the form fields to gather more precise information.</p>
-                    </div>
-                </div>
                 <div class="s_website_form_rows row s_col_no_bgcolor">
                     <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_dnone">
                         <div class="row s_col_no_resize s_col_no_bgcolor">

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -302,7 +302,7 @@
                 </t>
 
                 <!-- Contact & Forms group -->
-                <t t-snippet="website.s_website_form" string="Form" t-forbid-sanitize="form" t-thumbnail="/website/static/src/img/snippets_thumbs/s_website_form.svg" group="contact_and_forms"/>
+                <t t-snippet="website.s_title_form" string="Title - Form" t-forbid-sanitize="form" t-thumbnail="/website/static/src/img/snippets_thumbs/s_website_form.svg" group="contact_and_forms"/>
                 <t t-snippet="website.s_opening_hours" string="Opening Hours" group="contact_and_forms"/>
                 <t t-snippet="website.s_contact_info" string="Contact Info" group="contact_and_forms"/>
 
@@ -384,6 +384,14 @@
                 <t t-snippet="website.s_blockquote" string="Blockquote" t-thumbnail="/website/static/src/img/snippets_thumbs/s_blockquote.svg">
                     <keywords>cite</keywords>
                 </t>
+                <!--
+                Note: this inner snippet is still allowed to be dropped as a
+                main snippet. Indeed, this handles the fact that the snippet
+                was previously a main one and can still be in old databases, but
+                also in some apps templates. It was just chosen to not suggest
+                it in the snippets modal anymore, and just *used* as an inner
+                snippet by other snippets in there.
+                -->
                 <t t-snippet="website.s_website_form" string="Form" t-thumbnail="/website/static/src/img/snippets_thumbs/s_website_form.svg" t-forbid-sanitize="form"/>
                 <t t-snippet="website.s_countdown" string="Countdown" t-thumbnail="/website/static/src/img/snippets_thumbs/s_countdown.svg">
                     <keywords>celebration, launch</keywords>


### PR DESCRIPTION
It was still possible to use it as an inner snippet, but since [1], it
looked broken without further edition of the dropped inner snippet:
- The form had a gray background (instead of transparent).
- It was forced to be small-width and centered.
- There was a big title coming with it, forcing the user to remove it.
- ...

Since then, [2] was introduced to regroup "main" snippets in a dedicated
modal. The form snippet was moved there but also remained outside of it
to keep the inner form snippet feature.

This commit just splits the two usecases:
- The original `s_website_form` snippet is now only suggested as an
  inner snippet. It was restored to be without title, background and
  other default styling features.
- A new `s_title_form` is introduced, using the `s_website_form` inside,
  and suggested in the snippets modal instead of the original one. That
  one comes with a background color, title, etc.

Note: in old databases and other codebase places, `s_website_form` will
still be used as a main snippet so the code here also keeps that
possibility to drop it as a main snippet and move it. It is just not
suggested to be used as a main one anymore, but still possible.

[1]: https://github.com/odoo/odoo/commit/a3b176bf21e4ad291f51b69360ca2194517617a0
[2]: https://github.com/odoo/odoo/commit/edf81c13d8f2f6d29a77d68cbfa0dc9216da3c2a

Related to task-4206683