### PR TITLE
[FIX] purchase: enable accept/decline buttons from portal

### DIFF
--- a/addons/purchase/controllers/portal.py
+++ b/addons/purchase/controllers/portal.py
@@ -157,9 +157,9 @@ class CustomerPortal(portal.CustomerPortal):
         if confirm_type == 'reminder':
             order_sudo.confirm_reminder_mail(kw.get('confirmed_date'))
         if confirm_type == 'reception':
-            order_sudo.confirm_reception_mail()
+            order_sudo._confirm_reception_mail()
         if confirm_type == 'decline':
-            order_sudo.decline_reception_mail()
+            order_sudo._decline_reception_mail()
 
         values = self._purchase_order_get_page_view_values(order_sudo, access_token, **kw)
         update_date = kw.get('update')

--- a/addons/purchase/i18n/purchase.pot
+++ b/addons/purchase/i18n/purchase.pot
@@ -382,16 +382,6 @@ msgid "<strong>Qty</strong>"
 msgstr ""
 
 #. module: purchase
-#: model_terms:ir.ui.view,arch_db:purchase.portal_my_purchase_order
-msgid "<strong>Quotation has been Declined</strong><br/>"
-msgstr ""
-
-#. module: purchase
-#: model_terms:ir.ui.view,arch_db:purchase.portal_my_purchase_order
-msgid "<strong>Quotation has been acknowledged</strong><br/>"
-msgstr ""
-
-#. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.purchase_order_portal_content
 msgid "<strong>Receipt Date:</strong>"
 msgstr ""
@@ -429,6 +419,16 @@ msgstr ""
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.portal_my_purchase_order
 msgid "<strong>This purchase has been cancelled.</strong>"
+msgstr ""
+
+#. module: purchase
+#: model_terms:ir.ui.view,arch_db:purchase.portal_my_purchase_order
+msgid "<strong>This quotation has been accepted.</strong>"
+msgstr ""
+
+#. module: purchase
+#: model_terms:ir.ui.view,arch_db:purchase.portal_my_purchase_order
+msgid "<strong>This quotation has been declined.</strong>"
 msgstr ""
 
 #. module: purchase
@@ -2435,16 +2435,6 @@ msgstr ""
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.purchase_order_form
 msgid "Quantity:"
-msgstr ""
-
-#. module: purchase
-#: model_terms:ir.ui.view,arch_db:purchase.portal_my_purchase_order
-msgid "Quotation Accepted"
-msgstr ""
-
-#. module: purchase
-#: model_terms:ir.ui.view,arch_db:purchase.portal_my_purchase_order
-msgid "Quotation Declined"
 msgstr ""
 
 #. module: purchase

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -1111,26 +1111,26 @@ class PurchaseOrder(models.Model):
                     self.date_order or fields.Date.today()))
             or self.env.user.has_group('purchase.group_purchase_manager'))
 
-    def confirm_reception_mail(self):
+    def _confirm_reception_mail(self):
         for order in self:
             if order.state in ['purchase', 'done'] and not order.mail_reception_confirmed:
                 order.mail_reception_confirmed = True
-                order.sudo().message_post(body=_("The order receipt has been acknowledged by %s.", order.partner_id.name))
+                order.message_post(body=_("The order receipt has been acknowledged by %s.", order.partner_id.name))
             elif order.state == 'sent' and not order.mail_reception_confirmed:
                 order.mail_reception_confirmed = True
-                order.sudo().message_post(body=_("The RFQ has been acknowledged by %s.", order.partner_id.name))
+                order.message_post(body=_("The RFQ has been acknowledged by %s.", order.partner_id.name))
 
-    def decline_reception_mail(self):
+    def _decline_reception_mail(self):
         for order in self:
             if order.state in ['purchase', 'done'] and not order.mail_reception_declined:
                 order.mail_reception_declined = True
