### PR TITLE
[FIX] website, website_mass_mailing: add/remove snippets keywords

### DIFF
--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -368,23 +368,13 @@
 
             <!-- Inner snippets -->
             <snippets id="snippet_content" string="Inner content">
-                <t t-snippet="website.s_button" string="Button" t-thumbnail="/website/static/src/img/snippets_thumbs/s_button.svg">
-                    <keywords>button, action</keywords>
-                </t>
-                <t t-snippet="website.s_image" string="Image" t-thumbnail="/website/static/src/img/snippets_thumbs/s_image.svg">
-                    <keywords>image, picture, photo</keywords>
-                </t>
-                <t t-snippet="website.s_video" string="Video" t-thumbnail="/website/static/src/img/snippets_thumbs/s_video.svg">
-                    <keywords>video, youtube, vimeo, dailymotion, youku</keywords>
-                </t>
-                <t t-snippet="website.s_hr" string="Separator" t-thumbnail="/website/static/src/img/snippets_thumbs/s_hr.svg">
-                    <keywords>separator, divider</keywords>
-                </t>
+                <t t-snippet="website.s_button" string="Button" t-thumbnail="/website/static/src/img/snippets_thumbs/s_button.svg"/>
+                <t t-snippet="website.s_image" string="Image" t-thumbnail="/website/static/src/img/snippets_thumbs/s_image.svg"/>
+                <t t-snippet="website.s_video" string="Video" t-thumbnail="/website/static/src/img/snippets_thumbs/s_video.svg"/>
+                <t t-snippet="website.s_hr" string="Separator" t-thumbnail="/website/static/src/img/snippets_thumbs/s_hr.svg"/>
                 <t t-snippet="website.s_accordion" string="Accordion" t-thumbnail="/website/static/src/img/snippets_thumbs/s_accordion.svg"/>
                 <t t-snippet="website.s_alert" string="Alert" t-thumbnail="/website/static/src/img/snippets_thumbs/s_alert.svg"/>
-                <t t-snippet="website.s_rating" string="Rating" t-thumbnail="/website/static/src/img/snippets_thumbs/s_rating.svg">
-                    <keywords>valuation, rank</keywords>
-                </t>
+                <t t-snippet="website.s_rating" string="Rating" t-thumbnail="/website/static/src/img/snippets_thumbs/s_rating.svg"/>
                 <t t-snippet="website.s_card" string="Card" t-thumbnail="/website/static/src/img/snippets_thumbs/s_card.svg"/>
                 <t t-snippet="website.s_share" string="Share" t-thumbnail="/website/static/src/img/snippets_thumbs/s_share.svg"/>
                 <t t-snippet="website.s_social_media" string="Social Media" t-thumbnail="/website/static/src/img/snippets_thumbs/s_social_media.svg"/>
@@ -393,19 +383,11 @@
                 <t id="mass_mailing_newsletter_hook"/>
                 <t id="mail_group_hook"/>
                 <t t-snippet="website.s_text_highlight" string="Text Highlight" t-thumbnail="/website/static/src/img/snippets_thumbs/s_text_highlight.svg"/>
-                <t t-snippet="website.s_chart" string="Chart" t-thumbnail="/website/static/src/img/snippets_thumbs/s_chart.svg">
-                    <keywords>chart, table, diagram, pie</keywords>
-                </t>
-                <t t-snippet="website.s_progress_bar" string="Progress Bar" t-thumbnail="/website/static/src/img/snippets_thumbs/s_progress_bar.svg">
-                    <keywords>evolution, growth</keywords>
-                </t>
+                <t t-snippet="website.s_chart" string="Chart" t-thumbnail="/website/static/src/img/snippets_thumbs/s_chart.svg"/>
+                <t t-snippet="website.s_progress_bar" string="Progress Bar" t-thumbnail="/website/static/src/img/snippets_thumbs/s_progress_bar.svg"/>
                 <t t-snippet="website.s_badge" string="Badge" t-thumbnail="/website/static/src/img/snippets_thumbs/s_badge.svg"/>
