### PR TITLE
[FIX] html_editor: hint in block containing media

### DIFF
--- a/addons/html_editor/static/src/main/hint_plugin.js
+++ b/addons/html_editor/static/src/main/hint_plugin.js
@@ -13,13 +13,11 @@ function isMutationRecordSavable(record) {
  * @param {HTMLElement} editable
  */
 function target(selectionData, editable) {
+    if (selectionData.documentSelectionIsInEditable || editable.childNodes.length !== 1) {
+        return;
+    }
     const el = editable.firstChild;
-    if (
-        !selectionData.documentSelectionIsInEditable &&
-        el &&
-        el.tagName === "P" &&
-        editable.textContent === ""
-    ) {
+    if (el.tagName === "P" && isEmptyBlock(el)) {
         return el;
     }
 }

--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -510,7 +510,7 @@ export function isEmptyBlock(blockEl) {
         // this visible is a "visible empty" node like an image.
         if (
             node.nodeName != "BR" &&
-            (isSelfClosingElement(node) || isIconElement(node) || isProtecting(node))
+            (isSelfClosingElement(node) || isMediaElement(node) || isProtecting(node))
         ) {
             return false;
         }

--- a/addons/html_editor/static/tests/hint.test.js
+++ b/addons/html_editor/static/tests/hint.test.js
@@ -48,6 +48,22 @@ test("placeholder must not be visible if there is content in the editor", async 
     expect(getContent(el)).toBe(`<p></p><p>Hello</p>`);
 });
 
+test("placeholder must not be visible if there is content in the editor (2)", async () => {
+    const content =
+        '<p><a href="#" title="document" data-mimetype="application/pdf" class="o_image" contenteditable="false"></a></p>';
+    const { el } = await setupEditor(content, { config: { placeholder: "test" } });
+    // Unchanged, no placeholder hint.
+    expect(getContent(el)).toBe(content);
+});
+
+test("should not display hint in paragraph with media content", async () => {
+    const content =
+        '<p><a href="#" title="document" data-mimetype="application/pdf" class="o_image" contenteditable="false"></a>[]</p>';
+    const { el } = await setupEditor(content);
+    // Unchanged, no empty paragraph hint.
+    expect(getContent(el)).toBe(content);
+});
+
 test("should not lose track of temporary hints on split block", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>", {});
     expect(getContent(el)).toBe(`<p placeholder='Type "/" for commands' class="o-we-hint">[]</p>`);

--- a/addons/html_editor/static/tests/utils/dom_info.test.js
+++ b/addons/html_editor/static/tests/utils/dom_info.test.js
@@ -417,6 +417,14 @@ describe("isEmptyBlock", () => {
         const result = isEmptyBlock(a);
         expect(result).toBe(false);
     });
+
+    test("should return false for a p containing media element", () => {
+        const [p] = insertTestHtml(
+            '<p><a href="#" title="document" data-mimetype="application/pdf" class="o_image" contenteditable="false"></a></p>'
+        );
+        const result = isEmptyBlock(p);
+        expect(result).toBe(false);
+    });
 });
 
 describe("isShrunkBlock", () => {


### PR DESCRIPTION
Steps:
1. In an empty editable, insert a document with /image -> Documents
2. Move the cursor to before or after the document icon.

-> The 'Type "/" for commands' hint is displayed over the icon.

3. Now click outside the editable.

-> The "Type here" hint is displayed over the icon.

Both hints display are undesirable, as the content of the first (and only) paragraph is not empty.

This commit makes sure media elements are considered as visible content when checking if a block is empty.
