### PR TITLE
[FIX] l10n_es_edi_facturae: enable the feature for B2B only

### DIFF
--- a/addons/l10n_es_edi_facturae/models/account_move.py
+++ b/addons/l10n_es_edi_facturae/models/account_move.py
@@ -87,6 +87,7 @@ class AccountMove(models.Model):
             and not self.l10n_es_edi_facturae_xml_id \
             and not self.l10n_es_is_simplified \
             and self.is_invoice(include_receipts=True) \
+            and (self.partner_id.is_company or self.partner_id.vat) \
             and self.company_id.country_code == 'ES' \
             and self.company_id.currency_id.name == 'EUR'
 


### PR DESCRIPTION
To reproduce the issue:
(Need website_sale)
1. Set up a website shop for ES company
   - With demo payment method
2. In Settings:
   - Website > Automatic Invoice: enabled
3. With a portal user, add a product to the cart
4. Open the cart
5. Pay with Demo

Error: The client is redirected to a page "Internal server error:
The partner needs a set tax identification number or VAT number"

When post-processing the payment, and because of step 2, it leads to
https://github.com/odoo/odoo/blob/20365bcab548c4a2d93194c8c2b8b2577d14d3ce/addons/l10n_es_edi_facturae/wizard/account_move_send.py#L86-L88
Where we will generate the data for the Facturae XML. There, we
check few things, like the vat number of the partner:
https://github.com/odoo/odoo/blob/e157cb2d8640fac1365beb135763cb25cff554f5/addons/l10n_es_edi_facturae/models/account_move.py#L312-L313
And since the portal user does not have any vat number, the error is
raised.

The Facturae feature should only be enabled for B2B flows

OPW-4121724