### PR TITLE
[FIX] base: attachment write should raise errors

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -116,7 +116,7 @@ class IrAttachment(models.Model):
         try:
             with open(full_path, 'rb') as f:
                 return f.read()
-        except (IOError, OSError):
+        except OSError:
             _logger.info("_read_file reading %s", full_path, exc_info=True)
         return b''
 
@@ -130,8 +130,9 @@ class IrAttachment(models.Model):
                     fp.write(bin_value)
                 # add fname to checklist, in case the transaction aborts
                 self._mark_for_gc(fname)
-            except IOError:
-                _logger.info("_file_write writing %s", full_path, exc_info=True)
+            except OSError:
+                _logger.info("_file_write writing %s", full_path)
+                raise
         return fname
 
     @api.model

--- a/odoo/addons/base/tests/test_ir_attachment.py
+++ b/odoo/addons/base/tests/test_ir_attachment.py
@@ -9,6 +9,7 @@ from PIL import Image
 
 import odoo
 from odoo.exceptions import AccessError
+from odoo.addons.base.models.ir_attachment import IrAttachment
 from odoo.addons.base.tests.common import TransactionCaseWithUserDemo
 from odoo.tools.image import image_to_base64
 
@@ -376,3 +377,10 @@ class TestPermissions(TransactionCaseWithUserDemo):
         # even from a record with write permissions
         with self.assertRaises(AccessError):
             copied.copy({'res_model': unwritable._name, 'res_id': unwritable.id})
+
+    def test_write_error(self):
+        # try to write a file in a place where we have no access
+        # /proc is not writeable, check if we have an error raised
+        self.patch(IrAttachment, '_get_path', lambda self, binary, _checksum: (binary, '/proc/dummy_test'))
+        with self.assertRaises(OSError):
+            self.env['ir.attachment']._file_write(b'test', 'test')


### PR DESCRIPTION
When writing files, errors should not be masked. We may commit a transaction as if everything went well, even when we get write errors. This may lead to data loss.

An example is calling `_migrate` on a non-writable partition or a full partition. We want it to fail instaed of ignoring the writes and committing.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
