### PR TITLE
[IMP] website: allow highlighted text content in snippets preview

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -288,6 +288,7 @@
         'web_editor.assets_wysiwyg': [
             'website/static/src/js/editor/editor.js',
             'website/static/src/xml/web_editor.xml',
+            'website/static/src/js/editor/add_snippet_dialog.js'
         ],
         'website.assets_wysiwyg': [
             ('include', 'web._assets_helpers'),

--- a/addons/website/static/src/components/dialog/add_page_dialog.js
+++ b/addons/website/static/src/components/dialog/add_page_dialog.js
@@ -7,6 +7,7 @@ import { useAutofocus, useService } from '@web/core/utils/hooks';
 import { _t } from "@web/core/l10n/translation";
 import { WebsiteDialog } from '@website/components/dialog/dialog';
 import { Switch } from '@website/components/switch/switch';
+import { applyTextHighlight } from "@website/js/text_processing";
 import { useRef, useState, useSubEnv, Component, onWillStart, onMounted } from "@odoo/owl";
 import wUtils from '@website/js/utils';
 
@@ -242,6 +243,14 @@ export class AddPageTemplatePreview extends Component {
             if (this.props.isCustom) {
                 this.adaptCustomTemplate(wrapEl);
             }
+            // We need this to correctly compute the highlights size (the
+            // `ResizeObserver` that adapts the effects when a custom font
+            // is applied is not available), for now, we need a setTimeout.
+            setTimeout(() => {
+                for (const textEl of iframeEl.contentDocument?.querySelectorAll(".o_text_highlight") || []) {
+                    applyTextHighlight(textEl);
+                }
+            }, 200);
         });
     }
 

--- a/addons/website/static/src/js/editor/add_snippet_dialog.js
+++ b/addons/website/static/src/js/editor/add_snippet_dialog.js
@@ -1,0 +1,17 @@
+import { AddSnippetDialog } from "@web_editor/js/editor/add_snippet_dialog";
+import { patch } from "@web/core/utils/patch";
+import { applyTextHighlight } from "@website/js/text_processing";
+
+patch(AddSnippetDialog.prototype, {
+    /**
+     * Build the highlighted text for the snippets preview.
+     *
+     * @override
+     */
+    async insertSnippets() {
+        await super.insertSnippets();
+        for (const textEl of this.iframeDocument?.querySelectorAll(".o_text_highlight") || []) {
+            applyTextHighlight(textEl);
+        }
+    },
+});

--- a/addons/website/static/src/js/text_processing.js
+++ b/addons/website/static/src/js/text_processing.js
@@ -198,7 +198,10 @@ export const getDOMRectWidth = el => el.getBoundingClientRect().width;
  * @returns {String[]}
  */
 function drawPath(textEl, options) {
-    const {width, height} = textEl.getBoundingClientRect();
+    // Note: cannot use getBoundingClientRect as we want to be able to draw
+    // text highlights in snippets/add page dialogs where iframe is scaled.
+    const width = textEl.offsetWidth;
+    const height = textEl.offsetHeight;
     options = {...options, width, height};
     const yStart = options.position === "center" ? height / 2 : height;
 


### PR DESCRIPTION
A highlighted text has the following structure:

```
<span class="o_text_highlight o_text_highlight_[highlightId]"
    style="--text-highlight-width: ...; --text-highlight-color: ...;">
    <span class="o_text_highlight_item">
        text content (line 1) ...
        <svg.../>
    </span>
    [<br/>]
    <span class="o_text_highlight_item">
        text content (line 2) ...
        <svg.../>
    </span>
    ...
</span>
```

Which is saved in a minimal format that allows the JS code to rebuild
the SVGs when it's needed:

```
<span class="o_text_highlight o_text_highlight_[highlightId]"
    style="--text-highlight-width: ...; --text-highlight-color: ...;">
    text content ...
</span>
```

The goal of this commit is to use the simplified format for theme
customizations and adapt the code from the "Snippets Preview" and the
"New Page Templates Preview" to be able to build the highlights using
this format when provided in XML.

PR (DT):https://github.com/odoo/design-themes/pull/956

task-4215788