### PR TITLE
[FIX] account: allow manual label on payment term line

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -456,20 +456,15 @@ class AccountMoveLine(models.Model):
             else:
                 line.currency_id = line.currency_id or line.company_id.currency_id
 
-    @api.depends('product_id')
+    @api.depends('product_id', 'move_id.payment_reference')
     def _compute_name(self):
-        for line in self:
-            if line.display_type == 'payment_term':
-                line.name = line.move_id.payment_reference or ''
-                continue
-            if not line.product_id or line.display_type in ('line_section', 'line_note'):
-                continue
+        def get_name(line):
+            values = []
             if line.partner_id.lang:
                 product = line.product_id.with_context(lang=line.partner_id.lang)
             else:
                 product = line.product_id
 
-            values = []
             if product.partner_ref:
                 values.append(product.partner_ref)
             if line.journal_id.type == 'sale':
@@ -478,7 +473,18 @@ class AccountMoveLine(models.Model):
             elif line.journal_id.type == 'purchase':
                 if product.description_purchase:
                     values.append(product.description_purchase)
-            line.name = '\n'.join(values)
+            return '\n'.join(values)
+
+        for line in self:
+            if line.display_type == 'payment_term':
+                if not line.name or line._origin.name == line._origin.move_id.payment_reference:
+                    line.name = line.move_id.payment_reference or ''
+                continue
+            if not line.product_id or line.display_type in ('line_section', 'line_note'):
+                continue
+
+            if not line.name or line._origin.name == get_name(line._origin):
+                line.name = get_name(line)
 
     def _compute_account_id(self):
         term_lines = self.filtered(lambda line: line.display_type == 'payment_term')

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -2539,3 +2539,16 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         bill = self.init_invoice(move_type='in_invoice', products=[product])
         bill_uom = bill.invoice_line_ids[0].product_uom_id
         self.assertEqual(bill_uom, uom_kgm)
+
+    def test_manual_label_change_on_payment_term_line(self):
+        """
+        Ensure label of the payment term line can be changed manually
+        """
+        payment_term_line = self.invoice.line_ids.filtered(lambda l: l.display_type == 'payment_term')
+        index = self.invoice.line_ids.ids.index(payment_term_line.id)
+        with Form(self.invoice) as move_form:
+            with move_form.line_ids.edit(index) as line_form:
+                line_form.name = 'XYZ'
+        move_form.save()
+        self.invoice.action_post()
+        self.assertEqual(payment_term_line.name, 'XYZ', 'Manual name of payment term line should be kept')


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting
- Create an invoice with any product
- Go to "Journal Items" tab
- Input a label for the payment term line (it should be empty)
- Confirm the invoice

**Issue:**
The input label of the payment term line is replaced by the "Payment Reference" of the invoice.
For bills, it is replaced by an empty string as there is no default value for the payment reference.

**Solution:**
Only use the payment reference of the invoice as label for the payment term line if it has not been modified manually.
This can be done by checking that their values in _origin are similar.

opw-4173634



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
