### PR TITLE
[IMP] mrp: improve the accuracy of workcenters load graph

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -133,7 +133,7 @@ class MrpWorkorder(models.Model):
 
     scrap_ids = fields.One2many('stock.scrap', 'workorder_id')
     scrap_count = fields.Integer(compute='_compute_scrap_move_count', string='Scrap Move')
-    production_date = fields.Datetime('Production Date', related='production_id.date_start', store=True)
+    production_date = fields.Datetime('Production Date', compute='_compute_production_date', store=True)
     json_popover = fields.Char('Popover Data JSON', compute='_compute_json_popover')
     show_json_popover = fields.Boolean('Show Popover?', compute='_compute_json_popover')
     consumption = fields.Selection(related='production_id.consumption')
@@ -172,6 +172,11 @@ class MrpWorkorder(models.Model):
                 workorder.state = 'ready'
             elif workorder.production_availability != 'assigned' and workorder.state == 'ready':
                 workorder.state = 'waiting'
+
+    @api.depends('production_id.date_start', 'date_start')
+    def _compute_production_date(self):
+        for workorder in self:
+            workorder.production_date = workorder.date_start or workorder.production_id.date_start
 
     @api.depends('production_state', 'date_start', 'date_finished')
     def _compute_json_popover(self):


### PR DESCRIPTION
This commit improves the accuracy of the workcenters load graph shown in the overview page of MRP module. Previously, if the workorders of a manufacturing order were planned over different weeks, they were all shown as a part of the load of the first week of the manufacturing order. After this commit, the start date of each workorder is considered, and not necissariy linked to the start date of the manufacturing order if the order is planned.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
