### PR TITLE
[FIX] base: cut context key when creating company partner

### DIFF
--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -238,7 +238,7 @@ class Company(models.Model):
             if vals.get('name') and not vals.get('partner_id')
         ]
         if no_partner_vals_list:
-            partners = self.env['res.partner'].create([
+            partners = self.env['res.partner'].with_context(default_parent_id=False).create([
                 {
                     'name': vals['name'],
                     'is_company': True,

--- a/odoo/addons/base/tests/test_res_company.py
+++ b/odoo/addons/base/tests/test_res_company.py
@@ -64,3 +64,7 @@ class TestCompany(TransactionCase):
         with self.assertRaises(UserError):
             parent_company.unlink()
         self.assertTrue(parent_company.exists())
+
+    def test_create_branch_with_default_parent_id(self):
+        branch = self.env['res.company'].with_context(default_parent_id=self.env.company.id).create({'name': 'Branch Company'})
+        self.assertFalse(branch.partner_id.parent_id)


### PR DESCRIPTION
### Steps to reproduce the issue:

1. Create a Parent Company and a Branch Company
2. In the Parent Company, click on the "Branches" Smart Button
3. From there, create another Branch Company
4. On save, this error appears:

>     odoo.exceptions.UserError: Incompatible companies on records:
>     - [Company Name] belongs to company [Company Name] and 'Address' (partner_id: [Company Name]) belongs to another company.

### Explanation:

When accessing its branches, the context key `default_parent_id` is set to the Parent Company's `id`. It is used to make sure the Branch Company has the Parent Company as `parent_id`. https://github.com/odoo/odoo/blob/4d5195d6756d47c33929fffa972ee801bb833622/odoo/addons/base/models/res_company.py#L423-L426
It is not removed when creating the Branch Partner, and this value will be used to assign a `parent_id` to the Branch Partner through `get_default`, this alone could create an out of range error if there is no `res.partner` with the same `id` as the Parent Company. https://github.com/odoo/odoo/blob/fbf95d3c4655b23554fe5dfa136382472041c195/odoo/addons/base/models/res_partner.py#L193-L197 https://github.com/odoo/odoo/blob/71b6eeed0a648934525cd758afebdb87500ec939/odoo/models.py#L1488-L1491
If there is a Parent Partner, it will give its `company_id` to the Branch Partner. Afterwards, `stock.warehouse` is created with the Branch Company as `company_id` and the Branch Partner as `partner_id`. https://github.com/odoo/odoo/blob/78e44dc5a3dee67956f380fa468bab02692ce5ac/addons/stock/models/res_company.py#L202-L207
During its creation, `stock.warehouse` will call `_check_company` and, when `res.partner.company_id` is not in `stock.warehouse.company_id.parent_ids`, will report the inconsistency. https://github.com/odoo/odoo/blob/71b6eeed0a648934525cd758afebdb87500ec939/odoo/models.py#L4068-L4073 https://github.com/odoo/odoo/blob/71b6eeed0a648934525cd758afebdb87500ec939/odoo/models.py#L185-L189

### Fix reasoning:

Removing the problematic context key `default_parent_id` during the creation of the Branch Partner will avoid any out of range error and most importantly will not assign a default value to the Partner when it should not have one.

opw-4194396
