### PR TITLE
[FIX] web: kanban sample records flicker on quick create

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -228,6 +228,9 @@ export class KanbanController extends Component {
                 await firstGroup.toggle();
             }
             this.quickCreateState.groupId = firstGroup.id;
+            if (!this.model.root.records.length) {
+                this.render(true);
+            }
         } else if (onCreate && onCreate !== "quick_create") {
             const options = {
                 additionalContext: root.context,


### PR DESCRIPTION
#### Issue:
When there are no records in pipeline and you create a new record with quick create for a moment sample data is displayed.

#### Technical:
When a record is created, from relational_model `load` method is called, which uses sample data in rendering because while creating a record we're not rendering the page thus 'load' method uses old data/config with sample data. 
[Reference Here](https://github.com/odoo/odoo/blob/17.0/addons/web/static/src/model/relational_model/relational_model.js#L189)

#### After this PR:
There will be no flickering sample data on quick create.

Task-4196741