### PR TITLE
[FIX] microsoft_calendar: consider system parameter on event fetch

### DIFF
--- a/addons/microsoft_calendar/tests/test_microsoft_service.py
+++ b/addons/microsoft_calendar/tests/test_microsoft_service.py
@@ -38,8 +38,8 @@ class TestMicrosoftService(TransactionCase):
         self.call_without_sync_token = call(
             "/v1.0/me/calendarView/delta",
             {
-                'startDateTime': fields.Datetime.subtract(fields.Datetime.now(), years=1).strftime("%Y-%m-%dT00:00:00Z"),
-                'endDateTime': fields.Datetime.add(fields.Datetime.now(), years=2).strftime("%Y-%m-%dT00:00:00Z"),
+                'startDateTime': fields.Datetime.subtract(fields.Datetime.now(), days=365).strftime("%Y-%m-%dT00:00:00Z"),
+                'endDateTime': fields.Datetime.add(fields.Datetime.now(), days=365 * 2).strftime("%Y-%m-%dT00:00:00Z"),
             },
             {**self.header, 'Prefer': self.header_prefer},
             method="GET", timeout=DEFAULT_TIMEOUT,
@@ -226,8 +226,8 @@ class TestMicrosoftService(TransactionCase):
         mock_do_request.assert_called_with(
             "/v1.0/me/events/123/instances",
             {
-                'startDateTime': fields.Datetime.subtract(fields.Datetime.now(), years=1).strftime("%Y-%m-%dT00:00:00Z"),
-                'endDateTime': fields.Datetime.add(fields.Datetime.now(), years=2).strftime("%Y-%m-%dT00:00:00Z"),
+                'startDateTime': fields.Datetime.subtract(fields.Datetime.now(), days=365).strftime("%Y-%m-%dT00:00:00Z"),
+                'endDateTime': fields.Datetime.add(fields.Datetime.now(), days=365 * 2).strftime("%Y-%m-%dT00:00:00Z"),
             },
             {**self.header, 'Prefer': self.header_prefer},
             method='GET', timeout=DEFAULT_TIMEOUT,

--- a/addons/microsoft_calendar/utils/microsoft_calendar.py
+++ b/addons/microsoft_calendar/utils/microsoft_calendar.py
@@ -65,9 +65,11 @@ class MicrosoftCalendarService():
         }
         if not params:
             # By default, fetch events from at most one year in the past and two years in the future.
+            # Can be modified by microsoft_calendar.sync.range_days system parameter.
+            day_range = int(self.microsoft_service.env['ir.config_parameter'].sudo().get_param('microsoft_calendar.sync.range_days', default=365))
             params = {
-                'startDateTime': fields.Datetime.subtract(fields.Datetime.now(), years=1).strftime("%Y-%m-%dT00:00:00Z"),
-                'endDateTime': fields.Datetime.add(fields.Datetime.now(), years=2).strftime("%Y-%m-%dT00:00:00Z"),
+                'startDateTime': fields.Datetime.subtract(fields.Datetime.now(), days=day_range).strftime("%Y-%m-%dT00:00:00Z"),
+                'endDateTime': fields.Datetime.add(fields.Datetime.now(), days=day_range * 2).strftime("%Y-%m-%dT00:00:00Z"),
             }
 
         # get the first page of events


### PR DESCRIPTION
Before:
All event from last year to the next 2 years were fetched. This might cause timeout depending on the amount of events.

After this commit:
Reuse the system parameter to allow limiting to a set value

Note: This does not need to be done on google as the fetch limit is already present, see:
https://github.com/odoo/odoo/pull/66250/files#diff-f1bbd37c3355f798d3f2d89ccc00c778aa4faa4c6709b6d66cc9650ad0d553b6

opw-4077113