### PR TITLE
[REF] html_editor, *: dialog plugin

### DIFF
--- a/addons/html_editor/static/src/core/dialog_plugin.js
+++ b/addons/html_editor/static/src/core/dialog_plugin.js
@@ -1,0 +1,16 @@
+import { Plugin } from "../plugin";
+
+export class DialogPlugin extends Plugin {
+    static name = "dialog";
+    static dependencies = ["selection"];
+    static shared = ["addDialog"];
+
+    addDialog(dialogClass, props, options = {}) {
+        this.services.dialog.add(dialogClass, props, {
+            onClose: () => {
+                this.shared.focusEditable();
+            },
+            ...options,
+        });
+    }
+}

--- a/addons/html_editor/static/src/main/chatgpt/chatgpt_plugin.js
+++ b/addons/html_editor/static/src/main/chatgpt/chatgpt_plugin.js
@@ -8,7 +8,7 @@ import { LanguageSelector } from "./language_selector";
 
 export class ChatGPTPlugin extends Plugin {
     static name = "chatgpt";
-    static dependencies = ["selection", "history", "dom", "sanitize"];
+    static dependencies = ["selection", "history", "dom", "sanitize", "dialog"];
     /** @type { (p: ChatGPTPlugin) => Record<string, any> } */
     static resources = (p) => ({
         toolbarCategory: {
@@ -103,21 +103,15 @@ export class ChatGPTPlugin extends Plugin {
             },
             ...params,
         };
-        const onClose = () => this.shared.focusEditable();
         // collapse to end
         const sanitize = this.shared.sanitize;
         if (selection.isCollapsed) {
-            this.services.dialog.add(
-                ChatGPTPromptDialog,
-                { ...dialogParams, sanitize },
-                { onClose }
-            );
+            this.shared.addDialog(ChatGPTPromptDialog, { ...dialogParams, sanitize });
         } else {
             const originalText = selection.textContent() || "";
-            this.services.dialog.add(
+            this.shared.addDialog(
                 params.language ? ChatGPTTranslateDialog : ChatGPTAlternativesDialog,
-                { ...dialogParams, originalText, sanitize },
-                { onClose }
+                { ...dialogParams, originalText, sanitize }
             );
         }
         if (this.services.ui.isSmall) {

--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -15,7 +15,7 @@ const MEDIA_SELECTOR = `${ICON_SELECTOR} , .o_image, .media_iframe_video`;
 
 export class MediaPlugin extends Plugin {
     static name = "media";
-    static dependencies = ["selection", "history", "dom"];
+    static dependencies = ["selection", "history", "dom", "dialog"];
     static shared = ["savePendingImages"];
     /** @type { (p: MediaPlugin) => Record<string, any> } */
     static resources = (p) => {
@@ -159,27 +159,23 @@ export class MediaPlugin extends Plugin {
 
     openMediaDialog(params = {}) {
         const { resModel, resId, field, type } = this.recordInfo;
-        this.services.dialog.add(
-            MediaDialog,
-            {
-                resModel,
-                resId,
-                useMediaLibrary: !!(
-                    field &&
-                    ((resModel === "ir.ui.view" && field === "arch") || type === "html")
-                ), // @todo @phoenix: should be removed and moved to config.mediaModalParams
-                media: params.node,
-                save: (element) => {
-                    this.onSaveMediaDialog(element, { node: params.node });
-                },
-                onAttachmentChange: this.config.onAttachmentChange || (() => {}),
-                noVideos: !!this.config.disableVideo,
-                noImages: !!this.config.disableImage,
-                ...this.config.mediaModalParams,
-                ...params,
+        this.shared.addDialog(MediaDialog, {
+            resModel,
+            resId,
+            useMediaLibrary: !!(
+                field &&
+                ((resModel === "ir.ui.view" && field === "arch") || type === "html")
+            ), // @todo @phoenix: should be removed and moved to config.mediaModalParams
+            media: params.node,
+            save: (element) => {
+                this.onSaveMediaDialog(element, { node: params.node });
             },
-            { onClose: () => this.shared.focusEditable() }
-        );
+            onAttachmentChange: this.config.onAttachmentChange || (() => {}),
+            noVideos: !!this.config.disableVideo,
+            noImages: !!this.config.disableImage,
+            ...this.config.mediaModalParams,
+            ...params,
+        });
     }
 
     async savePendingImages() {

--- a/addons/html_editor/static/src/plugin_sets.js
+++ b/addons/html_editor/static/src/plugin_sets.js
@@ -2,6 +2,7 @@ import { DynamicPlaceholderPlugin } from "@html_editor/others/dynamic_placeholde
 import { ClipboardPlugin } from "./core/clipboard_plugin";
 import { CommentPlugin } from "./core/comment_plugin";
 import { DeletePlugin } from "./core/delete_plugin";
+import { DialogPlugin } from "./core/dialog_plugin";
 import { DomPlugin } from "./core/dom_plugin";
 import { FormatPlugin } from "./core/format_plugin";
 import { HistoryPlugin } from "./core/history_plugin";
@@ -28,9 +29,9 @@ import { OdooLinkSelectionPlugin } from "./main/link/link_selection_odoo_plugin"
 import { LinkSelectionPlugin } from "./main/link/link_selection_plugin";
 import { ListPlugin } from "./main/list/list_plugin";
 import { LocalOverlayPlugin } from "./main/local_overlay_plugin";
-import { ImagePlugin } from "./main/media/image_plugin";
 import { IconPlugin } from "./main/media/icon_plugin";
 import { ImageCropPlugin } from "./main/media/image_crop_plugin";
+import { ImagePlugin } from "./main/media/image_plugin";
 import { MediaPlugin } from "./main/media/media_plugin";
 import { MoveNodePlugin } from "./main/movenode_plugin";
 import { PositionPlugin } from "./main/position_plugin";
@@ -60,6 +61,7 @@ export const CORE_PLUGINS = [
     ClipboardPlugin,
     CommentPlugin,
     DeletePlugin,
+    DialogPlugin,
     DomPlugin,
     FormatPlugin,
     HistoryPlugin,


### PR DESCRIPTION
The purpose of this commit is to add a dialog plugin that will centralise the behaviour shared between dialogs opened from the editor. The behaviour shared by all the editor dialogs is the repositioning of the selection in the editable when a dialog closes.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
