### PR TITLE
[FIX] website: adapt dynamic snippet size when 1 elt is fetched

### DIFF
--- a/addons/website/static/src/snippets/s_dynamic_snippet/000.scss
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/000.scss
@@ -46,4 +46,13 @@
             }
         }
     }
+
+    .dynamic_snippet_template .col-12:not(:has(.o_template_product_product_banner)) {
+    // When a single element has been fetched, it takes up the entire width and becomes
+    // too tall according to the page height.
+    // This forces the same size to be used as when two elements are fetched.
+        @include media-breakpoint-up(lg) {
+            max-width: 50%;
+        }
+    }
 }

--- a/addons/website_sale/data/product_snippet_template_data.xml
+++ b/addons/website_sale/data/product_snippet_template_data.xml
@@ -246,7 +246,7 @@
         <template id="dynamic_filter_template_product_product_banner" name="Large Banner">
             <t t-foreach="records" t-as="data" data-number-of-elements="1" data-number-of-elements-sm="1" data-thumb="/website_sale/static/src/img/snippets_options/product_banner.svg">
                 <t t-set="record" t-value="data['_record']"/>
-                <div class="o_carousel_product_card card w-100" t-att-data-add2cart-rerender="data.get('_add2cart_rerender')">
+                <div class="o_template_product_product_banner o_carousel_product_card card w-100" t-att-data-add2cart-rerender="data.get('_add2cart_rerender')">
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
                     <div class="row flex-row-reverse">
                         <div class="col-lg-6 d-flex align-items-center justify-content-center justify-content-lg-end o_wrap_product_img position-relative">


### PR DESCRIPTION
Prior to this this commit, when a single element was fetched in the dynamic snippet, it took the entire width and became too tall according to the page height. (e.g. Products or Appointments snippet)

To limit the height of this snippet, this commit forces the same size to be used as when two elements are fetched.

task-4215773




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
