### PR TITLE
[FIX] pos_sale: due balance not correctly updated

### DIFF
--- a/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js
+++ b/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js
@@ -315,7 +315,7 @@ export class SaleOrderManagementScreen extends ControlButtonsMixin(Component) {
                         title: popupTitle,
                         subtitle: sprintf(
                             popupSubtitle,
-                            this.env.utils.formatCurrency(sale_order.amount_total)
+                            this.env.utils.formatCurrency(sale_order.amount_unpaid)
                         ),
                         inputSuffix: popupInputSuffix,
                         startingValue: 0,


### PR DESCRIPTION
Steps to reproduce :
====
- Install pos_sale module.
- Create a quotation in sales and confirm it.
- Open Point of Sale
- Open Session and load orders from session.
- Select the quotation and do 50% down payment.
- Create new order and again load the same quotation.
- Due balance remains same.

Issue:
====
- Due balance is not updated, everytime it shows total amount.

Fix :
====
- Instead of total amount , amount unpaid is displayed which show correct due balance.

task- 4204048
