### PR TITLE
[FIX] hr_expense,purchase,sale,pos: fix kanban views layout

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -296,9 +296,9 @@
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                     <templates>
                         <t t-name="card">
-                            <div class="d-flex">
-                                <field class="fw-bold fs-5" name="name"/>
-                                <field class="fw-bold ms-auto" name="total_amount_currency" widget="monetary"/>
+                            <div class="d-flex align-items-baseline">
+                                <field class="fw-bold fs-5 me-2" name="name"/>
+                                <field class="fw-bold ms-auto flex-shrink-0" name="total_amount_currency" widget="monetary"/>
                             </div>
                             <div class="d-flex mt8 text-muted">
                                 <field name="employee_id" widget="many2one_avatar_user"

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -217,21 +217,21 @@
                 <field name="currency_id"/>
                 <templates>
                     <t t-name="card">
-                            <div class="d-flex mb-1">
-                                <span t-if="record.partner_id.value">
-                                    <field name="partner_id" class="fw-bolder"/>
-                                </span>
-                                <span t-else="">
-                                    <field name="name" class="fw-bolder"/>
-                                </span>
-                                <field name="amount_total" widget="monetary" class="fw-bolder ms-auto"/>
-                            </div>
-                            <field name="pos_reference" />
-                            <div class="d-flex">
-                                <field name="date_order" class="text-muted"/>
-                                <field name="state" widget="label_selection" options="{'classes': {'draft': 'default',
-                                'invoiced': 'success', 'cancel': 'danger'}}" class="ms-auto"/>
-                            </div>
+                        <div class="d-flex align-items-baseline mb-1">
+                            <span t-if="record.partner_id.value">
+                                <field name="partner_id" class="fw-bolder me-2"/>
+                            </span>
+                            <span t-else="">
+                                <field name="name" class="fw-bolder me-2"/>
+                            </span>
+                            <field name="amount_total" widget="monetary" class="fw-bolder ms-auto flex-shrink-0"/>
+                        </div>
+                        <field name="pos_reference" />
+                        <footer class="flex-wrap">
+                            <field name="date_order" class="text-muted text-nowrap"/>
+                            <field name="state" widget="label_selection" options="{'classes': {'draft': 'default',
+                            'invoiced': 'success', 'cancel': 'danger'}}" class="ms-auto text-truncate"/>
+                        </footer>
                     </t>
                 </templates>
             </kanban>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -481,15 +481,16 @@
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                     <templates>
                         <t t-name="card">
-                            <div class="d-flex mb-3">
+                            <div class="d-flex align-items-baseline">
                                 <field name="priority" widget="priority" class="mt-1 me-1"/>
-                                <field name="partner_id" class="fw-bolder fs-5"/>
-                                <field name="amount_total" widget="monetary" class="fw-bolder ms-auto"/>
+                                <field name="partner_id" class="fw-bolder fs-5 me-2"/>
+                                <field name="amount_total" widget="monetary" class="fw-bolder ms-auto flex-shrink-0"/>
                             </div>
-                            <footer class="pt-0">
-                                <div class="d-flex">
-                                    <field name="name" class="me-1"/> <field name="date_order" options="{'show_time': false}"/>
-                                    <field name="activity_ids" widget="kanban_activity" class="ms-1"/>
+                            <footer class="align-items-end">
+                                <div class="d-flex flex-wrap gap-1 text-nowrap">
+                                    <field name="name"/>
+                                    <field name="date_order" options="{'show_time': false}"/>
+                                    <field name="activity_ids" widget="kanban_activity"/>
                                 </div>
                                 <field name="state" widget="label_selection" options="{'classes': {'draft': 'default', 'cancel': 'default', 'done': 'success', 'approved': 'warning'}}" class="ms-auto"/>
                             </footer>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -75,15 +75,15 @@
                     colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                 <templates>
                     <t t-name="card">
-                        <div class="d-flex mb-2">
-                            <field name="partner_id" class="fw-bolder fs-5" />
-                            <field name="amount_total" widget="monetary" class="fw-bolder ms-auto"/>
+                        <div class="d-flex align-items-baseline mb-2">
+                            <field name="partner_id" class="fw-bolder fs-5 me-2"/>
+                            <field name="amount_total" widget="monetary" class="fw-bolder ms-auto flex-shrink-0"/>
                         </div>
-                        <footer>
-                            <div class="d-flex text-muted">
+                        <footer class="align-items-end">
+                            <div class="d-flex flex-wrap gap-1 text-muted text-nowrap">
                                 <field name="name"/>
-                                <field name="date_order" class="ms-1"/>
-                                <field name="activity_ids" widget="kanban_activity" class="ms-2"/>
+                                <field name="date_order"/>
+                                <field name="activity_ids" widget="kanban_activity"/>
                             </div>
                             <field name="state"
                                 widget="label_selection"


### PR DESCRIPTION
This commit fixes small UI issues in expense, pos, purchase and sale kanban views, introduced by the conversion to the API [1][2][3][4]. They had similar issues. The amount displayed on the right of the title row sometimes overflowed, when the title was too long. And the left part of the footer was weirdly displayed when the label of the badge displayed next to it was too long (which might easily happen with translations).

[1] https://github.com/odoo/odoo/pull/171214
[2] https://github.com/odoo/odoo/pull/173466
[3] https://github.com/odoo/odoo/pull/174308
[4] https://github.com/odoo/odoo/pull/174134

Task~4215979

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
