### PR TITLE
[FIX] point_of_sale: fix order change on note change

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -260,9 +260,12 @@ export class PosOrder extends Base {
 
         // Checks whether an orderline has been deleted from the order since it
         // was last sent to the preparation tools. If so we delete it to the changes.
-        for (const [key, change] of Object.entries(this.last_order_preparation_change.lines)) {
-            if (!this.models["pos.order.line"].getBy("uuid", change.uuid)) {
-                delete this.last_order_preparation_change.lines[key];
+        for (const [oldKey, change] of Object.entries(this.last_order_preparation_change.lines)) {
+            const orderline = this.models["pos.order.line"].getBy("uuid", change.uuid)
+            const key = orderline?.preparationKey
+
+            if (!orderline || oldKey != key) {
+                delete this.last_order_preparation_change.lines[oldKey];
             }
         }
         this.last_order_preparation_change.generalNote = this.general_note;

--- a/addons/point_of_sale/static/src/app/models/utils/order_change.js
+++ b/addons/point_of_sale/static/src/app/models/utils/order_change.js
@@ -84,10 +84,13 @@ export const getOrderChanges = (order, skipped = false, orderPreparationCategori
     }
     // Checks whether an orderline has been deleted from the order since it
     // was last sent to the preparation tools. If so we add this to the changes.
-    for (const [lineKey, lineResume] of Object.entries(order.last_order_preparation_change.lines)) {
-        if (!order.models["pos.order.line"].getBy("uuid", lineResume["uuid"])) {
-            if (!changes[lineKey]) {
-                changes[lineKey] = {
+    for (const [oldLineKey, lineResume] of Object.entries(order.last_order_preparation_change.lines)) {
+        const orderline = order.models["pos.order.line"].getBy("uuid", lineResume["uuid"])
+        const lineKey = orderline?.preparationKey;
+
+        if (!orderline || oldLineKey != lineKey) {
+            if (!changes[oldLineKey]) {
+                changes[oldLineKey] = {
                     uuid: lineResume["uuid"],
                     product_id: lineResume["product_id"],
                     name: lineResume["name"],
@@ -98,7 +101,7 @@ export const getOrderChanges = (order, skipped = false, orderPreparationCategori
                 changeAbsCount += Math.abs(lineResume["quantity"]);
                 changesCount += lineResume["quantity"];
             } else {
-                changes[lineKey]["quantity"] -= lineResume["quantity"];
+                changes[oldLineKey]["quantity"] -= lineResume["quantity"];
             }
         }
     }


### PR DESCRIPTION
The return value of [`changesToOrder`](https://github.com/abichinger/odoo/blob/74273fea6a9c7f57da95aa120fd2767443822c46/addons/point_of_sale/static/src/app/models/utils/order_change.js#L1) is missing a line inside the `cancelled` array, while updating the note of an existing order line. From the POV of a preperation tool, this makes it look like a new item has been added to the order.

https://github.com/user-attachments/assets/618263ac-0a61-42f2-b662-10e1ae63e39f

While recording the video I captured the following values from `changesToOrder`

```jsonc
// 1st output after the orderline was created
{
    "new": [
        {
            "uuid": "db47ade6-c8e1-47e1-8dcc-8c43ef67de8a",
            "name": "Coca-Cola",
            "product_id": 100,
            "attribute_value_ids": [],
            "quantity": 1,
            "note": "",
            "pos_categ_id": 10,
            "pos_categ_sequence": 0
        }
    ],
    "cancelled": []
}

// 2nd output after the note was added
{
    "new": [
        {
            "uuid": "db47ade6-c8e1-47e1-8dcc-8c43ef67de8a",
            "name": "Coca-Cola",
            "product_id": 100,
            "attribute_value_ids": [],
            "quantity": 1,
            "note": "Zero",
            "pos_categ_id": 10,
            "pos_categ_sequence": 0
        }
    ],
    "cancelled": []
}
```

I would expect the second output to look like this

```jsonc
{
    "new": [
        {
            "uuid": "db47ade6-c8e1-47e1-8dcc-8c43ef67de8a",
            "name": "Coca-Cola",
            "product_id": 100,
            "attribute_value_ids": [],
            "quantity": 1,
            "note": "Zero",
            "pos_categ_id": 10,
            "pos_categ_sequence": 0
        }
    ],
    "cancelled": [
        {
            "uuid": "db47ade6-c8e1-47e1-8dcc-8c43ef67de8a",
            "name": "Coca-Cola",
            "product_id": 100,
            "attribute_value_ids": [],
            "quantity": 1,
            "note": "",
            "pos_categ_id": 10,
            "pos_categ_sequence": 0
        }
    ]
}
```




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
