### PR TITLE
[FIX] payment_xendit: unblock other payment method options in Xendit

### DIFF
--- a/addons/payment_xendit/models/payment_transaction.py
+++ b/addons/payment_xendit/models/payment_transaction.py
@@ -27,7 +27,7 @@ class PaymentTransaction(models.Model):
         :rtype: dict
         """
         res = super()._get_specific_rendering_values(processing_values)
-        if self.provider_code != 'xendit' or self.payment_method_code != 'card':
+        if self.provider_code != 'xendit' or self.payment_method_code == 'card':
             return res
 
         # Initiate the payment and retrieve the invoice data.


### PR DESCRIPTION
Currently, for other payment method options in xendit, the redirect flow will not be triggered. method `_get_specific_rendering_values` is supposed to return the API URL when the payment is not 'card'. Currently, it does the opposite, where it will only return the rendering_values when payment is in card (eventhough it won't be triggered when doing direct flow)

4212477

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
