### PR TITLE
[FIX] website_sale, website: fix products carousel layout issues

### DIFF
--- a/addons/website/static/src/snippets/s_dynamic_snippet_carousel/000.xml
+++ b/addons/website/static/src/snippets/s_dynamic_snippet_carousel/000.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="website.s_dynamic_snippet.carousel.arrows">
-        <a t-attf-href="##{unique_id}" class="carousel-control-prev position-absolute w-auto" data-bs-slide="prev" role="button" aria-label="Previous" title="Previous">
-            <span class="oi oi-chevron-left ms-n4 rounded-pill p-3 bg-700"/>
+        <a t-attf-href="##{unique_id}" class="carousel-control-prev position-md-absolute w-auto" data-bs-slide="prev" role="button" aria-label="Previous" title="Previous">
+            <span class="oi oi-chevron-left ms-md-n4 rounded-pill p-3 bg-700"/>
             <span class="visually-hidden">Previous</span>
         </a>
-        <a t-attf-href="##{unique_id}" class="carousel-control-next position-absolute w-auto" data-bs-slide="next" role="button" aria-label="Next" title="Next">
-            <span class="oi oi-chevron-right me-n4 rounded-pill p-3 bg-700"/>
+        <a t-attf-href="##{unique_id}" class="carousel-control-next position-md-absolute w-auto" data-bs-slide="next" role="button" aria-label="Next" title="Next">
+            <span class="oi oi-chevron-right me-md-n4 rounded-pill p-3 bg-700"/>
             <span class="visually-hidden">Next</span>
         </a>
     </t>
@@ -15,7 +15,7 @@
             <!-- Content -->
             <t t-set="rowSize" t-value="chunkSize" />
             <t t-set="slideSize" t-value="rowSize * rowPerSlide" />
-            <t t-set="colClass" t-value="'d-flex flex-grow-0 flex-shrink-0 col-12 col-lg-' + Math.trunc(12 / rowSize).toString()"/>
+            <t t-set="colClass" t-value="'d-flex flex-grow-0 flex-shrink-0 col-' + Math.trunc(12 / rowSize).toString()"/>
             <t t-set="slideIndexGenerator" t-value="Array.from(Array(Math.ceil(data.length/slideSize)).keys())"/>
             <t t-set="rowIndexGenerator" t-value="Array.from(Array(rowPerSlide).keys())"/>
             <t t-set="colIndexGenerator" t-value="Array.from(Array(rowSize).keys())"/>
@@ -44,7 +44,7 @@
             <!-- Controls -->
             <t t-if='slideIndexGenerator.length > 1'>
                 <t t-if="arrowPosition === 'bottom'">
-                    <div class="s_dynamic_snippet_arrow_bottom pt-2 d-flex justify-content-center">
+                    <div class="s_dynamic_snippet_arrow_bottom px-3 px-md-0 pt-2 d-flex justify-content-between">
                         <t t-call="website.s_dynamic_snippet.carousel.arrows">
                             <t t-set="unique_id" t-value="unique_id" />
                         </t>

--- a/addons/website_sale/data/product_snippet_template_data.xml
+++ b/addons/website_sale/data/product_snippet_template_data.xml
@@ -141,7 +141,7 @@
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
                     <input type="hidden" name="product-id" t-att-data-product-id="record.id"/>
                     <a class="o_carousel_product_img_link position-absolute mx-auto" t-att-href="record.website_url">
-                        <img class="card-img-top" loading="lazy" t-att-src="data['image_512']" t-att-alt="record.display_name"/>
+                        <img class="card-img-top rounded-0" loading="lazy" t-att-src="data['image_512']" t-att-alt="record.display_name"/>
                     </a>
                     <div class="o_carousel_product_card_body card-body d-flex flex-column justify-content-between">
                         <div class="card-title h5 text-center" t-field="record.display_name"/>

--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.scss
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.scss
@@ -6,6 +6,10 @@
         overflow: visible;
         margin-top: 6rem;
         padding-top: 6rem;
+
+        img {
+            height: 12rem;
+        }
     }
 
     .o_carousel_product_img_link {


### PR DESCRIPTION
This commit fixes two layout issues:

1. In the dynamic products snippet: using the layout "centered", the
image was overlapping the text of the card due to having no height set
for the image.

2. On the dynamic carousel snippet: on mobile, a scrollbar was
appearing because of the arrow buttons.

task-4215589

| | Before | After |
|--------|--------|--------|
| Image issue | ![Screenshot 2024-10-01 at 10 26 08](https://github.com/user-attachments/assets/c61c2d8f-063e-4dbe-a0bc-07fc82e720b3) | <img width="1394" alt="Capture d’écran 2024-10-08 à 09 01 46" src="https://github.com/user-attachments/assets/ba710372-dd08-4854-8cfd-c8c999197dca"> |
| Scroll issue | ![Screenshot 2024-10-01 at 10 27 51](https://github.com/user-attachments/assets/547928c3-1e0e-4eaa-89d0-52bcb2da67a0) | <img width="447" alt="Capture d’écran 2024-10-08 à 09 02 25" src="https://github.com/user-attachments/assets/415aa9f3-94fd-45e1-9743-ad1ac0a3a205"> | 

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
