### PR TITLE
[FIX] website: check cookies consent before YouTube mobile autoplay

### DIFF
--- a/addons/website/static/src/js/content/snippets.animation.js
+++ b/addons/website/static/src/js/content/snippets.animation.js
@@ -718,7 +718,7 @@ const MobileYoutubeAutoplayMixin = {
         this.isYoutubeVideo = src.indexOf('youtube') >= 0;
         this.isMobileEnv = uiUtils.getSize() <= SIZES.LG && hasTouch();
 
-        if (this.isYoutubeVideo && this.isMobileEnv && !window.YT) {
+        if (this.isYoutubeVideo && this.isMobileEnv && !window.YT && !this.el.dataset.needCookiesApproval) {
             const oldOnYoutubeIframeAPIReady = window.onYouTubeIframeAPIReady;
             promise = new Promise(resolve => {
                 window.onYouTubeIframeAPIReady = () => {
@@ -740,7 +740,7 @@ const MobileYoutubeAutoplayMixin = {
     _triggerAutoplay: function (iframeEl) {
         // YouTube does not allow to auto-play video in mobile devices, so we
         // have to play the video manually.
-        if (this.isMobileEnv && this.isYoutubeVideo) {
+        if (this.isMobileEnv && this.isYoutubeVideo && !this.el.dataset.needCookiesApproval) {
             new window.YT.Player(iframeEl, {
                 events: {
                     onReady: ev => ev.target.playVideo(),


### PR DESCRIPTION
Commit [958b41c4] added support to block third-party cookies, but some flows on mobile did not work properly.

Steps to reproduce (on Chrome):
- Enable the Cookies Bar in the settings and check "Block tracking 3rd-party services"
- Add a Cover block (or another block)
- Set a YouTube video as background of the block
- Open an incognito window
- Resize it so that it displays the page in the mobile version
- Refresh the page => AssetsLoadingError: The loading of https://www.youtube.com/iframe_api failed

[958b41c4]: https://github.com/odoo/odoo/commit/958b41c4acec7e1700ca4d6e0b25ee0ad2aac9f1

opw-4202306