### PR TITLE
[IMP] maintenance: Add Enterprise Widget On Worksheet for Maintenance Module

### DIFF
--- a/addons/maintenance/views/res_config_settings_views.xml
+++ b/addons/maintenance/views/res_config_settings_views.xml
@@ -12,7 +12,7 @@
                     <app data-string="Maintenance" string="Maintenance" name="maintenance" groups="maintenance.group_equipment_manager">
                         <block title="Custom Worksheets">
                             <setting help="Create custom worksheet templates">
-                                <field name="module_maintenance_worksheet"/>
+                                <field name="module_maintenance_worksheet" widget="upgrade_boolean"/>
                             </setting>
                         </block>
                     </app>


### PR DESCRIPTION
**[ADD] maintenance: Add Enterprise Widget On Worksheet for Maintenance Module**

**Description of the issue/feature this PR addresses:**
Enterprise Widget is not showing on Worksheet for Maintenance Module as that module is in enterprise addons.

**Impacted versions:**
* 17.0
* 18.0

**Steps to Reproduce :**
- Install Maintenance module.
- Now Go to the Maintenance --> Configuration --> Setting.
- See the Enterprise Widget is not showing on Custom Maintenance Worksheets.

**Current behaviour before PR:**
Enterprise Widget is not showing on Worksheet for Maintenance Module.

**Desired behaviour after PR is merged:**
After this PR merge, System will show Enterprise Widget on Custom Maintenance Worksheets.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
