### PR TITLE
[FIX] website: fix Facebook snippet

### DIFF
--- a/addons/website/static/src/snippets/s_facebook_page/000.js
+++ b/addons/website/static/src/snippets/s_facebook_page/000.js
@@ -37,9 +37,11 @@ const FacebookPageWidget = publicWidget.Widget.extend({
     destroy: function () {
         this._super.apply(this, arguments);
         if (this.iframeEl) {
+            this._deactivateEditorObserver();
             this.iframeEl.remove();
+            this._activateEditorObserver();
+            this.resizeObserver.disconnect();
         }
-        this.resizeObserver.disconnect();
     },
 
     //--------------------------------------------------------------------------
@@ -53,7 +55,7 @@ const FacebookPageWidget = publicWidget.Widget.extend({
      * @param {Object} params
     */
     _renderIframe(params) {
-        this.options.wysiwyg && this.options.wysiwyg.odooEditor.observerUnactive();
+        this._deactivateEditorObserver();
 
         params.width = utils.confine(Math.floor(this.$el.width()), 180, 500);
         if (this.previousWidth !== params.width) {
@@ -61,20 +63,32 @@ const FacebookPageWidget = publicWidget.Widget.extend({
             const src = $.param.querystring("https://www.facebook.com/plugins/page.php", params);
             this.iframeEl = Object.assign(document.createElement("iframe"), {
                 src: src,
-                width: params.width,
-                height: params.height,
-                css: {
-                    border: "none",
-                    overflow: "hidden",
-                },
                 scrolling: "no",
-                frameborder: "0",
-                allowTransparency: "true",
             });
+            // TODO: remove, the "scrolling", "frameborder" and
+            // "allowTransparency" attributes in master as they are deprecated.
+            // Also put the width and height as iframe attribute.
+            this.iframeEl.setAttribute("frameborder", "0");
+            this.iframeEl.setAttribute("allowTransparency", "true");
+            this.iframeEl.setAttribute("style", `width: ${params.width}px; height: ${params.height}px; border: none; overflow: hidden;`);
             this.el.replaceChildren(this.iframeEl);
         }
 
+        this._activateEditorObserver();
+    },
+
+    /**
+     * Activates the editor observer if it exists.
+     */
+    _activateEditorObserver() {
         this.options.wysiwyg && this.options.wysiwyg.odooEditor.observerActive();
+    },
+
+    /**
+     * Deactivates the editor observer if it exists.
+     */
+    _deactivateEditorObserver() {
+        this.options.wysiwyg && this.options.wysiwyg.odooEditor.observerUnactive();
     },
 });
 


### PR DESCRIPTION
[FIX] website: fix Facebook snippet
The goal of this commit is to solve three bugs introduced by [1].

The first one can be observed thanks to the `/website/demo/snippets`
page:
- Go on the `/website/demo/snippets` page.
- Try to enter in edit mode.

-> The system never enters in edit mode.

The problem is that the Facebook snippet on this page does not have the
`href` data attribute. Due to it, the public widget is started without
creating `this.resizeObserver`. When the user tries to enter in edit
mode, the `FacebookPageWidget` public widget is destroyed and the system
tries to disconnect `this.resizeObserver`. As it is not defined, the
system fails in the `destroy()` method.

Steps to reproduce the second bug:
- Add an "Image-Text" snippet on the website.
- Add a "Text-Image" snippet under the "Image-Text" one.
- Save and edit.
- Drop a "Facebook" snippet on the "Image-Text" snippet.
- Move the "Facebook" snippet on the "Text-Image" snippet.
- Click on the undo button.

-> Two iframes are on the Facebook snippet.

The problem is that since [1], the editor observer is not deactivated
when removing the iframe in the `destroy()` method of the
`FacebookPageWidget` widget.

Finally, this commit also adds back the `frameborder` and
`allowTransparency` attributes on the iframe (removed due to [1]) and
sets the width and height in the style attribute. Although the
`frameborder` and `allowTransparency` attributes are deprecated, this
commit adds them back in case a potential customization relies on it.

[1]: https://github.com/odoo/odoo/commit/707dd91d1e83342a328e50b5ad38e6ec1064ec25

task-4220972

