### PR TITLE
[FIX] account: Fix rounding when currency rounding has been edited

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1654,8 +1654,12 @@ class AccountTax(models.Model):
                     continue
 
                 amount_to_distribute = total_error / nb_of_errors
-                for tax_rep in sorted_tax_reps_data[:nb_of_errors]:
+                index = 0
+                while nb_of_errors:
+                    tax_rep = sorted_tax_reps_data[index]
                     tax_rep[field] += amount_to_distribute
+                    nb_of_errors -= 1
+                    index = (index + 1) % len(sorted_tax_reps_data)
 
         subsequent_taxes = self.env['account.tax']
         subsequent_tags = self.env['account.account.tag']

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1069,11 +1069,6 @@ class AccountTax(models.Model):
                 continue
 
             total_tax_amount = sum(taxes_data[other_tax.id]['tax_amount'] for other_tax in taxes_data[tax.id]['batch'])
-            total_tax_amount += sum(
-                reverse_charge_taxes_data[other_tax.id]['tax_amount']
-                for other_tax in taxes_data[tax.id]['batch']
-                if other_tax.has_negative_factor
-            )
             base = raw_base + taxes_data[tax.id]['extra_base_for_base']
             if taxes_data[tax.id]['price_include'] and special_mode in (False, 'total_included'):
                 base -= total_tax_amount

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -337,14 +337,10 @@ export const accountTaxHelpers = {
                 continue;
             }
 
-            let total_tax_amount = taxes_data[tax.id].batch.reduce(
+            const total_tax_amount = taxes_data[tax.id].batch.reduce(
                 (sum, other_tax) => sum + taxes_data[other_tax.id].tax_amount,
                 0
             );
-            total_tax_amount += Object.values(taxes_data[tax.id].batch)
-                .filter(other_tax => other_tax.has_negative_factor)
-                .reduce((sum, other_tax) => sum + reverse_charge_taxes_data[other_tax.id].tax_amount, 0);
-
             let base = raw_base + taxes_data[tax.id].extra_base_for_base;
             if (
                 taxes_data[tax.id].price_include &&

--- a/addons/account/tests/test_invoice_taxes.py
+++ b/addons/account/tests/test_invoice_taxes.py
@@ -651,7 +651,7 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
 
         self.assertRecordValues(invoice.line_ids.filtered('tax_line_id'), [{
             'tax_base_amount': 48098.24,    # 20000 * 2.82 / 1.1726
-            'credit': 10100.64,             # tax_base_amount * 0.21
+            'credit': 10100.63,             # tax_base_amount * 0.21
         }])
 
     def test_ensure_no_unbalanced_entry(self):

--- a/addons/account/tests/test_taxes_tax_totals_summary.py
+++ b/addons/account/tests/test_taxes_tax_totals_summary.py
@@ -2021,20 +2021,20 @@ class TestTaxesTaxTotalsSummary(TestTaxCommon):
         expected_values = {
             'same_tax_base': True,
             'currency_id': self.currency.id,
-            'base_amount_currency': 121.0,
+            'base_amount_currency': 100.0,
             'tax_amount_currency': 0.0,
-            'total_amount_currency': 121.0,
+            'total_amount_currency': 100.0,
             'subtotals': [
                 {
                     'name': "Untaxed Amount",
-                    'base_amount_currency': 121.0,
+                    'base_amount_currency': 100.0,
                     'tax_amount_currency': 0.0,
                     'tax_groups': [
                         {
                             'id': self.tax_groups[0].id,
-                            'base_amount_currency': 121.0,
+                            'base_amount_currency': 100.0,
                             'tax_amount_currency': 0.0,
-                            'display_base_amount_currency': 121.0,
+                            'display_base_amount_currency': 100.0,
                         },
                     ],
                 },
@@ -2044,8 +2044,8 @@ class TestTaxesTaxTotalsSummary(TestTaxCommon):
         invoice = self.convert_document_to_invoice(document)
         self.assert_invoice_tax_totals_summary(invoice, expected_values)
         self.assertRecordValues(invoice.invoice_line_ids, [{
-            'price_subtotal': 121.0,
-            'price_total': 121.0,
+            'price_subtotal': 100.0,
+            'price_total': 100.0,
         }])
         self._run_js_tests()
 
@@ -2106,20 +2106,20 @@ class TestTaxesTaxTotalsSummary(TestTaxCommon):
         expected_values = {
             'same_tax_base': True,
             'currency_id': self.currency.id,
-            'base_amount_currency': 100.0,
+            'base_amount_currency': 79.0,
             'tax_amount_currency': 0.0,
-            'total_amount_currency': 100.0,
+            'total_amount_currency': 79.0,
             'subtotals': [
                 {
                     'name': "Untaxed Amount",
-                    'base_amount_currency': 100.0,
+                    'base_amount_currency': 79.0,
                     'tax_amount_currency': 0.0,
                     'tax_groups': [
                         {
                             'id': self.tax_groups[0].id,
-                            'base_amount_currency': 100.0,
+                            'base_amount_currency': 79.0,
                             'tax_amount_currency': 0.0,
-                            'display_base_amount_currency': 100.0,
+                            'display_base_amount_currency': 79.0,
                         },
                     ],
                 },
@@ -2129,8 +2129,8 @@ class TestTaxesTaxTotalsSummary(TestTaxCommon):
         invoice = self.convert_document_to_invoice(document)
         self.assert_invoice_tax_totals_summary(invoice, expected_values)
         self.assertRecordValues(invoice.invoice_line_ids, [{
-            'price_subtotal': 100.0,
-            'price_total': 100.0,
+            'price_subtotal': 79.0,
+            'price_total': 79.0,
         }])
         self._run_js_tests()
 


### PR DESCRIPTION
The test was computing:
20000 * 2.82 / 1.1726 = 48098.24
48098.24 * 0.21 ~= 10100.63
When splitting to tax repartition lines, we get 10100.65 because of the rounding set on the currency.
The error is computed as 10100.63 - 10100.65 = -0.02 so 2 x -0.01 to distribute. Before this commit, we had the time to fix only one rounding error so: 10100.65 - 0.01 = 10100.64

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
