### PR TITLE
[FIX] base/models.py: Fix unlinking records referenced by ir.default

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4548,7 +4548,7 @@ class BaseModel(metaclass=MetaModel):
                 field_ids = tuple(IrModelFields._get_ids(field.model_name).get(field.name) for field in many2one_fields)
                 sub_ids_json_text = tuple(json.dumps(id_) for id_ in sub_ids)
                 if default := Defaults.search([('field_id', 'in', field_ids), ('json_value', 'in', sub_ids_json_text)], limit=1, order='id desc'):
-                    ir_field = self.env['ir.model.fields'].browse(default.field_id).sudo()
+                    ir_field = default.field_id.sudo()
                     field = self.env[ir_field.model]._fields[ir_field.name]
                     record = self.browse(json.loads(default.json_value))
                     raise UserError(_('Unable to delete %(record)s because it is used as the default value of %(field)s', record=record, field=field))


### PR DESCRIPTION
To reproduce:
- Setup 2 companies. Company 1 should use the generic CoA.
- Go to Accounting -> Configuration -> Chart of Accounts
- Open the account 110400 Cost of Production in Company 1.
- In the 'Mapping' tab, add a code for the account in Company 2.
- Change the account's `company_ids` to remove Company 1 and put Company 2 instead.
- Open the Chart of Accounts list view with Company 2, and try to delete the account.
- A traceback appears: `psycopg2.ProgrammingError: can't adapt type 'ir.model.fields'`

Diagnosis:
- `ir.default.field_id` is already a recordset, so we shouldn't do `self.env['ir.default'].browse(default.field_id)` in `BaseModel.unlink()`.

taskid: none