### PR TITLE
[FIX] mail: crash when folding sidebar category with portal

### DIFF
--- a/addons/mail/static/src/core/public_web/discuss_app_category_model.js
+++ b/addons/mail/static/src/core/public_web/discuss_app_category_model.js
@@ -75,7 +75,7 @@ export class DiscussAppCategory extends Record {
     }
 
     get saveStateToServer() {
-        return this.serverStateKey && this.store.self?.type === "partner";
+        return this.serverStateKey && this.store.self?.isInternalUser;
     }
 
     set open(value) {


### PR DESCRIPTION
The discuss sidebar was recently added to the public page. The state of the sidebar (folded categories) is saved for internal users. Guests and portal users do not have the rights to do this. However, it was only disabled for guests. As a result, folding a category as a portal user would lead to a crash. This PR fixes this issue.
