### PR TITLE
[FIX] website_sale: customer unable to edit incomplete address

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1972,7 +1972,10 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
         # Check that the billing address is complete.
         invoice_partner_sudo = order_sudo.partner_invoice_id
-        if not self._check_billing_address(invoice_partner_sudo):
+        if (
+            not self._check_billing_address(invoice_partner_sudo)
+            and invoice_partner_sudo._can_be_edited_by_current_customer(order_sudo, 'billing')
+        ):
             return request.redirect(
                 f'/shop/address?partner_id={invoice_partner_sudo.id}&address_type=billing'
             )
@@ -1982,6 +1985,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         if (
             not order_sudo.only_services
             and not self._check_delivery_address(delivery_partner_sudo)
+            and delivery_partner_sudo._can_be_edited_by_current_customer(order_sudo, 'delivery')
         ):
             return request.redirect(
                 f'/shop/address?partner_id={delivery_partner_sudo.id}&address_type=delivery'


### PR DESCRIPTION
Recent changes and refactorings in the addresses management of the ecommerce checkout have restricted the ability of customers to use and update sibling/parent addresses in their own company.

Those changes have also increased the checks on addresses to make sure that the necessary information is available to ensure proper delivery and invoicing to the customer.

Nevertheless, some address, either from the past, or from other flows might still be incomplete, and be the default delivery/billing address of a given customer, despite belonging to siblings or to their parent company.

In those situations, the customer could be constantly requested to fill the incomplete address and be automatically redirected on the /shop/address page to fill the missing information, where he would face a Forbidden (403) error as they cannot update an address that doesn't belong to them.

This commit makes sure to consider a default address as complete if the current customer is unable to edit it.

opw-4202528

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
