### PR TITLE
[FIX] account: only pre-mount true matches with reconcile models

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -831,6 +831,10 @@ class AccountReconcileModel(models.Model):
                     'allow_auto_reconcile': True,
                     'amls': self.env['account.move.line'].browse(candidate_ids),
                 }
+            elif self.match_text_location_label or self.match_text_location_note or self.match_text_location_reference:
+                # In the case any of the Label, Note or Reference matching rule has been toggled, and the query didn't return
+                # any candidates, the model should not try to mount another aml instead.
+                return
 
         if not partner:
             st_line_currency = st_line.foreign_currency_id or st_line.journal_id.currency_id or st_line.company_currency_id

--- a/addons/account/tests/test_reconciliation_matching_rules.py
+++ b/addons/account/tests/test_reconciliation_matching_rules.py
@@ -215,6 +215,7 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
 
     def test_matching_fields(self):
         # Check without restriction.
+        self.rule_1.match_text_location_label = False
         self._check_statement_matching(self.rule_1, {
             self.bank_line_1: {'amls': self.invoice_line_1, 'model': self.rule_1},
             self.bank_line_2: {'amls': self.invoice_line_1 + self.invoice_line_2 + self.invoice_line_3, 'model': self.rule_1},
@@ -222,6 +223,7 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
         })
 
     def test_matching_fields_match_journal_ids(self):
+        self.rule_1.match_text_location_label = False
         self.rule_1.match_journal_ids |= self.cash_line_1.journal_id
         self._check_statement_matching(self.rule_1, {
             self.bank_line_1: {},
@@ -230,6 +232,7 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
         })
 
     def test_matching_fields_match_nature(self):
+        self.rule_1.match_text_location_label = False
         self.rule_1.match_nature = 'amount_received'
         self._check_statement_matching(self.rule_1, {
             self.bank_line_1: {'amls': self.invoice_line_1, 'model': self.rule_1},
@@ -247,6 +250,7 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
         })
 
     def test_matching_fields_match_amount(self):
+        self.rule_1.match_text_location_label = False
         self.rule_1.match_amount = 'lower'
         self.rule_1.match_amount_max = 150
         self._check_statement_matching(self.rule_1, {
@@ -271,6 +275,7 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
         })
 
     def test_matching_fields_match_label(self):
