### PR TITLE
[FIX] project: limit task recursion until date

### DIFF
--- a/addons/project/models/project_task_recurrence.py
+++ b/addons/project/models/project_task_recurrence.py
@@ -81,13 +81,12 @@ class ProjectTaskRecurrence(models.Model):
 
     def _create_next_occurrence(self, occurrence_from):
         self.ensure_one()
-        if self.repeat_type == 'until' and fields.Date.today() > self.repeat_until:
-            return
         # Prevent double mail_followers creation
         self = self.with_context(mail_create_nosubscribe=True)
-        self.env['project.task'].sudo().create(
-            self._create_next_occurrence_values(occurrence_from)
-        )
+        create_values = self._create_next_occurrence_values(occurrence_from)
+        date_deadline = create_values['date_deadline']
+        if not (self.repeat_type == 'until' and date_deadline and date_deadline.date() > self.repeat_until):
+            self.env['project.task'].sudo().create(create_values)
 
     def _create_next_occurrence_values(self, occurrence_from):
         self.ensure_one()

--- a/addons/project/tests/test_project_recurrence.py
+++ b/addons/project/tests/test_project_recurrence.py
@@ -102,23 +102,18 @@ class TestProjectRecurrence(TransactionCase):
             form.name = 'test recurring task'
             form.project_id = self.project_recurring
             form.recurring_task = True
-            form.repeat_interval = 5
+            form.repeat_interval = 1
             form.repeat_unit = 'month'
             form.repeat_type = 'until'
-            form.repeat_until = self.date_01_01 + relativedelta(months=1)
+            form.repeat_until = self.date_01_01 + relativedelta(months=1, days=1)
+            form.date_deadline = self.date_01_01
             task = form.save()
 
-        with freeze_time(self.date_01_01 + relativedelta(days=30)):
-            task.state = '1_done'
+        task.state = '1_done'
         self.assertEqual(len(task.recurrence_id.task_ids), 2, "Since this is before repeat_until, next occurrence should have been created")
 
-        with freeze_time(self.date_01_01 + relativedelta(days=32)):
-            task.state = '1_done'
-        self.assertEqual(len(task.recurrence_id.task_ids), 2, "Since this is not the last task of the recurrence, next occurrence shouldn't have been created")
-
         last_recurring_task = task.recurrence_id.task_ids.filtered(lambda t: t != task)
-        with freeze_time(self.date_01_01 + relativedelta(days=32)):
-            last_recurring_task.state = '1_done'
+        last_recurring_task.state = '1_done'
         self.assertEqual(len(task.recurrence_id.task_ids), 2, "Since this is after repeat_until, next occurrence shouldn't have been created")
 
     def test_recurring_settings_change(self):


### PR DESCRIPTION
Steps to reproduce:
- Project > New Task > Set 'Deadline' to today
- 'Repeat Every' 1 week Until tomorrow
- Save > Change task state to 'Done'

A recurring task is created with a deadline beyond the limit date, this can be repeated indefinitely. This happens because we check he limit date against today instead of comparing it to the task deadline. This is most likely an artifact of 85e9290711c5376660941122dffb3b335b223091, where we allowed immediate recurring task creation (Which would have previously been handled by the CRON at the appropriate date).

opw-4210251

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
