### PR TITLE
[FIX] phone_validation: rwanda phone numbers

### DIFF
--- a/addons/phone_validation/lib/phonenumbers_patch/__init__.py
+++ b/addons/phone_validation/lib/phonenumbers_patch/__init__.py
@@ -67,6 +67,10 @@ else:
         # https://github.com/daviddrysdale/python-phonenumbers/blob/v8.13.40/python/phonenumbers/data/region_KE.py
         phonenumbers.phonemetadata.PhoneMetadata.register_region_loader('KE', _local_load_region)
 
+    if parse_version(phonenumbers.__version__) < parse_version('8.13.46'):
+        # https://github.com/daviddrysdale/python-phonenumbers/blob/v8.13.46/python/phonenumbers/data/region_RW.py
+        phonenumbers.phonemetadata.PhoneMetadata.register_region_loader('RW', _local_load_region)
+
     # MONKEY PATCHING phonemetadata to fix Brazilian phonenumbers following 2016 changes
     def _hook_load_region(code):
         if parse_version(phonenumbers.__version__) < parse_version('8.13.39'):

--- a/addons/phone_validation/lib/phonenumbers_patch/region_RW.py
+++ b/addons/phone_validation/lib/phonenumbers_patch/region_RW.py
@@ -1,0 +1,14 @@
+"""Auto-generated file, do not edit by hand. RW metadata"""
+from ..phonemetadata import NumberFormat, PhoneNumberDesc, PhoneMetadata
+
+PHONE_METADATA_RW = PhoneMetadata(id='RW', country_code=250, international_prefix='00',
+    general_desc=PhoneNumberDesc(national_number_pattern='(?:06|[27]\\d\\d|[89]00)\\d{6}', possible_length=(8, 9)),
+    fixed_line=PhoneNumberDesc(national_number_pattern='(?:06|2[23568]\\d)\\d{6}', example_number='250123456', possible_length=(8, 9)),
+    mobile=PhoneNumberDesc(national_number_pattern='7[237-9]\\d{7}', example_number='720123456', possible_length=(9,)),
+    toll_free=PhoneNumberDesc(national_number_pattern='800\\d{6}', example_number='800123456', possible_length=(9,)),
+    premium_rate=PhoneNumberDesc(national_number_pattern='900\\d{6}', example_number='900123456', possible_length=(9,)),
+    national_prefix='0',
+    national_prefix_for_parsing='0',
+    number_format=[NumberFormat(pattern='(\\d{2})(\\d{2})(\\d{2})(\\d{2})', format='\\1 \\2 \\3 \\4', leading_digits_pattern=['0']),
+        NumberFormat(pattern='(\\d{3})(\\d{3})(\\d{3})', format='\\1 \\2 \\3', leading_digits_pattern=['2']),
+        NumberFormat(pattern='(\\d{3})(\\d{3})(\\d{3})', format='\\1 \\2 \\3', leading_digits_pattern=['[7-9]'], national_prefix_formatting_rule='0\\1')])

--- a/addons/phone_validation/tests/test_phonenumbers_patch.py
+++ b/addons/phone_validation/tests/test_phonenumbers_patch.py
@@ -167,6 +167,14 @@ class TestPhonenumbersPatch(BaseCase):
         )
         self._assert_parsing_phonenumbers(parse_test_lines_PA)
 
+    def test_region_RW_monkey_patch(self):
+        """Makes sure that patch for Rwanda's phone numbers work"""
+        parse_test_lines_RW = (
+            self.PhoneInputOutputLine("0792 123 456", "RW"),
+            self.PhoneInputOutputLine("+250 792 321 654"),
+        )
+        self._assert_parsing_phonenumbers(parse_test_lines_RW)
+
     def test_region_SN_monkey_patch(self):
         """Makes sure that patch for Senegalese phone numbers work"""
         parse_test_lines_SN = (


### PR DESCRIPTION
Current behavior:
---
Rwandan numbers starting with 79 are not supported.

Steps to reproduce:
---
```py
parsed = phonenumbers.parse("0792 123 456", "RW")
is_valid = phonenumbers.is_valid_number(parsed)
is_valid == False
```

Cause of the issue:
---
Old versions of phonenumbers (external library) are not up to date with the latest rwandan phone system changes 
Source: phonenumbers library

Fix:
---
Monkey patched old versions of the library
Similar as: https://github.com/odoo/odoo/commit/b7878038e0aca885aa174ccd74be9ffd4b393a89

opw-4197787

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
