### PR TITLE
[FIX] account: match accounts and groups in branch companies

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -798,7 +798,7 @@ class AccountGroup(models.Model):
     name = fields.Char(required=True, translate=True)
     code_prefix_start = fields.Char(compute='_compute_code_prefix_start', readonly=False, store=True, precompute=True)
     code_prefix_end = fields.Char(compute='_compute_code_prefix_end', readonly=False, store=True, precompute=True)
-    company_id = fields.Many2one('res.company', required=True, readonly=True, default=lambda self: self.env.company)
+    company_id = fields.Many2one('res.company', required=True, readonly=True, default=lambda self: self.env.company.root_id)
 
     _sql_constraints = [
         (
@@ -908,40 +908,41 @@ class AccountGroup(models.Model):
         self.env['account.account'].flush_model(['code'])
 
         if company:
-            company_ids = company.root_id.ids
+            root_companies = company.root_id
         elif account_ids:
-            company_ids = account_ids.company_id.root_id.ids
-            account_ids = account_ids.ids
+            root_companies = account_ids.company_id.root_id
         else:
-            company_ids = []
-            for company in self.company_id:
-                company_ids.extend(company._accessible_branches().ids)
-            account_ids = []
-        if not company_ids and not account_ids:
-            return
-        account_where_clause = SQL('account.company_id IN %s', tuple(company_ids))
-        if account_ids:
-            account_where_clause = SQL('%s AND account.id IN %s', account_where_clause, tuple(account_ids))
+            root_companies = self.company_id
 
-        self._cr.execute(SQL("""
+        account_domain = [('company_id', 'child_of', root_companies.ids)]
+        if account_ids:
+            account_domain.append(('id', 'in', account_ids.ids))
+
+        account_query = self.env['account.account']._where_calc(account_domain)
+
+        self._cr.execute(SQL(
+            """
             WITH relation AS (
-                 SELECT DISTINCT ON (account.id)
-                        account.id AS account_id,
+                 SELECT DISTINCT ON (account_account.id)
+                        account_account.id AS account_id,
                         agroup.id AS group_id
-                   FROM account_account account
-                   JOIN res_company account_company ON account_company.id = account.company_id
+                   FROM %(from_clause)s
+                   JOIN res_company account_company ON account_company.id = account_account.company_id
               LEFT JOIN account_group agroup
-                     ON agroup.code_prefix_start <= LEFT(account.code, char_length(agroup.code_prefix_start))
-                    AND agroup.code_prefix_end >= LEFT(account.code, char_length(agroup.code_prefix_end))
+                     ON agroup.code_prefix_start <= LEFT(account_account.code, char_length(agroup.code_prefix_start))
+                    AND agroup.code_prefix_end >= LEFT(account_account.code, char_length(agroup.code_prefix_end))
                     AND agroup.company_id = split_part(account_company.parent_path, '/', 1)::int
-                  WHERE %s
-               ORDER BY account.id, char_length(agroup.code_prefix_start) DESC, agroup.id
+                  WHERE %(where_clause)s
+               ORDER BY account_account.id, char_length(agroup.code_prefix_start) DESC, agroup.id
             )
             UPDATE account_account
                SET group_id = rel.group_id
               FROM relation rel
              WHERE account_account.id = rel.account_id
-        """, account_where_clause))
+            """,
+            from_clause=account_query.from_clause,
+            where_clause=account_query.where_clause,
+        ))
         self.env['account.account'].invalidate_model(['group_id'], flush=False)
 
     def _adapt_parent_account_group(self, company=None):

--- a/addons/account/tests/test_account_account.py
+++ b/addons/account/tests/test_account_account.py
@@ -485,3 +485,51 @@ class TestAccountAccount(AccountTestInvoicingCommon):
         self.assertEqual(group_10.parent_id, group_1)
         self.assertEqual(group_100.parent_id, group_10)
         self.assertEqual(group_101.parent_id, group_10)
+
+    def test_muticompany_account_groups(self):
+        """
+            Ensure that account groups are always in a root company
+            Ensure that accounts and account groups from a same company tree match
+        """
+
+        branch_company = self.env['res.company'].create({
+            'name': 'Branch Company',
+            'parent_id': self.env.company.id,
+        })
+
+        parent_group = self.env['account.group'].create({
+            'name': 'Parent Group',
+            'code_prefix_start': '123',
+            'code_prefix_end': '124'
+        })
+        child_group = self.env['account.group'].with_company(branch_company).create({
+            'name': 'Child Group',
+            'code_prefix_start': '125',
+            'code_prefix_end': '126',
+        })
+        self.assertEqual(
+            child_group.company_id,
+            child_group.company_id.root_id,
+            "company_id should never be a branch company"
+        )
+
+        branch_account = self.env['account.account'].with_company(branch_company).create({
+            'name': 'Branch Account',
+            'code': '1234',
+        })
+        self.assertEqual(
+            branch_account.group_id,
+            parent_group,
+            "group_id computation should work for accounts that are not in the root company"
+        )
+
+        parent_account = self.env['account.account'].create({
+            'name': 'Parent Account',
+            'code': '1235'
+        })
+        parent_account.with_company(branch_company).code = '1256'
+        self.assertEqual(
+            parent_account.with_company(branch_company).group_id,
+            child_group,
+            "group_id computation should work if company_id is not in self.env.companies"
+        )


### PR DESCRIPTION
### Steps to reproduce the issue:

1. Make sure you are in a company that is not a branch
2. Create a branch company
3. In the parent company, create an account group
4. In the branch company, create an account that should be set in the account group
5. The branch account is not set in the account group

### Explanation:

When creating an account, we will enter `_adapt_accounts_for_account_groups` with a value for `account_ids`. As can be seen, `company_ids` is then assigned `account_ids.company_id.root_id.ids` which only corresponds to the id of the root company, not its branches.

### Fix reasoning:

As asked by TSB, `account.group.company_id` can not have a `parent_id`, redirecting default value to `root_id`.
`_accessible_branches` is only looking for active companies, the objective is to retrieve all children of `root_companies` (recursively).

opw-4192988