### PR TITLE
[FIX] project: prevent tracking on visibility related field

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -218,7 +218,7 @@ class Task(models.Model):
     child_ids = fields.One2many('project.task', 'parent_id', string="Sub-tasks", domain="[('recurring_task', '=', False)]")
     subtask_count = fields.Integer("Sub-task Count", compute='_compute_subtask_count')
     closed_subtask_count = fields.Integer("Closed Sub-tasks Count", compute='_compute_subtask_count')
-    project_privacy_visibility = fields.Selection(related='project_id.privacy_visibility', string="Project Visibility")
+    project_privacy_visibility = fields.Selection(related='project_id.privacy_visibility', string="Project Visibility", tracking=False)
     # Computed field about working time elapsed between record creation and assignation/closing.
     working_hours_open = fields.Float(compute='_compute_elapsed', string='Working Hours to Assign', digits=(16, 2), store=True, aggregator="avg")
     working_hours_close = fields.Float(compute='_compute_elapsed', string='Working Hours to Close', digits=(16, 2), store=True, aggregator="avg")


### PR DESCRIPTION
The project's visibility should be tracked in the chatter of the project, but not in the tasks chatter. This PR will set the tracking of the "project_privacy_visibility" field to False, so that it is no longer displayed in the tasks chatter.

task-4210181