### PR TITLE
[FIX] website_forum: Prevent traceback on edit mode after posting a question

### DIFF
--- a/addons/website_forum/static/src/js/website_forum.share.js
+++ b/addons/website_forum/static/src/js/website_forum.share.js
@@ -52,11 +52,13 @@ var ForumShare = publicWidget.registry.socialShare.extend({
         } else if (this.targetType === 'social-alert') {
             $question.before(qweb.render('website.social_alert', {medias: this.socialList}));
         } else {
-            $('body').append(qweb.render('website.social_modal', {
+            const socialModal = qweb.render("website.social_modal", {
                 medias: this.socialList,
                 target_type: this.targetType,
-                state: $question.data('state'),
-            }));
+                state: $question[0].dataset.state,
+            });
+            document.body.insertAdjacentHTML("beforeend", socialModal);
+            // TODO in master, remove the modal from the DOM when it is closed.
             $('#oe_social_share_modal').modal('show');
         }
     },
@@ -70,6 +72,30 @@ var ForumShare = publicWidget.registry.socialShare.extend({
                 post_id: this.element.data('id'),
             },
         });
+    },
+    /**
+    * @override
+    * TODO remove me in master. This has been introduced as a stable fix to not
+    * remove the document body at the `destroy()` of the `ForumShare` public
+    * widget.
+    *
+    * Background: The `ForumShare` public widget is initially attached to the document
+    * body upon instantiation, which means its root element (`this.$el`) is set
+    * to the document body. Normally, when a widget is destroyed, its root
+    * element is removed which, in this case, would result in the document body
+    * removal.
+    *
+    * To prevent this, the fix assigns `null` to the root element before
+    * invoking the `destroy()` method, ensuring that the document body remains
+    * intact.
+    */
+    destroy: function () {
+        this.setElement(null);
+        const socialModalEl = document.querySelector("body #oe_social_share_modal");
+        if (socialModalEl) {
+            socialModalEl.remove();
+        }
+        this._super();
     },
 });
 


### PR DESCRIPTION
Steps to reproduce:
1. Go to website --> forum
2. Click on "New Post," add a title/description, and post the question.
3. A pop-up appears --> close the pop-up.
4. Enter edit mode, resulting in a traceback.

Before this fix, the `publicWidget` responsible for attaching the modal in DOM was bound to the `body` element, which led to the removal of the `body` on `widget_stop_request` when trying to open the editor.

This commit addresses the issue by creating a dummy element to bind the `ForumShare` publicWidget instead of the `body`, preventing its removal. Additionally, an event listener has been added to remove the modal from the DOM after it's closed, ensuring no further issues during the editor opening process.

task-3834378
