### PR TITLE
[FIX] website: make `s_numbers_charts` graph resize properly

### DIFF
--- a/addons/website/views/snippets/s_numbers_charts.xml
+++ b/addons/website/views/snippets/s_numbers_charts.xml
@@ -33,6 +33,7 @@
                 </div>
                 <div class="o_grid_item o_cc o_cc2 g-col-lg-5 g-height-12 col-lg-5 rounded" style="grid-area: 1 / 8 / 13 / 13; --grid-item-padding-y: 80px; --grid-item-padding-x: 40px; z-index: 4;">
                     <div class="s_chart" data-type="doughnut" data-legend-position="none" data-tooltip-display="false" data-stacked="false" data-border-width="2" data-data='{"labels":["First","Second"],"datasets":[{"label":"One","data":["25","75"],"backgroundColor":["o-color-3","o-color-2"],"borderColor":["",""]}]}' data-snippet="s_chart" data-name="Chart">
+                        <p><br/></p>
                         <canvas style="box-sizing: border-box;" width="456" height="228"/>
                     </div>
                     <!-- Placeholder chart, to be displayed in the preview modal -->


### PR DESCRIPTION
This commit aims to make the graph in `s_numbers_charts` resize
simultaneously with it's col parent.

It looks like the problem came from the fact that the `s_chart` div was
composed of the chart alone. Adding some other type of content makes the
chart resize properly.

task-4207620

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
