### PR TITLE
[WIP][IMP] account: Make account code conditionally required in mapping view

### DIFF
--- a/addons/account/views/account_account_views.xml
+++ b/addons/account/views/account_account_views.xml
@@ -78,7 +78,8 @@
                                 <field name="code_mapping_ids" nolabel="1">
                                     <list editable="bottom">
                                         <field name="company_id"/>
-                                        <field name="code"/>
+                                        <field name="is_required" column_invisible="1"/>
+                                        <field name="code" required="is_required"/>
                                     </list>
                                 </field>
                             </page>


### PR DESCRIPTION
In the account form view, we want the UI to reflect the constraint that a code must be set for each of the companies of the accounts.
We make the account code required in the mapping for all the companies that belong to the account's `company_ids`. 

taskid: 4221026