### PR TITLE
[IMP] pos_*: allow the use of loyalty points without ordelines

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.js
@@ -13,6 +13,7 @@ export class ActionpadWidget extends Component {
         actionName: String,
         actionToTrigger: Function,
         showActionButton: { type: Boolean, optional: true },
+        validToPay: Boolean,
     };
     static defaultProps = {
         showActionButton: true,

--- a/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.xml
@@ -13,6 +13,7 @@
             <div t-if="props.showActionButton" class="validation d-flex gap-2">
                 <BackButton t-if="pos.showBackButton()" onClick="() => pos.onClickBackButton()"/>
                 <button class="pay pay-order-button button btn btn-primary btn-lg py-3 d-flex align-items-center justify-content-center flex-fill"
+                    t-att-class="{ 'disabled' : !props.validToPay }"
                     t-on-click="props.actionToTrigger"
                     t-esc="props.actionName"
                 />

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -455,6 +455,10 @@ export class ProductScreen extends Component {
         const info = await reactive(this.pos).getProductInfo(productTemplate, 1);
         this.dialog.add(ProductInfoPopup, { info: info, productTemplate: productTemplate });
     }
+
+    isValidToPay() {
+        return true;
+    }
 }
 
 registry.category("pos_screens").add("ProductScreen", ProductScreen);

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
@@ -17,6 +17,7 @@
                             actionName.translate="Payment"
                             actionToTrigger="() => pos.pay()"
                             showActionButton="!currentOrder?.is_empty()"
+                            validToPay="isValidToPay()"
                         />
                     </div>
                 </div>

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -169,6 +169,7 @@
                                         partner="getSelectedOrder()?.get_partner()"
                                         actionName.translate="Refund"
                                         actionToTrigger.bind="onDoRefund"
+                                        validToPay="true"
                                     />
                                 </div>
                             </t>

--- a/addons/pos_loyalty/static/src/overrides/components/control_buttons/control_buttons.js
+++ b/addons/pos_loyalty/static/src/overrides/components/control_buttons/control_buttons.js
@@ -172,7 +172,7 @@ patch(ControlButtons.prototype, {
                     product_tmpl_id: product.product_tmpl_id,
                     qty: potentialQty || 1,
                 },
-                {}
+                { isRewardProductLine: true }
             );
             return true;
         } else {

--- a/addons/pos_loyalty/static/src/overrides/components/product_screen/product_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/product_screen/product_screen.js
@@ -26,4 +26,11 @@ patch(ProductScreen.prototype, {
         await super._barcodeGS1Action(code);
         this.pos.updateRewards();
     },
+    isValidToPay() {
+        let res = super.isValidToPay();
+        res = this.currentOrder
+            ?.getLoyaltyPoints()
+            ?.reduce((acc, loyalty) => (loyalty.points.total < 0 ? (acc = false) : true), res);
+        return res;
+    },
 });

--- a/addons/pos_loyalty/static/src/overrides/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_order.js
@@ -333,7 +333,7 @@ patch(PosOrder.prototype, {
                 });
             let [won, spent, total] = [0, 0, 0];
             const balance = loyaltyCard.points;
