### PR TITLE
[FIX] website: adapt arrow anchors of `s_image_gallery`

### DIFF
--- a/addons/website/views/snippets/s_image_gallery.xml
+++ b/addons/website/views/snippets/s_image_gallery.xml
@@ -17,7 +17,7 @@
                     </div>
                 </div>
                 <div class="o_carousel_controllers">
-                    <button class="carousel-control-prev o_not_editable" contenteditable="false" t-attf-data-bs-target="#myCarousel{{uniq}}" data-bs-slide="prev" aria-label="Previous" title="Previous">
+                    <button class="carousel-control-prev o_not_editable" contenteditable="false" t-attf-data-bs-target="#slideshow_sample" data-bs-slide="prev" aria-label="Previous" title="Previous">
                         <span class="carousel-control-prev-icon" aria-hidden="true"/>
                         <span class="visually-hidden">Previous</span>
                     </button>
@@ -26,7 +26,7 @@
                         <button type="button" style="background-image: url(/web/image/website.library_image_03)" data-bs-target="#slideshow_sample" data-bs-slide-to="1"/>
                         <button type="button" style="background-image: url(/web/image/website.library_image_02)" data-bs-target="#slideshow_sample" data-bs-slide-to="2"/>
                     </div>
-                    <button class="carousel-control-next o_not_editable" contenteditable="false" t-attf-data-bs-target="#myCarousel{{uniq}}" data-bs-slide="next" aria-label="Next" title="Next">
+                    <button class="carousel-control-next o_not_editable" contenteditable="false" t-attf-data-bs-target="#slideshow_sample" data-bs-slide="next" aria-label="Next" title="Next">
                         <span class="carousel-control-next-icon" aria-hidden="true"/>
                         <span class="visually-hidden">Next</span>
                     </button>


### PR DESCRIPTION
Since the redesign of `s_image_gallery` in commit 9042b1cae7b630b20e0670788b7a4ed9e4c97609, the arrow anchors has been changed and no longer work in slideshows that are in page templates.

To fix this issue, this commit reintroduces the previous ID.

task-4215411



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
