### PR TITLE
[FIX] sale: synchronize T&C section with PDF invoice

### DIFF
--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -642,14 +642,7 @@
             <section t-if="not is_html_empty(sale_order.note)" id="terms" class="mt-4">
                 <h4 class="">Terms &amp; Conditions</h4>
                 <hr class="mt-0 mb-1"/>
-                <t t-if="sale_order.terms_type == 'html'">
-                    <!-- Note is plain text. This ensures a clickable link  -->
-                    <t t-set="tc_url" t-value="'%s/terms' % (sale_order.get_base_url())"/>
-                    <em>Terms &amp; Conditions: <a href="/terms"><t t-out="tc_url"/></a></em>
-                </t>
-                <t t-else="">
-                    <em t-field="sale_order.note"/>
-                </t>
+                <em t-field="sale_order.note"/>
             </section>
 
             <section t-if="sale_order.payment_term_id" class="mt-4">


### PR DESCRIPTION
Problem:
When the option "Add a link to a Web Page" is enabled, the preview page always shows the T&C link regardless of the content added to the notes. This behavior is inconsistent with the T&C section in the PDF invoice.

Steps to reproduce:

- Enable "Add a link to a Web Page."
- Create a new Sales Order (SO).
- Add content (text or image) to the notes.
- Confirm and preview the SO.
- The added content does not appear in the T&C section.

opw-4170021

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
