### PR TITLE
[IMP] l10n_de: Indicate in manifest that audit trail is enabled

### DIFF
--- a/addons/l10n_de/__manifest__.py
+++ b/addons/l10n_de/__manifest__.py
@@ -14,6 +14,7 @@ Dieses  Modul beinhaltet einen deutschen Kontenrahmen basierend auf dem SKR03 od
 =========================================================================================
 
 German accounting chart and localization.
+By default, the audit trail is enabled for GoBD compliance.
     """,
     'depends': [
         'base_iban',

--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -2770,6 +2770,7 @@ msgid ""
 "=========================================================================================\n"
 "\n"
 "German accounting chart and localization.\n"
+"By default, the audit trail is enabled for GoBD compliance.\n"
 msgstr ""
 
 #. module: base


### PR DESCRIPTION
In #167973 (merged in 17.0+), we enabled the audit trail by default when loading the German localization.

TSB requested that we indicate this explicitly in the manifest.

task-none