### PR TITLE
[FIX] hr_attendance: Fix overtime computation with adjustments

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -99,6 +99,7 @@ class HrAttendance(models.Model):
                                   as date)) = date_trunc('day', ot.date)
                    AND att.employee_id = ot.employee_id
                    AND att.employee_id IN %s
+                   AND ot.adjustment IS false
               ORDER BY att.check_in DESC
             ''', (tuple(self.employee_id.ids),))
             a = self.env.cr.dictfetchall()


### PR DESCRIPTION
When overtime is converted to time off, an hr.attendance.overtime record is created with a negative amount to offset the total overtime amount available with adjustment set to True. Those records should not be taking into account when computing overtime itself.
