### PR TITLE
[FIX] account: audit_trail activated without any companies with it

### DIFF
--- a/addons/account_audit_trail/models/mail_message.py
+++ b/addons/account_audit_trail/models/mail_message.py
@@ -175,7 +175,19 @@ class Message(models.Model):
     def _except_audit_log(self):
         if self.env.context.get('bypass_audit') is bypass_token:
             return
-        for message in self:
+        to_check = self
+        partner_message = self.filtered(lambda m: m.account_audit_log_partner_id)
+        if partner_message:
+            # The audit trail uses the cheaper check on `customer_rank`, but that field could be set
+            # without actually having an invoice linked (i.e. creation of the contact through the
+            # Invoicing/Customers menu)
+            has_related_move = self.env['account.move'].sudo().search_count([
+                ('partner_id', 'in', partner_message.account_audit_log_partner_id.ids),
+                ('company_id.check_account_audit_trail', '=', True),
+            ], limit=1)
+            if not has_related_move:
+                to_check -= partner_message
+        for message in to_check:
             if message.show_audit_log and not (
                 message.account_audit_log_move_id
                 and not message.account_audit_log_move_id.posted_before

--- a/addons/account_audit_trail/tests/test_audit_trail.py
+++ b/addons/account_audit_trail/tests/test_audit_trail.py
@@ -131,3 +131,11 @@ class TestAuditTrail(AccountTestInvoicingCommon):
         # identify that user as being a customer
         user.partner_id._increase_rank('customer_rank', 1)
         user.partner_id.message_post(body='Test', partner_ids=user.partner_id.ids)
+
+    def test_partner_unlink(self):
+        """Audit trail should not block partner unlink if they didn't create moves"""
+        partner = self.env['res.partner'].create({
+            'name': 'Test',
+            'customer_rank': 1,
+        })
+        partner.unlink()


### PR DESCRIPTION
To reproduce:
Go to Accounting/Invoicing, Customers and create a new Customer. Delete it.
You get an error talking about audit trail while you don't have it activated.

The issue is that we block based on customer/supplier rank 
when there is no company on the partner.

We now check if we should block the deletion of a message of a 
partner if this partner has at least one journal entry with a 
company that has audit trail activated.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
