### PR TITLE
[FIX] pos_loyalty: promocode not working with pricelists

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -221,7 +221,8 @@ patch(PosStore.prototype, {
             const program_pricelists = rule.program_id.pricelist_ids;
             if (
                 program_pricelists.length > 0 &&
-                (!order.pricelist_id || !program_pricelists.includes(order.pricelist_id.id))
+                (!order.pricelist_id ||
+                    !program_pricelists.some((pr) => pr.id === order.pricelist_id.id))
             ) {
                 return _t("That promo code program requires a specific pricelist.");
             }

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
@@ -536,3 +536,13 @@ registry.category("web_tour.tours").add("PosRewardProductScanGS1", {
             PosLoyalty.finalizeOrder("Cash", "575.00"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("PosLoyaltyPromocodePricelist", {
+    test: true,
+    steps: () =>
+        [
+            ProductScreen.addOrderline("Test Product 1", "1"),
+            PosLoyalty.enterCode("hellopromo"),
+            PosLoyalty.orderTotalIs("25.87"),
+        ].flat(),
+});

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -2281,3 +2281,57 @@ class TestUi(TestPointOfSaleHttpCommon):
         coupon = loyalty_program.coupon_ids
         self.assertEqual(len(coupon), 1, "Coupon not generated")
         self.assertEqual(coupon.expiration_date, date.today() + timedelta(days=2), "Coupon not generated with correct expiration date")
+
+    def test_coupon_pricelist(self):
+        self.env["product.product"].create(
+            {
+                "name": "Test Product 1",
+                "is_storable": True,
+                "list_price": 25,
+                "available_in_pos": True,
+            }
+        )
+
+        alt_pos_config = self.main_pos_config.copy()
+        pricelist_1 = self.env['product.pricelist'].create(
+            {
+                "name": "test pricelist 1",
+                "currency_id": self.env.ref("base.USD").id,
+            }
+        )
+        alt_pos_config.write({
+            'use_pricelist': True,
+            'available_pricelist_ids': [(4, pricelist_1.id)],
+            'pricelist_id': pricelist_1.id,
+        })
+
+        self.env["loyalty.program"].create(
+            {
+                "name": "Test Loyalty Program",
+                "program_type": "promotion",
+                "trigger": "with_code",
+                'pos_ok': True,
+                "pricelist_ids": [(4, pricelist_1.id)],
+                "rule_ids": [
+                    Command.create({"mode": "with_code", "code": "hellopromo", "minimum_amount": 10}),
+                ],
+                "reward_ids": [
+                    Command.create({
+                        "reward_type": "discount",
+                        "discount": 10,
+                        "discount_mode": "percent",
+                        "discount_applicability": "order",
+                        "required_points": 1,
+                    }),
+                ],
+                'pos_config_ids': [Command.link(alt_pos_config.id)],
+
+            }
+        )
+
+        alt_pos_config.with_user(self.pos_admin).open_ui()
+        self.start_tour(
+            "/pos/web?config_id=%d" % alt_pos_config.id,
+            "PosLoyaltyPromocodePricelist",
+            login="pos_user",
+        )


### PR DESCRIPTION
## Issue:
When we create a loyalty program with promo code on a specific pricelist and try using the code in pos it gives the error "That promo code program requires a specific pricelist." even if we select that pricelist on pos, and put it on default.

## Steps to reproduce:
- Go to pos settings and enable flexible pricelists
- under the Available Field pick some pricelist and also set it as default
- create a loyalty program with a promo code and set the pricelist you picked before as it's pricelist
- open a pos session, add some products and try applying the promo code
- a popup will show saying "That promo code program requires a specific pricelist."

## Solution:
- While debugging the `activateCode` method, I found that the issue occurred because the code was using `.includes()` to check if `order.pricelist_id.id` was in `program_pricelists`, a list of objects. Since `.includes()` compares values directly, it couldn’t match an ID with objects, leading to it always returning False.
- The fix uses the `.some()` method, which checks whether any object in the `program_pricelists` array has an id matching `order.pricelist_id.id`. This ensures that the comparison is made correctly on the id property of the objects. If a match is found, it returns true, and the validation proceeds as expected.

OPW-4149335


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
