### PR TITLE
[FIX] account_edi_ubl_cii,*: Line/Description full value

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -224,7 +224,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         if self._context.get('convert_fixed_taxes'):
             taxes = taxes.filtered(lambda t: t.amount_type != 'fixed')
         tax_category_vals_list = self._get_tax_category_list(line.move_id, taxes)
-        description = (line.product_id.display_name and line.product_id.display_name.replace('\n', ', ')) or (line.name and line.name.replace('\n', ', '))
+        description = line.name and line.name.replace('\n', ', ')
         return {
             'description': description,
             'name': product.name or description,

--- a/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice.xml
+++ b/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice.xml
@@ -130,7 +130,7 @@
     <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
     <cbc:LineExtensionAmount currencyID="RON">500.00</cbc:LineExtensionAmount>
     <cac:Item>
-      <cbc:Description>product_a</cbc:Description>
+      <cbc:Description>Test Product A</cbc:Description>
       <cbc:Name>product_a</cbc:Name>
       <cac:ClassifiedTaxCategory>
         <cbc:ID>S</cbc:ID>
@@ -149,7 +149,7 @@
     <cbc:InvoicedQuantity unitCode="DZN">1.0</cbc:InvoicedQuantity>
     <cbc:LineExtensionAmount currencyID="RON">1000.00</cbc:LineExtensionAmount>
     <cac:Item>
-      <cbc:Description>product_b</cbc:Description>
+      <cbc:Description>Test Product B</cbc:Description>
       <cbc:Name>product_b</cbc:Name>
       <cac:ClassifiedTaxCategory>
         <cbc:ID>S</cbc:ID>

--- a/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice_different_currency.xml
+++ b/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice_different_currency.xml
@@ -133,7 +133,7 @@
     <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
     <cbc:LineExtensionAmount currencyID="USD">500.00</cbc:LineExtensionAmount>
     <cac:Item>
-      <cbc:Description>product_a</cbc:Description>
+      <cbc:Description>Test Product A</cbc:Description>
       <cbc:Name>product_a</cbc:Name>
       <cac:ClassifiedTaxCategory>
         <cbc:ID>S</cbc:ID>
@@ -152,7 +152,7 @@
     <cbc:InvoicedQuantity unitCode="DZN">1.0</cbc:InvoicedQuantity>
     <cbc:LineExtensionAmount currencyID="USD">1000.00</cbc:LineExtensionAmount>
     <cac:Item>
-      <cbc:Description>product_b</cbc:Description>
+      <cbc:Description>Test Product B</cbc:Description>
       <cbc:Name>product_b</cbc:Name>
       <cac:ClassifiedTaxCategory>
         <cbc:ID>S</cbc:ID>

--- a/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice_no_prefix_vat.xml
+++ b/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice_no_prefix_vat.xml
@@ -130,7 +130,7 @@
     <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
     <cbc:LineExtensionAmount currencyID="RON">500.00</cbc:LineExtensionAmount>
     <cac:Item>
-      <cbc:Description>product_a</cbc:Description>
+      <cbc:Description>Test Product A</cbc:Description>
       <cbc:Name>product_a</cbc:Name>
       <cac:ClassifiedTaxCategory>
         <cbc:ID>S</cbc:ID>
@@ -149,7 +149,7 @@
     <cbc:InvoicedQuantity unitCode="DZN">1.0</cbc:InvoicedQuantity>
     <cbc:LineExtensionAmount currencyID="RON">1000.00</cbc:LineExtensionAmount>
     <cac:Item>
-      <cbc:Description>product_b</cbc:Description>
+      <cbc:Description>Test Product B</cbc:Description>
       <cbc:Name>product_b</cbc:Name>
       <cac:ClassifiedTaxCategory>
         <cbc:ID>S</cbc:ID>

--- a/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_refund.xml
+++ b/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_refund.xml
@@ -130,7 +130,7 @@
     <cbc:CreditedQuantity unitCode="C62">1.0</cbc:CreditedQuantity>
     <cbc:LineExtensionAmount currencyID="RON">500.00</cbc:LineExtensionAmount>
     <cac:Item>
-      <cbc:Description>product_a</cbc:Description>
+      <cbc:Description>Test Product A</cbc:Description>
       <cbc:Name>product_a</cbc:Name>
       <cac:ClassifiedTaxCategory>
         <cbc:ID>S</cbc:ID>
@@ -149,7 +149,7 @@
     <cbc:CreditedQuantity unitCode="DZN">1.0</cbc:CreditedQuantity>
     <cbc:LineExtensionAmount currencyID="RON">1000.00</cbc:LineExtensionAmount>
     <cac:Item>
-      <cbc:Description>product_b</cbc:Description>
+      <cbc:Description>Test Product B</cbc:Description>
       <cbc:Name>product_b</cbc:Name>
       <cac:ClassifiedTaxCategory>
         <cbc:ID>S</cbc:ID>

--- a/addons/l10n_ro_edi/tests/test_xml_ubl_ro.py
+++ b/addons/l10n_ro_edi/tests/test_xml_ubl_ro.py
@@ -62,11 +62,13 @@ class TestUBLRO(TestUBLCommon):
             move_type=move_type,
             invoice_line_ids=[
                 {
+                    'name': 'Test Product A',
                     'product_id': self.product_a.id,
                     'price_unit': 500.0,
                     'tax_ids': [Command.set(self.tax_19.ids)],
                 },
                 {
+                    'name': 'Test Product B',
                     'product_id': self.product_b.id,
                     'price_unit': 1000.0,
                     'tax_ids': [Command.set(self.tax_19.ids)],


### PR DESCRIPTION
*: l10n_ro_edi

When a user generate a UBL XML that inherits from ubl 2.0, the Item/Description xml node will only contain the information about the product name, without any description. This commit aims at restoring the behavior before saas-17.4 and gives the full description on that XML value.

To make sure it keeps this new behavior, a test was modified in l10n_ro_edi (the ticket origin) to make sure the Description display the `line.name`

The change was previously introduced in
https://github.com/odoo/odoo/commit/4f325ef620263c27e095eb49026a677ac617a0ee

Similar fix to l10n_es_edi_facturae for reference: https://github.com/odoo/odoo/pull/180315

opw-4213014