### PR TITLE
[PERF] purchase_stock:16.0 improve  get related invoices kasm

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -217,7 +217,8 @@ class StockMove(models.Model):
         """ Overridden to return the vendor bills related to this stock move.
         """
         rslt = super(StockMove, self)._get_related_invoices()
-        rslt += self.mapped('picking_id.purchase_id.invoice_ids').filtered(lambda x: x.state == 'posted')
+        purchase_ids = self.env['purchase.order'].search([('picking_ids', 'in', self.picking_id.ids)])
+        rslt += purchase_ids.invoice_ids.filtered(lambda x: x.state == 'posted')
         return rslt
 
     def _get_source_document(self):


### PR DESCRIPTION
Currently, the relationship between stock.picking and purchase.order is done via a `related` non-store field that requires iterating all moves. This becomes problematic in a case like `_get_related_invoices` in the purchase_stock module because we need to get the purchase_id of a move, but to do that, we will have to go through the picking_id which will need to iterate all moves related to the same picking. When you have `_prefetch_ids` set on that move, this process becomes extremely slow and memory-expensive because the `purchase_id` field is not stored so it needs to compute the relationship for all moves in the expanded ids due to prefetching. 

Since there exists a Many2many relationship between stock pickings and purchase orders, it's possible to rely on a search query instead of the `mapped` call. Although this might miss some cache optimizations, it's still much more efficient in terms of memory. This is because this approach is not susceptible to prefetch_ids explosion. It's also worth noting that this function is only called on individual stock moves instead of batches as part of the anglo_saxon_accounting logic. That being said, we don't have to worry this much about cache optimization since the method is not batched to begin with.

Using this optimization, we get the following benchmarks. 

Benchmark:
| num stock.move (_prefetch_ids) | time before | no. queries before | time after | no. queries after|
|----|------|-----| ----- | ----- |
| 1000                   | timeout | N/A | ~ 85 seconds | 47897 |

opw-4096108





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
