### PR TITLE
[IMP] account: past selected date warning in secure entries wizard

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -12971,6 +12971,13 @@ msgstr ""
 #. module: account
 #. odoo-python
 #: code:addons/account/wizard/account_secure_entries_wizard.py:0
+msgid ""
+"Securing these entries will also secure entries after the selected date."
+msgstr ""
+
+#. module: account
+#. odoo-python
+#: code:addons/account/wizard/account_secure_entries_wizard.py:0
 msgid "Securing these entries will create at least one gap in the sequence."
 msgstr ""
 

--- a/addons/account/wizard/account_secure_entries_wizard.py
+++ b/addons/account/wizard/account_secure_entries_wizard.py
@@ -197,6 +197,14 @@ class AccountSecureEntries(models.TransientModel):
                     }
                 }
 
+            moves_to_hash_after_selected_date = wizard.move_to_hash_ids.filtered(lambda move: move.date > wizard.hash_date)
+            if moves_to_hash_after_selected_date:
+                warnings['account_move_to_secure_after_selected_date'] = {
+                    'message': _("Securing these entries will also secure entries after the selected date."),
+                    'action_text': _("Review"),
+                    'action': wizard.action_show_moves(moves_to_hash_after_selected_date),
+                }
+
             wizard.warnings = warnings
 
     @api.model


### PR DESCRIPTION
Consider the Secure Entries wizard.
There it can happen that entries that are past the selected date are secured. This is possible since the hash chain corresponds to the sequence prefix, ordered by sequence number.

Currently the user is not warned in case this happened.

This commit introduces a warning containing an action to show all moves that are past the selected date.

To generate the warning on runbot
  1. Ensure there are no invoices with prefix INV/2020
     (There should not be any on the runbot)
  2. Create an invoice with (accounting) date 2020/01/02 (2 Jan 2020)
     It should have name INV/2020/0001
  3. Create an invoice with (accounting) date 2020/01/01 (1 Jan 2020)
     It should have name INV/2020/0002
  4. Activate debug mode (to see the wizard)
  5. Go to Accounting (app) -> Accounting (menu) -> Secure Entries Wizard
  6. Select 2020/01/01 as date (to include INV/2020/0002 but not INV/2020/0001)
  7. The warning should show up
     Clicking "Review" leads to a list view that includes INV/2020/0001 .
     (INV/2020/002 has a higher sequence number but lower accounting date than INV/2020/0001).