-            won += points - this._getPointsCorrection(program);
+            won += points - (points > 0 ? this._getPointsCorrection(program) : 0);
             if (coupon_id !== 0) {
                 for (const line of this._get_reward_lines()) {
                     if (line.coupon_id.id === coupon_id) {
@@ -1271,10 +1271,10 @@ patch(PosOrder.prototype, {
                 reward.reward_product_ids.map((reward) => reward.id).includes(line.get_product().id)
             ) {
                 if (this._get_reward_lines() == 0) {
-                    if (line.get_product() === product) {
+                    if (line.uiState.isRewardProductLine && line.get_product() === product) {
                         available += line.get_quantity();
                     }
-                } else {
+                } else if (line.uiState.isRewardProductLine) {
                     available += line.get_quantity();
                 }
             } else if (
@@ -1356,12 +1356,8 @@ patch(PosOrder.prototype, {
                 this._isRewardProductPartOfRules(reward, product) &&
                 reward.program_id.applies_on !== "future"
             ) {
-                const line = this.get_orderlines().find(
-                    (line) => line._reward_product_id?.id === product.id
-                );
                 // Compute the correction points once even if there are multiple reward lines.
-                // This is because _getPointsCorrection is taking into account all the lines already.
-                const claimedPoints = line ? this._getPointsCorrection(reward.program_id) : 0;
+                const claimedPoints = this._getPointsCorrection(reward.program_id);
                 return Math.floor((remainingPoints - claimedPoints) / reward.required_points) > 0
                     ? reward.reward_product_qty
                     : 0;

--- a/addons/pos_loyalty/static/src/overrides/models/pos_order_line.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_order_line.js
@@ -42,6 +42,13 @@ patch(PosOrderline, {
 });
 
 patch(PosOrderline.prototype, {
+    setup(vals) {
+        super.setup(...arguments);
+        this.uiState = {
+            ...this.uiState,
+            isRewardProductLine: vals.isRewardProductLine || false,
+        };
+    },
     serialize(options = {}) {
         const json = super.serialize(...arguments);
         if (options.orm && json.coupon_id < 0) {
@@ -92,5 +99,12 @@ patch(PosOrderline.prototype, {
             return;
         }
         return super.getDisplayData();
+    },
+    can_be_merged_with(orderline) {
+        const res = super.can_be_merged_with(...arguments);
+        if (this.uiState.isRewardProductLine === orderline.uiState.isRewardProductLine) {
+            return res;
+        }
+        return false;
     },
 });

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
@@ -27,14 +27,14 @@ registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram1", {
             ProductScreen.clickDisplayedProduct("Whiteboard Pen", true, "2.00"),
             // At this point, AAA Test Partner has 4 points.
             PosLoyalty.isRewardButtonHighlighted(true),
-            ProductScreen.clickDisplayedProduct("Whiteboard Pen", true, "3.00"),
+            PosLoyalty.claimReward("Free Product - Whiteboard Pen"),
             PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "-3.20", "1.00"),
             PosLoyalty.isRewardButtonHighlighted(false),
             PosLoyalty.orderTotalIs("6.40"),
             PosLoyalty.finalizeOrder("Cash", "10"),
 
             // Order3: Generate 4 points.
-            // - Initially gets free product, but was removed automatically by changing the
+            // - Initially gets free product, but was removed rewardline by changing the
             //   number of items to zero.
             // - It's impossible to checked here if the free product reward is really removed
             //   so we check in the backend the number of orders that consumed the reward.
@@ -43,24 +43,26 @@ registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram1", {
             ProductScreen.clickPartnerButton(),
             ProductScreen.clickCustomer("AAA Test Partner"),
             PosLoyalty.isRewardButtonHighlighted(true),
-            ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
+            PosLoyalty.claimReward("Free Product - Whiteboard Pen"),
             PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "-3.20", "1.00"),
             PosLoyalty.isRewardButtonHighlighted(false),
             ProductScreen.clickNumpad("⌫"),
             // At this point, the reward line should have been automatically removed
-            // because there is not enough points to purchase it. Unfortunately, we
-            // can't check that here.
-            PosLoyalty.orderTotalIs("0.00"),
-            ProductScreen.clickDisplayedProduct("Whiteboard Pen", true, "1.00"),
-            ProductScreen.clickDisplayedProduct("Whiteboard Pen", true, "2.00"),
-            ProductScreen.clickDisplayedProduct("Whiteboard Pen", true, "3.00"),
-            ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
-            PosLoyalty.isRewardButtonHighlighted(false),
-            ProductScreen.selectedOrderlineHas("Whiteboard Pen", "4.00"),
-            PosLoyalty.isRewardButtonHighlighted(true),
-
+            // because we decreased the quantity of the related reward product order line.
+            // However, there is still a normal order line for products added from the product
+            // card with a quantity of 4.
             PosLoyalty.orderTotalIs("12.80"),
-            PosLoyalty.finalizeOrder("Cash", "20"),
+            PosLoyalty.isRewardButtonHighlighted(true),
+            PosLoyalty.claimReward("Free Product - Whiteboard Pen"),
+            PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "-3.20", "1.00"),
+            PosLoyalty.isRewardButtonHighlighted(false),
+            ProductScreen.clickDisplayedProduct("Whiteboard Pen", true, "5.00"),
+            ProductScreen.clickDisplayedProduct("Whiteboard Pen", true, "6.00"),
+            ProductScreen.clickDisplayedProduct("Whiteboard Pen", true, "7.00"),
+            ProductScreen.clickDisplayedProduct("Whiteboard Pen", true, "8.00"),
+
+            PosLoyalty.orderTotalIs("25.60"),
+            PosLoyalty.finalizeOrder("Cash", "30"),
         ].flat(),
 });
 
@@ -75,9 +77,9 @@ registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram2", {
             ProductScreen.clickPartnerButton(),
             ProductScreen.clickCustomer("AAA Test Partner"),
             // No item in the order, so reward button is off.
-            PosLoyalty.isRewardButtonHighlighted(false),
-            ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
             PosLoyalty.isRewardButtonHighlighted(true),
+            PosLoyalty.claimReward("Free Product - Whiteboard Pen"),
+            PosLoyalty.isRewardButtonHighlighted(false),
             ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
             PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "-3.20", "1.00"),
             PosLoyalty.isRewardButtonHighlighted(false),
@@ -107,7 +109,7 @@ registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram2", {
             // - But set CCC Test Partner first as the customer.
             ProductScreen.clickPartnerButton(),
             ProductScreen.clickCustomer("CCC Test Partner"),
-            PosLoyalty.isRewardButtonHighlighted(false),
+            PosLoyalty.isRewardButtonHighlighted(true),
             ProductScreen.addOrderline("Whiteboard Pen", "3"),
             ProductScreen.clickPartnerButton(),
             ProductScreen.clickCustomer("BBB Test Partner"),

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_reward_button_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_reward_button_tour.js
@@ -17,42 +17,42 @@ registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour", {
             // At this point, the free_product program is triggered.
             // The reward button should be highlighted.
             PosLoyalty.isRewardButtonHighlighted(true),
-            // Since the reward button is highlighted, clicking the reward product should be added as reward.
             ProductScreen.clickDisplayedProduct("Desk Organizer", "3.00"),
+            // Since the reward button is highlighted, we can add reward.
+            PosLoyalty.claimReward("Free Product - Desk Organizer"),
             PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "-5.10", "1.00"),
-            // In the succeeding 2 clicks on the product, it is considered as a regular product.
-            // In the third click, the product will be added as reward.
             ProductScreen.clickDisplayedProduct("Desk Organizer"),
             ProductScreen.clickDisplayedProduct("Desk Organizer"),
             PosLoyalty.isRewardButtonHighlighted(true),
+            PosLoyalty.claimReward("Free Product - Desk Organizer"),
             ProductScreen.clickDisplayedProduct("Desk Organizer", true, "6.00"),
             PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "-10.20", "2.00"),
 
             ProductScreen.clickDisplayedProduct("Desk Organizer"),
-            PosLoyalty.isRewardButtonHighlighted(false),
-            PosLoyalty.orderTotalIs("25.50"),
+            PosLoyalty.isRewardButtonHighlighted(true),
+            PosLoyalty.orderTotalIs("35.70"),
             // Finalize order that consumed a reward.
-            PosLoyalty.finalizeOrder("Cash", "30"),
+            PosLoyalty.finalizeOrder("Cash", "40"),
 
             ProductScreen.clickDisplayedProduct("Desk Organizer", true, "1.00"),
             ProductScreen.clickDisplayedProduct("Desk Organizer", true, "2.00"),
-            ProductScreen.clickDisplayedProduct("Desk Organizer"),
+            PosLoyalty.claimReward("Free Product - Desk Organizer"),
             PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "-5.10", "1.00"),
             ProductScreen.clickNumpad("⌫"),
             ProductScreen.selectedOrderlineHas("Desk Organizer", "0.00"),
