### PR TITLE
[IMP] Disable download of dashboard json file in list view

### DIFF
--- a/addons/spreadsheet/static/src/assets_backend/spreadsheet_binary_field/spreadsheet_binary_field.js
+++ b/addons/spreadsheet/static/src/assets_backend/spreadsheet_binary_field/spreadsheet_binary_field.js
@@ -1,0 +1,19 @@
+import { registry } from "@web/core/registry";
+import { BinaryField, binaryField } from "@web/views/fields/binary/binary_field";
+
+export class SpreadsheetBinaryField extends BinaryField {
+    static template = "spreadsheet.SpreadsheetBinaryField";
+
+    setup() {
+        super.setup();
+    }
+
+    async onFileDownload() {}
+}
+
+export const spreadsheetBinaryField = {
+    ...binaryField,
+    component: SpreadsheetBinaryField,
+};
+
+registry.category("fields").add("binary_spreadsheet", spreadsheetBinaryField);

--- a/addons/spreadsheet/static/src/assets_backend/spreadsheet_binary_field/spreadsheet_binary_field.xml
+++ b/addons/spreadsheet/static/src/assets_backend/spreadsheet_binary_field/spreadsheet_binary_field.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="spreadsheet.SpreadsheetBinaryField" t-inherit="web.BinaryField" t-inherit-mode="primary">
+        <xpath expr="//t[@name='download']" position="replace"></xpath>
+        <xpath expr="//span[hasclass('fa-download')]" position="replace">
+            <span class="fa fa-file-text-o me-2" />
+        </xpath>
+    </t>
+</templates>

--- a/addons/spreadsheet/static/tests/widgets/spreadsheet_binary_field.test.js
+++ b/addons/spreadsheet/static/tests/widgets/spreadsheet_binary_field.test.js
@@ -1,0 +1,53 @@
+import { expect, test } from "@odoo/hoot";
+import { defineModels, fields, models, mountView, onRpc } from "@web/../tests/web_test_helpers";
+import { defineMailModels } from "@mail/../tests/mail_test_helpers";
+import { click } from "@odoo/hoot-dom";
+import { animationFrame } from "@odoo/hoot-mock";
+
+class TestSpreadsheet extends models.Model {
+    _name = "test.spreadsheet";
+    spreadsheet_binary_data = fields.Binary();
+    _records = [{ spreadsheet_binary_data: "R0lGODlhDAMAKIFAF5LAP/zxANyuAP/gaP//wACH5BAEAUALAw" }];
+}
+
+defineMailModels();
+defineModels([TestSpreadsheet]);
+
+onRpc("has_group", () => true);
+
+test("Downloading dashboard json file should be disabled in list view", async () => {
+    onRpc("/web/content", () => {
+        expect.step("We shouldn't be getting the file.");
+    });
+    await mountView({
+        resModel: "test.spreadsheet",
+        type: "list",
+        arch: `<list>
+                    <field
+                        name="spreadsheet_binary_data"
+                        widget="binary_spreadsheet"
+                        filename="dashboard.json"
+                    />
+                </list>`,
+    });
+    click(`.o_field_widget[name="spreadsheet_binary_data"]`);
+    await animationFrame();
+    expect.verifySteps([]);
+});
+
+test("Download button for dashboard json file should be hidden in list view", async () => {
+    await mountView({
+        resModel: "test.spreadsheet",
+        type: "list",
+        arch: `<list>
+                    <field
+                        name="spreadsheet_binary_data"
+                        widget="binary_spreadsheet"
+                        filename="dashboard.json"
+                    />
+                </list>`,
+    });
+    expect(`.o_field_widget[name="spreadsheet_binary_data"] .fa-download`).toHaveCount(0, {
+        message: "The download button should be hidden",
+    });
+});

--- a/addons/spreadsheet_dashboard/views/spreadsheet_dashboard_views.xml
+++ b/addons/spreadsheet_dashboard/views/spreadsheet_dashboard_views.xml
@@ -10,6 +10,7 @@
                 <field name="name"/>
                 <field name="group_ids" widget="many2many_tags" required="1"/>
                 <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
+                <field name="spreadsheet_binary_data" groups="base.group_no_one" widget="binary_spreadsheet" filename="spreadsheet_file_name" string="Data" />
                 <field name="is_published" widget="boolean_toggle"/>
                 <field name="dashboard_group_id" optional="hidden"/>
             </list>


### PR DESCRIPTION
When downloading a dashboard's json file in debug mode, we get the initial version of the dashboard file and not the latest (without the revisions). This commit's goal is to prevent downloading the dashboard's json file and displaying a warning message to the user.

task-4196930

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