-                order.sudo().activity_schedule(
+                order.activity_schedule(
                     'mail.mail_activity_data_todo',
                     note=_('The vendor asked to decline this confirmed RfQ, if you agree on that, cancel this PO'))
-                order.sudo().message_post(body=_("The order receipt has been declined by %s.", order.partner_id.name))
+                order.message_post(body=_("The order receipt has been declined by %s.", order.partner_id.name))
             elif order.state  == 'sent' and not order.mail_reception_declined:
                 order.mail_reception_declined = True
-                order.sudo().message_post(body=_("The RFQ has been declined by %s.", order.partner_id.name))
+                order.message_post(body=_("The RFQ has been declined by %s.", order.partner_id.name))
 
     def get_localized_date_planned(self, date_planned=False):
         """Returns the localized date planned in the timezone of the order's user or the

--- a/addons/purchase/static/src/js/purchase_portal_sidebar.js
+++ b/addons/purchase/static/src/js/purchase_portal_sidebar.js
@@ -6,10 +6,6 @@ import { uniqueId } from "@web/core/utils/functions";
 
 publicWidget.registry.PurchasePortalSidebar = PortalSidebar.extend({
     selector: ".o_portal_purchase_sidebar",
-    events: {
-        'click .o_portal_decline': '_onDecline',
-        'click .o_portal_accept': '_onAccept',
-    },
 
     /**
      * @constructor
@@ -138,13 +134,5 @@ publicWidget.registry.PurchasePortalSidebar = PortalSidebar.extend({
             }
         });
         return rawText.join(" ");
-    },
-    _onDecline: function (ev) {
-        const orderId = parseInt(ev.currentTarget.dataset.orderId);
-        this.orm.call("purchase.order", "decline_reception_mail", [orderId]);
-    },
-    _onAccept: function (ev) {
-        const orderId = parseInt(ev.currentTarget.dataset.orderId);
-        this.orm.call("purchase.order", "confirm_reception_mail", [orderId]);
     },
 });

--- a/addons/purchase/views/portal_templates.xml
+++ b/addons/purchase/views/portal_templates.xml
@@ -133,36 +133,6 @@
                   <t t-set="backend_url" t-value="'/odoo/action-purchase.purchase_rfq/%s' % (order.id)"/>
               </t>
           </t>
-          <div class="modal fade" id="accept_quotation" role="dialog">
-              <div class="modal-dialog">
-                  <div class="modal-content">
-                      <div class="modal-header">
-                          <h3 class="modal-title">Quotation Accepted</h3>
-                          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                      </div>
-                      <div class="modal-body">
-                          <div class="alert alert-warning">
-                              <strong>Quotation has been acknowledged</strong><br/>
-                          </div>
-                      </div>
-                  </div>
-              </div>
-          </div>
-          <div class="modal fade" id="decline_quotation" role="dialog">
-              <div class="modal-dialog">
-                  <div class="modal-content">
-                      <div class="modal-header">
-                          <h3 class="modal-title">Quotation Declined</h3>
-                          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                      </div>
-                      <div class="modal-body">
-                          <div class="alert alert-warning">
-                              <strong>Quotation has been Declined</strong><br/>
-                          </div>
-                      </div>
-                  </div>
-              </div>
-          </div>
 
           <div class="row o_portal_purchase_sidebar">
               <!-- Sidebar -->
@@ -175,10 +145,12 @@
                   <t t-set="entries">
                     <div t-if="not request.env.user._is_public() and order.state in ['sent']" class="flex-grow-1 d-flex gap-2">
                         <div class="btn-group flex-grow-1 mb-1">
-                            <a t-att-data-order-id="order.id" class="btn btn-secondary btn-block o_print_btn o_portal_invoice_print o_portal_accept px-3" data-bs-target="#accept_quotation" data-bs-toggle="modal" id="accept" name="accept" title="Accept" style="background-color: #875A7B;"> Accept</a>
+                            <a t-if="not order.mail_reception_confirmed" t-att-href="order.get_confirm_url(confirm_type='reception')" target="_self" class="btn btn-secondary btn-block px-3" name="accept" title="Accept" style="background-color: #875A7B;">Accept</a>
+                            <a t-else="" href="#" class="btn btn-secondary btn-block px-3 disabled" style="background-color: #875A7B;" tabindex="-1" aria-disabled="true" name="accept" title="Accept">Accept</a>
                         </div>
                         <div class="btn-group flex-grow-1 mb-1">
-                            <a t-att-data-order-id="order.id" class="btn btn-secondary btn-block o_print_btn o_portal_invoice_print o_portal_decline px-3" data-bs-target="#decline_quotation" data-bs-toggle="modal" id="decline" name="decline" title="View Details"> Decline</a>
+                            <a t-if="not order.mail_reception_declined" t-att-href="order.get_confirm_url(confirm_type='decline')" target="_self" class="btn btn-secondary btn-block px-3" name="decline" title="Decline">Decline</a>
+                            <a t-else="" href="#" class="btn btn-secondary btn-block px-3 disabled" tabindex="-1" aria-disabled="true" name="decline" title="Decline">Decline</a>
                         </div>
                     </div>
 
@@ -247,6 +219,14 @@
                   <div t-if="order.state == 'cancel'" class="alert alert-danger alert-dismissable d-print-none" role="alert">
                       <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="close"></button>
                       <strong>This purchase has been cancelled.</strong>
+                  </div>
+                  <div t-if="order.mail_reception_confirmed and order.state not in ['purchase', 'done']" class="alert alert-success alert-dismissible d-print-none" role="alert">
+                      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="close"></button>
+                      <strong>This quotation has been accepted.</strong>
+                  </div>
+                  <div t-if="order.mail_reception_declined and order.state not in ['purchase', 'done']" class="alert alert-warning alert-dismissible d-print-none" role="alert">
+                      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="close"></button>
+                      <strong>This quotation has been declined.</strong>
                   </div>
 
                   <!-- main content -->


### PR DESCRIPTION
There is two ways of confirming/declining a reception mail through the portal. Either by clicking on the sidebar or clicking on the button in the mail.

While it works correctly when going through the mail link, as it goes through the controller that checks the access rights before preparing the order if the access token is good.

However this didn't happen when using the buttons from the portal sidebar, as we don't go through the controller in this case. Unified both ways to always go to the controller.

Also changed the feedback for accepted/declined quotations, so that's more visible for the user.

Task-4207380

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
