### PR TITLE
[FIX] account, account_payment: portal payment and invoice status

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1088,7 +1088,7 @@ class AccountMove(models.Model):
             move.amount_residual_signed = total_residual
             move.amount_total_in_currency_signed = abs(move.amount_total) if move.move_type == 'entry' else -(sign * move.amount_total)
 
-    @api.depends('amount_residual', 'move_type', 'state', 'company_id', 'matched_payment_ids')
+    @api.depends('amount_residual', 'move_type', 'state', 'company_id', 'matched_payment_ids.state')
     def _compute_payment_state(self):
         stored_ids = tuple(self.ids)
         if stored_ids:
@@ -1178,6 +1178,8 @@ class AccountMove(models.Model):
                         new_pmt_state = invoice._get_invoice_in_payment_state()
                     elif reconciliation_vals:
                         new_pmt_state = 'partial'
+                    elif invoice.matched_payment_ids.filtered(lambda p: not p.move_id and p.state == 'paid'):
+                        new_pmt_state = invoice._get_invoice_in_payment_state()
             invoice.payment_state = new_pmt_state
 
     @api.depends('payment_state', 'state')
@@ -5163,13 +5165,6 @@ class AccountMove(models.Model):
 
     def _get_invoice_next_payment_values(self, custom_amount=None):
         self.ensure_one()
-        if self.currency_id.is_zero(self.amount_residual):
-            payment_state = 'fully_paid'
-        elif self.currency_id.is_zero(self.amount_total - self.amount_residual):
-            payment_state = 'not_paid'
-        else:
-            payment_state = 'partially_paid'
-
         term_lines = self.line_ids.filtered(lambda line: line.display_type == 'payment_term')
         installments = term_lines._get_installments_data()
         not_reconciled_installments = [x for x in installments if not x['reconciled']]
