### PR TITLE
[IMP] core: cli import only needed commands

### DIFF
--- a/odoo/__init__.py
+++ b/odoo/__init__.py
@@ -72,9 +72,3 @@ from . import fields
 from . import api
 from odoo.tools.translate import _, _lt
 from odoo.fields import Command
-
-# ----------------------------------------------------------
-# Other imports, which may require stuff from above
-# ----------------------------------------------------------
-from . import cli
-from . import http

--- a/odoo/cli/__init__.py
+++ b/odoo/cli/__init__.py
@@ -1,21 +1,2 @@
-import logging
-import sys
-import os
-
-import odoo
-
-from .command import Command, main
-
-from . import cloc
-from . import upgrade_code
-from . import deploy
-from . import scaffold
-from . import server
-from . import shell
-from . import start
-from . import populate
-from . import tsconfig
-from . import neutralize
-from . import obfuscate
-from . import genproxytoken
-from . import db
+# Import just the command, the rest will get imported as needed
+from .command import Command, main  # noqa: F401

--- a/odoo/cli/command.py
+++ b/odoo/cli/command.py
@@ -1,15 +1,19 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import contextlib
 import logging
-import os
 import sys
 from pathlib import Path
 
-import odoo
-from odoo.modules import get_modules, get_module_path, initialize_sys_path
+import odoo.cli
+from odoo.modules import get_module_path, get_modules, initialize_sys_path
 
 commands = {}
+"""All loaded commands"""
+
+
 class Command:
     name = None
+
     def __init_subclass__(cls):
         cls.name = cls.name or cls.__name__.lower()
         commands[cls.name] = cls
@@ -23,46 +27,83 @@ Available commands:
 
 Use '{odoo_bin} <command> --help' for individual command help."""
 
+
 class Help(Command):
     """ Display the list of available commands """
     def run(self, args):
-        padding = max([len(cmd) for cmd in commands]) + 2
+        load_internal_commands()
+        load_addons_commands()
+        padding = max(len(cmd) for cmd in commands) + 2
         command_list = "\n    ".join([
             "    {}{}".format(name.ljust(padding), (command.__doc__ or "").strip())
-            for name, command in sorted(commands.items())
+            for name in sorted(commands)
+            if (command := find_command(name))
         ])
-        print(ODOO_HELP.format(  # pylint: disable=bad-builtin
+        print(ODOO_HELP.format(  # pylint: disable=bad-builtin  # noqa: T201
             odoo_bin=Path(sys.argv[0]).name,
             command_list=command_list
         ))
+
+
+def load_internal_commands():
+    """Load `commands` from `odoo.cli`"""
+    for path in odoo.cli.__path__:
+        for module in Path(path).iterdir():
+            if module.suffix != '.py':
+                continue
+            __import__(f'odoo.cli.{module.stem}')
+
+
+def load_addons_commands():
+    """Load `commands` from `odoo.addons.*.cli`"""
+    logging.disable(logging.CRITICAL)
+    initialize_sys_path()
+    for module in get_modules():
+        if (Path(get_module_path(module)) / 'cli').is_dir():
+            with contextlib.suppress(ImportError):
+                __import__(f'odoo.addons.{module}')
+    logging.disable(logging.NOTSET)
+    return list(commands)
+
+
+def find_command(name: str) -> Command | None:
+    """ Get command by name. """
+    # check in the loaded commands
+    if command := commands.get(name):
+        return command
+    # import from odoo.cli
+    try:
+        __import__(f'odoo.cli.{name}')
+    except ImportError:
+        pass
+    else:
+        if command := commands.get(name):
+            return command
+    # last try, import from odoo.addons.*.cli
+    load_addons_commands()
+    return commands.get(name)
+
 
 def main():
     args = sys.argv[1:]
 
     # The only shared option is '--addons-path=' needed to discover additional
     # commands from modules
-    if len(args) > 1 and args[0].startswith('--addons-path=') and not args[1].startswith("-"):
+    if len(args) > 1 and args[0].startswith('--addons-path=') and not args[1].startswith('-'):
         # parse only the addons-path, do not setup the logger...
         odoo.tools.config._parse_config([args[0]])
         args = args[1:]
 
     # Default legacy command
-    command = "server"
+    command_name = 'server'
 
-    # TODO: find a way to properly discover addons subcommands without importing the world
     # Subcommand discovery
-    if len(args) and not args[0].startswith("-"):
-        logging.disable(logging.CRITICAL)
-        initialize_sys_path()
-        for module in get_modules():
-            if (Path(get_module_path(module)) / 'cli').is_dir():
-                __import__('odoo.addons.' + module)
-        logging.disable(logging.NOTSET)
-        command = args[0]
+    if len(args) and not args[0].startswith('-'):
+        command_name = args[0]
         args = args[1:]
 
-    if command in commands:
-        o = commands[command]()
+    if command := find_command(command_name):
+        o = command()
         o.run(args)
     else:
         sys.exit('Unknown command %r' % (command,))

--- a/odoo/cli/shell.py
+++ b/odoo/cli/shell.py
@@ -8,8 +8,9 @@ from pathlib import Path
 
 import odoo
 from odoo.modules.registry import Registry
+from odoo.service import server
 from odoo.tools import config
-from . import Command
+from . import Command, server as cli_server
 
 _logger = logging.getLogger(__name__)
 
@@ -57,8 +58,8 @@ class Shell(Command):
     def init(self, args):
         config.parser.prog = f'{Path(sys.argv[0]).name} {self.name}'
         config.parse_config(args, setup_logging=True)
-        odoo.cli.server.report_configuration()
-        odoo.service.server.start(preload=[], stop=True)
+        cli_server.report_configuration()
+        server.start(preload=[], stop=True)
         signal.signal(signal.SIGINT, raise_keyboard_interrupt)
 
     def console(self, local_vars):


### PR DESCRIPTION
When importing `odoo` we don't need to import the cli every time. It is imported as needed in the scripts that start Odoo.

The `Command` discovery only needs to happen to the used command. We can avoid importing all commands if we just run one of them saving time at startup.

Related to #175940

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
