### PR TITLE
[FIX] point_of_sale: handle multiple missing for the same relation

### DIFF
--- a/addons/point_of_sale/static/src/app/models/data_service.js
+++ b/addons/point_of_sale/static/src/app/models/data_service.js
@@ -376,7 +376,7 @@ export class PosData extends Reactive {
     }
 
     async missingRecursive(recordMap, idsMap = {}, acc = {}) {
-        const missingRecords = [];
+        const missingRecords = {};
 
         for (const [model, records] of Object.entries(recordMap)) {
             if (!acc[model]) {
@@ -409,13 +409,20 @@ export class PosData extends Reactive {
                 });
 
                 if (missing.length > 0) {
-                    missingRecords.push([rel.relation, Array.from(new Set(missing))]);
+                    if (!missingRecords[rel.relation]) {
+                        missingRecords[rel.relation] = new Set(missing);
+                    } else {
+                        missingRecords[rel.relation] = new Set([
+                            ...missingRecords[rel.relation],
+                            ...missing,
+                        ]);
+                    }
                 }
             }
         }
 
         const newRecordMap = {};
-        for (const [model, ids] of missingRecords) {
+        for (const [model, ids] of Object.entries(missingRecords)) {
             if (!idsMap[model]) {
                 idsMap[model] = new Set(ids);
             } else {


### PR DESCRIPTION
When there are multiple missing records for the same relation across different models, only one was being retained. This fix ensures that missing records are merged correctly and no data is overwritten, preventing potential data loss during recursive loading.

opw-4183904

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
