### PR TITLE
[FIX] product: correctly populate product_variant_id of inactive template

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -179,7 +179,9 @@ class ProductTemplate(models.Model):
     @api.depends('product_variant_ids')
     def _compute_product_variant_id(self):
         for p in self:
-            p.product_variant_id = p.product_variant_ids[:1].id
+            # The active_test enables inactive product.templates to compute
+            # their (also inactive) product_variant_id correctly.
+            p.product_variant_id = p.with_context(active_test=p.active).product_variant_ids[:1].id
 
     @api.depends('company_id')
     def _compute_currency_id(self):

--- a/addons/product/tests/test_variants.py
+++ b/addons/product/tests/test_variants.py
@@ -78,6 +78,14 @@ class TestVariants(common.TestProductCommon):
         self.assertEqual({True}, set(v.is_product_variant for v in variants),
                          'Product variants are variants')
 
+    def test_variant_of_inactive_template(self):
+        template = self.env['product.template'].create({'name': 'Test Product'})
+        variants = template.product_variant_ids
+        template.active = False
+        for variant in variants:
+            self.assertFalse(variant.active)
+        self.assertEqual(template.product_variant_id, variants[0])
+
     def test_variants_creation_mono(self):
         test_template = self.env['product.template'].create({
             'name': 'Sofa',


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Previously, when calling `product_variant_id` on an inactive `product.template`, it would return an empty recordset.

The reason this is relevant, is because I had some code that used `product_variant_id` upon creation of a `product.template`. However, when a customer would clone an archived `product.template`, this code was wrongly executed.

Current behavior before PR:

Previously, when calling `product_variant_id` on an inactive `product.template`, it would return an empty recordset.

Desired behavior after PR is merged:

A populated recordset is returned.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
