### PR TITLE
[FIX] mail: broken mention urls

### DIFF
--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -1,7 +1,7 @@
+import { stateToUrl } from "@web/core/browser/router";
 import { loadEmoji } from "@web/core/emoji_picker/emoji_picker";
 
 import { escape, unaccent } from "@web/core/utils/strings";
-import { url } from "@web/core/utils/urls";
 
 const urlRegexp =
     /\b(?:https?:\/\/\d{1,3}(?:\.\d{1,3}){3}|(?:https?:\/\/|(?:www\.))[-a-z0-9@:%._+~#=\u00C0-\u024F\u1E00-\u1EFF]{2,256}\.[a-z]{2,13})\b(?:[-a-z0-9@:%_+~#?&[\]^|{}`\\'$//=\u00C0-\u024F\u1E00-\u1EFF]|[.]*[-a-z0-9@:%_+~#?&[\]^|{}`\\'$//=\u00C0-\u024F\u1E00-\u1EFF]|,(?!$| )|\.(?!$| |\.)|;(?!$| ))*/gi;
@@ -195,9 +195,8 @@ function generateMentionsLinks(body, { partners = [], threads = [], specialMenti
             `<a href="#" class="o-discuss-mention">@${escape(special)}</a>`
         );
     }
-    const baseHREF = url("/odoo");
     for (const mention of mentions) {
-        const href = `href='${baseHREF}#model=${mention.model}&id=${mention.id}'`;
+        const href = `href='${stateToUrl({ model: mention.model, resId: mention.id })}'`;
         const attClass = `class='${mention.class}'`;
         const dataOeId = `data-oe-id='${mention.id}'`;
         const dataOeModel = `data-oe-model='${mention.model}'`;


### PR DESCRIPTION
This PR corrects an issue introduced in [1], where the `base href` of mention URLs was converted from `web` to `odoo`, but the associated query parameters were not updated accordingly.
As a result, the redirection to the proper record failed.

[1]: https://github.com/odoo/odoo/pull/174516

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
