### PR TITLE
[FIX] website_profile: prevent multiple email verifications in portal

### DIFF
--- a/addons/website_profile/static/src/js/website_profile.js
+++ b/addons/website_profile/static/src/js/website_profile.js
@@ -8,7 +8,7 @@ const rpc = require('web.rpc');
 publicWidget.registry.websiteProfile = publicWidget.Widget.extend({
     selector: '.o_wprofile_email_validation_container',
     read_events: {
-        'click .send_validation_email': '_onSendValidationEmailClick',
+        'click .send_validation_email': 'async _onSendValidationEmailClick',
         'click .validated_email_close': '_onCloseValidatedEmailClick',
     },
 
@@ -22,12 +22,13 @@ publicWidget.registry.websiteProfile = publicWidget.Widget.extend({
     _onSendValidationEmailClick: function (ev) {
         ev.preventDefault();
         var $element = $(ev.currentTarget);
-        this._rpc({
+        return this._rpc({
             route: '/profile/send_validation_email',
             params: {'redirect_url': $element.data('redirect_url')},
         }).then(function (data) {
             if (data) {
                 window.location = $element.data('redirect_url');
+                return new Promise(() => {});
             }
         });
     },


### PR DESCRIPTION
**Problem:**
Newly created users on the portal can click the 'verify email' button multiple times quickly, leading to the generation of multiple verification emails without refreshing the page.

**Steps to Reproduce:**
1. Create a new user on the website.
2. Sign in as the new user and navigate to the 'Forum' page.
3. Click the 'verify email' button multiple times quickly.
4. Check Mailhog / Network requests for multiple verification emails.

opw-4122195