-                <t t-snippet="website.s_cta_badge" string="CTA Badge" t-thumbnail="/website/static/src/img/snippets_thumbs/s_cta_badge.svg">
-                    <keywords>cta, button, btn, action, engagement, link, appeal, trigger, promotion, promote</keywords>
-                </t>
-                <t t-snippet="website.s_blockquote" string="Blockquote" t-thumbnail="/website/static/src/img/snippets_thumbs/s_blockquote.svg">
-                    <keywords>cite</keywords>
-                </t>
+                <t t-snippet="website.s_cta_badge" string="CTA Badge" t-thumbnail="/website/static/src/img/snippets_thumbs/s_cta_badge.svg"/>
+                <t t-snippet="website.s_blockquote" string="Blockquote" t-thumbnail="/website/static/src/img/snippets_thumbs/s_blockquote.svg"/>
                 <!--
                 Note: this inner snippet is still allowed to be dropped as a
                 main snippet. Indeed, this handles the fact that the snippet
@@ -415,9 +397,7 @@
                 snippet by other snippets in there.
                 -->
                 <t t-snippet="website.s_website_form" string="Form" t-thumbnail="/website/static/src/img/snippets_thumbs/s_website_form.svg" t-forbid-sanitize="form"/>
-                <t t-snippet="website.s_countdown" string="Countdown" t-thumbnail="/website/static/src/img/snippets_thumbs/s_countdown.svg">
-                    <keywords>celebration, launch</keywords>
-                </t>
+                <t t-snippet="website.s_countdown" string="Countdown" t-thumbnail="/website/static/src/img/snippets_thumbs/s_countdown.svg"/>
                 <t t-snippet="website.s_embed_code" string="Embed Code" t-thumbnail="/website/static/src/img/snippets_thumbs/s_embed_code.svg" t-forbid-sanitize="true"/>
                 <t t-if="debug or not google_maps_api_key" t-snippet="website.s_map" string="Map" t-thumbnail="/website/static/src/img/snippets_thumbs/s_map.svg"/>
                 <t t-if="debug or google_maps_api_key" t-snippet="website.s_google_map" string="Map" t-thumbnail="/website/static/src/img/snippets_thumbs/s_google_map.svg"/>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -43,16 +43,16 @@
 
                 <!-- Intro group -->
                 <t t-snippet="website.s_banner" string="Banner" group="intro">
-                    <keywords>hero, jumbotron</keywords>
+                    <keywords>hero, jumbotron, headline, header, branding, intro, home, showcase, spotlight, lead, welcome, announcement, splash, top, main</keywords>
                 </t>
                 <t t-snippet="website.s_cover" string="Cover" group="intro">
-                    <keywords>hero, jumbotron</keywords>
+                    <keywords>hero, jumbotron, headline, header, branding, intro, home, showcase, spotlight, main, landing, presentation, top, splash</keywords>
                 </t>
                 <t t-snippet="website.s_text_cover" string="Text Cover" group="intro">
-                    <keywords>hero, jumbotron</keywords>
+                    <keywords>hero, jumbotron, headline, header, intro, home, content, description, primary, highlight, lead</keywords>
                 </t>
                 <t t-snippet="website.s_carousel" string="Carousel" group="intro">
-                    <keywords>gallery, carousel</keywords>
+                    <keywords>gallery, carousel, slider, slideshow, picture, photo, image-slider, rotating, swipe, transition, media-carousel, movement</keywords>
                 </t>
                 <t t-snippet="website.s_carousel_intro" string="Carousel Intro" group="intro">
                     <keywords>gallery, carousel, slider, slideshow, picture, photo, image-slider, rotating, swipe, transition, media-carousel, movement</keywords>
@@ -61,16 +61,16 @@
                     <keywords>journey, exploration, travel, outdoor, excitement, quest, start, onboarding, discovery, thrill</keywords>
                 </t>
                 <t t-snippet="website.s_striped_center_top" string="Striped Center Top" group="intro">
-                    <keywords>hero, jumbotron, headline, header, intro, home, content, picture, photo, illustration, media, visual, article, combination, trendy, pattern, design</keywords>
+                    <keywords>hero, jumbotron, headline, header, introduction, home, content, picture, photo, illustration, media, visual, article, combination, trendy, pattern, design, centered</keywords>
                 </t>
                 <t t-snippet="website.s_motto" string="Motto" group="intro">
