### PR TITLE
[FIX] mail: 'object-fit: cover' on all persona avatar in discuss

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -16,7 +16,7 @@
             <button t-if="state.showClose and !env.embedLivechat" class="o-mail-ChatBubble-close position-absolute shadow rounded-circle fw-bold bg-view" title="Close Chat Window" t-on-click.stop="() => this.props.chatWindow.close()"><i class="oi oi-close"/></button>
             <ImStatus t-if="thread?.correspondent?.persona?.im_status and thread?.correspondent?.persona?.im_status != 'offline'" className="'o-mail-ChatBubble-status position-absolute o-mail-brighter'" persona="thread.correspondent.persona" thread="thread"/>
             <button class="o-mail-ChatHub-bubbleBtn btn bg-view">
-                <img class="o-mail-ChatBubble-avatar rounded-circle" t-att-class="{ 'o-big': env.embedLivechat }" t-att-src="thread?.avatarUrl" alt="Thread image" draggable="false"/>
+                <img class="o-mail-ChatBubble-avatar rounded-circle o_object_fit_cover" t-att-class="{ 'o-big': env.embedLivechat }" t-att-src="thread?.avatarUrl" alt="Thread image" draggable="false"/>
             </button>
         </div>
     </t>

--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -59,7 +59,7 @@
             <ul class="m-0 p-0 overflow-auto" role="menu" t-ref="more-menu">
                 <t t-foreach="chatHub.folded.slice(chatHub.maxFolded)" t-as="cw" t-key="cw.localId">
                     <li class="o-mail-ChatHub-hiddenItem gap-2 px-2 py-1" role="menuitem" t-att-name="cw.displayName" t-on-click="() => cw.open()">
-                        <img class="o-mail-ChatHub-hiddenAvatar rounded-circle" t-att-src="cw.thread?.avatarUrl" alt="Thread image" draggable="false"/>
+                        <img class="o-mail-ChatHub-hiddenAvatar rounded-circle o_object_fit_cover" t-att-src="cw.thread?.avatarUrl" alt="Thread image" draggable="false"/>
                         <p class="text-truncate fw-bold mb-0" t-esc="cw.displayName"/>
                         <div t-if="cw.thread?.importantCounter > 0" class="o-mail-ChatHub-hiddenCounter badge rounded-pill fw-bold o-discuss-badge" style="padding: 3px 6px">
                             <t t-out="cw.thread?.importantCounter"/>

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -93,7 +93,7 @@
 
 <t t-name="mail.ChatWindow.headerContent">
     <div t-if="thread" class="o-mail-ChatWindow-threadAvatar my-0" t-attf-class="{{ threadActions.actions.length > 4 ? 'ms-1' : 'ms-3' }} me-1">
-        <img class="rounded" t-att-src="thread.avatarUrl" alt="Thread Image"/>
+        <img class="rounded o_object_fit_cover" t-att-src="thread.avatarUrl" alt="Thread Image"/>
     </div>
     <ThreadIcon t-if="thread and thread.channel_type === 'chat' and thread.correspondent" thread="thread"/>
     <div t-if="!state.editingName" class="text-truncate fw-bold border border-transparent me-1 my-0" t-att-title="props.chatWindow.displayName" t-esc="props.chatWindow.displayName" t-att-class="thread ? 'ms-1' : 'ms-3'"/>

--- a/addons/mail/static/src/core/common/message_in_reply.xml
+++ b/addons/mail/static/src/core/common/message_in_reply.xml
@@ -8,7 +8,7 @@
             <small class="position-relative d-block text-small mb-1" t-attf-class="{{ env.inChatWindow and props.alignedRight ? 'justify-content-end pe-5': 'ps-5' }}">
                 <span class="o-mail-MessageInReply-corner position-absolute bottom-0 top-50 pe-4 border-top text-300" t-attf-class="{{ env.inChatWindow and props.alignedRight ? 'o-isRightAlign border-end' : 'o-isLeftAlign border-start' }}" t-att-class="{ 'ms-n2': store.discuss.isActive }"/>
                 <span t-if="!props.message.parentMessage.isEmpty" class="d-inline-flex align-items-center text-muted opacity-75" t-att-class="{ 'cursor-pointer opacity-100-hover': props.onClick }" t-on-click="() => this.props.onClick?.()">
