### PR TITLE
[FIX] project_sale_expense, sale_project: fix project updates

### DIFF
--- a/addons/project_sale_expense/models/project_project.py
+++ b/addons/project_sale_expense/models/project_project.py
@@ -89,3 +89,19 @@ class Project(models.Model):
             if expense_ids:
                 expense_data['costs']['action'] = get_action(expense_ids)
         return expense_data
+
+    def _get_already_included_profitability_invoice_line_ids(self):
+        move_line_ids = super()._get_already_included_profitability_invoice_line_ids()
+        query = self.env['hr.expense']._search([('is_refused', '=', False), ('state', 'in', ['approved', 'done'])])
+        query.add_where('hr_expense.analytic_distribution ? %s', [str(self.analytic_account_id.id)])
+        query.order = None
+        query_string, query_param = query.select('sale_order_id')
+        query_string = f"{query_string} GROUP BY sale_order_id"
+        self._cr.execute(query_string, query_param)
+        expenses_read_group = list(self._cr.dictfetchall())
+        if not expenses_read_group:
+            return move_line_ids
+        for res in expenses_read_group:
+            sale_order = self.env['sale.order'].browse(res['sale_order_id'])
+            move_line_ids.extend(sale_order.invoice_ids.mapped('invoice_line_ids').ids)
+        return move_line_ids

--- a/addons/project_sale_expense/tests/test_project_profitability.py
+++ b/addons/project_sale_expense/tests/test_project_profitability.py
@@ -129,6 +129,82 @@ class TestProjectSaleExpenseProfitability(TestProjectProfitabilityCommon, TestPr
             {},
         )
 
+    def test_project_profitability_2(self):
+        """
+        Test Case:
+        ==========
+        - Create an expense for a project.
+        - post it's entry moves
+        - create an invoice for the sale order linked to the expense
+        - post the invoice
+        - the project profitability should not include the Customer invoice
+        linked to the expense in the revenues, as the Expenses will be there.
+        """
+
+        product_new_project_task = self.env['product.product'].create({
+            'name': "Service, create task in new project",
+            'standard_price': 30,
+            'list_price': 90,
+            'type': 'service',
+            'default_code': 'SERV-ORDERED2',
+            'service_tracking': 'task_in_project',
+        })
+
+        sale_order = self.env['sale.order'].with_context(tracking_disable=True).create({
+            'partner_id': self.partner.id,
+            'partner_invoice_id': self.partner.id,
+            'partner_shipping_id': self.partner.id,
+        })
+
+        self.env['sale.order.line'].create({
+            'product_id': product_new_project_task.id,
+            'product_uom_qty': 1,
+            'order_id': sale_order.id,
+        })
+
+        sale_order.action_confirm()
+        project = sale_order.order_line.project_id
+
+        expense = self.env['hr.expense'].create({
+            'name': 'expense',
+            'product_id': self.company_data['product_order_cost'].id,
+            'unit_amount': self.company_data['product_order_cost'].list_price,
+            'employee_id': self.expense_employee.id,
+            'analytic_distribution': {project.analytic_account_id.id: 100},
+            'sale_order_id': sale_order.id,
+        })
+
+        expense_sheet_vals_list = expense._get_default_expense_sheet_values()
+        expense_sheet = self.env['hr.expense.sheet'].create(expense_sheet_vals_list)
+        expense_sheet.action_submit_sheet()
+        expense_sheet.approve_expense_sheets()
+        expense_sheet.action_sheet_move_create()
+
+        invoice = sale_order._create_invoices()
+        invoice.action_post()
+
+        sale_items = project.sudo()._get_sale_order_items()
+        domain = [
+            ('order_id', 'in', sale_items.order_id.ids),
+            '|',
+                '|',
+                    ('project_id', 'in', project.ids),
+                    ('project_id', '=', False),
+                ('id', 'in', sale_items.ids),
+        ]
+
+        revenue_items_from_sol = project._get_revenues_items_from_sol(domain, False)
+        expense_profitability = project._get_expenses_profitability_items(False)
+        project_profitability = project._get_profitability_items(False)
+        # invoice linked to the expense should not be included in the revenues
+        self.assertDictEqual(
+            project_profitability.get('revenues', {}),
+            {
+                'data': [expense_profitability['revenues'], revenue_items_from_sol['data'][0]],
+                'total': {'invoiced': expense_profitability['revenues']['invoiced'] + revenue_items_from_sol['total']['invoiced'], 'to_invoice': expense_profitability['revenues']['to_invoice'] + revenue_items_from_sol['total']['to_invoice']},
+            },
+        )
+
     def test_project_profitability_multi_currency(self):
         currency_rate = 0.5
         other_currency = self.env['res.currency'].create({

--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -457,12 +457,14 @@ class Project(models.Model):
     def _get_revenues_items_from_invoices_domain(self, domain=None):
         if domain is None:
             domain = []
+        included_invoice_line_ids = self._get_already_included_profitability_invoice_line_ids()
         return expression.AND([
             domain,
             [('move_id.move_type', 'in', self.env['account.move'].get_sale_types()),
             ('parent_state', 'in', ['draft', 'posted']),
             ('price_subtotal', '!=', 0),
-            ('is_downpayment', '=', False)],
+            ('is_downpayment', '=', False),
+            ('id', 'not in', included_invoice_line_ids)],
         ])
 
     def _get_revenues_items_from_invoices(self, excluded_move_line_ids=None):


### PR DESCRIPTION
To reproduce:
=============
- with service product S with create project & task
- create sale order with that product
- with another service product E with Re-invoice Expenses at cost
- create expense with this product and link it to the first sale order
- go back to sale order, we find product E added to sale order
- create invoice and post it

Problem:
========
on project updates we have the expense + the customer invoice which gives wrong profits in stats

Solution:
=========
exclude the customer invoice from the revenues when it's linked to an expense, as the expense is already included in the revenues

opw-4000095
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
