### PR TITLE
[FIX] mrp: Fix rounding issue to get correct value

### DIFF
--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -280,11 +280,11 @@ class ProductProduct(models.Model):
                         "free_qty": float_round(component.free_qty, precision_rounding=rounding),
                     }
                 )
-                ratios_virtual_available.append(component_res["virtual_available"] / qty_per_kit)
-                ratios_qty_available.append(component_res["qty_available"] / qty_per_kit)
-                ratios_incoming_qty.append(component_res["incoming_qty"] / qty_per_kit)
-                ratios_outgoing_qty.append(component_res["outgoing_qty"] / qty_per_kit)
-                ratios_free_qty.append(component_res["free_qty"] / qty_per_kit)
+                ratios_virtual_available.append(float_round(component_res["virtual_available"] / qty_per_kit, precision_rounding=rounding))
+                ratios_qty_available.append(float_round(component_res["qty_available"] / qty_per_kit, precision_rounding=rounding))
+                ratios_incoming_qty.append(float_round(component_res["incoming_qty"] / qty_per_kit, precision_rounding=rounding))
+                ratios_outgoing_qty.append(float_round(component_res["outgoing_qty"] / qty_per_kit, precision_rounding=rounding))
+                ratios_free_qty.append(float_round(component_res["free_qty"] / qty_per_kit, precision_rounding=rounding))
             if bom_sub_lines and ratios_virtual_available:  # Guard against all cnsumable bom: at least one ratio should be present.
                 res[product.id] = {
                     'virtual_available': min(ratios_virtual_available) * bom_kits[product].product_qty // 1,

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -1507,16 +1507,22 @@ class TestBoM(TestMrpCommon):
         self.assertEqual(mo.move_byproduct_ids.product_uom_qty, 3)
 
     def test_bom_kit_with_sub_kit(self):
-        p1, p2, p3, p4 = self.make_prods(4)
+        p1, p2, p3, p4, p5, p6 = self.make_prods(6)
         self.make_bom(p1, p2, p3)
         self.make_bom(p2, p3, p4)
+        bom = self.make_bom(p5, p6)
+        bom.bom_line_ids[0].product_qty = 0.1
 
         loc = self.env.ref("stock.stock_location_stock")
         self.env["stock.quant"]._update_available_quantity(p3, loc, 10)
         self.env["stock.quant"]._update_available_quantity(p4, loc, 10)
+        self.env["stock.quant"]._update_available_quantity(p6, loc, 5.5)
+        self.env["stock.quant"]._update_available_quantity(p6, loc, -4.8)
+
         self.assertEqual(p1.qty_available, 5.0)
         self.assertEqual(p2.qty_available, 10.0)
         self.assertEqual(p3.qty_available, 10.0)
+        self.assertEqual(p5.qty_available, 7.0)
 
     def test_bom_updates_mo(self):
         """ Creates a Manufacturing Order using a BoM, then modifies the BoM.


### PR DESCRIPTION
As this pr is [merged] (https://github.com/odoo/odoo/pull/152709) so due to this ``float_round`` behaviour is bit changed due to that here is test case is failing in upgrade that checks the qty_available with product their is difference come. [Here](https://github.com/odoo/odoo/blob/251ef3edcc7e0894683acb7c69bfa437a024110f/addons/stock/models/product.py#L207) before product record ``qty_avaliable`` (it non stored field and compute) to come like this ``'qty_available': 0.7000000000000001 `` after new changes in ``float_round``  after this [pr](https://github.com/odoo/odoo/pull/152709) in 17.4 value is  ``'qty_available': 0.7`` coming like this and after dividing [here](https://github.com/odoo/odoo/blob/913c081a8687d0f2aa6c40faeee9013fa10865db/addons/mrp/models/product.py#L280) with 0.1(qty per kit) becomes like
```py
before
0.7000000000000001/0.1
7.0

after
0.7/0.1
6.999999999999999
```
while taking quotent [here](https://github.com/odoo/odoo/blob/b3d61b372a8cd315f9063b6add634ad194f3341b/addons/mrp/models/product.py#L264) it taking 6 instead of 7 so this difference come and test case failed

```
AssertionError: Lists differ: [[142[456 chars]63, '7'], [14264, '0.7'], [14265, '-30'], [142[12426 chars]-2']] != [[142[456 chars]63, '6'], [14264, '0.7'], [14265, '-30'], [142[12426 chars]-2']]

First differing element 27:
[14263, '7']
[14263, '6']

Diff is 15569 characters long. Set self.maxDiff to None to see it. : Invariant check fail
```
for correcting this as discussed here https://github.com/odoo/odoo/pull/152709#issuecomment-2383006955 this  fixed is proposed.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
