### PR TITLE
[FIX] mass_mailing: onboarding tour issue

### DIFF
--- a/addons/mass_mailing/static/src/js/tours/mass_mailing_tour.js
+++ b/addons/mass_mailing/static/src/js/tours/mass_mailing_tour.js
@@ -4,7 +4,6 @@ odoo.define('mass_mailing.mass_mailing_tour', function (require) {
     const {_t} = require('web.core');
     const {Markup} = require('web.utils');
     var tour = require('web_tour.tour');
-    var now = moment();
 
     tour.register('mass_mailing_tour', {
         url: '/web',
@@ -26,10 +25,10 @@ odoo.define('mass_mailing.mass_mailing_tour', function (require) {
         content: Markup(_t("Start by creating your first <b>Mailing</b>.")),
         position: 'bottom',
     }, {
-        trigger: 'input[name="subject"]',
+        trigger: 'div[name="subject"]',
         content: Markup(_t('Pick the <b>email subject</b>.')),
         position: 'bottom',
-        run: 'text ' + now.format("MMMM") + " Newsletter",
+        run: 'click',
     }, {
         trigger: 'div[name="contact_list_ids"] > .o_input_dropdown > input[type="text"]',
         run: 'click',
@@ -51,7 +50,7 @@ odoo.define('mass_mailing.mass_mailing_tour', function (require) {
         edition: 'community',
         run: 'click',
     }, {
-        trigger: 'div[name="body_arch"] iframe div.s_text_block',
+        trigger: 'div[name="body_arch"] iframe div.theme_selection_done div.s_text_block',
         content: _t('Click on this paragraph to edit it.'),
         position: 'top',
         edition: 'enterprise',


### PR DESCRIPTION
Fixed onboarding Email Marketing tour which is not working properly.

Reason
======
We're not getting this `'input[name="subject"]',` trigger for some reasons,
& there is no `name` attribute with input.
we do have `id` in input, but in v16 we got id as `subject` and v17+ gets `subject_0` so that can't be used.
Also, the next trigger should be after user click on input field not when they write.

One more point, sometimes it got stuck after selecting a theme and did not shows the pointer.

Fixed/Improved that & used common classes that works on all version.

Task-4210376
