### PR TITLE
[IMP] project: add target attribute for project portal link section

### DIFF
--- a/addons/project/views/project_portal_project_task_templates.xml
+++ b/addons/project/views/project_portal_project_task_templates.xml
@@ -181,7 +181,7 @@
                                 <ul class="nav flex-column">
                                     <t t-foreach="task_link_section" t-as="task_link">
                                         <li class="nav-item">
-                                            <a class="nav-link p-0" t-att-href="task_link['access_url']">
+                                            <a class="nav-link p-0" t-att-href="task_link['access_url']" t-att-target="task_link.get('target', '_self')">
                                                 <t t-out="task_link['title']"/>
                                             </a>
                                         </li>


### PR DESCRIPTION
- 18.0

Before this commit, the portal link opens in the current tab. After this commit, we can open the link in a new tab also, by only passing one key 'target' in task_link_section list.

e.g.values['task_link_section'].append({
	'access_url': url,
        'title': _('Documents'),
        'target': '_blank'
    })

task-4194318


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
