### PR TITLE
[FIX] pos_restaurant: properly mark booked table

### DIFF
--- a/addons/point_of_sale/views/product_view.xml
+++ b/addons/point_of_sale/views/product_view.xml
@@ -179,6 +179,10 @@
         <field name="model">product.product</field>
         <field name="inherit_id" ref="product.product_product_view_form_normalized"/>
         <field name="arch" type="xml">
+            <xpath expr="//field[@name='barcode']" position="after">
+                <field name="is_storable" invisible="type != 'consu'"/>
+                <field name="tracking" invisible="not is_storable" groups="stock.group_production_lot"/>
+            </xpath>
             <div name="tax_info" position="after">
                 <field name="pos_categ_ids" string="POS Category" class="oe_inline" widget="many2many_tags" placeholder="Unsaleable"/>
             </div>

--- a/addons/pos_restaurant/static/src/app/models/restaurant_table.js
+++ b/addons/pos_restaurant/static/src/app/models/restaurant_table.js
@@ -70,9 +70,6 @@ export class RestaurantTable extends Base {
                 (!o.finalized || o.uiState.screen_data?.value?.name === "TipScreen")
         );
     }
-    getOrder() {
-        return this.parent_id?.getOrder?.() || this["<-pos.order.table_id"][0];
-    }
     setPositionAsIfLinked(parent, side) {
         // console.log("132")
         this.parent_id = parent;

--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -319,7 +319,7 @@ patch(PosStore.prototype, {
         );
     },
     tableHasOrders(table) {
-        return Boolean(table.getOrder());
+        return table.orders.length > 0;
     },
     async transferOrder(destinationTable) {
         const order = this.models["pos.order"].getBy("uuid", this.orderToTransferUuid);


### PR DESCRIPTION
## Commit 1

After paying an order in a table, the table isn't rendered to be "emtpy". In this change, we make sure that the order that makes a table "booked" is based on the table's active order that is not paid. There is already a getter for that which is the `.orders`. And since the `getOrder` method isn't used, we are also removing it in this change.

## Commit 2

Before:

<img width="663" alt="Screenshot 2024-10-01 at 15 17 28" src="https://github.com/user-attachments/assets/cb7af694-cbc9-46d5-a219-048cfd6a1895">

After:

<img width="665" alt="Screenshot 2024-10-01 at 15 16 07" src="https://github.com/user-attachments/assets/29bf899c-9f92-4bd7-b4e2-ec98ffcce24a">


