### PR TITLE
[FIX] point_of_sale: make serializable models modifiable

### DIFF
--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -25,7 +25,7 @@ function mapObj(obj, fn) {
 const RELATION_TYPES = new Set(["many2many", "many2one", "one2many"]);
 const X2MANY_TYPES = new Set(["many2many", "one2many"]);
 const AVAILABLE_EVENT = ["create", "update", "delete"];
-const SERIALIZABLE_MODELS = [
+export const SERIALIZABLE_MODELS = [
     "pos.order",
     "pos.order.line",
     "pos.payment",


### PR DESCRIPTION
At the moment it is not possible to add new X2many relations to a model inside the `SERIALIZABLE_MODELS` list.

I would like to add an One2many relation to the `pos.order` model:

```python
class PosOrder(models.Model):
    _inherit = "pos.order"

   example_items = fields.One2many("example.item", "order_id")
```

```javascript
import { Base } from "@point_of_sale/app/models/related_models";
import { registry } from "@web/core/registry";

export class ExampleItem extends Base {
  static pythonModel = "example.item";

  setup(vals) {
    super.setup(vals);
  }

  // ...
}

registry.category("pos_available_models").add(ExampleItem.pythonModel, ExampleItem);
```

A call to [`order.serialize`](https://github.com/abichinger/odoo/blob/f9de1eef6dd403157c0222dc75de85c8b7b59e3c/addons/point_of_sale/static/src/app/models/related_models.js#L191) throws the following error:

```
Trying to create a non serializable record example.item
```

After this PR is merged it is possible to add new models to the list of serializable models:

```javascript
import { SERIALIZABLE_MODELS } from "@point_of_sale/app/models/related_models"
SERIALIZABLE_MODELS.push("example.item")
```

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
