### PR TITLE
[FIX] point_of_sale: prevent error when clicking on order

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1057,6 +1057,10 @@ export class PosStore extends Reactive {
                 // a higher id than the original one since it's the last one created.
                 const session = this.models["pos.session"].sort((a, b) => a.id - b.id)[0];
                 session.delete();
+                this.models["pos.order"]
+                    .getAll()
+                    .filter((order) => order.state === "draft")
+                    .forEach((order) => (order.session_id = this.session));
             }
 
             return newData["pos.order"];


### PR DESCRIPTION
When we try to add any product for order in the first browser with ``Mitchell Admin`` as the user and simultaneously close the session in the second browser with ``Marc Demo`` as the user, the error will occur in the first browser when we click on order.

Steps to reproduce:
---
- Install the ``pos_online_payment_self_order`` module
- Open the Bar, copy the URL, and Open a POS session on 2 different browsers with different user on both browser
- Now go to the second browser and then close the session there
- Now come to the first browser and add any product
- Click on Order

Traceback:
---
``ValueError: Expected singleton: pos.config()``

Previous Behaviour:
---
This error occurred after this commit 
https://github.com/odoo/odoo/pull/179382/commits/a351107ade64a0ef67b28283a38b7add0cef689e
because when a session is open in two different browsers and one browser is closed, at point [1], we delete the session, and after the deleted session, the orders are not linked to any session.

After FIX Behaviour:
---
After the deletion of the session from one browser if the orders are not completed then those orders are transferred to the rescue session(recuse session will be created).

[1]- https://github.com/odoo/odoo/blob/462acc6853dfdc1418b790e99a0611c5ef5e17e2/addons/point_of_sale/static/src/app/store/pos_store.js#L1048-L1053

sentry-5699019259

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
