### PR TITLE
[FIX] web: avoid using iframe coordinates for drag-and-drop

### DIFF
--- a/addons/web/static/src/core/utils/draggable_hook_builder.js
+++ b/addons/web/static/src/core/utils/draggable_hook_builder.js
@@ -523,7 +523,11 @@ export function makeDraggableHook(hookParams) {
 
                 dom.addClass(document.body, "pe-none", "user-select-none");
                 if (params.iframeWindow) {
-                    dom.addClass(params.iframeWindow.body, "pe-none", "user-select-none");
+                    for (const iframe of document.getElementsByTagName("iframe")) {
+                        if (iframe.contentWindow === params.iframeWindow) {
+                            dom.addClass(iframe, "pe-none", "user-select-none");
+                        }
+                    }
                 }
                 // FIXME: adding pe-none and cursor on the same element makes
                 // no sense as pe-none prevents the cursor to be displayed.


### PR DESCRIPTION
Steps to reproduce:
- Have a draggable that uses an iframe
- The iframe must be offset from the page (0,0)
- The draggable must be outside of the iframe
- Yank the mouse fast over the iframe, such that the mouse goes over the
  iframe before the dragged item can catch up.

-> the dragged item is offset from the mouse so long as the mouse
remains over the iframe.

In 17.2 this issue affects the mailing editor inside marketing automation
when editing an activity. This is because it does not inherit pe-none
in that scenario, unlike inside form views.

Drag and drop relies on `clientX` and `clientY` being in the coordinates
of the viewport.

When entering an iframe, mouse event coordinates (other than screen-based) are
given relative to the viewport of the iframe.

This means the position of the drag and drop does not match
the position of the mouse.

This can be fixed by preventing the iframe from becoming the target of the event
using style="pointer-event: none;" on the iframe itself.

task-4160857
