### PR TITLE
[IMP] hr: improve badge ID validation in employee profile

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -428,8 +428,9 @@ class HrEmployee(models.Model):
     @api.constrains('barcode')
     def _verify_barcode(self):
         for employee in self:
-            if employee.barcode and not employee.barcode.isdigit():
-                raise ValidationError(_("The Badge ID must be a sequence of digits."))
+            if employee.barcode:
+                if not (employee.barcode.isalnum() and len(employee.barcode) <= 18):
+                    raise ValidationError(_("The Badge ID must be alphanumeric and no longer than 18 characters."))
 
     @api.constrains('ssnid')
     def _check_ssnid(self):

--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -338,3 +338,19 @@ class TestHrEmployee(TestHrCommon):
         employee_norbert = self.env['hr.employee'].create({'name': 'Norbert Employee', 'user_id': user_norbert.id})
         self.assertEqual(employee_norbert.image_1920, user_norbert.image_1920)
         self.assertEqual(employee_norbert.avatar_1920, user_norbert.avatar_1920)
+
+    def test_badge_validation(self):
+        # check employee's barcode should be a sequence of digits and alphabets
+        employee = self.env['hr.employee'].create({
+            'name': 'Badge Employee'
+        })
+
+        employee_form = Form(employee)
+        employee_form.barcode = 'Test@badge1'
+        with self.assertRaises(ValidationError):
+            employee_form.save()
+
+        employee_form.barcode = 'Testbadge2'
+        employee_form.save()
+
+        self.assertEqual(employee_form.barcode, 'Testbadge2')


### PR DESCRIPTION
This PR improves the validation for badge IDs in employee profiles. Previously, only numeric values were allowed, but now alphanumeric values are accepted.

task-4213889
