### PR TITLE
[FIX] website_sale_loyalty_delivery: factor tax display in discount

### DIFF
--- a/addons/website_sale_loyalty_delivery/controllers/main.py
+++ b/addons/website_sale_loyalty_delivery/controllers/main.py
@@ -21,7 +21,10 @@ class WebsiteSaleLoyaltyDelivery(WebsiteSaleDelivery):
 
         if free_shipping_lines:
             currency = order.currency_id
-            amount_free_shipping = sum(free_shipping_lines.mapped('price_subtotal'))
+            if request.env.user.has_group('account.group_show_line_subtotals_tax_excluded'):
+                amount_free_shipping = sum(free_shipping_lines.mapped('price_subtotal'))
+            else:
+                amount_free_shipping = sum(free_shipping_lines.mapped('price_total'))
             result.update({
                 'new_amount_delivery_discounted': Monetary.value_to_html(order.amount_delivery + amount_free_shipping, {'display_currency': currency}),
                 'new_amount_delivery_discount': Monetary.value_to_html(amount_free_shipping, {'display_currency': currency}),


### PR DESCRIPTION
Versions
--------
- 16.0 (shipping discount no longer gets displayed on checkout in 17.0+)

Steps
-----
1. Set website prices to be displayed tax included;
2. create a free shipping promotion;
3. add a product to cart and go to checkout;
4. apply shipping promotion.

Issue
-----
Shipping amount displayed is neither zero nor the original price.

Cause
-----
Commit 9c401632bd9a added a way for the shipping discount to be displayed on checkout, by subtracting the discount from `amount_delivery`.

Issue is that the value of `amount_delivery` depends on the whether taxes are displayed excluded or included, i.e. summing `price_subtotal` or `price_total` respectively, while the discount will always subtract the `price_subtotal`.

Solution
--------
Like `_compute_amount_delivery`,
https://github.com/odoo/odoo/blob/b43d381a9277009d708e1232978aba60e4423990/addons/website_sale_delivery/models/sale_order.py#L16-L21
 check the value of `env.user.has_group('account.group_show_line_subtotals_tax_excluded')` to sum either `price_subtotal` or `price_total`.

opw-4150258