### PR TITLE
[FIX] html_editor: rename embedded file component's accessToken key

### DIFF
--- a/addons/html_editor/static/src/main/media/media_dialog/file_media_dialog.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/file_media_dialog.js
@@ -41,7 +41,7 @@ export class FileMediaDialog extends MediaDialog {
         const dotSplit = selectedMedia.name.split(".");
         const extension = dotSplit.length > 1 ? dotSplit.pop() : undefined;
         const fileData = {
-            accessToken,
+            access_token: accessToken,
             checksum: selectedMedia.checksum,
             extension,
             filename: selectedMedia.name,

--- a/addons/html_editor/static/src/others/embedded_components/core/file/state_file_model.js
+++ b/addons/html_editor/static/src/others/embedded_components/core/file/state_file_model.js
@@ -5,7 +5,7 @@ export class StateFileModel extends FileModel {
         super();
         this.state = state;
         for (const property of [
-            "accessToken",
+            "access_token",
             "checksum",
             "extension",
             "filename",


### PR DESCRIPTION
Purpose:
--------
Currently, portal users cannot preview nor download files inserted in knowledge articles.

The issue arises because there is a mismatch between the accessToken key used inside the embedded props of the embedded file component and the access_token field used in the file model. Therefore, portal users try to preview/download attachments without access tokens, which results in access errors.

This commit renames the key used for the embedded file component so that it matches the one of the file model.

Task-4221554
