### PR TITLE
[FIX] mrp: 'PLAN ORDERS' button leads to WO view instead of MO view

### DIFF
--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -291,6 +291,12 @@ class MrpWorkcenter(models.Model):
         action = self.env["ir.actions.actions"]._for_xml_id("mrp.action_work_orders")
         return action
 
+    def action_work_order_alternatives(self):
+        action = self.env["ir.actions.actions"]._for_xml_id("mrp.mrp_workorder_todo")
+        action['domain'] = ['|', ('workcenter_id', 'in', self.alternative_workcenter_ids.ids),
+                            ('workcenter_id.alternative_workcenter_ids', '=', self.id)]
+        return action
+
     def _get_unavailability_intervals(self, start_datetime, end_datetime):
         """Get the unavailabilities intervals for the workcenters in `self`.
 

--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -209,7 +209,7 @@
                                         <button t-if="record.workorder_count.raw_value &gt; 0" class="btn btn-primary" name="action_work_order" type="object" context="{'search_default_ready': 1, 'search_default_progress': 1, 'desktop_list_view': 1, 'search_default_workcenter_id': id}">
                                             <span>WORK ORDERS</span>
                                         </button>
-                                        <button t-if="record.workorder_count.raw_value &lt;= 0" class="btn btn-warning" name="%(act_product_mrp_production_workcenter)d" type="action">
+                                        <button t-if="record.workorder_count.raw_value &lt;= 0" class="btn btn-warning" name="action_work_order_alternatives" type="object">
                                             <span>PLAN ORDERS</span>
                                         </button>
                                     </div>


### PR DESCRIPTION
The 'PLAN ORDERS' button in the Manufacturing overview now leads to the list of all WOs regardless of workcenter and status.

Task ID: [4154879](https://www.odoo.com/odoo/966/tasks/4154879)