-                    <img class="o-mail-MessageInReply-avatar me-2 rounded" t-att-src="authorAvatarUrl" t-att-title="props.message.parentMessage.author?.name ?? props.message.parentMessage.email_from" alt="Avatar"/>
+                    <img class="o-mail-MessageInReply-avatar me-2 rounded o_object_fit_cover" t-att-src="authorAvatarUrl" t-att-title="props.message.parentMessage.author?.name ?? props.message.parentMessage.email_from" alt="Avatar"/>
                     <span class="o-mail-MessageInReply-content overflow-hidden smaller">
                         <b>@<t t-out="props.message.parentMessage.author?.name ?? props.message.parentMessage.email_from"/></b>:
                         <br t-if="env.inChatWindow and !props.alignedRight"/>

--- a/addons/mail/static/src/core/common/message_seen_indicator.xml
+++ b/addons/mail/static/src/core/common/message_seen_indicator.xml
@@ -12,7 +12,7 @@
     <t t-name="mail.MessageSeenIndicatorPopover.card">
         <div class="o-mail-MessageSeenIndicatorPopover-card d-flex align-items-center gap-2">
             <span class="o_avatar position-relative o_card_avatar" style="width: 30px;height:30px;">
-                <img t-att-src="member.persona.avatarUrl" class="w-100 h-100 rounded" />
+                <img t-att-src="member.persona.avatarUrl" class="w-100 h-100 rounded o_object_fit_cover" />
             </span>
             <span class="fw-bold" t-esc="member.persona.name"/>
             <span t-if="member.lastSeenDt" class="ms-auto text-muted small" t-out="member.lastSeenDt"/>

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -7,7 +7,7 @@
             <div class="o-mail-Discuss-header px-3 bg-view d-flex flex-shrink-0 align-items-center border-bottom z-1" t-att-class="{ 'flex-grow-1': !ui.isSmall and !store.inPublicPage }" t-ref="header">
                 <t t-if="thread">
                     <div t-if="['channel', 'group', 'chat'].includes(thread.channel_type)" class="o-mail-Discuss-threadAvatar position-relative align-self-center align-items-center mt-2 mb-2 me-2">
-                        <img class="rounded" t-att-src="thread.avatarUrl" alt="Thread Image"/>
+                        <img class="rounded o_object_fit_cover" t-att-src="thread.avatarUrl" alt="Thread Image"/>
                         <FileUploader t-if="thread.is_editable" acceptedFileExtensions="'.bmp, .jpg, .jpeg, .png, .svg'" showUploadingText="false" multiUpload="false" onUploaded.bind="(data) => this.onFileUploaded(data)">
                             <t t-set-slot="toggler">
                                 <a href="#" class="position-absolute z-1 h-100 w-100 rounded start-0 bottom-0" title="Upload Avatar">

--- a/addons/mail/static/src/core/web/activity.xml
+++ b/addons/mail/static/src/core/web/activity.xml
@@ -5,7 +5,7 @@
     <div class="o-mail-Activity d-flex py-1 mb-2" t-on-click="onClick">
         <div class="o-mail-Activity-sidebar flex-shrink-0 position-relative">
             <a role="button" t-on-click="onClickAvatar">
-                <img class="w-100 h-100 rounded" t-att-src="props.activity.persona.avatarUrl" />
+                <img class="w-100 h-100 rounded o_object_fit_cover" t-att-src="props.activity.persona.avatarUrl" />
             </a>
             <div
                 class="o-mail-Activity-iconContainer position-absolute top-100 start-100 translate-middle d-flex align-items-center justify-content-center mt-n1 ms-n1 rounded-circle w-50 h-50"

--- a/addons/mail/static/src/core/web/activity_list_popover_item.xml
+++ b/addons/mail/static/src/core/web/activity_list_popover_item.xml
@@ -29,7 +29,7 @@
                 </button>
             </div>
             <div class="d-flex align-items-center flex-wrap mx-3">
-                <img t-if="props.activity.user_id[0]" class="me-2 rounded" t-att-src="activityAssigneeAvatar" style="max-width: 1.5rem; max-height: 1.5rem;"/>
+                <img t-if="props.activity.user_id[0]" class="me-2 rounded o_object_fit_cover" t-att-src="activityAssigneeAvatar" style="max-width: 1.5rem; max-height: 1.5rem;"/>
                 <div class="mt-1">
                     <t t-if="props.activity.user_id[0]">
                         <small class="text-truncate" t-esc="props.activity.user_id[1]"/>

