### PR TITLE
[FIX] website_slides: enable comment on content course

### DIFF
--- a/addons/website_slides/controllers/mail.py
+++ b/addons/website_slides/controllers/mail.py
@@ -23,12 +23,13 @@ class SlidesPortalChatter(PortalChatter):
 
     @http.route()
     def portal_chatter_post(self, res_model, res_id, message, **kw):
-        previous_post = request.env['mail.message'].search([('res_id', '=', res_id),
-                                                            ('author_id', '=', request.env.user.partner_id.id),
-                                                            ('model', '=', 'slide.channel'),
-                                                            ('subtype_id', '=', request.env.ref('mail.mt_comment').id)])
-        if previous_post:
-            raise ValidationError(_("Only a single review can be posted per course."))
+        if res_model == 'slide.channel':
+            previous_post = request.env['mail.message'].search([('res_id', '=', res_id),
+                                                                ('author_id', '=', request.env.user.partner_id.id),
+                                                                ('model', '=', 'slide.channel'),
+                                                                ('subtype_id', '=', request.env.ref('mail.mt_comment').id)])
+            if previous_post:
+                raise ValidationError(_("Only a single review can be posted per course."))
 
         result = super(SlidesPortalChatter, self).portal_chatter_post(res_model, res_id, message, **kw)
         if result and res_model == 'slide.channel':


### PR DESCRIPTION
Steps to reproduce:
1. Open the course content.
2. Exit the full screen.
3. Try to comment on the content.
4. The Send button on comments not working

Technical Reason:
In portal_chatter_post, a ValidationError was shown in the terminal: "Only a single review can be posted per course." This occurred because it was checking the 'res_id' in the 'slide.channel' model while being in the 'slide.slide' model.

After this Commit:
The send button on the comment should work properly on the content.

Task-4213443