### PR TITLE
[FIX] website: fix `s_tabs` underline contrast issue

### DIFF
--- a/addons/website/static/src/snippets/s_tabs/002.scss
+++ b/addons/website/static/src/snippets/s_tabs/002.scss
@@ -50,7 +50,8 @@
 
             .nav-link {
                 margin-bottom: -1px;
-
+                color: inherit;
+                
                 &:not(.active) {
                     border: 0;
                 }


### PR DESCRIPTION
Before this commit, when using the "Tabs" snippet with the underline layout and adding one of the darker color presets, there was a contrast issue, particularly with the active state.

This commit fixes the contrast issue by ensuring that the active text color dynamically inherits the appropriate color based on the background

task-4215783

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
