### PR TITLE
[FIX] event_crm: improve multi registrations grouping

### DIFF
--- a/addons/event_crm/models/event_registration.py
+++ b/addons/event_crm/models/event_registration.py
@@ -297,8 +297,10 @@ class EventRegistration(models.Model):
         lead creation and update existing groups with new registrations.
 
         Heuristic in event is the following. Registrations created in multi-mode
-        are grouped by event. Customer use case: website_event flow creates
-        several registrations in a create-multi.
+        are grouped by event and creation_date. Customer use case: website_event
+        flow creates several registrations in a create-multi. Cron use case:
+        when running a rule on existing registrations, grouping on event only
+        is not sufficient, create_date is a safe bet for registration groups.
 
         Update is not supported as there is no way to determine if a registration
         is part of an existing batch.
@@ -315,13 +317,15 @@ class EventRegistration(models.Model):
                            belonging to the same group;
           )
         """
-        event_to_reg_ids = defaultdict(lambda: self.env['event.registration'])
-        for registration in self:
-            event_to_reg_ids[registration.event_id] += registration
+        grouped_registrations = {
+            (create_date, event): sub_registrations
+            for event, registrations in self.grouped('event_id').items()
+            for create_date, sub_registrations in registrations.grouped('create_date').items()
+        }
 
         return dict(
-            (rule, [(False, event, (registrations & rule_to_new_regs[rule]).sorted('id'))
-                    for event, registrations in event_to_reg_ids.items()])
+            (rule, [(False, key, (registrations & rule_to_new_regs[rule]).sorted('id'))
+                    for key, registrations in grouped_registrations.items()])
             for rule in rules
         )
 

--- a/addons/event_crm/tests/test_event_crm_flow.py
+++ b/addons/event_crm/tests/test_event_crm_flow.py
@@ -7,7 +7,7 @@ from odoo.tests.common import users
 from odoo.tools import mute_logger
 
 
-@tagged('event_flow')
+@tagged('event_crm')
 class TestEventCrmFlow(TestEventCrmCommon):
 
     @classmethod

--- a/addons/website_event_crm/models/event_registration.py
+++ b/addons/website_event_crm/models/event_registration.py
@@ -29,8 +29,8 @@ class EventRegistration(models.Model):
     def _get_lead_values(self, rule):
         """Update lead values from Lead Generation rules to include the visitor and their language"""
         lead_values = super()._get_lead_values(rule)
-        lead_values.update({
-            'visitor_ids': self.visitor_id,
-            'lang_id': self.visitor_id.lang_id.id,
-        })
+        if self.visitor_id:
+            lead_values['visitor_ids'] = self.visitor_id
+        if self.visitor_id.lang_id:
+            lead_values['lang_id'] = self.visitor_id.lang_id[0].id
         return lead_values

--- a/addons/website_event_crm/tests/test_event_registration.py
+++ b/addons/website_event_crm/tests/test_event_registration.py
@@ -2,33 +2,119 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.event_crm.tests.common import TestEventCrmCommon
+from odoo.tests.common import tagged, users
 
 
+@tagged('event_crm', 'post_install', '-at_install')
 class EventRegistrationCase(TestEventCrmCommon):
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.event_0.write({
+            "question_ids": [
+                (0, 0, {
+                'title': 'Text Input Question',
+                'question_type': 'text_box',
+                }),
+            ],
+        })
+        # add sales rights to event manager, to enable lead check
+        cls.user_eventmanager.write({
+            'groups_id': [(4, cls.env.ref('sales_team.group_sale_salesman').id)],
+        })
+
+        cls.test_lang_website = cls.env['website'].sudo().create({
+            'name': 'test lang website',
+            'user_id': cls.env.ref('base.user_admin').id,
+            'language_ids': [cls.env.ref('base.lang_en').id, cls.env.ref('base.lang_fr').id]
+        })
+        cls.test_lang_visitor = cls.env['website.visitor'].sudo().create({
+            'name': 'test visitor language',
+            'lang_id': cls.env.ref('base.lang_en').id,
+            'access_token': 'f9d2ffa0427d4e4b1d740cf5eb3cdc20',
+            'website_id': cls.test_lang_website.id,
+        })
+
+    @users('user_eventregistrationdesk')
     def test_event_registration_lead_description(self):
         """ Ensure that the lead description is well formatted/escaped
         when created from an event registration. """
+        self.env.invalidate_all()
 
-        questions = self.env['event.question'].create([{
-            'title': 'Text Input Question',
-            'question_type': 'text_box',
-        }])
+        # registration desk user: limited rights
+        test_rule_attendee = self.test_rule_attendee.with_user(self.env.user)
+        test_rule_order = self.test_rule_order.with_user(self.env.user)
+        # manager with sales rights
+        test_rule_attendee_manager = self.test_rule_attendee.with_user(self.user_eventmanager)
+        test_rule_order_manager = self.test_rule_order.with_user(self.user_eventmanager)
 
-        self.event_0.write({
-            'question_ids': [(4, question.id) for question in questions]
-        })
+        # have some registration values holding answers, to check their presence
+        # in lead description
+        registration_values = [
+            dict(
+                customer_data,
+                event_id=self.event_0.id,
+                registration_answer_ids=[(0, 0, {
+                    'question_id': self.event_0.question_ids[0].id,
+                    'value_text_box': f"<div>answer from {customer_data.get('name', 'no_name')}</div>",
+                })],
+            )
+            for customer_data in self.batch_customer_data
+        ]
 
-        customer_data = self.batch_customer_data[1]
-        customer_data['registration_answer_ids'] = [(0, 0, {
-            'question_id': questions[0].id,
-            'value_text_box': "<div>hello world</div>",
-        })]
+        self.assertEqual(len(test_rule_attendee_manager.lead_ids), 0)
+        self.assertEqual(len(test_rule_order_manager.lead_ids), 0)
 
-        registration_values = dict(self.batch_customer_data[1], event_id=self.event_0.id)
-        self.assertEqual(len(self.test_rule_attendee.lead_ids), 0)
-        self.env['event.registration'].create(registration_values)
-        lead = self.test_rule_attendee.lead_ids
-        self.assertEqual(len(self.test_rule_attendee.lead_ids), 1)
-        self.assertTrue('&lt;div&gt;hello world&lt;/div&gt;' in lead.description, 'Description should contain the escaped text box value')
-        self.assertTrue('<li>' in lead.description, 'HTML around the text box value should not be escaped')
+        registrations = self.env['event.registration'].create(registration_values)
+        registrations = registrations.sorted('id')
+        self.assertEqual(len(registrations), 5)
+        self.assertEqual(len(test_rule_attendee.lead_ids), 5)
+        self.assertEqual(len(test_rule_order.lead_ids), 1)
+
+        # grouped description: all answers in lead
+        order_lead = test_rule_order.lead_ids
+        for customer_data in self.batch_customer_data:
+            self.assertIn(
+                f'&lt;div&gt;answer from {customer_data.get("name", "no_name")}&lt;/div&gt;',
+                order_lead.description,
+                "Answers should be escaped")
+            self.assertIn('<li>', order_lead.description, 'HTML around the text box value should not be escaped')
+
+        # attendee-based descriptions
+        attendee_leads = test_rule_attendee.lead_ids
+        for lead, registration, customer_data in zip(attendee_leads, registrations, self.batch_customer_data):
+            self.assertEqual(lead.registration_ids, registration)
+            self.assertEqual(registration.lead_ids, lead + order_lead)
+            self.assertIn(
+                f'&lt;div&gt;answer from {customer_data.get("name", "no_name")}&lt;/div&gt;', lead.description,
+                "Answers should be escaped")
+            self.assertIn('<li>', lead.description, 'HTML around the text box value should not be escaped')
+
+    @users('user_eventregistrationdesk')
+    def test_visitor_language_propagation(self):
+        """
+        This test makes sure that visitor and its language are propagated to the lead when a lead is
+        created through a lead generation rule.
+
+        `_run_on_registration`, which creates the lead, is called at `event.registration` creation
+        and does not need to be called manually.
+        """
+        self.env.invalidate_all()
+
+        # 3 leads created w/ Lead Generation rules in TestEventCrmCommon: 1 per attendee and 1 per order
+        reg1, reg2 = self.env['event.registration'].create([
+            {
+                'event_id': self.event_0.id,
+                'visitor_id': self.test_lang_visitor.id,
+                'email': 'test@test.example.com',
+            }, {
+                'event_id': self.event_0.id,
+                'visitor_id': self.test_lang_visitor.id,
+                'email': 'test2@test.example.com',
+            },
+        ])
+        leads = reg1.lead_ids + reg2.lead_ids
+        self.assertEqual(leads.visitor_ids, self.test_lang_visitor)
+        self.assertEqual(leads.lang_id, self.test_lang_visitor.lang_id)

--- a/addons/website_event_crm/tests/test_visitor_propagation.py
+++ b/addons/website_event_crm/tests/test_visitor_propagation.py
@@ -1,44 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests.common import users
 from odoo.addons.event_crm.tests.common import TestEventCrmCommon
 
+
 class TestWebsiteEventCrmFlow(TestEventCrmCommon):
-
-    @users('user_eventregistrationdesk')
-    def test_visitor_language_propagation(self):
-        """
-        This test makes sure that visitor and its language are propagated to the lead when a lead is
-        created through a lead generation rule.
-
-        `_run_on_registration`, which creates the lead, is called at `event.registration` creation
-        and does not need to be called manually.
-        """
-        test_lang_website = self.env['website'].sudo().create({
-            'name': 'test lang website',
-            'user_id': self.env.ref('base.user_admin').id,
-            'language_ids': [self.env.ref('base.lang_en').id, self.env.ref('base.lang_fr').id]
-        })
-        test_lang_visitor = self.env['website.visitor'].sudo().create({
-            'name': 'test visitor language',
-            'lang_id': self.env.ref('base.lang_en').id,
-            'access_token': 'f9d2ffa0427d4e4b1d740cf5eb3cdc20',
-            'website_id': test_lang_website.id,
-        })
-        # 3 leads created w/ Lead Generation rules in TestEventCrmCommon: 1 per attendee and 1 per order
-        test_lang_registration1, test_lang_registration2 = self.env['event.registration'].create([
-            {
-                'event_id': self.event_0.id,
-                'visitor_id': test_lang_visitor.id,
-                'email': 'test@test.example.com',
-            },
-            {
-                'event_id': self.event_0.id,
-                'visitor_id': test_lang_visitor.id,
-                'email': 'test2@test.example.com',
-            },
-        ])
-        leads = test_lang_registration1.lead_ids | test_lang_registration2.lead_ids
-        self.assertEqual(leads.visitor_ids, test_lang_visitor)
-        self.assertEqual(leads.lang_id, test_lang_visitor.lang_id)
+    pass


### PR DESCRIPTION
When being order-based, several registrations are used to create a new
lead. In some cases we might end up with several possible langs due
to multiple visitors. We should take the first found one, as lang is
a m2o on lead model.

When running on registrations without linked SO, registrations are
grouped by "event" in case of group-based lead generation. We should
also group by create_date, as same event - same create_date indicates
tickets belong to the same "group".

Task-3940853

Co-Authored-By: Jeremy Hennecart <jeh@odoo.com>