### PR TITLE
[FIX] web: company switcher search input only works when hovered

### DIFF
--- a/addons/web/static/src/core/dropdown/_behaviours/dropdown_nesting.js
+++ b/addons/web/static/src/core/dropdown/_behaviours/dropdown_nesting.js
@@ -113,7 +113,7 @@ export function useDropdownNesting(state) {
         navigationOptions: {
             onEnabled: (items) => {
                 if (current.parent) {
-                    items[0]?.focus();
+                    items[0]?.setActive();
                 }
             },
             onMouseEnter: (item) => {

--- a/addons/web/static/src/core/navigation/navigation.js
+++ b/addons/web/static/src/core/navigation/navigation.js
@@ -25,28 +25,28 @@ class NavigationItem {
             this.target = el;
         }
 
-        const focus = (ev) => this.focus(ev);
+        const onFocus = () => this.setActive(false);
         const onMouseEnter = (ev) => this.onMouseEnter(ev);
 
-        this.target.addEventListener("focus", focus);
+        this.target.addEventListener("focus", onFocus);
         this.target.addEventListener("mouseenter", onMouseEnter);
         this.removeListeners = () => {
-            this.target.removeEventListener("focus", focus);
+            this.target.removeEventListener("focus", onFocus);
             this.target.removeEventListener("mouseenter", onMouseEnter);
         };
     }
 
     select() {
-        this.focus();
+        this.setActive();
         this.target.click();
     }
 
-    focus(event = undefined) {
+    setActive(focus = true) {
         scrollTo(this.target);
         this.setActiveItem(this.index, this);
         this.target.classList.add(ACTIVE_ELEMENT_CLASS);
 
-        if (!event && !this.options.virtualFocus) {
+        if (focus && !this.options.virtualFocus) {
             focusElement(this.target);
         }
     }
@@ -56,7 +56,7 @@ class NavigationItem {
     }
 
     onMouseEnter() {
-        this.focus();
+        this.setActive(false);
         this.options.onMouseEnter?.(this);
     }
 }
@@ -74,11 +74,11 @@ class Navigator {
             const isFocused = this.activeItem?.el.isConnected;
             const index = this.currentActiveIndex + increment;
             if (isFocused && index >= 0) {
-                return this.items[index % this.items.length]?.focus();
+                return this.items[index % this.items.length]?.setActive();
             } else if (!isFocused && increment >= 0) {
-                return this.items[0]?.focus();
+                return this.items[0]?.setActive();
             } else {
-                return this.items.at(-1)?.focus();
+                return this.items.at(-1)?.setActive();
             }
         };
 
@@ -90,8 +90,8 @@ class Navigator {
             ...options,
 
             hotkeys: {
-                home: (index, items) => items[0]?.focus(),
-                end: (index, items) => items.at(-1)?.focus(),
+                home: (index, items) => items[0]?.setActive(),
+                end: (index, items) => items.at(-1)?.setActive(),
                 tab: () => focusAt(+1),
                 "shift+tab": () => focusAt(-1),
                 arrowdown: () => focusAt(+1),
@@ -155,7 +155,7 @@ class Navigator {
         if (this.options.onEnabled) {
             this.options.onEnabled(this.items);
         } else if (this.items.length > 0) {
-            this.items[0]?.focus();
+            this.items[0]?.setActive();
         }
 
         this.enabled = true;
@@ -202,7 +202,7 @@ class Navigator {
         });
 
         if (oldItemsLength != this.items.length && this.currentActiveIndex >= this.items.length) {
-            this.items.at(-1)?.focus();
+            this.items.at(-1)?.setActive();
         }
     }
 

--- a/addons/web/static/tests/core/navigation_hook.test.js
+++ b/addons/web/static/tests/core/navigation_hook.test.js
@@ -2,7 +2,7 @@ import { Component, xml } from "@odoo/owl";
 import { useNavigation } from "@web/core/navigation/navigation";
 import { useAutofocus } from "@web/core/utils/hooks";
 import { describe, expect, test } from "@odoo/hoot";
-import { press } from "@odoo/hoot-dom";
+import { press, hover } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { mountWithCleanup } from "@web/../tests/web_test_helpers";
 
@@ -88,11 +88,11 @@ test("hotkey override options", async () => {
             hotkeys: {
                 arrowleft: (index, items) => {
                     expect.step(index);
-                    items[(index + 2) % items.length].focus();
+                    items[(index + 2) % items.length].setActive();
                 },
                 escape: (index, items) => {
                     expect.step("escape");
-                    items[0].focus();
+                    items[0].setActive();
                 },
             },
         };
@@ -163,4 +163,25 @@ test("navigation with virtual focus", async () => {
     await press("enter");
     await animationFrame();
     expect.verifySteps([2]);
+});
+
+test("hover selects the items makes but doesn't focus", async () => {
+    await mountWithCleanup(BasicHookParent);
+
+    press("arrowdown");
+    await animationFrame();
+
+    expect(".two").toBeFocused();
+    expect(".two").toHaveClass("focus");
+
+    hover(".three");
+    expect(".two").toBeFocused();
+    expect(".two").not.toHaveClass("focus");
+    expect(".three").not.toBeFocused();
+    expect(".three").toHaveClass("focus");
+
+    press("arrowdown");
+    await animationFrame();
+    expect(".four").toBeFocused();
+    expect(".four").toHaveClass("focus");
 });


### PR DESCRIPTION
This commit fixes a bug where the search input would only work when it was hovered. This was caused by the navigation hook used by the dropdown which would focus the items on hover, loosing the focus of the search input in the process.

Task: 4207756

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
