### PR TITLE
[FIX] hr_expense: Fix payment journal entry optional

### DIFF
--- a/addons/hr_expense/i18n/hr_expense.pot
+++ b/addons/hr_expense/i18n/hr_expense.pot
@@ -148,6 +148,15 @@ msgid "<span>The total amount doesn't match the original amount.</span>"
 msgstr ""
 
 #. module: hr_expense
+#. odoo-python
+#: code:addons/hr_expense/models/hr_expense_sheet.py:0
+msgid ""
+"A default outstanding account must be defined in the settings for company-"
+"paid expenses. Or specify one in the Journal for the %(method)s payment "
+"method."
+msgstr ""
+
+#. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense__account_id
 msgid "Account"
 msgstr ""
@@ -581,6 +590,11 @@ msgstr ""
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.res_config_settings_view_form
+msgid "Default outstanding account for expenses paid by company."
+msgstr ""
+
+#. module: hr_expense
+#: model_terms:ir.ui.view,arch_db:hr_expense.res_config_settings_view_form
 msgid "Default outstanding account for expenses paid by employees."
 msgstr ""
 
@@ -769,6 +783,11 @@ msgstr ""
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_employee_public__expense_manager_id
 msgid "Expense Manager"
+msgstr ""
+
+#. module: hr_expense
+#: model_terms:ir.ui.view,arch_db:hr_expense.res_config_settings_view_form
+msgid "Expense Outstanding Account"
 msgstr ""
 
 #. module: hr_expense
@@ -1004,6 +1023,12 @@ msgstr ""
 #. module: hr_expense
 #: model_terms:product.template,description:hr_expense.expense_product_gift_product_template
 msgid "Gifts to customers or vendors"
+msgstr ""
+
+#. module: hr_expense
+#. odoo-python
+#: code:addons/hr_expense/models/hr_expense_sheet.py:0
+msgid "Go to settings"
 msgstr ""
 
 #. module: hr_expense
@@ -1978,6 +2003,11 @@ msgstr ""
 #. module: hr_expense
 #: model:ir.model.fields,help:hr_expense.field_res_company__expense_outstanding_account_id
 #: model:ir.model.fields,help:hr_expense.field_res_config_settings__expense_outstanding_account_id
+msgid ""
+"The account used to record the outstanding amount of the company expenses."
+msgstr ""
+
+#. module: hr_expense
 msgid ""
 "The account used to record the outstanding amount of the employee expenses."
 msgstr ""

--- a/addons/hr_expense/models/account_move.py
+++ b/addons/hr_expense/models/account_move.py
@@ -84,9 +84,8 @@ class AccountMove(models.Model):
 
     def button_cancel(self):
         # EXTENDS account
-        # We need to override this method to unlink the move from the expenses paid by an employee, else we cannot reimburse them anymore.
+        # We need to override this method to remove the link with the move, else we cannot reimburse them anymore.
         # And cancelling the move != cancelling the expense
         res = super().button_cancel()
-        own_expense_moves = self.filtered(lambda move: move.expense_sheet_id.payment_mode == 'own_account')
-        own_expense_moves.write({'expense_sheet_id': False, 'ref': False})
+        self.write({'expense_sheet_id': False, 'ref': False})
         return res

--- a/addons/hr_expense/models/account_payment.py
+++ b/addons/hr_expense/models/account_payment.py
@@ -10,6 +10,13 @@ class AccountPayment(models.Model):
 
     expense_sheet_id = fields.Many2one(related='move_id.expense_sheet_id')
 
