### PR TITLE
[FIX] l10n_in: fix invisible reseller on invoice

### DIFF
--- a/addons/l10n_in/views/account_invoice_views.xml
+++ b/addons/l10n_in/views/account_invoice_views.xml
@@ -30,7 +30,7 @@
                     <field name="l10n_in_shipping_port_code_id" readonly="state != 'draft'"/>
                 </group>
             </xpath>
-            <xpath expr="//field[@name='partner_id']" position="after">
+            <xpath expr="//field[@name='partner_shipping_id']" position="before">
                 <field name="l10n_in_reseller_partner_id"
                        groups="l10n_in.group_l10n_in_reseller"
                        invisible="move_type not in ('out_invoice', 'out_refund') or country_code != 'IN' or move_type == 'entry'"


### PR DESCRIPTION
## Before this commit
The Reseller field was visible on the sales order but not the invoice. Although the field existed on the invoice, it wasn't displayed. It needed to be made visible.

## After this commit
The Reseller field is now visible on the invoice as well.

> Task-4216234