### PR TITLE
[FIX] spreadsheet: properly handle boolean values in lists

### DIFF
--- a/addons/spreadsheet/static/src/list/list_data_source.js
+++ b/addons/spreadsheet/static/src/list/list_data_source.js
@@ -208,7 +208,7 @@ export class ListDataSource extends OdooViewsDataSource {
                 return value ? value[1] : "";
             }
             case "boolean":
-                return record[fieldName] ? "TRUE" : "FALSE";
+                return record[fieldName] ? true : false;
             case "date":
                 return record[fieldName]
                     ? toNumber(this._formatDate(record[fieldName]), DEFAULT_LOCALE)

--- a/addons/spreadsheet/static/tests/lists/list_plugin.test.js
+++ b/addons/spreadsheet/static/tests/lists/list_plugin.test.js
@@ -72,8 +72,8 @@ test("Return display_name of many2one field", async () => {
 
 test("Boolean fields are correctly formatted", async () => {
     const { model } = await createSpreadsheetWithList({ columns: ["bar"] });
-    expect(getCellValue(model, "A2")).toBe("TRUE");
-    expect(getCellValue(model, "A5")).toBe("FALSE");
+    expect(getCellValue(model, "A2")).toBe(true);
+    expect(getCellValue(model, "A5")).toBe(false);
 });
 
 test("properties field displays property display names", async () => {
@@ -99,7 +99,7 @@ test("Can display a field which is not in the columns", async function () {
     expect(getCellValue(model, "A1")).toBe("Loading...");
     await waitForDataLoaded(model); // Await for batching collection of missing fields
     await animationFrame();
-    expect(getCellValue(model, "A1")).toBe("TRUE");
+    expect(getCellValue(model, "A1")).toBe(true);
 });
 
 test("Can remove a list with undo after editing a cell", async function () {
@@ -480,7 +480,7 @@ test("can edit list domain", async () => {
     const { model } = await createSpreadsheetWithList();
     const [listId] = model.getters.getListIds();
     expect(model.getters.getListDefinition(listId).domain).toEqual([]);
-    expect(getCellValue(model, "B2")).toBe("TRUE");
+    expect(getCellValue(model, "B2")).toBe(true);
     model.dispatch("UPDATE_ODOO_LIST_DOMAIN", {
         listId,
         domain: [["foo", "in", [55]]],
@@ -492,7 +492,7 @@ test("can edit list domain", async () => {
     await waitForDataLoaded(model);
     expect(model.getters.getListDefinition(listId).domain).toEqual([]);
     await waitForDataLoaded(model);
-    expect(getCellValue(model, "B2")).toBe("TRUE");
+    expect(getCellValue(model, "B2")).toBe(true);
     model.dispatch("REQUEST_REDO");
     expect(model.getters.getListDefinition(listId).domain).toEqual([["foo", "in", [55]]]);
     await waitForDataLoaded(model);
@@ -506,18 +506,18 @@ test("can edit list sorting", async () => {
     // prettier-ignore
     const initialGrid = [
         ["Foo", "Bar",   "Date", "Probability", "Money!"],
-        [12,    "TRUE",  42474,  10,                74.4],
-        [1,     "TRUE",  42669,  11,                74.8],
-        [17,    "TRUE",  42719,  95,                   4],
-        [2,     "FALSE", 42715,  15,                1000],
+        [12,     true,   42474,  10,                74.4],
+        [1,      true,   42669,  11,                74.8],
+        [17,     true,   42719,  95,                   4],
+        [2,      false,  42715,  15,                1000],
     ]
     // prettier-ignore
     const orderedGrid = [
         ["Foo", "Bar",   "Date", "Probability", "Money!"],
-        [17,    "TRUE",  42719,   95,                  4],
-        [12,    "TRUE",  42474,   10,               74.4],
-        [1,     "TRUE",  42669,   11,               74.8],
-        [2,     "FALSE", 42715,   15,               1000],
+        [17,     true,   42719,   95,                  4],
+        [12,     true,   42474,   10,               74.4],
+        [1,      true,   42669,   11,               74.8],
+        [2,      false,  42715,   15,               1000],
     ]
     const [listId] = model.getters.getListIds();
     expect(model.getters.getListDefinition(listId).orderBy).toEqual([]);


### PR DESCRIPTION
The method returning a list field value based on its type did not properly handle the boolean fields. It would return the string "TRUE" and "FALSE" which are interpreted as strings by the evaluation process.

task-4182574

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
