### PR TITLE
[FIX] stock: set null inventory diff quantity at quant creation

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -111,7 +111,7 @@ class StockQuant(models.Model):
         'Scheduled Date', compute='_compute_inventory_date', store=True, readonly=False,
         help="Next date the On Hand Quantity should be counted.")
     last_count_date = fields.Date(compute='_compute_last_count_date', help='Last time the Quantity was Updated')
-    inventory_quantity_set = fields.Boolean(store=True, compute='_compute_inventory_quantity_set', readonly=False, default=False)
+    inventory_quantity_set = fields.Boolean(store=True, compute='_compute_inventory_quantity_set', readonly=False)
     is_outdated = fields.Boolean('Quantity has been moved since last count', compute='_compute_is_outdated', search='_search_is_outdated')
     user_id = fields.Many2one(
         'res.users', 'Assigned To', help="User assigned to do product count.",
@@ -183,10 +183,13 @@ class StockQuant(models.Model):
         )
         return super()._search(domain, *args, **kwargs)
 
-    @api.depends('inventory_quantity')
+    @api.depends('inventory_quantity', 'inventory_quantity_set')
     def _compute_inventory_diff_quantity(self):
         for quant in self:
-            quant.inventory_diff_quantity = quant.inventory_quantity - quant.quantity
+            if quant.inventory_quantity_set:
+                quant.inventory_diff_quantity = quant.inventory_quantity - quant.quantity
+            else:
+                quant.inventory_diff_quantity = 0
 
     @api.depends('inventory_quantity')
     def _compute_inventory_quantity_set(self):
@@ -301,6 +304,8 @@ class StockQuant(models.Model):
                     quant.inventory_date = fields.Date.today()
                 quants |= quant
             else:
+                if 'inventory_quantity' not in vals:
+                    vals['inventory_quantity_set'] = vals.get('inventory_quantity_set', False)
                 quant = super().create(vals)
                 _add_to_cache(quant)
                 quants |= quant
@@ -1002,6 +1007,8 @@ class StockQuant(models.Model):
             ).lot_stock_id
 
     def _apply_inventory(self):
+        # Consider the inventory_quantity as set => recompute the inventory_diff_quantity if needed
+        self.inventory_quantity_set = True
         move_vals = []
         for quant in self:
             # Create and validate a move so that the quant matches its `inventory_quantity`.


### PR DESCRIPTION
### Issue:

When creating new quants, a non correct `inventory_diff_quantity` might be set outside of inventory mode. This is usually unseen as the field is invisible in the inventory quant view unless manually set but then the set value erase the error.

### Steps to reproduce:

- Enable Multi-steps route
- Create a receipt for 5 unit of a storable product that is not in stock
- Mark as Todo  and validate the receipt Validate
- Go to Inventory Adjustments and group by product
#### > on the summary line for quants of the product, the total diff is -5

### Fix:

We change the dependencies of the `_compute_inventory_diff_quantity` method to only change the `inventory_diff_quantity` when the inventory quantity was set since this is the only situtation where this field should be relevant any way. As such, the `inventory_quantity_set` needs to be properly set when the `_compute_inventory_diff_quantity` method is called. As such, we had to revert [1] which added a default value to bypass computation and we provided an alternative fix of [1] in the create method of quants outsied of inventory mode.

[1] https://github.com/odoo/odoo/commit/e54ea3228301592875e9eaf4c69c8153818b86e7

opw-3944310 and opw-4188686
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
