### PR TITLE
[IMP] account: Auto validate payments

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -394,18 +394,20 @@ class AccountPayment(models.Model):
             if payment.journal_id.company_id not in payment.company_id.parent_ids:
                 payment.company_id = (payment.journal_id.company_id or self.env.company)._accessible_branches()[:1]
 
-    @api.depends('invoice_ids.payment_state')
+    @api.depends('invoice_ids.payment_state', 'move_id.line_ids.amount_residual')
     def _compute_state(self):
         accounting_installed = self.env['account.move']._get_invoice_in_payment_state() == 'in_payment'
         for payment in self:
             if not payment.state:
                 payment.state = 'draft'
-            if (
-                (not payment.outstanding_account_id or not accounting_installed)
-                and payment.invoice_ids
-                and all(invoice.payment_state == 'paid' for invoice in payment.invoice_ids)
-            ):
-                payment.state = 'paid'
+            if payment.state == 'in_process':  # in_process --> paid
+                if payment.outstanding_account_id and accounting_installed:
+                    move = payment.move_id
+                    liquidity, _counterpart, _writeoff = payment._seek_for_lines()
+                    if move and move.currency_id.is_zero(sum(liquidity.mapped('amount_residual'))):
+                        payment.state = 'paid'
+                elif payment.invoice_ids and all(invoice.payment_state == 'paid' for invoice in payment.invoice_ids):
+                    payment.state = 'paid'
 
     @api.depends('move_id.line_ids.amount_residual', 'move_id.line_ids.amount_residual_currency', 'move_id.line_ids.account_id', 'state')
     def _compute_reconciliation_status(self):


### PR DESCRIPTION
When you validate a bank reconciliation with an invoice,
and there is a payment with state = 'In Process' of the exact amount on the invoice,
the payment was not validated automatically (had state of 'Paid') before.
This commit validates such payments automatically.

task-4213193


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
