### PR TITLE
[FIX] website: fix `website_loader` visual glitches

### DIFF
--- a/addons/website/static/src/components/website_loader/website_loader.scss
+++ b/addons/website/static/src/components/website_loader/website_loader.scss
@@ -14,7 +14,10 @@
         color: var(--website-loader-color);
         background-color: $gray-100;
         width: 100%;
-        max-width: 30rem;
+
+        @include media-breakpoint-up(lg) {
+            max-width: 30rem;
+        }
     }
     .o_website_loader_tip {
         color: var(--website-loader-color);
@@ -205,21 +208,17 @@
         }
 
         .o_website_loader_filmstrip_inner {
-            width: 237.5%;
+            width: 200%;
             animation: filmstripScroll 30s linear infinite;
             animation-play-state: inherit;
         }
         img {
-            width: percentage(1/8);
             height: auto;
             padding: 4px;
             border-radius: .6rem;
             object-fit: cover;
-
-            &.double {
-                width: percentage(1/4);
-            }
         }
+
         &.o_website_loader_filmstrip_middle {
             flex-grow: 1;
             z-index: 1;
@@ -228,9 +227,6 @@
                 animation-name: filmstripScroll;
                 animation-duration: 20s;
                 animation-direction: reverse;
-            }
-            img {
-                width: 25%;
             }
         }
 

--- a/addons/website/static/src/components/website_loader/website_loader.xml
+++ b/addons/website/static/src/components/website_loader/website_loader.xml
@@ -34,7 +34,7 @@
                 <span class="o_website_loader_done">Generating inspiring text.</span>
             </div>
             <div t-if="state.showWaitingMessages" class="o_website_loader_tip d-flex gap-2 h3-fs">
-                <div><i class="fa fa-circle-o-notch fa-spin fa-fw"/></div> <t t-out="currentWaitingMessage.description"/>
+                <div><i class="fa fa-circle-o-notch fa-spin fa-fw"/></div><div><t t-out="currentWaitingMessage.description"/></div>
             </div>
 
             <p class="o_website_loader_tip mt-auto mb-3">
@@ -66,29 +66,29 @@
             </div>
             <div id="o_website_loader_step_images" class="flex-column h-100">
                 <div class="o_website_loader_filmstrip d-flex w-100 overflow-hidden">
-                    <div class="o_website_loader_filmstrip_inner d-flex">
+                    <div class="o_website_loader_filmstrip_inner d-flex flex-shrink-0 flex-grow-0">
                         <img src="/website/static/src/img/website_loader/1.jpg" alt="Image 1"/>
-                        <img class="double" src="/website/static/src/img/website_loader/2.jpg" alt="Image 2"/>
+                        <img src="/website/static/src/img/website_loader/2.jpg" alt="Image 2"/>
                         <img src="/website/static/src/img/website_loader/3.jpg" alt="Image 3"/>
-                        <img class="double" src="/website/static/src/img/website_loader/4.jpg" alt="Image 4"/>
+                        <img src="/website/static/src/img/website_loader/8.jpg" alt="Image 8"/>
                         <img src="/website/static/src/img/website_loader/5.jpg" alt="Image 5"/>
                         <img src="/website/static/src/img/website_loader/6.jpg" alt="Image 6"/>
-                        <img class="double" src="/website/static/src/img/website_loader/7.jpg" alt="Image 7"/>
-                        <img src="/website/static/src/img/website_loader/8.jpg" alt="Image 8"/>
+                        <img src="/website/static/src/img/website_loader/7.jpg" alt="Image 7"/>
+                        <img src="/website/static/src/img/website_loader/4.jpg" alt="Image 4"/>
 
                         <!-- Duplicate images for seamless looping -->
                         <img src="/website/static/src/img/website_loader/1.jpg" alt="Image 1"/>
-                        <img class="double" src="/website/static/src/img/website_loader/2.jpg" alt="Image 2"/>
+                        <img src="/website/static/src/img/website_loader/2.jpg" alt="Image 2"/>
                         <img src="/website/static/src/img/website_loader/3.jpg" alt="Image 3"/>
-                        <img class="double" src="/website/static/src/img/website_loader/4.jpg" alt="Image 4"/>
+                        <img src="/website/static/src/img/website_loader/8.jpg" alt="Image 8"/>
                         <img src="/website/static/src/img/website_loader/5.jpg" alt="Image 5"/>
                         <img src="/website/static/src/img/website_loader/6.jpg" alt="Image 6"/>
-                        <img class="double" src="/website/static/src/img/website_loader/7.jpg" alt="Image 7"/>
-                        <img src="/website/static/src/img/website_loader/8.jpg" alt="Image 8"/>
+                        <img src="/website/static/src/img/website_loader/7.jpg" alt="Image 7"/>
+                        <img src="/website/static/src/img/website_loader/4.jpg" alt="Image 4"/>
                     </div>
                 </div>
                 <div class="o_website_loader_filmstrip o_website_loader_filmstrip_middle d-flex w-100 overflow-hidden">
-                    <div class="o_website_loader_filmstrip_inner d-flex">
+                    <div class="o_website_loader_filmstrip_inner d-flex flex-shrink-0 flex-grow-0">
                         <img src="/web/image/website.s_three_columns_default_image_1" alt=""/>
                         <img src="/web/image/website.s_showcase_default_image" alt=" "/>
                         <img src="/web/image/website.s_image_title_default_image" alt=""/>
@@ -102,9 +102,9 @@
                     </div>
                 </div>
                 <div class="o_website_loader_filmstrip d-flex w-100 overflow-hidden mt-auto">
-                    <div class="o_website_loader_filmstrip_inner d-flex">
+                    <div class="o_website_loader_filmstrip_inner d-flex flex-shrink-0 flex-grow-0">
                         <img src="/website/static/src/img/website_loader/8.jpg" alt="Image 8"/>
-                        <img class="double" src="/website/static/src/img/website_loader/7.jpg" alt="Image 7"/>
+                        <img src="/website/static/src/img/website_loader/7.jpg" alt="Image 7"/>
                         <img src="/website/static/src/img/website_loader/6.jpg" alt="Image 6"/>
                         <img src="/website/static/src/img/website_loader/5.jpg" alt="Image 5"/>
                         <img src="/website/static/src/img/website_loader/4.jpg" alt="Image 4"/>
@@ -114,7 +114,7 @@
 
                         <!-- Duplicate images for seamless looping -->
                         <img src="/website/static/src/img/website_loader/8.jpg" alt="Image 8"/>
-                        <img class="double" src="/website/static/src/img/website_loader/7.jpg" alt="Image 7"/>
+                        <img src="/website/static/src/img/website_loader/7.jpg" alt="Image 7"/>
                         <img src="/website/static/src/img/website_loader/6.jpg" alt="Image 6"/>
                         <img src="/website/static/src/img/website_loader/5.jpg" alt="Image 5"/>
                         <img src="/website/static/src/img/website_loader/4.jpg" alt="Image 4"/>


### PR DESCRIPTION
This PR resolves several minor `website_loader` visual glitches.

The first fix addresses Firefox miscalculating fixed image sizes in the "filmstrip" animation. Fixed image sizes were necessary to achieve a seamless looping effect.
However, since the animation doesn't last long enough for a full loop and the approach isn't fully cross-browser compatible, fine-tuned classes and sizes were removed.
The flex layout now adjusts image sizes based on available space.

The second fix resolves a layout misplacement for the `currentWaitingMessage` when rendering long strings in a flex layout.

Additionally, this commit scopes the `o_website_loader_container_content` max-width property to only apply when the animation block is visible.

task-4214353





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
