### PR TITLE
[FIX] tools: fix date spread in populate

### DIFF
--- a/odoo/tools/populate.py
+++ b/odoo/tools/populate.py
@@ -65,7 +65,7 @@ def get_field_variation_date(model: Model, field: Field, factor: int, series_ali
 
     def redistribute(value):
         return SQL(
-            "(%(value)s - (%(factor)s - %(series_alias)s) * floor(%(total_days)s/%(factor)s) * interval '1 days')::%(cast_type)s",
+            "(%(value)s - (%(factor)s - %(series_alias)s) * (%(total_days)s::float/%(factor)s) * interval '1 days')::%(cast_type)s",
             value=value,
             factor=factor,
             series_alias=SQL.identifier(series_alias),


### PR DESCRIPTION
Before this commit `total_days/factor` could return 0 because PG truncates integer division. Casting
total_days to a float and moving the floor's position fixes this issue, providing a correct date spread for 
`factors > (MAX_DATETIME-MIN_DATETIME).days`

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
