### PR TITLE
[FIX] stock_account: ensure balance AMLs if neg. qty cost method change

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -679,9 +679,20 @@ class ProductProduct(models.Model):
                 raise UserError(_('You don\'t have any stock input account defined on your product category. You must define one before processing this operation.'))
             if not product_accounts[product.id].get('stock_valuation'):
                 raise UserError(_('You don\'t have any stock valuation account defined on your product category. You must define one before processing this operation.'))
+            if not product_accounts[product.id].get('stock_output'):
+                raise UserError(
+                    _('You don\'t have any output valuation account defined on your product '
+                      'category. You must define one before processing this operation.')
+                )
 
-            debit_account_id = stock_input_account.id
-            credit_account_id = product_accounts[product.id]['stock_valuation'].id
+            precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
+            orig_qtys = self.env.context.get('products_orig_quantity_svl')
+            if orig_qtys and float_compare(orig_qtys[product.id], 0, precision_digits=precision) == 1:
+                debit_account_id = stock_input_account.id
+                credit_account_id = product_accounts[product.id]['stock_valuation'].id
+            else:
+                debit_account_id = product_accounts[product.id]['stock_valuation'].id
+                credit_account_id = product_accounts[product.id]['stock_output'].id
             value = out_stock_valuation_layer.value
             move_vals = {
                 'journal_id': product_accounts[product.id]['stock_journal'].id,
@@ -963,7 +974,7 @@ class ProductCategory(models.Model):
                     ._svl_empty_stock(description, product_category=product_category)
                 out_stock_valuation_layers = SVL.sudo().create(out_svl_vals_list)
                 if product_category.property_valuation == 'real_time':
-                    move_vals_list += Product._svl_empty_stock_am(out_stock_valuation_layers)
+                    move_vals_list += Product.with_context(product_orig_quantity_svl=products_orig_quantity_svl)._svl_empty_stock_am(out_stock_valuation_layers)
                 impacted_categories[product_category] = (products, description, products_orig_quantity_svl)
 
         res = super(ProductCategory, self).write(vals)

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -4317,3 +4317,58 @@ class TestStockValuation(TestStockValuationBase):
         ]).account_move_id
 
         self.assertIn('OdooBot changed stock valuation from  15.0 to 25.0 -', account_move.line_ids[0].name)
+
+    def test_journal_entries_from_change_product_cost_method(self):
+        """ Changing between non-standard cost methods when an underlying product has real_time
+        accounting and a negative on hand quantity should result in journal entries with offsetting
+        debit/credits for the stock valuation and stock output accounts (inverse of positive qty).
+        """
+        self.product1.categ_id.property_cost_method = 'fifo'
+        move1 = self.env['stock.move'].create({
+            'name': 'IN 10 units @ 7.20 per unit',
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'product_id': self.product1.id,
+            'product_uom_qty': 10.0,
+            'price_unit': 7.2,
+        })
+        move2 = self.env['stock.move'].create({
+            'name': 'IN 20 units @ 15.30 per unit',
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'product_id': self.product1.id,
+            'product_uom_qty': 20.0,
+            'price_unit': 15.3,
+        })
+        (move1 + move2)._action_confirm()
+        (move1 + move2)._action_assign()
+        move1.quantity = 10
+        move2.quantity = 20
+        (move1 + move2).picked = True
+        (move1 + move2)._action_done()
+        move3 = self.env['stock.move'].create({
+            'name': 'OUT 100 units',
+            'product_id': self.product1.id,
+            'product_uom_qty': 100,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+        })
+        move3._action_confirm()
+        move3._action_assign()
+        move3.quantity = 100
+        move3.picked = True
+        move3._action_done()
+        self.product1.categ_id.property_cost_method = 'average'
+        amls = self.env['account.move.line'].search([
+            ('product_id', '=', self.product1.id),
+            ('name', 'ilike', 'Costing method change%'),
+        ], order='id')
+        self.assertRecordValues(
+            amls,
+            [
+                {'account_id': self.stock_valuation_account.id, 'debit': 1071, 'credit': 0},
+                {'account_id': self.stock_output_account.id, 'debit': 0, 'credit': 1071},
+                {'account_id': self.stock_output_account.id, 'debit': 1071, 'credit': 0},
+                {'account_id': self.stock_valuation_account.id, 'debit': 0, 'credit': 1071},
+            ]
+        )


### PR DESCRIPTION
**Current behavior:**
Changing the cost method of a product's category when that product has a negative on-hand quantity will result in illogical account move's being created during the empty/replenish mechanism which revalues the inventory.

Specifically, the stock valuation account will be credited twice, once in each move, the stock input account debited in the emptying move, and the stock output account debited in the replenishing move.

**Expected behavior:**
The moves and their corresponding lines should be the inverse of those which are generated by this action when the product's on-hand quantity is positive.

**Steps to reproduce:**
1. Enable automatic accounting, create a stored product whose category has `FIFO` costing and `real_time` valuation

2. Create an in move for the product so it gets some cost assigned to it

3. Create an out move for more of the product than is currently in stock (so it's on-hand qty becomes negative)

4. Change the product category's `cost_method` to average/AVCO

5. Observe the journal items created by this action in the accounting application -> see that the stock valuation account is credited in both of the created moves

**Cause of the issue:**
The replenishing move's debiting/crediting accounts are currently adjusted if the associated SVL's quantity is non-positive, but the preceding emptying move's accounts are not. This results in the mismatch.

**Fix:**
Similarly adjust the emptying move accounts as was done to the replenishing move in commit: f7e3ada

opw-4127737