-                    <keywords>cite, slogan, tagline, mantra, catchphrase, statements, sayings, comments, mission, citations, maxim, quotes, principle</keywords>
+                    <keywords>cite, slogan, tagline, mantra, catchphrase, statements, sayings, comments, mission, citations, maxim, quotes, principle, ethos, values</keywords>
                 </t>
                 <t t-snippet="website.s_kickoff" string="Kickoff" group="intro">
-                    <keywords>picture, photo, illustration, media, visual, start, launch, commencement, initiation, opening, kick-off, kickoff</keywords>
+                    <keywords>picture, photo, illustration, media, visual, start, launch, commencement, initiation, opening, kick-off, kickoff, beginning, events</keywords>
                 </t>
                 <t t-snippet="website.s_closer_look" string="Closer Look" group="intro">
-                    <keywords>content, picture, photo, illustration, media, visual, focus, in-depth, analysis, more, contact, detailed, mockup</keywords>
+                    <keywords>content, picture, photo, illustration, media, visual, focus, in-depth, analysis, more, contact, detailed, mockup, explore, insight</keywords>
                 </t>
                 <t t-snippet="website.s_striped_top" string="Striped Top" group="intro">
                     <keywords>content, picture, photo, illustration, media, visual, article, story, combination, trendy, pattern, design</keywords>
@@ -79,29 +79,31 @@
                     <keywords>grid, gallery, pictures, photos, media, text, content, album, showcase, visuals, portfolio, mosaic, collage, arrangement, collection, visual-grid, split, alignment</keywords>
                 </t>
                 <t t-snippet="website.s_discovery" string="Discovery" group="intro">
-                    <keywords>hero, jumbotron, headline, header, intro, home, content, introduction, overview, spotlight, presentation, welcome, context, description, primary, highlight, lead, discover</keywords>
+                    <keywords>hero, jumbotron, headline, header, introduction, home, content, introduction, overview, spotlight, presentation, welcome, context, description, primary, highlight, lead, discover, exploration, reveal</keywords>
                 </t>
                 <t t-snippet="website.s_intro_pill" string="Intro Pill" group="intro">
-                    <keywords>hero, jumbotron, headline, header, intro, home, content, introduction, overview, spotlight, presentation, welcome, context, description, primary, highlight, lead, journey, skills, expertises, experts, accomplishments, knowledge</keywords>
+                    <keywords>hero, jumbotron, headline, header, introduction, home, content, introduction, overview, spotlight, presentation, welcome, context, description, primary, highlight, lead, journey, skills, expertises, experts, accomplishments, knowledge</keywords>
                 </t>
                 <t t-snippet="website.s_framed_intro" string="Framed Intro" group="intro">
-                    <keywords>hero, jumbotron, headline, header, intro, home, content, introduction, overview, spotlight, presentation, welcome, context, description, primary, highlight, lead</keywords>
+                    <keywords>hero, jumbotron, headline, header, introduction, home, content, introduction, overview, spotlight, presentation, welcome, context, description, primary, highlight, lead</keywords>
                 </t>
                 <t t-snippet="website.s_empowerment" string="Empowerment" group="intro">
-                    <keywords>hero, jumbotron, headline, header, intro, home, content, introduction, overview, spotlight, presentation, welcome, context, description, primary, highlight, lead, CTA, promote, promotion</keywords>
+                    <keywords>hero, jumbotron, headline, header, introduction, home, content, introduction, overview, spotlight, presentation, welcome, context, description, primary, highlight, lead, CTA, promote, promotion</keywords>
                 </t>
 
                 <!-- Columns group -->
                 <t t-snippet="website.s_three_columns" string="Columns" group="columns">
-                    <keywords>columns, description</keywords>
+                    <keywords>description, containers, layouts, structures, multi-columns, modules, boxes</keywords>
                 </t>
                 <t t-snippet="website.s_features_wall" string="Features Wall" group="columns">
                     <keywords>reveal, showcase, launch, presentation, announcement, content, picture, photo, illustration, media, visual, combination</keywords>
                 </t>
                 <t t-snippet="website.s_key_benefits" string="Key benefits" group="columns">
