### PR TITLE
18.0 clean mtso aels

### DIFF
--- a/addons/mrp/models/stock_warehouse.py
+++ b/addons/mrp/models/stock_warehouse.py
@@ -126,7 +126,7 @@ class StockWarehouse(models.Model):
             'manufacture_mto_pull_id': {
                 'depends': ['manufacture_steps', 'manufacture_to_resupply'],
                 'create_values': {
-                    'procure_method': 'mts_else_mto',
+                    'procure_method': 'make_to_order',
                     'company_id': self.company_id.id,
                     'action': 'pull',
                     'auto': 'manual',

--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -650,7 +650,7 @@ class TestReorderingRule(TransactionCase):
         customer_loc, _ = warehouse._get_partner_locations()
         mto_rule = self.env['stock.rule'].search(
             [('warehouse_id', '=', warehouse.id),
-             ('procure_method', '=', 'mts_else_mto'),
+             ('procure_method', '=', 'make_to_order'),
              ('location_dest_id', '=', customer_loc.id)
             ]
         )

--- a/addons/sale_mrp/models/sale_order.py
+++ b/addons/sale_mrp/models/sale_order.py
@@ -24,7 +24,7 @@ class SaleOrder(models.Model):
         production_order_by_sale_line = self.env['mrp.production']._read_group([('sale_line_id', 'in', self.order_line.ids)], ['sale_line_id'], ['id:recordset'])
         mrp_productions = defaultdict(self.env['mrp.production'].browse)
         for sale, procurement_groups in data:
-            mrp_productions[sale.id] |= procurement_groups.stock_move_ids.created_production_id.procurement_group_id.mrp_production_ids | procurement_groups.mrp_production_ids
+            mrp_productions[sale.id] |= procurement_groups.mrp_production_ids
         for sale_line, production_id in production_order_by_sale_line:
             mrp_productions[sale_line.order_id.id] |= production_id
         for sale in self:

--- a/addons/sale_mrp/tests/test_sale_mrp_report.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_report.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import Command
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import common
 
@@ -69,60 +68,3 @@ class TestSaleMrpInvoices(AccountTestInvoicingCommon):
             'account.report_invoice_with_payments', invoice.ids)[0]
         text = html2plaintext(html.decode())
         self.assertRegex(text, r'Product By Lot\n1.00Units\nLOT0001', "There should be a line that specifies 1 x LOT0001")
-
-    def test_report_forecast_for_mto_procure_method(self):
-        """
-        Check that mto moves are not reported as taking from stock in the forecast report
-        """
-        mto_route = self.env.ref('stock.route_warehouse0_mto')
-        mto_route.active = True
-        manufacturing_route = self.env.ref('mrp.route_warehouse0_manufacture')
-        product = self.env['product.product'].create({
-            'name': 'SuperProduct',
-            'is_storable': True,
-            'route_ids': [Command.set((mto_route + manufacturing_route).ids)]
-        })
-        warehouse = self.warehouse
-        # make 2 so: so_1 can be fulfilled and so_2 requires a replenishment
-        self.env['stock.quant']._update_available_quantity(product, warehouse.lot_stock_id, 10.0)
-        so_1, so_2 = self.env['sale.order'].create([
-            {
-                'partner_id': self.partner_a.id,
-                'order_line': [Command.create({
-                    'name': product.name,
-                    'product_id': product.id,
-                    'product_uom_qty': 8.0,
-                    'product_uom': product.uom_id.id,
-                    'price_unit': product.list_price,
-                })]
-            },
-            {
-                'partner_id': self.partner_a.id,
-                'order_line': [Command.create({
-                    'name': product.name,
-                    'product_id': product.id,
-                    'product_uom_qty': 7.0,
-                    'product_uom': product.uom_id.id,
-                    'price_unit': product.list_price,
-                })]
-            },
-
-        ])
-        (so_1 | so_2).action_confirm()
-        report_lines = self.env['stock.forecasted_product_product'].with_context(warehouse=warehouse.id).get_report_values(docids=product.ids)['docs']['lines']
-        self.assertEqual(len(report_lines), 3)
-        so_1_line = next(filter(lambda line: line.get('document_out') and line['document_out'].get('id') == so_1.id, report_lines))
-        self.assertEqual(
-            [so_1_line['quantity'], so_1_line['move_out']['id'], so_1_line['replenishment_filled']],
-            [8.0, so_1.picking_ids.move_ids.id, True]
-        )
-        so_2_line = next(filter(lambda line: line.get('document_out') and line['document_out'].get('id') == so_2.id and not line.get('document_in'), report_lines))
-        self.assertEqual(
-            [so_2_line['quantity'], so_2_line['move_out']['id'], so_2_line['replenishment_filled']],
-            [2.0, so_2.picking_ids.move_ids.id, True]
-        )
-        replenisment_line = next(filter(lambda line: line.get('document_in'), report_lines))
-        self.assertEqual(
-            [replenisment_line['document_in']['_name'], replenisment_line['document_out']['id'], replenisment_line['quantity'], replenisment_line['move_out']['id'], replenisment_line['replenishment_filled']],
-            ["mrp.production", so_2.id, 5.0, so_2.picking_ids.move_ids.id, True]
-        )

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -168,7 +168,7 @@ class StockRule(models.Model):
             if self.procure_method == 'make_to_order' and self.location_src_id:
                 suffix += _("<br>A need is created in <b>%s</b> and a rule will be triggered to fulfill it.", source)
             if self.procure_method == 'mts_else_mto' and self.location_src_id:
-                suffix += _("<br>If the products are not available in <b>%s</b>, a rule will be triggered to bring products in this location.", source)
+                suffix += _("<br>If the products are not available in <b>%s</b>, a rule will be triggered to bring the missing quantity in this location.", source)
             message_dict = {
                 'pull': _(
                     'When products are needed in <b>%(destination)s</b>, <br> <b>%(operation)s</b> are created from <b>%(source_location)s</b> to fulfill the need.',

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -48,9 +48,9 @@ class StockRule(models.Model):
         'Active', default=True,
         help="If unchecked, it will allow you to hide the rule without removing it.")
     group_propagation_option = fields.Selection([
-        ('none', 'Leave Empty'),
+        ('none', 'Create New'),
         ('propagate', 'Propagate'),
-        ('fixed', 'Fixed')], string="Propagation of Procurement Group", default='propagate')
+        ('fixed', 'Fixed')], string="Propagation of Procurement Group", default='propagate', required=True)
     group_id = fields.Many2one('procurement.group', 'Fixed Procurement Group')
     action = fields.Selection(
         selection=[('pull', 'Pull From'), ('push', 'Push To'), ('pull_push', 'Pull & Push')], string='Action',

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -453,7 +453,7 @@ class Warehouse(models.Model):
                 'depends': ['delivery_steps'],
                 'create_values': {
                     'active': True,
-                    'procure_method': 'mts_else_mto',
+                    'procure_method': 'make_to_order',
                     'company_id': self.company_id.id,
                     'action': 'pull',
                     'auto': 'manual',

--- a/addons/stock_dropshipping/tests/test_dropship.py
+++ b/addons/stock_dropshipping/tests/test_dropship.py
@@ -41,9 +41,8 @@ class TestDropship(common.TransactionCase):
         })
 
     def test_change_qty(self):
