### PR TITLE
[FIX] website: handle BCP 47 language codes to prevent SEO traceback

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -24,7 +24,7 @@ from odoo import http, models, fields, _
 from odoo.exceptions import AccessError, UserError
 from odoo.http import request, SessionExpiredException
 from odoo.osv import expression
-from odoo.tools import OrderedSet, escape_psql, html_escape as escape
+from odoo.tools import OrderedSet, escape_psql, html_escape as escape, py_to_js_locale
 from odoo.addons.base.models.ir_http import EXTENSION_TO_WEB_MIMETYPES
 from odoo.addons.base.models.ir_qweb import QWebException
 from odoo.addons.portal.controllers.portal import pager as portal_pager
@@ -201,7 +201,7 @@ class Website(Home):
 
     @http.route('/website/get_languages', type='json', auth="user", website=True)
     def website_languages(self, **kwargs):
-        return [(lg.code, lg.url_code, lg.name) for lg in request.website.language_ids]
+        return [(py_to_js_locale(lg.code), lg.url_code, lg.name) for lg in request.website.language_ids]
 
     @http.route('/website/lang/<lang>', type='http', auth="public", website=True, multilang=False)
     def change_lang(self, lang, r='/', **kwargs):

--- a/addons/website/static/src/components/dialog/seo.js
+++ b/addons/website/static/src/components/dialog/seo.js
@@ -216,7 +216,6 @@ class MetaKeywords extends Component {
 
         onWillStart(async () => {
             this.languages = await rpc('/website/get_languages');
-            this.languages = this.languages.map(([code, urlCode, name]) => [pyToJsLocale(code), urlCode, name]);
             this.state.language = this.getLanguage();
         });
     }


### PR DESCRIPTION
[1] fixed the correct application of jsToPyLocale and pyToJsLocale
conversions due to the new language code format used in the front-end
and was forward-ported to master in [2].

The goal of this commit is to backport [2] to ensure the same API is
used in both v.18 and master.

[1]: https://github.com/odoo/odoo/commit/2cd53220c39f897c346b8174ac65b5dbd950b67f
[2]: https://github.com/odoo/odoo/commit/b012952e511f6ec70218d2fd5ead3cb93a2afd9f

task-4210172