### PR TITLE
[FIX] point_of_sale: static uuid tracebacks in demo orders

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from markupsafe import Markup
 from itertools import groupby
 from collections import defaultdict
+from uuid import uuid4
 
 import psycopg2
 import pytz
@@ -333,7 +334,7 @@ class PosOrder(models.Model):
     has_refundable_lines = fields.Boolean('Has Refundable Lines', compute='_compute_has_refundable_lines')
     ticket_code = fields.Char(help='5 digits alphanumeric code to be used by portal user to request an invoice')
     tracking_number = fields.Char(string="Order Number", compute='_compute_tracking_number', search='_search_tracking_number')
-    uuid = fields.Char(string='Uuid', readonly=True, copy=False)
+    uuid = fields.Char(string='Uuid', readonly=True, default=lambda self: str(uuid4()), copy=False)
     email = fields.Char(string='Email', compute="_compute_contact_details", readonly=False, store=True)
     mobile = fields.Char(string='Mobile', compute="_compute_contact_details", readonly=False, store=True)
     is_edited = fields.Boolean(string='Edited', compute='_compute_is_edited')
@@ -1321,7 +1322,7 @@ class PosOrderLine(models.Model):
     refund_orderline_ids = fields.One2many('pos.order.line', 'refunded_orderline_id', 'Refund Order Lines', help='Orderlines in this field are the lines that refunded this orderline.')
     refunded_orderline_id = fields.Many2one('pos.order.line', 'Refunded Order Line', help='If this orderline is a refund, then the refunded orderline is specified in this field.')
     refunded_qty = fields.Float('Refunded Quantity', compute='_compute_refund_qty', help='Number of items refunded in this orderline.')
-    uuid = fields.Char(string='Uuid', readonly=True, copy=False)
+    uuid = fields.Char(string='Uuid', readonly=True, default=lambda self: str(uuid4()), copy=False)
     note = fields.Char('Product Note')
 
     combo_parent_id = fields.Many2one('pos.order.line', string='Combo Parent') # FIXME rename to parent_line_id

--- a/addons/point_of_sale/models/pos_payment.py
+++ b/addons/point_of_sale/models/pos_payment.py
@@ -1,6 +1,7 @@
 from odoo import api, fields, models, _
 from odoo.tools import formatLang, float_is_zero
 from odoo.exceptions import ValidationError
+from uuid import uuid4
 
 
 class PosPayment(models.Model):
@@ -40,7 +41,7 @@ class PosPayment(models.Model):
     ticket = fields.Char(string='Payment Receipt Info')
     is_change = fields.Boolean(string='Is this payment change?', default=False)
     account_move_id = fields.Many2one('account.move', index='btree_not_null')
-    uuid = fields.Char(string='Uuid', readonly=True, copy=False)
+    uuid = fields.Char(string='Uuid', readonly=True, default=lambda self: str(uuid4()), copy=False)
 
     @api.model
     def _load_pos_data_domain(self, data):

--- a/addons/pos_restaurant/data/restaurant_session_floor.xml
+++ b/addons/pos_restaurant/data/restaurant_session_floor.xml
@@ -520,7 +520,6 @@
             <field name="qty">2</field>
             <field name="order_id" ref="pos_open_order_2" />
             <field name="full_product_name">Coca-Cola</field>
-            <field name="uuid">00000000-0000-4000-000000000000</field>
         </record>
 
         <record id="pos_orderline_3" model="pos.order.line" forcecreate="False">
@@ -532,7 +531,6 @@
             <field name="qty">2</field>
             <field name="order_id" ref="pos_open_order_2" />
             <field name="full_product_name">Salmon and Avocado</field>
-            <field name="uuid">00000000-0000-4000-000000000001</field>
         </record>
 
         <record id="pos_open_order_3" model="pos.order" forcecreate="False">
@@ -559,7 +557,6 @@
             <field name="qty">1</field>
             <field name="order_id" ref="pos_open_order_3" />
             <field name="full_product_name">Lunch Temaki mix 3pc</field>
-            <field name="uuid">00000000-0000-4000-000000000002</field>
         </record>
 
         <record id="pos_orderline_5" model="pos.order.line" forcecreate="False">
@@ -571,7 +568,6 @@
             <field name="qty">2</field>
             <field name="order_id" ref="pos_open_order_3" />
             <field name="full_product_name">Mozzarella Sandwich</field>
-            <field name="uuid">00000000-0000-4000-000000000003</field>
         </record>
 
         <record id="pos_open_order_4" model="pos.order" forcecreate="False">
@@ -598,7 +594,6 @@
             <field name="qty">1</field>
             <field name="order_id" ref="pos_open_order_4" />
             <field name="full_product_name">Chicken Curry Sandwich</field>
-            <field name="uuid">00000000-0000-4000-000000000004</field>
         </record>
 
         <record id="pos_orderline_7" model="pos.order.line" forcecreate="False">
@@ -610,7 +605,6 @@
             <field name="qty">1</field>
             <field name="order_id" ref="pos_open_order_4" />
             <field name="full_product_name">Bacon Burger</field>
-            <field name="uuid">00000000-0000-4000-000000000005</field>
         </record>
 
         <record id="pos_open_order_5" model="pos.order" forcecreate="False">


### PR DESCRIPTION
In this commit:
=================
Fix traceback when deleting demo records in POS.
When deleting some demo orders in the POS, a traceback was
raised because the lines of the orders did not had an order
linked to it. This was because they did not have an uuid.
We now have default uuid values for orders, order lines and
pos payments.

Task: 4212901

Related: https://github.com/odoo/enterprise/pull/70925