### PR TITLE
[FIX] mail: message subject more distinct from body text content

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -92,7 +92,7 @@
                                                             }" t-ref="body">
                                                     <Composer t-if="state.isEditing" autofocus="true" composer="message.composer" messageComponent="constructor" onDiscardCallback.bind="exitEditMode" onPostCallback.bind="exitEditMode" mode="env.inChatter ? 'extended' : 'compact'" sidebar="false"/>
                                                     <t t-else="">
-                                                        <em t-if="message.subject and !message.isSubjectSimilarToThreadName and !message.isSubjectDefault" class="mb-1 me-2">Subject: <t t-out="props.messageSearch?.highlight(message.subject) ?? message.subject"/></em>
+                                                        <em t-if="message.subject and !message.isSubjectSimilarToThreadName and !message.isSubjectDefault" class="d-block text-muted smaller">Subject: <t t-out="props.messageSearch?.highlight(message.subject) ?? message.subject"/></em>
                                                         <div class="overflow-x-auto" t-if="message.message_type and message.message_type.includes('email')" t-ref="shadowBody"/>
                                                         <t t-elif="state.showTranslation" t-out="message.translationValue"/>
                                                         <t t-elif="message.body" t-out="props.messageSearch?.highlight(message.body) ?? message.body"/>


### PR DESCRIPTION
Before this commit, when a message has a subject different from chatter name e.g. by renaming the record while some messages have been posted prior to rename, the subject was visible in prefix of message text content.

The showing of subject is good, but currently the style is almost the same as the text content, and this is put inline before the text content, so the subject looks like actual text content.

This commit improves the style so the subject is clearly different from the text content of the message, when the subject is displayed on UI.

Before
<img width="999" alt="Screenshot 2024-09-27 at 13 39 23" src="https://github.com/user-attachments/assets/d8a299b6-6c3c-4605-aa36-6f6d8286fdbc">
After
<img width="747" alt="Screenshot 2024-09-27 at 13 33 20" src="https://github.com/user-attachments/assets/a3919213-ba08-4662-8079-894183c68536">
