### PR TITLE
[FIX] website_sale: hide express checkout if mandatory sign-in is on

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2707,7 +2707,11 @@
                                  t-if="website_sale_order and website_sale_order.website_order_line">
                                 <div class="card-body p-0 p-lg-4">
                                     <t t-call="website_sale.total"/>
-                                    <t t-call="payment.express_checkout"/>
+                                    <t
+                                        t-if="website.account_on_checkout != 'mandatory' or
+                                              not website.is_public_user()"
+                                        t-call="payment.express_checkout"
+                                    />
                                     <t t-call="website_sale.navigation_buttons"/>
                                 </div>
                             </div>


### PR DESCRIPTION
Issue:
- When the 'Sign in/up at checkout - mandatory' option is enabled, the 'Express Checkout' button is still visible on the cart page even when the user is not signed in. This causes an inconsistency, as express checkout bypasses the mandatory creation of portal account, which should not be allowed in this mode.

Fix:
- Added a condition at the t-call of express checkout template to ensure that it is hidden when mandatory sign-in at checkout is activated and user is not signed in.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
