### PR TITLE
[FIX] mail: livechat visitor should not see their country flag

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -16,7 +16,7 @@
             <div t-if="thread?.importantCounter > 0" class="o-mail-ChatBubble-counter position-absolute badge rounded-pill fw-bold o-discuss-badge shadow" t-out="thread?.importantCounter"/>
             <button t-if="state.showClose and !env.embedLivechat" class="o-mail-ChatBubble-close position-absolute shadow rounded-circle fw-bold bg-view" title="Close Chat Bubble" t-on-click.stop="() => this.props.chatWindow.close()"><i class="oi oi-close"/></button>
             <ImStatus t-if="thread?.correspondent?.persona?.im_status and thread?.correspondent?.persona?.im_status != 'offline'" className="'o-mail-ChatBubble-status position-absolute o-mail-brighter'" member="thread.correspondent"/>
-            <CountryFlag t-if="thread?.anonymous_country" country="thread.anonymous_country" class="'o-mail-ChatBubble-country position-absolute bottom-0 border'"/>
+            <CountryFlag t-if="thread?.showCorrespondentCountry" country="thread.correspondentCountry" class="'o-mail-ChatBubble-country position-absolute bottom-0 border'"/>
             <button class="o-mail-ChatHub-bubbleBtn btn bg-view">
                 <img class="o-mail-ChatBubble-avatar rounded-circle" t-att-class="{ 'o-big': env.embedLivechat }" t-att-src="thread?.avatarUrl" alt="Thread image" draggable="false"/>
             </button>

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -139,7 +139,7 @@
         </t>
     </div>
     <ThreadIcon t-if="thread and thread.channel_type === 'chat' and thread.correspondent" thread="thread"/>
-    <CountryFlag t-if="thread?.anonymous_country" country="thread.anonymous_country" class="'o-mail-ChatWindow-country border'"/>
+    <CountryFlag t-if="thread?.showCorrespondentCountry" country="thread.correspondentCountry" class="'o-mail-ChatWindow-country border'"/>
     <div t-if="!state.editingName" class="text-truncate fw-bolder border border-transparent mx-1 my-0 py-1" t-att-title="props.chatWindow.displayName" t-esc="props.chatWindow.displayName" t-att-class="{ 'fs-4': ui.isSmall }"/>
 </t>
 </templates>

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -138,6 +138,19 @@ export class Thread extends Record {
             return this.computeCorrespondent();
         },
     });
+    correspondentCountry = Record.one("Country", {
+        /** @this {import("models").Thread} */
+        compute() {
+            return this.correspondent?.persona?.country ?? this.anonymous_country;
+        },
+    });
+    get showCorrespondentCountry() {
+        return (
+            this.channel_type === "livechat" &&
+            this.operator?.eq(this.store.self) &&
+            Boolean(this.correspondentCountry)
+        );
+    }
     counter = 0;
     counter_bus_id = 0;
     /** @type {string} */

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -21,7 +21,7 @@
                     <t t-else="">
                         <ThreadIcon className="'me-2 align-self-center'" size="'large'" thread="thread"/>
                     </t>
-                    <CountryFlag t-if="thread.anonymous_country" country="thread.anonymous_country" class="'o-mail-Discuss-headerCountry border'"/>
+                    <CountryFlag t-if="thread.showCorrespondentCountry" country="thread.correspondentCountry" class="'o-mail-Discuss-headerCountry border'"/>
                     <ImStatus t-if="thread.channel_type === 'chat' and thread.correspondent" className="'me-1'" member="thread.correspondent" />
                     <div class="d-flex flex-grow-1 align-self-center align-items-center h-100 py-2">
                         <div t-if="thread.parent_channel_id" class="d-flex align-items-center gap-1 ms-1">

--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -32,7 +32,7 @@
                     </t>
                     <t t-set-slot="icon">
                         <ImStatus t-if="thread.channel_type === 'chat' and thread.correspondent" member="thread.correspondent" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>
-                        <CountryFlag t-if="thread.anonymous_country" country="thread.anonymous_country" class="'o-mail-NotificationItem-country position-absolute border'"/>
+                        <CountryFlag t-if="thread.showCorrespondentCountry" country="thread.correspondentCountry" class="'o-mail-NotificationItem-country position-absolute border'"/>
                     </t>
                     <t t-if="message" t-set-slot="body-icon">
                         <t t-call="mail.message_preview_prefix">

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -162,7 +162,7 @@
                 <div class="bg-inherit position-relative d-flex flex-shrink-0" style="width:26px;height:26px" t-att-class="{ 'ms-3': !store.discuss.isSidebarCompact }">
                     <img class="w-100 h-100 rounded" t-att-src="thread.avatarUrl" alt="Thread Image"/>
                     <ThreadIcon t-if="thread.channel_type?.includes('chat') or (thread.channel_type === 'channel' and !thread.authorizedGroupFullName)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute bottom-0 end-0 p-1 me-n1 mb-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
-                    <CountryFlag t-if="thread.anonymous_country" country="thread.anonymous_country" class="'position-absolute o-mail-DiscussSidebarChannel-country border'"/>
+                    <CountryFlag t-if="thread.showCorrespondentCountry" country="thread.correspondentCountry" class="'position-absolute o-mail-DiscussSidebarChannel-country border'"/>
                 </div>
                 <span t-if="!store.discuss.isSidebarCompact" class="mx-2 text-truncate" t-att-class="thread.selfMember?.message_unread_counter > 0 and !thread.isMuted ? 'o-item-unread fw-bolder' : 'text-muted'">
                     <t t-esc="thread.displayName"/>


### PR DESCRIPTION
Before this commit, when a visitor posts a message in livechat, the header was showing their country flag.

Steps to reproduce:
- log in as Mitchell Admin as available operator
- log in as Joel Willis (portal user, on another browser context)
- open a livechat as Joel and send a message => Country of joel "USA" is visible in header

This happens because it was always showing `anonymous_country` when available, which is the visitor country.

This commit fixes the issue by limiting the showing of the country flag to the operator of livechat conversation.

Before / After
![Screenshot 2024-09-26 at 18 20 23](https://github.com/user-attachments/assets/a6d488e2-9153-409f-b238-bd86a0cae944) ![Screenshot 2024-09-26 at 18 19 49](https://github.com/user-attachments/assets/92a81f74-7e04-42b7-8a47-8e9427cb2134)
