### PR TITLE
[FIX] pos_restaurant: fix switching table in restaurant mode

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
@@ -40,7 +40,14 @@ patch(Navbar.prototype, {
     setFloatingOrder(floatingOrder) {
         this.pos.selectedTable = null;
         this.pos.set_order(floatingOrder);
-        this.pos.showScreen("ProductScreen");
+
+        const props = {};
+        const screenName = floatingOrder.get_screen_data().name;
+        if (screenName === "PaymentScreen") {
+            props.orderUuid = floatingOrder.uuid;
+        }
+
+        this.pos.showScreen(screenName || "ProductScreen", props);
     },
     async onClickTableTab() {
         await this.pos.syncAllOrders();


### PR DESCRIPTION
When switching table a traceback was raised for order that was on Payment Screen, that was because the props OrderUuid was not given.

This commit fix the issue by adding the OrderUuid to the props when switching table.

Little fonctional change: before when switching to a floating order the redirecting was always set to product screen, now it is set to the last screen of the order.