-                    <keywords>promotion, characteristic, quality, highlights, specs, advantages, functionalities, features, exhibit, details, capabilities, attributes, promotion, headline, content, overiew, spotlight</keywords>
+                    <keywords>promotion, characteristic, quality, highlights, specs, advantages, functionalities, features, exhibit, details, capabilities, attributes, promotion, headline, content, overview, spotlight</keywords>
                 </t>
-                <t t-snippet="website.s_product_list" string="Items" group="columns"/>
+                <t t-snippet="website.s_product_list" string="Items" group="columns">
+                    <keywords>shop, group, list, card, cart, products, inventory, catalog, merchandise, goods</keywords>
+                </t>
                 <t t-snippet="website.s_freegrid" string="Free grid" group="columns">
                     <keywords>description, containers, layouts, structures, multi-columns, modules, boxes, content, picture, photo, illustration, media, visual, article, story, combination, showcase, announcement, reveal, trendy, design, shape, geometric, engage, call to action, cta, button</keywords>
                 </t>
@@ -112,7 +114,7 @@
                     <keywords>columns, gallery, pictures, photos, media, text, content, album, showcase, visuals, portfolio, arrangement, collection, visual-grid, split, alignment, added value</keywords>
                 </t>
                 <t t-snippet="website.s_wavy_grid" string="Wavy Grid" group="columns">
-                    <keywords>reveal, showcase, launch, presentation, announcement, content, picture, photo, illustration, media, visual, combination</keywords>
+                    <keywords>reveal, showcase, launch, presentation, announcement, content, picture, photo, illustration, media, visual, combination</keywords>
                 </t>
                 <t t-snippet="website.s_card_offset" string="Card Offset" group="columns">
                     <keywords>content, picture, photo, illustration, media, visual, article, story, combination, trendy, pattern, design</keywords>
@@ -123,10 +125,10 @@
 
                 <!-- Content group -->
                 <t t-snippet="website.s_text_image" string="Text - Image" group="content">
-                    <keywords>content</keywords>
+                    <keywords>content, picture, photo, illustration, media, visual, article, story, combination</keywords>
                 </t>
                 <t t-snippet="website.s_image_text" string="Image - Text" group="content">
-                    <keywords>content</keywords>
+                    <keywords>content, picture, photo, illustration, media, visual, article, story, combination</keywords>
                 </t>
                 <t t-snippet="website.s_shape_image" string="Shape image" group="content">
                     <keywords>content, picture, photo, illustration, media, visual, article, story, combination, trendy, pattern, design, shape, geometric, patterned</keywords>
@@ -147,60 +149,72 @@
                     <keywords>content, picture, photo, illustration, media, visual, article, story, combination, trendy, pattern, design</keywords>
                 </t>
                 <t t-snippet="website.s_call_to_action" string="Call to Action" group="content">
-                    <keywords>CTA</keywords>
+                    <keywords>CTA, button, btn, action, engagement, link, offer, appeal</keywords>
                 </t>
                 <t t-snippet="website.s_cta_box" string="Box Call to Action" group="content">
                     <keywords>CTA, button, btn, action, engagement, link, offer, appeal, call to action, prompt, interact, trigger</keywords>
                 </t>
                 <t t-snippet="website.s_striped" string="Striped section" group="content">
-                    <keywords>hero, jumbotron, headline, header, intro, home, content, picture, photo, illustration, media, visual, article, combination, trendy, pattern, design</keywords>
+                    <keywords>hero, jumbotron, headline, header, introduction, home, content, picture, photo, illustration, media, visual, article, combination, trendy, pattern, design</keywords>
                 </t>
                 <t t-snippet="website.s_cta_card" string="Card Call to Action" group="content">
                     <keywords>CTA, button, btn, action, engagement, link, offer, appeal, call to action, prompt, interact, trigger, items, checklists, entries, sequences, bullets, points, list, group, benefits, features, advantages</keywords>
                 </t>
                 <t t-snippet="website.s_searchbar" string="Search" t-forbid-sanitize="form" group="content"/>
                 <t t-snippet="website.s_color_blocks_2" string="Big Boxes" group="content">
