### PR TITLE
[FIX] point_of_sale: prevent duplicate payment with one payment method

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -51,7 +51,8 @@ export class PaymentScreen extends Component {
     }
 
     onMounted() {
-        if (this.payment_methods_from_config.length == 1) {
+        // add a payment line if there is only one payment method and no payment lines
+        if (this.payment_methods_from_config.length == 1 && this.paymentLines.length == 0) {
             this.addNewPaymentLine(this.payment_methods_from_config[0]);
         }
     }


### PR DESCRIPTION
Before this commit, when only one payment method was available, an additional payment line with a value of zero would be automatically added, even if a payment line already existed.

opw-4186191

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
