### PR TITLE
[FIX] pos: disable the archived combination options

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -215,15 +215,32 @@ export class ProductProduct extends Base {
         if (!this._archived_combinations) {
             return false;
         }
+        const excludedPTAV = new Set();
+        let isCombinationArchived = false;
         for (const archivedCombination of this._archived_combinations) {
             const ptavCommon = archivedCombination.filter((ptav) =>
                 attributeValueIds.includes(ptav)
             );
             if (ptavCommon.length === attributeValueIds.length) {
-                return true;
+                // all attributes must be disabled from each other
+                archivedCombination.forEach((ptav) => excludedPTAV.add(ptav));
+            } else if (ptavCommon.length === attributeValueIds.length - 1) {
+                // In this case we only need to disable the remaining ptav
+                const disablePTAV = archivedCombination.find(
+                    (ptav) => !attributeValueIds.includes(ptav)
+                );
+                excludedPTAV.add(disablePTAV);
+            }
+            if (ptavCommon.length === attributeValueIds.length) {
+                isCombinationArchived = true;
             }
         }
-        return false;
+        this.attribute_line_ids.forEach((attribute_line) => {
+            attribute_line.product_template_value_ids.forEach((ptav) => {
+                ptav["excluded"] = excludedPTAV.has(ptav.id);
+            });
+        });
+        return isCombinationArchived;
     }
 }
 registry.category("pos_available_models").add(ProductProduct.pythonModel, ProductProduct);

--- a/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.js
@@ -90,6 +90,44 @@ export class ComboConfiguratorPopup extends Component {
         }
     }
 
