### PR TITLE
[FIX] mail: open message link in mobile opens the conversation

### DIFF
--- a/addons/mail/static/src/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/core/public_web/thread_model_patch.js
@@ -70,6 +70,9 @@ patch(Thread.prototype, {
         if (pushState) {
             this.setActiveURL();
         }
+        if (this.store.env.services.ui.isSmall && this.model !== "mail.box") {
+            this.open();
+        }
     },
 
     setActiveURL() {

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -59,15 +59,14 @@ test("Mobile: chat window shouldn't open automatically after receiving a new mes
 
 test('chat window: post message on channel with "CTRL-Enter" keyboard shortcut for small screen size', async () => {
     const pyEnv = await startServer();
-    pyEnv["discuss.channel"].create({
+    const channelId = pyEnv["discuss.channel"].create({
         channel_member_ids: [
             Command.create({ fold_state: "open", partner_id: serverState.partnerId }),
         ],
     });
     patchUiSize({ size: SIZES.SM });
     await start();
-    await click(".o_menu_systray i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem");
+    await openDiscuss(channelId);
     await insertText(".o-mail-ChatWindow .o-mail-Composer-input", "Test");
     triggerHotkey("control+Enter");
     await contains(".o-mail-Message");
@@ -221,8 +220,7 @@ test("Mobile: opening a chat window should not update channel state on the serve
     });
     patchUiSize({ size: SIZES.SM });
     await start();
-    await click(".o_menu_systray i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem");
+    await openDiscuss(channelId);
     await click(".o-mail-ChatWindow");
     const [member] = pyEnv["discuss.channel.member"].search_read([
         ["channel_id", "=", channelId],
@@ -318,9 +316,7 @@ test("Mobile: closing a chat window should not update channel state on the serve
     });
     patchUiSize({ size: SIZES.SM });
     await start();
-    await click("button i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem");
-    await contains(".o-mail-ChatWindow");
+    await openDiscuss(channelId);
     await click("[title*='Close Chat Window']");
     await contains(".o-mail-ChatWindow", { count: 0 });
     const [member] = pyEnv["discuss.channel.member"].search_read([
@@ -843,15 +839,15 @@ test("folded chat window should hide member-list and settings buttons", async ()
 
 test("Chat window in mobile are not foldable", async () => {
     const pyEnv = await startServer();
-    pyEnv["discuss.channel"].create({
+    const channelId = pyEnv["discuss.channel"].create({
         channel_member_ids: [
             Command.create({ fold_state: "open", partner_id: serverState.partnerId }),
         ],
     });
     patchUiSize({ size: SIZES.SM });
     await start();
-    await click("button i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem");
+    await openDiscuss(channelId);
+    await contains(".o-mail-ChatWindow");
     await contains(".o-mail-ChatWindow-header.cursor-pointer", { count: 0 });
     await click(".o-mail-ChatWindow-header");
     await contains(".o-mail-Thread"); // content => non-folded
@@ -875,12 +871,10 @@ test("Server-synced chat windows should not open at page load on mobile", async 
 
 test("chat window of channels should not have 'Open in Discuss' (mobile)", async () => {
     const pyEnv = await startServer();
-    pyEnv["discuss.channel"].create({ name: "General" });
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     patchUiSize({ size: SIZES.SM });
     await start();
-    await click(".o_menu_systray i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem");
-    await contains(".o-mail-ChatWindow");
+    await openDiscuss(channelId);
     await contains("[title='Open Actions Menu']");
     await click("[title='Open Actions Menu']");
     await contains(".o-dropdown-item", { text: "Open in Discuss", count: 0 });

--- a/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
+++ b/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
@@ -3,6 +3,7 @@ import {
     click,
     contains,
     defineMailModels,
+    openDiscuss,
     patchUiSize,
     SIZES,
     start,
@@ -36,11 +37,10 @@ test("Renders the call settings", async () => {
         },
     });
     const pyEnv = await startServer();
-    pyEnv["discuss.channel"].create({ name: "test" });
+    const channelId = pyEnv["discuss.channel"].create({ name: "test" });
     patchUiSize({ size: SIZES.SM });
     await start();
-    await click(".o_menu_systray i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem", { text: "test" });
+    await openDiscuss(channelId);
     await click("[title='Open Actions Menu']");
     await click(".o-dropdown-item", { text: "Call Settings" });
     await contains(".o-discuss-CallSettings");
@@ -56,11 +56,10 @@ test("Renders the call settings", async () => {
 
 test("activate push to talk", async () => {
     const pyEnv = await startServer();
-    pyEnv["discuss.channel"].create({ name: "test" });
+    const channelId = pyEnv["discuss.channel"].create({ name: "test" });
     patchUiSize({ size: SIZES.SM });
     await start();
-    await click(".o_menu_systray i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem", { text: "test" });
+    await openDiscuss(channelId);
     await click("[title='Open Actions Menu']");
     await click(".o-dropdown-item", { text: "Call Settings" });
     await click("button", { text: "Push to Talk" });
@@ -71,11 +70,10 @@ test("activate push to talk", async () => {
 
 test("activate blur", async () => {
     const pyEnv = await startServer();
-    pyEnv["discuss.channel"].create({ name: "test" });
+    const channelId = pyEnv["discuss.channel"].create({ name: "test" });
     patchUiSize({ size: SIZES.SM });
     await start();
-    await click(".o_menu_systray i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem", { text: "test" });
+    await openDiscuss(channelId);
     await click("[title='Open Actions Menu']");
     await click(".o-dropdown-item", { text: "Call Settings" });
     await click("input[title='Blur video background']");
@@ -85,7 +83,7 @@ test("activate blur", async () => {
 
 test("local storage for call settings", async () => {
     const pyEnv = await startServer();
-    pyEnv["discuss.channel"].create({ name: "test" });
+    const channelId = pyEnv["discuss.channel"].create({ name: "test" });
     patchWithCleanup(browser.localStorage, {
         getItem(key) {
             if (key === "mail_user_setting_background_blur_amount") {
@@ -111,9 +109,8 @@ test("local storage for call settings", async () => {
     });
     patchUiSize({ size: SIZES.SM });
     await start();
+    await openDiscuss(channelId);
     // testing load from local storage
-    await click(".o_menu_systray i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem", { text: "test" });
     await click("[title='Open Actions Menu']");
     await click(".o-dropdown-item", { text: "Call Settings" });
     await contains("input[title='Show video participants only']:checked");

--- a/addons/mail/static/tests/discuss/call/ptt_ad_banner.test.js
+++ b/addons/mail/static/tests/discuss/call/ptt_ad_banner.test.js
@@ -3,6 +3,7 @@ import {
     contains,
     defineMailModels,
     mockGetMedia,
+    openDiscuss,
     patchUiSize,
     SIZES,
     start,
@@ -17,7 +18,7 @@ defineMailModels();
 test("display banner when ptt extension is not enabled", async () => {
     mockGetMedia();
     const pyEnv = await startServer();
-    pyEnv["discuss.channel"].create({ name: "General" });
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     mockService("discuss.ptt_extension", {
         get isEnabled() {
             return false;
@@ -25,8 +26,7 @@ test("display banner when ptt extension is not enabled", async () => {
     });
     patchUiSize({ size: SIZES.SM });
     await start();
-    await click(".o_menu_systray i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem", { text: "General" });
+    await openDiscuss(channelId);
     await click("[title='Open Actions Menu']");
     await click(".o-dropdown-item", { text: "Call Settings" });
     await click("button", { text: "Push to Talk" });

--- a/addons/mail/static/tests/discuss/call/web/call.test.js
+++ b/addons/mail/static/tests/discuss/call/web/call.test.js
@@ -60,7 +60,7 @@ test.tags("mobile")("show Push-to-Talk button on mobile", async () => {
     mockGetMedia();
     mockUserAgent("android");
     const pyEnv = await startServer();
-    pyEnv["discuss.channel"].create({ name: "General" });
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     mockService("discuss.ptt_extension", {
         get isEnabled() {
             return false;
@@ -68,8 +68,7 @@ test.tags("mobile")("show Push-to-Talk button on mobile", async () => {
     });
     patchUiSize({ size: SIZES.SM });
     await start();
-    await click(".o_menu_systray i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem", { text: "General" });
+    await openDiscuss(channelId);
     await click("[title='Start a Call']");
     await click("[title='Open Actions Menu']");
     await click(".o-dropdown-item", { text: "Call Settings" });

--- a/addons/mail/static/tests/discuss/core/web/messaging_menu.test.js
+++ b/addons/mail/static/tests/discuss/core/web/messaging_menu.test.js
@@ -1,4 +1,5 @@
 import {
+    SIZES,
     click,
     contains,
     defineMailModels,
@@ -25,7 +26,7 @@ describe.current.tags("desktop");
 defineMailModels();
 
 test('"Start a conversation" item selection opens chat', async () => {
-    patchUiSize({ height: 360, width: 640 });
+    patchUiSize({ size: SIZES.SM });
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "Gandalf" });
     pyEnv["res.users"].create({ partner_id: partnerId });
@@ -42,7 +43,7 @@ test('"Start a conversation" item selection opens chat', async () => {
 });
 
 test('"New channel" item selection opens channel (existing)', async () => {
-    patchUiSize({ height: 360, width: 640 });
+    patchUiSize({ size: SIZES.SM });
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create({ name: "Gryffindors" });
     await start();
@@ -57,7 +58,7 @@ test('"New channel" item selection opens channel (existing)', async () => {
 });
 
 test('"New channel" item selection opens channel (new)', async () => {
-    patchUiSize({ height: 360, width: 640 });
+    patchUiSize({ size: SIZES.SM });
     await start();
     await openDiscuss();
     await contains("button.active", { text: "Inbox" });

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -2,6 +2,7 @@ import { waitUntilSubscribe } from "@bus/../tests/bus_test_helpers";
 
 import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
 import {
+    SIZES,
     assertSteps,
     click,
     contains,
@@ -1545,7 +1546,7 @@ test("Channel is added to discuss after invitation", async () => {
 });
 
 test("select another mailbox", async () => {
-    patchUiSize({ height: 360, width: 640 });
+    patchUiSize({ size: SIZES.SM });
     await start();
     await openDiscuss();
     await contains(".o-mail-Discuss");
@@ -1556,7 +1557,7 @@ test("select another mailbox", async () => {
 });
 
 test('auto-select "Inbox nav bar" when discuss had inbox as active thread', async () => {
-    patchUiSize({ height: 360, width: 640 });
+    patchUiSize({ size: SIZES.SM });
     await start();
     await openDiscuss();
     await contains(".o-mail-Discuss-threadName", { value: "Inbox" });

--- a/addons/mail/static/tests/gif_picker/gif_picker.test.js
+++ b/addons/mail/static/tests/gif_picker/gif_picker.test.js
@@ -170,7 +170,6 @@ test("Composer GIF button should open the GIF picker keyboard for mobile device"
     patchUiSize({ size: SIZES.SM });
     await start();
     await openDiscuss(channelId);
-    await click("span", { text: "General" });
     await click("button[aria-label='Emojis']");
     await contains(".o-mail-PickerContent-picker .o-mail-PickerContent-emojiPicker");
     await click("button", { text: "GIFs" });

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -70,10 +70,7 @@ test("Edit message (mobile)", async () => {
         message_type: "comment",
     });
     await start();
-    await openDiscuss();
-    await contains("button.active", { text: "Inbox" });
-    await click("button", { text: "Channel" });
-    await click("button", { text: "general" });
+    await openDiscuss(channelId);
     await contains(".o-mail-Message");
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message-moreMenu [title='Edit']");
@@ -145,7 +142,7 @@ test("Can edit message comment in chatter (mobile)", async () => {
         res_id: partnerId,
     });
     await start();
-    openFormView("res.partner", partnerId);
+    await openFormView("res.partner", partnerId);
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message-moreMenu [title='Edit']");
     await contains("button", { text: "Discard editing" });

--- a/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
+++ b/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
@@ -584,7 +584,7 @@ test("open chat window from preview", async () => {
 });
 
 test('"Start a conversation" in mobile shows channel selector (+ click away)', async () => {
-    patchUiSize({ height: 360, width: 640 });
+    patchUiSize({ size: SIZES.SM });
     await start();
     await openDiscuss();
     await contains("button.active", { text: "Inbox" });
@@ -599,7 +599,7 @@ test('"Start a conversation" in mobile shows channel selector (+ click away)', a
     await contains("input[placeholder='Start a conversation']", { count: 0 });
 });
 test('"New Channel" in mobile shows channel selector (+ click away)', async () => {
-    patchUiSize({ height: 360, width: 640 });
+    patchUiSize({ size: SIZES.SM });
     await start();
     await openDiscuss();
     await contains("button.active", { text: "Inbox" });
@@ -618,7 +618,7 @@ test("'Start a conversation' button should open a thread in mobile", async () =>
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "Demo" });
     pyEnv["res.users"].create({ partner_id: partnerId });
-    patchUiSize({ height: 360, width: 640 });
+    patchUiSize({ size: SIZES.SM });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await click("button", { text: "Start a conversation" });

--- a/addons/mail/static/tests/mobile/mobile.test.js
+++ b/addons/mail/static/tests/mobile/mobile.test.js
@@ -1,4 +1,5 @@
 import {
+    SIZES,
     click,
     contains,
     defineMailModels,
@@ -17,9 +18,10 @@ defineMailModels();
 test("auto-select 'Inbox' when discuss had channel as active thread", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "test" });
-    patchUiSize({ height: 360, width: 640 });
+    patchUiSize({ size: SIZES.SM });
     await start();
     await openDiscuss(channelId);
+    await click(".o-mail-ChatWindow [title*='Close Chat Window']");
     await contains(".o-mail-MessagingMenu-tab.text-primary.fw-bolder", { text: "Channel" });
     await click("button", { text: "Mailboxes" });
     await contains(".o-mail-MessagingMenu-tab.text-primary.fw-bolder", { text: "Mailboxes" });
@@ -41,7 +43,7 @@ test("show loading on initial opening", async () => {
     });
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create({ name: "General" });
-    patchUiSize({ height: 360, width: 640 });
+    patchUiSize({ size: SIZES.SM });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-MessagingMenu .fa.fa-circle-o-notch.fa-spin");


### PR DESCRIPTION
Before this commit, clicking on message link from a channel in mobile app was not opening the conversation with the message.

This happens because when the conversation is a channel, it relies on `active_id` of Discuss app. The auto-set of active thread in Discuss app based on `active_id` works in Desktop but not in mobile, as a result it stays in the "main" screen of discuss app.

This commit fixes the issue by invoking explicitly `thread.open()` when thread is set as the Discuss app active thread in mobile. This made it open in chat window, which is how threads are open in mobile in all cases including discuss app.

Task-4208169