### PR TITLE
[FIX] hr_holidays: wrong value when get remaining leaves

### DIFF
--- a/addons/hr_holidays/models/hr_employee_base.py
+++ b/addons/hr_holidays/models/hr_employee_base.py
@@ -74,7 +74,7 @@ class HrEmployeeBase(models.AbstractModel):
                 s.requires_allocation='yes' AND
                 h.employee_id in %s
             GROUP BY h.employee_id""", (tuple(self.ids),))
-        return {(row['employee_id'], row['days']) for row in self._cr.dictfetchall()}
+        return {row['employee_id']: row['days'] for row in self._cr.dictfetchall()}
 
     def _compute_remaining_leaves(self):
         remaining = {}


### PR DESCRIPTION
Close https://github.com/odoo/odoo/issues/181546
* Wrong dict comprehension format, should be {key: value for ...} instead of {(key, value) for ....}

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
