### PR TITLE
[FIX] point_of_sale: change field name to the newer one

### DIFF
--- a/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.js
+++ b/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.js
@@ -42,8 +42,8 @@ export class OrderTabs extends Component {
     }
     get orders() {
         return this.props.orders.sort((a, b) => {
-            const noteA = a.note || "";
-            const noteB = b.note || "";
+            const noteA = a.floating_order_name || "";
+            const noteB = b.floating_order_name || "";
             if (noteA && noteB) {
                 // Both have notes
                 const timePattern = /^\d{1,2}:\d{2}/;


### PR DESCRIPTION
Steps to reproduce :
--------------------------
- Install the point_of_sale module.
- Place orders on two or more floating orders.
- Give the orders some name.

Issue :
---------
The floating orders are not sorted according to alphabet properly.

Cause :
----------
The field containg floating order name is changed but, at this place still try to sequence by old name.
[Referance PR](https://github.com/odoo/odoo/pull/175535)

Fix :
-----
Now updated the field name properly from note to floating_order_name.
