### PR TITLE
[FIX] hr_work_entry_contract, hr_work_entry_holidays: split leaves by type

### DIFF
--- a/addons/hr_work_entry_holidays/tests/test_leave.py
+++ b/addons/hr_work_entry_holidays/tests/test_leave.py
@@ -199,3 +199,52 @@ class TestWorkEntryLeave(TestWorkEntryHolidaysBase):
         self.assertTrue(leave.number_of_days, 1)
         contract.state = "open"
         self.assertTrue(leave.number_of_days, 1)
+
+    def test_split_leaves_by_entry_type(self):
+        entry_type_paid, entry_type_unpaid = self.env['hr.work.entry.type'].create([
+            {'name': 'Paid leave', 'code': 'PAID', 'is_leave': True},
+            {'name': 'Unpaid leave', 'code': 'UNPAID', 'is_leave': True},
+        ])
+
+        leave_type_paid, leave_type_unpaid = self.env['hr.leave.type'].create([{
+            'name': 'Paid leave type',
+            'requires_allocation': 'no',
+            'request_unit': 'hour',
+            'work_entry_type_id': entry_type_paid.id,
+        },
+        {
+            'name': 'Unpaid leave type',
+            'requires_allocation': 'no',
+            'request_unit': 'hour',
+            'work_entry_type_id': entry_type_unpaid.id,
+        }])
+
+        leave_paid, leave_unpaid = self.env['hr.leave'].create([{
+            'name': 'Paid leave',
+            'employee_id': self.jules_emp.id,
+            'holiday_status_id': leave_type_paid.id,
+            'request_date_from': datetime(2024, 9, 10),
+            'request_date_to': datetime(2024, 9, 10),
+            'request_unit_hours': True,
+            'request_hour_from': '8',
+            'request_hour_to': '9',
+        },
+        {
+            'name': 'Unpaid leave',
+            'employee_id': self.jules_emp.id,
+            'holiday_status_id': leave_type_unpaid.id,
+            'request_date_from': datetime(2024, 9, 10),
+            'request_date_to': datetime(2024, 9, 10),
+            'request_unit_hours': True,
+            'request_hour_from': '9',
+            'request_hour_to': '10',
+        }])
+
+        (leave_paid | leave_unpaid).with_user(SUPERUSER_ID).action_validate()
+        entries = self.contract_cdi._generate_work_entries(datetime(2024, 9, 10, 0, 0, 0), datetime(2024, 9, 10, 23, 59, 59))
+        paid_leave_entry = entries.filtered_domain([('work_entry_type_id', '=', entry_type_paid.id)])
+        unpaid_leave_entry = entries.filtered_domain([('work_entry_type_id', '=', entry_type_unpaid.id)])
+
+        self.assertEqual(len(entries), 4, 'Leaves should have 1 entry per type')
+        self.assertEqual((paid_leave_entry.date_stop - paid_leave_entry.date_start).seconds, 3600)
+        self.assertEqual((unpaid_leave_entry.date_stop - unpaid_leave_entry.date_start).seconds, 3600)


### PR DESCRIPTION
Steps to reproduce:
- Download payroll and Time off
- Time Off > Configuration > Time off types
- In Paid and unpaid type, set 'Take Time Off in' to Hours

- Employees > Pick one > Time off
- Click calendar day and create 2 leaves:
-- Paid type, Custom hours from 8:00 to 9:00
-- Unpaid type, Custom hours from 9:00 o 10:00
- Time off > Management > Time off
- Approve and validate both leaves

- The employee needs to have a running contract so if needed
-- Payroll > Contracts > Contracts > New
- Payroll > Regenerate work entries for your employee
- Leaves are generated as a single block of type 'Generic time off'

The leaves are merged. The Interval class sorts its entries' boundaries in
such a way that it will see the start of an entry before the stop of the
previous one if the start/stop time are the same. Its counterpart
WorkIntervals does not merge overlapping entries.

i.e with entries 8:00-9:00 and 9:00-10:00 Intervals will interpret as:
8:00 start, 9:00 start, 9:00 stop, 10:00 stop => Merged entries.
And WorkIntervals as:
8:00 start, 9:00 stop, 9:00 start, 10:00 stop => No merged entries.

This happens regardless of the content of the merged resources, in this
case two different types of leaves which should not be treated the same
by nature (Paid/Unpaid).

When going though the leaves, we currently loop over the associated work
intervals, this is part of the reason several leaves are processed as a
single interval. The only reason we need the attendance interval is
because some work entry types can take precedence over leaves (For
instance a long term medical disability must supercede a public
holiday).

In the interest of avoiding a change in the return type of the method
'_get_interval_leave_work_entry_type' we instead rebuild the intervals
with the bounds of the leave and the work entry type of the attendance.

opw-4193334

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
