### PR TITLE
[FIX] web_editor: not consider URL attachments as documents in linktools

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/media_dialog.js
+++ b/addons/web_editor/static/src/components/media_dialog/media_dialog.js
@@ -278,9 +278,9 @@ export class MediaDialog extends Component {
         if (saveSelectedMedia) {
             const elements = await this.renderMedia(selectedMedia);
             if (this.props.multiImages) {
-                this.props.save(elements);
+                await this.props.save(elements);
             } else {
-                this.props.save(elements[0]);
+                await this.props.save(elements[0]);
             }
         }
         this.props.close();

--- a/addons/web_editor/static/src/xml/wysiwyg.xml
+++ b/addons/web_editor/static/src/xml/wysiwyg.xml
@@ -304,7 +304,7 @@
                     </div>
                 </we-select>
             </we-row>
-            <we-row  t-if="!state.isButton and !props.forceNewWindow">
+            <we-row t-if="!state.isButton and !props.forceNewWindow and !state.isDocument">
                 <we-button t-attf-class="o_we_user_value_widget o_we_checkbox_wrapper o_we_sublevel_1 #{this.initialNewWindow ? 'active' : ''}">
                     <we-title class="o_long_title">Open in New Window</we-title>
                         <div class="o_switch">


### PR DESCRIPTION
Since [1] documents can be uploaded in links.
All these attachments are considered as documents, even if they are
URLs.
The "Open in New Window" option is available for any link, while it
should be forced to a new window for documents.

This commit introduces the distinction between URL and non-URL
attachments: only the non-URL attachments are now considered as
documents.
In order to make that information available when switching between
links:
- missing steps of `start` are now included when updating props
- sequence of updating props is forced by putting it in a method
The "Open in New Window" option is only visible for non-documents.
Upon link update, documents are always open in new window and
non-document are never download links.

[1]: https://github.com/odoo/odoo/commit/cec6ee74de4b904b590d41140d99ae844ed1f15d

task-4208243