+    getSelectedComboItems() {
+        const comboItems = this.props.product.combo_ids.flatMap(
+            (comboLine) => comboLine.combo_line_ids
+        );
+
+        return Object.values(this.state.combo)
+            .filter((x) => x) // we only keep the non-zero values
+            .map((x) => {
+                const combo_item_id = comboItems.find((comboItem) => comboItem.id == x);
+                return {
+                    combo_item_id: combo_item_id,
+                    configuration: this.state.configuration[combo_item_id.id],
+                };
+            });
+    }
+
+    isArchived(comboItem) {
+        const product = comboItem.product_id;
+        const archivedCombinations = product._archived_combinations;
+        if (!archivedCombinations) {
+            return false;
+        }
+
+        const productCombination = product.product_template_variant_value_ids.map(
+            (ptav) => ptav.id
+        );
+        return archivedCombinations.some(
+            (archivedCombination) =>
+                JSON.stringify(archivedCombination) === JSON.stringify(productCombination)
+        );
+    }
+
+    isArchivedProductSelected() {
+        return this.getSelectedComboItems().some((comboItem) =>
+            this.isArchived(comboItem.combo_item_id)
+        );
+    }
+
     confirm() {
         this.props.getPayload(this.getSelectedComboLines());
         this.props.close();

--- a/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.xml
@@ -2,11 +2,14 @@
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.ComboConfiguratorPopup">
         <Dialog title="props.product.display_name" contentClass="'combo-configurator-popup'">
+            <div t-if="isArchivedProductSelected()" class="alert alert-warning mt-3">
+                <span>This combination does not exist.</span>
+            </div>
             <div t-foreach="props.product.combo_ids" t-as="combo" t-key="combo.id" class="d-flex flex-column m-3 mb-4">
                 <t t-if="shouldShowCombo(combo)">
                     <h3 class="me-auto mb-3" t-esc="combo.name"/>
                     <div class="product-list d-grid gap-1">
-                        <div t-foreach="combo.combo_line_ids" t-as="combo_line" t-key="combo_line.id" class="m-2">
+                        <div t-foreach="combo.combo_line_ids" t-as="combo_line" t-key="combo_line.id" class="m-2" t-att-class="{'ptav-not-available' : isArchived(combo_line)}">
                             <t t-set="product" t-value="combo_line.product_id"/>
                             <input type="radio"
                                 t-attf-name="combo-{{combo.id}}"
@@ -30,11 +33,11 @@
             <t t-set-slot="footer">
                 <div class="d-flex w-100 justify-content-start gap-2">
                     <button class="confirm btn btn-lg btn-primary"
-                        t-att-disabled="!areAllCombosSelected()" t-on-click="confirm">
+                        t-att-disabled="!areAllCombosSelected() || isArchivedProductSelected()" t-on-click="confirm">
                         Add to order
                     </button>
                     <div class="ms-auto">
-                        <t t-if="!areAllCombosSelected">
+                        <t t-if="!areAllCombosSelected()">
                             Complete the selection to proceed
                         </t>
                     </div>

--- a/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.scss
+++ b/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.scss
@@ -1,0 +1,25 @@
+.configurator_color{
+    // This code is copied from the sale/static/src/js/product_template_attribute_line/product_template_attribute_line.scss
+    // since the POS does not directly depend on it.
+    // In the future, we should explore options to import the CSS directly to avoid duplication.
+    &.ptav-not-available {
+        opacity: 1;
+
+        &:after {
+            content: "";
+            @include o-position-absolute(-5px, -5px, -5px, -5px);
+            border: 2px solid map-get($theme-colors, 'danger');
+            border-radius: 50%;
+            background: str-replace(url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='39' height='39'><line y2='0' x2='39' y1='39' x1='0' style='stroke:#{map-get($theme-colors, 'danger')};stroke-width:2'/><line y2='1' x2='40' y1='40' x1='1' style='stroke:rgb(255,255,255);stroke-width:1'/></svg>"), "#", "%23") ;
+            background-position: center;
+            background-repeat: no-repeat;
+        }
+    }
+}
+.ptav-not-available{
+    opacity: .5;
+}
+option.ptav-not-available {
+    opacity: 1;
+    color: #ccc;
+}

--- a/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.xml
@@ -5,7 +5,7 @@
         <div class="configurator_radio" t-ref="root">
             <div class="d-flex flex-wrap gap-3">
                 <t t-foreach="values" t-as="value" t-key="value.id">
-                    <div class="attribute-name-cell form-check">
+                    <div class="attribute-name-cell form-check" t-att-class="{'ptav-not-available': value.excluded}">
                         <input class="form-check-input radio-check" type="radio" t-model="state.attribute_value_ids" t-att-name="value.attribute_id.id"
                                 t-attf-id="{{ value.attribute_id.id }}_{{ value.id }}" t-att-value="value.id"/>
                         <span t-esc="value.name"/>
@@ -27,7 +27,7 @@
         <div class="configurator_radio" t-ref="root">
             <div class="d-flex flex-wrap gap-2">
                 <t t-foreach="values" t-as="value" t-key="value.id">
-                    <div class="attribute-name-cell">
+                    <div class="attribute-name-cell" t-att-class="{'ptav-not-available': value.excluded}">
                         <input class="form-check-input d-none" type="radio" t-model="state.attribute_value_ids" t-att-name="value.attribute_id.id"
                             t-attf-id="{{ value.attribute_id.id }}_{{ value.id }}" t-att-value="value.id"/>
                         <label
@@ -55,7 +55,7 @@
             <t t-set="is_custom" t-value="false"/>
 
             <select class="configurator_select form-select form-select-md" t-model="state.attribute_value_ids">
-                <option t-foreach="values" t-as="value" t-key="value.id" t-att-value="value.id">
+                <option t-foreach="values" t-as="value" t-key="value.id" t-att-value="value.id" t-att-class="{'ptav-not-available': value.excluded}">
                     <t t-set="is_custom" t-value="is_custom || (value.is_custom and value.id == state.attribute_value_ids)"/>
                     <t t-esc="value.name"/>
                     <t t-if="value.price_extra">
@@ -78,11 +78,12 @@
                     <t t-set="img_style" t-value="value.image ? 'background:url(/web/image/product.template.attribute.value/' + value.id + '/image); background-size:cover;' : ''"/>
                     <t t-set="color_style" t-value="value.is_custom ? '' : 'background-color: ' + value.html_color" />
                     <span class="d-flex flex-row justify-content-center align-items-center">
-                        <label t-attf-class="configurator_color rounded-circle border {{ value.id == state.attribute_value_ids ? 'active border-3 border-primary' : 'border-3 border-secondary' }}"
+                        <label t-attf-class="configurator_color rounded-circle border position-relative {{ value.id == state.attribute_value_ids ? 'active border-3 border-primary' : 'border-3 border-secondary' }}"
+                            t-att-class="{'ptav-not-available' : value.excluded}"
                             t-attf-style="{{ img_style or color_style }}" t-att-data-color="value.name">
                             <input class="m-2 opacity-0" type="radio" t-model="state.attribute_value_ids" t-att-value="value.id" t-att-name="value.attribute_id.id"/>
                         </label>
-                        <div t-if="value.price_extra" class="price-extra-cell d-inline-block ms-2">
+                        <div t-if="value.price_extra" class="price-extra-cell d-inline-block ms-2" t-att-class="{'ptav-not-available' : value.excluded}">
                             <span class="price_extra px-2 py-1 rounded-pill text-bg-info">
                                 <t t-esc="getFormatPriceExtra(value.price_extra)"/>
                             </span>
@@ -123,7 +124,7 @@
         <Dialog title="'Attribute selection'">
             <div t-ref="input-area">
                 <div t-if="isArchivedCombination()" class="alert alert-warning mt-3">
-                    <span>This option or combination of options is not available</span>
+                    <span>This combination does not exist.</span>
                 </div>
                 <div t-foreach="this.props.product.attribute_line_ids" t-as="attributeLine" t-key="attributeLine.id" class="attribute mb-3">
                     <div class="attribute_name mb-2 fw-bolder" t-esc="attributeLine.attribute_id.name"/>

--- a/addons/point_of_sale/static/tests/tours/pos_combo_tour.js
+++ b/addons/point_of_sale/static/tests/tours/pos_combo_tour.js
@@ -26,10 +26,17 @@ registry.category("web_tour.tours").add("PosComboPriceTaxIncludedTour", {
                 content: "check that amount is properly displayed when it is not 0",
                 trigger: `article.product .product-content .product-name:contains("Combo Product 3") ~.price-tag:contains("2.60")`,
             },
+            {
+                content: "Check that Combo Product 10 (White) archived variant is disabled",
+                trigger: `.ptav-not-available article.product .product-content .product-name:contains("Combo Product 10 (White)")`,
+            },
             combo.isConfirmationButtonDisabled(),
             combo.select("Combo Product 5"),
             combo.select("Combo Product 7"),
             combo.isSelected("Combo Product 7"),
+            // Check archived variant Selection
+            combo.select("Combo Product 10 (White)"),
+            combo.isConfirmationButtonDisabled(),
             combo.select("Combo Product 8"),
             combo.isSelected("Combo Product 8"),
             combo.isNotSelected("Combo Product 7"),

--- a/addons/point_of_sale/tests/common_setup_methods.py
+++ b/addons/point_of_sale/tests/common_setup_methods.py
@@ -198,6 +198,30 @@ def setup_pos_combo_items(self):
         'value_ids': [(6, 0, [chair_color_red.id, chair_color_blue.id])]
     })
 
+    color_attribute = self.env['product.attribute'].create({
+        'name': 'Color always',
+        'sequence': 4,
+        'create_variant': 'always',
+        'value_ids': [(0, 0, {
+            'name': 'White',
+            'sequence': 1,
+        }), (0, 0, {
+            'name': 'Red',
+            'sequence': 2,
+        })],
+    })
+
+    product_10_template = self.env['product.template'].create({
+        'name': 'Combo Product 10',
+        'list_price': 200,
+        'taxes_id': False,
+        'available_in_pos': True,
+        'attribute_line_ids': [(0, 0, {
+            'attribute_id': color_attribute.id,
+            'value_ids': [(6, 0, color_attribute.value_ids.ids)]
+        })],
+    })
+
     product_6_combo_line = self.env["pos.combo.line"].create(
         {
             "product_id": combo_product_6.id,
@@ -225,6 +249,20 @@ def setup_pos_combo_items(self):
             "combo_price": 5,
         }
     )
+    product_10_combo_line_1 = self.env["pos.combo.line"].create(
+        {
+            "product_id": product_10_template.product_variant_ids[0].id,
+            "combo_price": 2,
+        }
+    )
+    product_10_combo_line_2 = self.env["pos.combo.line"].create(
+        {
+            "product_id": product_10_template.product_variant_ids[1].id,
+            "combo_price": 2,
+        }
+    )
+    # Archive one variant
+    product_10_template.product_variant_ids[0].write({'active': False})
 
     self.chairs_combo = self.env["pos.combo"].create(
         {
@@ -238,6 +276,8 @@ def setup_pos_combo_items(self):
                         product_7_combo_line.id,
                         product_8_combo_line.id,
                         product_9_combo_line.id,
+                        product_10_combo_line_1.id,
+                        product_10_combo_line_2.id,
                     ],
                 )
             ],

