### PR TITLE
[FIX] account: no sequence number on draft moves

### DIFF
--- a/addons/account/wizard/account_automatic_entry_wizard.py
+++ b/addons/account/wizard/account_automatic_entry_wizard.py
@@ -241,6 +241,7 @@ class AutomaticEntryWizard(models.TransientModel):
         return [{
             'currency_id': self.journal_id.currency_id.id or self.journal_id.company_id.currency_id.id,
             'move_type': 'entry',
+            'name': '/',
             'journal_id': self.journal_id.id,
             'company_id': lowest_child_company.id,
             'date': fields.Date.to_string(self.date),

--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -226,6 +226,7 @@ class AccruedExpenseRevenue(models.TransientModel):
         move_type = _('Expense') if is_purchase else _('Revenue')
         move_vals = {
             'ref': _('Accrued %s entry as of %s', move_type, format_date(self.env, self.date)),
+            'name': '/',
             'journal_id': self.journal_id.id,
             'date': self.date,
             'line_ids': move_lines,
@@ -243,6 +244,7 @@ class AccruedExpenseRevenue(models.TransientModel):
         move._post()
         reverse_move = move._reverse_moves(default_values_list=[{
             'ref': _('Reversal of: %s', move.ref),
+            'name': '/',
             'date': self.reversal_date,
         }])
         reverse_move._post()


### PR DESCRIPTION
When automatic entries are generated, a sequence number should not be assigned on them as long as they are on draft state. This is done because it may be confusing to see a sequenced name for a move in draft. This commit ensures that the name of the entries is 'Draft' (or '/') when the move is generated. A sequence number will be assigned once the move is posted. Before this commit, it was possible to generate a draft move with a sequence number when doing an automatic transfer in the future or with accrued orders.

task-4069862

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
