### PR TITLE
[FIX] pos_sale: fix order line date formatting for non english

### DIFF
--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
-from odoo.tools import float_compare, float_is_zero
+from odoo.tools import float_compare, float_is_zero, format_date
 
 
 class PosOrder(models.Model):
@@ -60,7 +60,11 @@ class PosOrder(models.Model):
                         self.env['sale.advance.payment.inv']._prepare_down_payment_section_values(sale_order_origin)
                     )
                 order_reference = line.name
-                sale_order_line_description = _("Down payment (ref: %(order_reference)s on \n %(date)s)", order_reference=order_reference, date=line.order_id.date_order.strftime('%m-%d-%y'))
+
+                if order.partner_id.lang and order.partner_id.lang != line.env.lang:
+                    line = line.with_context(lang=order.partner_id.lang)
+
+                sale_order_line_description = _("Down payment (ref: %(order_reference)s on \n %(date)s)", order_reference=order_reference, date=format_date(line.env, line.order_id.date_order))
                 sale_line = self.env['sale.order.line'].create({
                     'order_id': sale_order_origin.id,
                     'product_id': line.product_id.id,

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -6,6 +6,7 @@ import odoo
 from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
 from odoo.tests import Form
 from odoo import fields
+from odoo.tools import format_date
 
 @odoo.tests.tagged('post_install', '-at_install')
 class TestPoSSale(TestPointOfSaleHttpCommon):
@@ -694,6 +695,10 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.assertEqual(invoice_pdf_content.count('Product A'), 1)
         self.assertEqual(invoice_pdf_content.count('Product B'), 1)
         self.assertEqual(invoice_pdf_content.count('Product C'), 1)
+
+        for order_line in sale_order.order_line.filtered(lambda l: l.product_id == self.downpayment_product):
+            order_line = order_line.with_context(lang=partner_test.lang)
+            self.assertIn(format_date(order_line.env, order_line.order_id.date_order), order_line.name)
 
     def test_settle_so_with_pos_downpayment(self):
         so = self.env['sale.order'].create({


### PR DESCRIPTION
The date was always formatted as `'%m-%d-%y'` which creates confusion for some users. Now we use `format_date` which takes into consideration the language of the user yielding the expected date format.

Current behavior before PR:
In the quotation page, a downpayment's date is formatted mm/dd/yyyy when the client has the language es_ES.

Desired behavior after PR is merged:
The downpayment's date should be formatted dd/mm/yyyy following the standard date formatting in Spanish (assuming that the client's language is Spanish)

opw-4197849
