### PR TITLE
[FIX] mail: reduce chances to accidentally start a call in mobile

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -65,7 +65,7 @@
             </t>
             <t t-call="mail.ChatWindow.dropdownAction">
                 <t t-set="action" t-value="threadActions.actions.at(-1)"/>
-                <t t-set="itemClass" t-value="'me-1'"/>
+                <t t-set="itemClass" t-value="ui.isSmall ? 'mx-2' : 'me-1'"/>
             </t>
         </div>
         <div t-if="!props.chatWindow.folded or ui.isSmall" class="bg-100 d-flex flex-column h-100 overflow-auto position-relative" t-ref="content">
@@ -88,7 +88,7 @@
 </t>
 
 <t t-name="mail.ChatWindow.dropdownAction">
-    <button class="o-mail-ChatWindow-command btn d-flex p-2 opacity-75 opacity-100-hover" t-att-class="itemClass" t-att-title="action.name" t-on-click.stop="() => action.onSelect()"><i t-att-class="action.icon"/></button>
+    <button class="o-mail-ChatWindow-command btn d-flex p-2 opacity-75 opacity-100-hover" t-att-class="ui.isSmall ? 'border' : ''" t-attf-class="{{ itemClass }}" t-att-title="action.name" t-on-click.stop="() => action.onSelect()"><i t-att-class="ui.isSmall ? 'fa-lg' : ''" t-attf-class="{{ action.icon }}"/></button>
 </t>
 
 <t t-name="mail.ChatWindow.headerContent">


### PR DESCRIPTION
Button to close conversation and start a call are too small and close to each other. This means attempt to close the conversation can lead to accidentally starting a call, which scare all members of the conversation.

This commit increases the size of these buttons and show borders so that it is less likely to click on start a call when the intent is to close the conversation.

Before / After
<img width="365" alt="Screenshot 2024-09-29 at 22 22 17" src="https://github.com/user-attachments/assets/7781eb6f-20e4-4ef2-ac0a-be50b39869ee">
<img width="366" alt="Screenshot 2024-09-29 at 22 21 56" src="https://github.com/user-attachments/assets/eede8d9c-891a-4cda-8dca-853b155ed6c3">
