### PR TITLE
[FIX] portal: portal users can't create api keys

### DIFF
--- a/addons/portal/static/src/js/components/input_confirmation_dialog/input_confirmation_dialog.js
+++ b/addons/portal/static/src/js/components/input_confirmation_dialog/input_confirmation_dialog.js
@@ -6,7 +6,7 @@ import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_d
 export class InputConfirmationDialog extends ConfirmationDialog {
     static props = {
         ...ConfirmationDialog.props,
-        onInput: Function,
+        onInput: { type: Function, optional: true },
     };
     static template = "portal.InputConfirmationDialog";
 


### PR DESCRIPTION
This issue occurs only in frontend debug (which I initially missed but odony caught), the problem is that the `InputConfirmationDialog` used for the creation dialog has a required `onInput` callback in its props but none is provided by the "new api key" button case. Props are (I assume) only validated in debug mode, so that's the only situation in which the error appears... and blocks users.

While `onInput` seems like a useful hooks for input validation and stuff, it doesn't seem necessary to mandate it, and the code specifically checks if it's unchecked (and ignores it in that case).

OPW-4194305