--- a/addons/mail/static/src/core/web/follower_list.xml
+++ b/addons/mail/static/src/core/web/follower_list.xml
@@ -30,7 +30,7 @@
 <t t-name="mail.Follower">
     <div class="dropdown-item o-mail-Follower d-flex justify-content-between p-0">
         <a class="o-mail-Follower-details d-flex align-items-center flex-grow-1 px-3 o-min-width-0" t-att-class="{ 'o-inactive fst-italic opacity-25': !follower.is_active }" href="#" role="menuitem" t-on-click.prevent="(ev) => this.onClickDetails(ev, follower)">
-            <img class="o-mail-Follower-avatar me-2 rounded" t-att-src="follower.partner.avatarUrl" alt=""/>
+            <img class="o-mail-Follower-avatar me-2 rounded o_object_fit_cover" t-att-src="follower.partner.avatarUrl" alt=""/>
             <span class="flex-shrink text-truncate" t-esc="follower.partner.name"/>
         </a>
         <t t-if="follower.isEditable">

--- a/addons/mail/static/src/discuss/call/common/call_invitation.xml
+++ b/addons/mail/static/src/discuss/call/common/call_invitation.xml
@@ -4,7 +4,7 @@
     <t t-name="discuss.CallInvitation">
         <div class="o-discuss-CallInvitation d-flex flex-column m-2 p-5 border border-dark rounded-1 text-bg-900" t-attf-class="{{ className }}" t-ref="root">
             <div t-if="props.thread.rtcInvitingSession" class="o-discuss-CallInvitation-correspondent d-flex flex-column justify-content-around align-items-center text-nowrap">
-                <img class="mb-2 rounded-circle cursor-pointer"
+                <img class="mb-2 rounded-circle cursor-pointer o_object_fit_cover"
                     t-att-src="props.thread.rtcInvitingSession.channelMember.persona.avatarUrl"
                     t-on-click="onClickAvatar"
                     alt="Avatar"/>

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.xml
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.xml
@@ -21,15 +21,10 @@
             <!-- card -->
             <CallParticipantVideo t-if="hasVideo" session="rtcSession" type="props.cardData.type" inset="props.inset"/>
             <div t-else="" class="o-discuss-CallParticipantCard-avatar d-flex align-items-center justify-content-center h-100 w-100 rounded-1" t-att-class="{ 'o-minimized': props.minimized }" draggable="false">
-                <img alt="Avatar"
-                        t-att-class="{
-                        'o-isTalking': isTalking,
-                        'o-isInvitation': !rtcSession,
-                        }"
-                        class="h-100 rounded-circle border-5 o_object_fit_cover"
-                        t-att-src="channelMember?.persona.avatarUrl"
-                        draggable="false"
-                />
+                <img alt="Avatar" class="h-100 rounded-circle border-5 o_object_fit_cover" t-att-src="channelMember?.persona.avatarUrl" draggable="false" t-att-class="{
+                    'o-isTalking': isTalking,
+                    'o-isInvitation': !rtcSession,
+                }"/>
             </div>
             <t t-if="rtcSession">
                 <!-- overlay -->

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -11,8 +11,7 @@
                             <div class="o-discuss-ChannelInvitation-selectable o_object_fit_cover d-flex align-items-center px-3 py-1 btn" t-on-click="() => this.onClickSelectablePartner(selectablePartner)">
                                 <div class="d-flex align-items-center p-2">
                                     <div class="o-discuss-ChannelInvitation-avatar position-relative d-flex flex-shrink-0">
-                                        <img class="w-100 h-100 rounded o_object_fit_cover"
-                                            t-att-src="selectablePartner.avatarUrl"/>
+                                        <img class="w-100 h-100 rounded o_object_fit_cover" t-att-src="selectablePartner.avatarUrl"/>
                                         <ImStatus persona="selectablePartner" className="'position-absolute top-100 start-100 translate-middle bg-view mt-n1 ms-n1'"/>
                                     </div>
                                 </div>

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -29,8 +29,7 @@
     <t t-name="discuss.channel_member">
         <div class="o-discuss-ChannelMember d-flex align-items-center p-2 bg-inherit" t-att-class="{ 'cursor-pointer': canOpenChatWith(member) }" t-on-click.stop="(ev) => this.onClickAvatar(ev, member)">
             <div class="bg-inherit o-discuss-ChannelMember-avatar position-relative d-flex ms-4 flex-shrink-0">
