### PR TITLE
[FIX] stock: remember orderpoint horizon setting

### DIFF
--- a/addons/stock/static/src/views/search/stock_orderpoint_search_panel.js
+++ b/addons/stock/static/src/views/search/stock_orderpoint_search_panel.js
@@ -9,11 +9,13 @@ export class StockOrderpointSearchPanel extends SearchPanel {
 
     setup() {
         super.setup(...arguments);
-        this.globalVisibilityDays = useState({value: 0});
+        const storedVal = localStorage.getItem("stock.orderpoint_horizon")
+        this.globalVisibilityDays = useState({value: storedVal === null ? 0 : parseInt(storedVal)});
     }
 
     async applyGlobalVisibilityDays(ev) {
         this.globalVisibilityDays.value = Math.max(parseInt(ev.target.value), 0);
+        localStorage.setItem("stock.orderpoint_horizon", this.globalVisibilityDays.value.toString());
         await this.env.searchModel.applyGlobalVisibilityDays(this.globalVisibilityDays.value);
     }
 }


### PR DESCRIPTION
To reproduce:
- Open replenishment view
- Change horizon value in the panel to 5
- Open any other view and reopen replenishment view

Current behavior:
Horizon is reset back to 0.

Expected behavior:
Horizon will remember the last value (5 in this example).

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
