### PR TITLE
[FIX] pos_self_order: fix kiosk not closing

### DIFF
--- a/addons/pos_self_order/static/src/app/self_order_bus_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_bus_service.js
@@ -76,7 +76,7 @@ export class SelfOrderBus {
         const payload = message.payload;
 
         if (payload.status === "closed") {
-            this.selfOrder.pos_session = [];
+            this.selfOrder.pos_session = null;
             this.selfOrder.ordering = false;
         } else {
             // reload to get potential new settings


### PR DESCRIPTION
When the session of the kiosk is closed in the backoffice, the kiosk is supposed to show the "We are closed" banner and to no longer accept orders. Currently, this is not the case.

In this commit we fix the issue

Task: 4219525

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
