### PR TITLE
[IMP] hide numpad when opening cart for small UI

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -289,6 +289,7 @@ export class ProductScreen extends Component {
 
     switchPane() {
         this.pos.scanning = false;
+        this.currentOrder.deselect_orderline();
         this.pos.switchPane();
     }
 


### PR DESCRIPTION
-When the UI is small and we open the cart, unselect the orderline so that the numpad remain down by default

task-id: 4167563




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
