### PR TITLE
[FIX] html_editor: escape close powerbox

### DIFF
--- a/addons/html_editor/static/src/main/powerbox/powerbox_plugin.js
+++ b/addons/html_editor/static/src/main/powerbox/powerbox_plugin.js
@@ -104,6 +104,10 @@ export class PowerboxPlugin extends Plugin {
     }
 
     closePowerbox() {
+        if (!this.overlay.isOpen) {
+            return;
+        }
+        this.onClose();
         this.overlay.close();
     }
 

--- a/addons/html_editor/static/tests/powerbox.test.js
+++ b/addons/html_editor/static/tests/powerbox.test.js
@@ -303,6 +303,11 @@ describe("search", () => {
             await animationFrame();
             expect(".o-we-powerbox").toHaveCount(0);
             expect(getContent(el)).toBe(`<p>/[]</p>`);
+
+            await insertText(editor, "h");
+            await animationFrame();
+            expect(".o-we-powerbox").toHaveCount(0);
+            expect(getContent(el)).toBe(`<p>/h[]</p>`);
         });
     });
 });


### PR DESCRIPTION
Before this commit, pressing “escape” when the powerbox is open did not stop the current search. Adding a new character reopened it.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
