### PR TITLE
[FIX] website: fix grid options in snippet templates

### DIFF
--- a/addons/website/views/snippets/s_cta_mockups.xml
+++ b/addons/website/views/snippets/s_cta_mockups.xml
@@ -5,7 +5,7 @@
     <section class="s_cta_mockups o_cc o_cc2 pt64 pb64">
         <div class="container">
             <div class="row o_grid_mode" data-row-count="9">
-                <div class="o_grid_item o_grid_item_image g-height-9 g-col-lg-6 col-lg-6" style="grid-area: 1 / 6 / 10 / 13; z-index: 1;">
+                <div class="o_grid_item o_grid_item_image g-height-9 g-col-lg-7 col-lg-7" style="grid-area: 1 / 6 / 10 / 13; z-index: 1;">
                     <img src="web_editor/image_shape/website.s_cta_mockups_default_image/web_editor/devices/macbook_front.svg" class="img img-fluid" data-shape="web_editor/devices/macbook_front" data-original-mimetype="image/jpeg" data-file-name="s_cta_mockups.jpg"/>
                 </div>
                 <div class="o_grid_item g-height-6 g-col-lg-4 col-lg-4" style="grid-area: 3 / 1 / 9 / 5; z-index: 2;">

--- a/addons/website/views/snippets/s_image_punchy.xml
+++ b/addons/website/views/snippets/s_image_punchy.xml
@@ -4,11 +4,11 @@
 <template id="s_image_punchy" name="Image Punchy">
     <section class="s_image_punchy o_cc o_cc2 pt64 pb64">
         <div class="container">
-            <div class="row o_grid_mode" data-row-count="14">
+            <div class="row o_grid_mode" data-row-count="13">
                 <div class="o_grid_item o_grid_item_image g-height-11 g-col-lg-12 col-lg-12" style="grid-area: 1 / 1 / 12 / 13; z-index: 1">
                     <img src="/web/image/website.s_image_punchy_default_image" class="figure-img img-fluid rounded" alt=""/>
                 </div>
-                <div class="o_grid_item g-height-6 g-col-lg-7 col-lg-7" style="grid-area: 9 / 6 / 14 / 13; z-index: 2;">
+                <div class="o_grid_item g-height-5 g-col-lg-7 col-lg-7" style="grid-area: 9 / 6 / 14 / 13; z-index: 2;">
                     <h2 class="display-1-fs" style="text-align: right;">A PUNCHY HEADLINE</h2>
                 </div>
             </div>

--- a/addons/website/views/snippets/s_numbers_grid.xml
+++ b/addons/website/views/snippets/s_numbers_grid.xml
@@ -5,35 +5,35 @@
     <section class="s_numbers_grid o_cc o_cc2 pt56 pb56">
         <div class="container">
             <div class="row o_grid_mode" data-row-count="6" style="gap: 8px;">
-                <div class="o_grid_item g-col-md-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 1 / 1 / 4 / 4; z-index: 1; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                <div class="o_grid_item g-col-lg-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 border rounded" data-name="Number Cell" style="grid-area: 1 / 1 / 4 / 4; z-index: 1; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
                     <p>Revenue Growth</p>
                     <span class="display-5">54%</span>
                 </div>
-                <div class="o_grid_item g-col-md-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 1 / 4 / 4 / 7;; z-index: 2; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                <div class="o_grid_item g-col-lg-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 border rounded" data-name="Number Cell" style="grid-area: 1 / 4 / 4 / 7;; z-index: 2; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
                     <p>Projects deployed</p>
                     <span class="display-5">+225</span>
                 </div>
-                <div class="o_grid_item g-col-md-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 1 / 7 / 4 / 10; z-index: 3; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                <div class="o_grid_item g-col-lg-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 border rounded" data-name="Number Cell" style="grid-area: 1 / 7 / 4 / 10; z-index: 3; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
                     <p>Expected revenue</p>
                     <span class="display-5">$50M</span>
                 </div>
-                <div class="o_grid_item g-col-md-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 1 / 10 / 4 / 13; z-index: 4; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                <div class="o_grid_item g-col-lg-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 border rounded" data-name="Number Cell" style="grid-area: 1 / 10 / 4 / 13; z-index: 4; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
                     <p>Online Members</p>
                     <span class="display-5">235,403</span>
                 </div>
-                <div class="o_grid_item g-col-md-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 4 / 1 / 7 / 4; z-index: 5; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                <div class="o_grid_item g-col-lg-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 border rounded" data-name="Number Cell" style="grid-area: 4 / 1 / 7 / 4; z-index: 5; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
                     <p>Customer Retention</p>
                     <span class="display-5">85%</span>
                 </div>
