### PR TITLE
[FIX] web: kanban: color cards even if field not in arch

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -180,6 +180,11 @@ export class KanbanController extends Component {
         const { resModel, archInfo, limit, defaultGroupBy } = this.props;
         const { activeFields, fields } = extractFieldsFromArchInfo(archInfo, this.props.fields);
 
+        const cardColorField = archInfo.cardColorField;
+        if (cardColorField) {
+            addFieldDependencies(activeFields, fields, [{ name: cardColorField, type: "integer" }]);
+        }
+
         // Remove fields aggregator unused to avoid asking them for no reason
         const aggregateFieldNames = this.progressBarAggregateFields.map((field) => field.name);
         for (const [key, value] of Object.entries(activeFields)) {

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -8013,7 +8013,6 @@ test("kanban with color attribute", async () => {
         resModel: "category",
         arch: `
             <kanban highlight_color="color">
-                <field name="color"/>
                 <templates>
                     <t t-name="card">
                         <field name="name"/>


### PR DESCRIPTION
Kanban cards can be colored (their left border) dynamically by using the root attribute `highlight_color="color"`, where `color` is the name of the integer field to use as color field. However, before this commit, this required the given `color` to be also defined in the arch, otherwise it wouldn't have been fetched, and no card would be colored.

With this commit, we automatically fetch the highlight_color field.

This fixes a bug in planning where colors weren't displayed.

Task~4215979

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