+    def _compute_outstanding_account_id(self):
+        # EXTENDS account
+        expense_company_payments = self.filtered(lambda payment: payment.expense_sheet_id.payment_mode == 'company_account')
+        for payment in expense_company_payments:
+            payment.outstanding_account_id = payment.expense_sheet_id._get_expense_account_destination()
+        super(AccountPayment, self - expense_company_payments)._compute_outstanding_account_id()
+
     def write(self, vals):
         trigger_fields = {
             'date', 'amount', 'payment_type', 'partner_type', 'payment_reference',

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -949,6 +949,7 @@ class HrExpense(models.Model):
             'partner_id': self.vendor_id.id,
             'currency_id': self.currency_id.id,
             'payment_method_line_id': payment_method_line.id,
+            'company_id': self.company_id.id,
         }
         move_vals = {
             **self.sheet_id._prepare_move_vals(),

--- a/addons/hr_expense/models/hr_expense_sheet.py
+++ b/addons/hr_expense/models/hr_expense_sheet.py
@@ -586,8 +586,16 @@ class HrExpenseSheet(models.Model):
 
     def action_sheet_move_post(self):
         # When a move has been deleted
-        self.filtered(lambda sheet: not sheet.account_move_ids).with_prefetch()._do_create_moves()
-        self.account_move_ids.action_post()
+        self.filtered(lambda sheet: not sheet.account_move_ids)._do_create_moves()
+
+        company_sheets = self.filtered(lambda sheet: sheet.payment_mode == 'company_account')
+        employee_sheets = self - company_sheets
+
+        # Post the employee-paid expenses moves
+        employee_sheets.account_move_ids.action_post()
+
+        # Post the company-paid expense through the payment instead, to post both at the same time
+        company_sheets.account_move_ids.origin_payment_id.action_post()
 
     def action_reset_expense_sheets(self):
         self.filtered(lambda sheet: sheet.state not in {'draft', 'submit'})._check_can_reset_approval()
@@ -757,12 +765,21 @@ class HrExpenseSheet(models.Model):
                 expense._prepare_payments_vals()
                 for expense in company_account_sheets.expense_line_ids
             ])
+
+            payment_moves_sudo = self.env['account.move'].sudo().create(move_vals_list)
+            for payment_vals, move in zip(payment_vals_list, payment_moves_sudo):
+                payment_vals['move_id'] = move.id
+
             payments_sudo = self.env['account.payment'].sudo().create(payment_vals_list)
-            moves_sudo = self.env['account.move'].sudo().create(move_vals_list)
-            for payment, move in zip(payments_sudo, moves_sudo):
-                payment.write({'move_id': move.id, 'state': 'in_process'})
-                move.origin_payment_id = payment
-            moves_sudo |= payments_sudo.move_id
+            for payment_sudo, move_sudo in zip(payments_sudo, payment_moves_sudo):
+                move_sudo.update({
+                    'origin_payment_id': payment_sudo.id,
+                    # We need to put the journal_id because editing origin_payment_id triggers a re-computation chain
+                    # that voids the company_currency_id of the lines
+                    'journal_id': move_sudo.journal_id.id,
+                })
+
+            moves_sudo |= payment_moves_sudo
 
         # returning the move with the super user flag set back as it was at the origin of the call
         return moves_sudo.sudo(self.env.su)
@@ -862,11 +879,16 @@ class HrExpenseSheet(models.Model):
                 or journal.company_id.expense_outstanding_account_id
             )
             if not account_dest:
-                raise UserError(_(
-                    "The payment method %(method)s needs an account, "
-                    "or a default outstanding account must be defined in the settings.",
+                error_msg = _(
+                    "A default outstanding account must be defined in the settings for company-paid expenses. "
+                    "Or specify one in the Journal for the %(method)s payment method.",
                     method=self.payment_method_line_id.display_name,
-                ))
+                )
+                if self.env['res.config.settings'].has_access('write'):
+                    action = self.env.ref('hr_expense.action_hr_expense_configuration')
+                    raise RedirectWarning(error_msg, action=action.id, button_text=_("Go to settings"))
+                else:
+                    raise UserError(error_msg)
         else:
             if not self.employee_id.sudo().work_contact_id:
                 raise UserError(_("No work contact found for the employee %s, please configure one.", self.employee_id.name))

--- a/addons/hr_expense/models/res_company.py
+++ b/addons/hr_expense/models/res_company.py
@@ -18,7 +18,7 @@ class ResCompany(models.Model):
         string="Outstanding Account",
         check_company=True,
         domain="[('account_type', '=', 'asset_current'), ('reconcile', '=', True)]",
