### PR TITLE
[IMP] point_of_sale: hide numpad when opening cart for small UI

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -289,6 +289,7 @@ export class ProductScreen extends Component {
 
     switchPane() {
         this.pos.scanning = false;
+        this.currentOrder.deselect_orderline();
         this.pos.switchPane();
     }
 


### PR DESCRIPTION
-When the UI is small and we open the cart, deselect the orderline so that the numpad remain down

task-id: 4167563