### PR TITLE
Misc fixes

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -186,7 +186,7 @@
                                         <table class="o_total_table table table-borderless avoid-page-break-inside">
 
                                             <!-- Tax totals summary (invoice currency) -->
-                                            <t t-if="tax_totals" t-call="account.document_tax_totals">
+                                            <t t-if="o.tax_totals" t-call="account.document_tax_totals">
                                                 <t t-set="tax_totals" t-value="o.tax_totals"/>
                                                 <t t-set="currency" t-value="o.currency_id"/>
                                             </t>

--- a/addons/l10n_hu_edi/models/account_move.py
+++ b/addons/l10n_hu_edi/models/account_move.py
@@ -996,39 +996,32 @@ class AccountMove(models.Model):
             """ Replace the values of keys_to_invert by their negative. """
             dictionary.update({
                 key: -value
-                for key, value in dictionary.items() if key in keys_to_invert
-            })
-            keys_to_reformat = {f'formatted_{x}': x for x in keys_to_invert}
-            dictionary.update({
-                key: formatLang(self.env, dictionary[keys_to_reformat[key]], currency_obj=self.company_id.currency_id)
-                for key, value in dictionary.items() if key in keys_to_reformat
+                for key, value in dictionary.items()
+                if key in keys_to_invert
             })
 
         self.ensure_one()
-
         tax_totals = self.tax_totals
-        if not isinstance(tax_totals, dict):
+        if not tax_totals or self.move_type not in ('out_refund', 'in_refund'):
             return tax_totals
 
-        tax_totals['display_tax_base'] = True
+        fields_to_reverse = (
+            'base_amount_currency', 'base_amount',
+            'display_base_amount_currency', 'display_base_amount',
+            'tax_amount_currency', 'tax_amount',
+            'total_amount_currency', 'total_amount',
+            'cash_rounding_base_amount_currency', 'cash_rounding_base_amount',
+        )
 
-        if 'refund' in self.move_type:
-            invert_dict(tax_totals, ['amount_total', 'amount_untaxed', 'rounding_amount', 'amount_total_rounded'])
-
-            for subtotal in tax_totals['subtotals']:
-                invert_dict(subtotal, ['amount'])
-
-            for tax_list in tax_totals['groups_by_subtotal'].values():
-                for tax in tax_list:
-                    keys_to_invert = ['tax_group_amount', 'tax_group_base_amount', 'tax_group_amount_company_currency', 'tax_group_base_amount_company_currency']
-                    invert_dict(tax, keys_to_invert)
+        invert_dict(tax_totals, fields_to_reverse)
+        for subtotal in tax_totals['subtotals']:
+            invert_dict(subtotal, fields_to_reverse)
+            for tax_group in subtotal['tax_groups']:
+                invert_dict(tax_group, fields_to_reverse)
 
         currency_huf = self.env.ref('base.HUF')
-        currency_rate = self._l10n_hu_get_currency_rate()
-
         tax_totals['total_vat_amount_in_huf'] = sum(
-            -line.balance if self.company_id.currency_id == currency_huf else currency_huf.round(-line.amount_currency * currency_rate)
-            for line in self.line_ids.filtered(lambda l: l.tax_line_id.l10n_hu_tax_type)
+            -line.balance for line in self.line_ids.filtered(lambda l: l.tax_line_id.l10n_hu_tax_type)
         )
         tax_totals['formatted_total_vat_amount_in_huf'] = formatLang(
             self.env, tax_totals['total_vat_amount_in_huf'], currency_obj=currency_huf

--- a/addons/l10n_mx/models/template_mx.py
+++ b/addons/l10n_mx/models/template_mx.py
@@ -37,6 +37,7 @@ class AccountChartTemplate(models.AbstractModel):
                 'account_journal_early_pay_discount_loss_account_id': 'cuenta9993',
                 'account_journal_early_pay_discount_gain_account_id': 'cuenta9994',
                 'tax_cash_basis_journal_id': 'cbmx',
+                'tax_calculation_rounding_method': 'round_globally',
                 'account_sale_tax_id': 'tax12',
                 'account_purchase_tax_id': 'tax14',
             },


### PR DESCRIPTION
[FIX] account: Fix wrong condition to display tax_totals on PDF

[IMP] l10n_mx: round_globally in mexico by default
Now the round globally is fully managed, let's enforce it in Mexico.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
