### PR TITLE
[FIX] spreadsheet_dashboard_pos_hr: Fix dashboard dependency

### DIFF
--- a/addons/spreadsheet_dashboard_pos_hr/data/dashboards.xml
+++ b/addons/spreadsheet_dashboard_pos_hr/data/dashboards.xml
@@ -4,7 +4,7 @@
     <record id="spreadsheet_dashboard_pos" model="spreadsheet.dashboard">
         <field name="name">Point of Sale</field>
         <field name="spreadsheet_binary_data" type="base64" file="spreadsheet_dashboard_pos_hr/data/files/pos_dashboard.json"/>
-        <field name="main_data_model_ids" eval="[(4, ref('sale.model_sale_order'))]"/>
+        <field name="main_data_model_ids" eval="[(4, ref('point_of_sale.model_report_pos_order')),(4, ref('point_of_sale.model_pos_order'))]"/>
         <field name="sample_dashboard_file_path">spreadsheet_dashboard_pos_hr/data/files/pos_sample_dashboard.json</field>
         <field name="dashboard_group_id" ref="spreadsheet_dashboard.spreadsheet_dashboard_group_sales"/>
         <field name="group_ids" eval="[Command.link(ref('point_of_sale.group_pos_manager'))]"/>


### PR DESCRIPTION
We recently added some model dependencies to determine if a dashboard should display its sample data if the database did not have enough information worth showing.

The pos_hr dashboard was depending on sale orders by mistake. It's supposed to depend on `pos.order` and to a certain extent `report.pos.order`.

Task-4220370

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