-                <div class="o_grid_item g-col-md-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 4 / 4 / 7 / 7; z-index: 6; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                <div class="o_grid_item g-col-lg-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 border rounded" data-name="Number Cell" style="grid-area: 4 / 4 / 7 / 7; z-index: 6; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
                     <p>Inventory turnover</p>
                     <span class="display-5">4x</span>
                 </div>
-                <div class="o_grid_item g-col-md-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 4 / 7 / 7 / 10; z-index: 7; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                <div class="o_grid_item g-col-lg-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 border rounded" data-name="Number Cell" style="grid-area: 4 / 7 / 7 / 10; z-index: 7; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
                     <p>Website visitors</p>
                     <span class="display-5">100,000</span>
                 </div>
-                <div class="o_grid_item g-col-md-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 4 / 10 / 7 / 13; z-index: 8; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                <div class="o_grid_item g-col-lg-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 border rounded" data-name="Number Cell" style="grid-area: 4 / 10 / 7 / 13; z-index: 8; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
                     <p>Transactions</p>
                     <span class="display-5">45,958</span>
                 </div>

--- a/addons/website/views/snippets/s_sidegrid.xml
+++ b/addons/website/views/snippets/s_sidegrid.xml
@@ -5,20 +5,20 @@
     <section class="s_sidegrid pt56 pb56">
         <div class="container">
             <div class="row o_grid_mode" data-row-count="13">
-                <div class="o_grid_item g-col-lg-5 g-height-9 col-lg-3" style="z-index: 1; grid-area: 1 / 8 / 10 / 13; --grid-item-padding-x: 24px">
+                <div class="o_grid_item g-col-lg-5 g-height-9 col-lg-5" style="z-index: 1; grid-area: 1 / 8 / 10 / 13; --grid-item-padding-x: 24px">
                     <h1 class="display-4">Experience<br/>the real<br/>innovation</h1>
                     <p class="lead"><br/>Every groundbreaking innovation, whether meticulously engineered or born from spontaneous creativity, contains stories waiting to be discovered.<br/><br/></p>
                 </div>
-                <div class="o_grid_item o_grid_item_image g-height-4 g-col-lg-4 col-lg-2" style="z-index: 2; grid-area: 1 / 1 / 5 / 5;">
+                <div class="o_grid_item o_grid_item_image g-height-4 g-col-lg-4 col-lg-4" style="z-index: 2; grid-area: 1 / 1 / 5 / 5;">
                     <img class="img img-fluid rounded" src="/web/image/website.s_sidegrid_default_image_1" alt=""/>
                 </div>
-                <div class="o_grid_item o_grid_item_image o_snippet_mobile_invisible g-height-9 g-col-lg-3 col-lg-2 d-lg-block d-none" style="z-index: 3; grid-area: 1 / 5 / 10 / 8;">
+                <div class="o_grid_item o_grid_item_image o_snippet_mobile_invisible g-height-9 g-col-lg-3 col-lg-3 d-lg-block d-none" style="z-index: 3; grid-area: 1 / 5 / 10 / 8;">
                     <img class="img img-fluid rounded" src="/web/image/website.s_sidegrid_default_image_2" alt=""/>
                 </div>
-                <div class="o_grid_item o_grid_item_image o_snippet_mobile_invisible g-height-9 g-col-lg-4 col-lg-2 d-lg-block d-none" style="z-index: 4; grid-area: 5 / 1 / 14 / 5;">
+                <div class="o_grid_item o_grid_item_image o_snippet_mobile_invisible g-height-9 g-col-lg-4 col-lg-4 d-lg-block d-none" style="z-index: 4; grid-area: 5 / 1 / 14 / 5;">
                     <img class="img img-fluid rounded" src="/web/image/website.s_sidegrid_default_image_4" alt=""/>
                 </div>
-                <div class="o_grid_item o_grid_item_image o_snippet_mobile_invisible g-height-4 g-col-lg-8 col-lg-3 d-lg-block d-none" style="z-index: 5; grid-area: 10 / 5 / 14 / 13;">
+                <div class="o_grid_item o_grid_item_image o_snippet_mobile_invisible g-height-4 g-col-lg-8 col-lg-8 d-lg-block d-none" style="z-index: 5; grid-area: 10 / 5 / 14 / 13;">
                     <img class="img img-fluid rounded" src="/web/image/website.s_sidegrid_default_image_3" alt=""/>
                 </div>
             </div>


### PR DESCRIPTION
This commit fixes several issues related toin grid options:
- `s_cta_mockups`: wrong column count
- `s_image_punchy`: wrong row count and column count
- `s_numbers_grid`: `g-col-md-3` was used instead of `g-col-lg-3`
- `s_sidegrid`: distinct sizes were used for `g-col-lg` and `col-lg`
                padding classes were used

task-4213996
