### PR TITLE
[FIX] product: cost reset to 0 on page reload

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -80,8 +80,17 @@
                                       <field name="list_price" class="oe_inline" widget='monetary'
                                         options="{'currency_field': 'currency_id', 'field_digits': True}"/>
                                     </div>
-                                    <label for="standard_price" invisible="product_variant_count &gt; 1 and not is_product_variant"/>
-                                    <div name="standard_price_uom" invisible="product_variant_count &gt; 1 and not is_product_variant">
+
+                                    <!--
+                                        `id` condition to prevent invisibility on new products
+                                        when `product_variant_count` is 0.
+                                        `product_variant_count != 1` to handle cases with dynamic
+                                        / multiple variants since id will be set after saving.
+                                        #TODO : revert this and create a compute field in master
+                                        to ensure invisivility for dynamic variants only.
+                                    -->
+                                    <label for="standard_price" invisible="id and product_variant_count != 1 and not is_product_variant"/>
+                                    <div name="standard_price_uom" invisible="id and product_variant_count != 1 and not is_product_variant">
                                         <field name="standard_price" class="oe_inline" widget='monetary' options="{'currency_field': 'cost_currency_id', 'field_digits': True}"/>
                                         <span groups="uom.group_uom" >per
                                             <field name="uom_name" class="oe_inline"/>


### PR DESCRIPTION
Steps:
- Create a dynamic attribute with some attribute Lines
- Create a product with attributes set to the new attribute
- Change cost price and save
- Reload the webpage

Issue:
- Cost price changes back to 0

Cause:
- `_compute_template_field_from_variant_field` is called on `_compute_standard_price` which sets the value of field to default (false) for variant_count=0

Fix:
- Cost price will be invisible for variant_count=0 (only on saved records, to allow products with non-dynamic attributes to still be configured directly on creation).

opw-4054647
