### PR TITLE
[FIX] website_sale: applied pricelist not based on sequence

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -270,11 +270,11 @@ class Website(models.Model):
             if available_pricelists and pricelist not in available_pricelists:
                 # If there is at least one pricelist in the available pricelists
                 # and the chosen pricelist is not within them
-                # it then choose the first available pricelist.
+                # it then choose the first available pricelist based on _order of the model.
                 # This can only happen when the pricelist is the public user pricelist and this pricelist is not in the available pricelist for this localization
                 # If the user is signed in, and has a special pricelist (different than the public user pricelist),
                 # then this special pricelist is amongs these available pricelists, and therefore it won't fall in this case.
-                pricelist = available_pricelists[0]
+                pricelist = available_pricelists.sorted()[0]
 
             if not pricelist:
                 _logger.error(


### PR DESCRIPTION
a bug was reported that when there were multiple available pricelists, the sequence provided by the admin wasn't taken into consideration. This fix returns the first available pricelist based on the model's order, instead of based on the creation order.

> [EBC] pricelist country detection issue with more than 2 pricelists:
> https://drive.google.com/file/d/1eHlCqA_2CW2HB_IvGlOscQhXZVi_Owq3/view?usp=sharing

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
