### PR TITLE
[FIX] sale_timesheet: Access Error when creating task in billable project

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1200,7 +1200,7 @@ class SaleOrderLine(models.Model):
 
     def _get_partner_display(self):
         self.ensure_one()
-        commercial_partner = self.order_partner_id.commercial_partner_id
+        commercial_partner = self.sudo().order_partner_id.commercial_partner_id
         return f'({commercial_partner.ref or commercial_partner.name})'
 
     def _additional_name_per_id(self):

--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -560,7 +560,7 @@ class ProjectTask(models.Model):
         super()._inverse_partner_id()
         for task in self:
             if task.allow_billable and not task.sale_line_id:
-                task.sale_line_id = task._get_last_sol_of_customer()
+                task.sale_line_id = task.sudo()._get_last_sol_of_customer()
 
     @api.depends('sale_line_id.order_partner_id', 'parent_id.sale_line_id', 'project_id.sale_line_id', 'allow_billable')
     def _compute_sale_line(self):


### PR DESCRIPTION
# First fix

Steps to reproduce:
-------------------
1. Install Project and Sales apps
2. Log in as admin user (e.g. Mitchell Admin), and create a billable project for a customer A
3. Invite user B (e.g. Marc Demo) to the project
4. Only give project (user) access rights to the user B, remove all other access rights
5. Create an SO with customer A as partner, add a service product (e.g. Junior Architect), confirm the SO and create a timesheet
6. Log in as user B, create a task in the billable project from the task form, make sure customer A is set as partner
7. Save the task, an access error is raised

Fix:
-------------------
When creating a new task from the form, _inverse_partner_id() is called, which calls task._get_last_sol_of_customer().
As the user has no Sales access, the search of the SOL in _get_last_sol_of_customer() will raise an Access Error in such case.
We add a sudo() before calling _get_last_sol_of_customer() to give the user access to the SOL we are looking for.

# Second fix

Steps to reproduce:
-------------------
1. Configure a user with the project > user and sales > user: own documents access rights
2. Log in with this user
3. Create a task in a billable project (e.g. for Deco Addict)
4. The compute automatically sets an SOL but the current user doesn't have access to the SOL (make sure that the user does not have access to the SOL that is set)
5. Error when trying to update the value of the SOL

Fix:
-------------------
We add a sudo() in _get_partner_display() to give the user access to the SO. As the user may not have access to the SO of the SOL that is currently set in the task.

task-4207245
version-17.2

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
