### PR TITLE
[REM] l10n_in: Remove Enterprise Widget from Indian Electronic Waybill.

### DIFF
--- a/addons/l10n_in/views/res_config_settings_views.xml
+++ b/addons/l10n_in/views/res_config_settings_views.xml
@@ -43,7 +43,7 @@
                                  help="Connect to NIC (National Informatics Center) to submit e-waybill on posting."
                                  company_dependent="1"
                                  documentation="/applications/finance/fiscal_localizations/india.html#indian-e-waybill">
-                            <field name="module_l10n_in_edi_ewaybill" class="oe_inline" widget="upgrade_boolean"/>
+                            <field name="module_l10n_in_edi_ewaybill" class="oe_inline"/>
                         </setting>
                         <setting name="india_gstin_status_api_settings"
                                  string="Check GST Number Status"


### PR DESCRIPTION
**[REM] l10n_in: Remove Enterprise Widget from Indian Electronic Waybill**

**Description of the issue/feature this PR addresses:**
System shows Enterprise Widget on Indian Electronic Waybill module.
Although Indian Electronic Waybill is available in community addons .

**Impacted versions:**
* 17.0
* 18.0

**Steps to Reproduce :**
- Install l10n_in module.
- Now Go to the invoicing --> Configuration --> Setting.
- See the Enterprise Widget is on Indian Electronic Waybill.

**Current behaviour before PR:**
Enterprise Widget Should not show on Indian Electronic Waybill as it is available in community addons.

**Desired behaviour after PR is merged:**
After this PR merge, System will allow to install Indian Electronic Waybill module in community version.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
