### PR TITLE
[IMP] account: add common for journal dashboard tests

### DIFF
--- a/addons/account/tests/__init__.py
+++ b/addons/account/tests/__init__.py
@@ -18,6 +18,7 @@ from . import test_account_move_partner_count
 from . import test_account_move_rounding
 from . import test_account_invoice_report
 from . import test_account_move_line_tax_details
+from . import test_account_journal_dashboard_common
 from . import test_account_journal_dashboard
 from . import test_chart_template
 from . import test_company_branch

--- a/addons/account/tests/test_account_journal_dashboard.py
+++ b/addons/account/tests/test_account_journal_dashboard.py
@@ -2,25 +2,12 @@ from dateutil.relativedelta import relativedelta
 from freezegun import freeze_time
 
 from odoo import Command
-from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.account.tests.test_account_journal_dashboard_common import TestAccountJournalDashboardCommon
 from odoo.tests import tagged
 from odoo.tools.misc import format_amount
 
 @tagged('post_install', '-at_install')
-class TestAccountJournalDashboard(AccountTestInvoicingCommon):
-
-    def assertDashboardPurchaseSaleData(self, journal, number_draft, sum_draft, number_waiting, sum_waiting, number_late, sum_late, currency, **kwargs):
-        expected_values = {
-            'number_draft': number_draft,
-            'sum_draft': format_amount(self.env, sum_draft, currency),
-            'number_waiting': number_waiting,
-            'sum_waiting': format_amount(self.env, sum_waiting, currency),
-            'number_late': number_late,
-            'sum_late': format_amount(self.env, sum_late, currency),
-            **kwargs
-        }
-        dashboard_data = journal._get_journal_dashboard_data_batched()[journal.id]
-        self.assertDictEqual({**dashboard_data, **expected_values}, dashboard_data)
+class TestAccountJournalDashboard(TestAccountJournalDashboardCommon):
 
     @freeze_time("2019-01-22")
     def test_customer_invoice_dashboard(self):

--- a/addons/account/tests/test_account_journal_dashboard_common.py
+++ b/addons/account/tests/test_account_journal_dashboard_common.py
@@ -1,0 +1,96 @@
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo import Command
+from odoo.tests import tagged
+from odoo.tools.misc import format_amount
+
+
+@tagged('post_install', '-at_install')
+class TestAccountJournalDashboardCommon(AccountTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+    def _create_test_vendor_bills(self, journal):
+        # Setup multiple payments term
+        twentyfive_now_term = self.env['account.payment.term'].create({
+            'name': '25% now, rest in 30 days',
+            'note': 'Pay 25% on invoice date and 75% 30 days later',
+            'line_ids': [
+                Command.create({
+                    'value': 'percent',
+                    'value_amount': 25.00,
+                    'delay_type': 'days_after',
+                    'nb_days': 0,
+                }),
+                Command.create({
+                    'value': 'percent',
+                    'value_amount': 75.00,
+                    'delay_type': 'days_after',
+                    'nb_days': 30,
+                }),
+            ],
+        })
+        self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'journal_id': journal.id,
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2023-04-01',
+            'date': '2023-03-15',
+            'invoice_payment_term_id': twentyfive_now_term.id,
+            'invoice_line_ids': [Command.create({
+                'product_id': self.product_a.id,
+                'quantity': 1,
+                'name': 'product test 1',
+                'price_unit': 4000,
+                'tax_ids': [],
+            })]
+        }).action_post()
+        # This bill has two amls of 10$. Both are waiting for payment and due in 16 and 46 days.
+        # number_waiting += 2, sum_waiting += -4000$, number_late += 0, sum_late += 0$
+        self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'journal_id': journal.id,
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2023-03-01',
+            'date': '2023-03-15',
+            'invoice_payment_term_id': twentyfive_now_term.id,
+            'invoice_line_ids': [Command.create({
+                'product_id': self.product_a.id,
+                'quantity': 1,
+                'name': 'product test 1',
+                'price_unit': 400,
+                'tax_ids': [],
+            })]
+        }).action_post()
+        # This bill has two amls of 100$. One which is late and due 14 days prior and one which is waiting for payment and due in 15 days.
+        # number_waiting += 2, sum_waiting += -400$, number_late += 1, sum_late += -100$
+        self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'journal_id': journal.id,
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2023-02-01',
+            'date': '2023-03-15',
+            'invoice_payment_term_id': twentyfive_now_term.id,
+            'invoice_line_ids': [Command.create({
+                'product_id': self.product_a.id,
+                'quantity': 1,
+                'name': 'product test 1',
+                'price_unit': 40,
+                'tax_ids': [],
+            })]
+        }).action_post()
+        # This bill has two amls of 1000$. Both of them are late and due 45 and 15 days prior.
+        # number_waiting += 2, sum_waiting += -40$, number_late += 2, sum_late += -40$
+
+    def assertDashboardPurchaseSaleData(self, journal, number_draft, sum_draft, number_waiting, sum_waiting, number_late, sum_late, currency, **kwargs):
+        expected_values = {
+            'number_draft': number_draft,
+            'sum_draft': format_amount(self.env, sum_draft, currency),
+            'number_waiting': number_waiting,
+            'sum_waiting': format_amount(self.env, sum_waiting, currency),
+            'number_late': number_late,
+            'sum_late': format_amount(self.env, sum_late, currency),
+            **kwargs
+        }
+        dashboard_data = journal._get_journal_dashboard_data_batched()[journal.id]
+        self.assertDictEqual({**dashboard_data, **expected_values}, dashboard_data)


### PR DESCRIPTION
Manual back porting the part of 02f78498972a6fc7d560c0e6c0a5b3bf63eb58d3
that add common for account journal dashbaord tests.

opw-4182523
