### PR TITLE
[FIX] hr_holidays: fix remaining leaves return type

### DIFF
--- a/addons/hr_holidays/models/hr_employee_base.py
+++ b/addons/hr_holidays/models/hr_employee_base.py
@@ -74,7 +74,7 @@ class HrEmployeeBase(models.AbstractModel):
                 s.requires_allocation='yes' AND
                 h.employee_id in %s
             GROUP BY h.employee_id""", (tuple(self.ids),))
-        return {(row['employee_id'], row['days']) for row in self._cr.dictfetchall()}
+        return {row['employee_id']: row['days'] for row in self._cr.dictfetchall()}
 
     def _compute_remaining_leaves(self):
         remaining = {}


### PR DESCRIPTION
The method `_get_remaining_leaves` is supposed to return a dict object not a set of tuples, as it is used in [`_compute_remaining_leaves`](https://github.com/odoo/odoo/blob/913c081a8687d0f2aa6c40faeee9013fa10865db/addons/hr_holidays/models/hr_employee_base.py#L84)

How to reproduce:
1- Install module hr_holidays
2- Add any of the fields [`remaining_leaves`, `leaves_count`] to an employee view






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
