### PR TITLE
[FIX] point_of_sale: fix product warning

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.xml
@@ -8,7 +8,7 @@
             t-on-click="props.onClick"
             t-att-data-product-id="props.productId"
             t-attf-aria-labelledby="article_product_{{props.productId}}">
-            <div t-if="props.productInfo" class="product-information-tag" t-on-click.stop="props.onProductInfoClick" t-att-class="{'red-tag' : !props.showWarning}">
+            <div t-if="props.productInfo" class="product-information-tag" t-on-click.stop="props.onProductInfoClick" t-att-class="{'red-tag' : props.showWarning}">
                 <i class="product-information-tag-logo fa fa-info" role="img" aria-label="Product Information" title="Product Information" />
             </div>
             <div t-if="props.imageUrl" class="product-img">

--- a/addons/pos_self_order/static/src/overrides/components/product_screen.xml
+++ b/addons/pos_self_order/static/src/overrides/components/product_screen.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="ProductScreen" t-inherit="point_of_sale.ProductScreen" t-inherit-mode="extension">
         <xpath expr="//ProductCard" position="attributes">
-            <attribute name="showWarning">product?.self_order_available</attribute>
+            <attribute name="showWarning">!product?.self_order_available</attribute>
         </xpath>
     </t>
 </templates>


### PR DESCRIPTION
The condition that dictates whether or not the product warning is shown in the product list in pos is inverted. This means that we currently show the product warning when it's not the case.

Steps to reproduce:
1. On a db without self order installed, open a pos;
2. Observe that the "info" tags on the corners of the product cards are red;

Task: 4214248




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
