### PR TITLE
[FIX] website_sale: ensure delivery page is displayed in checkout

### DIFF
--- a/addons/website_sale/static/tests/tours/website_sale_buy.js
+++ b/addons/website_sale/static/tests/tours/website_sale_buy.js
@@ -20,6 +20,7 @@ registry.category("web_tour.tours").add('shop_buy_product', {
         },
         tourUtils.goToCart(),
         tourUtils.goToCheckout(),
+        tourUtils.confirmOrder(),
         ...tourUtils.payWithTransfer(true),
     ]
 });

--- a/addons/website_sale/static/tests/tours/website_sale_update_address.js
+++ b/addons/website_sale/static/tests/tours/website_sale_update_address.js
@@ -10,6 +10,7 @@ registry.category("web_tour.tours").add('update_billing_shipping_address', {
         ...tourUtils.addToCart({productName: "Office Chair Black TEST"}),
         tourUtils.goToCart({quantity: 1}),
         tourUtils.goToCheckout(),
+        tourUtils.confirmOrder(),
         {
             content: "Edit Address",
             trigger: '#shipping_and_billing a:contains("Edit")',


### PR DESCRIPTION
Version: saas-17.4

Issue:
When only one delivery method is available, the checkout process skips the delivery page and redirects directly to payment, which confuses users.

Fix:
Removed the redundant `can_skip_delivery_step` logic.
- Updated `shop_checkout` to always go through the delivery step if the
 order has deliverable products.
- Now checking `order_sudo._has_deliverable_products()` to determine
 if delivery selection is needed.
- Orders with non-deliverable products skip the delivery step and go directly
 to payment.

The delivery page will now be displayed regardless of the number of delivery methods, improving user experience by allowing them to review their delivery details before payment.