### PR TITLE
[IMP] web: clarify m2m edit_tags option behavior

### DIFF
--- a/addons/web/static/src/core/tags_list/tags_list.xml
+++ b/addons/web/static/src/core/tags_list/tags_list.xml
@@ -8,6 +8,7 @@
                 t-att-class="{
                     'o_avatar opacity-trigger-hover' : tag.img,
                     'o_badge badge rounded-pill lh-1': !tag.img,
+                    'cursor-pointer': tag.canEdit,
                 }"
                 t-attf-class="{{ !tag.img ? 'o_tag_color_' + (tag.colorIndex ? tag.colorIndex : '0') : '' }}"
                 tabindex="-1"


### PR DESCRIPTION
This commit slightly changes the behavior of the m2m edit_tags option so that it will only be effective in form view (like tag color edition) and also so that it will override color edition when color_field is set. It also adds visual feedback with the pointer style when the edit_tags option is set.

task-3961350