### PR TITLE
[IMP] point_of_sale,pos_restaurant: cleanup demo cash journals

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -842,11 +842,15 @@ class PosConfig(models.Model):
         }
 
     @api.model
-    def _create_cash_payment_method(self):
+    def _create_cash_payment_method(self, cash_journal_vals=None):
+        if cash_journal_vals is None:
+            cash_journal_vals = {}
+
         cash_journal = self.env['account.journal'].create({
             'name': _('Cash'),
             'type': 'cash',
             'company_id': self.env.company.id,
+            **cash_journal_vals,
         })
         return self.env['pos.payment.method'].create({
             'name': _('Cash'),
@@ -854,7 +858,7 @@ class PosConfig(models.Model):
             'company_id': self.env.company.id,
         })
 
-    def _create_journal_and_payment_methods(self, cash_ref=None):
+    def _create_journal_and_payment_methods(self, cash_ref=None, cash_journal_vals=None):
         """This should only be called at creation of a new pos.config."""
 
         journal = self.env['account.journal']._ensure_company_account_journal()
@@ -868,9 +872,9 @@ class PosConfig(models.Model):
                 cash_pm_from_ref.check_access_rule('read')
                 cash_pm = cash_pm_from_ref
             except AccessError:
-                cash_pm = self._create_cash_payment_method()
+                cash_pm = self._create_cash_payment_method(cash_journal_vals)
         else:
-            cash_pm = self._create_cash_payment_method()
+            cash_pm = self._create_cash_payment_method(cash_journal_vals)
 
         if cash_ref and cash_pm != cash_pm_from_ref:
             self.env['ir.model.data']._update_xmlids([{
@@ -934,7 +938,7 @@ class PosConfig(models.Model):
             'point_of_sale.pos_category_lower',
             'point_of_sale.pos_category_others'
         ])
-        journal, payment_methods_ids = self._create_journal_and_payment_methods()
+        journal, payment_methods_ids = self._create_journal_and_payment_methods(cash_journal_vals={'name': 'Cash Clothes Shop', 'show_on_dashboard': False})
         config = self.env['pos.config'].create([{
             'name': _('Clothes Shop'),
             'company_id': self.env.company.id,
@@ -955,7 +959,7 @@ class PosConfig(models.Model):
         if not self.env.ref(ref_name, raise_if_not_found=False):
             convert.convert_file(self.env, 'point_of_sale', 'data/scenarios/bakery_data.xml', None, mode='init', noupdate=True, kind='data')
 
-        journal, payment_methods_ids = self._create_journal_and_payment_methods()
+        journal, payment_methods_ids = self._create_journal_and_payment_methods(cash_journal_vals={'name': 'Cash Bakery', 'show_on_dashboard': False})
         bakery_categories = self.get_categories([
             'point_of_sale.pos_category_breads',
             'point_of_sale.pos_category_pastries',
@@ -980,7 +984,10 @@ class PosConfig(models.Model):
         if not self.env.ref(ref_name, raise_if_not_found=False):
             self._load_furniture_data()
 
-        journal, payment_methods_ids = self._create_journal_and_payment_methods('point_of_sale.cash_payment_method_furniture')
+        journal, payment_methods_ids = self._create_journal_and_payment_methods(
+            cash_ref='point_of_sale.cash_payment_method_furniture',
+            cash_journal_vals={'name': 'Cash Furn. Shop', 'show_on_dashboard': False},
+        )
         furniture_categories = self.get_categories([
             'point_of_sale.pos_category_miscellaneous',
             'point_of_sale.pos_category_desks',

--- a/addons/pos_restaurant/models/pos_config.py
+++ b/addons/pos_restaurant/models/pos_config.py
@@ -122,7 +122,7 @@ class PosConfig(models.Model):
         if not self.env.ref(ref_name, raise_if_not_found=False):
             self._load_bar_data()
 
-        journal, payment_methods_ids = self._create_journal_and_payment_methods()
+        journal, payment_methods_ids = self._create_journal_and_payment_methods(cash_journal_vals={'name': 'Cash Bar', 'show_on_dashboard': False})
         bar_categories = self.get_categories([
             'pos_restaurant.pos_category_cocktails',
             'pos_restaurant.pos_category_soft_drinks',
@@ -149,7 +149,7 @@ class PosConfig(models.Model):
         if not self.env.ref(ref_name, raise_if_not_found=False):
             self._load_restaurant_data()
 
-        journal, payment_methods_ids = self._create_journal_and_payment_methods()
+        journal, payment_methods_ids = self._create_journal_and_payment_methods(cash_journal_vals={'name': 'Cash Restaurant', 'show_on_dashboard': False})
         restaurant_categories = self.get_categories([
             'pos_restaurant.food',
             'pos_restaurant.drinks',


### PR DESCRIPTION
Point of Sale installs many demo data shops to offer a demo business as close as possible to the client's needs.
Each of these shop has its own cash journal, and all of these journals have the same name. This makes the accounting dashboard hard to read and the database messy.

This commit will rename the cash demo journals according to their use: for example the previous "Cash" journal created by the Restaurant POS will now be named "Cash Restaurant".
We also removed these journals from favorites journals, so that they are no longer shown by default on the Accounting dashboard

task-4200476


![image](https://github.com/user-attachments/assets/e85fcfc7-81ee-436e-9325-c85fd0a4e92c)
![image](https://github.com/user-attachments/assets/c10efcd5-e83e-448d-96fb-c2e08a8b4c75)
