### PR TITLE
[FIX] stock_account: don't skip journal_dict arg when extending

### DIFF
--- a/addons/stock_account/models/account_chart_template.py
+++ b/addons/stock_account/models/account_chart_template.py
@@ -12,7 +12,7 @@ class AccountChartTemplate(models.Model):
 
     @api.model
     def generate_journals(self, acc_template_ref, company, journals_dict=None):
-        journal_to_add = [{'name': _('Inventory Valuation'), 'type': 'general', 'code': 'STJ', 'favorite': False, 'sequence': 8}]
+        journal_to_add = (journals_dict or []) + [{'name': _('Inventory Valuation'), 'type': 'general', 'code': 'STJ', 'favorite': False, 'sequence': 8}]
         return super(AccountChartTemplate, self).generate_journals(acc_template_ref=acc_template_ref, company=company, journals_dict=journal_to_add)
 
     def generate_properties(self, acc_template_ref, company, property_list=None):


### PR DESCRIPTION
Journals passed in journal_dict weren't actually created.

Credits to Roy Le @ Viindoo, original PR: odoo/odoo#134446