### PR TITLE
[FIX] account: prevent an error when archiving multiple journals

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -801,7 +801,7 @@ class AccountJournal(models.Model):
         return res
 
     def action_archive(self):
-        if self.env['account.payment.method.line'].search_count([('journal_id', '=', self.id)], limit=1):
+        if self.env['account.payment.method.line'].search_count([('journal_id', 'in', self.ids)], limit=1):
             raise ValidationError(_("This journal is associated with a payment method. You cannot archive it"))
         return super().action_archive()
 

--- a/addons/account/tests/test_account_journal.py
+++ b/addons/account/tests/test_account_journal.py
@@ -184,3 +184,24 @@ class TestAccountJournal(AccountTestInvoicingCommon):
             })
         with self.assertRaises(ValidationError):
             journal.action_archive()
+
+    def test_archive_multiple_journals(self):
+        journals = self.env['account.journal'].create([{
+                'name': 'Test Journal 1',
+                'type': 'sale',
+                'code': 'A1'
+            }, {
+                'name': 'Test Journal 2',
+                'type': 'sale',
+                'code': 'A2'
+            }])
+
+        # Archive the Journals
+        journals.action_archive()
+        self.assertFalse(journals[0].active)
+        self.assertFalse(journals[1].active)
+
+        # Unarchive the Journals
+        journals.action_unarchive()
+        self.assertTrue(journals[0].active)
+        self.assertTrue(journals[1].active)


### PR DESCRIPTION
This Error occurs when a user tries to archive multiple journals.

Steps to reproduce:

- Install the ```account``` module
- Go to Invoicing / Configuration / Accounting / Journals.
- Select two or more journals and try to archive them.

```ValueError: Expected singleton: account.journal(15, 18)```

An error occurs at [1] because the system attempts to retrieve the id from 'self', which contains multiple records.

link [1]:https://github.com/odoo/odoo/blob/1f7debc24bab4e0a7f2ef0d85e50d9381e1826cd/addons/account/models/account_journal.py#L801

To resolve this issue, Use an ```ids``` instead of an ```id``` to get a multiple records.

Sentry-5917175119

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