+        self.rule_1.match_text_location_label = False
         self.rule_1.match_label = 'contains'
         self.rule_1.match_label_param = 'yyyyy'
         self._check_statement_matching(self.rule_1, {
@@ -302,21 +307,21 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
             invl = self._create_invoice_line(1000.0, self.partner_a, inv_type, inv_date='2019-01-01')
 
             # Exact matching.
-            st_line = self._create_st_line(amount=bsl_sign * 1000.0)
+            st_line = self._create_st_line(amount=bsl_sign * 1000.0, payment_ref=invl.name)
             self._check_statement_matching(
                 rule,
                 {st_line: {'amls': invl, 'model': rule}},
             )
 
             # No matching because there is no tolerance.
-            st_line = self._create_st_line(amount=bsl_sign * 990.0)
+            st_line = self._create_st_line(amount=bsl_sign * 990.0, payment_ref=invl.name)
             self._check_statement_matching(
                 rule,
                 {st_line: {}},
             )
 
             # The payment amount is higher than the invoice one.
-            st_line = self._create_st_line(amount=bsl_sign * 1010.0)
+            st_line = self._create_st_line(amount=bsl_sign * 1010.0, payment_ref=invl.name)
             self._check_statement_matching(
                 rule,
                 {st_line: {'amls': invl, 'model': rule}},
@@ -334,7 +339,7 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
             invl = self._create_invoice_line(1000.0, self.partner_a, inv_type, pay_reference='123456', inv_date='2019-01-01')
 
             # No matching because there is no tolerance.
-            st_line = self._create_st_line(amount=bsl_sign * 990.0)
+            st_line = self._create_st_line(amount=bsl_sign * 990.0, payment_ref='123456')
             self._check_statement_matching(
                 rule,
                 {st_line: {}},
@@ -360,7 +365,7 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
                 invl = self._create_invoice_line(1000.0, self.partner_a, inv_type, inv_date='2019-01-01')
 
                 # No matching because there is no enough tolerance.
-                st_line = self._create_st_line(amount=bsl_sign * 990.0)
+                st_line = self._create_st_line(amount=bsl_sign * 990.0, payment_ref=invl.name)
                 self._check_statement_matching(
                     rule,
                     {st_line: {}},
@@ -369,7 +374,7 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
                 # The payment amount is higher than the invoice one.
                 # However, since the invoice amount is lower than the payment amount,
                 # the tolerance is not checked and the invoice line is matched.
-                st_line = self._create_st_line(amount=bsl_sign * 1010.0)
+                st_line = self._create_st_line(amount=bsl_sign * 1010.0, payment_ref=invl.name)
                 self._check_statement_matching(
                     rule,
                     {st_line: {'amls': invl, 'model': rule}},
@@ -387,7 +392,7 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
             invl = self._create_invoice_line(1210.0, self.partner_a, inv_type, inv_date='2019-01-01')
 
             # Enough tolerance to match the invoice line.
-            st_line = self._create_st_line(amount=bsl_sign * 1185.80)
+            st_line = self._create_st_line(amount=bsl_sign * 1185.80, payment_ref=invl.name)
             self._check_statement_matching(
                 rule,
                 {st_line: {'amls': invl, 'model': rule, 'status': 'write_off'}},
@@ -396,7 +401,7 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
             # The payment amount is higher than the invoice one.
             # However, since the invoice amount is lower than the payment amount,
             # the tolerance is not checked and the invoice line is matched.
-            st_line = self._create_st_line(amount=bsl_sign * 1234.20)
+            st_line = self._create_st_line(amount=bsl_sign * 1234.20, payment_ref=invl.name)
             self._check_statement_matching(
                 rule,
                 {st_line: {'amls': invl, 'model': rule}},
@@ -428,7 +433,7 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
         for inv_type, bsl_sign in (('out_invoice', 1), ('in_invoice', -1)):
 
             invl = self._create_invoice_line(990.0, self.partner_a, inv_type, inv_date='2019-01-01')
-            st_line = self._create_st_line(amount=bsl_sign * 1000)
+            st_line = self._create_st_line(amount=bsl_sign * 1000, payment_ref=invl.name)
 
             # Partial reconciliation.
             self._check_statement_matching(
@@ -485,6 +490,7 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
             )
 
     def test_matching_fields_match_partner_category_ids(self):
+        self.rule_1.match_text_location_label = False
         test_category = self.env['res.partner.category'].create({'name': 'Consulting Services'})
         test_category2 = self.env['res.partner.category'].create({'name': 'Consulting Services2'})
         self.partner_2.category_id = test_category + test_category2
@@ -498,6 +504,7 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
 
     def test_mixin_rules(self):
         ''' Test usage of rules together.'''
+        self.rule_1.match_text_location_label = False
         # rule_1 is used before rule_2.
         self.rule_1.sequence = 1
         self.rule_2.sequence = 2
@@ -540,6 +547,7 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
         self.rule_1.sequence = 2
         self.rule_1.auto_reconcile = True
         self.rule_1.payment_tolerance_param = 10.0
+        self.rule_1.match_text_location_label = False
         self.rule_2.sequence = 1
         self.rule_2.match_partner_ids |= self.partner_2
         self.rule_2.auto_reconcile = True
@@ -571,6 +579,7 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
         self.rule_1.allow_payment_tolerance = False
         self.rule_1.auto_reconcile = True
         self.rule_1.line_ids = [(5, 0, 0)]
+        self.rule_1.match_text_location_label = False
 
         self._check_statement_matching(self.rule_1, {
             self.bank_line_1: {
@@ -674,6 +683,7 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
         move_reversed = move._reverse_moves()
         self.assertTrue(move_reversed.exists())
 
+        self.rule_1.match_text_location_label = False
         self.bank_line_1.write({
             'payment_ref': '8',
             'partner_id': partner.id,
@@ -699,7 +709,7 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
 
         invoice_line = self._create_invoice_line(100, partner, 'out_invoice', currency=currency_inv)
 
-        self.bank_line_1.write({'partner_id': partner.id, 'foreign_currency_id': currency_statement.id, 'amount_currency': 100, 'payment_ref': 'test'})
+        self.bank_line_1.write({'partner_id': partner.id, 'foreign_currency_id': currency_statement.id, 'amount_currency': 100, 'payment_ref': invoice_line.name})
         self._check_statement_matching(self.rule_1, {
             self.bank_line_1: {'amls': invoice_line, 'model': self.rule_1},
             self.bank_line_2: {},
@@ -831,6 +841,7 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
             'match_same_currency': False,
             'company_id': self.company_data['company'].id,
             'past_months_limit': False,
+            'match_text_location_label': False,
         })
 
         statement_line = self.env['account.bank.statement.line'].create({
@@ -951,6 +962,7 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
         of 100, 200 and 300 (retrieved in this order), only 100 and 200 should be proposed.
         """
         self.rule_1.allow_payment_tolerance = False
+        self.rule_1.match_text_location_label = False
         self.bank_line_2.amount = 250
         self.bank_line_1.partner_id = None
 
@@ -970,6 +982,7 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
         other ones are disregarded.
         """
         self.rule_1.allow_payment_tolerance = False
+        self.rule_1.match_text_location_label = False
         self.bank_line_2.amount = 300
         self.bank_line_1.partner_id = None
 


### PR DESCRIPTION
Before, when using reconcile models that wanted to match invoice/bills to statement based on the Label and/or Note and/or Reference, if there is no real match with the statement label, the bank reco would mount/ suggest another entry from the same partner.

This is misleading as we expect to only have mounted lines that match with the statement, as stated in the reconciliation model.

task-4194671