### PR TITLE
[FIX] account: Fix payment action_post action

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -1025,8 +1025,9 @@ class AccountPayment(models.Model):
                     method_name=self.payment_method_line_id.name,
                     partner=payment.partner_id.display_name,
                 ))
-
-        self.state = 'in_process'
+        # Avoid going back one state when clicking on the confirm action in the payment list view and having paid expenses selected
+        # We need to set values to each payment to avoid recomputation later
+        self.filtered(lambda pay: pay.state in {False, 'draft', 'in_process'}).state = 'in_process'
 
     def action_validate(self):
         self.state = 'paid'

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -1100,7 +1100,7 @@ class AccountPaymentRegister(models.TransientModel):
             # order to fully paid the source journal items.
             # For example, suppose a new currency B having a rate 100:1 regarding the company currency A.
             # If you try to pay 12.15A using 0.12B, the computed balance will be 12.00A for the payment instead of 12.15A.
-            if edit_mode:
+            if edit_mode and payment.move_id:
                 lines = vals['to_reconcile']
 
                 # Batches are made using the same currency so making 'lines.currency_id' is ok.


### PR DESCRIPTION
This fixes issues that arose since 2609fc2

The confirm button (action_post) on the list view of payments allows to move the payment state one step back
from `paid` to `in_process`

We now only consider payment in draft when doing so, to keep all other payments mistakenly selected intact

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
