### PR TITLE
[FIX] snailmail: use right format for snailmail letter for germany

### DIFF
--- a/addons/snailmail/models/res_partner.py
+++ b/addons/snailmail/models/res_partner.py
@@ -38,6 +38,12 @@ class ResPartner(models.Model):
     @api.model
     def _get_address_format(self):
         # When sending a letter, the fields 'street' and 'street2' should be on a single line to fit in the address area
+        if self.env.context.get('snailmail_layout') and self.country_id.code == 'DE':
+            # Germany requires specific address formatting for Pingen
+            result = "%(street)s"
+            if self.street2:
+                result += " // %(street2)s"
+            return result + "\n%(zip)s %(city)s\n%(country_name)s"
         if self.env.context.get('snailmail_layout') and self.street2:
             return "%(street)s, %(street2)s\n%(city)s %(state_code)s %(zip)s\n%(country_name)s"
 

--- a/addons/snailmail/models/snailmail_letter.py
+++ b/addons/snailmail/models/snailmail_letter.py
@@ -455,9 +455,18 @@ class SnailmailLetter(models.Model):
         required_keys = ['street', 'city', 'zip', 'country_id']
         return all(record[key] for key in required_keys)
 
+    def _get_cover_address_split(self):
+        address_split = self.partner_id.with_context(show_address=True, lang='en_US').display_name.split('\n')
+        if self.country_id.code == 'DE':
+            # Germany requires specific address formatting for Pingen
+            if self.street2:
+                address_split[1] = f'{self.street} // {self.street2}'
+            address_split[2] = f'{self.zip} {self.city}'
+        return address_split
+
     def _append_cover_page(self, invoice_bin: bytes):
         out_writer = PdfFileWriter()
-        address_split = self.partner_id.with_context(show_address=True, lang='en_US').display_name.split('\n')
+        address_split = self._get_cover_address_split()
         address_split[0] = self.partner_id.name or self.partner_id.parent_id and self.partner_id.parent_id.name or address_split[0]
         address = '<br/>'.join(address_split)
         address_x = 118 * mm


### PR DESCRIPTION
Steps to reproduce:
- Install `snailmail_account` and `contacts`
- Add a company as a contact, this company should be a german one
  add address and street 2
- Create an invoice for that contact
- Confirm invoice
- Send invoice using post only
- With debug mode go to snailmail letters
- Click on send
- Check pdf document

Issue:
The format is not respected, for german letter we should have a '//' preceeding the supplementary notes, as such pingen flag the document as invalid.

https://help.pingen.com/en/faq-post/adressanforderungen-deutsche-post

opw-4160129