### PR TITLE
[IMP] hr_holidays: show warning if `date_to` is in the past

### DIFF
--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -146,6 +146,10 @@
                                 <div id="no_limit_label" class="oe_read_only"
                                     invisible="not id or date_to or state != 'confirm'">No limit</div>
                             </div>
+                            <div colspan="2" class="oe_row alert alert-warning my-2" role="alert"
+                                 invisible="id or not date_to or not (date_to &lt; context_today().strftime('%Y-%m-%d')) or (date_from and (date_to &lt; date_from))">
+                                <span>The allocated days cannot be used, because the allocation is set to finish in the past.</span>
+                            </div>
                             <field name="number_of_days" invisible="1"/>
                             <div class="o_td_label">
                                 <label for="number_of_days_display" string="Allocation"


### PR DESCRIPTION
This commit shows a warning when the user wants to create an allocation that runs until a date in the past.

task-4213876

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
