### PR TITLE
[FIX] web: kanban with sample data: no flicker when quick create

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_record_quick_create.js
+++ b/addons/web/static/src/views/kanban/kanban_record_quick_create.js
@@ -222,7 +222,7 @@ export class KanbanRecordQuickCreate extends Component {
             isLoaded: false,
         });
         this.viewService = useService("view");
-        onWillStart(() => {
+        onMounted(() => {
             this.getQuickCreateProps(this.props).then(() => {
                 this.state.isLoaded = true;
             });

--- a/addons/web/static/tests/views/fields/priority_field_tests.js
+++ b/addons/web/static/tests/views/fields/priority_field_tests.js
@@ -347,6 +347,7 @@ QUnit.module("Fields", (hooks) => {
             target,
             ".o_control_panel_main_buttons .d-none.d-xl-inline-flex .o-kanban-button-new"
         );
+        await nextTick();
         await click(target, ".o_kanban_quick_create .o_kanban_add");
         await click(target.querySelector(".o_priority a.o_priority_star.fa-star-o"));
         assert.verifySteps(['web_save [[6],{"selection":"1"}]']);

--- a/addons/web/static/tests/views/kanban/helpers.js
+++ b/addons/web/static/tests/views/kanban/helpers.js
@@ -55,10 +55,12 @@ export function getTooltips(target, groupIndex) {
 // Record
 export async function createRecord(target) {
     await click(target, ".o_control_panel_main_buttons .d-none button.o-kanban-button-new");
+    await nextTick();
 }
 
 export async function quickCreateRecord(target, groupIndex) {
     await click(getColumn(target, groupIndex), ".o_kanban_quick_add");
+    await nextTick();
 }
 
 export async function editQuickCreateInput(target, field, value) {

--- a/addons/web/static/tests/views/kanban/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban/kanban_view_tests.js
@@ -2115,6 +2115,66 @@ QUnit.module("Views", (hooks) => {
         assert.containsNone(target, ".o_kanban_load_more");
     });
 
+    QUnit.test("quick create record with sample data: no flickering", async (assert) => {
+        serverData.models.partner.records = [];
+
+        const def = makeDeferred();
+        await makeView({
+            type: "kanban",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <kanban on_create="quick_create" sample="1">
+                    <field name="bar"/>
+                    <templates>
+                        <t t-name="kanban-box">
+                            <div>
+                                <field name="foo"/>
+                            </div>
+                        </t>
+                    </templates>
+                </kanban>`,
+            groupBy: ["bar"],
+            async mockRPC(route, { method }) {
+                if (method === "web_read_group") {
+                    // override read_group to return empty groups, as this is
+                    // the case for several models (e.g. project.task grouped
+                    // by stage_id)
+                    return {
+                        groups: [
+                            {
+                                __domain: [["product_id", "=", 3]],
+                                product_id_count: 0,
+                                product_id: [3, "xplone"],
+                            },
+                            {
+                                __domain: [["product_id", "=", 5]],
+                                product_id_count: 0,
+                                product_id: [5, "xplan"],
+                            },
+                        ],
+                        length: 2,
+                    };
+                } else if (method === "onchange") {
+                    await def;
+                }
+            },
+        });
+
+        assert.containsOnce(target, ".o_view_sample_data");
+        assert.containsN(target, ".o_kanban_record", 32);
+
+        // click on 'Create' -> should open the quick create in the first column
+        await createRecord(target);
+        assert.containsNone(target, ".o_view_sample_data");
+        assert.containsNone(target, ".o_kanban_record");
+        assert.containsNone(target, ".o_kanban_quick_create"); // blocked by def
+
+        def.resolve();
+        await nextTick();
+        assert.containsOnce(target, ".o_kanban_quick_create");
+    });
+
     QUnit.test(
         "quick create record should focus default field [REQUIRE FOCUS]",
         async function (assert) {
@@ -2211,6 +2271,7 @@ QUnit.module("Views", (hooks) => {
 
         // click "+" icon in first column -> should open the quick create
         await click(target.querySelector(".o_kanban_quick_add"));
+        await nextTick();
         assert.containsOnce(target.querySelector(".o_kanban_group"), ".o_kanban_quick_create");
         assert.verifySteps([]);
     });

--- a/addons/web/static/tests/webclient/actions/window_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/window_action_tests.js
@@ -169,6 +169,7 @@ QUnit.module("ActionManager", (hooks) => {
         assert.containsOnce(target, ".o_kanban_view", "should display the kanban view");
         // quick create record
         await clickKanbanNew(target);
+        await nextTick();
         await editInput(target, ".o_field_widget[name=display_name] input", "New name");
 
         // edit quick-created record


### PR DESCRIPTION
Have a grouped kanban view with existing groups but no records s.t. sample records are displayed (e.g. in CRM pipeline with a default filter, or in Project in a new project). Click on the "+" icon in a column to quick create a record. The first time, it's fine. Click on the menu again to relaunch the action (do not reload the webclient), and do the same: there's a flickering as sample records briefly appear "as real records" (i.e. they're not displayed as ghosts), before completely desappearing. This is even more obvious on a slow network.

The difference between the first time and the others is that the form view used in the quick create must be loaded the first time, and is in cache afterwards.

When we click on the "+" icon, the following happens:
 - we remove sample records from the groups and we enable the quick create in a column => triggers a rendering of the KanbanRenderer
 - in the same tick, we toggle the useSampleModel flag on the model => triggers a rendering of the Controller

After its rendering, the Controller no longer has the classname `o_view_sample_data` which ensures that sample records are displayed as ghosts. After its rendering, the Renderer no longer contains sample records.

The flickering occurs when the rendering of the Renderer is async (the one of the Controller being always sync, as it doesn't wait for his children to be re-rendered, as their props didn't change). Indeed, in that case, there's a small timeframe during which the controller no longer has the classname `o_view_sample_data` but the renderer still contains sample records.

Normally, the rendering of the Renderer should always be sync. Indeed, we triggered the loadViews in its onWillStart but we didn't wait for the rpc to return (we have a `isLoaded` flag, and we have an empty rendering while `isLoaded` is false). However, when the loadViews is already in the cache, the promise is resolves in the next microTick, and we directly render the component with the state `isLoaded` true, i.e. with the KanbanQuickCreateController. But that component is always async, as it loads the form view data (onchange) in its onWillStart, and must wait for it. As a consequence, in that case, the whole rendering of the Renderer is delayed.

To fix the issue, this commit simply ensures that the rendering of the KanbanRecordQuickCreate is **always** sync, by toggling the `isLoaded` flag in onMounted instead of onWillStart. That way, the Renderer is rendered without the
sample records in the same animationFrame as the Controller, and only then we toggle the KanbanQuickCreateController.

Closes #181743

Task~4196741