-                <img class="w-100 h-100 rounded o_object_fit_cover"
-                     t-att-src="member.persona.avatarUrl"/>
+                <img class="w-100 h-100 rounded o_object_fit_cover" t-att-src="member.persona.avatarUrl"/>
                 <ImStatus persona="member.persona" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>
             </div>
             <span t-ref="displayName" class="ms-2 text-truncate" t-esc="member.name"/>

--- a/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.xml
@@ -56,7 +56,7 @@
         >
             <button class="o-mail-DiscussSidebarChannel-itemMain btn border-0 rounded-0 text-reset overflow-hidden d-flex align-items-center px-0 py-2">
                 <div class="bg-inherit position-relative d-flex ms-3 flex-shrink-0" style="width:26px;height:26px">
-                    <img class="w-100 h-100 rounded" t-att-src="thread.avatarUrl" alt="Thread Image"/>
+                    <img class="w-100 h-100 rounded o_object_fit_cover" t-att-src="thread.avatarUrl" alt="Thread Image"/>
                     <ThreadIcon t-if="thread.channel_type === 'chat' or (thread.channel_type === 'channel' and !thread.authorizedGroupFullName)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute bottom-0 end-0 p-1 me-n1 mb-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
                 </div>
                 <span class="mx-2 text-truncate" t-att-class="thread.selfMember?.message_unread_counter > 0 and !thread.mute_until_dt ? 'o-item-unread fw-bolder' : 'text-muted'">

--- a/addons/website_livechat/static/src/web/thread_patch.scss
+++ b/addons/website_livechat/static/src/web/thread_patch.scss
@@ -6,5 +6,4 @@
 .o-website_livechat-VisitorBanner-avatar {
     height: $o-mail-Avatar-size;
     width: $o-mail-Avatar-size;
-    object-fit: cover;
 }

--- a/addons/website_livechat/static/src/web/thread_patch.xml
+++ b/addons/website_livechat/static/src/web/thread_patch.xml
@@ -5,7 +5,7 @@
             <t t-set="visitor" t-value="props.thread.visitor"/>
             <div t-if="visitor and !env.inChatWindow" class="o-website_livechat-VisitorBanner py-4 px-2 d-flex border-bottom">
                 <div t-if="props.thread.correspondent" class="o-website_livechat-VisitorBanner-sidebar me-2 d-flex justify-content-center">
-                    <img class="rounded o-website_livechat-VisitorBanner-avatar" t-att-src="props.thread.correspondent.persona.avatarUrl" alt="Avatar"/>
+                    <img class="rounded o-website_livechat-VisitorBanner-avatar o_object_fit_cover" t-att-src="props.thread.correspondent.persona.avatarUrl" alt="Avatar"/>
                 </div>
                 <div>
                     <div class="d-flex align-items-baseline">


### PR DESCRIPTION
Without it, images with ratio different than 1 had width or height either shrunk or expanded, which definitely makes these avatar look hideous.

This commit fixes most of them. Note that the ones with `.o_avatar` have implicitly `o_object_fit_cover` so this was unnecessary to add them.

Before / After
<img width="51" alt="Screenshot 2024-10-01 at 00 51 05" src="https://github.com/user-attachments/assets/bee81b6c-b3cc-4610-b855-3a66f6defff9"> <img width="55" alt="Screenshot 2024-10-01 at 00 50 44" src="https://github.com/user-attachments/assets/f3d1937c-3a3a-4a8c-aa01-d91e25bceaac">


Before / After
<img width="1280" alt="Screenshot 2024-10-01 at 00 51 40" src="https://github.com/user-attachments/assets/983aa74f-2904-4037-a373-517b13a014d9">
<img width="1280" alt="Screenshot 2024-10-01 at 00 49 40" src="https://github.com/user-attachments/assets/4227137a-aab4-48be-bbf0-803704cb9575">
