### PR TITLE
[FIX] {purchase, mrp}_repair: Correct linkage between repair and purchase

### DIFF
--- a/addons/mrp_repair/models/repair.py
+++ b/addons/mrp_repair/models/repair.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, models, fields, _
+from odoo import api, fields, models, _
 
 
 class Repair(models.Model):

--- a/addons/mrp_repair/tests/__init__.py
+++ b/addons/mrp_repair/tests/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_mrp_repair_flow
 from . import test_tracability

--- a/addons/mrp_repair/tests/test_mrp_repair_flow.py
+++ b/addons/mrp_repair/tests/test_mrp_repair_flow.py
@@ -1,0 +1,54 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.fields import Command
+from odoo.tests import tagged
+from odoo.addons.mrp.tests.common import TestMrpCommon
+
+
+@tagged('post_install', '-at_install')
+class TestMrpRepairFlow(TestMrpCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.ref('base.group_user').write({'implied_ids': [(4, cls.env.ref('stock.group_production_lot').id)]})
+
+    def test_repair_with_manufacture_mto_link(self):
+        """
+        Test the integration between a repair order and a manufacturing order (MTO)
+        for a product with 'Make to Order' (MTO) and 'Manufacture' routes.
+
+        Validates that a repair order triggers a manufacturing order with correct product
+        and quantity, and ensures proper linking via the procurement group.
+        """
+        mto_route = self.env.ref('stock.route_warehouse0_mto')
+        mto_route.active = True
+        manufacturing_route = self.env['stock.rule'].search([('action', '=', 'manufacture')]).route_id
+        rule = mto_route.rule_ids.filtered(lambda r: r.picking_type_id.code == 'repair_operation')
+        rule.procure_method = 'make_to_order'
+
+        product = self.product_2
+        product.write({
+            'route_ids': [Command.set([mto_route.id, manufacturing_route.id])],
+        })
+
+        repair = self.env['repair.order'].create([
+            {
+                'move_ids': [
+                    Command.create({
+                        'repair_line_type': 'add',
+                        'product_id': product.id,
+                        'product_uom_qty': 1.0,
+                    })
+                ]
+            }
+        ])
+
+        repair.action_validate()
+
+        production = repair.procurement_group_id.stock_move_ids.created_production_id
+        self.assertEqual(production.product_id, product)
+        self.assertEqual(production.product_qty, 1.0)
+        self.assertEqual(production.move_dest_ids.repair_id, repair)
+        self.assertEqual(production.repair_count, 1)
+        self.assertEqual(repair.production_count, 1)

--- a/addons/purchase_repair/models/repair_order.py
+++ b/addons/purchase_repair/models/repair_order.py
@@ -7,14 +7,14 @@ class RepairOrder(models.Model):
 
     purchase_count = fields.Integer(string="Count of generated POs", compute="_compute_purchase_count", groups="purchase.group_purchase_user")
 
-    @api.depends('move_ids.move_orig_ids.purchase_line_id.order_id')
+    @api.depends('move_ids.created_purchase_line_ids.order_id')
     def _compute_purchase_count(self):
         for repair in self:
-            repair.purchase_count = len(repair.move_ids.move_orig_ids.purchase_line_id.order_id)
+            repair.purchase_count = len(repair.move_ids.created_purchase_line_ids.order_id)
 
     def action_view_purchase_orders(self):
         self.ensure_one()
-        purchase_ids = self.move_ids.move_orig_ids.purchase_line_id.order_id
+        purchase_ids = self.move_ids.created_purchase_line_ids.order_id
         action = {
             'type': 'ir.actions.act_window',
             'res_model': 'purchase.order',

--- a/addons/purchase_repair/tests/__init__.py
+++ b/addons/purchase_repair/tests/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_repair_purchase_flow

--- a/addons/purchase_repair/tests/test_repair_purchase_flow.py
+++ b/addons/purchase_repair/tests/test_repair_purchase_flow.py
@@ -1,0 +1,64 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.fields import Command
+from odoo.tests import tagged
+from odoo.addons.stock.tests.common import TestStockCommon
+
+
+@tagged('post_install', '-at_install')
+class TestRepairPurchaseFlow(TestStockCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+    def test_repair_with_purchase_mto_link(self):
+        """
+        Test the integration between a repair order and a purchase order (MTO)
+        for a product with 'Make to Order' (MTO) and 'Buy' routes.
+
+        Validates that a repair order triggers a purchase order with correct product
+        and quantity, and ensures proper linking via the procurement group.
+        """
+        self.env.ref('stock.route_warehouse0_mto').active = True
+        mto_route = self.env['stock.route'].search([('name', '=', 'Replenish on Order (MTO)')])
+        buy_route = self.env['stock.route'].search([('name', '=', 'Buy')])
+        rule = mto_route.rule_ids.filtered(lambda r: r.picking_type_id.code == 'repair_operation')
+        rule.update({'procure_method': 'make_to_order'})
+
+        seller = self.env['res.partner'].create({
+            'name': 'Vendor',
+        })
+
+        product = self.productA
+        product.write({
+            'route_ids': [(4, mto_route.id), (4, buy_route.id)],
+            'seller_ids': [
+                Command.create({
+                    'partner_id': seller.id,
+                    'min_qty': 1,
+                    'price': 150,
+                }),
+            ],
+        })
+
+        repair = self.env['repair.order'].create([
+            {
+                'move_ids': [
+                    Command.create({
+                        'repair_line_type': 'add',
+                        'product_id': product.id,
+                        'product_uom_qty': 1.0,
+                    })
+                ]
+            }
+        ])
+
+        repair.action_validate()
+
+        purchase = repair.move_ids.created_purchase_line_ids.order_id
+        self.assertEqual(purchase.order_line.product_id, product)
+        self.assertEqual(purchase.order_line.product_qty, 1.0)
+        self.assertEqual(purchase.order_line.move_dest_ids.repair_id, repair)
+        self.assertEqual(repair.purchase_count, 1)
+        self.assertEqual(purchase.repair_count, 1)

--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -624,7 +624,7 @@ class Repair(models.Model):
         repairs_to_confirm = self.filtered(lambda repair: repair.state == 'draft')
         repairs_to_confirm._check_company()
         repairs_to_confirm.move_ids._check_company()
-        repairs_to_confirm.move_ids._adjust_procure_method()
+        repairs_to_confirm.move_ids._adjust_procure_method(picking_type_code='repair_operation')
         repairs_to_confirm.move_ids._action_confirm()
         repairs_to_confirm.move_ids._trigger_scheduler()
         repairs_to_confirm.write({'state': 'confirmed'})

--- a/addons/repair/models/stock_move.py
+++ b/addons/repair/models/stock_move.py
@@ -91,7 +91,7 @@ class StockMove(models.Model):
         draft_repair_moves = repair_moves.filtered(lambda m: m.state == 'draft' and m.repair_id.state in ('confirmed', 'under_repair'))
         other_repair_moves = repair_moves - draft_repair_moves
         draft_repair_moves._check_company()
-        draft_repair_moves._adjust_procure_method()
+        draft_repair_moves._adjust_procure_method(picking_type_code='repair_operation')
         res = draft_repair_moves._action_confirm()
         res._trigger_scheduler()
         confirmed_repair_moves = (res | other_repair_moves)

--- a/addons/repair/tests/test_rules_installation.py
+++ b/addons/repair/tests/test_rules_installation.py
@@ -3,18 +3,15 @@ from odoo.tests import common, tagged
 
 @tagged('at_install', '-post_install')
 class TestGlobalRouteRulesInstallation(common.TransactionCase):
-    def setUp(self):
-        super().setUp()
-        self.company = self.env.ref('base.main_company')
-
     def test_rule_installation(self):
+        company_id = self.env.ref('base.main_company').id
         rule = self.env['stock.rule'].search([
-            ('name', '=', 'WH: Stock → Production (MTO)'),
-            ('picking_type_id.name', '=', 'Repairs'),
+            ('picking_type_id.code', '=', 'repair_operation'),
+            ('company_id', '=', company_id)
         ])
-        self.assertTrue(rule, "Stock rule was not created")
+        self.assertTrue(rule, "Stock Rule was not created")
         self.assertEqual(rule.procure_method, 'make_to_order', "Procure method is incorrect")
-        self.assertEqual(rule.company_id.id, self.company.id, "Company ID is incorrect")
+        self.assertEqual(rule.company_id.id, company_id, "Company ID is incorrect")
         self.assertEqual(rule.action, 'pull', "Action is incorrect")
         self.assertEqual(rule.auto, 'manual', "Auto is incorrect")
         self.assertEqual(rule.route_id.name, 'Replenish on Order (MTO)', "Route name is incorrect")

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2198,9 +2198,12 @@ Please change the quantity done or the rounding precision of your unit of measur
         # These new SMLs need to be redirected thanks to putaway rules
         (self.move_line_ids - existing_smls)._apply_putaway_strategy()
 
-    def _adjust_procure_method(self):
+    def _adjust_procure_method(self, picking_type_code=False):
         """ This method will try to apply the procure method MTO on some moves if
         a compatible MTO route is found. Else the procure method will be set to MTS
+        picking_type_code (str, optional): Adjusts the procurement method based on
+            the specified picking type code. The code to specify the picking type for
+            the procurement group. Defaults to False.
         """
         # Prepare the MTSO variables. They are needed since MTSO moves are handled separately.
         # We need 2 dicts:
@@ -2214,6 +2217,8 @@ Please change the quantity done or the rounding precision of your unit of measur
                 ('location_dest_id', '=', move.location_dest_id.id),
                 ('action', '!=', 'push')
             ]
+            if picking_type_code:
+                domain.append(('picking_type_id.code', '=', picking_type_code))
             rule = self.env['procurement.group']._search_rule(False, move.product_packaging_id, product_id, move.warehouse_id, domain)
             if not rule:
                 move.procure_method = 'make_to_stock'


### PR DESCRIPTION
Steps to reproduce the issue:

1. Install the Repair and Purchase modules
2. Activate multi-steps routes
3. Unarchive the MTO route
4. Change the trigger action for the associated rule to
5. Create a product with the MTO route enabled
6. Create a Repair Order with the  line type and include the product
7. Confirm the Repair Order

Explanation:

A Purchase Order will be created to handle the repair; However, the smart button does not appear at the top of the page. This happens because we are using the wrong linkage from repair to purchase. The current linkage is via , and this field is set when the purchase order
confirmed. We need the link to be established when the Purchase Order is in draft state. The fix is to use
instead.

This commit introduces a minor fix in :

-> Ensuring the correct rule is used by relying on instead of searching by name.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
