### PR TITLE
[IMP] base: session rotation

### DIFF
--- a/addons/auth_signup/tests/test_auth_signup.py
+++ b/addons/auth_signup/tests/test_auth_signup.py
@@ -59,7 +59,7 @@ class TestAuthSignupFlow(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
             # Call the controller
             url_free_signup = self._get_free_signup_url()
             response = self.url_open(url_free_signup, data=payload)
-            self.assertIn('/web/login?redirect=%2Fweb%2Flogin_successful%3Faccount_created%3DTrue', response.url)
+            self.assertIn('/web/login_successful?account_created=True', response.url)
             # Check if an email is sent to the new userw
             new_user = self.env['res.users'].search([('name', '=', name)])
             self.assertTrue(new_user)

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -735,6 +735,9 @@ class Websocket:
         session = root.session_store.get(self._session.sid)
         if not session:
             raise SessionExpiredException()
+        if 'next_sid' in session:
+            self._session = root.session_store.get(session['next_sid'])
+            return self._dispatch_bus_notifications()
          # Mark the notification request as processed.
         self._waiting_for_dispatch = False
         with acquire_cursor(session.db) as cr:
@@ -920,6 +923,9 @@ class WebsocketRequest:
 
     def _get_session(self):
         session = root.session_store.get(self.ws._session.sid)
+        if 'next_sid' in session:
+            self.ws._session = root.session_store.get(session['next_sid'])
+            return self._get_session()
         if not session:
             raise SessionExpiredException()
         return session

--- a/addons/test_website/tests/test_session.py
+++ b/addons/test_website/tests/test_session.py
@@ -82,11 +82,11 @@ class TestWebsiteSession(HttpCaseWithUserDemo):
         self.assertTrue(has_branding(result.text), "Should have branding for user demo")
 
         # Public user.
-        self.opener.cookies['session_id'] = public_session.sid
+        self.opener.cookies.set("session_id", public_session.sid, domain=odoo.tests.common.HOST)
         result = self.url_open(f'/test_website/model_item_sudo/{record.id}')
         self.assertFalse(has_branding(result.text), "Should have no branding for public user")
 
         # Back to demo user.
-        self.opener.cookies['session_id'] = demo_session.sid
+        self.opener.cookies.set("session_id", demo_session.sid, domain=odoo.tests.common.HOST)
         result = self.url_open(f'/test_website/model_item_sudo/{record.id}')
         self.assertTrue(has_branding(result.text), "Should have branding for user demo")

--- a/odoo/addons/base/models/res_device.py
+++ b/odoo/addons/base/models/res_device.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import logging
 
 from odoo import api, fields, models, tools
-from odoo.http import GeoIP, request, root
+from odoo.http import GeoIP, request, root, STORED_SESSION_BYTES
 from odoo.tools import SQL, OrderedSet, unique
 from odoo.tools.translate import _
 from .res_users import check_identity
@@ -64,7 +64,7 @@ class ResDeviceLog(models.Model):
 
     def _order_field_to_sql(self, alias, field_name, direction, nulls, query):
         if field_name == 'is_current' and request:
-            return SQL("session_identifier = %s DESC", request.session.sid[:42])
+            return SQL("session_identifier = %s DESC", request.session.sid[:STORED_SESSION_BYTES])
         return super()._order_field_to_sql(alias, field_name, direction, nulls, query)
 
     def _is_mobile(self, platform):
@@ -87,7 +87,7 @@ class ResDeviceLog(models.Model):
 
         geoip = GeoIP(trace['ip_address'])
         user_id = request.session.uid
-        session_identifier = request.session.sid[:42]
+        session_identifier = request.session.sid[:STORED_SESSION_BYTES]
 
         if self.env.cr.readonly:
             self.env.cr.rollback()

--- a/odoo/addons/test_http/tests/test_misc.py
+++ b/odoo/addons/test_http/tests/test_misc.py
@@ -256,7 +256,7 @@ class TestHttpEnsureDb(TestHttpBase):
         self.assertEqual(new_session.uid, None)
 
         # follow redirection
-        self.opener.cookies['session_id'] = new_session.sid
+        self.opener.cookies.set("session_id", new_session.sid, domain=HOST)
         res = self.multidb_url_open('/test_http/ensure_db')
         res.raise_for_status()
         self.assertEqual(res.status_code, 200)

--- a/odoo/addons/test_http/tests/test_registry.py
+++ b/odoo/addons/test_http/tests/test_registry.py
@@ -80,7 +80,7 @@ class TestHttpRegistry(BaseCase):
         session.update(odoo.http.get_default_session(), db=db or get_db_name())
         session.context['lang'] = odoo.http.DEFAULT_LANG
         odoo.http.root.session_store.save(session)
-        self.opener.cookies['session_id'] = session.sid
+        self.opener.cookies.set("session_id", session.sid, domain=HOST)
         return session
 
     def url_open(self, path, *, allow_redirects=False):

--- a/odoo/addons/test_http/utils.py
+++ b/odoo/addons/test_http/utils.py
@@ -74,8 +74,17 @@ class MemorySessionStore(SessionStore):
     def get_missing_session_identifiers(self, identifiers):
         return set(identifiers).difference(self.store)
 
-    def rotate(self, session, env):
-        FilesystemSessionStore.rotate(self, session, env)
+    def delete_old_sessions(self, session):
+        return FilesystemSessionStore.delete_old_sessions(self, session)
+
+    def rotate(self, session, env, soft=None):
+        FilesystemSessionStore.rotate(self, session, env, soft)
+
+    def generate_key(self, salt=None):
+        return FilesystemSessionStore.generate_key(self, salt)
+
+    def is_valid_key(self, key):
+        return FilesystemSessionStore.is_valid_key(self, key)
 
     def vacuum(self):
         return

--- a/odoo/service/security.py
+++ b/odoo/service/security.py
@@ -1,5 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import time
+
 from odoo.tools.misc import consteq
 
 
@@ -9,6 +11,10 @@ def compute_session_token(session, env):
 
 
 def check_session(session, env, request=None):
+    session._delete_old_sessions()
+    # Make sure we don't use a deleted session that can be saved again
+    if 'deletion_time' in session and session['deletion_time'] <= time.time():
+        return False
     self = env['res.users'].browse(session.uid)
     expected = self._compute_session_token(session.sid)
     if expected:

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -2297,7 +2297,7 @@ class HttpCase(TransactionCase):
         # An alternative would be to set the cookie to None (unsetting it
         # completely) or clear-ing session.cookies.
         self.opener = Opener(self)
-        self.opener.cookies['session_id'] = session.sid
+        self.opener.cookies.set("session_id", session.sid, domain=HOST)
         if browser:
             self._logger.info('Setting session cookie in browser')
             browser.set_cookie('session_id', session.sid, '/', HOST)


### PR DESCRIPTION
Generic infostealers usually dump sessions in a platform such as telegram or discord, where they're sold on the dark web. The goal of this commit is having sessions expire before the bad guys have time to impersonate the user.

In case a bad guy is able to steal a session ID, their window of exploitation is:
- if the user is idle/gone: until the idle session timeout (`sessions.max_inactivity_seconds`, 7d by default)
- if the user is still active: until the session rotation timeout (this PR)

Task-4191719