### PR TITLE
[FIX] sale_project: avoid stop iteration issue

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -201,7 +201,7 @@ class SaleOrder(models.Model):
             return {'type': 'ir.actions.act_window_close'}
 
         sorted_line = self.order_line.sorted('sequence')
-        default_sale_line = next(sol for sol in sorted_line if sol.product_id.detailed_type == 'service')
+        default_sale_line = next((sol for sol in sorted_line if sol.product_id.detailed_type == 'service'), None)
         action = {
             'type': 'ir.actions.act_window',
             'name': _('Projects'),
@@ -212,7 +212,7 @@ class SaleOrder(models.Model):
             'context': {
                 **self._context,
                 'default_partner_id': self.partner_id.id,
-                'default_sale_line_id': default_sale_line.id,
+                'default_sale_line_id': default_sale_line.id if default_sale_line else False,
                 'default_allow_billable': 1,
             }
         }

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -817,3 +817,24 @@ class TestSaleProject(TestSaleProjectCommon):
             'sale_line_id': sale_order.order_line.id,
         })
         self.assertEqual(task3.sale_order_id, sale_order, "Task matches SO's partner_id")
+
+    def test_action_view_project_ids(self):
+        order = self.env['sale.order'].create({
+            'name': 'Project Order',
+            'partner_id': self.partner.id
+        })
+
+        sol = self.env['sale.order.line'].create({
+            'product_id': self.product_order_service4.id,
+            'order_id': order.id,
+        })
+
+        order.action_confirm()
+        action = order.action_view_project_ids()
+        self.assertEqual(action['type'], 'ir.actions.act_window', 'Should return a window action')
+        self.assertEqual(action['context']['default_sale_line_id'], sol.id, 'The SOL linked to the SO should be chosen as default value')
+
+        self.product_order_service4.type = 'consu'
+        action = order.action_view_project_ids()
+        self.assertEqual(action['type'], 'ir.actions.act_window', 'Should return a window action')
+        self.assertFalse(action['context']['default_sale_line_id'], 'No SOL should be set by default since the product changed')


### PR DESCRIPTION
Steps to reproduce:
1. Install the `sale_project` module.
2. Create a product with the following properties: 
    - Type: 'Service'
    - Create on Order: 'Project & Task'
4. Create a sale order and add the product to it.
5. Confirm the sale order.
6. In another tab, change the product type to 'Consumable' in the product form (a popup will appear informing you that you cannot change the type, but it can be dismissed.)

The issue arises because the 'Project' smart button remains visible in the sale order tab until the page is reloaded, and there are no longer any order lines with a product of type 'Service', resulting in a StopIteration error.

Closes #180340