### PR TITLE
[FIX] hr_attendance: show correct company in kiosk mode

### DIFF
--- a/addons/hr_attendance/controllers/main.py
+++ b/addons/hr_attendance/controllers/main.py
@@ -3,6 +3,7 @@
 from odoo.service.common import exp_version
 from odoo import http, _
 from odoo.http import request
+from odoo.osv import expression
 from odoo.tools import float_round, SQL
 from odoo.tools.image import image_data_uri
 
@@ -149,6 +150,7 @@ class HrAttendance(http.Controller):
     def employees_infos(self, token, limit, offset, domain):
         company = self._get_company(token)
         if company:
+            domain = expression.AND([domain, [('company_id', '=', company.id)]])
             employees = request.env['hr.employee'].sudo().search_fetch(domain, ['id', 'display_name', 'job_id'],
                 limit=limit, offset=offset, order="name, id")
             employees_data = [{

--- a/addons/hr_attendance/static/src/components/card_layout/card_layout.js
+++ b/addons/hr_attendance/static/src/components/card_layout/card_layout.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import { Component, useState, onWillUnmount } from "@odoo/owl";
-import { url } from "@web/core/utils/urls";
 
 const { DateTime } = luxon;
 export class CardLayout extends Component {
@@ -27,9 +26,6 @@ export class CardLayout extends Component {
             this.state.date = now.toLocaleString({ ...DateTime.DATE_FULL, weekday: undefined });
             this.state.dayOfWeek = now.toFormat("cccc");
         }, 1000);
-        this.companyImageUrl = url("/web/binary/company_logo", {
-            company: this.props.companyId,
-        });
         onWillUnmount(() => {
             clearInterval(this.timeInterval);
         });

--- a/addons/hr_attendance/static/src/components/card_layout/card_layout.xml
+++ b/addons/hr_attendance/static/src/components/card_layout/card_layout.xml
@@ -12,7 +12,7 @@
                     <i class="oi oi-chevron-left" role="img" aria-label="Go back" title="Go back"/>
                 </button>
                 <t t-call="hr_attendance.companyHeader">
-                    <t t-set="companyImageUrl" t-value="companyImageUrl"/>
+                    <t t-set="companyImageUrl" t-value="this.props.companyImageUrl"/>
                     <t t-set="companyName" t-value="this.props.companyName"/>
                 </t>
             </div>
@@ -46,7 +46,7 @@
                     </div>
                 </div>
                 <t t-call="hr_attendance.companyHeader">
-                    <t t-set="companyImageUrl" t-value="companyImageUrl"/>
+                    <t t-set="companyImageUrl" t-value="this.props.companyImageUrl"/>
                     <t t-set="companyName" t-value="this.props.companyName"/>
                 </t>
             </div>

--- a/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.xml
+++ b/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.xml
@@ -111,7 +111,7 @@
 
 <t t-name="hr_attendance.public_kiosk_app">
     <MainComponentsContainer/>
-    <CardLayout fromTrialMode="this.props.fromTrialMode" kioskReturn.bind="kioskReturn">
+    <CardLayout fromTrialMode="this.props.fromTrialMode" companyImageUrl="this.companyImageUrl" kioskReturn.bind="kioskReturn">
         <t t-if="this.state.active_display === 'settings'">
             <t t-call="hr_attendance.PublicKiosksSettingScreen"/>
         </t>


### PR DESCRIPTION
This commit fixes two issues:
- The logo displayed on the attendance kiosk mode is always the one of the
first company in DB (id=1), no matter which one the user is actually logged.
- The list of employees shown when manually indentifying isn't filtered by
company and shows all employees.

opw-4189915