### PR TITLE
[FIX] website_sale: undefined el in product accordion

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -718,6 +718,8 @@ publicWidget.registry.WebsiteSaleAccordionProduct = publicWidget.Widget.extend({
      */
     _updateAccordionActiveItem() {
         const firstAccordionItemEl = this.el.querySelector('.accordion-item');
+        if (!firstAccordionItemEl) return;
+
         const firstAccordionItemButtonEl = firstAccordionItemEl.querySelector('.accordion-button');
         firstAccordionItemButtonEl.classList.remove('collapsed');
         firstAccordionItemButtonEl.setAttribute('aria-expanded', 'true');

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1447,8 +1447,9 @@
             class="o_accordion_not_initialized accordion accordion-flush my-4"
         >
             <div
+                t-if="is_view_active('website_sale.accordion_more_information')"
                 id="more_information_accordion_item"
-                t-attf-class="accordion-item {{not is_view_active('website_sale.accordion_more_information') and 'border-bottom-0'}}"
+                class="accordion-item"
             />
         </div>
     </template>


### PR DESCRIPTION
Issue: when the product specifications are empty, the `#product_accordion` exists without an `.accordion-item` which fails the `._updateAccordionActiveItem` function.

follow-up of task-3987039
task-4215477




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
