### PR TITLE
[FIX] point_of_sale: prevent duplicate key error on 'Search more'

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -338,13 +338,16 @@ export class ProductScreen extends Component {
     }
 
     addMainProductsToDisplay(products) {
-        const uniqueProducts = new Set(products);
+        const uniqueProductsMap = new Map();
         for (const product of products) {
             if (product.id in this.pos.mainProductVariant) {
-                uniqueProducts.add(this.pos.mainProductVariant[product.id]);
+                const mainProduct = this.pos.mainProductVariant[product.id];
+                uniqueProductsMap.set(mainProduct.id, mainProduct);
+            } else {
+                uniqueProductsMap.set(product.id, product);
             }
         }
-        return Array.from(uniqueProducts);
+        return Array.from(uniqueProductsMap.values());
     }
 
     getProductsByCategory(category) {


### PR DESCRIPTION
Before this commit, using the 'Search more' button to load products with variants from the server resulted in a duplicate key error. This issue arose from creating new product objects upon loading from the server, where using a Set did not prevent duplicates. This commit resolves the problem by employing a Map, keyed by product ID, to ensure uniqueness.

opw-4211407

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
