### PR TITLE
[FIX] web: Allow users to change reports font size

### DIFF
--- a/addons/web/static/src/webclient/actions/reports/report.scss
+++ b/addons/web/static/src/webclient/actions/reports/report.scss
@@ -269,3 +269,44 @@ li.oe-nested {
         display: inline-block;
     }
 }
+
+// Override html_editor display styles as it uses 'calc' which doesn't work with wkhtmltopdf
+.display-1-fs {
+    font-size: 6rem;
+}
+
+.display-2-fs {
+    font-size: 5.5rem;
+}
+
+.display-3-fs {
+    font-size: 4.5rem;
+}
+
+.display-4-fs {
+    font-size: 3.5rem;
+}
+
+.h1-fs {
+    font-size: 2.5rem;
+}
+
+.h2-fs {
+    font-size: 2rem;
+}
+
+.h3-fs {
+    font-size: 1.75rem;
+}
+
+.h4-fs {
+    font-size: 1.5rem;
+}
+
+.h5-fs {
+    font-size: 1.25rem;
+}
+
+.h6-fs {
+    font-size: 1rem;
+}


### PR DESCRIPTION
Steps:
    - Install `web_studio`
    - Open studio
    - Go to Reports
    - Create or edit an existing report
    - Add some text and try to change its size
    - Preview will display the right size but printed
        pdf ignores it

`wkhtmltopdf` uses an old version of Webkit which doesn't support CSS3. Since 17.0 we use the new html_editor in our report editor but it uses `display-x-fs` (x is an int from 1 to 4).

```css
.display-2-fs {
  font-size: calc(1.575rem + 3.9vw);
}
```

The problem with this class is the 'calc', which is not supported by the old Webkit version.

see https://github.com/odoo/odoo/issues/136360
https://github.com/wkhtmltopdf/wkhtmltopdf/issues/4092

One solution would be to use the old (hardcoded) bootstrap 4 values in the reports.

opw-3894005