### PR TITLE
18.0 external dependencies v2 xdo

### DIFF
--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -6,14 +6,16 @@ import collections.abc
 import copy
 import functools
 import importlib
+import importlib.metadata
 import logging
 import os
-import pkg_resources
 import re
 import sys
 import traceback
 import warnings
 from os.path import join as opj, normpath
+
+from packaging.requirements import InvalidRequirement, Requirement
 
 import odoo
 import odoo.tools as tools
@@ -455,21 +457,23 @@ current_test = False
 
 def check_python_external_dependency(pydep):
     try:
-        pkg_resources.get_distribution(pydep)
-    except pkg_resources.DistributionNotFound as e:
-        try:
-            importlib.import_module(pydep)
-            _logger.info("python external dependency on '%s' does not appear to be a valid PyPI package. Using a PyPI package name is recommended.", pydep)
-        except ImportError:
-            # backward compatibility attempt failed
-            _logger.warning("DistributionNotFound: %s", e)
-            raise Exception('Python library not installed: %s' % (pydep,))
-    except pkg_resources.VersionConflict as e:
-        _logger.warning("VersionConflict: %s", e)
-        raise Exception('Python library version conflict: %s' % (pydep,))
-    except Exception as e:
-        _logger.warning("get_distribution(%s) failed: %s", pydep, e)
-        raise Exception('Error finding python library %s' % (pydep,))
+        requirement = Requirement(pydep)
+    except InvalidRequirement as e:
+        msg = f"{pydep} is an invalid external dependency specification: {e}"
+        raise Exception(msg) from e
+    if requirement.marker and not requirement.marker.evaluate():
+        _logger.debug(
+            "Ignored external dependency %s because environment markers do not match",
+            pydep
+        )
+    try:
+        version = importlib.metadata.version(requirement.name)
+    except importlib.metadata.PackageNotFoundError as e:
+        msg = f"External dependency {pydep} not installed: {e}"
+        raise Exception(msg) from e
+    if requirement.specifier and not requirement.specifier.contains(version):
+        msg = f"External dependency version mismatch: {pydep} (installed: {version})"
+        raise Exception(msg)
 
 
 def check_manifest_dependencies(manifest):

--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -197,6 +197,13 @@ def init_logger():
     # need to be adapted later but too muchwork for this pr.
     warnings.filterwarnings('ignore', r'^datetime.datetime.utcnow\(\) is deprecated and scheduled for removal in a future version.*', category=DeprecationWarning)
 
+    # pkg_ressouce is used in google-auth < 1.23.0 (removed in https://github.com/googleapis/google-auth-library-python/pull/596)
+    # unfortunately, in ubuntu jammy and noble, the google-auth version is 1.5.1
+    # starting from noble, the default pkg_ressource version emits a warning on import, triggered when importing
+    # google-auth
+    warnings.filterwarnings('ignore', r'pkg_resources is deprecated as an API.+', category=DeprecationWarning)
+    warnings.filterwarnings('ignore', r'Deprecated call to \`pkg_resources.declare_namespace.+', category=DeprecationWarning)
+
     from .tools.translate import resetlocale
     resetlocale()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,7 @@ num2words==0.5.13 ; python_version >= '3.12'
 ofxparse==0.21
 openpyxl==3.0.9 ; python_version < '3.12'
 openpyxl==3.1.2 ; python_version >= '3.12'
+packaging==24.0
 passlib==1.7.4 # min version = 1.7.2 (Focal with security backports)
 Pillow==9.0.1 ; python_version <= '3.10'
 Pillow==9.4.0 ; python_version > '3.10' and python_version < '3.12'

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,6 @@ num2words==0.5.13 ; python_version >= '3.12'
 ofxparse==0.21
 openpyxl==3.0.9 ; python_version < '3.12'
 openpyxl==3.1.2 ; python_version >= '3.12'
-packaging==24.0
 passlib==1.7.4 # min version = 1.7.2 (Focal with security backports)
 Pillow==9.0.1 ; python_version <= '3.10'
 Pillow==9.4.0 ; python_version > '3.10' and python_version < '3.12'

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(
         'num2words',
         'ofxparse',
         'openpyxl',
-        'packaging',
         'passlib',
         'pillow',  # windows binary http://www.lfd.uci.edu/~gohlke/pythonlibs/
         'polib',

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'num2words',
         'ofxparse',
         'openpyxl',
+        'packaging',
         'passlib',
         'pillow',  # windows binary http://www.lfd.uci.edu/~gohlke/pythonlibs/
         'polib',


### PR DESCRIPTION
This is a followup pr to #174951

This pr is a combined work  from @sbidoul who proposed an alternative to pkg_ressource using packaging, removing dependency on pkg_ressource (witch is excellent)

Unfortunately, we don't want to add a requirement on packaging since it is not needed to run odoo by default. It should be only useful when defining a "complex" external dependency (with version or markers)

This pr proposes to replace` packaging.Requirement` by a simple replacement, that would work for basic external_dependencies. (no version or marker)

Note that another change was made to the original proposal to continue to support module name dependency (ex: PIL instead of Pillow, the distribution package name) but will log a warning in this case instead of the previous info. Still to discuss if we need to  keep it.

Note that a first version (see 4e9e5924f7254b470397b61573b7c634c654d61c) was trying to combine both logic in `check_python_external_dependency` but some code needed to be duplicated and a version proposing a similar api to Requirements allows a smaller change to the original pr. 

