### PR TITLE
[FIX] website_sale: fix traceback in ecommerce checkout page if no delivery method

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1051,7 +1051,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         :return: Whether the delivery step can be skipped.
         :rtype: bool
         """
-        if not order_sudo.carrier_id or len(delivery_methods) > 1:
+        if not order_sudo.carrier_id or len(delivery_methods) != 1:
             # The user must choose a delivery method or see a warning if no available ones.
             return False
         delivery_method = delivery_methods[0]


### PR DESCRIPTION
Currently, a traceback is occurring in the checkout page if there is no published delivery method.

To reproduce this issue:

1) Install commerce
2) Unpublish all the delivery methods from the website configuration 
3) Add some products to the cart and checkout

Error:- 
```
IndexError: tuple index out of range
```

This is because when the user unpublished all the delivery methods, 
we get an empty recordset in the delivery methods.

which leads to the above traceback from the below lines

https://github.com/odoo/odoo/blob/4cb6ac56624f038d064227ed4810b2e0ffb00980/addons/website_sale/controllers/main.py#L1054-L1057

we can resolve this issue by returning false if the delivery method is not one

sentry-5929786103
