### PR TITLE
[FIX] calendar: correct timezone for calendar activities

### DIFF
--- a/addons/calendar/models/res_users.py
+++ b/addons/calendar/models/res_users.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import datetime
@@ -37,15 +36,14 @@ class Users(models.Model):
         #   |           |
         #   |           | <--- `stop_dt_utc` = `stop_dt` if user lives in an area of West longitude (positive shift compared to UTC, America for example)
         #   |           |
-        now_utc = datetime.datetime.utcnow()
-        start_dt_utc = start_dt = now_utc.replace(tzinfo=UTC)
-        stop_dt_utc = datetime.datetime.combine(now_utc.date(), datetime.time.max).replace(tzinfo=UTC)
+        start_dt_utc = start_dt = datetime.datetime.now(UTC)
+        stop_dt_utc = UTC.localize(datetime.datetime.combine(start_dt.date(), datetime.time.max))
 
         tz = self.env.user.tz
         if tz:
             user_tz = timezone(tz)
             start_dt = start_dt_utc.astimezone(user_tz)
-            stop_dt = datetime.datetime.combine(start_dt.date(), datetime.time.max).replace(tzinfo=user_tz)
+            stop_dt = user_tz.localize(datetime.datetime.combine(start_dt.date(), datetime.time.max))
             stop_dt_utc = stop_dt.astimezone(UTC)
 
         start_date = start_dt.date()

--- a/addons/calendar/tests/test_event_notifications.py
+++ b/addons/calendar/tests/test_event_notifications.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from unittest.mock import patch
@@ -205,22 +204,28 @@ class TestEventNotifications(TransactionCase, MailCase, CronMixinCase):
             return self.env['calendar.event'].search(self.env['res.users']._systray_get_calendar_event_domain())
 
         self.env.user.tz = 'Europe/Brussels' # UTC +1 15th November 2023
-        event = self.env['calendar.event'].create({
+        events = self.env['calendar.event'].create([{
             'name': "Meeting",
             'start': datetime(2023, 11, 15, 18, 0), # 19:00
             'stop': datetime(2023, 11, 15, 19, 0),  # 20:00
-        }).with_context(mail_notrack=True)
+        },
+        {
+            'name': "Tomorrow meeting",
+            'start': datetime(2023, 11, 15, 23, 0),  # 00:00 next day
+            'stop': datetime(2023, 11, 16, 0, 0),  # 01:00 next day
+        }
+        ]).with_context(mail_notrack=True)
         with freeze_time('2023-11-15 17:30:00'):    # 18:30 before event
-            self.assertEqual(search_event(), event)
+            self.assertEqual(search_event(), events[0])
         with freeze_time('2023-11-15 18:00:00'):    # 19:00 during event
-            self.assertEqual(search_event(), event)
+            self.assertEqual(search_event(), events[0])
         with freeze_time('2023-11-15 18:30:00'):    # 19:30 during event
-            self.assertEqual(search_event(), event)
+            self.assertEqual(search_event(), events[0])
         with freeze_time('2023-11-15 19:00:00'):    # 20:00 during event
-            self.assertEqual(search_event(), event)
+            self.assertEqual(search_event(), events[0])
         with freeze_time('2023-11-15 19:30:00'):    # 20:30 after event
             self.assertEqual(len(search_event()), 0)
-        event.unlink()
+        events.unlink()
 
         self.env.user.tz = 'America/Lima' # UTC -5 15th November 2023
         event = self.env['calendar.event'].create({
@@ -248,3 +253,29 @@ class TestEventNotifications(TransactionCase, MailCase, CronMixinCase):
         with freeze_time('2023-11-15 19:00:00'):    # 14:00 the day before event
             self.assertEqual(len(search_event()), 0)
         event.unlink()
+
+        self.env.user.tz = 'Asia/Manila'  # UTC +8 15th November 2023
+        events = self.env['calendar.event'].create([{
+            'name': "Very early meeting",
+            'start': datetime(2023, 11, 14, 16, 30),  # 0:30
+            'stop': datetime(2023, 11, 14, 17, 0),  # 1:00
+        },
+        {
+            'name': "Meeting on 2 days",
+            'start': datetime(2023, 11, 15, 15, 30),  # 23:30
+            'stop': datetime(2023, 11, 15, 16, 30),  # 0:30 next day
+        },
+        {
+            'name': "Early meeting tomorrow",
+            'start': datetime(2023, 11, 15, 23, 0),  # 00:00 next day
+            'stop': datetime(2023, 11, 16, 0, 0),  # 01:00 next day
+        },
+        {
+            'name': "All day meeting",
+            'allday': True,
+            'start': "2023-11-15",
+        }
+        ]).with_context(mail_notrack=True)
+        with freeze_time('2023-11-15 16:00:00'):
+            self.assertEqual(len(search_event()), 3)
+        events.unlink()


### PR DESCRIPTION
Issue
-----
The activities from the calendar, which should be today's
meetings, are in some circumstances displaying meetings
from the next day.

Steps
-----
- Set the user timezone to "Asia/Manila".
- In Calendar, create a meeting early (before 18:00) the
next day.
- Check the activities (clock in the navbar), tomorrow's
meeting appears.

Cause
-----
`datetime.datetime` objects are not timezone aware, and using
the `replace` function on them will simply lead to a naive
conversion which causes potential issues.

Example:
```
import pytz
import datetime

dt = datetime.datetime(2024,1,1,0,0)
dt = dt.replace(tzinfo=pytz.timezone("Asia/Manila")).astimezone(pytz.UTC)
print(dt)
>>> 2024-01-01 15:56:00+00:00 # 1 day offset to expected result
```

Instead, it is better to use the pytz `localize` function.

opw-4142911
