### PR TITLE
[FIX] point_of_sale: fix MoneyDetailsPopup prop def

### DIFF
--- a/addons/point_of_sale/static/src/app/utils/money_details_popup/money_details_popup.js
+++ b/addons/point_of_sale/static/src/app/utils/money_details_popup/money_details_popup.js
@@ -10,7 +10,7 @@ export class MoneyDetailsPopup extends Component {
     static template = "point_of_sale.MoneyDetailsPopup";
     static components = { NumericInput, Dialog };
     static props = {
-        moneyDetails: { type: Object, optional: true },
+        moneyDetails: { type: [Object, { value: null }], optional: true },
         action: String,
         getPayload: Function,
         close: Function,


### PR DESCRIPTION
Backport of 0a60ea114f690b18d7ef8d06e5f659d0122f1ea6

In the prop definition of `MoneyDetailsPopup` it is specified that the `moneyDetails` prop either not be passed or be an object. There are instances where the prop is passed with value `null`.

We adapt the definition to reflect this reality.






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
