### PR TITLE
[FIX] survey: fix tour

### DIFF
--- a/addons/survey/static/src/js/tours/survey_tour.js
+++ b/addons/survey/static/src/js/tours/survey_tour.js
@@ -44,7 +44,7 @@ registry.category("web_tour.tours").add('survey_tour', {
     content: _t("Let's have a look at your answers!"),
     position: 'bottom',
 }, {
-    trigger: '.alert-info a:contains("This is a Test Survey")',
+    trigger: '.survey_button_form_view_hook',
     content: _t("Now, use this shortcut to go back to the survey."),
     position: 'bottom',
 }, {


### PR DESCRIPTION
**Before this commit:**
- The existing selector fails due to the change in the the text of the `<a>` tag
  redirecting us to the survey.

ref. to where it was changed---
https://github.com/odoo/odoo/pull/131710/files#diff-134fd6929e7c8db7a39038879bf9a01c9f4525ca8db1475974c74576ffd7e3fb

---

**After this commit:**
- The new selector ensures we get the tour pointer as desired.

Task-**4207478**