@@ -5237,7 +5232,7 @@ class AccountMove(models.Model):
                 next_due_date = installments[0]['date_maturity']
 
         return {
-            'payment_state': payment_state,
+            'payment_state': self.payment_state,
             'installment_state': installment_state,
             'next_amount_to_pay': next_amount_to_pay,
             'next_payment_reference': next_payment_reference,

--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -75,10 +75,15 @@
                         <td class="text-end pe-3"><span t-out="-invoice.amount_residual if invoice.move_type == 'out_refund' else invoice.amount_residual" t-options='{"widget": "monetary", "display_currency": invoice.currency_id}'/></td>
                         <td name="invoice_status">
                             <t t-if="invoice.state == 'posted'" name="invoice_status_posted">
-                                <span t-if="invoice.payment_state in ('paid', 'in_payment')"
+                                <span t-if="invoice.currency_id.is_zero(invoice.amount_residual)"
                                       class="badge rounded-pill text-bg-success">
                                     <i class="fa fa-fw fa-check" aria-label="Paid" title="Paid" role="img"/>
                                     <span class="d-none d-md-inline"> Paid</span>
+                                </span>
+                                <span t-elif="invoice.payment_state == 'in_payment' and not invoice.currency_id.is_zero(invoice.amount_residual)"
+                                      class="badge rounded-pill text-bg-info">
+                                    <i class="fa fa-fw fa-check" aria-label="processing_payment" title="Processing Payment" role="img"/>
+                                    <span class="d-none d-md-inline"> Processing Payment</span>
                                 </span>
                                 <span t-elif="invoice.payment_state == 'reversed'"
                                       class="badge rounded-pill text-bg-success">
@@ -120,11 +125,11 @@
                         <h2 class="mb-0 text-break mx-auto">
                             <span t-field="invoice.amount_total"/>
                         </h2>
-                        <div class="my-1 w-100" t-if="payment_state in ('not_paid', 'partially_paid')">
-                            <div class="alert alert-success px-2 py-1 text-center mb-2" t-if="payment_state == 'partially_paid'">
+                        <div class="my-1 w-100" t-if="payment_state in ('not_paid', 'partial')">
+                            <div class="alert alert-success px-2 py-1 text-center mb-2" t-if="payment_state == 'partial'">
                                 Already Paid: <span t-out="amount_paid" t-options="{'widget': 'monetary', 'display_currency': currency}"/>
                             </div>
-                            <div t-if="payment_state == 'partially_paid'" class="alert alert-warning px-2 py-1 text-center mb-2">
+                            <div t-if="payment_state == 'partial'" class="alert alert-warning px-2 py-1 text-center mb-2">
                                 Left to Pay:
                                 <span t-out="amount_due" t-options="{'widget': 'monetary', 'display_currency': currency}"/>
                                 <div t-if="installment_state and is_last_installment" class="w-100 mt-2">
@@ -136,7 +141,7 @@
                                 <t t-out="epd_discount_msg"/>
                             </div>
                         </div>
-                        <t t-if="installment_state in ('next', 'overdue') and not is_last_installment and amount_due != 0.0">
+                        <t t-if="installment_state in ('next', 'overdue') and not is_last_installment and amount_due != 0.0 and payment_state != 'in_payment'">
                             <h5 name="installment_title" class="w-100 text-center mb-0">
                                 <t t-if="installment_state == 'next'">Next Installment</t>
                                 <t t-elif="installment_state == 'overdue'">Overdue</t>
@@ -148,7 +153,7 @@
                                 t-options="{'widget': 'monetary', 'display_currency': currency}"
                             />
                         </t>
-                        <div class="small w-100 text-center" t-if="payment_state in ('not_paid', 'partially_paid') and not (is_last_installment and installment_state)">
+                        <div class="small w-100 text-center" t-if="payment_state in ('not_paid', 'partial') and not (is_last_installment and installment_state)">
                             <i class="fa fa-clock-o"/>
                             <span class="o_portal_sidebar_timeago ml4" t-att-datetime="next_due_date"/>
                         </div>

--- a/addons/account/wizard/account_payment_register_views.xml
+++ b/addons/account/wizard/account_payment_register_views.xml
@@ -52,7 +52,7 @@
                         <field name="duplicate_payment_ids" widget="x2many_buttons" string="Duplicated Payments"/>
                     </div>
                     <div role="alert" invisible="not actionable_errors">
-                        <field name="actionable_errors" widget="actionable_errors"/>
+                        <field name="actionable_errors" widget="actionable_errors" class="w-100"/>
                     </div>
                     <group>
                         <group name="group1">

--- a/addons/account_payment/models/account_move.py
+++ b/addons/account_payment/models/account_move.py
@@ -62,7 +62,8 @@ class AccountMove(models.Model):
         return enabled_feature and bool(
             (self.amount_residual or not transactions)
             and self.state == 'posted'
-            and self.payment_state in ('not_paid', 'partial')
+            and self.payment_state in ('not_paid', 'in_payment', 'partial')
+            and not self.currency_id.is_zero(self.amount_residual)
             and self.amount_total
             and self.move_type == 'out_invoice'
             and not pending_transactions

--- a/addons/account_payment/models/payment_transaction.py
+++ b/addons/account_payment/models/payment_transaction.py
@@ -165,6 +165,7 @@ class PaymentTransaction(models.Model):
             'payment_transaction_id': self.id,
             'memo': reference,
             'write_off_line_vals': [],
+            'invoice_ids': self.invoice_ids,
             **extra_create_values,
         }
 

--- a/addons/account_payment/views/account_portal_templates.xml
+++ b/addons/account_payment/views/account_portal_templates.xml
@@ -173,6 +173,9 @@
                                     </button>
                                 </div>
                                 <div class="tab-content" id="o_payment_tabcontent">
+                                    <div t-if="payment_state == 'in_payment'" class="alert alert-danger mt-2">
+                                        A payment has already been made on this invoice, please make sure to not pay twice.
+                                    </div>
                                     <div
                                         class="tab-pane my-3 show active"
                                         id="o_payment_installments"
@@ -231,6 +234,9 @@
                                 <div t-if="show_epd" class="alert alert-success">
                                     Early Payment Discount of <span t-out="epd_discount_amount_currency" t-options="{'widget': 'monetary', 'display_currency': currency}"/> has been applied.
                                 </div>
+                                <div t-if="payment_state == 'in_payment'" class="alert alert-danger">
+                                    A payment has already been made on this invoice, please make sure to not pay twice.
+                                </div>
                                 <div class="text-bg-light row row-cols-1 row-cols-md-2 mx-0 mb-3 py-2 rounded">
                                     <t t-call="payment.summary_item">
                                         <t t-set="name" t-value="'amount_full'"/>
@@ -279,8 +285,11 @@
     <template id="portal_invoice_page_inherit_payment" name="Payment on My Invoices" inherit_id="account.portal_invoice_page">
         <xpath expr="//t[@t-call='portal.portal_record_sidebar']//h2[1]" position="after">
             <t t-set="pending_txs" t-value="invoice.transaction_ids.filtered(lambda tx: tx.state in ('pending', 'authorized') and tx.provider_code not in ('none', 'custom'))"/>
-            <div t-if="invoice.payment_state in ('paid', 'in_payment')" class="rounded text-bg-success fw-normal badge">
+            <div t-if="invoice.currency_id.is_zero(invoice.amount_residual)" class="rounded text-bg-success fw-normal badge">
                 <i class="fa fa-fw fa-check-circle"/> Paid
+            </div>
+            <div t-if="invoice.payment_state == 'in_payment' and not invoice.currency_id.is_zero(invoice.amount_residual)" class="rounded text-bg-info fw-normal badge">
+                <i class="fa fa-fw fa-check-circle"/> Processing Payment
             </div>
             <div t-elif="pending_txs" class="rounded text-bg-info fw-normal badge">
                 <i class="fa fa-fw fa-check-circle"/> Pending


### PR DESCRIPTION
Fix the status of invoices when registering a payment. Also improves the portal view depending on the invoice payment state.

The following cases assume that no outstanding account is set on the bank journal

Portal:
 - In case the invoice payment state is 'in payment', the portal should display "Processing payment", the "Next installment" section should be hidden, and a banner should appear in the popup of the payment (when pressing the "Pay Now" button).

Portal list view:
- Same payment state should be displayed as in the portal form view, e.g. "Processing Payment"

Invoice Payment state:
 - If a payment is created for an invoice, then the state of the invoice is set to 'in payment' When the invoice is reconciled, and the payment is manually validated (This manual operation of validating the payment will be made automatically in another task) if the payment corresponds to a portion of the invoice amount, the invoice payment state is 'Partial' if the payment corresponds to the full invoice amount, the invoice payment state is 'Paid' If the payment is rejected, then the invoice payment state is reset If the payment is confirmed (before any reco), then the invoice payment state keeps being "in payment"

 task-4212954

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
