### PR TITLE
[FIX] base: attachment write should raise errors

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -119,7 +119,7 @@ class IrAttachment(models.Model):
         try:
             with open(full_path, 'rb') as f:
                 return f.read()
-        except (IOError, OSError):
+        except OSError:
             _logger.info("_read_file reading %s", full_path, exc_info=True)
         return b''
 
@@ -133,8 +133,9 @@ class IrAttachment(models.Model):
                     fp.write(bin_value)
                 # add fname to checklist, in case the transaction aborts
                 self._mark_for_gc(fname)
-            except IOError:
-                _logger.info("_file_write writing %s", full_path, exc_info=True)
+            except OSError:
+                _logger.info("_file_write writing %s", full_path)
+                raise
         return fname
 
     @api.model


### PR DESCRIPTION
When writing files, errors should not be masked. We may commit a transaction as if everything went well, even when we get write errors. This may lead to data loss.

An example is calling `_migrate` on a non-writable partition or a full partition. We want it to fail instaed of ignoring the writes and committing.

closes #181998

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
