### PR TITLE
[REM/FIX] Spreadsheet dashboard: Remove dashboard spreadsheet edit button from dashboard.

### DIFF
--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
@@ -84,16 +84,6 @@
                         <div class="o_dashboard_name">
                             <t t-esc="dashboard.displayName" />
                         </div>
-                        <button
-                            t-if="isDashboardAdmin"
-                            type="button"
-                            class="btn btn-link o_edit_dashboard fa fa-pencil"
-                            tabindex="-1"
-                            draggable="false"
-                            aria-label="Edit"
-                            data-tooltip="Edit"
-                            t-on-click.stop="() => this.editDashboard(dashboard.id)"
-                        />
                     </li>
                 </ul>
             </section>


### PR DESCRIPTION
**[REM/FIX] Spreadsheet dashboard: Remove dashboard spreadsheet edit button from dashboard.** 

**Description of the issue/feature this PR addresses:**
Activate the developer mode
Currently We can see dashboard spreadsheet edit button, when we press it, it raised error.

**Impacted versions:**
* 18.0
* master

**Steps to Reproduce :**
- Activate the Developer Mode.
- Go to the Dashboard.   
- Click on edit button from one of the dashboard.
- Can see Raised Error.

**Current behaviour before PR:**
Edit button shows on the Dashboard, On click it raised error.

**Desired behaviour after PR is merged:**
Edit dashboard spreadsheet button should not show as it is enterprise Function.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
