### PR TITLE
[FIX] point_of_sale, pos_sms: traceback occurs while sending pos receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -112,7 +112,7 @@ export class ReceiptScreen extends Component {
             [order.id],
             destination,
             fullTicketImage,
-            this.pos.basic_receipt ? basicTicketImage : null,
+            this.pos.config.basic_receipt ? basicTicketImage : null,
         ]);
     }
 }

--- a/addons/pos_sms/models/pos_order.py
+++ b/addons/pos_sms/models/pos_order.py
@@ -4,7 +4,7 @@ from odoo import models
 class PosOrder(models.Model):
     _inherit = 'pos.order'
 
-    def action_sent_message_on_sms(self, phone, _):
+    def action_sent_message_on_sms(self, phone, _, basic_image=False):
         if not (self and self.config_id.module_pos_sms and self.config_id.sms_receipt_template_id and phone):
             return
         self.ensure_one()


### PR DESCRIPTION
Before this commit:
==========
- There was a traceback error when sending receipts through SMS and WhatsApp.
- Basic receipts were not being added as email attachments when sending receipts through email.

After this commit:
==========
- The traceback error while sending receipts has been resolved, and the receipt sending flow is now seamless.
- Basic receipts will now be attached as email attachments when sending receipts through email.

task-4212901

Related:
- Enterprise: https://github.com/odoo/enterprise/pull/70891