### PR TITLE
[FIX] web_tour: start tour by url

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_service.js
+++ b/addons/web_tour/static/src/tour_service/tour_service.js
@@ -111,6 +111,10 @@ export const tourService = {
                 throw new Error(`Tour '${tourName}' is not found in the database.`);
             }
 
+            if (!tour.steps.length && tourRegistry.contains(tour.name)) {
+                tour.steps = tourRegistry.get(tour.name).steps();
+            }
+
             return tour;
         }
 
@@ -201,9 +205,9 @@ export const tourService = {
                 new TourInteractive(tour).start(pointer, async () => {
                     pointer.stop();
                     endTour(tour);
-
-                    if (tourConfig.rainbowManMessage) {
-                        const message = window.DOMPurify.sanitize(tourConfig.rainbowManMessage);
+                    let message = tourConfig.rainbowManMessage || tour.rainbowManMessage;
+                    if (message) {
+                        message = window.DOMPurify.sanitize(tourConfig.rainbowManMessage);
                         effect.add({
                             type: "rainbow_man",
                             message: markup(message),


### PR DESCRIPTION
When starting tour by url, if the tour was an onboarding tour (info in db and steps in registry), the steps were missing.
Now, if the steps are missing, I search them in the registry.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
