### PR TITLE
[FIX] website: increase tolerance for olg call

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -355,7 +355,7 @@ class Website(models.Model):
 
     def _OLG_api_rpc(self, route, params):
         # For text content generation
-        return self._api_rpc(route, params, 'website.olg_api_endpoint', DEFAULT_OLG_ENDPOINT, timeout=20)
+        return self._api_rpc(route, params, 'website.olg_api_endpoint', DEFAULT_OLG_ENDPOINT, timeout=45)
 
     def get_cta_data(self, website_purpose, website_type):
         return {'cta_btn_text': False, 'cta_btn_href': '/contactus'}


### PR DESCRIPTION
When asking for website text replacements to IAP, a timeout of 20 seconds was set. Meaning that after 20 seconds, the user waited for no reason as texts won't be replaced for him (but will be for the next user, using the cache, if still valid).

This commit increases that 20 seconds value to 45 seconds. While testing, this 20 seconds timeout is really annoying and from a functional point of view, waiting an extra 25 seconds (at worst) for a much greater chance of having text replacements seems acceptable. This will be even more true with the 18.0 new waiting screen which is nicer.

Also, it might just be needed to increase that timeout as we may increase the overall delay a bit in future updates to have better quality text replacements.
