### PR TITLE
[FIX] website_sale: shop links unavailable in autocomplete

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -146,8 +146,9 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
     def sitemap_shop(env, rule, qs):
         website = env['website'].get_current_website()
-        # Make sure urls are not listed in sitemap when restriction is active
-        if website and website.ecommerce_access == 'logged_in':
+        if website and website.ecommerce_access == 'logged_in' and not qs:
+            # Make sure urls are not listed in sitemap when restriction is active
+            # and no autocomplete query string is provided
             return
 
         if not qs or qs.lower() in '/shop':
@@ -163,8 +164,9 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
     def sitemap_products(env, rule, qs):
         website = env['website'].get_current_website()
-        # Make sure urls are not listed in sitemap when restriction is active
-        if website and website.ecommerce_access == 'logged_in':
+        if website and website.ecommerce_access == 'logged_in' and not qs:
+            # Make sure urls are not listed in sitemap when restriction is active
+            # and no autocomplete query string is provided
             return
 
         ProductTemplate = env['product.template']


### PR DESCRIPTION
Finetuning of #176391, when ecommerce access was disabled to public users, the admin were unable to reference /shop urls even in restricted parts of the website if needed, because autocomplete didn't suggest those links anymore.
