### PR TITLE
[FIX] base: added writeable permission check when migrating to filestore

### DIFF
--- a/doc/cla/individual/zain2323.md
+++ b/doc/cla/individual/zain2323.md
@@ -1,0 +1,11 @@
+Pakistan, 2024-09-28
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Zain Siddiqui zainsiddiqui2323@gmail.com https://github.com/zain2323

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -83,6 +83,11 @@ class IrAttachment(models.Model):
     def _migrate(self):
         record_count = len(self)
         storage = self._storage().upper()
+        # When migrating to filestore verifying if the directory has write permission
+        if storage == 'FILE':
+            filestore = self._filestore()
+            if not os.access(filestore, os.W_OK):
+                raise PermissionError("Write permission denied for filestore directory.")
         for index, attach in enumerate(self):
             _logger.debug("Migrate attachment %s/%s to %s", index + 1, record_count, storage)
             # pass mimetype, to avoid recomputation


### PR DESCRIPTION
Description this PR addresses:

Fixes #181899: Prevents data loss when migrating attachments from DB to filestore by adding a writable permission check before migration.

Current behavior before PR:

Migration to filestore proceeds even if the target directory is not writable, resulting in data loss.

Desired behavior after PR is merged:
Writable permissions are checked before migration. If the target directory is not writable, an exception will be raised

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