--- a/addons/pos_self_order/static/src/app/components/combo_selection/combo_selection.xml
+++ b/addons/pos_self_order/static/src/app/components/combo_selection/combo_selection.xml
@@ -5,7 +5,7 @@
             <h2 class="attribute_name mb-5 mb-md-3"><small class="text-muted">Choose your</small> <strong t-esc="props.combo.name" /></h2>
             <div class="combo-list align-items-center justify-content-start">
                 <div class="combo-list-products o-so-products-row">
-                    <t t-foreach="props.combo.combo_line_ids" t-as="line" t-key="line.id">
+                    <t t-foreach="props.combo.combo_line_ids" t-as="line" t-key="line.id" t-if="line.product_id">
                         <t t-set="product" t-value="line.product_id"/>
                         <t t-set="isOutOfStock" t-value="!product.self_order_available"/>
                         <article


### PR DESCRIPTION
before this commit:
==============
- The configuration popup did not indicate which combinations were unavailable.
- Able to select archived products in combo configuration popup.
![pos_before](https://github.com/user-attachments/assets/3ef746e2-e62b-4f06-b653-ebb18118f985)

after this commit:
==============
- Disabled attribute values that are part of archived combinations in the
  product configuration popup.
- Disabled archived products in the combo configuration popup.
- Restricted the creation of combo product if any selected products are archived
![pos_after](https://github.com/user-attachments/assets/af060bdd-0ecf-4829-ae29-95fbb27ab650)

Task - 4231315
