### PR TITLE
[FIX] web: css border issue in printed report

### DIFF
--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -274,6 +274,8 @@ This module provides the core of the Odoo Web Client.
 
             ('include', 'web._assets_bootstrap_backend'),
 
+            ('after', 'web/static/src/scss/utilities_custom.scss', 'web/static/src/scss/utilities_custom_report.scss'),
+
             'web/static/lib/popper/popper.js',
             'web/static/lib/bootstrap/js/dist/util/index.js',
             'web/static/lib/bootstrap/js/dist/dom/data.js',

--- a/addons/web/static/src/scss/utilities_custom_report.scss
+++ b/addons/web/static/src/scss/utilities_custom_report.scss
@@ -1,0 +1,67 @@
+///
+/// Backend Custom Utility Classes
+/// ==============================================================================
+
+$utilities: map-merge(
+    $utilities,
+    (
+        // Fix border
+        "border": map-merge(
+            map-get($utilities, "border"),
+            (
+                values: map-merge(
+                    map-get(map-get($utilities, "border"), "values"),
+                    (null: $border-width solid $border-color),
+                ),
+            ),
+        ),
+        "border-top": map-merge(
+            map-get($utilities, "border-top"),
+                (
+                    values: map-merge(
+                        map-get(map-get($utilities, "border-top"), "values"),
+                        (null: $border-width solid $border-color),
+                    ),
+                ),
+        ),
+        "border-end": map-merge(
+            map-get($utilities, "border-end"),
+                (
+                    values: map-merge(
+                        map-get(map-get($utilities, "border-end"), "values"),
+                        (null: $border-width solid $border-color),
+                    ),
+                ),
+        ),
+        "border-bottom": map-merge(
+            map-get($utilities, "border-bottom"),
+                (
+                    values: map-merge(
+                        map-get(map-get($utilities, "border-bottom"), "values"),
+                        (null: $border-width solid $border-color),
+                    ),
+                ),
+        ),
+        "border-start": map-merge(
+            map-get($utilities, "border-start"),
+            (
+                values: map-merge(
+                    map-get(map-get($utilities, "border-start"), "values"),
+                    (null: $border-width solid $border-color),
+                ),
+            ),
+        ),
+        "border-color": map-merge(
+            map-get($utilities, "border-color"),
+            (
+                values: map-merge(
+                    $theme-colors,
+                    (
+                        "black": $black,
+                        "white": $white,
+                    )
+                ),
+            ),
+        ),
+    )
+);


### PR DESCRIPTION
Elements with border class are missing the colored border

How to reproduce:
With a cl company setup
Create an invoice to a CL partner
Print invoice

Issue:
Border of top right element is missing

This occurs because wkhtmltopdf is not recognizing the css vars

opw-4210167
opw-4211635
