### PR TITLE
[FIX] mail: handle IMAP4.abort error during connection close

### DIFF
--- a/addons/mail/models/fetchmail.py
+++ b/addons/mail/models/fetchmail.py
@@ -250,7 +250,7 @@ odoo_mailgate: "|/path/to/odoo-mailgate.py --host=localhost -u %(uid)d -p PASSWO
                         try:
                             imap_server.close()
                             imap_server.logout()
-                        except OSError:
+                        except (OSError, IMAP4.abort):
                             _logger.warning('Failed to properly finish imap connection: %s.', server.name, exc_info=True)
             elif connection_type == 'pop':
                 try:


### PR DESCRIPTION
When the server connection is already terminated or in an invalid state
due to network issues, server timeouts, or SSL problems.
A traceback will appear.

Traceback:
```
SSLEOFError: EOF occurred in violation of protocol (_ssl.c:2406)
  File "imaplib.py", line 1006, in _command
    self.send(data + CRLF)
  File "imaplib.py", line 332, in send
    self.sock.sendall(data)
  File "ssl.py", line 1211, in sendall
    v = self.send(byte_view[count:])
  File "ssl.py", line 1180, in send
    return self._sslobj.write(data)
IMAP4.abort: socket error: EOF occurred in violation of protocol (_ssl.c:2406)
  File "odoo/tools/safe_eval.py", line 391, in safe_eval
    return unsafe_eval(c, globals_dict, locals_dict)
  File "ir.actions.server(1214,)", line 1, in <module>
  File "addons/mail/models/fetchmail.py", line 213, in _fetch_mails
    return self.search([('state', '=', 'done'), ('server_type', '!=', 'local')]).fetch_mail(raise_exception=False)
  File "addons/mail/models/fetchmail.py", line 254, in fetch_mail
    imap_server.close()
  File "imaplib.py", line 475, in close
    typ, dat = self._simple_command('CLOSE')
  File "imaplib.py", line 1230, in _simple_command
    return self._command_complete(name, self._command(name, *args))
  File "imaplib.py", line 1008, in _command
    raise self.abort('socket error: %s' % val)
ValueError: <class 'imaplib.IMAP4.abort'>: "socket error: EOF occurred in violation of protocol (_ssl.c:2406)" while evaluating
'model._fetch_mails()'
  File "odoo/addons/base/models/ir_cron.py", line 562, in _callback
    self.env['ir.actions.server'].browse(server_action_id).run()
  File "home/odoo/src/custom/trial/saas_trial/models/sentry.py", line 33, in run
    res = super().run()
  File "odoo/addons/base/models/ir_actions.py", line 989, in run
    res = runner(run_self, eval_context=eval_context)
  File "addons/website/models/ir_actions_server.py", line 61, in _run_action_code_multi
    res = super(ServerAction, self)._run_action_code_multi(eval_context)
  File "odoo/addons/base/models/ir_actions.py", line 821, in _run_action_code_multi
    safe_eval(self.code.strip(), eval_context, mode="exec", nocopy=True, filename=str(self))  # nocopy allows to return 'action'
  File "odoo/tools/safe_eval.py", line 405, in safe_eval
    raise ValueError('%s: "%s" while evaluating\n%r' % (ustr(type(e)), ustr(e), expr))
```


This commit catches IMAP4.abort error and prevents crashes during email fetching
when the IMAP connection is unstable or already closed.

sentry-5924967386

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
