### PR TITLE
[FIX] point_of_sale: prevent singleton error when opening rescue sessions

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -662,13 +662,23 @@ class PosConfig(models.Model):
         }
 
     def open_opened_rescue_session_form(self):
-        self.ensure_one()
-        return {
-            'res_model': 'pos.session',
-            'view_mode': 'form',
-            'res_id': self.session_ids.filtered(lambda s: s.state != 'closed' and s.rescue).id,
-            'type': 'ir.actions.act_window',
-        }
+        rescue_session_ids = self.session_ids.filtered(lambda s: s.state != 'closed' and s.rescue)
+
+        if len(rescue_session_ids) == 1:
+            return {
+                'res_model': 'pos.session',
+                'view_mode': 'form',
+                'res_id': rescue_session_ids.id,
+                'type': 'ir.actions.act_window',
+            }
+        else:
+            return {
+                'name': _('Rescue Sessions'),
+                'res_model': 'pos.session',
+                'view_mode': 'tree,form',
+                'domain': [('id', 'in', rescue_session_ids.ids)],
+                'type': 'ir.actions.act_window',
+            }
 
     def _get_available_categories(self):
         return (


### PR DESCRIPTION
When a point of sale has more than one rescue session and the user tries to open
the rescue sessions, a traceback will appear.

Steps to reproduce the error:
- Make 2 or more rescue sessions for one point of sale
- Click on the outstanding rescue session

Traceback:
```
ValueError: Expected singleton: pos.session(22, 21)
  File "odoo/http.py", line 2383, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1913, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1976, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1943, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2187, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 227, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 757, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 40, in call_button
    action = call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 459, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/point_of_sale/models/pos_config.py", line 669, in open_opened_rescue_session_form
    'res_id': self.session_ids.filtered(lambda s: s.state != 'closed' and s.rescue).id,
  File "odoo/fields.py", line 5215, in __get__
    raise ValueError("Expected singleton: %s" % record)
```

https://github.com/odoo/odoo/blob/7638f1bdd6be52554ac4266291941ef0953edfd9/addons/point_of_sale/models/pos_config.py#L669
Here, ```session_ids``` have multiple records, so when it tries to access the ```id```,
It will lead to the above traceback.

sentry-5916215733

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
