### PR TITLE
[FIX] website_sale: sign-in prompt hidden when disable option is selected

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2388,10 +2388,13 @@
                                     <t t-if="is_anonymous_cart">
                                         <div id="div_email_public" t-attf-class="col-lg-12">
                                             <label class="col-form-label" for="o_email">Email</label>
-                                            <div class="align-items-center float-end" style="margin-top: -11px">
+                                            <div
+                                                t-if="website.account_on_checkout != 'disabled'"
+                                                class="align-items-center float-end"
+                                                style="margin-top: -11px"
+                                            >
                                                 <span>Already have an account?</span>
                                                 <a
-                                                    t-if="account_on_checkout != 'disabled'"
                                                     role="button"
                                                     href='/web/login?redirect=/shop/checkout'
                                                     class="btn btn-primary"


### PR DESCRIPTION
Issue:
- When 'disabled' option is selected for Sign in/up at checkout, sign-in prompt is still showing on address page.

Fix:
- Updated the t-if condition to ensure that the sign-in prompt is no longer displayed when the 'disabled' option is selected.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
