### PR TITLE
[IMP] mail: slight improvements to discuss sidebar style

### DIFF
--- a/addons/mail/static/src/core/common/navigable_list.dark.scss
+++ b/addons/mail/static/src/core/common/navigable_list.dark.scss
@@ -1,0 +1,3 @@
+.o-mail-NavigableList {
+    --mail-NavigableList-activeBgColor: #{mix($white, $o-action, 90%)};
+}

--- a/addons/mail/static/src/core/common/navigable_list.scss
+++ b/addons/mail/static/src/core/common/navigable_list.scss
@@ -2,6 +2,10 @@
     z-index: $o-mail-NavigableList-zIndex;
 }
 
+.o-mail-NavigableList-active {
+    background-color: var(--mail-NavigableList-activeBgColor, mix($o-view-background-color, $o-action, 90%));
+}
+
 .o-mail-NavigableList-floatingLoading {
     right: $border-width; // as to not overlap border
 }

--- a/addons/mail/static/src/core/common/navigable_list.xml
+++ b/addons/mail/static/src/core/common/navigable_list.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.NavigableList">
-        <div class="o-mail-NavigableList bg-view m-0 p-0" t-ref="root" t-att-class="props.class">
+        <div class="o-mail-NavigableList bg-view m-0 p-0 shadow-sm" t-ref="root" t-att-class="props.class">
             <div t-if="show" class="o-open border d-flex flex-column bg-inherit" t-on-mousedown.prevent="">
                 <div t-if="state.showLoading" t-att-class="{ 'position-absolute bg-inherit smaller o-mail-NavigableList-floatingLoading': props.options.length, 'bg-300': props.options.length and state.activeIndex === 0, 'o-mail-NavigableList-item': !props.options.length }">
                     <t t-call="mail.NavigableList.spinner"/>
@@ -15,7 +15,7 @@
                     t-on-click="(ev) => this.selectOption(ev, option_index)"
                 >
                     <hr class="my-2" t-if="option.group != lastGroup and option_index != 0"/>
-                    <a role="button" class="d-flex align-items-center w-100 px-3 py-1 small" t-att-class="{ 'o-mail-NavigableList-active bg-300': state.activeIndex === option_index }">
+                    <a role="button" class="d-flex align-items-center w-100 px-3 py-1 small" t-att-class="{ 'o-mail-NavigableList-active': state.activeIndex === option_index }">
                         <t t-if="option.optionTemplate" t-call="{{ option.optionTemplate }}"/>
                         <t t-elif="props.optionTemplate" t-call="{{ props.optionTemplate }}"/>
                         <t t-else="" t-esc="option.label"/>

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.js
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.js
@@ -1,8 +1,6 @@
-import { useHover } from "@mail/utils/common/hooks";
 import { Component, useState } from "@odoo/owl";
 import { Dropdown } from "@web/core/dropdown/dropdown";
