### PR TITLE
[FIX] html_editor: fix indeterministic banner test

### DIFF
--- a/addons/html_editor/static/tests/banner.test.js
+++ b/addons/html_editor/static/tests/banner.test.js
@@ -4,6 +4,7 @@ import { animationFrame } from "@odoo/hoot-mock";
 import { setupEditor } from "./_helpers/editor";
 import { getContent, setSelection } from "./_helpers/selection";
 import { insertText } from "./_helpers/user_actions";
+import { loader } from "@web/core/emoji_picker/emoji_picker";
 
 test("should insert a banner with focus inside followed by a paragraph", async () => {
     const { el, editor } = await setupEditor("<p>Test[]</p>");
@@ -128,8 +129,9 @@ test("Can change an emoji banner", async () => {
     await insertText(editor, "/bannerinfo");
     await press("enter");
     expect("i.o_editor_banner_icon").toHaveText("💡");
+    await loader.loadEmoji();
     await click("i.o_editor_banner_icon");
-    await waitFor(".o-EmojiPicker", { timeout: 500 });
+    await waitFor(".o-EmojiPicker");
     await click(".o-EmojiPicker .o-Emoji");
     await animationFrame();
     expect("i.o_editor_banner_icon").toHaveText("😀");


### PR DESCRIPTION
This commits fix an indeterministic test error. The indeterministic error was made by a getBundle triggered by a click, the solution is get the bundle ourself and await it.
