### PR TITLE
[FIX] survey: added background for next button in livesession

### DIFF
--- a/addons/survey/views/survey_templates_user_input_session.xml
+++ b/addons/survey/views/survey_templates_user_input_session.xml
@@ -126,7 +126,7 @@
                     <div t-field="survey.description_done"/>
                 </div>
                 <a role="button"
-                    class="o_survey_session_navigation o_survey_session_navigation_next p-2">
+                    class="o_survey_session_navigation o_survey_session_navigation_next p-2 bg-light">
                     <span class="o_survey_session_navigation_next_label me-2 fw-bold"/>
                     <i class="fw-bold oi oi-chevron-right"/>
                 </a>


### PR DESCRIPTION
Earlier next button in the live session was not visible for some backgrounds.

This pr addresses the issue and adds a separate background color for the start button so it can be compatible with any background.

Task-4210804