### PR TITLE
[IMP] payment_custom, sale: auto confirm SO for wire transfer payments

### DIFF
--- a/addons/payment_custom/__manifest__.py
+++ b/addons/payment_custom/__manifest__.py
@@ -7,11 +7,12 @@
     'sequence': 350,
     'summary': "A payment provider for custom flows like wire transfers.",
     'description': " ",  # Non-empty string to avoid loading the README file.
-    'depends': ['payment'],
+    'depends': ['payment', 'account_payment'],
     'data': [
         'views/payment_custom_templates.xml',
         'views/payment_provider_views.xml',
 
+        'data/ir_cron.xml',
         'data/payment_method_data.xml',
         'data/payment_provider_data.xml',  # Depends on `payment_method_wire_transfer`.
     ],

--- a/addons/payment_custom/data/ir_cron.xml
+++ b/addons/payment_custom/data/ir_cron.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="cron_auto_confirm_paid_wire_transfer_txs" model="ir.cron">
+        <field name="name">Wire Transfer: Confirm paid transactions</field>
+        <field name="model_id" ref="payment_custom.model_account_bank_statement_line"/>
+        <field name="state">code</field>
+        <field name="code">model._cron_confirm_wire_transfer_transactions()</field>
+        <field name="user_id" ref="base.user_root" />
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+    </record>
+
+</odoo>

--- a/addons/payment_custom/models/__init__.py
+++ b/addons/payment_custom/models/__init__.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import account_bank_statement_line
 from . import payment_provider
 from . import payment_transaction

--- a/addons/payment_custom/models/account_bank_statement_line.py
+++ b/addons/payment_custom/models/account_bank_statement_line.py
@@ -1,0 +1,55 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from itertools import groupby
+
+from odoo import api, models
+
+
+class AccountBankStatementLine(models.Model):
+    _inherit = 'account.bank.statement.line'
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        statement_lines = super().create(vals_list)
+
+        wire_transfer_cron = self.env.ref('payment_custom.cron_auto_confirm_paid_wire_transfer_txs', False)
+        if wire_transfer_cron:
+            wire_transfer_cron._trigger()
+
+        return statement_lines
+
+    def _cron_confirm_wire_transfer_transactions(self):
+        """ Confirm pending wire transfer payment transactions for which a matching bank statement is found.
+
+        Note: This method is called by the `cron_auto_confirm_paid_wire_transfer_txs` cron.
+        :return: None
+        """
+
+        pending_wire_transfer_txs = self.env['payment.transaction'].search([
+            ('payment_method_id.code', '=', 'wire_transfer'),
+            ('state', '=', 'pending'),
+        ])
+        if not pending_wire_transfer_txs:
+            return
+
+        for company, txs_list in groupby(pending_wire_transfer_txs, key=lambda tx: tx.company_id):
+            txs_list = list(txs_list)
+            statement_lines = self.search([
+                ('payment_ref', 'in', [tx.reference for tx in txs_list]),
+                ('company_id', '=', company.id),
+            ])
+            if not statement_lines:
+                continue
+
+            for tx in txs_list:
+                if any(
+                    line.payment_ref == tx.reference
+                    and line.partner_id == tx.partner_id.commercial_partner_id
+                    and (
+                        line.currency_id == tx.currency_id
+                        and tx.currency_id.compare_amounts(line.amount, tx.amount) == 0
+                    )
+                    for line in statement_lines
+                ):
+                    tx._set_done()
+                    tx._post_process()

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1413,6 +1413,16 @@ class SaleOrder(models.Model):
         action['context'] = context
         return action
 
+    def action_view_payment_transaction(self):
+        action = self.env['ir.actions.act_window']._for_xml_id('payment.action_payment_transaction')
+        if len(self.transaction_ids) == 1:
+            action['view_mode'] = 'form'
+            action['res_id'] = self.transaction_ids.id
+            action['views'] = []
+        else:
+            action['domain'] = [('id', 'in', self.transaction_ids.ids)]
+        return action
+
     def _get_invoice_grouping_keys(self):
         return ['company_id', 'partner_id', 'currency_id']
 

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -328,6 +328,16 @@
                         invisible="invoice_count == 0">
                         <field name="invoice_count" widget="statinfo" string="Invoices"/>
                     </button>
+                    <button
+                        name="action_view_payment_transaction"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-money"
+                        invisible="not transaction_ids"
+                        groups="base.group_no_one"
+                    >
+                        <field name="transaction_ids" widget="statinfo" string="Payments"/>
+                    </button>
                 </div>
                 <div class="badge rounded-pill text-bg-secondary float-end fs-6 border-0"
                     invisible="not locked">


### PR DESCRIPTION
Improve usability by confirming automatically orders when the wire transfer payment is received.
Clean the interface by confirming the main payment transaction and cancel the extra generated ones. 

Current behavior before PR:
When paying with wire transfer:
- the created payement transaction stays in pending state forever
- sale orders have to be confirmed manually

Desired behavior after PR is merged:
At creation (and with a daily cron), verify if the account.bank.statement.line matches a pending transaction. 
If so, confirm the transaction and cancel the eventual remaining ones related to the same SO.
Add a button on the SO to have direct access to the payment.transaction records. 

task-4075189