### PR TITLE
[FIX] sale: allow the customer to sign in the quotation

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1031,10 +1031,10 @@ class SaleOrder(models.Model):
             analytic = self.env['account.analytic.account'].create(order._prepare_analytic_account_data(prefix))
             order.analytic_account_id = analytic
 
-    def has_to_be_signed(self, include_draft=False):
+    def has_to_be_signed(self, include_draft=True):
         return (self.state == 'sent' or (self.state == 'draft' and include_draft)) and not self.is_expired and self.require_signature and not self.signature
 
-    def has_to_be_paid(self, include_draft=False):
+    def has_to_be_paid(self, include_draft=True):
         transaction = self.get_portal_last_transaction()
         return (self.state == 'sent' or (self.state == 'draft' and include_draft)) and not self.is_expired and self.require_payment and transaction.state != 'done' and self.amount_total
 


### PR DESCRIPTION
Currently, we are not allowed to sign the quotation if the order is in the quotation stage, which is confusing as if the customer has access to the quote, he should be able to sign/pay instead of getting some strange feedback that the order is not in a state requiring signature/feedback.

Takes behavior from #124486 implemented since 17.0

cc @Tecnativa TT51009

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
