### PR TITLE
[FIX] html_editor: reset table size

### DIFF
--- a/addons/html_editor/static/src/main/table/table_menu.js
+++ b/addons/html_editor/static/src/main/table/table_menu.js
@@ -28,6 +28,13 @@ export class TableMenu extends Component {
         this.items = this.props.type === "column" ? this.colItems() : this.rowItems();
     }
 
+    get hasCustomSize() {
+        return (
+            !!this.props.target.closest("tr").style.height ||
+            !!this.props.target.closest("td").style.width
+        );
+    }
+
     onSelected(item) {
         item.action(this.props.target);
         this.props.overlay.close();
@@ -66,6 +73,12 @@ export class TableMenu extends Component {
                 text: _t("Delete"),
                 action: this.deleteColumn.bind(this),
             },
+            this.hasCustomSize && {
+                name: "reset_size",
+                icon: "fa-table",
+                text: _t("Reset Size"),
+                action: this.resetSize.bind(this),
+            },
         ].filter(Boolean);
     }
 
@@ -101,6 +114,12 @@ export class TableMenu extends Component {
                 text: _t("Delete"),
                 action: this.deleteRow.bind(this),
             },
+            this.hasCustomSize && {
+                name: "reset_size",
+                icon: "fa-table",
+                text: _t("Reset Size"),
+                action: this.resetSize.bind(this),
+            },
         ].filter(Boolean);
     }
 
@@ -126,5 +145,9 @@ export class TableMenu extends Component {
 
     deleteRow(target) {
         this.props.dispatch("REMOVE_ROW", { row: target.parentElement });
+    }
+
+    resetSize(target) {
+        this.props.dispatch("RESET_SIZE", { table: target.closest("table") });
     }
 }

--- a/addons/html_editor/static/tests/table/ui.test.js
+++ b/addons/html_editor/static/tests/table/ui.test.js
@@ -855,3 +855,85 @@ test("preserve table rows width on move row below operation", async () => {
         </table>`)
     );
 });
+
+test("reset table size to remove custom width", async () => {
+    const { el, editor } = await setupEditor(
+        unformat(`
+        <table style="width: 150px;">
+            <tbody>
+            <tr><td style="width: 100px;" class="a">1[]</td></tr>
+            <tr><td style="width: 50px;" class="b">2</td></tr>
+            </tbody>
+        </table>`)
+    );
+    expect(".o-we-table-menu").toHaveCount(0);
+
+    await hover(el.querySelector("td.a"));
+    await waitFor(".o-we-table-menu");
+    expect("[data-type='row'].o-we-table-menu").toHaveCount(1);
+
+    await click("[data-type='row'].o-we-table-menu");
+    await waitFor(".dropdown-menu");
+    await click(queryOne(".dropdown-menu [name='reset_size']"));
+    expect(getContent(el)).toBe(
+        unformat(`
+        <table>
+            <tbody>
+                <tr><td style="" class="a">1[]</td></tr>
+                <tr><td style="" class="b">2</td></tr>
+            </tbody>
+        </table>`)
+    );
+
+    undo(editor);
+    expect(getContent(el)).toBe(
+        unformat(`
+        <table style="width: 150px;">
+            <tbody>
+            <tr><td style="width: 100px;" class="a">1[]</td></tr>
+            <tr><td style="width: 50px;" class="b">2</td></tr>
+            </tbody>
+        </table>`)
+    );
+});
+
+test("reset table size to remove custom height", async () => {
+    const { el, editor } = await setupEditor(
+        unformat(`
+        <table>
+            <tbody>
+            <tr style="height: 100px;"><td class="a">1[]</td></tr>
+            <tr style="height: 50px;"><td class="b">2</td></tr>
+            </tbody>
+        </table>`)
+    );
+    expect(".o-we-table-menu").toHaveCount(0);
+
+    await hover(el.querySelector("td.a"));
+    await waitFor(".o-we-table-menu");
+    expect("[data-type='row'].o-we-table-menu").toHaveCount(1);
+
+    await click("[data-type='row'].o-we-table-menu");
+    await waitFor(".dropdown-menu");
+    await click(queryOne(".dropdown-menu [name='reset_size']"));
+    expect(getContent(el)).toBe(
+        unformat(`
+        <table>
+            <tbody>
+                <tr style=""><td class="a">1[]</td></tr>
+                <tr style=""><td class="b">2</td></tr>
+            </tbody>
+        </table>`)
+    );
+
+    undo(editor);
+    expect(getContent(el)).toBe(
+        unformat(`
+        <table>
+            <tbody>
+            <tr style="height: 100px;"><td class="a">1[]</td></tr>
+            <tr style="height: 50px;"><td class="b">2</td></tr>
+            </tbody>
+        </table>`)
+    );
+});


### PR DESCRIPTION
The Goal of this commit is to add the “Reset Size” table menu item that
had been omitted during conversion to html_editor.