### PR TITLE
[FIX] point_of_sale: Scan coupon error

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/components/product_screen/product_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/product_screen/product_screen.js
@@ -13,7 +13,7 @@ patch(ProductScreen.prototype, {
     },
     async _onCouponScan(code) {
         // IMPROVEMENT: Ability to understand if the scanned code is to be paid or to be redeemed.
-        const res = await this.currentOrder.activateCode(code.base_code);
+        const res = await this.pos.activateCode(code.base_code);
         if (res !== true) {
             this.notification.add(res, { type: "danger" });
         }


### PR DESCRIPTION
Ensured coupon codes can be scanned and applied directly in the POS UI.


Task ID: 4221332


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