-        # enable the dropship and MTO route on the product
-        mto_route = self.env.ref('stock.route_warehouse0_mto')
-        self.dropship_product.write({'route_ids': [(6, 0, [self.dropshipping_route.id, mto_route.id])]})
+        # enable the dropship route on the product
+        self.dropship_product.write({'route_ids': [(6, 0, [self.dropshipping_route.id])]})
 
         # sell one unit of dropship product
         so = self.env['sale.order'].create({

--- a/addons/stock_dropshipping/tests/test_stockvaluation.py
+++ b/addons/stock_dropshipping/tests/test_stockvaluation.py
@@ -22,10 +22,9 @@ class TestStockValuation(ValuationReconciliationTestCommon):
         })
 
     def _dropship_product1(self):
-        # enable the dropship and MTO route on the product
+        # enable the dropship route on the product
         dropshipping_route = self.env.ref('stock_dropshipping.route_drop_shipping')
-        mto_route = self.env.ref('stock.route_warehouse0_mto')
-        self.product1.write({'route_ids': [(6, 0, [dropshipping_route.id, mto_route.id])]})
+        self.product1.write({'route_ids': [(6, 0, [dropshipping_route.id])]})
 
         # add a vendor
         vendor1 = self.env['res.partner'].create({'name': 'vendor1'})


### PR DESCRIPTION
This PR introduces a couple of modifications regarding procurement methods, namely

- Stock to Customer/Production rules are now using make to order procurement method instead of `mts_else_mto`
- `mts_else_mto` message has been modified to better reflect its behavior now

task-4150122



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