-                    <keywords>big</keywords>
+                    <keywords>columns, containers, layouts, large, panels, modules</keywords>
                 </t>
                 <t t-snippet="website.s_popup" string="Popup" group="content"/>
                 <t t-snippet="website.s_countdown" string="Countdown" t-thumbnail="/website/static/src/img/snippets_thumbs/s_countdown.svg" group="content">
                     <keywords>celebration, launch</keywords>
                 </t>
                 <t t-snippet="website.s_numbers_charts" string="Numbers Charts" group="content">
-                    <keywords>graph, table, diagram, pie, plot, bar, metrics, figures, data-visualization, statistics, stats, analytics, infographic, performance, report</keywords>
+                    <keywords>graph, table, diagram, pie, plot, bar, metrics, figures, data-visualization, statistics, stats, analytics, infographic, skills, report</keywords>
                 </t>
                 <t t-snippet="website.s_numbers" string="Numbers" group="content">
-                    <keywords>statistics, stats, KPI</keywords>
+                    <keywords>statistics, stats, KPI, metrics, dashboard, analytics, highlights, figures, skills, achievements, benchmarks, milestones, indicators, data, measurements, reports, trends, results, analytics, summaries, summary</keywords>
                 </t>
                 <t t-snippet="website.s_numbers_list" string="Numbers list" group="content">
-                    <keywords>statistics, stats, KPI, metrics, dashboard, analytics, highlights, figures, performance, achievements, benchmarks, milestones, indicators, data, measurements, reports, trends, results, analytics, cta, call to action, button</keywords>
+                    <keywords>statistics, stats, KPI, metrics, dashboard, analytics, highlights, figures, skills, achievements, benchmarks, milestones, indicators, data, measurements, reports, trends, results, analytics, cta, call to action, button</keywords>
                 </t>
                 <t t-snippet="website.s_numbers_grid" string="Numbers Grid" group="content">
-                    <keywords>statistics, stats, KPI, metrics, dashboard, analytics, highlights, figures, performance, achievements, benchmarks, milestones, indicators, data, measurements, reports, trends, results</keywords>
+                    <keywords>statistics, stats, KPI, metrics, dashboard, analytics, highlights, figures, skills, achievements, benchmarks, milestones, indicators, data, measurements, reports, trends, results</keywords>
                 </t>
                 <t t-snippet="website.s_big_number" string="Big number" group="content">
-                    <keywords>statistics, stats, KPI, metrics, dashboard, analytics, highlights, figures, performance, achievements, benchmarks, milestones, indicators, data, measurements, reports, trends, results, analytics, summaries, summary, large-figures, prominent, standout</keywords>
+                    <keywords>statistics, stats, KPI, metrics, dashboard, analytics, highlights, figures, skills, achievements, benchmarks, milestones, indicators, data, measurements, reports, trends, results, analytics, summaries, summary, large-figures, prominent, standout</keywords>
                 </t>
                 <t t-snippet="website.s_features" string="Features" group="content">
-                    <keywords>promotion, characteristic, quality</keywords>
+                    <keywords>promotion, characteristic, quality, highlights, specs, advantages, functionalities, exhibit, details, capabilities, attributes, promotion</keywords>
                 </t>
                 <t t-snippet="website.s_features_wave" string="Features Wave" group="content">
-                    <keywords>promotion, characteristic, quality, highlights, specs, advantages, functionalities, exhibit, details, capabilities, attributes, promotion, headline, content, overiew, spotlight</keywords>
+                    <keywords>promotion, characteristic, quality, highlights, specs, advantages, functionalities, exhibit, details, capabilities, attributes, promotion, headline, content, overview, spotlight</keywords>
                 </t>
-                <t t-snippet="website.s_media_list" string="Media List" group="content"/>
-                <t t-snippet="website.s_showcase" string="Showcase" group="content"/>
+                <t t-snippet="website.s_media_list" string="Media List" group="content">
+                    <keywords>block, blog, post, catalog, feed, items, entries, entry, collection</keywords>
+                </t>
+                <t t-snippet="website.s_showcase" string="Showcase" group="content">
+                    <keywords>promotion, characteristic, quality, highlights, specs, advantages, functionalities, exhibit, details, capabilities, attributes, promotion, presentation, demo, feature</keywords>
+                </t>
                 <t t-snippet="website.s_comparisons" string="Comparisons" group="content">
