### PR TITLE
[FIX] product: hide kanban images if empty

### DIFF
--- a/addons/product/views/product_template_views.xml
+++ b/addons/product/views/product_template_views.xml
@@ -115,7 +115,13 @@
                             <field name="product_properties" widget="properties"/>
                         </main>
                         <aside>
-                            <field name="image_128" widget="image" alt="Product" options="{'img_class': 'w-100 object-fit-contain'}"/>
+                            <field
+                                name="image_128"
+                                widget="image"
+                                alt="Product"
+                                options="{'img_class': 'w-100 object-fit-contain'}"
+                                invisible="not image_128"
+                            />
                         </aside>
                     </t>
                 </templates>


### PR DESCRIPTION
Previously done in commit 683deecb51e240c5cbf1fd369e0eeefb0267530d but reverted in the refactor done in commit 0279c53930735b65e9342ca66fbb62ff61ac65f6

Objective: hide placeholder images if no image is provided on product


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
