### PR TITLE
[FIX] spreadsheet: see records in calculated fields

### DIFF
--- a/addons/spreadsheet/static/src/pivot/pivot_actions.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_actions.js
@@ -47,7 +47,8 @@ export const SEE_RECORDS_PIVOT_VISIBLE = (position, getters) => {
     const evaluatedCell = getters.getEvaluatedCell(position);
     const pivotId = getters.getPivotIdFromPosition(position);
     const pivotCell = getters.getPivotCellFromPosition(position);
-    return (
+    return !!(
+        pivotId &&
         evaluatedCell.type !== "empty" &&
         evaluatedCell.type !== "error" &&
         evaluatedCell.value !== "" &&
@@ -55,7 +56,8 @@ export const SEE_RECORDS_PIVOT_VISIBLE = (position, getters) => {
         cell &&
         cell.isFormula &&
         getNumberOfPivotFunctions(cell.compiledFormula.tokens) === 1 &&
-        getters.getPivotCoreDefinition(pivotId).type === "ODOO"
+        getters.getPivotCoreDefinition(pivotId).type === "ODOO" &&
+        getters.getPivot(pivotId).getPivotCellDomain(pivotCell.domain)
     );
 };
 

--- a/addons/spreadsheet/static/src/pivot/pivot_model.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_model.js
@@ -102,6 +102,9 @@ export class OdooPivotModel extends PivotModel {
      * @param {PivotDomain} domain
      */
     getPivotCellValue(measure, domain) {
+        if (domain.some((node) => node.value === NO_RECORD_AT_THIS_POSITION)) {
+            return "";
+        }
         const { cols, rows } = this._getColsRowsValuesFromDomain(domain);
         const group = JSON.stringify([rows, cols]);
         const values = this.data.measurements[group];
@@ -186,6 +189,9 @@ export class OdooPivotModel extends PivotModel {
      * @param {PivotDomain} domain
      */
     getPivotCellDomain(domain) {
+        if (domain.some((node) => node.value === NO_RECORD_AT_THIS_POSITION)) {
+            return undefined;
+        }
         const { cols, rows } = this._getColsRowsValuesFromDomain(domain);
         const key = JSON.stringify([rows, cols]);
         const domains = this.data.groupDomains[key];


### PR DESCRIPTION
Some methods in the pivot_model didn't handle the
`NO_RECORD_AT_THIS_POSITION` constant returned by positional pivot formulas. This lead to a `see_record` visible where it shouldn't be, that caused a tracabeck.

Task: [4210956](https://www.odoo.com/web#id=4210956&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
