### PR TITLE
[IMP] purchase: filter and search improvements

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -406,18 +406,17 @@
                     <filter name="my_purchases" string="My Purchases" domain="[('user_id', '=', uid)]"/>
                     <filter string="Starred" name="starred" domain="[('priority', '=', '1')]"/>
                     <separator/>
-                    <filter name="draft" string="RFQs" domain="[('state', 'in', ('draft', 'sent', 'to approve'))]"/>
-                    <separator/>
-                    <filter name="approved" string="Purchase Orders" domain="[('state', '=', 'purchase')]"/>
                     <filter name="to_approve" string="To Approve" domain="[('state', '=', 'to approve')]" invisible="1"/>
                     <separator/>
-                    <filter name="order_date" string="Order Date" date="date_order"/>
                     <filter name="draft_rfqs" string="New" domain="[('state', '=', 'draft')]"/>
                     <filter name="waiting_rfqs" string="Sent" domain="[('state', '=', 'sent')]"/>
+                    <filter name="approved" string="Purchase Orders" domain="[('state', '=', 'purchase')]"/>
+                    <separator/>
                     <filter name="late" string="Late" domain="[('state', 'in', ['draft', 'sent', 'to approve']),('date_order', '&lt;', datetime.datetime.now())]"/>
                     <filter name="not_acknowledged" string="Not Acknowledged" domain="[('state', '=', 'purchase'), ('acknowledged', '=', False)]"/>
                     <filter name="late_receipt" string="Late Receipts" domain="[('is_late', '=', True)]"/>
                     <separator/>
+                    <filter name="order_date" string="Order Date" date="date_order"/>
                     <filter invisible="1" string="My Activities" name="filter_activities_my"
                         domain="[('activity_user_id', '=', uid)]"/>
                     <separator invisible="1"/>

--- a/addons/purchase_requisition/views/purchase_views.xml
+++ b/addons/purchase_requisition/views/purchase_views.xml
@@ -49,9 +49,12 @@
         <field name="model">purchase.order</field>
         <field name="inherit_id" ref="purchase.view_purchase_order_filter"/>
         <field name="arch" type="xml">
-            <xpath expr="//filter[@name='approved']" position="after">
-                <filter string="Requisition" name="requisition" domain="[('requisition_id', '!=', False)]"  help="Purchase Orders with requisition"/>
-            </xpath>
+            <field name="product_id" position="after">
+                <field name="requisition_id"/>
+            </field>
+            <filter name="representative" position="after">
+                <filter string="Agreement" name="requisition" domain="[]" context="{'group_by': 'requisition_id'}"/>
+            </filter>
         </field>
     </record>
 

--- a/addons/stock/views/stock_move_line_views.xml
+++ b/addons/stock/views/stock_move_line_views.xml
@@ -150,7 +150,7 @@
                 <filter string="Last 3 Months" name="filter_last_3_months" domain="[('date','&gt;=', (context_today() - relativedelta(months=3)).strftime('%Y-%m-%d'))]"/>
                 <filter string="Last 12 Months" name="filter_last_12_months" domain="[('date','&gt;=', (context_today() - relativedelta(years=1)).strftime('%Y-%m-%d'))]"/>
                 <separator/>
-                <filter string="Inventory" name="inventory" domain="[('is_inventory', '=', True)]"/>
+                <filter string="Inventory Adjustments" name="inventory" domain="[('is_inventory', '=', True)]"/>
                 <separator/>
                 <group expand="0" string="Group By" name="groupby">
                     <filter string="Product" name="groupby_product_id" domain="[]" context="{'group_by': 'product_id'}"/>


### PR DESCRIPTION
In this PR
========================

- Change the filter name in the stock move search view from
 'Inventory' to 'Inventory Adjustments' for better clarity.
- Removed the RFQs and Requisition filters.
- Moved the Purchase Orders filter below the Sent filter.
- Add search filter for Agreements.
- Add a Group By filter for Agreement.
- Moved the Order Date filter below the Late Receipts filter.

TaskId: 4004862
