### PR TITLE
[FIX/IMP] core: import properties

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -332,7 +332,7 @@ class Import(models.TransientModel):
                         definition_type == 'separator' or
                         (
                             definition_type in ('many2one', 'many2many')
-                            and definition['comodel'] not in Model.env
+                            and definition.get('comodel') not in Model.env
                         )
                     ):
                         continue

--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -338,7 +338,7 @@ class Export(http.Controller):
                         definition['type'] == 'separator' or
                         (
                             definition['type'] in ('many2one', 'many2many')
-                            and definition['comodel'] not in Model.env
+                            and definition.get('comodel') not in Model.env
                         )
                     ):
                         continue

--- a/odoo/addons/base/models/ir_fields.py
+++ b/odoo/addons/base/models/ir_fields.py
@@ -292,14 +292,14 @@ class IrFieldsConverter(models.AbstractModel):
                 try:
                     property_dict['value'] = int(val)
                 except ValueError:
-                    msg = _("Unknown value '%(value)s' for integer '%(label_property)s' property (subfield of '%%(field)s' field).")
+                    msg = _("'%(value)s' does not seem to be an integer for field '%(label_property)s' property (subfield of '%%(field)s' field).")
                     raise self._format_import_error(ValueError, msg, {'value': val, 'label_property': property_dict['string']})
 
             elif property_type == 'float':
                 try:
                     property_dict['value'] = float(val)
                 except ValueError:
-                    msg = _("Unknown value '%(value)s' for float '%(label_property)s' property (subfield of '%%(field)s' field).")
+                    msg = _("'%(value)s' does not seem to be an float for field '%(label_property)s' property (subfield of '%%(field)s' field).")
                     raise self._format_import_error(ValueError, msg, {'value': val, 'label_property': property_dict['string']})
 
         return value, warnings


### PR DESCRIPTION
## [FIX] core: fix traceback when importing many2one Property without comodel

It is possible to create a Property field as many2one but without
choosing a model. But it generates a Traceback in the import.

## [IMP] core: improve error message for import of Properties int/float.
