### PR TITLE
[FIX] web: company switcher search input only works when hovered

### DIFF
--- a/addons/web/static/src/core/navigation/navigation.js
+++ b/addons/web/static/src/core/navigation/navigation.js
@@ -25,7 +25,7 @@ class NavigationItem {
             this.target = el;
         }
 
-        const focus = (ev) => this.focus(ev);
+        const focus = () => this.focus(true);
         const onMouseEnter = (ev) => this.onMouseEnter(ev);
 
         this.target.addEventListener("focus", focus);
@@ -41,12 +41,12 @@ class NavigationItem {
         this.target.click();
     }
 
-    focus(event = undefined) {
+    focus(skipRealFocus = false) {
         scrollTo(this.target);
         this.setActiveItem(this.index, this);
         this.target.classList.add(ACTIVE_ELEMENT_CLASS);
 
-        if (!event && !this.options.virtualFocus) {
+        if (!skipRealFocus && !this.options.virtualFocus) {
             focusElement(this.target);
         }
     }
@@ -56,7 +56,7 @@ class NavigationItem {
     }
 
     onMouseEnter() {
-        this.focus();
+        this.focus(true);
         this.options.onMouseEnter?.(this);
     }
 }

--- a/addons/web/static/tests/legacy/core/navigation_hook_tests.js
+++ b/addons/web/static/tests/legacy/core/navigation_hook_tests.js
@@ -176,4 +176,31 @@ QUnit.module("Hooks", ({ beforeEach }) => {
         await triggerHotkey("enter");
         assert.verifySteps(["2"]);
     });
+
+    QUnit.test("hovering an item makes it active but doesn't focus", async (assert) => {
+        const env = await makeTestEnv();
+        await mount(createNavComponent(), target, { env });
+
+        await triggerHotkey("arrowdown");
+
+        assert.strictEqual(document.activeElement, target.querySelector(".two"));
+        assert.hasClass(target.querySelector(".two"), "focus");
+
+
+        const event = new MouseEvent('mouseenter', {
+            'view': window,
+            'bubbles': true,
+            'cancelable': true
+        });
+        document.querySelector(".three").dispatchEvent(event);
+
+        assert.strictEqual(document.activeElement, target.querySelector(".two"));
+        assert.hasClass(target.querySelector(".three"), "focus");
+        assert.notStrictEqual(document.activeElement, target.querySelector(".three"));
+        assert.hasClass(target.querySelector(".three"), "focus");
+
+        await triggerHotkey("arrowdown");
+        assert.strictEqual(document.activeElement, target.querySelector(".four"));
+        assert.hasClass(target.querySelector(".four"), "focus");
+    });
 });


### PR DESCRIPTION
This commit fixes a bug where the search input would only work when it was hovered. This was caused by the navigation hook used by the dropdown which would focus the items on hover, loosing the focus of the search input in the process.

Task: 4207756

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
