### PR TITLE
[FIX] website_sale: convert eCommerce categories image to webp

### DIFF
--- a/addons/website_sale/views/product_public_category_views.xml
+++ b/addons/website_sale/views/product_public_category_views.xml
@@ -7,7 +7,12 @@
         <field name="arch" type="xml">
             <form string="Website Public Categories">
                 <sheet>
-                    <field name="image_1920" widget="image" class="oe_avatar" options="{'preview_image': 'image_128'}"/>
+                    <field
+                        name="image_1920"
+                        widget="image"
+                        class="oe_avatar"
+                        options="{'convert_to_webp': True, 'preview_image': 'image_128'}"
+                    />
                     <div>
                         <group class="col-md-4 col-lg-6 pe-3">
                             <field name="name"/>


### PR DESCRIPTION
A new option to convert images to webp was added in 1a978183001e0503104285f4bd5bed983beb0efb. This commit adds this option to eCommerce categories' form view image field so categories images uploaded from the backend benefit from webp improvements too.