### PR TITLE
[IMP] html_editor: move existing text inside banner

### DIFF
--- a/addons/html_editor/static/src/main/banner_plugin.js
+++ b/addons/html_editor/static/src/main/banner_plugin.js
@@ -4,6 +4,8 @@ import { closestElement } from "@html_editor/utils/dom_traversal";
 import { parseHTML } from "@html_editor/utils/html";
 import { withSequence } from "@html_editor/utils/resource";
 import { _t } from "@web/core/l10n/translation";
+import { closestBlock } from "@html_editor/utils/blocks";
+import { isParagraphRelatedElement } from "../utils/dom_info";
 
 function isAvailable(selection) {
     return !closestElement(selection.anchorNode, ".o_editor_banner");
@@ -86,8 +88,20 @@ export class BannerPlugin extends Plugin {
     }
 
     insertBanner(title, emoji, alertClass) {
-        const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-        fillShrunkPhrasingParent(baseContainer);
+        const selection = this.dependencies.selection.getEditableSelection();
+        const blockEl = closestBlock(selection.anchorNode);
+        let baseContainer;
+        if (isParagraphRelatedElement(blockEl)) {
+            baseContainer = this.document.createElement(blockEl.nodeName);
+            baseContainer.append(...blockEl.childNodes);
+        } else if (blockEl.nodeName === "LI") {
+            baseContainer = this.dependencies.baseContainer.createBaseContainer();
+            baseContainer.append(...blockEl.childNodes);
+            fillShrunkPhrasingParent(blockEl);
+        } else {
+            baseContainer = this.dependencies.baseContainer.createBaseContainer();
+            fillShrunkPhrasingParent(baseContainer);
+        }
         const baseContainerHtml = baseContainer.outerHTML;
         const bannerElement = parseHTML(
             this.document,
@@ -96,9 +110,13 @@ export class BannerPlugin extends Plugin {
                 <div class="w-100 px-3" contenteditable="true">
                     ${baseContainerHtml}
                 </div>
-            </div`
+            </div>`
         ).childNodes[0];
         this.dependencies.dom.insert(bannerElement);
+        const nextNode = this.dependencies.baseContainer.isCandidateForBaseContainer(blockEl)
+            ? blockEl.nodeName
+            : "DIV";
+        this.dependencies.dom.setTag({ tagName: nextNode });
         // If the first child of editable is contenteditable false element
         // a chromium bug prevents selecting the container. Prepend a
         // zero-width space so it's no longer the first child.
@@ -106,8 +124,8 @@ export class BannerPlugin extends Plugin {
             const zws = document.createTextNode("\u200B");
             bannerElement.before(zws);
         }
-        this.dependencies.selection.setCursorStart(
-            bannerElement.querySelector(".o_editor_banner > div > p")
+        this.dependencies.selection.setCursorEnd(
+            bannerElement.querySelector(`.o_editor_banner > div > ${baseContainer.tagName}`)
         );
         this.dependencies.history.addStep();
     }

--- a/addons/html_editor/static/tests/banner.test.js
+++ b/addons/html_editor/static/tests/banner.test.js
@@ -17,10 +17,10 @@ test("should insert a banner with focus inside followed by a paragraph", async (
     await press("enter");
     expect(unformat(getContent(el))).toBe(
         unformat(
-            `<p>Test</p><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
+            `\u200b<div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
                     <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
                     <div class="w-100 px-3" contenteditable="true">
-                        <p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>
+                        <p>Test[]</p>
                     </div>
                 </div><p><br></p>`
         )
@@ -41,6 +41,9 @@ test("press 'ctrl+a' inside a banner should select all the banner content", asyn
     const { el, editor } = await setupEditor("<p>Test[]</p>");
     await insertText(editor, "/bannerinfo");
     await press("enter");
+    await manuallyDispatchProgrammaticEvent(editor.editable, "beforeinput", {
+        inputType: "insertParagraph",
+    });
     await insertText(editor, "Test1");
     await manuallyDispatchProgrammaticEvent(editor.editable, "beforeinput", {
         inputType: "insertParagraph",
@@ -49,10 +52,10 @@ test("press 'ctrl+a' inside a banner should select all the banner content", asyn
     await press(["ctrl", "a"]);
     expect(unformat(getContent(el))).toBe(
         unformat(
-            `<p>Test</p><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
+            `\u200b<div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
                     <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
                     <div class="w-100 px-3" contenteditable="true">[
-                        <p>Test1</p><p>Test2<br></p>
+                        <p>Test</p><p>Test1</p><p>Test2<br></p>
                     ]</div>
                 </div><p><br></p>`
         )
@@ -63,6 +66,9 @@ test("remove all content should preserves the first paragraph tag inside the ban
     const { el, editor } = await setupEditor("<p>Test[]</p>");
     await insertText(editor, "/bannerinfo");
     await press("enter");
+    await manuallyDispatchProgrammaticEvent(editor.editable, "beforeinput", {
+        inputType: "insertParagraph",
+    });
     await insertText(editor, "Test1");
     await manuallyDispatchProgrammaticEvent(editor.editable, "beforeinput", {
         inputType: "insertParagraph",
@@ -71,10 +77,10 @@ test("remove all content should preserves the first paragraph tag inside the ban
     await press(["ctrl", "a"]);
     expect(unformat(getContent(el))).toBe(
         unformat(
-            `<p>Test</p><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
+            `\u200b<div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
                     <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
                     <div class="w-100 px-3" contenteditable="true">[
-                        <p>Test1</p><p>Test2<br></p>
+                        <p>Test</p><p>Test1</p><p>Test2<br></p>
                     ]</div>
                 </div><p><br></p>`
         )
@@ -83,7 +89,7 @@ test("remove all content should preserves the first paragraph tag inside the ban
     await press("Backspace");
     expect(unformat(getContent(el))).toBe(
         unformat(
-            `<p>Test</p><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
+            `\u200b<div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
                     <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
                     <div class="w-100 px-3" contenteditable="true"><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p></div>
                 </div><p><br></p>`
@@ -92,7 +98,7 @@ test("remove all content should preserves the first paragraph tag inside the ban
 });
 
 test("Everything gets selected with ctrl+a, including a contenteditable=false as first element", async () => {
-    const { el, editor } = await setupEditor("<p>[]</p>");
+    const { el, editor } = await setupEditor("<p>[]<br></p>");
     await insertText(editor, "/bannerinfo");
     await press("enter");
     // Move the selection outside of the banner
@@ -157,6 +163,7 @@ test("add banner inside empty list", async () => {
     const { el, editor } = await setupEditor("<ul><li>[]<br></li></ul>");
     await insertText(editor, "/bannerinfo");
     await press("enter");
+    await animationFrame();
     expect(unformat(getContent(el))).toBe(
         unformat(
             `<ul><li><br><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
@@ -173,14 +180,32 @@ test("add banner inside non-empty list", async () => {
     const { el, editor } = await setupEditor("<ul><li>Test[]</li></ul>");
     await insertText(editor, "/bannerinfo");
     await press("enter");
+    await animationFrame();
     expect(unformat(getContent(el))).toBe(
         unformat(
-            `<ul><li>Test<div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
+            `<ul><li><br><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
                     <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
                     <div class="w-100 px-3" contenteditable="true">
-                        <p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>
+                        <p>Test[]</p>
                     </div>
                 </div><br></li></ul>`
         )
+    );
+});
+
+test("should move heading element inside the banner, with paragraph element after the banner", async () => {
+    const { el, editor } = await setupEditor("<h1>Test[]</h1>");
+    await insertText(editor, "/banner");
+    await animationFrame();
+    expect(".active .o-we-command-name").toHaveText("Banner Info");
+
+    await press("enter");
+    expect(getContent(el)).toBe(
+        `\u200b<div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
+                <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
+                <div class="w-100 px-3" contenteditable="true">
+                    <h1>Test[]</h1>
+                </div>
+            </div><div class="o-paragraph"><br></div>`
     );
 });


### PR DESCRIPTION
**Current behavior before PR:**

- Creating a banner besides existing text will creates the banner after the current text block.

**Desired behavior after PR is merged:**

- Now, creating a banner besides existing text will move the current text block inside the newly created banner.

task: 4214029