-                    <keywords>pricing</keywords>
+                    <keywords>pricing, promotion, price, feature-comparison, side-by-side, evaluation, competitive, overview</keywords>
                 </t>
-                <t t-snippet="website.s_features_grid" string="Features Grid" group="content"/>
-                <t t-snippet="website.s_tabs" string="Tabs" group="content"/>
-                <t t-snippet="website.s_timeline" string="Timeline" group="content"/>
+                <t t-snippet="website.s_features_grid" string="Features Grid" group="content">
+                    <keywords>promotion, characteristic, quality, highlights, specs, advantages, functionalities, exhibit, details, capabilities, attributes, promotion</keywords>
+                </t>
+                <t t-snippet="website.s_tabs" string="Tabs" group="content">
+                    <keywords>navigation, sections, multi-tab, panel, toggle</keywords>
+                </t>
+                <t t-snippet="website.s_timeline" string="Timeline" group="content">
+                    <keywords>history, story, events, milestones, chronology, sequence, progression, achievements</keywords>
+                </t>
                 <t t-snippet="website.s_timeline_list" string="Timeline List" group="content">
                     <keywords>history, story, events, milestones, chronology, sequence, progression, achievements, changelog, updates, announcements, recent, latest</keywords>
                 </t>
-                <t t-snippet="website.s_process_steps" string="Steps" t-forbid-sanitize="true" group="content"/>
+                <t t-snippet="website.s_process_steps" string="Steps" t-forbid-sanitize="true" group="content">
+                    <keywords>process, progression, guide, workflow, sequence, instructions, stages, procedure, roadmap</keywords>
+                </t>
                 <t t-snippet="website.s_numbers_showcase" string="Numbers Showcase" group="content">
-                    <keywords>statistics, stats, KPI, metrics, dashboard, analytics, highlights, figures, performance, achievements, benchmarks, milestones, indicators, data, measurements, reports, trends, results, analytics, cta, call to action, button</keywords>
+                    <keywords>statistics, stats, KPI, metrics, dashboard, analytics, highlights, figures, skills, achievements, benchmarks, milestones, indicators, data, measurements, reports, trends, results, analytics, cta, call to action, button</keywords>
                 </t>
                 <t t-snippet="website.s_accordion_image" string="Accordion Image" group="content">
                     <keywords>common answers, common questions, faq, QA, collapse, expandable, toggle, collapsible, hide-show, movement, information, image, picture, photo, illustration, media, visual</keywords>
@@ -213,30 +227,34 @@
 
                 <!-- Images group -->
                 <t t-snippet="website.s_picture" string="Title - Image" group="images">
-                    <keywords>image, media, illustration, picture</keywords>
+                    <keywords>content, picture, photo, illustration, media, visual, article, story, combination, heading, headline</keywords>
                 </t>
                 <t t-snippet="website.s_masonry_block" string="Masonry" group="images">
-                    <keywords>masonry, grid</keywords>
+                    <keywords>masonry, grid, column, pictures, photos, album, showcase, visuals, portfolio, mosaic, collage, arrangement, collection, visual-grid</keywords>
                 </t>
                 <t t-snippet="website.s_quadrant" string="Quadrant" group="images">
                     <keywords>four sections, column, grid, division, split, segments, pictures, illustration, media, photos, tiles, arrangement, gallery, images-grid, mixed, collection, stacking, visual-grid, showcase, visuals, portfolio, thumbnails, engage, call to action, cta, showcase</keywords>
                 </t>
                 <t t-snippet="website.s_image_gallery" string="Image Gallery" group="images">
-                    <keywords>gallery, carousel</keywords>
+                    <keywords>gallery, carousel, pictures, photos, album, showcase, visuals, portfolio, thumbnails, slideshow</keywords>
                 </t>