-import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
-import { _t } from "@web/core/l10n/translation";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
@@ -16,23 +14,11 @@ export const discussSidebarItemsRegistry = registry.category("mail.discuss_sideb
 export class DiscussSidebar extends Component {
     static template = "mail.DiscussSidebar";
     static props = {};
-    static components = { Dropdown };
+    static components = { Dropdown, DropdownItem };
 
     setup() {
         super.setup();
         this.store = useState(useService("mail.store"));
-        this.compactHover = useHover(["compact-btn", "compact-floating*"], {
-            onHover: () => (this.compactFloating.isOpen = true),
-            onAway: () => (this.compactFloating.isOpen = false),
-        });
-        this.compactFloating = useDropdownState();
-    }
-
-    get compactBtnText() {
-        if (this.store.discuss.isSidebarCompact) {
-            return _t("Expand");
-        }
-        return _t("Collapse");
     }
 
     get discussSidebarItems() {

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.scss
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.scss
@@ -7,17 +7,11 @@
     }
 }
 
-.o-mail-DiscussSidebar-compactBtn {
-    color: $o-action !important;
-    padding-left: map-get($spacers, 2) + map-get($spacers, 1) + $border-width;
-    padding-right: map-get($spacers, 2) + map-get($spacers, 1) + $border-width;
-
-    &:hover {
-        border-color: rgba($o-action, .75);
-    }
+.o-mail-DiscussSidebar-optionsBtn {
+    padding: map-get($spacers, 1) / 2;
 
     &:not(.o-compact) {
-        right: map-get($spacers, 3) / 2;
+        right: map-get($spacers, 2) + map-get($spacers, 1);
     }
 }
 

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.xml
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.xml
@@ -4,12 +4,18 @@
         <div class="o-mail-DiscussSidebar d-flex d-print-none flex-column overflow-auto flex-shrink-0 h-100 border-end z-1 o-mail-discussSidebarBgColor gap-1" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }">
             <div class="o-mail-DiscussSidebar-top position-sticky justify-content-center top-0 z-2 o-mail-discussSidebarBgColor" t-att-class="{ 'pt-2 pb-1': !store.inPublicPage, 'pt-1': store.inPublicPage }">
                 <div class="d-flex align-items-center justify-content-center" t-att-class="{ 'flex-column gap-2': store.discuss.isSidebarCompact }">
-                    <t name="compact-btn">
-                        <Dropdown state="compactFloating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-view border p-2 mx-2 my-0 min-w-0 shadow-sm'" manual="true">
-                            <button class="o-mail-DiscussSidebar-compactBtn btn btn-light py-1 align-items-center justify-content-center smaller" t-att-aria-label="compactBtnText" t-att-class="{ 'ms-auto me-0': !store.discuss.isSidebarCompact, 'position-absolute': !store.discuss.isSidebarCompact and !store.inPublicPage, 'o-compact': store.discuss.isSidebarCompact }" t-on-click="() => this.store.discuss.isSidebarCompact = !this.store.discuss.isSidebarCompact" t-ref="compact-btn"><i class="oi fa-fw" t-att-class="store.discuss.isSidebarCompact ? 'oi-arrow-right' : 'oi-arrow-left'"/></button>
+                    <t name="options-btn">
+                        <Dropdown position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-view border px-0 py-1 mx-2 my-0 min-w-0 shadow-sm'">
+                            <button class="o-mail-DiscussSidebar-optionsBtn btn btn-light p-0 align-items-center justify-content-center smaller border border-dark-subtle rounded-circle opacity-50 opacity-100-hover" title="Options" t-att-class="{ 'ms-auto': !store.discuss.isSidebarCompact, 'position-absolute': !store.discuss.isSidebarCompact and !store.inPublicPage, 'o-compact': store.discuss.isSidebarCompact }"><i class="fa fa-ellipsis-h fa-fw fa-lg" style="font-size: 15px;"/></button>
                             <t t-set-slot="content">
-                                <div t-ref="compact-floating">
-                                    <span class="text-muted user-select-none" t-esc="compactBtnText"/>
+                                <div>
+                                    <DropdownItem class="'px-2 py-1 d-flex align-items-center rounded-0'" onSelected="() => this.store.discuss.isSidebarCompact = !this.store.discuss.isSidebarCompact">
+                                         <i class="fa fa-fw" t-att-class="{ 'fa-expand': store.discuss.isSidebarCompact, 'fa-compress': !store.discuss.isSidebarCompact }"/>
+                                         <span class="mx-2">
+                                             <t t-if="store.discuss.isSidebarCompact">Expand panel</t>
+                                             <t t-else="">Collapse panel</t>
+                                         </span>
+                                     </DropdownItem>
                                 </div>
                             </t>
                         </Dropdown>

--- a/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.DiscussSidebarMailboxes">
-        <div class="d-flex flex-column flex-grow-0 gap-1">
+        <div class="d-flex flex-column flex-grow-0 gap-1 mt-2">
             <Mailbox mailbox="store.inbox"/>
             <Mailbox mailbox="store.starred"/>
             <Mailbox mailbox="store.history"/>
@@ -35,13 +35,13 @@
         >
             <ThreadIcon className="'bg-inherit ' + (store.discuss.isSidebarCompact ? '' : 'ms-3 me-2')" thread="mailbox"/>
             <t t-if="!store.discuss.isSidebarCompact">
-                <div class="me-2 text-truncate" t-esc="mailbox.name"/>
+                <div class="me-2 text-truncate small" style="line-height: 1.65;" t-esc="mailbox.name"/>
                 <div t-attf-class="flex-grow-1 {{ mailbox.counter === 0 ? 'me-3': '' }}"/>
             </t>
             <span
                 t-if="mailbox.counter > 0"
                 class="o-mail-DiscussSidebar-badge o-discuss-badge badge rounded-pill fw-bold"
-                t-att-class="{ 'o-muted': mailbox.id === 'starred', 'ms-1 me-2': !store.discuss.isSidebarCompact, 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact }"
+                t-att-class="{ 'o-muted': mailbox.id === 'starred', 'mx-1': !store.discuss.isSidebarCompact, 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact }"
                 t-esc="mailbox.counter"
             />
         </button>

--- a/addons/mail/static/src/core/web/discuss_sidebar_patch.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_patch.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-inherit="mail.DiscussSidebar" t-inherit-mode="extension">
-        <xpath expr="//*[@name='compact-btn']" position="after">
+        <xpath expr="//*[@name='options-btn']" position="after">
             <Dropdown t-if="store.discuss.isSidebarCompact" state="meetingFloating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu border bg-view p-2 mx-2 my-0 min-w-0 shadow-sm'" manual="true">
                 <t t-call="mail.DiscussSidebar.startMeetingButton"/>
                 <t t-set-slot="content">
@@ -15,6 +15,6 @@
     </t>
 
     <t t-name="mail.DiscussSidebar.startMeetingButton">
-        <button class="btn btn-primary rounded d-flex align-items-center gap-1 mx-5" t-att-class="{ 'py-2': store.discuss.isSidebarCompact }" t-on-click="store.startMeeting" data-hotkey="m" t-ref="meeting-btn"><i class="fa fa-fw fa-users"/><span t-if="!store.discuss.isSidebarCompact" t-esc="startMeetingText"/></button>
+        <button class="btn btn-primary rounded d-flex align-items-center gap-1 mx-5" t-att-class="{ 'py-2': store.discuss.isSidebarCompact, 'btn-sm': !store.discuss.isSidebarCompact }" t-on-click="store.startMeeting" data-hotkey="m" t-ref="meeting-btn"><i class="fa fa-fw fa-users"/><span t-if="!store.discuss.isSidebarCompact" t-esc="startMeetingText"/></button>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
@@ -11,9 +11,6 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .1;
     --border-opacity: var(--mail-DiscussSidebarChannel-borderOpacity, #{$o-mail-DiscussSidebarChannel-borderOpacity});
     gap: 1px;
 
-    margin-left: map-get($spacers, 1) + map-get($spacers, 1) / 2 !important;
-    margin-right: map-get($spacers, 1) + map-get($spacers, 1) / 2 !important;
-
     &.o-bordered {
         background-color: var(---mail-DiscussSidebarChannel-borderedBgColor, mix($white, $dark, 99%)) !important;
     }
@@ -31,6 +28,8 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .1;
 }
 
 .o-mail-DiscussSidebar-item {
+    line-height: 2; // so that same height as actions
+
     &:hover .o-mail-DiscussSidebarChannel-commands {
         display: flex !important;
         .btn-group .btn {
@@ -46,15 +45,12 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .1;
     }
 }
 
-.o-mail-DiscussSidebar-item {
-    line-height: 2.15; // so that same height as actions, so folding doesn't resize
-}
-
 .o-mail-DiscussSidebarCategory-toggler {
-    line-height: 2.15; // so that same height as actions, so folding doesn't resize
-
     &.o-compact {
         font-size: .65rem;
+    }
+    &:not(.o-compact) {
+        line-height: 2.35; // so that same height as actions, so folding doesn't resize
     }
 }
 
@@ -64,11 +60,6 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .1;
 
 .o-mail-DiscussSidebarChannel-itemMain {
     background-color: inherit !important; // Not 'bg-inherit' so it cancels btn hover effect too
-}
-
-.o-mail-DiscussSidebarChannel-marginEnd::before {
-    // invisible character so that typing status bar has constant height, regardless of text content.
-    content: "\200b"; /* unicode zero width space character */
 }
 
 .o-mail-DiscussSidebarChannel-threadIcon {
@@ -89,10 +80,14 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .1;
 .o-mail-DiscussSidebar-unreadIndicator {
     font-size: 0.35rem;
     left: 6px;
-    opacity: 50%;
+    opacity: 35%;
 
     &.o-compact {
         left: 1px;
+    }
+
+    .o-mail-DiscussSidebarSubchannel &:not(.o-compact) {
+        left: 12px;
     }
 }
 

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebarCategories">
-        <hr t-if="!store.discuss.isSidebarCompact and !store.inPublicPage" class="mt-1 mb-0 w-100 opacity-0 flex-shrink-0"/>
         <t t-if="hasQuickSearch">
             <Dropdown t-if="store.discuss.isSidebarCompact" state="quickSearchFloating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-view border mx-2 my-0 min-w-0 p-0 shadow-sm'" manual="true">
-                <button class="o-mail-DiscussSidebarCategories-quickSearchBtn btn btn-light d-flex align-items-center justify-content-center px-1 mx-2 bg-inherit" t-att-class="{ 'o-active': state.quickSearchVal.length }" t-on-click="() => state.floatingQuickSearchOpen = true" t-ref="quick-search-btn"><i class="fa fa-search"/></button>
+                <button class="o-mail-DiscussSidebarCategories-quickSearchBtn btn btn-secondary d-flex align-items-center justify-content-center px-1 mx-2 bg-inherit" t-att-class="{ 'o-active': state.quickSearchVal.length, 'opacity-50 opacity-100-hover': store.discuss.isSidebarCompact }" t-on-click="() => state.floatingQuickSearchOpen = true" t-ref="quick-search-btn"><i class="fa fa-search"/></button>
                 <t t-set-slot="content">
                     <div t-att-class="{ 'p-2': !state.floatingQuickSearchOpen }" t-ref="quick-search-floating">
                         <DiscussSidebarQuickSearchInput t-if="state.floatingQuickSearchOpen" state="state" autofocus="true"/>
-                        <span t-else="" class="fst-italic user-select-none">Quick search</span>
+                        <span t-else="" class="text-muted user-select-none">Quick search</span>
                     </div>
                 </t>
             </Dropdown>
@@ -22,7 +21,7 @@
     </t>
 
     <t t-name="mail.DiscussSidebarQuickSearchInput">
-        <div class="o-mail-DiscussSidebarQuickSearchInput d-flex align-items-center justify-content-center rounded gap-1" t-att-class="{ 'o-active': state.quickSearchVal.length, 'mx-4 mb-2': !store.discuss.isSidebarCompact }">
+        <div class="o-mail-DiscussSidebarQuickSearchInput d-flex align-items-center justify-content-center rounded gap-1" t-att-class="{ 'o-active': state.quickSearchVal.length, 'mx-2': !store.discuss.isSidebarCompact }">
             <input class="form-control rounded-3 border-0" placeholder="Quick search…" t-model="state.quickSearchVal" t-ref="root"/>
             <button t-if="state.quickSearchVal.length" class="btn btn-light p-1 rounded-0" t-on-click="() => state.quickSearchVal = ''"><i class="oi oi-close" title="Clear quick search"/></button>
         </div>
@@ -38,11 +37,11 @@
     </t>
 
     <t t-name="mail.DiscussSidebarCategory">
-        <Dropdown t-if="actions.length and store.discuss.isSidebarCompact" state="floating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-view border p-2 mx-2 my-0 min-w-0 shadow-sm'" manual="true">
+        <Dropdown t-if="store.discuss.isSidebarCompact" state="floating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-view border p-2 mx-2 my-0 min-w-0 shadow-sm'" manual="true">
             <t t-call="mail.DiscussSidebarCategory.main"/>
             <t t-set-slot="content">
                 <div class="overflow-hidden" t-ref="floating">
-                    <span class="fw-bold text-uppercase small user-select-none" t-esc="category.name"/>
+                    <span class="fw-bold text-uppercase o-xsmaller user-select-none text-muted" t-esc="category.name"/>
                     <t t-call="mail.DiscussSidebarCategory.actions"/>
                 </div>
             </t>
@@ -51,7 +50,7 @@
     </t>
 
     <t t-name="mail.DiscussSidebarCategory.main">
-        <div class="o-mail-DiscussSidebarCategory d-flex align-items-center" t-att-class="{ 'mx-1 my-2 position-relative': store.discuss.isSidebarCompact, 'mt-1': !store.discuss.isSidebarCompact }" t-attf-class="#{category.extraClass}" name="header" t-ref="root">
+        <div class="o-mail-DiscussSidebarCategory d-flex align-items-center" t-att-class="{ 'mx-1 my-2 position-relative': store.discuss.isSidebarCompact, 'mt-1 me-2': !store.discuss.isSidebarCompact }" t-attf-class="#{category.extraClass}" name="header" t-ref="root">
             <button class="o-mail-DiscussSidebarCategory-toggler btn btn-link text-reset flex-grow-1 d-flex p-0 text-start opacity-100-hover opacity-75" t-att-class="{ 'mx-1 align-items-baseline': !store.discuss.isSidebarCompact, 'align-items-center justify-content-center border-0 o-compact': store.discuss.isSidebarCompact }" t-on-click="() => this.toggle()" name="toggler">
                 <t t-if="store.discuss.isSidebarCompact">
                     <i class="start-0 position-absolute" t-att-class="{
@@ -61,25 +60,25 @@
                     <span class="rounded p-1" t-att-class="{ 'opacity-50': !category.open }"><i t-if="store.channels.status === 'fetching'" class="fa fa-fw fa-circle-o-notch fa-spin"/><i t-else="" class="fa-fw fa-lg" t-att-class="category.icon ?? 'fa fa-user'"/></span>
                 </t>
                 <t t-else="">
-                    <span t-if="store.channels.status === 'fetching'" class="o-visible-short-delay"><i class="o-mail-DiscussSidebarCategory-icon smaller me-1 fa fa-fw fa-circle-o-notch fa-spin opacity-50"/></span>
-                    <i t-else="" class="o-mail-DiscussSidebarCategory-icon smaller me-1" t-att-class="category.open ? 'oi oi-chevron-down opacity-100' : 'oi oi-chevron-right opacity-50'"/>
-                    <span class="btn-sm p-0 text-uppercase text-break fw-bolder smaller" t-att-class="{ 'opacity-50': !category.open }"><t t-esc="category.name"/></span>
+                    <span t-if="store.channels.status === 'fetching'" class="o-visible-short-delay"><i class="o-mail-DiscussSidebarCategory-icon o-xsmaller mx-1 fa fa-fw fa-circle-o-notch fa-spin opacity-50"/></span>
+                    <i t-else="" class="o-mail-DiscussSidebarCategory-icon o-xsmaller mx-1" t-att-class="category.open ? 'oi oi-chevron-down opacity-100' : 'oi oi-chevron-right opacity-50'"/>
+                    <span class="btn-sm p-0 text-uppercase text-break fw-bolder o-xsmaller text-muted" t-att-class="{ 'opacity-50': !category.open }"><t t-esc="category.name"/></span>
                 </t>
             </button>
             <t t-if="actions.length and !store.discuss.isSidebarCompact" t-call="mail.DiscussSidebarCategory.actions"/>
-            <div t-if="!category.open and store.getDiscussSidebarCategoryCounter(category.id) > 0" class="o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge fw-bold" t-att-class="{ 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact, 'me-3': !store.discuss.isSidebarCompact }">
+            <div t-if="!category.open and store.getDiscussSidebarCategoryCounter(category.id) > 0" class="o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge fw-bold" t-att-class="{ 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact, 'me-1': !store.discuss.isSidebarCompact }">
                 <t t-esc="store.getDiscussSidebarCategoryCounter(category.id)"/>
             </div>
         </div>
     </t>
 
     <t t-name="mail.DiscussSidebarCategory.actions">
-        <div class="d-flex" t-att-class="{ 'me-3': !store.discuss.isSidebarCompact }">
-            <div t-att-class="{ 'd-flex flex-column align-items-start pt-1': store.discuss.isSidebarCompact, 'btn-group btn-group-sm': !store.discuss.isSidebarCompact }">
+        <div class="d-flex">
+            <div class="o-mail-DiscussSidebarCategory-actions" t-att-class="{ 'd-flex flex-column align-items-start pt-1': store.discuss.isSidebarCompact, 'btn-group btn-group-sm mx-1': !store.discuss.isSidebarCompact }">
                 <t name="action-group">
                     <t t-foreach="actions" t-as="action" t-key="action_index">
-                        <button class="btn w-100 px-1 mb-1" t-on-click="() => action.onSelect()" t-att-class="{ 'd-flex align-items-center py-0 gap-1 text-start smaller opacity-75 opacity-100-hover btn-secondary': store.discuss.isSidebarCompact, 'btn-light': !store.discuss.isSidebarCompact }" t-attf-class="#{action.class}" t-att-title="store.discuss.isSidebarCompact ? '' : action.label" t-att-data-hotkey="action.hotkey">
-                            <i role="img" t-att-class="action.icon"/>
+                        <button class="btn w-100 opacity-50 opacity-100-hover" t-on-click="() => action.onSelect()" t-att-class="{ 'd-flex align-items-center px-1 py-0 gap-1 text-start smaller btn-secondary': store.discuss.isSidebarCompact, 'btn-light bg-transparent rounded-circle p-0': !store.discuss.isSidebarCompact }" t-attf-class="#{action.class}" t-att-title="store.discuss.isSidebarCompact ? '' : action.label" t-att-data-hotkey="action.hotkey">
+                            <i role="img" class="fa-fw" t-att-class="action.icon"/>
                             <span t-if="store.discuss.isSidebarCompact" class="text-muted" t-esc="action.label"/>
                         </button>
                     </t>
@@ -125,11 +124,11 @@
     <t t-name="mail.DiscussSidebarSubchannel.main">
         <li class="o-mail-DiscussSidebarSubchannel d-flex align-items-center flex-grow-1 position-relative" t-att-class="{ 'p-0': !store.discuss.isSidebarCompact }" t-ref="root">
             <t t-if="!store.discuss.isSidebarCompact">
-                <svg t-if="props.isFirst" class="position-absolute me-1" style="left: 20px; top: -6px;" xmlns="http://www.w3.org/2000/svg" width="12" height="20" viewBox="0 0 12 20">
+                <svg t-if="props.isFirst" class="position-absolute me-1" style="left: 26px; top: -6px;" xmlns="http://www.w3.org/2000/svg" width="10" height="20" viewBox="0 0 10 20">
                     <line x1="0" y1="3" x2="0" y2="100%" stroke="currentColor" stroke-width="3"/>
                     <line x1="0" y1="100%" x2="100%" y2="100%" stroke="currentColor" stroke-width="3"/>
                 </svg>
-                <svg t-else="" class="position-absolute me-1" style="left: 20px; top: -20px;" xmlns="http://www.w3.org/2000/svg" width="12" height="34" viewBox="0 0 12 34">
+                <svg t-else="" class="position-absolute me-1" style="left: 26px; top: -20px;" xmlns="http://www.w3.org/2000/svg" width="10" height="34" viewBox="0 0 10 34">
                     <line x1="0" y1="3" x2="0" y2="100%" stroke="currentColor" stroke-width="3"/>
                     <line x1="0" y1="100%" x2="100%" y2="100%" stroke="currentColor" stroke-width="3"/>
                 </svg>
@@ -138,22 +137,25 @@
                 'o-active': thread.eq(this.store.discuss.thread),
                 'px-1 py-2 mx-1 text-wrap word-break lh-1': store.discuss.isSidebarCompact,
                 'o-nonCompact me-0 mb-1 p-0 ps-2': !store.discuss.isSidebarCompact,
-                'o-item-unread fw-bolder': thread.selfMember?.message_unread_counter > 0 and !thread.isMuted,
+                'o-item-unread': thread.selfMember?.message_unread_counter > 0 and !thread.isMuted,
             }">
                 <span class="text-truncate" t-esc="thread.displayName" t-att-class="{
-                    'fw-bold': thread.selfMember?.message_unread_counter > 0,
+                    'fw-bolder': thread.selfMember?.message_unread_counter > 0,
                     'text-muted': !(thread.selfMember?.message_unread_counter > 0 and !thread.isMuted),
                 }"/>
                 <span class="flex-grow-1"/>
-                <span t-if="thread.importantCounter > 0" t-attf-class="o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge fw-bold top-0 {{thread.isMuted ? 'o-muted' : ''}}" t-att-class="{ 'ms-1 me-2': !store.discuss.isSidebarCompact, 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact }" t-esc="thread.importantCounter"/>
+                <span t-if="thread.importantCounter > 0" t-attf-class="o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge fw-bold top-0 {{thread.isMuted ? 'o-muted' : ''}}" t-att-class="{ 'mx-1': !store.discuss.isSidebarCompact, 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact }" t-esc="thread.importantCounter"/>
             </button>
-            <span t-if="thread.selfMember?.message_unread_counter > 0 and !thread.isMuted and thread.importantCounter === 0" class="o-mail-DiscussSidebar-unreadIndicator position-absolute" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }" title="Thread has unread messages"><i class="fa fa-circle smaller"/></span>
-
+            <t t-if="thread.selfMember?.message_unread_counter > 0 and !thread.isMuted and thread.importantCounter === 0" t-call="mail.DiscussSidebar.unreadIndicator"/>
         </li>
     </t>
 
