### PR TITLE
[IMP] mail: respective thread icon in suggestion list

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1181,6 +1181,10 @@ class Channel(models.Model):
             'model': "discuss.channel",
             'id': channel.id,
             'name': channel.name,
+            'parent_channel_id': {
+                'id': channel.parent_channel_id.id,
+                'model': 'discuss.channel'
+            } if channel.parent_channel_id else False,
         } for channel in channels]
 
     def _get_last_messages(self):

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -374,7 +374,9 @@ export class Composer extends Component {
                     optionTemplate: "mail.Composer.suggestionThread",
                     options: suggestions.map((suggestion) => {
                         return {
-                            label: suggestion.displayName,
+                            label: suggestion.parent_channel_id
+                                ? `${suggestion.parent_channel_id.displayName} > ${suggestion.displayName}`
+                                : suggestion.displayName,
                             thread: suggestion,
                             classList: "o-mail-Composer-suggestion",
                         };

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -150,7 +150,12 @@
 
     <t t-name="mail.Composer.suggestionThread">
         <strong class="px-2 py-1 align-self-center flex-shrink-0 text-truncate">
-            #<t t-esc="option.label"/>
+            <i t-attf-class="fa #{option.thread.parent_channel_id ? 'fa-comments-o' : 'fa-hashtag'} me-2"/>
+            <t t-if="option.thread.parent_channel_id">
+                <t t-esc="option.thread.parent_channel_id.displayName"/>
+                <i class="oi oi-chevron-right o-xsmaller mx-1"/>
+            </t>
+            <t t-esc="option.thread.displayName"/>
         </strong>
     </t>
 

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -212,4 +212,8 @@
     <span t-else="" class="o-mail-Message-pendingProgress"><i class="fa fa-fw fa-circle-o-notch fa-spin opacity-50"/></span>
 </t>
 
+<t t-name="mail.Message.mentionedChannelIcon">
+    <i t-att-class="icon"/>
+</t>
+
 </templates>

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -485,9 +485,14 @@ export class Store extends BaseStore {
         { mentionedChannels = [], mentionedPartners = [], specialMentions = [] } = {}
     ) {
         const validMentions = {};
-        validMentions.threads = mentionedChannels.filter((thread) =>
-            body.includes(`#${thread.displayName}`)
-        );
+        validMentions.threads = mentionedChannels.filter((thread) => {
+            if (thread.parent_channel_id) {
+                return body.includes(
+                    `#${thread.parent_channel_id.displayName} > ${thread.displayName}`
+                );
+            }
+            return body.includes(`#${thread.displayName}`);
+        });
         validMentions.partners = mentionedPartners.filter((partner) =>
             body.includes(`@${partner.name}`)
         );

--- a/addons/mail/static/src/core/web_portal/message_patch.js
+++ b/addons/mail/static/src/core/web_portal/message_patch.js
@@ -18,6 +18,7 @@ patch(Message.prototype, {
      * @param {HTMLElement} bodyEl
      */
     prepareMessageBody(bodyEl) {
+        super.prepareMessageBody(...arguments);
         Array.from(bodyEl.querySelectorAll(".o-mail-read-more-less")).forEach((el) => el.remove());
         this.insertReadMoreLess(bodyEl);
     },

--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -179,9 +179,16 @@ function generateMentionsLinks(body, { partners = [], threads = [], specialMenti
     }
     for (const thread of threads) {
         const placeholder = `#-mention-channel-${thread.id}`;
-        const text = `#${escape(thread.displayName)}`;
+        let className, text;
+        if (thread.parent_channel_id) {
+            className = "o_channel_redirect o_channel_redirect_asThread";
+            text = escape(`#${thread.parent_channel_id.displayName} > ${thread.displayName}`);
+        } else {
+            className = "o_channel_redirect";
+            text = escape(`#${thread.displayName}`);
+        }
         mentions.push({
-            class: "o_channel_redirect",
+            class: className,
             id: thread.id,
             model: "discuss.channel",
             placeholder,

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -395,13 +395,13 @@ test("composer suggestion should match with input selection", async () => {
     await openDiscuss(channelId);
     await contains(".o-mail-Composer-input", { value: "" });
     await insertText(".o-mail-Composer-input", "#");
-    await contains(".o-mail-Composer-suggestion", { text: "#Mario Party" });
+    await contains(".o-mail-Composer-suggestion", { text: "Mario Party" });
     await click(".o-mail-Composer-suggestion");
     await contains(".o-mail-Composer-input", { value: "#Mario Party " });
     await insertText(".o-mail-Composer-input", "@");
     await contains(".o-mail-Composer-suggestion", { text: "Luigi" });
     $(".o-mail-Composer-input")[0].setSelectionRange(3, 3);
-    await contains(".o-mail-Composer-suggestion", { text: "#Mario Party" });
+    await contains(".o-mail-Composer-suggestion", { text: "Mario Party" });
     const textarea = $(".o-mail-Composer-input")[0];
     textarea.setSelectionRange(textarea.value.length, textarea.value.length);
     await contains(".o-mail-Composer-suggestion", { text: "Luigi" });

--- a/addons/mail/static/tests/message/link_preview.test.js
+++ b/addons/mail/static/tests/message/link_preview.test.js
@@ -392,9 +392,9 @@ test("link preview request is only made when message contains URL", async () => 
     });
     await assertSteps([]);
     await insertText(".o-mail-Composer-input", "#");
-    await click(".o-mail-NavigableList-item", { text: "#Sales" });
+    await click(".o-mail-NavigableList-item", { text: "Sales" });
     await click("button[aria-label='Send']:enabled");
-    await contains(".o-mail-Message", { text: "#Sales" });
+    await contains(".o-mail-Message", { text: "Sales" });
     await assertSteps([]);
     await insertText(".o-mail-Composer-input", "https://www.odoo.com");
     await click("button[aria-label='Send']:enabled");

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -98,16 +98,16 @@ test("Editing message keeps the mentioned channels", async () => {
     await start();
     await openDiscuss(channelId1);
     await insertText(".o-mail-Composer-input", "#");
-    await click(".o-mail-Composer-suggestion strong", { text: "#other" });
+    await click(".o-mail-Composer-suggestion strong", { text: "other" });
     await click(".o-mail-Composer-send:enabled");
-    await contains(".o_channel_redirect", { count: 1, text: "#other" });
+    await contains(".o_channel_redirect", { count: 1, text: "other" });
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message-moreMenu [title='Edit']");
     await contains(".o-mail-Message .o-mail-Composer-input", { value: "#other" });
     await insertText(".o-mail-Message .o-mail-Composer-input", "#other bye", { replace: true });
     await click(".o-mail-Message a", { text: "save" });
-    await contains(".o-mail-Message-content", { text: "#other bye (edited)" });
-    await click(".o_channel_redirect", { text: "#other" });
+    await contains(".o-mail-Message-content", { text: "other bye (edited)" });
+    await click(".o_channel_redirect", { text: "other" });
     await contains(".o-mail-Discuss-threadName", { value: "other" });
 });
 
@@ -1471,7 +1471,7 @@ test("Channel should be opened after clicking on its mention", async () => {
     await openFormView("res.partner", partnerId);
     await click("button", { text: "Send message" });
     await insertText(".o-mail-Composer-input", "#");
-    await click(".o-mail-Composer-suggestion strong", { text: "#my-channel" });
+    await click(".o-mail-Composer-suggestion strong", { text: "my-channel" });
     await click(".o-mail-Composer-send:enabled");
     await click(".o_channel_redirect");
     await contains(".o-mail-ChatWindow .o-mail-Thread");

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -752,6 +752,7 @@ export class DiscussChannel extends models.ServerModel {
                 })
                 .map((channel) => {
                     // expected format
+                    const parentChannel = this.browse(channel.parent_channel_id);
                     return {
                         authorizedGroupFullName: channel.group_public_id
                             ? channel.group_public_id.name
@@ -760,6 +761,9 @@ export class DiscussChannel extends models.ServerModel {
                         id: channel.id,
                         model: "discuss.channel",
                         name: channel.name,
+                        parent_channel_id: parentChannel.length
+                            ? { id: parentChannel[0].id, model: "discuss.channel" }
+                            : false,
                     };
                 });
             // reduce results to max limit

--- a/addons/mail/static/tests/thread/thread.test.js
+++ b/addons/mail/static/tests/thread/thread.test.js
@@ -266,7 +266,7 @@ test("mention a channel with space in the name", async () => {
     await click(".o-mail-Composer-suggestion");
     await contains(".o-mail-Composer-input", { value: "#General good boy " });
     await click(".o-mail-Composer-send:enabled");
-    await contains(".o-mail-Message-body .o_channel_redirect", { text: "#General good boy" });
+    await contains(".o-mail-Message-body .o_channel_redirect", { text: "General good boy" });
 });
 
 test('mention a channel with "&" in the name', async () => {
@@ -278,7 +278,7 @@ test('mention a channel with "&" in the name', async () => {
     await click(".o-mail-Composer-suggestion");
     await contains(".o-mail-Composer-input", { value: "#General & good " });
     await click(".o-mail-Composer-send:enabled");
-    await contains(".o-mail-Message-body .o_channel_redirect", { text: "#General & good" });
+    await contains(".o-mail-Message-body .o_channel_redirect", { text: "General & good" });
 });
 
 test("mark channel as fetched when a new message is loaded", async () => {
@@ -571,7 +571,7 @@ test("mention a channel on a second line when the first line contains #", async 
     await click(".o-mail-Composer-suggestion");
     await contains(".o-mail-Composer-input", { value: "#blabla\n#General good " });
     await click(".o-mail-Composer-send:enabled");
-    await contains(".o-mail-Message-body .o_channel_redirect", { text: "#General good" });
+    await contains(".o-mail-Message-body .o_channel_redirect", { text: "General good" });
 });
 
 test("mention a channel when replacing the space after the mention by another char", async () => {
@@ -586,7 +586,7 @@ test("mention a channel when replacing the space after the mention by another ch
     $(".o-mail-Composer-input").val(text.slice(0, -1));
     await insertText(".o-mail-Composer-input", ", test");
     await click(".o-mail-Composer-send:enabled");
-    await contains(".o-mail-Message-body .o_channel_redirect", { text: "#General good" });
+    await contains(".o-mail-Message-body .o_channel_redirect", { text: "General good" });
 });
 
 test("mention 2 different channels that have the same name", async () => {
@@ -613,11 +613,11 @@ test("mention 2 different channels that have the same name", async () => {
     await click(".o-mail-Composer-send:enabled");
     await contains(
         `.o-mail-Message-body .o_channel_redirect[data-oe-id="${channelId_1}"][data-oe-model="discuss.channel"]`,
-        { text: "#my channel" }
+        { text: "my channel" }
     );
     await contains(
         `.o-mail-Message-body .o_channel_redirect[data-oe-id="${channelId_2}"][data-oe-model="discuss.channel"]`,
-        { text: "#my channel" }
+        { text: "my channel" }
     );
 });
 


### PR DESCRIPTION
**Current behavior before PR:**

Channels and threads shared the same icon in the suggestion list and mentioned messages, making it difficult to visually differentiate between them.

**Desired behavior after PR is merged:**

This PR aims to display separate icons for threads and channels in the suggestion list and mentioned messages, improving clarity and  differentiation between the two.

Backport of #181742 

Task-4203558


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
