### PR TITLE
[FIX] point_of_sale: unselected floating order as button

### DIFF
--- a/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.xml
+++ b/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.xml
@@ -9,7 +9,7 @@
         >
             <t t-set="order" t-value="scope.item" />
             <button t-esc="order.getName()"
-                t-attf-class="{{pos.get_order()?.id === order.id ? 'btn-secondary active' : ''}}"
+                t-att-class="{ 'active': pos.get_order()?.id === order.id }"
                 class="btn btn-lg btn-secondary text-truncate mx-1"
                 style="min-width: 4rem;"
                 t-on-click="() => this.selectFloatingOrder(order)"


### PR DESCRIPTION
Prior to this commit, the floating order button doesn't appear to be a button when unselected. This is because the `btn-secondary` is potentially removed by the framework because of redundant declaration.

In this commit, we want the `btn-secondary` to be always there, and only the `active` class to be conditionally present.

Before:

![image](https://github.com/user-attachments/assets/d1e82ad6-b917-492a-b32f-8f563950b776)

After:

![image](https://github.com/user-attachments/assets/7d02541c-c7c2-428c-a7c7-d811bf1cadbd)

