### PR TITLE
[FIX] website: refine `AddPageConfirmDialog` interaction elements design

### DIFF
--- a/addons/test_website/static/tests/tours/website_page_properties.js
+++ b/addons/test_website/static/tests/tours/website_page_properties.js
@@ -359,7 +359,7 @@ registerWebsitePreviewTour(
         ...openCreatePageDialog,
         {
             content: "Use blank template",
-            trigger: ".o_page_template button",
+            trigger: ".o_page_template .o_button_area",
             run: "click",
         },
         {

--- a/addons/website/static/src/components/dialog/add_page_dialog.scss
+++ b/addons/website/static/src/components/dialog/add_page_dialog.scss
@@ -22,6 +22,8 @@
         $-preview-width-xl: 220; // Empirically obtained
         $-preview-width-lg: 408; // Empirically obtained
         width: #{$-preview-width}px;
+        box-shadow: 0 0 1rem rgba(0, 0, 0, 0.16);
+
         @include media-breakpoint-down(xl) {
             width: #{$-preview-width-xl}px;
         }
@@ -60,10 +62,8 @@
 
         .o_button_area {
             opacity: 0;
-            .o_page_name {
-                position: absolute;
-                bottom: 10px;
-            }
+            outline: $border-width * 2 solid $o-we-handles-accent-color;
+            outline-offset: $border-width * -1;
         }
 
         &:empty {
@@ -85,11 +85,7 @@
             }
 
             &:hover {
-                transform: translateY(-0.15rem);
-
-                iframe {
-                    opacity: .1;
-                }
+                box-shadow: 0 .5rem 2rem rgba(0, 0, 0, 0.2);
 
                 .o_button_area {
                     opacity: 1;

--- a/addons/website/static/src/components/dialog/add_page_dialog.xml
+++ b/addons/website/static/src/components/dialog/add_page_dialog.xml
@@ -20,18 +20,17 @@
 
 <t t-name="website.AddPageTemplatePreviewWrapper">
     <div t-ref="holder" class="o_page_template position-relative placeholder-glow mx-auto transition-base" t-att-class="{ 'mt-4': !props.firstRow }">
-        <div t-ref="preview" class="o_page_template_preview border border-white bg-white rounded shadow" t-out="0"/>
+        <div t-ref="preview" class="o_page_template_preview border border-white bg-white rounded" t-out="0"/>
         <span class="placeholder position-absolute top-0 w-100 h-100 rounded" t-attf-style="animation-duration: #{props.animationDelay + 500}ms"/>
-        <div class="o_button_area position-absolute top-0 w-100 h-100 d-flex align-items-center justify-content-center">
-            <button class="btn btn-primary" t-on-click="select">Use this template</button>
-            <div t-if="props.template and props.template.name" class="o_page_name" t-out="props.template.name"/>
+        <div class="o_button_area position-absolute top-0 w-100 h-100 start-0 cursor-pointer rounded" t-on-click="select">
+            <div t-if="props.template and props.template.name" class="position-absolute start-0 bottom-100 w-100 fw-bold lh-1 pb-1 pe-none text-center o_page_name" t-out="props.template.name"/>
         </div>
     </div>
 </t>
 
 <t t-name="website.AddPageTemplateBlank">
     <t t-call="website.AddPageTemplatePreviewWrapper">
-        <div class="mt-5 h1 text-center">Blank Page</div>
+        <div class="d-flex align-items-center justify-content-center h-100 h3-fs fw-bold text-muted">Blank Page</div>
     </t>
 </t>
 

--- a/addons/website/static/tests/tours/rte.js
+++ b/addons/website/static/tests/tours/rte.js
@@ -67,7 +67,7 @@ registerWebsitePreviewTour('rte_translator', {
     run: "click",
 }, {
     content: "click on Use this template",
-    trigger: ".o_page_template button.btn-primary",
+    trigger: ".o_page_template .o_button_area",
     run: "click",
 }, {
     content: "insert file name",
@@ -99,7 +99,7 @@ registerWebsitePreviewTour('rte_translator', {
     run: "click",
 }, {
     content: "click on Use this template",
-    trigger: ".o_page_template button.btn-primary",
+    trigger: ".o_page_template .o_button_area",
     run: "click",
 }, {
     content: "insert page name",


### PR DESCRIPTION
This PR removes the unnecessary "Use this template" button and refines interaction elements' design in order to achieve a visual result consistent with the snippet-library modal.

It also slightly improve the "Blank Page" placeholder for a better visual result.

task-4224057



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
