### PR TITLE
[FIX] website_(forum, profile): use `t-att-content` for textarea

### DIFF
--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -142,27 +142,11 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
             });
         }
 
-        $('textarea.o_wysiwyg_loader').toArray().forEach(async (textarea) => {
+        $('textarea.o_wysiwyg_loader').toArray().forEach((textarea) => {
             var $textarea = $(textarea);
             var editorKarma = $textarea.data('karma') || 0; // default value for backward compatibility
             var $form = $textarea.closest('form');
             var hasFullEdit = parseInt($("#karma").val()) >= editorKarma;
-            let recordContent = '';
-            let resId = 0;
-            if (window.location.pathname.includes('edit')) {
-                // Id is retrieved from URL, which is either:
-                // - /forum/name-1/post/something-5
-                // - /forum/name-1/post/something-5/edit
-                // TODO: Make this more robust.
-                resId = +window.location.pathname.split('-').slice(-1)[0].split('/')[0];
-                const data = await this.orm.call("forum.post", "search_read", [], {
-                    domain: [['id', '=', resId]],
-                    fields: ['content'],
-                });
-                if (data && data.length) {
-                    recordContent = data[0]['content'];
-                }
-            }
             var options = {
                 toolbarTemplate: 'website_forum.web_editor_toolbar',
                 toolbarOptions: {
@@ -178,9 +162,13 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
                 recordInfo: {
                     context: self._getContext(),
                     res_model: 'forum.post',
-                    res_id: resId,
+                    // Id is retrieved from URL, which is either:
+                    // - /forum/name-1/post/something-5
+                    // - /forum/name-1/post/something-5/edit
+                    // TODO: Make this more robust.
+                    res_id: +window.location.pathname.split('-').slice(-1)[0].split('/')[0],
                 },
-                value: recordContent,
+                value: $textarea.get(0).getAttribute("content"),
                 resizable: true,
                 userGeneratedContent: true,
                 height: 350,

--- a/addons/website_forum/views/forum_forum_templates.xml
+++ b/addons/website_forum/views/forum_forum_templates.xml
@@ -90,7 +90,8 @@
             <div class="row mb-3">
                 <label class="form-label col-lg-2" for="content">Description</label>
                 <div class="col">
-                    <textarea name="content" required="required" id="content" class="form-control o_wysiwyg_loader" t-att-data-karma="forum.karma_editor">
+                    <textarea name="content" required="required" id="content" class="form-control o_wysiwyg_loader" t-att-data-karma="forum.karma_editor"
+                    t-att-content="question_content">
                         <t t-out="question_content"/>
                     </textarea>
                     <div class="d-flex">
@@ -181,7 +182,7 @@
                 <label t-if="not is_answer" class="form-label col-lg-2" for="content">Description</label>
                 <label t-else="" class="form-label col-lg-2">Your Answer</label>
                 <div class="col">
-                    <textarea name="content" id="content" required="required" class="form-control o_wysiwyg_loader" t-att-data-karma="forum.karma_editor" t-out="post.content"/>
+                    <textarea name="content" id="content" required="required" class="form-control o_wysiwyg_loader" t-att-data-karma="forum.karma_editor" t-out="post.content" t-att-content="post.content"/>
                     <div t-if="not is_answer" class="d-flex mb-2">
                         <span class="form-text small text-muted me-1"><i class="fa fa-lightbulb-o"></i> Tip:</span>
                         <div class="carousel slide" data-bs-ride="carousel">

--- a/addons/website_profile/models/res_users.py
+++ b/addons/website_profile/models/res_users.py
@@ -64,6 +64,3 @@ class Users(models.Model):
         if token == validation_token and self.karma == 0:
             return self.write({'karma': VALIDATION_KARMA_GAIN})
         return False
-
-    def get_website_description(self):
-        return self.partner_id.website_description

--- a/addons/website_profile/static/src/js/website_profile.js
+++ b/addons/website_profile/static/src/js/website_profile.js
@@ -49,11 +49,6 @@ publicWidget.registry.websiteProfileEditor = publicWidget.Widget.extend({
         'click .o_forum_profile_bio_cancel_edit': '_onProfileBioCancelEditClick',
     },
 
-    init() {
-        this._super(...arguments);
-        this.orm = this.bindService("orm");
-    },
-
     /**
      * @override
      */
@@ -64,17 +59,14 @@ publicWidget.registry.websiteProfileEditor = publicWidget.Widget.extend({
         }
 
         const textareaEl = this.el.querySelector("textarea.o_wysiwyg_loader");
-        const resId = parseInt(this.el.querySelector("input[name=user_id]").value);
-        const recordContent =
-            (await this.orm.call("res.users", "get_website_description", [resId])) || "";
 
         const options = {
             recordInfo: {
                 context: this._getContext(),
                 res_model: "res.users",
-                res_id: resId,
+                res_id: parseInt(this.el.querySelector("input[name=user_id]").value),
             },
-            value: recordContent,
+            value: textareaEl.getAttribute("content"),
             resizable: true,
             userGeneratedContent: true,
         };

--- a/addons/website_profile/views/website_profile.xml
+++ b/addons/website_profile/views/website_profile.xml
@@ -156,7 +156,7 @@
                                 <div class="mb-3 col-12">
                                     <label class="mb-1 text-primary" for="description"><span class="fw-bold">Biography</span></label>
                                     <textarea name="description" id="description" style="min-height: 120px"
-                                        class="form-control o_wysiwyg_loader" placeholder="Write a few words about yourself..."><t t-out="user.partner_id.website_description"/></textarea>
+                                        class="form-control o_wysiwyg_loader" placeholder="Write a few words about yourself..." t-att-content="user.partner_id.website_description"><t t-out="user.partner_id.website_description"/></textarea>
                                 </div>
                                 <div class="col">
                                     <button type="submit" class="btn btn-primary o_wprofile_submit_btn">Update</button>
@@ -318,7 +318,8 @@
             <div class="row">
                 <div class="mb-1 col-12">
                     <textarea name="description" id="description" style="min-height: 120px"
-                        class="form-control o_wysiwyg_loader" placeholder="Write a few words about yourself...">
+                        class="form-control o_wysiwyg_loader" placeholder="Write a few words about yourself..."
+                        t-att-content="user.partner_id.website_description">
                         <t t-out="user.partner_id.website_description"/>
                     </textarea>
                 </div>


### PR DESCRIPTION
This is a partial revert of [1] and proposition of another solution.

Instead of doing an extra orm call we just add the content as attribute to the textarea and retrieve it directly from there.

opw-4148163

[1]: https://github.com/odoo/odoo/commit/82fbc0c30848763d6a55d4e5e78b0b34ff6c8245