### PR TITLE
[IMP] point_of_sale: ADD Enterprise Widget On POS Pricer Module

### DIFF
--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -257,7 +257,7 @@
                                 </div>
                             </setting>
                             <setting id="pos_pricer" string="Pricer" title="Pricer tags" help="Display and update your products information through electronic price tags">
-                                <field name="module_pos_pricer"/>
+                                <field name="module_pos_pricer" widget="upgrade_boolean"/>
                             </setting>
                             <setting id="pos-loyalty" title="Boost your sales with multiple kinds of programs: Coupons, Promotions, Gift Card, Loyalty. Specific conditions can be set (products, customers, minimum purchase amount, period). Rewards can be discounts (% or amount) or free products." string="Promotions, Coupons, Gift Card &amp; Loyalty Program" help="Manage promotion that will grant customers discounts or gifts" documentation="/applications/sales/point_of_sale/pricing/loyalty.html">
                                 <field name="module_loyalty"/>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Enterprise Widget is not showing on POS Pricer Module as that module is in enterprise addons.

**Impacted versions:**
* 18.0

**Steps to Reproduce :**
- Install Point of Sale module.
- Now Go to the Point of Sale --> Configuration --> Setting.
- See the Enterprise Widget is not showing on Pricer.

**Current behaviour before PR:**
Enterprise Widget is not showing on POS Pricer Module.

**Desired behaviour after PR is merged:**
After this PR merge, System will show Enterprise Widget on POS Pricer Module.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
