### PR TITLE
[FIX] point_of_sale: order categories and sub-categories based on server order

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -94,14 +94,32 @@ export class ProductScreen extends Component {
             ? [...selectedCategory.child_ids]
             : this.pos.models["pos.category"].filter((category) => !category.parent_id);
     }
-    getCategoriesAndSub() {
-        return this.getAncestorsAndCurrent()
-            .flatMap((category) => this.getChildCategoriesInfo(category))
-            .toSorted((a, b) => a.id - b.id);
+
+    getCategoriesList(list, allParents, depth) {
+        return list.map((category) => {
+            if (category.id === allParents[depth]?.id && category.child_ids?.length) {
+                return [
+                    category,
+                    this.getCategoriesList(category.child_ids, allParents, depth + 1),
+                ];
+            }
+            return category;
+        });
     }
 
-    getChildCategoriesInfo(selectedCategory) {
-        return this.getChildCategories(selectedCategory).map((category) => ({
+    getCategoriesAndSub() {
+        const rootCategories = this.pos.models["pos.category"].filter(
+            (category) => !category.parent_id
+        );
+        const selected = this.pos.selectedCategory ? [this.pos.selectedCategory] : [];
+        const allParents = selected.concat(this.pos.selectedCategory?.allParents || []).reverse();
+        return this.getCategoriesList(rootCategories, allParents, 0)
+            .flat(Infinity)
+            .map(this.getChildCategoriesInfo, this);
+    }
+
+    getChildCategoriesInfo(category) {
+        return {
             ...pick(category, "id", "name", "color"),
             imgSrc:
                 this.pos.config.show_category_images && category.has_image
@@ -109,7 +127,7 @@ export class ProductScreen extends Component {
                     : undefined,
             isSelected: this.getAncestorsAndCurrent().includes(category),
             isChildren: this.getChildCategories(this.pos.selectedCategory).includes(category),
-        }));
+        };
     }
 
     getNumpadButtons() {

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -348,3 +348,34 @@ registry.category("web_tour.tours").add("PosPopupPriceAndQuantity", {
             },
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("PosCategoriesOrder", {
+    test: true,
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            {
+                trigger: '.category-button:eq(0) > span:contains("AAA")',
+            },
+            {
+                trigger: '.category-button:eq(1) > span:contains("AAB")',
+            },
+            {
+                trigger: '.category-button:eq(2) > span:contains("AAC")',
+            },
+            {
+                trigger: '.category-button:eq(1) > span:contains("AAB")',
+                run: "click",
+            },
+            {
+                trigger: '.category-button:eq(2) > span:contains("AAX")',
+            },
+            {
+                trigger: '.category-button:eq(2) > span:contains("AAX")',
+                run: "click",
+            },
+            {
+                trigger: '.category-button:eq(3) > span:contains("AAY")',
+            },
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1523,6 +1523,31 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_admin).open_ui()
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PosPopupPriceAndQuantity', login="pos_admin")
 
+    def test_product_categories_order(self):
+        """ Verify that the order of categories doesnt change in the frontend """
+        self.env['pos.category'].create({
+            'name': 'AAA',
+            'parent_id': False,
+        })
+        self.env['pos.category'].create({
+            'name': 'AAC',
+            'parent_id': False,
+        })
+        parentA = self.env['pos.category'].create({
+            'name': 'AAB',
+            'parent_id': False,
+        })
+        parentB = self.env['pos.category'].create({
+            'name': 'AAX',
+            'parent_id': parentA.id,
+        })
+        self.env['pos.category'].create({
+            'name': 'AAY',
+            'parent_id': parentB.id,
+        })
+        self.main_pos_config.with_user(self.pos_admin).open_ui()
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PosCategoriesOrder', login="pos_admin")
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
Problem:
When sub-categories are sorted by ID in the PoS app, the order from the server is lost, which disrupts the intended category hierarchy. The expected behavior is that sub-categories appear immediately next to their parent, while preserving the server-defined order for all child categories.

Steps to reproduce:
- Create PoS categories with multiple levels of sub-categories.
- Sort them in the backend list.
- The same order should be preserved in the PoS app.

opw-4212470

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
