### PR TITLE
[FIX] html_editor: add/move/remove column should add_step

### DIFF
--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -58,27 +58,35 @@ export class TablePlugin extends Plugin {
         switch (command) {
             case "INSERT_TABLE":
                 this.insertTable(payload);
+                this.dispatch("ADD_STEP");
                 break;
             case "ADD_COLUMN":
                 this.addColumn(payload);
+                this.dispatch("ADD_STEP");
                 break;
             case "ADD_ROW":
                 this.addRow(payload);
+                this.dispatch("ADD_STEP");
                 break;
             case "REMOVE_COLUMN":
                 this.removeColumn(payload);
+                this.dispatch("ADD_STEP");
                 break;
             case "REMOVE_ROW":
                 this.removeRow(payload);
+                this.dispatch("ADD_STEP");
                 break;
             case "MOVE_COLUMN":
                 this.moveColumn(payload);
+                this.dispatch("ADD_STEP");
                 break;
             case "MOVE_ROW":
                 this.moveRow(payload);
+                this.dispatch("ADD_STEP");
                 break;
             case "RESET_SIZE":
                 this.resetSize(payload);
+                this.dispatch("ADD_STEP");
                 break;
             case "DELETE_TABLE":
                 this.deleteTable(payload);
@@ -149,7 +157,6 @@ export class TablePlugin extends Plugin {
     }
     insertTable({ rows = 2, cols = 2 } = {}) {
         const table = this._insertTable({ rows, cols });
-        this.dispatch("ADD_STEP");
         this.shared.setCursorStart(table.querySelector("p"));
     }
     addColumn({ position, reference } = {}) {

--- a/addons/html_editor/static/tests/table/ui.test.js
+++ b/addons/html_editor/static/tests/table/ui.test.js
@@ -4,6 +4,7 @@ import { animationFrame } from "@odoo/hoot-mock";
 import { setupEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { getContent } from "../_helpers/selection";
+import { undo } from "../_helpers/user_actions";
 
 function availableCommands(menu) {
     return queryAllAttributes("span div.user-select-none", "name", { root: menu });
@@ -309,7 +310,7 @@ test("open/close table menu", async () => {
 });
 
 test("basic delete column operation", async () => {
-    const { el } = await setupEditor(
+    const { el, editor } = await setupEditor(
         unformat(`
         <table>
             <tbody>
@@ -340,10 +341,21 @@ test("basic delete column operation", async () => {
             </tbody>
         </table>`)
     );
+
+    undo(editor);
+    expect(getContent(el)).toBe(
+        unformat(`
+        <table>
+            <tbody>
+                <tr><td class="a">1[]</td><td class="b">2</td></tr>
+                <tr><td class="c">3</td><td class="d">4</td></tr>
+            </tbody>
+        </table>`)
+    );
 });
 
 test("basic delete row operation", async () => {
-    const { el } = await setupEditor(
+    const { el, editor } = await setupEditor(
         unformat(`
         <table>
             <tbody>
@@ -373,10 +385,21 @@ test("basic delete row operation", async () => {
             </tbody>
         </table>`)
     );
+
+    undo(editor);
+    expect(getContent(el)).toBe(
+        unformat(`
+        <table>
+            <tbody>
+                <tr><td class="a">1[]</td><td class="b">2</td></tr>
+                <tr><td class="c">3</td><td class="d">4</td></tr>
+            </tbody>
+        </table>`)
+    );
 });
 
 test("insert column left operation", async () => {
-    const { el } = await setupEditor(
+    const { el, editor } = await setupEditor(
         unformat(`
         <table>
             <tbody>
@@ -414,10 +437,21 @@ test("insert column left operation", async () => {
             </tbody>
         </table>`)
     );
+
+    undo(editor);
+    expect(getContent(el)).toBe(
+        unformat(`
+        <table>
+            <tbody>
+                <tr><td class="a">1[]</td><td class="b">2</td></tr>
+                <tr><td class="c">3</td><td class="d">4</td></tr>
+            </tbody>
+        </table>`)
+    );
 });
 
 test("insert column right operation", async () => {
-    const { el } = await setupEditor(
+    const { el, editor } = await setupEditor(
         unformat(`
         <table>
             <tbody>
@@ -455,10 +489,21 @@ test("insert column right operation", async () => {
             </tbody>
         </table>`)
     );
+
+    undo(editor);
+    expect(getContent(el)).toBe(
+        unformat(`
+        <table>
+            <tbody>
+                <tr><td class="a">1[]</td><td class="b">2</td></tr>
+                <tr><td class="c">3</td><td class="d">4</td></tr>
+            </tbody>
+        </table>`)
+    );
 });
 
 test("insert row above operation", async () => {
-    const { el } = await setupEditor(
+    const { el, editor } = await setupEditor(
         unformat(`
         <table>
             <tbody>
@@ -498,10 +543,21 @@ test("insert row above operation", async () => {
             </tbody>
         </table>`)
     );
+
+    undo(editor);
+    expect(getContent(el)).toBe(
+        unformat(`
+        <table>
+            <tbody>
+                <tr><td class="a">1[]</td><td class="b">2</td></tr>
+                <tr><td class="c">3</td><td class="d">4</td></tr>
+            </tbody>
+        </table>`)
+    );
 });
 
 test("insert row below operation", async () => {
-    const { el } = await setupEditor(
+    const { el, editor } = await setupEditor(
         unformat(`
         <table>
             <tbody>
@@ -541,10 +597,21 @@ test("insert row below operation", async () => {
             </tbody>
         </table>`)
     );
+
+    undo(editor);
+    expect(getContent(el)).toBe(
+        unformat(`
+        <table>
+            <tbody>
+                <tr><td class="a">1[]</td><td class="b">2</td></tr>
+                <tr><td class="c">3</td><td class="d">4</td></tr>
+            </tbody>
+        </table>`)
+    );
 });
 
 test("move column left operation", async () => {
-    const { el } = await setupEditor(
+    const { el, editor } = await setupEditor(
         unformat(`
         <table>
             <tbody>
@@ -574,10 +641,21 @@ test("move column left operation", async () => {
             </tbody>
         </table>`)
     );
+
+    undo(editor);
+    expect(getContent(el)).toBe(
+        unformat(`
+        <table>
+            <tbody>
+                <tr><td class="a">1</td><td class="b">2[]</td></tr>
+                <tr><td class="c">3</td><td class="d">4</td></tr>
+            </tbody>
+        </table>`)
+    );
 });
 
 test("move column right operation", async () => {
-    const { el } = await setupEditor(
+    const { el, editor } = await setupEditor(
         unformat(`
         <table>
             <tbody>
@@ -607,10 +685,21 @@ test("move column right operation", async () => {
             </tbody>
         </table>`)
     );
+
+    undo(editor);
+    expect(getContent(el)).toBe(
+        unformat(`
+        <table>
+            <tbody>
+                <tr><td class="a">1</td><td class="b">2[]</td></tr>
+                <tr><td class="c">3</td><td class="d">4</td></tr>
+            </tbody>
+        </table>`)
+    );
 });
 
 test("move row above operation", async () => {
-    const { el } = await setupEditor(
+    const { el, editor } = await setupEditor(
         unformat(`
         <table>
             <tbody>
@@ -637,6 +726,17 @@ test("move row above operation", async () => {
             <tbody>
             <tr><td class="c">3</td><td class="d">4</td></tr>
             <tr><td class="a">1[]</td><td class="b">2</td></tr>
+            </tbody>
+        </table>`)
+    );
+
+    undo(editor);
+    expect(getContent(el)).toBe(
+        unformat(`
+        <table>
+            <tbody>
+                <tr><td class="a">1[]</td><td class="b">2</td></tr>
+                <tr><td class="c">3</td><td class="d">4</td></tr>
             </tbody>
         </table>`)
     );
@@ -678,7 +778,7 @@ test("preserve table rows width on move row above operation", async () => {
 });
 
 test("move row below operation", async () => {
-    const { el } = await setupEditor(
+    const { el, editor } = await setupEditor(
         unformat(`
         <table>
             <tbody>
@@ -705,6 +805,17 @@ test("move row below operation", async () => {
             <tbody>
             <tr><td class="c">3</td><td class="d">4</td></tr>
             <tr><td class="a">1[]</td><td class="b">2</td></tr>
+            </tbody>
+        </table>`)
+    );
+
+    undo(editor);
+    expect(getContent(el)).toBe(
+        unformat(`
+        <table>
+            <tbody>
+                <tr><td class="a">1[]</td><td class="b">2</td></tr>
+                <tr><td class="c">3</td><td class="d">4</td></tr>
             </tbody>
         </table>`)
     );


### PR DESCRIPTION
Before this commit, adding / moving / deleting a table column does not add a step. It is therefore not possible to undo/redo.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
