### PR TITLE
[FIX] account: prevent an errors when open an account report

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -6033,6 +6033,15 @@ msgid "Expression Label"
 msgstr ""
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_report.py:0
+#, python-format
+msgid ""
+"Expression_label \"%(expression_label)s\" already defines in previous column"
+" line"
+msgstr ""
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_account_report_line__expression_ids
 msgid "Expressions"
 msgstr ""

--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -151,6 +151,18 @@ class AccountReport(models.Model):
                       'The parent must always come first.', line.name, line.parent_id.name))
             previous_lines |= line
 
+    @api.constrains('column_ids')
+    def _validate_expression_label(self):
+        for record in self:
+            previous_expression_labels = []
+            for column_line in record.column_ids:
+                expression_label = column_line.expression_label
+                if expression_label in previous_expression_labels:
+                    raise ValidationError(
+                        _('Expression_label "%(expression_label)s" already defines in previous column line',
+                            expression_label=expression_label))
+                previous_expression_labels.append(expression_label)
+
     @api.onchange('availability_condition')
     def _onchange_availability_condition(self):
         if self.availability_condition != 'country':


### PR DESCRIPTION
Currently, an error is generated when opening the account report, And account report has multiple column lines with the same expression label.

Steps to reproduce:

- Install an ```account_reports``` module.
- Navigate to Accounting / Configuration / Management / Accounting Reports, and open 'Balance Sheet'.
- Add two or more column lines with the same expression label.
- Open reports Accounting / Reporting / Statement Reports / Balance Sheet.

```Expected singleton: account.report.column(94, 95)```

The issue occurs when the system tries to get 'figure_type' at [1] from multiple records.

link [1]: https://github.com/odoo/enterprise/blob/f71983832a271fe4ba0c700ec766ba9483113291/account_reports/models/account_report.py#L2452-L2453

To resolve this issue, add a constraint to raise a validation error if a user tries to add the same expression label that was already added in the previous column line.

Sentry-5913510833

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
