### PR TITLE
[FIX] spreadsheet: Speed up tests bypassing canvas drawing

### DIFF
--- a/addons/spreadsheet/static/tests/hoot_override.js
+++ b/addons/spreadsheet/static/tests/hoot_override.js
@@ -1,0 +1,24 @@
+import { getRunner } from "@web/../lib/hoot/main_runner";
+import { patch } from "@web/core/utils/patch";
+import { stores } from "@odoo/o-spreadsheet";
+
+const { RendererStore } = stores;
+
+/**
+ * When rendering a spreadsheet, drawing the grid in a canvas is a costly operation,
+ * perhaps the most costly operation. This patch allows to skip the grid/canvas drawing
+ * in standard tests, which speeds up the overall execution.
+ *
+ * For debugging urpose, the patch is ineffective when running tests in debug mode
+ * and the grid is drawn as usual.
+ */
+patch(RendererStore.prototype, {
+    drawLayer(ctx, layer) {
+        const runner = getRunner();
+        if (runner.debug) {
+            return super.drawLayer(ctx, layer);
+        } else {
+            return;
+        }
+    },
+});


### PR DESCRIPTION
Following the same optimization as in [1], we can bypass the canvas drawing of spreadsheet in the tests (as long as) we don't need it. This revision adds a generic patch that will disable the major part of the grid drawing of a spreadsheet while letting it enabled in debug mode for.. debug reasons.

Currently, the time spent in drawGrid is around 12~14% (depending on the screen size) when executing spreadsheet edition related tests (see task). This revision makes it drop to 0.5%.

[1]: https://github.com/odoo/o-spreadsheet/commit/d3036999989bb0d611ff8c3a05c7e0c2aa60dd49

task-4214049

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
