### PR TITLE
[FIX] project , hr_timesheet:  Correct alignment of footer elements

### DIFF
--- a/addons/hr_timesheet/static/src/scss/timesheets_task_form.scss
+++ b/addons/hr_timesheet/static/src/scss/timesheets_task_form.scss
@@ -1,7 +1,3 @@
-.o_project_kanban .o_kanban_renderer .oe_kanban_align.badge {
-    color: inherit;
-}
-
 .o_web_studio_form_view_editor .o_field_widget.o_web_studio_widget_empty.o_task_planned_hours {
     max-width: 70ch;
 }

--- a/addons/hr_timesheet/views/project_project_views.xml
+++ b/addons/hr_timesheet/views/project_project_views.xml
@@ -87,7 +87,7 @@
                     <t t-set="title" t-value="'Days Remaining'" t-if="record.encode_uom_in_days.raw_value"/>
                     <t t-set="title" t-value="'Time Remaining'" t-else=""/>
                     <div t-if="record.allow_timesheets.raw_value and record.allocated_hours.raw_value &gt; 0"
-                        t-attf-class="me-1 ms-1 oe_kanban_align badge border {{ badgeColor }}" t-att-title="title" groups="hr_timesheet.group_hr_timesheet_user">
+                        t-attf-class="me-1 ms-1 bg-transparent badge border {{ badgeColor }}" t-att-title="title" groups="hr_timesheet.group_hr_timesheet_user">
                         <field name="remaining_hours" widget="timesheet_uom" class="p-0"/>
                     </div>
                 </xpath>

--- a/addons/hr_timesheet/views/project_task_sharing_views.xml
+++ b/addons/hr_timesheet/views/project_task_sharing_views.xml
@@ -121,7 +121,7 @@
                     <t t-set="badge" t-value="'border border-danger'" t-if="record.remaining_hours.raw_value &lt; 0"/>
                     <t t-set="title" t-value="'Remaining days'" t-if="record.encode_uom_in_days.raw_value"/>
                     <t t-set="title" t-value="'Time Remaining'" t-else=""/>
-                    <div t-attf-class="oe_kanban_align badge {{ badge }}" t-att-title="title">
+                    <div t-attf-class="badge {{ badge }} bg-transparent flex-shrink-0" t-att-title="title">
                         <field name="remaining_hours" widget="timesheet_uom" />
                     </div>
                 </t>

--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -162,12 +162,12 @@
                 </templates>
                 <xpath expr="//footer/div" position="inside">
                    <t name="allocated_hours" t-if="record.allocated_hours.raw_value &gt; 0 and record.allow_timesheets.raw_value" groups="hr_timesheet.group_hr_timesheet_user">
-                        <t t-set="badge" t-value=""/>
+                        <t t-set="badge" t-value="'border border-success'"/>
                         <t t-set="badge" t-value="'border border-warning'" t-if="record.progress.raw_value &gt;= 0.8 and record.progress.raw_value &lt;= 1"/>
                         <t t-set="badge" t-value="'border border-danger'" t-if="record.remaining_hours.raw_value &lt; 0"/>
                         <t t-set="title" t-value="'Remaining days'" t-if="record.encode_uom_in_days.raw_value"/>
                         <t t-set="title" t-value="'Time Remaining'" t-else=""/>
-                        <div t-attf-class="oe_kanban_align badge {{ badge }} me-0" t-att-title="title">
+                        <div t-attf-class="bg-transparent badge {{ badge }} me-0" t-att-title="title">
                             <field name="remaining_hours" widget="timesheet_uom" />
                         </div>
                    </t>

--- a/addons/project/static/src/css/project.css
+++ b/addons/project/static/src/css/project.css
@@ -1,9 +1,3 @@
-.o_kanban_project_tasks .oe_kanban_align.badge, .o_project_kanban .oe_kanban_align.badge {
-  background: inherit;
-  color: inherit;
-  border: 1px solid var(--success);
-}
-
 .o_kanban_project_tasks .o_field_one2many_sub_task {
   margin-top:2px;
   margin-right: 6px;

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -52,17 +52,17 @@
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" context="{'project_id': project_id}"/>
                     <field t-if="record.date_deadline.raw_value" name="date_deadline" invisible="state in ['1_done', '1_canceled']" widget="remaining_days"/>
                     <field t-if="record.displayed_image_id.value" groups="base.group_user" name="displayed_image_id" widget="attachment_image"/>
-                    <div class="d-flex mt-2" t-if="!selection_mode">
+                    <footer t-if="!selection_mode">
                         <field name="priority" class="me-2" widget="priority"/>
-                        <div class="d-flex ms-auto">
-                            <span t-if="record.portal_user_names.raw_value.length > 0" class="pe-2" t-att-title="record.portal_user_names.raw_value">
+                        <div class="d-flex ms-auto text-truncate">
+                            <span t-if="record.portal_user_names.raw_value.length > 0" class="pe-2 text-truncate" t-att-title="record.portal_user_names.raw_value">
                                 <t t-set="user_count" t-value="record.portal_user_names.raw_value.split(',').length"/>
                                 <t t-if="user_count > 1"><t t-out="user_count"/> assignees</t>
                                 <field t-else="" name="portal_user_names"/>
                             </span>
                             <field name="state" widget="project_task_state_selection" options="{'is_toggle_mode': false}"/>
                         </div>
-                    </div>
+                    </footer>
                 </t>
                 </templates>
             </kanban>


### PR DESCRIPTION
**Before this commit:**
- The assignee's name would overflow instead of truncating in the footer.
- The remaining hour's widget displayed an unusual grey background.
- classes with the prefix `oe_` were present for styling.

**After this commit:**
 - The assignee's name will now truncate after a specific width in the footer.
 - The remaining hour's widget has a transparent background.
 - removed class `oe_kanban_align` from the code base.

Task-4207390