### PR TITLE
[FIX] html_editor: HR considered as a shrunk block

### DIFF
--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -225,7 +225,7 @@ export function isVisibleTextNode(testedNode) {
  * @param {Node} node
  * @returns {boolean}
  */
-const selfClosingElementTags = ["BR", "IMG", "INPUT", "T"];
+const selfClosingElementTags = ["BR", "IMG", "INPUT", "T", "HR"];
 export function isSelfClosingElement(node) {
     return node && selfClosingElementTags.includes(node.nodeName);
 }
@@ -525,7 +525,7 @@ export function isEmptyBlock(blockEl) {
  * @returns {boolean}
  */
 export function isShrunkBlock(blockEl) {
-    return isEmptyBlock(blockEl) && !blockEl.querySelector("br") && blockEl.nodeName !== "IMG";
+    return isEmptyBlock(blockEl) && !blockEl.querySelector("br") && !isSelfClosingElement(blockEl);
 }
 
 export function isEditorTab(node) {

--- a/addons/html_editor/static/tests/delete/delete_range.test.js
+++ b/addons/html_editor/static/tests/delete/delete_range.test.js
@@ -250,6 +250,14 @@ describe("deleteRange method", () => {
             expect(getContent(el)).toBe(contentAfter);
         });
     });
+    describe("Fill shrunk blocks", () => {
+        test("should not fill a HR with BR", async () => {
+            const { editor, el } = await setupEditor("<hr><p>abc[</p><p>]def</p>");
+            deleteRange(editor);
+            const hr = el.firstElementChild;
+            expect(hr.childNodes.length).toBe(0);
+        });
+    });
 });
 
 describe("DELETE_SELECTION command", () => {

--- a/addons/html_editor/static/tests/utils/dom_info.test.js
+++ b/addons/html_editor/static/tests/utils/dom_info.test.js
@@ -1,6 +1,7 @@
 import {
     getDeepestPosition,
     isEmptyBlock,
+    isShrunkBlock,
     isVisible,
     isVisibleTextNode,
     nextLeaf,
@@ -414,6 +415,14 @@ describe("isEmptyBlock", () => {
     test("should identify a tag with text as non-empty", () => {
         const [a] = insertTestHtml('<a href="#">Link text</a>');
         const result = isEmptyBlock(a);
+        expect(result).toBe(false);
+    });
+});
+
+describe("isShrunkBlock", () => {
+    test("should not consider a HR as a shrunk block", () => {
+        const [hr] = insertTestHtml("<hr>");
+        const result = isShrunkBlock(hr);
         expect(result).toBe(false);
     });
 });


### PR DESCRIPTION
Steps:
1. have a horizontal rule (HR) and two paragraphs in the editor
2. make a selection across the two paragraphs
3. press backspace or delete

Result: the HR gets filled with a BR element, leading to a vertical space being added below it.

The isShrunkBlock function is typically used to detect blocks that need to have a BR element added to it, otherwise they would be displayed collapsed in the editor.

Before this commit, the HR element was (incorrectly) considered as a shrunk block. The issue described above happened because the deleteRange method, after removing nodes as joining blocks, looks for shrunk blocks and fills them with a BR element.