-                <t t-snippet="website.s_images_wall" string="Images Wall" group="images"/>
+                <t t-snippet="website.s_images_wall" string="Images Wall" group="images">
+                    <keywords>grid, gallery, pictures, photos, album, showcase, visuals, portfolio, mosaic, collage, arrangement, collection, visual-grid</keywords>
+                </t>
                 <t t-snippet="website.s_image_punchy" string="Punchy Image" group="images">
                     <keywords>headline, header, content, picture, photo, illustration, media, visual, article, combination, trendy, pattern, design, bold, impactful, vibrant, standout</keywords>
                 </t>
-                <t t-snippet="website.s_parallax" string="Parallax" group="images"/>
+                <t t-snippet="website.s_parallax" string="Parallax" group="images">
+                    <keywords>scrolling, depth, effect, background, layer, visual, movement</keywords>
+                </t>
                 <t t-snippet="website.s_unveil" string="Unveil" group="images">
-                    <keywords>reveal, showcase, launch, presentation, announcement, content, picture, photo, illustration, media, visual, article, combination</keywords>
+                    <keywords>reveal, showcase, launch, presentation, announcement, content, picture, photo, illustration, media, visual, article, combination</keywords>
                 </t>
                 <t t-snippet="website.s_image_title" string="Image Title" group="images">
                     <keywords>headline, header, content, picture, photo, illustration, media, visual, combination</keywords>
                 </t>
                 <t t-snippet="website.s_image_frame" string="Image Frame" group="images">
-                    <keywords>header, intro, home, content, introduction, overview, spotlight, presentation, welcome, context, description, primary, highlight, lead</keywords>
+                    <keywords>header, introduction, home, content, introduction, overview, spotlight, presentation, welcome, context, description, primary, highlight, lead</keywords>
                 </t>
                 <t t-snippet="website.s_images_mosaic" string="Images Mosaic" group="images">
                     <keywords>content, picture, photo, illustration, media, visual, article, story, combination, trendy, pattern, design, shape, geometric, patterned, contrast</keywords>
@@ -247,7 +265,7 @@
 
                 <!-- People group -->
                 <t t-snippet="website.s_company_team" string="Team" group="people">
-                    <keywords>organization, structure</keywords>
+                    <keywords>organization, company, people, column, members, staffs, profiles, bios, roles, personnel, crew</keywords>
                 </t>
                 <t t-snippet="website.s_company_team_basic" string="Team Basic" group="people">
                     <keywords>organization, company, people, members, staffs, profiles, bios, roles, personnel, crew, patterned, trendy</keywords>
@@ -259,7 +277,7 @@
                     <keywords>organization, company, people, members, staffs, profiles, bios, roles, personnel, crew, patterned, trendy, social</keywords>
                 </t>
                 <t t-snippet="website.s_references" string="References" group="people">
-                    <keywords>customers, clients</keywords>
+                    <keywords>customers, clients, sponsors, partners, supporters, case-studies, collaborators, associations, associates, testimonials, endorsements</keywords>
                 </t>
                 <t t-snippet="website.s_references_social" string="References Social" group="people">
                     <keywords>customers, clients, sponsors, partners, supporters, case-studies, collaborators, associations, associates, testimonials, endorsements, social</keywords>
@@ -268,7 +286,7 @@
                     <keywords>customers, clients, sponsors, partners, supporters, case-studies, collaborators, associations, associates, testimonials, endorsements</keywords>
                 </t>
                 <t t-snippet="website.s_quotes_carousel" string="Quotes" group="people">
-                    <keywords>testimonials</keywords>
+                    <keywords>cite, testimonials, endorsements, reviews, feedback, statements, references, sayings, comments, appreciations, citations</keywords>
                 </t>
                 <t t-snippet="website.s_quotes_carousel_minimal" string="Quotes Minimal" group="people">
                     <keywords>cite, testimonials, endorsements, reviews, feedback, statements, references, sayings, comments, appreciations, citations</keywords>
@@ -276,10 +294,10 @@
 
                 <!-- Text group -->
                 <t t-snippet="website.s_title" string="Title" group="text">
-                    <keywords>heading, h1</keywords>
+                    <keywords>heading, h1, headline, header, main, top, caption, introductory, principal, key</keywords>
                 </t>
                 <t t-snippet="website.s_text_block" string="Text" group="text">
