### PR TITLE
[FIX] web_editor: fix hardcoded --gutter-x CSS variable

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.frontend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.frontend.scss
@@ -45,7 +45,7 @@
         // make them compensate the grid item horizontal padding (to avoid an
         // overflow).
         .o_grid_item > .row {
-            --grid-inner-row-gutter-x: clamp(0px, 2 * var(--grid-item-padding-x), 30px);
+            --grid-inner-row-gutter-x: clamp(0px, 2 * var(--grid-item-padding-x), #{$grid-gutter-width});
             margin-left: calc(-0.5 * var(--grid-inner-row-gutter-x));
             margin-right: calc(-0.5 * var(--grid-inner-row-gutter-x));
         }
@@ -70,7 +70,7 @@
 }
 
 .container-fluid > .o_grid_mode {
-    --gutter-x: 30px;
+    --gutter-x: #{$grid-gutter-width};
 }
 
 .o_extra_menu_items .o_grid_mode {


### PR DESCRIPTION
This commit is a backport of commit [1], fixing some hardcoded gutter values that should have been using the `$grid-gutter-width` variable instead.

[1]: https://github.com/odoo/odoo/commit/78f7b86884178e82c7160fb9fc20859c8478b156

task-4194685