### PR TITLE
[IMP] html_editor: table navigation using up/down arrow keys

### DIFF
--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -7,13 +7,21 @@ import {
     isProtecting,
     isEmptyBlock,
 } from "@html_editor/utils/dom_info";
-import { ancestors, closestElement, descendants, lastLeaf } from "@html_editor/utils/dom_traversal";
+import {
+    ancestors,
+    closestElement,
+    createDOMPathGenerator,
+    descendants,
+    firstLeaf,
+    lastLeaf,
+} from "@html_editor/utils/dom_traversal";
 import { parseHTML } from "@html_editor/utils/html";
 import { DIRECTIONS, leftPos, rightPos, nodeSize } from "@html_editor/utils/position";
 import { withSequence } from "@html_editor/utils/resource";
 import { findInSelection } from "@html_editor/utils/selection";
 import { getColumnIndex, getRowIndex } from "@html_editor/utils/table";
 import { isBrowserFirefox } from "@web/core/browser/feature_detection";
+import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 
 export const BORDER_SENSITIVITY = 5;
 
@@ -90,6 +98,12 @@ export class TablePlugin extends Plugin {
     setup() {
         this.addDomListener(this.editable, "mousedown", this.onMousedown);
         this.addDomListener(this.editable, "mouseup", this.onMouseup);
+        this.addDomListener(this.editable, "keydown", (ev) => {
+            const handled = ["arrowup", "control+arrowup", "arrowdown", "control+arrowdown"];
+            if (handled.includes(getActiveHotkey(ev))) {
+                this.navigateCell(ev);
+            }
+        });
         this.onMousemove = this.onMousemove.bind(this);
     }
 
@@ -640,6 +654,59 @@ export class TablePlugin extends Plugin {
             ) {
                 // Handle selecting an empty cell.
                 this.selectTableCells(selection);
+            }
+        }
+    }
+
+    navigateCell(ev) {
+        const selection = this.dependencies.selection.getSelectionData().deepEditableSelection;
+        const anchorNode = selection.anchorNode;
+        const currentCell = closestElement(anchorNode, "td");
+        const currentTable = closestElement(anchorNode, "table");
+        if (!selection.isCollapsed || !currentCell) {
+            return;
+        }
+        const isArrowUp = ev.key === "ArrowUp";
+        const cellPosition = {
+            row: getRowIndex(currentCell),
+            col: getColumnIndex(currentCell),
+        };
+        const tableRows = [...currentTable.rows].map((row) => [...row.cells]);
+        const shouldNavigateCell = (currentNode) => {
+            const siblingDirection = isArrowUp ? "previousElementSibling" : "nextElementSibling";
+            const direction = isArrowUp ? DIRECTIONS.LEFT : DIRECTIONS.RIGHT;
+            const domPath = createDOMPathGenerator(direction, {
+                stopTraverseFunction: (node) => node === currentCell,
+                stopFunction: (node) => node === currentCell,
+            });
+            const domPathNode = domPath(currentNode);
+            let node = domPathNode.next().value;
+            while (node) {
+                if ((isBlock(node) && node[siblingDirection]) || node.nodeName === "BR") {
+                    return false;
+                }
+                node = domPathNode.next().value;
+            }
+            return true;
+        };
+        const rowOffset = isArrowUp ? -1 : 1;
+        let targetNode = tableRows[cellPosition.row + rowOffset]?.[cellPosition.col];
+        const siblingElement = isArrowUp
+            ? currentTable.previousElementSibling
+            : currentTable.nextElementSibling;
+        if (!targetNode && siblingElement) {
+            // If no target cell is available, navigate to sibling element
+            targetNode = siblingElement;
+        }
+        if (shouldNavigateCell(anchorNode)) {
+            ev.preventDefault();
+            if (targetNode) {
+                targetNode = isArrowUp ? lastLeaf(targetNode) : firstLeaf(targetNode);
+                const targetOffset = isArrowUp ? nodeSize(targetNode) : 0;
+                this.dependencies.selection.setSelection({
+                    anchorNode: targetNode,
+                    anchorOffset: targetOffset,
+                });
             }
         }
     }

