### PR TITLE
[PERF] industry_fsm: timesheet list view requests spam

### DIFF
--- a/addons/hr_timesheet/static/src/components/task_with_hours/task_with_hours.js
+++ b/addons/hr_timesheet/static/src/components/task_with_hours/task_with_hours.js
@@ -3,32 +3,18 @@
 import { registry } from "@web/core/registry";
 import { Many2OneField, many2OneField } from "@web/views/fields/many2one/many2one_field";
 import { useService } from "@web/core/utils/hooks";
-import { onWillStart } from "@odoo/owl";
 
 class TaskWithHours extends Many2OneField {
     setup() {
         super.setup();
         this.orm = useService("orm");
-        onWillStart(this.onWillStart);
-    }
-
-    async onWillStart() {
-        this.createEditProject = await this.orm.call(
-            "project.project",
-            "get_create_edit_project_ids",
-            []
-        );
     }
 
     canCreate() {
-        if (this.createEditProject !== undefined) {
-            return (
-                Boolean(this.context.default_project_id) &&
-                !this.createEditProject.includes(this.props.record.data.project_id[0])
-            );
-        } else {
-            return Boolean(this.context.default_project_id);
-        }
+        return (
+            Boolean(this.context.default_project_id) &&
+            !this.props.record.data.is_fsm
+        );
     }
 
     /**

--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -19,6 +19,7 @@
                         decoration-danger="unit_amount &gt; 24 or unit_amount &lt; 0" decoration-muted="unit_amount == 0"/>
                     <field name="company_id" column_invisible="True"/>
                     <field name="user_id" column_invisible="True"/>
+                    <field name="is_fsm" column_invisible="True"/>
                 </tree>
             </field>
         </record>


### PR DESCRIPTION
## Issue
Some users are disconnected when opening the list view of Timesheets

## Analysis
Opening the list view of Timesheets triggers a request for each record displayed. 
This causes a lot of requests and slows down the loading of the page, eventually triggering a disconnection from the server.

## Solution
This commit references the new field `is_fsm` in the list view so we can filter `is_fsm`
records in the initial `web_search_read`, avoiding the need to send a request for each record.

### References
Enterprise PR: https://github.com/odoo/enterprise/pull/71127
opw-4208580