### PR TITLE
[IMP] account_peppol: peppol state col visible in invoice list

### DIFF
--- a/addons/account_peppol/views/account_move_views.xml
+++ b/addons/account_peppol/views/account_move_views.xml
@@ -37,7 +37,7 @@
         <field name="inherit_id" ref="account.view_out_invoice_tree"/>
         <field name="arch" type="xml">
             <field name="status_in_payment" position="before">
-                <field name="peppol_move_state" optional="hide"/>
+                <field name="peppol_move_state"/>
             </field>
         </field>
     </record>
@@ -48,7 +48,7 @@
         <field name="inherit_id" ref="account.view_out_credit_note_tree"/>
         <field name="arch" type="xml">
             <field name="status_in_payment" position="before">
-                <field name="peppol_move_state" optional="hide"/>
+                <field name="peppol_move_state"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
If a user installed the peppol module, he probably wants to have faster access to peppol status information about his invoices

task-4138750
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr