### PR TITLE
[FIX] web_editor: add `odoo-editor-editable` class before sanitize

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -311,12 +311,12 @@ export class OdooEditor extends EventTarget {
         // Convention: root node is ID root.
         editable.oid = 'root';
         this._idToNodeMap.set(1, editable);
+        this.editable = editable;
+        this.editable.classList.add("odoo-editor-editable");
         if (this.options.toSanitize) {
             sanitize(editable);
             this.options.onPostSanitize(editable);
         }
-        this.editable = editable;
-        this.editable.classList.add("odoo-editor-editable");
         this.editable.setAttribute('dir', this.options.direction);
 
         // Set contenteditable before clone as FF updates the content at this point.


### PR DESCRIPTION
This is a backport of [1].

Issue:
======
Infinte loop of rerendering.

Steps to reproduce the issue:
=============================
- Install inventory, ecommerce, studio
- Go to any product, activate studio
- On the left side bar open existing fields and add website description field
- close studio
- Add some content in the description containing a `tab`.
- Go to website page of the product and edit it
- Add some content to the old content with another `tab`
- Go to products page now
- Click on the product we updated
- Go left or right with the pager and go back
- Infinite loop of rerendering happens

Origin of the issue:
====================
When switching from a record to another record which have the tabs problem, the following happens:
- updateWidget with the new value ( content containing the tabs)
- resetEditor of wysisyg with the new value
- resetContent of odooEditor
- historyStep of odooEditor => dispatch event
- html_field listens to that event and update the `dirty` state of the field which is in this case dirty (explained in the first mentioned commit)
- Since the dirty state is reactive it will rerender but this time with the old record then the same thing will happen because now the old value is different than the new value and will consider it as dirty and the cycle continues everytime we will have lastValue is content of some record and the newValue is the content of the other record and they switch between each other.

Solution:
=========
described in the mentioned commit

opw-4116773

[1]: https://github.com/odoo/odoo/commit/c37b978b0313cecbe4e3eec2956b5dc1d37b9647