--- a/addons/html_editor/static/tests/table/selection.test.js
+++ b/addons/html_editor/static/tests/table/selection.test.js
@@ -3,7 +3,7 @@ import { setupEditor, testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { bold, resetSize, setColor } from "../_helpers/user_actions";
 import { getContent } from "../_helpers/selection";
-import { queryAll } from "@odoo/hoot-dom";
+import { press, queryAll } from "@odoo/hoot-dom";
 
 describe("custom selection", () => {
     test("should indicate selected cells with blue background", async () => {
@@ -1095,6 +1095,404 @@ describe("select columns on cross over", () => {
                             </td>
                         </tr></tbody>
                     </table>`),
+            });
+        });
+    });
+});
+
+describe("move cursor with arrow keys", () => {
+    describe("arrowup", () => {
+        test("should move cursor to the cell above", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                            <tr>
+                                <td>[]<br></td>
+                                <td><br></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+                stepFunction: async () => press("ArrowUp"),
+                contentAfter: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>[]<br></td>
+                                <td><br></td>
+                            </tr>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+            });
+        });
+        test("should move cursor to the end in the cell above", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>abc</td>
+                                <td><br></td>
+                            </tr>
+                            <tr>
+                                <td>[]<br></td>
+                                <td><br></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+                stepFunction: async () => press("ArrowUp"),
+                contentAfter: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>abc[]</td>
+                                <td><br></td>
+                            </tr>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+            });
+            await testEditor({
+                contentBefore: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>
+                                    <p>abc</p>
+                                    <p>def</p>
+                                </td>
+                                <td><br></td>
+                            </tr>
+                            <tr>
+                                <td>abc[]</td>
+                                <td><br></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+                stepFunction: async () => press("ArrowUp"),
+                contentAfter: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>
+                                    <p>abc</p>
+                                    <p>def[]</p>
+                                </td>
+                                <td><br></td>
+                            </tr>
+                            <tr>
+                                <td>abc</td>
+                                <td><br></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+            });
+        });
+        test("should move cursor to the previous sibling of table", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <p>abcd</p>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>[]<br></td>
+                                <td><br></td>
+                            </tr>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+                stepFunction: async () => press("ArrowUp"),
+                contentAfter: unformat(`
+                    <p>abcd[]</p>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+            });
+        });
+        test("should move cursor to the end cell of sibling table", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>[]<br></td>
+                                <td><br></td>
+                            </tr>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+                stepFunction: async () => press("ArrowUp"),
+                contentAfter: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                            <tr>
+                                <td><br></td>
+                                <td>[]<br></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+            });
+        });
+    });
+
+    describe("arrowdown", () => {
+        test("should move cursor to the cell below", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>[]<br></td>
+                                <td><br></td>
+                            </tr>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+                stepFunction: async () => press("ArrowDown"),
+                contentAfter: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                            <tr>
+                                <td>[]<br></td>
+                                <td><br></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+            });
+        });
+        test("should move cursor to the start of the cell below", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>[]<br></td>
+                                <td><br></td>
+                            </tr>
+                            <tr>
+                                <td>abc</td>
+                                <td><br></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+                stepFunction: async () => press("ArrowDown"),
+                contentAfter: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                            <tr>
+                                <td>[]abc</td>
+                                <td><br></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+            });
+            await testEditor({
+                contentBefore: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>abc[]</td>
+                                <td><br></td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <p>abc</p>
+                                    <p>def</p>
+                                </td>
+                                <td><br></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+                stepFunction: async () => press("ArrowDown"),
+                contentAfter: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>abc</td>
+                                <td><br></td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <p>[]abc</p>
+                                    <p>def</p>
+                                </td>
+                                <td><br></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+            });
+        });
+        test("should move cursor to the next sibling of table", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                            <tr>
+                                <td>[]<br></td>
+                                <td><br></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <p>abcd</p>
+                `),
+                stepFunction: async () => press("ArrowDown"),
+                contentAfter: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <p>[]abcd</p>
+                `),
+            });
+        });
+        test("should move cursor to the first cell of sibling table", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                            <tr>
+                                <td>[]<br></td>
+                                <td><br></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+                stepFunction: async () => press("ArrowDown"),
+                contentAfter: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>[]<br></td>
+                                <td><br></td>
+                            </tr>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
             });
         });
     });


### PR DESCRIPTION
### Current behavior before PR:

- On pressing up and down arrow keys, cursor navigates through table column-wise instead of row-wise.

### Description of the feature after PR is merged:

- Adjusted cursor movement to navigate row-wise within the table.
- Pressing down arrow from end of a cell moves to target cell's first leaf, and
pressing up from start moves to the last leaf.
- For block element siblings, pressing down from last cell goes to sibling's first leaf,
and pressing up goes to its last leaf.
- For sibling tables, pressing down from last row's cell moves to first leaf of sibling's first cell,
while pressing up from first row's cell moves to last leaf of sibling's last cell.
- If there is no sibling and cursor is in first or last row, it remains in current cell when
pressing  up or down arrow, respectively.

task-3476205