### PR TITLE
[FIX] sale_pdf_quote_builder: fix pdf document preview

### DIFF
--- a/addons/sale_pdf_quote_builder/views/quotation_document_views.xml
+++ b/addons/sale_pdf_quote_builder/views/quotation_document_views.xml
@@ -84,7 +84,7 @@
                     <t t-name="card" class="o_kanban_attachment flex-row">
                         <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                         <aside>
-                            <div class="o_image ms-3" t-att-data-mimetype="record.mimetype.value"/>
+                            <div class="o_image o_kanban_previewer w-100 h-100" t-att-data-mimetype="record.mimetype.value"/>
                         </aside>
                         <main class="ms-2">
                             <field name="name" class="fw-bolder text-truncate"/>


### PR DESCRIPTION
`o_kanban_previewer` was wrongly removed in dbe94039de1be49f33505445d1e27543c3137d4f. This commit brings it back and improves the display of the pdf placeholder.
