### PR TITLE
[FIX] mail: clearer discuss sidebar active item style in dark theme

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar.dark.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar.dark.scss
@@ -1,4 +1,4 @@
 .o-mail-DiscussSidebar-item {
-    --mail-DiscussSidebar-itemActiveBgColor: #{mix($white, $o-action, 90%)};
-    --mail-DiscussSidebar-itemActiveOutlineColor: #{$gray-400};
+    --mail-DiscussSidebar-itemActiveBgColor: #{mix($gray-100, $o-action, 87.5%)};
+    --mail-DiscussSidebar-itemActiveOutlineColor: #{rgba($o-action, .5)};
 }


### PR DESCRIPTION
The active item had black background with light grey rounding. The border looked too hard especially in a narrow space like the sidebar, and the black background was too similar with background of channel with subthreads or in a call when compact.

This commit adapt style to match `$o-action` of white theme, while adjusting color of background and border to look nice with dark theme of discuss app.

Before / After
<img width="300" alt="Screenshot 2024-09-26 at 18 30 11" src="https://github.com/user-attachments/assets/89ad4598-0182-44d6-9cd1-9dd29782c86a"> <img width="302" alt="Screenshot 2024-09-26 at 18 40 00" src="https://github.com/user-attachments/assets/526ad052-fab7-4e56-b6a1-88d1e8fe1a03">

Before / After
<img width="59" alt="Screenshot 2024-09-26 at 18 41 14" src="https://github.com/user-attachments/assets/18688413-04b8-4f14-9966-ebed7416585d"> <img width="63" alt="Screenshot 2024-09-26 at 18 40 59" src="https://github.com/user-attachments/assets/ab6178d2-2a05-41e0-bb73-0433191f64b9">
