### PR TITLE
[REV] sale_project: make sol field read-only if no sale access

### DIFF
--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -78,7 +78,7 @@
             </xpath>
             <xpath expr="//field[@name='partner_phone']" position="after">
                 <field name="sale_order_id" attrs="{'invisible': True}" groups="sales_team.group_sale_salesman"/>
-                <field name="sale_line_id" groups="!sales_team.group_sale_salesman" string="Sales Order Item" options='{"no_create": True, "no_open": True}' context="{'create': False, 'edit': False, 'delete': False, 'with_price_unit': True}"/>
+                <field name="sale_line_id" groups="!sales_team.group_sale_salesman" string="Sales Order Item" options='{"no_open": True}' readonly="1"/>
                 <field name="sale_line_id" groups="sales_team.group_sale_salesman" string="Sales Order Item" options='{"no_create": True}' readonly="0" context="{'create': False, 'edit': False, 'delete': False, 'with_price_unit': True}"/>
                 <field name="commercial_partner_id" invisible="1" />
             </xpath>


### PR DESCRIPTION
In this commit https://github.com/odoo/odoo/pull/155339/commits/ca2d54a81ebb2611c14b0fc06784bd5d285856e3, in the task form, we changed the sol field to make it editable even when the user has no sale access. Trying to edit this field in such conditions produces an Access Error, so we revert this commit.

task-4207245
related-https://github.com/odoo/odoo/pull/155339

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
