### PR TITLE
[FIX] {hr,sale}_timesheet: fallback on project's account when not in SOL

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -335,7 +335,7 @@ class AccountAnalyticLine(models.Model):
         if not project:
             return {}
         company = self.env['res.company'].browse(vals.get('company_id'))
-        mandatory_plans = self._get_mandatory_plans(company, business_domain='timesheet')
+        mandatory_plans = [plan for plan in self._get_mandatory_plans(company, business_domain='timesheet') if plan['column_name'] != 'account_id']
         missing_plan_names = [plan['name'] for plan in mandatory_plans if not project[plan['column_name']]]
         if missing_plan_names:
             raise ValidationError(_(

--- a/addons/sale_timesheet/models/hr_timesheet.py
+++ b/addons/sale_timesheet/models/hr_timesheet.py
@@ -222,7 +222,7 @@ class AccountAnalyticLine(models.Model):
         ])
 
         plan_column_names = {account.root_plan_id._column_name() for account in accounts}
-        mandatory_plans = self._get_mandatory_plans(company, business_domain='timesheet')
+        mandatory_plans = [plan for plan in self._get_mandatory_plans(company, business_domain='timesheet') if plan['column_name'] != 'account_id']
         missing_plan_names = [plan['name'] for plan in mandatory_plans if plan['column_name'] not in plan_column_names]
         if missing_plan_names:
             raise ValidationError(_(
@@ -235,3 +235,11 @@ class AccountAnalyticLine(models.Model):
         for account in accounts:
             account_id_per_fname[account.root_plan_id._column_name()] = account.id
         return account_id_per_fname
+
+    def _timesheet_postprocess(self, values):
+        if values.get('so_line'):
+            for timesheet in self.sudo():
+                # If no account_id was found in the SOL's distribution, we fallback on the project's account_id
+                if not timesheet.account_id:
+                    timesheet.account_id = timesheet.project_id.account_id
+        return super()._timesheet_postprocess(values)


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Install Timesheets and Sales app
2. Create an SO, add an SOL with a service product that creates a project/task (e.g. Junior Architect), confirm the SO
3. Remove the analytic account of the 'Project' plan from the SOL's analytic distribution
4. Add an analytic account for another plan such as 'Departments' (Basically, the 'Project' plan shouldn't be set but the distribution shouldn't be empty either)
5. Add a timesheet and link it to the project of the SO and to the SOL that we've just created
6. Error because the SOL doesn't have an account for the 'Project' plan

Fix:
-------------------
Before this commit, when the timesheet was given an SOL, we were only relying on its distribution to give its analytic accounts to the timesheet at timesheet creation/update (see _timesheet_preprocess_get_accounts()). We now take into account the project's account_id if no account_id was found in the SOL's distribution (see _timesheet_postprocess()).

task-4221106
version-18.0

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
