### PR TITLE
[IMP] Change the order of company values on report_template & report_invoice

### DIFF
--- a/addons/l10n_sk/views/report_invoice.xml
+++ b/addons/l10n_sk/views/report_invoice.xml
@@ -2,19 +2,19 @@
 <odoo>
     <template id="report_invoice_document" inherit_id="account.report_invoice_document">
         <!-- add company id to partner details-->
-        <xpath expr="//div[@id='partner_vat_address_not_same_as_shipping']" position="after">
+        <xpath expr="//div[@id='partner_vat_address_not_same_as_shipping']" position="before">
             <div t-if="o.partner_id.company_registry and o.company_id.country_code == 'SK'">
                 ID: <span t-field="o.partner_id.company_registry"/>
             </div>
         </xpath>
 
-        <xpath expr="//div[@id='partner_vat_address_same_as_shipping']" position="after">
+        <xpath expr="//div[@id='partner_vat_address_same_as_shipping']" position="before">
             <div t-if="o.partner_id.company_registry and o.company_id.country_code == 'SK'">
                 ID: <span t-field="o.partner_id.company_registry"/>
             </div>
         </xpath>
 
-        <xpath expr="//div[@id='partner_vat_no_shipping']" position="after">
+        <xpath expr="//div[@id='partner_vat_no_shipping']" position="before">
             <div t-if="o.partner_id.company_registry and o.company_id.country_code == 'SK'">
                 ID: <span t-field="o.partner_id.company_registry"/>
             </div>

--- a/addons/l10n_sk/views/report_template.xml
+++ b/addons/l10n_sk/views/report_template.xml
@@ -2,60 +2,60 @@
 <odoo>
     <template id="l10n_sk_external_layout_standard" inherit_id="web.external_layout_standard">
         <xpath expr="//ul[@name='company_address_list']" position="inside">
-            <li t-if="company.vat and company.account_fiscal_country_id.code == 'SK'">
-                <t t-esc="company.country_id.vat_label or 'Tax ID'"/>:
-                <span t-esc="company.vat"/>
-            </li>
             <li t-if="company.company_registry and company.account_fiscal_country_id.code == 'SK'">
                 ID: <span t-field="company.company_registry"/>
             </li>
             <li t-if="company.income_tax_id and company.account_fiscal_country_id.code == 'SK'">
                 Tax ID: <span t-field="company.income_tax_id"/>
+            </li>
+            <li t-if="company.vat and company.account_fiscal_country_id.code == 'SK'">
+                <t t-esc="company.country_id.vat_label or 'Tax ID'"/>:
+                <span t-esc="company.vat"/>
             </li>
         </xpath>
     </template>
 
     <template id="l10n_sk_external_layout_bold" inherit_id="web.external_layout_bold">
         <xpath expr="//ul[@name='company_address_list']" position="inside">
-            <li t-if="company.vat and company.account_fiscal_country_id.code == 'SK'">
-                <t t-esc="company.country_id.vat_label or 'Tax ID'"/>:
-                <span t-esc="company.vat"/>
-            </li>
             <li t-if="company.company_registry and company.account_fiscal_country_id.code == 'SK'">
                 ID: <span t-field="company.company_registry"/>
             </li>
             <li t-if="company.income_tax_id and company.account_fiscal_country_id.code == 'SK'">
                 Tax ID: <span t-field="company.income_tax_id"/>
+            </li>
+            <li t-if="company.vat and company.account_fiscal_country_id.code == 'SK'">
+                <t t-esc="company.country_id.vat_label or 'Tax ID'"/>:
+                <span t-esc="company.vat"/>
             </li>
         </xpath>
     </template>
 
     <template id="l10n_sk_external_layout_boxed" inherit_id="web.external_layout_boxed">
         <xpath expr="//ul[@name='company_address_list']" position="inside">
-            <li t-if="company.vat and company.account_fiscal_country_id.code == 'SK'">
-                <t t-esc="company.country_id.vat_label or 'Tax ID'"/>:
-                <span t-esc="company.vat"/>
-            </li>
             <li t-if="company.company_registry and company.account_fiscal_country_id.code == 'SK'">
                 ID: <span t-field="company.company_registry"/>
             </li>
             <li t-if="company.income_tax_id and company.account_fiscal_country_id.code == 'SK'">
                 Tax ID: <span t-field="company.income_tax_id"/>
+            </li>
+            <li t-if="company.vat and company.account_fiscal_country_id.code == 'SK'">
+                <t t-esc="company.country_id.vat_label or 'Tax ID'"/>:
+                <span t-esc="company.vat"/>
             </li>
         </xpath>
     </template>
 
     <template id="l10n_sk_external_layout_striped" inherit_id="web.external_layout_striped">
         <xpath expr="//ul[@name='company_address_list']" position="inside">
-            <li t-if="company.vat and company.account_fiscal_country_id.code == 'SK'">
-                <t t-esc="company.country_id.vat_label or 'Tax ID'"/>:
-                <span t-esc="company.vat"/>
-            </li>
             <li t-if="company.company_registry and company.account_fiscal_country_id.code == 'SK'">
                 ID: <span t-field="company.company_registry"/>
             </li>
             <li t-if="company.income_tax_id and company.account_fiscal_country_id.code == 'SK'">
                 Tax ID: <span t-field="company.income_tax_id"/>
+            </li>
+            <li t-if="company.vat and company.account_fiscal_country_id.code == 'SK'">
+                <t t-esc="company.country_id.vat_label or 'Tax ID'"/>:
+                <span t-esc="company.vat"/>
             </li>
         </xpath>
     </template>


### PR DESCRIPTION
Improvement - change the order of company values on report_template & report_invoice: vat/income_tax_id/company_registry values - to be in align with standard order used in reports in country Slovakia.
New order:
company_registry (IČO)
income_tax_id (DIČ)
vat (IČ DPH)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
