### PR TITLE
[FIX] point_of_sale: ensure accurate invoicing for the current order

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -268,9 +268,9 @@ export class PaymentScreen extends Component {
 
             // 2. Invoice.
             if (this.shouldDownloadInvoice() && this.currentOrder.is_to_invoice()) {
-                if (syncOrderResult[0]?.raw.account_move) {
+                if (this.currentOrder.raw.account_move) {
                     await this.report.doAction("account.account_invoices", [
-                        syncOrderResult[0].raw.account_move,
+                        this.currentOrder.raw.account_move,
                     ]);
                 } else {
                     throw {


### PR DESCRIPTION
Before this commit, in a scenario with multiple ongoing orders in a restaurant, attempting to invoice one of the orders could lead to an error. This was due to the fact that syncOrderResult[0] might correspond to a draft order. This commit addresses the issue by using the currentOrder, which is updated upon receiving data from the server, ensuring the correct order is invoiced.

opw-4189363

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