-                    <keywords>content</keywords>
+                    <keywords>content, paragraph, article, body, description, information</keywords>
                 </t>
                 <t t-snippet="website.s_faq_collapse" string="FAQ Block" group="text">
                     <keywords>common answers, common questions</keywords>
@@ -287,22 +305,26 @@
                 <t t-snippet="website.s_faq_list" string="FAQ List" group="text">
                     <keywords>questions, answers, common answers, common questions, faq, help, support, information, knowledge, guide, troubleshooting, assistance, columns, QA</keywords>
                 </t>
-                <t t-snippet="website.s_table_of_content" string="Table of Content" group="text"/>
+                <t t-snippet="website.s_table_of_content" string="Table of Content" group="text">
+                    <keywords>navigation, index, outline, chapters, sections, overview, menu</keywords>
+                </t>
                 <t t-snippet="website.s_faq_horizontal" string="Topics List" group="text">
                     <keywords>questions, answers, common answers, common questions, faq, help, support, information, knowledge, guide, troubleshooting, assistance, QA, terms of services</keywords>
                 </t>
                 <t t-snippet="website.s_product_catalog" string="Pricelist" group="text">
-                    <keywords>menu, pricing</keywords>
+                    <keywords>menu, pricing, shop, table, cart, product, cost, charges, fees, rates, prices, expenses</keywords>
                 </t>
                 <t t-snippet="website.s_pricelist_cafe" string="Pricelist Cafe" group="text">
-                    <keywords>menu, pricing, shop, table, cart, product, cost, charges, fees, tarifs, prices, expenses, columns</keywords>
+                    <keywords>menu, pricing, shop, table, cart, product, cost, charges, fees, rates, prices, expenses, columns</keywords>
                 </t>
                 <t t-snippet="website.s_pricelist_boxed" string="Pricelist Boxed" group="text">
-                    <keywords>menu, pricing, shop, table, cart, product, cost, charges, fees, tarifs, prices, expenses</keywords>
+                    <keywords>menu, pricing, shop, table, cart, product, cost, charges, fees, rates, prices, expenses</keywords>
                 </t>
 
                 <!-- Contact & Forms group -->
-                <t t-snippet="website.s_title_form" string="Title - Form" t-forbid-sanitize="form" t-thumbnail="/website/static/src/img/snippets_thumbs/s_website_form.svg" group="contact_and_forms"/>
+                <t t-snippet="website.s_title_form" string="Title - Form" t-forbid-sanitize="form" t-thumbnail="/website/static/src/img/snippets_thumbs/s_website_form.svg" group="contact_and_forms">
+                    <keywords>contact, collect, submission, input, fields, questionnaire, survey, registration, request</keywords>
+                </t>
                 <t t-snippet="website.s_opening_hours" string="Opening Hours" group="contact_and_forms"/>
                 <t t-snippet="website.s_contact_info" string="Contact Info" group="contact_and_forms"/>
 

--- a/addons/website_mass_mailing/views/snippets_templates.xml
+++ b/addons/website_mass_mailing/views/snippets_templates.xml
@@ -6,7 +6,9 @@
 
 <template id="snippets" inherit_id="website.snippets">
     <xpath expr="//t[@id='mass_mailing_newsletter_block_hook']" position="replace">
-        <t t-snippet="website_mass_mailing.s_newsletter_block" string="Newsletter Block" t-forbid-sanitize="form" group="contact_and_forms"/>
+        <t t-snippet="website_mass_mailing.s_newsletter_block" string="Newsletter Block" t-forbid-sanitize="form" group="contact_and_forms">
+            <keywords>form, updates, digest, bulletin, announcements, notifications, communication, email, modal, alert, dialog, prompt, pop-up, subscription</keywords>
+        </t>
     </xpath>
     <xpath expr="//t[@id='mass_mailing_newsletter_popup_hook']" position="replace">
         <t t-snippet="website_mass_mailing.s_newsletter_subscribe_popup" string="Newsletter Popup" t-forbid-sanitize="form" group="contact_and_forms"/>


### PR DESCRIPTION
This PR updatsd snippets keywords ensuring they accurately reflect the associated content.
It also removes inline-snippets' keywords' because, following the removal of the sidebar's search, these are no longer necessary.

task-4063510


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
