### PR TITLE
[FIX] hr_timesheet: avoid calling several times same rpc in list view

### DIFF
--- a/addons/hr_timesheet/static/src/components/task_with_hours/task_with_hours.js
+++ b/addons/hr_timesheet/static/src/components/task_with_hours/task_with_hours.js
@@ -2,33 +2,18 @@
 
 import { registry } from "@web/core/registry";
 import { Many2OneField, many2OneField } from "@web/views/fields/many2one/many2one_field";
-import { useService } from "@web/core/utils/hooks";
 import { onWillStart } from "@odoo/owl";
 
-class TaskWithHours extends Many2OneField {
+export class TaskWithHours extends Many2OneField {
     setup() {
         super.setup();
-        this.orm = useService("orm");
         onWillStart(this.onWillStart);
     }
 
-    async onWillStart() {
-        this.createEditProject = await this.orm.call(
-            "project.project",
-            "get_create_edit_project_ids",
-            []
-        );
-    }
+    async onWillStart() { }
 
     canCreate() {
-        if (this.createEditProject !== undefined) {
-            return (
-                Boolean(this.context.default_project_id) &&
-                !this.createEditProject.includes(this.props.record.data.project_id[0])
-            );
-        } else {
-            return Boolean(this.context.default_project_id);
-        }
+        return Boolean(this.context.default_project_id);
     }
 
     /**
@@ -43,7 +28,7 @@ class TaskWithHours extends Many2OneField {
      * @override
      */
     get context() {
-        return {...super.context, hr_timesheet_display_remaining_hours: true};
+        return { ...super.context, hr_timesheet_display_remaining_hours: true };
     }
 
     /**
@@ -69,7 +54,9 @@ class TaskWithHours extends Many2OneField {
 
 }
 
-registry.category("fields").add("task_with_hours", {
+export const taskWithHours = {
     ...many2OneField,
     component: TaskWithHours,
-});
+};
+
+registry.category("fields").add("task_with_hours", taskWithHours);

--- a/addons/hr_timesheet/static/tests/task_with_hours_tests.js
+++ b/addons/hr_timesheet/static/tests/task_with_hours_tests.js
@@ -1,5 +1,6 @@
 /** @odoo-module */
 
+import { registry } from "@web/core/registry";
 import { makeView } from "@web/../tests/views/helpers";
 import { click, clickDropdown, editInput, getFixture } from "@web/../tests/helpers/utils";
 
@@ -17,6 +18,11 @@ QUnit.module("hr_timesheet", (hooks) => {
             { task_id: "task_with_hours" },
             { task_id: "{ 'default_project_id': project_id }" });
         target = getFixture();
+        registry.category("services").add("create_edit_project_ids", {
+            start() {
+                return {};
+            },
+        });
     });
 
     QUnit.module("task_with_hours");


### PR DESCRIPTION
Before this commit, due to the commit https://github.com/odoo/odoo/commit/a5e27d8f6fad33f9dcd6121b42d4698009627bfd, when the user goes to list
view of timesheets, he could be disconnect due to a many rpc calls made
to get the projects for which we only allow to create and edit task
(because some fields could be required).

This commit moves most of changes made in https://github.com/odoo/odoo/commit/a5e27d8f6fad33f9dcd6121b42d4698009627bfd in enterprise since
only with hr_timesheet module installed, we will never get a project
for which we don't want to allow the quick create on task_id field.

Impacted versions: 17.0+

task-4221621
