### PR TITLE
[REF] point_of_sale: simplify numpad tour util

### DIFF
--- a/addons/point_of_sale/static/tests/tours/utils/numpad_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/numpad_util.js
@@ -1,18 +1,12 @@
-import { queryAll } from "@odoo/hoot-dom";
+import { escapeRegExp } from "@web/core/utils/strings";
 
-const buttonTriger = (buttonValue) => `div.numpad button[value="${buttonValue}"]`;
+const buttonTriger = (buttonValue) =>
+    `div.numpad button:contains(/^${escapeRegExp(buttonValue)}$/)`; // regex to match the exact button value ( for ex: avoids matching "+10" instead of "1")
+
 export const click = (buttonValue) => ({
     content: `click numpad button: ${buttonValue}`,
     trigger: buttonTriger(buttonValue),
-    // here we couldn't simply use the jquery `:contains` selector because it
-    // would match (for ex) the button with the value "+10" when we want to click the
-    // button with the value "1". Here we need to match the exact value.
-    run: () => {
-        queryAll(buttonTriger(buttonValue))
-            .filter((el) => el.innerText === buttonValue)
-            .at(0)
-            ?.click();
-    },
+    run: "click",
 });
 export const enterValue = (keys) => keys.split("").map((key) => click(key));
 export const isActive = (buttonValue) => ({


### PR DESCRIPTION
When simply using `:contains` for targeting a specific button on the numpad we might run into the issue where doing `:contains('1')` targets the `+10` button instead of the `1` button.

To solve this we currently rely on overly complicated js code.

In this commit we simplify the code by taking advantage of regex.

Task: 4214042





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