-            ProductScreen.clickDisplayedProduct("Desk Organizer", true, "1.00"),
-            ProductScreen.clickDisplayedProduct("Desk Organizer", true, "2.00"),
+            ProductScreen.clickDisplayedProduct("Desk Organizer", true, "3.00"),
+            ProductScreen.clickDisplayedProduct("Desk Organizer", true, "4.00"),
             PosLoyalty.isRewardButtonHighlighted(true),
             // Finalize order but without the reward.
             // This step is important. When syncing the order, no reward should be synced.
-            PosLoyalty.orderTotalIs("10.20"),
-            PosLoyalty.finalizeOrder("Cash", "20"),
+            PosLoyalty.orderTotalIs("20.40"),
+            PosLoyalty.finalizeOrder("Cash", "25"),
 
             ProductScreen.addOrderline("Magnetic Board", "2"),
             PosLoyalty.isRewardButtonHighlighted(false),
             ProductScreen.clickDisplayedProduct("Magnetic Board"),
             PosLoyalty.isRewardButtonHighlighted(true),
-            ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
+            PosLoyalty.claimReward("Free Product - Whiteboard Pen"),
             PosLoyalty.isRewardButtonHighlighted(false),
             PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "-3.20", "1.00"),
             ProductScreen.clickOrderline("Magnetic Board", "3.00"),