+    <t t-name="mail.DiscussSidebar.unreadIndicator">
+        <span class="o-mail-DiscussSidebar-unreadIndicator position-absolute" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }" title="Thread has unread messages"><i class="fa fa-circle smaller"/></span>
+    </t>
+
     <t t-name="mail.DiscussSidebarChannel.main">
-        <button class="o-mail-DiscussSidebarChannel btn o-mail-DiscussSidebar-item d-flex align-items-center cursor-pointer mb-0 position-relative rounded-2 gap-1 border-transparent"
+        <button class="o-mail-DiscussSidebarChannel btn o-mail-DiscussSidebar-item d-flex align-items-center cursor-pointer mb-0 position-relative rounded-2 gap-1 border-0"
             t-att-class="attClass"
             t-on-click="(ev) => this.openThread(ev, thread)"
             t-ref="root"
@@ -179,18 +181,17 @@
                     <t t-component="indicators[0]" t-props="{ thread }"/>
                 </div>
             </t>
-            <span t-if="thread.selfMember?.message_unread_counter > 0 and !thread.isMuted and thread.importantCounter === 0" class="o-mail-DiscussSidebar-unreadIndicator position-absolute" name="unread-indicator" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }" title="Thread has unread messages"><i class="fa fa-circle smaller"/></span>
-            <span t-if="thread.importantCounter > 0" t-attf-class="o-mail-DiscussSidebarChannel-badge o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge fw-bold {{thread.isMuted ? 'o-muted' : ''}}" t-att-class="{ 'ms-1 o-nonCompact': !store.discuss.isSidebarCompact, 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact }" t-esc="thread.importantCounter"/>
-            <span t-elif="!store.discuss.isSidebarCompact" class="o-mail-DiscussSidebarChannel-marginEnd me-2"/>
+            <t t-if="thread.selfMember?.message_unread_counter > 0 and !thread.isMuted and thread.importantCounter === 0" t-call="mail.DiscussSidebar.unreadIndicator"/>
+            <span t-if="thread.importantCounter > 0" t-attf-class="o-mail-DiscussSidebarChannel-badge o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge fw-bold {{thread.isMuted ? 'o-muted' : ''}}" t-att-class="{ 'mx-1': !store.discuss.isSidebarCompact, 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact }" t-esc="thread.importantCounter"/>
         </button>
     </t>
 
     <t t-name="mail.DiscussSidebarChannel.commands">
