### PR TITLE
[FIX] mrp_repair, website_sale_collect: replace tree with list

### DIFF
--- a/addons/mrp_repair/models/production.py
+++ b/addons/mrp_repair/models/production.py
@@ -29,6 +29,6 @@ class MrpProduction(models.Model):
             action['res_id'] = repair_ids.id
         elif self.repair_count > 1:
             action['name'] = _("Repair Source of %s", self.name)
-            action['views'] = [[False, 'tree']]
+            action['views'] = [[False, 'list']]
             action['domain'] = [('id', 'in', repair_ids.ids)]
         return action

--- a/addons/website_sale_collect/models/res_config_settings.py
+++ b/addons/website_sale_collect/models/res_config_settings.py
@@ -21,6 +21,6 @@ class ResConfigSettings(models.TransientModel):
             'type': 'ir.actions.act_window',
             'name': _("Delivery Methods"),
             'res_model': 'delivery.carrier',
-            'view_mode': 'tree,form',
+            'view_mode': 'list,form',
             'context': '{"search_default_delivery_type": "in_store"}',
         }


### PR DESCRIPTION
before this commit, few tree tags are left over without changing into list tag in this commit: https://github.com/odoo/odoo/commit/4ca79b1549eec988a31b80aa0e9f03e6420e84df#diff-e8da39382dbb141dfbfcec84a5a4365734015a25cd3ed94004f7eb7daa7e7ab0R12

after this commit, all tree tag will be converted into list tag

Related EE: https://github.com/odoo/enterprise/pull/71002

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
