### PR TITLE
[FIX] account: payment state

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -400,7 +400,7 @@ class AccountPayment(models.Model):
             if not payment.state:
                 payment.state = 'draft'
             if (
-                not payment.move_id
+                not payment.outstanding_account_id
                 and payment.invoice_ids
                 and all(invoice.payment_state == 'paid' for invoice in payment.invoice_ids)
             ):

--- a/addons/account_check_printing/views/account_payment_views.xml
+++ b/addons/account_check_printing/views/account_payment_views.xml
@@ -19,7 +19,7 @@
                     <field name="check_number" invisible="not show_check_number"/>
                 </xpath>
                 <xpath expr="//field[@name='name']" position='before'>
-                    <widget name="web_ribbon" title="Sent" invisible="not is_sent"/>
+                    <widget name="web_ribbon" title="Sent" invisible="not is_sent or state in ('rejected', 'canceled')"/>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
The matched state of the payment should be marked as reconciled when the payment is paid in the case there is no journal entry for the payment. Otherwise keep the states depending on the reconciliation.

