### PR TITLE
[FIX] mail: less distracting out-of-focus tab title message counter

### DIFF
--- a/addons/mail/static/src/core/public_web/out_of_focus_service_patch.js
+++ b/addons/mail/static/src/core/public_web/out_of_focus_service_patch.js
@@ -1,45 +1,27 @@
 import { OutOfFocusService, outOfFocusService } from "@mail/core/common/out_of_focus_service";
 import { patch } from "@web/core/utils/patch";
-import { _t } from "@web/core/l10n/translation";
-import { sprintf } from "@web/core/utils/strings";
-
-export const UNREAD_MSG_TITLE = 100;
 
 patch(OutOfFocusService.prototype, {
     setup(env, services) {
         super.setup(env, services);
         this.titleService = services.title;
         this.counter = 0;
+        this.contributingMessageLocalIds = new Set();
         env.bus.addEventListener("window_focus", () => this.clearUnreadMessage());
-        this.intervalShowing = true;
     },
     clearUnreadMessage() {
         this.counter = 0;
-        this.titleService.setParts({ [UNREAD_MSG_TITLE]: undefined });
-        this.intervalShowing = true;
-        this.titlePattern = undefined;
-        clearInterval(this.newMessageInterval);
+        this.contributingMessageLocalIds.clear();
+        this.titleService.setCounters({ discuss: undefined });
     },
-    setInterval(func, duration) {
-        return setInterval(func, duration);
-    },
-    updateTitle() {
-        this.titleService.setParts({
-            [UNREAD_MSG_TITLE]: this.intervalShowing
-                ? sprintf(this.titlePattern, this.counter)
-                : undefined,
-        });
-    },
-    notify() {
+    notify(message) {
         super.notify(...arguments);
-        clearInterval(this.newMessageInterval);
+        if (this.contributingMessageLocalIds.has(message.localId)) {
+            return;
+        }
+        this.contributingMessageLocalIds.add(message.localId);
         this.counter++;
-        this.titlePattern = this.counter === 1 ? _t("%s Message") : _t("%s Messages");
-        this.updateTitle();
-        this.newMessageInterval = this.setInterval(() => {
-            this.updateTitle();
-            this.intervalShowing = !this.intervalShowing;
-        }, 1_000);
+        this.titleService.setCounters({ discuss: this.counter });
     },
 });
 outOfFocusService.dependencies = [...outOfFocusService.dependencies, "title"];

--- a/addons/mail/static/src/core/web/mail_core_web_service.js
+++ b/addons/mail/static/src/core/web/mail_core_web_service.js
@@ -41,6 +41,7 @@ export class MailCoreWeb {
             if (message.thread && notifId > message.thread.message_needaction_counter_bus_id) {
                 message.thread.message_needaction_counter++;
             }
+            message.thread?.notifyMessageToUser(message);
         });
         this.busService.subscribe("mail.message/mark_as_read", (payload, { id: notifId }) => {
             const { message_ids: messageIds, needaction_inbox_counter } = payload;

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -32,7 +32,6 @@ import {
 } from "@web/../tests/web_test_helpers";
 
 import { rpc } from "@web/core/network/rpc";
-import { UNREAD_MSG_TITLE } from "@mail/core/public_web/out_of_focus_service_patch";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -1056,13 +1055,12 @@ test("no out-of-focus notification on receiving self messages in chat", async ()
     const channelId = pyEnv["discuss.channel"].create({ channel_type: "chat" });
     mockService("presence", { isOdooFocused: () => false });
     mockService("title", {
-        setParts(parts) {
-            if (parts[UNREAD_MSG_TITLE]) {
-                step("set_title_part");
+        setCounters(counters) {
+            if (counters.discuss) {
+                step("set_counters:discuss");
             }
         },
     });
-    mockService("mail.out_of_focus", { setInterval: () => {} }); // so that no setInterval runs
     await start();
     await contains(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-ChatWindow", { count: 0 });
@@ -1096,13 +1094,12 @@ test("out-of-focus notif on needaction message in channel", async () => {
     });
     mockService("presence", { isOdooFocused: () => false });
     mockService("title", {
-        setParts(parts) {
-            if (parts[UNREAD_MSG_TITLE]) {
-                step(`set_title_part:${parts[UNREAD_MSG_TITLE]}`);
+        setCounters(counters) {
+            if (counters.discuss) {
+                step(`set_counters:discuss:${counters.discuss}`);
             }
         },
     });
-    mockService("mail.out_of_focus", { setInterval: () => {} }); // so that no setInterval runs
     onRpcBefore("/mail/action", async (args) => {
         if (args.init_messaging) {
             step("init_messaging");
@@ -1114,7 +1111,7 @@ test("out-of-focus notif on needaction message in channel", async () => {
     await assertSteps(["init_messaging"]);
     // simulate receiving a new needaction message with odoo out-of-focused
     const adminId = serverState.partnerId;
-    withUser(userId, () =>
+    await withUser(userId, () =>
         rpc("/mail/message/post", {
             post_data: {
                 body: "@Michell Admin",
@@ -1126,7 +1123,7 @@ test("out-of-focus notif on needaction message in channel", async () => {
         })
     );
     await contains(".o-mail-ChatBubble");
-    await assertSteps(["set_title_part:1 Message"]);
+    await assertSteps(["set_counters:discuss:1"]);
 });
 
 test("receive new chat message: out of odoo focus (notification, chat)", async () => {
@@ -1142,13 +1139,12 @@ test("receive new chat message: out of odoo focus (notification, chat)", async (
     });
     mockService("presence", { isOdooFocused: () => false });
     mockService("title", {
-        setParts(parts) {
-            if (parts[UNREAD_MSG_TITLE]) {
-                step(`set_title_part:${parts[UNREAD_MSG_TITLE]}`);
+        setCounters(counters) {
+            if (counters.discuss) {
+                step(`set_counters:discuss:${counters.discuss}`);
             }
         },
     });
-    mockService("mail.out_of_focus", { setInterval: () => {} }); // so that no setInterval runs
     onRpcBefore("/mail/action", async (args) => {
         if (args.init_messaging) {
             step("init_messaging");
@@ -1170,7 +1166,7 @@ test("receive new chat message: out of odoo focus (notification, chat)", async (
         })
     );
     await contains(".o-mail-ChatBubble");
-    await assertSteps(["set_title_part:1 Message"]);
+    await assertSteps(["set_counters:discuss:1"]);
 });
 
 test("no out-of-focus notif on non-needaction message in channel", async () => {
@@ -1186,13 +1182,12 @@ test("no out-of-focus notif on non-needaction message in channel", async () => {
     });
     mockService("presence", { isOdooFocused: () => false });
     mockService("title", {
-        setParts(parts) {
-            if (parts[UNREAD_MSG_TITLE]) {
-                step("set_title_part");
+        setCounters(counters) {
+            if (counters.discuss) {
+                step("set_counters:discuss");
             }
         },
     });
-    mockService("mail.out_of_focus", { setInterval: () => {} }); // so that no setInterval runs
     onRpcBefore("/mail/action", async (args) => {
         if (args.init_messaging) {
             step("init_messaging");
@@ -1239,24 +1234,23 @@ test("receive new chat messages: out of odoo focus (tab title)", async () => {
     ]);
     mockService("presence", { isOdooFocused: () => false });
     mockService("title", {
-        setParts(parts) {
-            if (!parts[UNREAD_MSG_TITLE]) {
+        setCounters(counters) {
+            if (!counters.discuss) {
                 return;
             }
             stepCount++;
-            step("set_title_part");
+            step("set_counters:discuss");
             if (stepCount === 1) {
-                expect(parts[UNREAD_MSG_TITLE]).toBe("1 Message");
+                expect(counters.discuss).toBe(1);
             }
             if (stepCount === 2) {
-                expect(parts[UNREAD_MSG_TITLE]).toBe("2 Messages");
+                expect(counters.discuss).toBe(2);
             }
             if (stepCount === 3) {
-                expect(parts[UNREAD_MSG_TITLE]).toBe("3 Messages");
+                expect(counters.discuss).toBe(3);
             }
         },
     });
-    mockService("mail.out_of_focus", { setInterval: () => {} }); // so that no setInterval runs
     await start();
     await openDiscuss();
     await contains(".o-mail-DiscussSidebarChannel", { count: 2 });
@@ -1268,7 +1262,7 @@ test("receive new chat messages: out of odoo focus (tab title)", async () => {
             thread_model: "discuss.channel",
         })
     );
-    await assertSteps(["set_title_part"]);
+    await assertSteps(["set_counters:discuss"]);
     // simulate receiving a new message in chat 2 with odoo out-of-focused
     await withUser(bobUserId, () =>
         rpc("/mail/message/post", {
@@ -1277,7 +1271,7 @@ test("receive new chat messages: out of odoo focus (tab title)", async () => {
             thread_model: "discuss.channel",
         })
     );
-    await assertSteps(["set_title_part"]);
+    await assertSteps(["set_counters:discuss"]);
     // simulate receiving another new message in chat 2 with odoo focused
     await withUser(bobUserId, () =>
         rpc("/mail/message/post", {
@@ -1286,7 +1280,7 @@ test("receive new chat messages: out of odoo focus (tab title)", async () => {
             thread_model: "discuss.channel",
         })
     );
-    await assertSteps(["set_title_part"]);
+    await assertSteps(["set_counters:discuss"]);
 });
 
 test("new message in tab title has precedence over action name", async () => {
@@ -1301,7 +1295,6 @@ test("new message in tab title has precedence over action name", async () => {
         ],
     });
     mockService("presence", { isOdooFocused: () => false });
-    mockService("mail.out_of_focus", { setInterval: () => {} }); // so that no setInterval runs
     await start();
     await openDiscuss();
     await contains(".o_breadcrumb:contains(Inbox)"); // wait for action name being Inbox
@@ -1316,7 +1309,81 @@ test("new message in tab title has precedence over action name", async () => {
         })
     );
     await contains(".o_notification:contains(Hello World!)");
-    expect(titleService.current).toBe("1 Message - Inbox");
+    expect(titleService.current).toBe("(1) Inbox");
+});
+
+test("out-of-focus notif takes new inbox messages into account", async () => {
+    const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
+    const partnerId = pyEnv["res.partner"].create({ name: "Dumbledore" });
+    const userId = pyEnv["res.users"].create({ partner_id: partnerId });
+    mockService("presence", { isOdooFocused: () => false });
+    onRpcBefore("/mail/action", async (args) => {
+        if (args.init_messaging) {
+            step("init_messaging");
+        }
+    });
+    await start();
+    await openDiscuss();
+    const titleService = getService("title");
+    await assertSteps(["init_messaging"]);
+    // simulate receiving a new needaction message with odoo out-of-focused
+    const adminId = serverState.partnerId;
+    await withUser(userId, () =>
+        rpc("/mail/message/post", {
+            post_data: {
+                body: "@Michell Admin",
+                partner_ids: [adminId],
+                message_type: "comment",
+            },
+            thread_id: partnerId,
+            thread_model: "res.partner",
+        })
+    );
+    await contains(".o-mail-DiscussSidebar-item:has(.badge:contains(1))", { text: "Inbox" });
+    expect(titleService.current).toBe("(1) Inbox");
+});
+
+test("out-of-focus notif on needaction message in group chat contributes only once", async () => {
+    const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
+    const partnerId = pyEnv["res.partner"].create({ name: "Dumbledore" });
+    const userId = pyEnv["res.users"].create({ partner_id: partnerId });
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: partnerId }),
+        ],
+        channel_type: "group",
+    });
+    mockService("presence", { isOdooFocused: () => false });
+    onRpcBefore("/mail/action", async (args) => {
+        if (args.init_messaging) {
+            step("init_messaging");
+        }
+    });
+    await start();
+    await openDiscuss();
+    const titleService = getService("title");
+    await assertSteps(["init_messaging"]);
+    // simulate receiving a new needaction message with odoo out-of-focused
+    const adminId = serverState.partnerId;
+    await withUser(userId, () =>
+        rpc("/mail/message/post", {
+            post_data: {
+                body: "@Michell Admin",
+                partner_ids: [adminId],
+                message_type: "comment",
+            },
+            thread_id: channelId,
+            thread_model: "discuss.channel",
+        })
+    );
+    await contains(".o-mail-DiscussSidebar-item:has(.badge:contains(1))", { text: "Inbox" });
+    await contains(".o-mail-DiscussSidebar-item:has(.badge:contains(1))", {
+        text: "Mitchell Admin and Dumbledore",
+    });
+    expect(titleService.current).toBe("(1) Inbox");
 });
 
 test("should auto-pin chat when receiving a new DM", async () => {

--- a/addons/web/static/src/core/browser/title_service.js
+++ b/addons/web/static/src/core/browser/title_service.js
@@ -2,10 +2,23 @@ import { registry } from "../registry";
 
 export const titleService = {
     start() {
+        const titleCounters = {};
         const titleParts = {};
 
         function getParts() {
             return Object.assign({}, titleParts);
+        }
+
+        function setCounters(counters) {
+            for (const key in counters) {
+                const val = counters[key];
+                if (!val) {
+                    delete titleCounters[key];
+                } else {
+                    titleCounters[key] = val;
+                }
+            }
+            updateTitle();
         }
 
         function setParts(parts) {
@@ -17,7 +30,17 @@ export const titleService = {
                     titleParts[key] = val;
                 }
             }
-            document.title = Object.values(titleParts).join(" - ") || "Odoo";
+            updateTitle();
+        }
+
+        function updateTitle() {
+            const counter = Object.values(titleCounters).reduce((acc, count) => acc + count, 0);
+            const name = Object.values(titleParts).join(" - ") || "Odoo";
+            if (!counter) {
+                document.title = name;
+            } else {
+                document.title = `(${counter}) ${name}`;
+            }
         }
 
         return {
@@ -28,6 +51,7 @@ export const titleService = {
                 return document.title;
             },
             getParts,
+            setCounters,
             setParts,
         };
     },


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/177238

PR above improved showing of new messages in Odoo while being out of focus by showing it in tab title and blinking the text.

However this felt too obstructive in practice.

This commit removes the blinking part, and instead show the out-of-focus amount of unread messages as a counter as prefix of the tab title. For example, if the action is "Inbox", it shows "(4) Inbox" when there are 4 unread and important messages received while odoo is out-of-focus.

Also take new inbox messages into account for the out-of-focus counter.

Task-4242524

Inbox contains a single message, 21 messages are posted in a DM.

Before
![Oct-08-2024 19-20-04](https://github.com/user-attachments/assets/802d989b-c4fd-44fd-8d4c-b49691931887)
After
![Oct-16-2024 15-12-02](https://github.com/user-attachments/assets/27b16d07-b580-4125-bbfa-f01183e3daa5)
