### PR TITLE
[FIX] html_editor: toolbar positioning for mobile

### DIFF
--- a/addons/html_editor/static/src/main/toolbar/mobile_toolbar.js
+++ b/addons/html_editor/static/src/main/toolbar/mobile_toolbar.js
@@ -11,6 +11,7 @@ export class ToolbarMobile extends Component {
     setup() {
         this.toolbar = useRef("toolbarWrapper");
         useExternalListener(window.visualViewport, "resize", this.fixToolbarPosition);
+        useExternalListener(window.visualViewport, "scroll", this.fixToolbarPosition);
         onMounted(() => {
             this.fixToolbarPosition();
         });
@@ -20,7 +21,8 @@ export class ToolbarMobile extends Component {
      * Fixes the position of the toolbar for the keyboard height.
      */
     fixToolbarPosition() {
-        const keyboardHeight = window.innerHeight - window.visualViewport.height;
+        const keyboardHeight =
+            window.innerHeight - (window.visualViewport.height + window.visualViewport.offsetTop);
         if (keyboardHeight > 0) {
             this.toolbar.el.style.bottom = `${keyboardHeight}px`;
         } else {


### PR DESCRIPTION
Current behavior before PR:

When the keyboard opens on mobile, the toolbar appears in the wrong position, leaving a space between the toolbar and the keyboard.

Desired behavior after PR is merged:

Now, when the keyboard opens on mobile, the toolbar will correctly stick to the top of the keyboard.

task:4196686
