### PR TITLE
[FIX] spreadsheet: see list record with vectorized index

### DIFF
--- a/addons/spreadsheet/static/src/list/list_actions.js
+++ b/addons/spreadsheet/static/src/list/list_actions.js
@@ -1,9 +1,11 @@
 /** @odoo-module */
 // @ts-check
 
-import { astToFormula } from "@odoo/o-spreadsheet";
+import { astToFormula, helpers } from "@odoo/o-spreadsheet";
 import { getFirstListFunction, getNumberOfListFormulas } from "./list_helpers";
 import { navigateTo } from "../actions/helpers";
+
+const { isMatrix } = helpers;
 
 /**
  * @param {import("@odoo/o-spreadsheet").CellPosition} position
@@ -11,7 +13,7 @@ import { navigateTo } from "../actions/helpers";
  * @returns {Promise<void>}
  */
 export const SEE_RECORD_LIST = async (position, env) => {
-    const cell = env.model.getters.getCell(position);
+    const cell = env.model.getters.getCorrespondingFormulaCell(position);
     const sheetId = position.sheetId;
     if (!cell || !cell.isFormula) {
         return;
@@ -23,7 +25,14 @@ export const SEE_RECORD_LIST = async (position, env) => {
     const listId = env.model.getters.getListIdFromPosition(position);
     const { model, actionXmlId, context } = env.model.getters.getListDefinition(listId);
     const dataSource = await env.model.getters.getAsyncListDataSource(listId);
-    const index = evaluatedArgs[1];
+    let index = evaluatedArgs[1];
+    if (isMatrix(index)) {
+        const mainPosition = env.model.getters.getCellPosition(cell.id);
+        const rowOffset = position.row - mainPosition.row;
+        const colOffset = position.col - mainPosition.col;
+        index = index[colOffset][rowOffset];
+    }
+
     if (typeof index !== "number") {
         return;
     }
@@ -52,8 +61,8 @@ export const SEE_RECORD_LIST = async (position, env) => {
  */
 export const SEE_RECORD_LIST_VISIBLE = (position, getters) => {
     const evaluatedCell = getters.getEvaluatedCell(position);
-    const cell = getters.getCell(position);
-    return (
+    const cell = getters.getCorrespondingFormulaCell(position);
+    return !!(
         evaluatedCell.type !== "empty" &&
         evaluatedCell.type !== "error" &&
         evaluatedCell.value !== "" &&


### PR DESCRIPTION


Steps to reproduce:

- insert a list in a spreadsheet
- in a cell, write =ODOO.LIST(1, sequence(4), "foo")
- right click any cell but the top-left cell

=> the "See record" menu item is missing

Task: 4220373


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
