### PR TITLE
[FIX] website: MockRequest not working outside of HttpCase

### DIFF
--- a/addons/website/tools.py
+++ b/addons/website/tools.py
@@ -26,6 +26,10 @@ def MockRequest(
     from odoo.tests.common import HttpCase  # noqa: PLC0415
     lang_code = context.get('lang', env.context.get('lang', 'en_US'))
     env = env(context=dict(context, lang=lang_code))
+    if HttpCase.http_port():
+        base_url = HttpCase.base_url()
+    else:
+        base_url = f"http://{HOST}:{odoo.tools.config['http_port']}"
     request = Mock(
         # request
         httprequest=Mock(
@@ -35,7 +39,7 @@ def MockRequest(
             environ=dict(
                 EnvironBuilder(
                     path=path,
-                    base_url=HttpCase.base_url(),
+                    base_url=base_url,
                     environ_base=environ_base,
                 ).get_environ(),
                 REMOTE_ADDR=remote_addr,

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1847,6 +1847,8 @@ class HttpCase(TransactionCase):
 
     @classmethod
     def http_port(cls):
+        if odoo.service.server.server is None:
+            return None
         return odoo.service.server.server.httpd.server_port
 
     def setUp(self):


### PR DESCRIPTION
`MockRequest` calls `HttpCase.base_url()` even though it can be used outside of http cases. odoo/odoo#180461 made consistency a requirement as it retrieves the actually bound port from a running server.

Make `http_port()` return `None` if no server is running (rather than error), and have `MockRequest` fallback on ~the old behaviour (of just retrieving the http_port from the config) in that case. Technically we could probably hardcode `8069` to limit e.g. issues when running with `http_port=0`, but odds are none of that is really relevant.