-        help="The account used to record the outstanding amount of the employee expenses.",
+        help="The account used to record the outstanding amount of the company expenses.",
     )
     company_expense_allowed_payment_method_line_ids = fields.Many2many(
         "account.payment.method.line",

--- a/addons/hr_expense/models/res_config_settings.py
+++ b/addons/hr_expense/models/res_config_settings.py
@@ -16,7 +16,13 @@ class ResConfigSettings(models.TransientModel):
     module_hr_payroll_expense = fields.Boolean(string='Reimburse Expenses in Payslip')
     module_hr_expense_extract = fields.Boolean(string='Send bills to OCR to generate expenses')
     expense_journal_id = fields.Many2one('account.journal', related='company_id.expense_journal_id', readonly=False, check_company=True, domain="[('type', '=', 'purchase')]")
-    expense_outstanding_account_id = fields.Many2one('account.account', related='company_id.expense_outstanding_account_id', readonly=False, check_company=True)
+    expense_outstanding_account_id = fields.Many2one(
+        comodel_name='account.account',
+        related='company_id.expense_outstanding_account_id',
+        domain="[('account_type', '=', 'asset_current'), ('reconcile', '=', True)]",
+        readonly=False,
+        check_company=True,
+    )
     company_expense_allowed_payment_method_line_ids = fields.Many2many(
         comodel_name='account.payment.method.line',
         check_company=True,

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -982,6 +982,7 @@ class TestExpenses(TestExpenseCommon):
         expense_sheet.action_sheet_move_post()
         self.assertRecordValues(expense_sheet.account_move_ids.origin_payment_id, [{'payment_method_line_id': new_payment_method_line.id}])
 
+    @freeze_time('2024-01-01')
     def test_expense_vendor(self):
         """ This test will do a basic flow when a vendor is set on the expense """
         vendor_a = self.env['res.partner'].create({'name': 'Ruben'})
@@ -995,15 +996,17 @@ class TestExpenses(TestExpenseCommon):
                     'employee_id': self.expense_employee.id,
                     'product_id': self.product_c.id,
                     'payment_mode': 'company_account',
+                    'date': '2024-01-02',
                     'total_amount': 100,
                     'tax_ids': [self.tax_purchase_a.id, self.tax_purchase_b.id],
                     'vendor_id': vendor_a.id,
                 }),
                 Command.create({
-                    'name': 'Expense test',
+                    'name': 'Expense test 2',
                     'employee_id': self.expense_employee.id,
                     'product_id': self.product_c.id,
                     'payment_mode': 'company_account',
+                    'date': '2024-01-01',
                     'total_amount': 100,
                     'tax_ids': [self.tax_purchase_a.id, self.tax_purchase_b.id],
                     'vendor_id': vendor_b.id,

--- a/addons/hr_expense/views/res_config_settings_views.xml
+++ b/addons/hr_expense/views/res_config_settings_views.xml
@@ -43,8 +43,8 @@
                                      string="Employee Expense Journal">
                                 <field name="expense_journal_id"/>
                             </setting>
-                            <setting company_dependent="1" help="Default outstanding account for expenses paid by employees."
-                                     string="Employee Expense Oustanding Account">
+                            <setting company_dependent="1" help="Default outstanding account for expenses paid by company."
+                                     string="Expense Outstanding Account">
                                 <field name="expense_outstanding_account_id"/>
                             </setting>
                             <setting company_dependent="1" string="Payment methods"


### PR DESCRIPTION
## [FIX] hr_expense: Fix payment journal entry optional
This fixes issues that arose since https://github.com/odoo/odoo/commit/2609fc2e38b8a82c773f27f910f2030b5d704633

In https://github.com/odoo/odoo/commit/2609fc2e38b8a82c773f27f910f2030b5d704633, the tests were edited but failed to reflect the changes that
the user would be able to do from the interface.

This also improves the error & field name for
the new outstanding expense account,
which was mistakenly mentioning employee expense instead of company ones

## [FIX] hr_expense: Fix tests account.move order determinism

Fix a test where the sorting would be done
depending on the account.moves creation order, because the moves would
share all but the last element of their _order
'date desc, name desc, invoice_date desc, id desc'
which would break for no valid reason if this order is changed.

By changing the date, this make sure the test can always reliably
access the moves in the same order.

task-id: 4214018