### PR TITLE
[FIX] website: fix s_showcase external move arrow orientation

### DIFF
--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -219,6 +219,21 @@ export class WebsiteSnippetsMenu extends weSnippetEditor.SnippetsMenu {
      */
     _computeSnippetTemplates(html) {
         const $html = $(html);
+
+        // TODO Remove in master. This patches the snippet move selectors.
+        const oldSelector = ".s_showcase .row:not(.s_col_no_resize) > div";
+        let optionEl = $html[0].querySelector(`[data-js="SnippetMove"][data-selector*="${oldSelector}"]`);
+        if (optionEl) {
+            const newSelector = oldSelector.replace(".row", ".row .row");
+            optionEl.dataset.selector = optionEl.dataset.selector.replace(oldSelector, newSelector);
+        }
+        const oldExclude = ".s_showcase .row > div";
+        optionEl = $html[0].querySelector(`[data-js="SnippetMove"][data-exclude*="${oldExclude}"]`);
+        if (optionEl) {
+            const newExclude = oldExclude.replace(".row", ".row .row");
+            optionEl.dataset.exclude = optionEl.dataset.exclude.replace(oldExclude, newExclude);
+        }
+
         const toFind = $html.find("we-fontfamilypicker[data-variable]").toArray();
         const fontVariables = toFind.map((el) => el.dataset.variable);
         FontFamilyPickerUserValueWidget.prototype.fontVariables = fontVariables;

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -895,13 +895,13 @@
     </div>
 
     <!-- Move snippets around -->
-    <div data-js="SnippetMove" data-selector="section, .s_accordion .accordion-item, .s_showcase .row:not(.s_col_no_resize) > div, .s_hr" data-no-scroll=".s_accordion .accordion-item">
+    <div data-js="SnippetMove" data-selector="section, .s_accordion .accordion-item, .s_showcase .row .row:not(.s_col_no_resize) > div, .s_hr" data-no-scroll=".s_accordion .accordion-item">
         <we-button class="fa fa-fw fa-angle-up" data-move-snippet="prev" data-no-preview="true" data-name="move_up_opt"/>
         <we-button class="fa fa-fw fa-angle-down" data-move-snippet="next" data-no-preview="true" data-name="move_down_opt"/>
     </div>
     <div data-js="SnippetMove"
          data-selector=".row:not(.s_col_no_resize) > div, .nav-item"
-         data-exclude=".s_showcase .row > div"
+         data-exclude=".s_showcase .row .row > div"
          data-name="move_horizontally_opt">
         <we-button class="fa fa-fw fa-angle-left" data-move-snippet="prev" data-no-preview="true" data-name="move_left_opt"/>
         <we-button class="fa fa-fw fa-angle-right" data-move-snippet="next" data-no-preview="true" data-name="move_right_opt"/>


### PR DESCRIPTION
Since [1] when the layout of the `s_showcase` block has been revamped, the selectors of the `SnippetMove` option wrongly match the new external column layout of the block. Because of this, up/down arrows appear instead of left/right arrows.

This commit restores the horizontal `SnippetMove` on the external columns of the `s_showcase` block.

[1]: https://github.com/odoo/odoo/commit/fe52cb6780ab253e45f40607b1a192aab19fb3a2

task-4206919