### PR TITLE
[FIX] repair: fix delivered quantity of sol generated by repair order

### DIFF
--- a/addons/repair/models/stock_move.py
+++ b/addons/repair/models/stock_move.py
@@ -136,7 +136,9 @@ class StockMove(models.Model):
                 'order_id': move.repair_id.sale_order_id.id,
                 'product_id': move.product_id.id,
                 'product_uom_qty': product_qty, # When relying only on so_line compute method, the sol quantity is only updated on next sol creation
+                'product_uom': move.product_uom.id,
                 'move_ids': [Command.link(move.id)],
+                'qty_delivered': move.quantity if move.state == 'done' else 0.0,
             })
             if move.repair_id.under_warranty:
                 so_line_vals[-1]['price_unit'] = 0.0


### PR DESCRIPTION
Steps to reproduce:
- Create a repair order.
- Add a stock move to it with any quantity.
- Confirm, start and end the repair order. Make sure that quantity done is positive.
- Generate a sale order from the repair order.
- Confirm the sale order.

Expected result:
`qty_delivered` of the generated sale order line should be the same as the quantity done of the move in the repair order.

Current result:
`qty_delivered` is zero.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
