### PR TITLE
[FIX] website: fix traceback when the user delete all websites

### DIFF
--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -12906,6 +12906,13 @@ msgid "You may opt-out of a third-party's use of cookies by visiting the"
 msgstr ""
 
 #. module: website
+#. odoo-python
+#: code:addons/website/models/website.py:0
+#, python-format
+msgid "You must keep at least one website."
+msgstr ""
+
+#. module: website
 #: model_terms:ir.ui.view,arch_db:website.s_faq_collapse
 msgid ""
 "You should carefully review the legal statements and other conditions of use"

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -297,6 +297,9 @@ class Website(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_default_website(self):
+        website = self.search_count([('id', 'not in', self.ids)])
+        if not website:
+            raise UserError(_('You must keep at least one website.'))
         default_website = self.env.ref('website.default_website', raise_if_not_found=False)
         if default_website and default_website in self:
             raise UserError(_("You cannot delete default website %s. Try to change its settings instead", default_website.name))


### PR DESCRIPTION
Currently, a traceback occurs when the user deletes all the websites and tries to open the website.

To reproduce this issue:

1) Install the website
2) Delete the default website from external identifiers in settings/technical 
3) Now delete all websites from website/configuration/websites 
4) Tries to access or open the website

Error:- 
```
ValueError: Expected singleton: website()
```

Initially, there is a check for at least one website while uninstalling the websites,
But after the below commit the code is changed only to check for the default website.

But if the user deleted the external identifier of the default website and 
deleted all the websites it leads to a traceback.

https://github.com/odoo/odoo/pull/113405/commits/60adaf5632ddfe3f68da369a2e9642ad639da37e

After applying this commit, it will resolve this issue by ensuring at least one website is required.

sentry-5900356108
