### PR TITLE
[FIX] website_sale: website_sale_variants_modal_window tour

### DIFF
--- a/addons/website_sale/static/tests/tours/website_sale_variants_modal_window.js
+++ b/addons/website_sale/static/tests/tours/website_sale_variants_modal_window.js
@@ -15,22 +15,22 @@
         {
             content: "Click on the always variant",
             trigger: 'input[data-attribute_name="Always attribute size"][data-value_name="M always"]',
-            run: "click",
+            run: "check",
         },
         {
             content: "Click on the dynamic variant",
             trigger: 'input[data-attribute_name="Dynamic attribute size"][data-value_name="M dynamic"]',
-            run: "click",
+            run: "check",
         },
         {
             content: "Click on the never variant",
             trigger: 'input[data-attribute_name="Never attribute size"][data-value_name="M never"]',
-            run: "click",
+            run: "check",
         },
         {
             content: "Click on the never custom variant",
             trigger: 'input[data-attribute_name="Never attribute size custom"][data-value_name="Yes never custom"]',
-            run: "click",
+            run: "check",
         },
         {
             trigger: 'input.variant_custom_value',
@@ -42,32 +42,29 @@
             run: "click",
         },
         {
-            trigger: 'table.o_sale_product_configurator_table',
+            trigger:
+                ".modal:contains(configure your product) table.o_sale_product_configurator_table",
         },
         {
             content: "Go through the modal window of the product configurator",
-            trigger: 'button:contains(Proceed to Checkout)',
-            run: 'click',
+            trigger: ".modal:contains(configure your product) button:contains(Proceed to Checkout)",
+            run: "click",
         },
         {
             content: "Check the product is in the cart",
             trigger: 'div>a>h6:contains(Short (TEST))',
-            run: "click",
         },
         {
             content: "Check always variant",
             trigger: 'div>a>h6:contains(M always)',
-            run: "click",
         },
         {
             content: "Check dynamic variant",
             trigger: 'div>a>h6:contains(M dynamic)',
-            run: "click",
         },
         {
             content: "Check never variant",
             trigger: 'div.text-muted>span:contains(Never attribute size: M never)',
-            run: "click",
         },
         {
             content: "Check never custom variant",


### PR DESCRIPTION
In this commit, we remove unuseful click action, we use check action instead of click (to ensure the input is checked after clicking on it) and we precise some step trigger by adding .modal to check the element is well in a modal before proceed to checkout (in the tour).

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
