### PR TITLE
[FIX] analytic: remove view button to use the one from the list view

### DIFF
--- a/addons/analytic/models/analytic_distribution_model.py
+++ b/addons/analytic/models/analytic_distribution_model.py
@@ -92,14 +92,3 @@ class AccountAnalyticDistributionModel(models.Model):
             return [(fname, 'in', value)]
         else:
             return [(fname, 'in', [value, False])]
-
-    def action_read_distribution_model(self):
-        self.ensure_one()
-        return {
-            'name': self.display_name,
-            'type': 'ir.actions.act_window',
-            'view_type': 'form',
-            'view_mode': 'form',
-            'res_model': 'account.analytic.distribution.model',
-            'res_id': self.id,
-        }

--- a/addons/analytic/views/analytic_distribution_model_views.xml
+++ b/addons/analytic/views/analytic_distribution_model_views.xml
@@ -4,7 +4,7 @@
         <field name="name">account.analytic.distribution.model.list</field>
         <field name="model">account.analytic.distribution.model</field>
         <field name="arch" type="xml">
-            <list string="Analytic Distribution Model" editable="top" multi_edit="1" default_order="sequence, id desc">
+            <list string="Analytic Distribution Model" open_form_view="True" editable="top" multi_edit="1" default_order="sequence, id desc">
                 <field name="sequence" widget="handle"/>
                 <field name="partner_id" optional="show"/>
                 <field name="partner_category_id" optional="hide"/>
@@ -12,7 +12,6 @@
                 <field name="company_id" groups="base.group_multi_company" optional="show"/>
                 <field name="analytic_distribution" widget="analytic_distribution" optional="show"
                        options="{'force_applicability': 'optional', 'disable_save': true}"/>
-                <button name="action_read_distribution_model" type="object" string="View" class="float-end btn-secondary"/>
             </list>
         </field>
     </record>


### PR DESCRIPTION
In this commit: https://github.com/odoo/odoo/commit/43027a34a6e51901ff869beec2bba74218b29356 They added a new button to open the form view directly. If the view has an attribute open_form_view to True or being in debug mode. Since we manually added a button to do the exact same thing, let's use the button from the list view.

task: 4204366



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
