### PR TITLE
[FIX] hr_expense: Use bank account defined on employee form

### DIFF
--- a/addons/hr_expense/i18n/hr_expense.pot
+++ b/addons/hr_expense/i18n/hr_expense.pot
@@ -1434,6 +1434,30 @@ msgid "Only Managers and HR Officers can refuse expenses"
 msgstr ""
 
 #. module: hr_expense
+#. odoo-python
+#: code:addons/hr_expense/models/hr_expense.py:0
+#: code:addons/hr_expense/models/hr_expense.py:0
+#, python-format
+msgid "Employee(s) should have a bank account set."
+msgstr ""
+
+#. module: hr_expense
+#. odoo-python
+#: code:addons/hr_expense/models/hr_expense.py:0
+#: code:addons/hr_expense/models/hr_expense.py:0
+#, python-format
+msgid "Go to Employee(s)"
+msgstr ""
+
+#. module: hr_expense
+#. odoo-python
+#: code:addons/hr_expense/models/hr_expense.py:0
+#: code:addons/hr_expense/models/hr_expense.py:0
+#, python-format
+msgid "Employee(s)"
+msgstr ""
+
+#. module: hr_expense
 #: model_terms:ir.actions.act_window,help:hr_expense.hr_expense_actions_my_all
 msgid "Or"
 msgstr ""

--- a/addons/hr_expense/tests/common.py
+++ b/addons/hr_expense/tests/common.py
@@ -24,6 +24,11 @@ class TestExpenseCommon(AccountTestInvoicingCommon):
             groups='base.group_user',
             company_ids=[(6, 0, cls.env.companies.ids)],
         )
+        cls.employee_bank_account = cls.env['res.partner.bank'].create({
+            'acc_number': "0123456789",
+            'partner_id': cls.expense_user_employee.partner_id.id,
+            'acc_type': 'bank',
+        })
         cls.expense_user_manager = mail_new_test_user(
             cls.env,
             name='Expense manager',
@@ -48,6 +53,7 @@ class TestExpenseCommon(AccountTestInvoicingCommon):
             'user_id': cls.expense_user_employee.id,
             'address_home_id': cls.expense_user_employee.partner_id.id,
             'address_id': cls.expense_user_employee.partner_id.id,
+            'bank_account_id': cls.employee_bank_account.id,
         })
 
         cls.product_zero_cost = cls.env['product.product'].create({


### PR DESCRIPTION
For an expense report paid by an employee, the bank account should be set on the employee form and be used to create the Journal Entry and in Register Payment Wizard.

enterprise: https://github.com/odoo/enterprise/pull/71080

task-4206895

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
