### PR TITLE
[FIX] account: draft and delete payment

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -827,8 +827,7 @@ class AccountPayment(models.Model):
                 and payment.outstanding_account_id
             ):
                 raise ValidationError(_("A payment with an outstanding account cannot be confirmed without having a journal entry."))
-            if payment.state == 'draft' and payment.move_id:
-                raise ValidationError(_("A payment cannot have a journal entry if it is not confirmed."))
+
     # -------------------------------------------------------------------------
     # LOW-LEVEL METHODS
     # -------------------------------------------------------------------------
@@ -877,9 +876,16 @@ class AccountPayment(models.Model):
         if vals.get('state') == 'in_process' and not vals.get('move_id'):
             self.filtered(lambda p: not p.move_id)._generate_journal_entry()
             self.move_id.action_post()
-        return super().write(vals)
+
+        res = super().write(vals)
+        if self.move_id:
+            self._synchronize_to_moves(set(vals.keys()))
+        return res
 
     def unlink(self):
+        self.move_id.filtered(lambda m: m.state != 'draft').button_draft()
+        self.move_id.unlink()
+
         linked_invoices = self.invoice_ids
         res = super().unlink()
         self.env.add_to_compute(linked_invoices._fields['payment_state'], linked_invoices)
@@ -898,8 +904,57 @@ class AccountPayment(models.Model):
         })
 
     # -------------------------------------------------------------------------
-    # SYNCHRONIZATION account.payment <-> account.move
+    # SYNCHRONIZATION account.payment -> account.move
     # -------------------------------------------------------------------------
+
+    def _synchronize_to_moves(self, changed_fields):
+        '''
+            Update the account.move regarding the modified account.payment.
+            :param changed_fields: A list containing all modified fields on account.payment.
+        '''
+        if not any(field_name in changed_fields for field_name in self._get_trigger_fields_to_synchronize()):
+            return
+
+        for pay in self:
+            liquidity_lines, counterpart_lines, writeoff_lines = pay._seek_for_lines()
+            # Make sure to preserve the write-off amount.
+            # This allows to create a new payment with custom 'line_ids'.
+            write_off_line_vals = []
+            if liquidity_lines and counterpart_lines and writeoff_lines:
+                write_off_line_vals.append({
+                    'name': writeoff_lines[0].name,
+                    'account_id': writeoff_lines[0].account_id.id,
+                    'partner_id': writeoff_lines[0].partner_id.id,
+                    'currency_id': writeoff_lines[0].currency_id.id,
+                    'amount_currency': sum(writeoff_lines.mapped('amount_currency')),
+                    'balance': sum(writeoff_lines.mapped('balance')),
+                })
+            line_vals_list = pay._prepare_move_line_default_vals(write_off_line_vals=write_off_line_vals)
+            line_ids_commands = [
+                Command.update(liquidity_lines.id, line_vals_list[0]) if liquidity_lines else Command.create(line_vals_list[0]),
+                Command.update(counterpart_lines.id, line_vals_list[1]) if counterpart_lines else Command.create(line_vals_list[1])
+            ]
+            for line in writeoff_lines:
+                line_ids_commands.append((2, line.id))
+            for extra_line_vals in line_vals_list[2:]:
+                line_ids_commands.append((0, 0, extra_line_vals))
+            # Update the existing journal items.
+            # If dealing with multiple write-off lines, they are dropped and a new one is generated.
+            pay.move_id \
+                .with_context(skip_invoice_sync=True) \
+                .write({
+                'partner_id': pay.partner_id.id,
+                'currency_id': pay.currency_id.id,
+                'partner_bank_id': pay.partner_bank_id.id,
+                'line_ids': line_ids_commands,
+            })
+
+    @api.model
+    def _get_trigger_fields_to_synchronize(self):
+        return (
+            'date', 'amount', 'payment_type', 'partner_type', 'payment_reference',
+            'currency_id', 'partner_id', 'destination_account_id', 'partner_bank_id', 'journal_id'
+        )
 
     def _generate_journal_entry(self, write_off_line_vals=None, force_balance=None, line_ids=None):
         need_move = self.filtered(lambda p: not p.move_id and p.outstanding_account_id)
@@ -983,6 +1038,7 @@ class AccountPayment(models.Model):
 
     def action_draft(self):
         self.state = 'draft'
+        self.move_id.button_draft()
 
     def button_open_invoices(self):
         ''' Redirect the user to the invoice(s) paid by this payment.

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -211,17 +211,16 @@ class TestExpenses(TestExpenseCommon):
             (self.analytic_account_1 | self.analytic_account_2).unlink()
 
         # Unlinking moves
-        (payment_1 | payment_2).move_id.button_draft()
+        (payment_1 | payment_2).action_draft()
         self.assertRecordValues(expense_sheet_by_employee, [{'payment_state': 'not_paid', 'state': 'post'}])
         expense_sheet_by_employee.account_move_ids.button_draft()
         expense_sheet_by_employee.account_move_ids.unlink()
+        self.assertFalse(expense_sheet_by_employee.account_move_ids)
 
         with self.assertRaises(UserError, msg="For company-paid expenses report, deleting payments is an all-or-nothing situation"):
-            expense_sheet_by_company.account_move_ids[:-1].button_draft()
-            expense_sheet_by_company.account_move_ids[:-1].unlink()
+            expense_sheet_by_company.account_move_ids[:-1].origin_payment_id.unlink()
         expense_sheet_by_company.account_move_ids.origin_payment_id.unlink()
-        expense_sheet_by_company.account_move_ids.button_draft()
-        expense_sheet_by_company.account_move_ids.unlink()
+        self.assertFalse(expense_sheet_by_company.account_move_ids)
 
         self.assertRecordValues(expense_sheets.sorted('payment_mode'), [
             {'payment_mode': 'company_account', 'state': 'approve', 'payment_state': 'not_paid', 'account_move_ids': []},


### PR DESCRIPTION
Reset to Draft and Payment deletion should impact the linked Journal Entry as
well, or we'll just leave a bunch of created entries that will be lost in
Accounting.

Reset it to draft => Reset to Draft the Journal entry as well, no error message.
Delete the payment => Delete the Journal entry

We also revert the suppression of the synchronisation of the payment to move.
And in the _get_trigger_fields_to_synchronize we remove is_internal_transfer
since the field is no longer there.
(https://github.com/odoo/odoo/commit/01b87f1230beac0568f4e3b1b76e547909506892)

task: https://github.com/odoo-dev/odoo/commit/4215217583c566cc5188d71dcbbd7b1cd860b3ae




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
