### PR TITLE
[FIX] web_editor: correctly detect the state of selection with invisible characters

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -80,7 +80,8 @@ export const FONT_SIZE_CLASSES = ["display-1-fs", "display-2-fs", "display-3-fs"
  */
 export const TEXT_STYLE_CLASSES = ["display-1", "display-2", "display-3", "display-4", "lead", "o_small", "small"];
 
-export const ZERO_WIDTH_CHARS = ['\u200b', '\ufeff'];
+const ZWNBSP_CHAR = '\ufeff';
+export const ZERO_WIDTH_CHARS = ['\u200b', ZWNBSP_CHAR];
 export const ZERO_WIDTH_CHARS_REGEX = new RegExp(`[${ZERO_WIDTH_CHARS.join('')}]`, 'g');
 
 //------------------------------------------------------------------------------
@@ -1641,7 +1642,7 @@ export function hasClass(node, props) {
  */
 export function isSelectionFormat(editable, format) {
     const selectedNodes = getTraversedNodes(editable)
-        .filter(n => n.nodeType === Node.TEXT_NODE);
+        .filter((n) => n.nodeType === Node.TEXT_NODE && n.nodeValue.replaceAll(ZWNBSP_CHAR, '').length);
     const isFormatted = formatsSpecs[format].isFormatted;
     return selectedNodes.length && selectedNodes.every(n => isFormatted(n, editable));
 }

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/format.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/format.test.js
@@ -931,6 +931,14 @@ describe('Format', () => {
                 },
             });
         });
+        it('return true for isSelectionFormat selecting text nodes including invisible elements', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: `[<p>${strong("a")}\ufeff<p>${strong("b")}</p></p>]`,
+                stepFunction: async (editor) => {
+                    window.chai.expect(isSelectionFormat(editor.editable, 'bold')).to.be.equal(true);
+                },
+            });
+        });
     });
     describe('switchDirection', () => {
         it('should switch direction on a collapsed range', async () => {


### PR DESCRIPTION
Problem:
After [this commit](https://github.com/odoo/odoo/commit/59e252c715ba96af5ec66f9c543c2c6195082c7d), the editor fails to properly check the state of selections containing the character `\ufeff`. Since `\ufeff` has no style applied, any style check on a selection that includes this character returns `false`. While reverting the change would break support for styling elements containing only spaces, the fix involves checking if an element is a BOM character and assuming it is styled.

Steps to reproduce:
- Open any page with the web editor.
- Add text with part of it formatted as a link.
- Try toggling any style (e.g., bold, italic).
- The style is applied but cannot be reverted, and the button state remains off.

opw-4213717