### PR TITLE
[FIX] spreadsheet_account: get balance from other companies

### DIFF
--- a/addons/spreadsheet_account/models/account.py
+++ b/addons/spreadsheet_account/models/account.py
@@ -67,7 +67,7 @@ class AccountMove(models.Model):
             ]
             for code in codes
         )
-        account_ids = self.env["account.account"].search(code_domain).ids
+        account_ids = self.env["account.account"].with_company(company_id).search(code_domain).ids
         code_domain = [("account_id", "in", account_ids)]
         period_domain = expression.OR([balance_domain, pnl_domain])
         domain = expression.AND([code_domain, period_domain, [("company_id", "=", company_id)]])

--- a/addons/spreadsheet_account/tests/test_debit_credit.py
+++ b/addons/spreadsheet_account/tests/test_debit_credit.py
@@ -253,6 +253,37 @@ class SpreadsheetAccountingFunctionsTest(AccountTestInvoicingCommon):
             ],
         )
 
+    def test_company_not_in_env(self):
+        Account = self.env["account.account"].with_company(self.company_data["company"].id)
+        self.assertEqual(
+            Account.spreadsheet_fetch_debit_credit(
+                [
+                    {
+                        "date_range": {
+                            "range_type": "year",
+                            "year": 2022,
+                        },
+                        "codes": ["sp1234566"],  # only for company 1
+                        "company_id": self.company_data["company"].id,
+                        "include_unposted": True,
+                    },
+                    {
+                        "date_range": {
+                            "range_type": "year",
+                            "year": 2022,
+                        },
+                        "codes": ["sp99887755"],  # only for company 2
+                        "company_id": self.company_data_2["company"].id,
+                        "include_unposted": True,
+                    },
+                ]
+            ),
+            [
+                {"credit": 0, "debit": 500.0},
+                {"credit": 0, "debit": 1500.0},
+            ],
+        )
+
     def test_do_not_count_future_years(self):
         self.env["account.move"].create(
             {


### PR DESCRIPTION
Steps to reproduce:

- use ODOO.BALANCE("1",,1) (make sure it returns some value)
- switch to another company (company 1 should not be active) => the balance doesn't appear even though the company_id is provided
   and set to 1

Issue introduced with a707f8345cec8f40407

Task: 4223319

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
