### PR TITLE
[FIX] account: bank statement lock fix

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -17101,6 +17101,12 @@ msgstr ""
 
 #. module: account
 #. odoo-python
+#: code:addons/account/models/account_move_line.py:0
+msgid "You cannot delete journal items belonging to a locked journal entry."
+msgstr ""
+
+#. module: account
+#. odoo-python
 #: code:addons/account/models/account_account_tag.py:0
 msgid ""
 "You cannot delete this account tag (%s), it is used on the chart of account "

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1704,6 +1704,15 @@ class AccountMoveLine(models.Model):
                         "with the payment terms"
                     ))
 
+    @api.ondelete(at_uninstall=False)  # Hashed entres are legally required to not be deleted.
+    def _except_hashed_entry_lines(self):
+        """ Lines belonginig to a hashed (locked) entry should not be allowed to be deleted in order to protect the
+        hash chain.
+        """
+        for line in self:
+            if line.move_id.inalterable_hash:
+                raise UserError(_('You cannot delete journal items belonging to a locked journal entry.'))
+
     def unlink(self):
         if not self:
             return True


### PR DESCRIPTION
Some specific flows could lead to a break in the hash chain, due to a missing check that ensure no aml are deleted.

This check is added, as well as a nicer error message in the flow that would cause the issue to guide the user.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
