### PR TITLE
[FIX] point_of_sale: ensure no tax on tip

### DIFF
--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -528,6 +528,9 @@ class TestUi(TestPointOfSaleHttpCommon):
             _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
             return
 
+        self.tip.write({
+            'taxes_id': False,
+        })
         self.main_pos_config.write({
             'iface_tipproduct': True,
             'tip_product_id': self.tip.id,


### PR DESCRIPTION
During tests a tax was applied on the tip amount, which is not correct.

RB err: 76192, 76191

