### PR TITLE
[FIX] stock: Fixed Enterprise Widget on Stock Barcode Lookup Module

### DIFF
--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -48,7 +48,7 @@
                                 <field name="module_stock_barcode" widget="upgrade_boolean"/>
                             </setting>
                             <setting id="process_stock_barcodelookup" string="Stock Barcode Database" help="" documentation="https://www.barcodelookup.com/api-documentation">
-                                <field name="module_stock_barcode_barcodelookup" placeholder="e.g. d7vctmiv2rwgenebha8bxq7irooudn"/>
+                                <field name="module_stock_barcode_barcodelookup" widget="upgrade_boolean" placeholder="e.g. d7vctmiv2rwgenebha8bxq7irooudn"/>
                                 <span class="text-muted">
                                     Create products easily by scanning using <a href="https://www.barcodelookup.com" target="_blank">barcodelookup.com</a> in barcode.
                                 </span>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Fixing Enterprise Widget on Stock Barcode Lookup Module

**Impacted versions:**
* 18.0
* master

**Steps to Reproduce :**
- Go to the Inventory --> Configuration --> Setting.   
- Activate the Stock Barcode Database Module.
- Save the record and see.

**Current behaviour before PR:**
No Enterprise Widget on Stock Barcode Database Module.

**Desired behaviour after PR is merged:**
As Stock Barcode Database Module is in Enterprise, Added Enterprise Widget on it.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr