### PR TITLE
[FIX] l10n_din5008_stock: prevent duplicate delivery address in delivery slips

### DIFF
--- a/addons/l10n_din5008_stock/report/din5008_stock_templates.xml
+++ b/addons/l10n_din5008_stock/report/din5008_stock_templates.xml
@@ -5,10 +5,12 @@
             <t t-set="din5008_address_block">
                 <tr t-if="o and o._name=='stock.picking' and o.partner_id">
                     <td class="shipping_address">
-                        <span class="fw-bold" t-if="o.picking_type_id.code == 'incoming'">Vendor Address:</span>
-                        <span class="fw-bold" t-if="o.picking_type_id.code == 'internal'">Warehouse Address:</span>
-                        <span class="fw-bold" t-if="o.picking_type_id.code == 'outgoing' and o.move_ids_without_package and o.move_ids_without_package[0].partner_id and o.move_ids_without_package[0].partner_id.id != o.partner_id.id">Customer Address:</span>
-                        <address t-esc="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True}'/>
+                        <span class="fw-bold" t-if="o.picking_type_id.code == 'incoming'" t-set="has_din5008_address_block" t-value="True">Vendor Address:</span>
+                        <span class="fw-bold" t-if="o.picking_type_id.code == 'internal'" t-set="has_din5008_address_block" t-value="True">Warehouse Address:</span>
+                        <span class="fw-bold" t-if="o.picking_type_id.code == 'outgoing' and o.move_ids_without_package and o.move_ids_without_package[0].partner_id and o.move_ids_without_package[0].partner_id.id != o.partner_id.id" t-set="has_din5008_address_block" t-value="True">Customer Address:</span>
+                        <t t-if="has_din5008_address_block">
+                            <address t-esc="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True}'/>
+                        </t>
                     </td>
                 </tr>
             </t>


### PR DESCRIPTION
**Issue**
When using the DIN5008 document layout and printing a delivery slip, the delivery address appears twice. This fix ensures the delivery address is displayed only once.

**Steps to reproduce:**

1. Go to Settings
2. Navigate to Companies -> Configure Document Layout
3. Select DIN5008 as the layout
4. Go to the Inventory module
5. Navigate to Operations -> Deliveries
6. Create a new delivery
7. Print the delivery slip

The delivery address appear twice on the delivery slip, This fix ensures the delivery address is displayed only once.

opw-4213842
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
