### PR TITLE
[FIX] analytic: Fix traceback when no distribution

### DIFF
--- a/addons/analytic/models/analytic_distribution_model.py
+++ b/addons/analytic/models/analytic_distribution_model.py
@@ -66,7 +66,7 @@ class AccountAnalyticDistributionModel(models.Model):
         for model in applicable_models:
             # ignore model if it contains an account having a root plan that was already applied
             if not applied_plans & model.distribution_analytic_account_ids.root_plan_id:
-                res |= model.analytic_distribution
+                res |= model.analytic_distribution or {}
                 applied_plans += model.distribution_analytic_account_ids.root_plan_id
         return res
 


### PR DESCRIPTION
Steps
---------
1. Install `accounting` and `sale_management`
2. Activate Accounting > Configuration > Settings > Analytics > Analytic Accounting
3. Accounting > Configuration > Analytic Accounting > Distribution Model
4. Create a new model and only put Deco Addict as partner, then save
5. Go to the Sale app
6. New quotation
7. Select Deco Addict as partner
8. Click `Add a product`, a traceback is raised.

Problem
---------
Using `|=` requires two objects of the same type. Unfortunately, when there is no distribution line, `analytic_distribution` is False whereas `res` is a dict.

Solution
---------
Use a empty dict instead when `analytic_distribution` is False.

V18 Accounting PAD issues

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
