### PR TITLE
[FIX] website_sale: fix out-of-scope template variable

### DIFF
--- a/addons/website_sale/models/sale_order_line.py
+++ b/addons/website_sale/models/sale_order_line.py
@@ -69,10 +69,12 @@ class SaleOrderLine(models.Model):
         self.ensure_one()
         return self.product_id._is_add_to_cart_allowed()
 
-    def _get_combo_price_subtotal(self):
+    def _get_cart_display_price(self):
         self.ensure_one()
-        return sum(self.linked_line_ids.mapped(lambda line: line.price_subtotal))
-
-    def _get_combo_price_total(self):
-        self.ensure_one()
-        return sum(self.linked_line_ids.mapped(lambda line: line.price_total))
+        is_combo = self.product_type == 'combo'
+        price_type = (
+            'price_subtotal'
+            if self.order_id.website_id.show_line_subtotals_tax_selection == 'tax_excluded'
+            else 'price_total'
+        )
+        return sum(self.linked_line_ids.mapped(price_type)) if is_combo else self[price_type]

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1987,6 +1987,7 @@
                                      t-out="line._get_displayed_unit_price() * line.product_uom_qty"
                                      t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
                             </t>
+                            <t t-set="product_price" t-value="line._get_cart_display_price()"/>
                             <t t-call="website_sale.cart_product_price"/>
                             <small t-if="not line._is_not_sellable_line() and line.product_id.base_unit_price"
                                    class="cart_product_base_unit_price d-block text-muted"
@@ -2035,17 +2036,6 @@
     </template>
 
     <template id="cart_product_price">
-        <t t-set="is_combo" t-value="line.product_type == 'combo'"/>
-        <t
-            t-if="website.show_line_subtotals_tax_selection == 'tax_excluded'"
-            t-set="product_price"
-            t-value="line._get_combo_price_subtotal() if is_combo else line.price_subtotal"
-        />
-        <t
-            t-else=""
-            t-set="product_price"
-            t-value="line._get_combo_price_total() if is_combo else line.price_total"
-        />
         <span
             t-out="product_price"
             style="white-space: nowrap;"
@@ -2776,7 +2766,12 @@
                                                         </t>
                                                         <td t-attf-class="#{o_cart_sum_padding_top} td-price pe-0 text-end"
                                                             name="website_sale_cart_summary_line_price">
-                                                            <t t-call="website_sale.cart_product_price"/>
+                                                            <t t-call="website_sale.cart_product_price">
+                                                                <t
+                                                                    t-set="product_price"
+                                                                    t-value="line._get_cart_display_price()"
+                                                                />
+                                                            </t>
                                                         </td>
                                                     </tr>
                                                 </tbody>


### PR DESCRIPTION
A variable was initialized in a subtemplate but read both in the subtemplate and outside of it. It needs to be declared outside of the subtemplate in order to be readable there.