### PR TITLE
[FIX] mail: Handle unexpected Content-Type

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1402,9 +1402,13 @@ class MailThread(models.AbstractModel):
             mixed = False
             html = u''
             for part in message.walk():
-                if part.get_content_type() == 'binary/octet-stream':
-                    _logger.warning("Message containing an unexpected Content-Type 'binary/octet-stream', assuming 'application/octet-stream'")
-                    part.replace_header('Content-Type', 'application/octet-stream')
+                original_content_type = part.get_content_type()
+                if original_content_type in ['binary/octet-stream', 'bin/plain']:
+                    new_content_type = 'application/octet-stream'
+                    if part.get_filename(failobj='').endswith('.pdf'):
+                        new_content_type = 'application/pdf'
+                    part.replace_header('Content-Type', new_content_type)
+                    _logger.warning("Message containing an unexpected Content-Type '%s', assuming '%s'", original_content_type, new_content_type)
                 if part.get_content_type() == 'multipart/alternative':
                     alternative = True
                 if part.get_content_type() == 'multipart/mixed':

--- a/addons/test_mail/data/test_mail_data.py
+++ b/addons/test_mail/data/test_mail_data.py
@@ -278,6 +278,37 @@ Content-ID: <f_lfosfm0l0>
 --000000000000b951de05f7c47a9e--
 """
 
+MAIL_MULTIPART_BIN_PLAIN = """X-Original-To: john@doe.com
+Delivered-To: johndoe@example.com
+Received: by mail.example.com (Postfix, from userid 10002)
+    id E8166BFACB; Fri, 23 Aug 2013 13:18:02 +0200 (CEST)
+From: "Bruce Wayne" <bruce@wayneenterprises.com>
+Subject: test
+Message-ID: <c0c20fdd-a38e-b296-865b-d9232bf30ce5@odoo.com>
+Date: Mon, 26 Aug 2019 16:55:09 +0200
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+ boundary="------------FACA7766210AAA981EAE01F3"
+Content-Language: en-US
+
+This is a multi-part message in MIME format.
+--------------FACA7766210AAA981EAE01F3
+Content-Type: text/plain; charset=utf-8; format=flowed
+Content-Transfer-Encoding: 7bit
+
+plop
+
+
+--------------FACA7766210AAA981EAE01F3
+Content-Type: bin/plain; charset="ISO 8859-1"
+Content-Disposition: attachment; filename="20241007.pdf"
+Content-Transfer-Encoding: base64
+
+SSBhbSBhIGZpbGUgd2l0aCBhIHZhbGlkIHdpbmRvd3MgZmlsZW5hbWUK
+--------------FACA7766210AAA981EAE01F3--
+"""
+
+
 MAIL_MULTIPART_BINARY_OCTET_STREAM = """X-Original-To: raoul@grosbedon.fr
 Delivered-To: raoul@grosbedon.fr
 Received: by mail1.grosbedon.com (Postfix, from userid 10002)

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -40,6 +40,19 @@ class TestEmailParsing(TestMailCommon):
              "Content-Type 'binary/octet-stream', assuming 'application/octet-stream'"),
         ])
 
+    def test_message_parse_and_replace_bin_plain(self):
+        """ Incoming email containing bin/plain Content-Type with pdf attachment """
+        received_mail = self.from_string(test_mail_data.MAIL_MULTIPART_BIN_PLAIN)
+        with self.assertLogs('odoo.addons.mail.models.mail_thread', level="WARNING") as capture:
+            extracted_mail = self.env['mail.thread']._message_parse_extract_payload(received_mail)
+
+        self.assertEqual(len(extracted_mail['attachments']), 1)
+        attachment = extracted_mail['attachments'][0]
+        self.assertEqual(attachment.fname, '20241007.pdf')
+        self.assertEqual(capture.output, [
+            ("WARNING:odoo.addons.mail.models.mail_thread:Message containing an unexpected Content-Type 'bin/plain', assuming 'application/pdf'"),
+        ])
+
     def test_message_parse_body(self):
         # test pure plaintext
         plaintext = self.format(test_mail_data.MAIL_TEMPLATE_PLAINTEXT, email_from='"Sylvie Lelitre" <test.sylvie.lelitre@agrolait.com>')


### PR DESCRIPTION
Some mail clients set wrong content-type for PDF attachments.

Content-Type: bin/plain; charset="ISO 8859-1"
Content-Disposition: attachment; filename="filename.pdf"
Content-Transfer-Encoding: base64

In this case, receiving unexpected type like bin/plain instead of Application/pdf leads to Python content manager error:

File "/usr/lib/python3.9/email/contentmanager.py", line 25, in get_content
    raise KeyError(content_type)
KeyError: 'bin/plain'

This makes odoo impossible to parse such message, even if pdf attachment is not broken.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
