### PR TITLE
[FIX] account_payment: fix traceback if no access_token when doing invoice transaction

### DIFF
--- a/addons/account_payment/controllers/payment.py
+++ b/addons/account_payment/controllers/payment.py
@@ -12,7 +12,7 @@ from odoo.addons.payment.controllers import portal as payment_portal
 class PaymentPortal(payment_portal.PaymentPortal):
 
     @route('/invoice/transaction/<int:invoice_id>', type='json', auth='public')
-    def invoice_transaction(self, invoice_id, access_token, **kwargs):
+    def invoice_transaction(self, invoice_id, access_token=None, **kwargs):
         """ Create a draft transaction and return its processing values.
 
         :param int invoice_id: The invoice to pay, as an `account.move` id


### PR DESCRIPTION
Currently, a traceback may occur if there is no `access_token` when an RPC call is done for `invoice_transaction()`.

```
TypeError: PaymentPortal.invoice_transaction() missing 1 required positional argument: 'access_token'
```

Some context:
An empty `access_token` parameter is well handled, so we can address this issue by giving it a `None` fallback value.

https://github.com/odoo/odoo/blob/1f7debc24bab4e0a7f2ef0d85e50d9381e1826cd/addons/portal/controllers/portal.py#L428-L433

https://github.com/odoo/odoo/blob/1f7debc24bab4e0a7f2ef0d85e50d9381e1826cd/addons/account_payment/controllers/payment.py#L26-L31

sentry-5741581459