@@ -68,9 +68,9 @@ registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour", {
             PosLoyalty.finalizeOrder("Cash", "20"),
 
             ProductScreen.addOrderline("Magnetic Board", "6"),
-            ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
-            PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "-3.20", "1.00"),
-            PosLoyalty.isRewardButtonHighlighted(true),
+            PosLoyalty.claimReward("Free Product - Whiteboard Pen"),
+            PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "-6.40", "2.00"),
+            PosLoyalty.isRewardButtonHighlighted(false),
 
             ProductScreen.clickOrderline("Magnetic Board", "6.00"),
             ProductScreen.clickNumpad("⌫"),
@@ -86,7 +86,7 @@ registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour", {
             PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "-3.20", "1.00"),
             PosLoyalty.isRewardButtonHighlighted(false),
 
-            PosLoyalty.orderTotalIs("5.94"),
+            PosLoyalty.orderTotalIs("9.14"),
             PosLoyalty.finalizeOrder("Cash", "10"),
 
             // Promotion: 2 items of shelves, get desk_pad/monitor_stand free
@@ -98,7 +98,10 @@ registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour", {
             ProductScreen.selectedOrderlineHas("Small Shelf", "1.00"),
             PosLoyalty.isRewardButtonHighlighted(true),
             // Click reward product. Should be automatically added as reward.
-            ProductScreen.clickDisplayedProduct("Desk Pad"),
+            PosLoyalty.claimReward("Free Product - [Desk Pad, Monitor Stand]"),
+            SelectionPopup.has("Monitor Stand"),
+            SelectionPopup.has("Desk Pad"),
+            SelectionPopup.has("Desk Pad", { run: "click" }),
             PosLoyalty.isRewardButtonHighlighted(false),
             PosLoyalty.hasRewardLine("Free Product", "-1.98", "1.00"),
             // Remove the reward line. The next steps will check if cashier
@@ -109,9 +112,9 @@ registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour", {
             PosLoyalty.claimReward("Free Product - [Desk Pad, Monitor Stand]"),
             SelectionPopup.has("Monitor Stand"),
             SelectionPopup.has("Desk Pad"),
-            SelectionPopup.has("Desk Pad", { run: "click" }),
+            SelectionPopup.has("Monitor Stand", { run: "click" }),
             PosLoyalty.isRewardButtonHighlighted(false),
-            PosLoyalty.hasRewardLine("Free Product", "-1.98", "1.00"),
+            PosLoyalty.hasRewardLine("Free Product", "-3.19", "1.00"),
             ProductScreen.clickNumpad("⌫"),
             ProductScreen.clickNumpad("⌫"),
             PosLoyalty.isRewardButtonHighlighted(true),
@@ -136,6 +139,7 @@ registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour2", {
 
             ProductScreen.clickPartnerButton(),
             ProductScreen.clickCustomer("AAA Partner"),
