### PR TITLE
[IMP] html_editor, web_editor: select single cell using on double click

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -2663,10 +2663,11 @@ export class OdooEditor extends EventTarget {
         // Get the top table ancestors at range bounds.
         const startTable = ancestors(range.startContainer, this.editable).filter(node => node.nodeName === 'TABLE').pop();
         const endTable = ancestors(range.endContainer, this.editable).filter(node => node.nodeName === 'TABLE').pop();
-        if (startTd !== endTd && startTable === endTable) {
+        if ((startTd !== endTd || this.keepCellSelected) && startTable === endTable) {
             if (!isProtected(startTable)) {
                 // The selection goes through at least two different cells ->
-                // select cells.
+                // select cells. Select single cell if cell is selected through
+                // double click.
                 this._selectTableCells(range);
                 appliedCustomSelection = true;
             }
@@ -4796,6 +4797,17 @@ export class OdooEditor extends EventTarget {
             this._activateContenteditable();
         }
 
+        const selection = this.document.getSelection();
+        const td = closestElement(selection.anchorNode, 'td');
+        if (td &&
+            !isProtected(td) &&
+            ((isEmptyBlock(td) && ev.detail === 2) || ev.detail === 3)
+        ) {
+            this._selectTableCells(selection.getRangeAt(0));
+            this.keepCellSelected = true;
+            return;
+        }
+        delete this.keepCellSelected;
         // Ignore any changes that might have happened before this point.
         this.observer.takeRecords();
 


### PR DESCRIPTION
**Current behaviour before PR:**
    
In table, user can't select single cell using a double click.
    
**Desired behaviour after PR:**
    
Now user can select single empty cell using a double click.
    
task-4190232


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
