### PR TITLE
[FIX] website_slides: fix nondeterministic failure of fullscreen tour

### DIFF
--- a/addons/website_slides/static/tests/tours/slides_full_screen_web_editor.js
+++ b/addons/website_slides/static/tests/tours/slides_full_screen_web_editor.js
@@ -26,7 +26,7 @@ registerWebsitePreviewTour('full_screen_web_editor', {
     // click on a slide to open the fullscreen view
     trigger: ':iframe a.o_wslides_js_slides_list_slide_link:contains("Home Gardening")',
     run: "click",
-}, {
+}, stepUtils.waitIframeIsReady(), {
     // check we land on the fullscreen view
     trigger: ':iframe .o_wslides_fs_main',
 },


### PR DESCRIPTION
The tour full_screen_web_editor fails at step ":iframe .o_wslides_fs_main" (check we land on the fullscreen view) from time to time on the runbot.

We could reproduce the problem locally by setting a timeout on that step below 1400 ms. As this step (like others) is loaded in the WebsitePreview iframe that set the attribute "is-ready" on the iframe node when some assets are loaded (website.assets_all_wysiwyg), we have added a step before, that wait for that (stepUtils.waitIframeIsReady()). With that change, the tour succeeed even if we set a very low timeout on the failing step. So it should solve the problem.

Task-4222573