### PR TITLE
[IMP] auth_*: do not disconnect on install of oauth or passkey

### DIFF
--- a/addons/auth_passkey/models/res_users.py
+++ b/addons/auth_passkey/models/res_users.py
@@ -80,6 +80,9 @@ class UsersPasskey(models.Model):
 
     def _get_session_token_query_params(self):
         params = super()._get_session_token_query_params()
-        params['select'] = SQL("%s, ARRAY_AGG(key.id ORDER BY key.id DESC)", params['select'])
+        params['select'] = SQL(
+            "%s, ARRAY_AGG(key.id ORDER BY key.id DESC) FILTER (WHERE key.id IS NOT NULL)",
+            params['select']
+        )
         params['joins'] = SQL("%s LEFT JOIN auth_passkey_key key ON res_users.id = key.create_uid", params['joins'])
         return params

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1015,7 +1015,7 @@ class Users(models.Model):
         if self.env.cr.rowcount != 1:
             self.env.registry.clear_cache()
             return False
-        data_fields = self.env.cr.fetchone()
+        data_fields = [data for data in self.env.cr.fetchone() if data is not None]
         # generate hmac key
         key = (u'%s' % (data_fields,)).encode('utf-8')
         # hmac the session id


### PR DESCRIPTION
When installing
- `auth_oauth`
- `auth_passkey`

All users, including the user who just installed the module, were disconnected following the invalidation of the sessions because new fields were added to the session tokens, even if their data was empty
e.g.
the `oauth_access_token` fields
the passkeys in `auth_passkey_key`

This revision suggests to not include the fields
when they are empty, to avoid to invalidate
sessions on installation of the `auth_*` module.