+            PosLoyalty.isRewardButtonHighlighted(true),
             ProductScreen.addOrderline("Test Product A", "1"),
             PosLoyalty.isRewardButtonHighlighted(true, true),
             ProductScreen.clickControlButton("Reward"),

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
@@ -45,6 +45,7 @@ registry.category("web_tour.tours").add("PosLoyaltyTour1", {
             PosLoyalty.enterCode("invalid_code"),
             Notification.has("invalid_code"),
             PosLoyalty.enterCode("1234"),
+            PosLoyalty.claimReward("Free Product - Desk Organizer"),
             PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "-15.30"),
             PosLoyalty.finalizeOrder("Cash", "50"),
 
@@ -56,10 +57,11 @@ registry.category("web_tour.tours").add("PosLoyaltyTour1", {
             PosLoyalty.hasRewardLine("90% on the cheapest product", "-4.59"),
             PosLoyalty.orderTotalIs("62.43"),
             PosLoyalty.enterCode("5678"),
+            PosLoyalty.claimReward("Free Product - Desk Organizer"),
             PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "-15.30"),
-            PosLoyalty.orderTotalIs("47.13"),
-            PosLoyalty.removeRewardLine("Free Product"),
             PosLoyalty.orderTotalIs("62.43"),
+            PosLoyalty.removeRewardLine("Free Product"),
+            PosLoyalty.orderTotalIs("77.73"),
             PosLoyalty.finalizeOrder("Cash", "90"),
 
             // specific product discount
@@ -116,16 +118,17 @@ registry.category("web_tour.tours").add("PosLoyaltyTour2", {
             // the discount should change after having free products
             // it should go back to cheapest discount as it is higher
             PosLoyalty.enterCode("5678"),
+            PosLoyalty.claimReward("Free Product - Desk Organizer"),
             PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "-20.40"),
             PosLoyalty.hasRewardLine("90% on the cheapest product", "-4.59"),
             // set quantity to 18
             // free qty stays the same since the amount of points on the card only allows for 4 free products
             ProductScreen.clickNumpad("⌫", "8"),
-            PosLoyalty.hasRewardLine("10% on your order", "-6.68"),
+            PosLoyalty.hasRewardLine("10% on your order", "-7.19"),
             PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "-20.40"),
             // scan the code again and check notification
             PosLoyalty.enterCode("5678"),
-            PosLoyalty.orderTotalIs("60.13"),
+            PosLoyalty.orderTotalIs("64.72"),
             PosLoyalty.finalizeOrder("Cash", "65"),
 
             // Specific products discount (with promocode) and free product (1357)
@@ -138,9 +141,10 @@ registry.category("web_tour.tours").add("PosLoyaltyTour2", {
             PosLoyalty.enterCode("promocode"),
             PosLoyalty.hasRewardLine("50% on specific products", "-15.30"),
             PosLoyalty.enterCode("1357"),
+            PosLoyalty.claimReward("Free Product - Desk Organizer"),
             PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "-10.20"),
-            PosLoyalty.hasRewardLine("50% on specific products", "-10.20"),
-            PosLoyalty.orderTotalIs("10.20"),
+            PosLoyalty.hasRewardLine("50% on specific products", "-15.30"),
+            PosLoyalty.orderTotalIs("15.30"),
             PosLoyalty.finalizeOrder("Cash", "20"),
 
             // Check reset program
@@ -251,7 +255,8 @@ registry.category("web_tour.tours").add("PosLoyaltyTour8", {
 
             ProductScreen.clickDisplayedProduct("Product B"),
             ProductScreen.clickDisplayedProduct("Product A"),
-            ProductScreen.totalAmountIs("50.00"),
+            PosLoyalty.claimReward("Free Product - Product A"),
+            ProductScreen.totalAmountIs("107.50"),
         ].flat(),
 });
 
@@ -371,19 +376,25 @@ registry.category("web_tour.tours").add("PosLoyaltyTour12", {
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
             ProductScreen.addOrderline("Free Product A", "2"),
-            ProductScreen.clickDisplayedProduct("Free Product A"),
+            PosLoyalty.claimReward("Free Product - [Free Product A, Free Product B]"),
+            SelectionPopup.has("Free Product A"),
+            SelectionPopup.has("Free Product B"),
+            SelectionPopup.has("Free Product A", { run: "click" }),
             ProductScreen.totalAmountIs("2.00"),
             PosLoyalty.hasRewardLine("Free Product", "-1.00"),
             ProductScreen.addOrderline("Free Product B", "2"),
-            ProductScreen.clickDisplayedProduct("Free Product B"),
+            PosLoyalty.claimReward("Free Product - [Free Product A, Free Product B]"),
+            SelectionPopup.has("Free Product A"),
+            SelectionPopup.has("Free Product B"),
+            SelectionPopup.has("Free Product B", { run: "click" }),
             ProductScreen.totalAmountIs("12.00"),
             PosLoyalty.hasRewardLine("Free Product", "-5.00"),
             ProductScreen.clickDisplayedProduct("Free Product B"),
             ProductScreen.clickDisplayedProduct("Free Product B"),
             ProductScreen.clickDisplayedProduct("Free Product B"),
-            ProductScreen.selectedOrderlineHas("Free Product B", "6.00"),
-            ProductScreen.totalAmountIs("22.00"),
-            PosLoyalty.hasRewardLine("Free Product", "-10.00"),
+            ProductScreen.selectedOrderlineHas("Free Product B", "5.00"),
+            ProductScreen.totalAmountIs("27.00"),
+            PosLoyalty.hasRewardLine("Free Product", "-5.00"),
         ].flat(),
 });
 

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -332,13 +332,13 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         aaa_loyalty_card = loyalty_program.coupon_ids.filtered(lambda coupon: coupon.partner_id.id == partner_aaa.id)
 
-        self.assertEqual(loyalty_program.pos_order_count, 1)
+        self.assertEqual(loyalty_program.pos_order_count, 2)
         self.assertAlmostEqual(aaa_loyalty_card.points, 4)
 
         # Part 2
         self.start_pos_tour("PosLoyaltyLoyaltyProgram2")
 
-        self.assertEqual(loyalty_program.pos_order_count, 2, msg='Only 2 orders should have reward lines.')
+        self.assertEqual(loyalty_program.pos_order_count, 3, msg='Only 3 orders should have reward lines.')
         self.assertAlmostEqual(aaa_loyalty_card.points, 1)
 
         bbb_loyalty_card = loyalty_program.coupon_ids.filtered(lambda coupon: coupon.partner_id.id == partner_bbb.id)

--- a/addons/pos_restaurant/static/src/overrides/components/product_screen/product_screen.xml
+++ b/addons/pos_restaurant/static/src/overrides/components/product_screen/product_screen.xml
@@ -16,7 +16,7 @@
                 <t t-else="">
                     <button
                         class="btn-switchpane pay-button btn btn-lg w-50 lh-sm"
-                        t-attf-class="{{ currentOrder.is_empty() ? 'btn-light disabled' : 'btn-primary' }}"
+                        t-attf-class="{{ currentOrder.is_empty() or !isValidToPay() ? 'btn-light disabled' : 'btn-primary' }}"
                         t-on-click="() => this.pos.pay()">
                         <span class="d-block">Pay</span>
                         <small><t t-esc="total" /></small>


### PR DESCRIPTION
pos_*: point_of_sale, pos_loyalty, pos_restaurant

Before this commit:
==========
- Customers cannot use their points for loyalty rewards on empty orders, even if they have enough points for a reward.
- Orderlines for reward products and those added from the product card are confusing users because they are being merged, making it difficult to distinguish which items are reward-related and which are from the product card.
- If loyalty points become negative after removing the order line, users can still proceed with the order.
- There is an error in calculating loyalty points when adding reward products simultaneously from the product card and reward popup.
- Users can add discounts and update the prices of reward-related products in the order line.

After this commit:
==========
- Customers can redeem loyalty points for rewards without any orderline restrictions.
- Order lines for reward products and products added from the product card are separated. Reward-type products are only added from the reward popup.
- If loyalty points turn negative after removing the order line, the payment button will be disabled, preventing the user from proceeding with the order.
- Reward products are only eligible for rewards through the reward popup, while reward products added directly from the product card are treated as different order lines, eliminating miscalculations of loyalty points.
- Users will not be able to add discounts or update the prices of reward-related products in the order line.

task- 4024282