-        <div class="o-mail-DiscussSidebarChannel-commands" t-att-class="{ 'd-none ms-1': !store.discuss.isSidebarCompact }">
+        <div class="o-mail-DiscussSidebarChannel-commands" t-att-class="{ 'd-none mx-1': !store.discuss.isSidebarCompact }">
             <div t-att-class="{ 'd-flex flex-column align-items-start ps-1 pt-1': store.discuss.isSidebarCompact, 'btn-group btn-group-sm gap-1': !store.discuss.isSidebarCompact }">
                 <t t-foreach="sortedCommands" t-as="command" t-key="command_index">
-                    <button class="btn px-1" t-att-class="{ 'd-flex align-items-center py-0 gap-1 text-start smaller opacity-75 opacity-100-hover btn-secondary': store.discuss.isSidebarCompact, 'btn-light': !store.discuss.isSidebarCompact }" t-on-click.stop="() => command.onSelect()" t-att-title="store.discuss.isSidebarCompact ? '' : command.label">
-                        <i role="img" t-att-class="command.icon"/>
+                    <button class="btn opacity-50 opacity-100-hover" t-att-class="{ 'd-flex align-items-center px-1 py-0 gap-1 text-start smaller btn-secondary': store.discuss.isSidebarCompact, 'btn-light rounded-circle p-0': !store.discuss.isSidebarCompact }" t-on-click.stop="() => command.onSelect()" t-att-title="store.discuss.isSidebarCompact ? '' : command.label">
+                        <i role="img" class="fa-fw" t-att-class="command.icon"/>
                         <span t-if="store.discuss.isSidebarCompact" t-esc="command.label"/>
                     </button>
                 </t>

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -1319,7 +1319,8 @@ test("Can make sidebar smaller", async () => {
     await openDiscuss();
     await contains(".o-mail-DiscussSidebar");
     const normalWidth = queryFirst(".o-mail-DiscussSidebar").getBoundingClientRect().width;
-    await click(".o-mail-DiscussSidebar [aria-label='Collapse']");
+    await click(".o-mail-DiscussSidebar [title='Options']");
+    await click(".dropdown-item", { text: "Collapse panel" });
     await contains(".o-mail-DiscussSidebar.o-compact");
     const compactWidth = queryFirst(".o-mail-DiscussSidebar").getBoundingClientRect().width;
     expect(normalWidth).toBeGreaterThan(compactWidth);
@@ -1333,10 +1334,12 @@ test("Sidebar compact is locally persistent (saved in local storage)", async () 
     await start();
     await openDiscuss();
     await contains(".o-mail-DiscussSidebar.o-compact");
-    await click(".o-mail-DiscussSidebar [aria-label='Expand']");
+    await click(".o-mail-DiscussSidebar [title='Options']");
+    await click(".dropdown-item", { text: "Expand panel" });
     await contains(".o-mail-DiscussSidebar:not(.o-compact)");
     expect(browser.localStorage.getItem("mail.user_setting.discuss_sidebar_compact")).toBe(null);
-    await click(".o-mail-DiscussSidebar [aria-label='Collapse']");
+    await click(".o-mail-DiscussSidebar [title='Options']");
+    await click(".dropdown-item", { text: "Collapse panel" });
     await contains(".o-mail-DiscussSidebar.o-compact");
     expect(browser.localStorage.getItem("mail.user_setting.discuss_sidebar_compact")).toBe("true");
 });


### PR DESCRIPTION
Discuss sidebar feels too crowded, and items take too much space.
This commit makes slight adjustments to make it look nicer:

1. discuss Expand/Collapse icon replaced by "..." clickable dropdown
   - motivation: this looks consistent with chat window options, prevent accidental click, and allow to put more options in the future. Also the button looks more like an "options" button
2. sidebar items are smaller in height but wider
   - motivation: more efficient spacing which looks better
3. mailboxes are significantly smaller in height
   - motivation: some users do not use mailboxes so less presence is appreciate for them. Besides, they don't need big size of avatar so they can be smaller without much compromise
4. category names are smaller and muted
   - motivation: they looked too alike to channel items, so this put more distinctive style making less exhausting to use Discuss app
5. category and channel actions are circle buttons, so it looks nice inside square on hovered/active items. Also less opacity so they are less distracting in general
6. active navigable list item is easier to see (colorful rather than greyish)
7. Unread threads are more visible (bolder text)

Before
<img width="1281" alt="Screenshot 2024-09-29 at 16 57 36" src="https://github.com/user-attachments/assets/88ead9ab-ea2d-44bb-a9c1-762d88050e92">

After
<img width="1282" alt="Screenshot 2024-09-30 at 13 29 36" src="https://github.com/user-attachments/assets/97cd2513-d84e-408a-ad78-9d3da57cb977">
