### PR TITLE
[FIX] l10n_ar_withholding, l10n_latam_check: Checks fix

### DIFF
--- a/addons/l10n_ar_withholding/models/account_payment.py
+++ b/addons/l10n_ar_withholding/models/account_payment.py
@@ -7,3 +7,18 @@ class AccountPayment(models.Model):
     _inherit = 'account.payment'
 
     l10n_ar_withholding_ids = fields.One2many(related='move_id.l10n_ar_withholding_ids')
+
+    def _synchronize_to_moves(self, changed_fields):
+        ''' If we change a payment with withholdings, delete all withholding lines as the synchronization mechanism is not
+        implemented yet
+        '''
+        if not any(field_name in changed_fields for field_name in self._get_trigger_fields_to_synchronize()):
+            return
+        for pay in self:
+            pay.move_id.line_ids.filtered(
+                lambda x:
+                x.account_id == pay.company_id.l10n_ar_tax_base_account_id or
+                x.tax_line_id.l10n_ar_withholding_payment_type
+            ).unlink()
+        res = super()._synchronize_to_moves(changed_fields)
+        return res

--- a/addons/l10n_ar_withholding/views/report_payment_receipt_templates.xml
+++ b/addons/l10n_ar_withholding/views/report_payment_receipt_templates.xml
@@ -13,7 +13,6 @@
                         </thead>
                         <tbody>
                             <t t-foreach="o.l10n_ar_withholding_ids" t-as="line">
-                                <t t-set="withholding_base" t-value="o.line_ids.filtered(lambda x: line.tax_line_id.id in x.tax_ids.ids and line.balance != 0.0)"/>
                                 <tr>
                                     <td>
                                         <span t-field='line.tax_line_id.name'/>
@@ -22,7 +21,7 @@
                                         <span t-field='line.name'/>
                                     </td>
                                     <td class="text-end">
-                                        <span t-out="abs(withholding_base.amount_currency)" t-options="{'widget': 'monetary', 'display_currency': o.currency_id}"/>
+                                        <span t-out="abs(line.tax_base_amount)" t-options="{'widget': 'monetary', 'display_currency': o.currency_id}"/>
                                     </td>
                                     <td class="text-end">
                                         <span t-out="abs(line.amount_currency)" t-options="{'widget': 'monetary', 'display_currency': o.currency_id}"/>

--- a/addons/l10n_latam_check/data/account_payment_method_data.xml
+++ b/addons/l10n_latam_check/data/account_payment_method_data.xml
@@ -26,4 +26,10 @@
         <field name="payment_type">outbound</field>
     </record>
 
+    <record id="account_payment_method_return_third_party_checks" model="account.payment.method">
+        <field name="name">Return Third Party Checks</field>
+        <field name="code">return_third_party_checks</field>
+        <field name="payment_type">outbound</field>
+    </record>
+
 </odoo>

--- a/addons/l10n_latam_check/i18n/es_419.po
+++ b/addons/l10n_latam_check/i18n/es_419.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.4alpha1+e\n"
+"Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-18 16:55+0000\n"
-"PO-Revision-Date: 2024-06-18 13:58-0300\n"
+"POT-Creation-Date: 2024-10-07 13:16+0000\n"
+"PO-Revision-Date: 2024-10-07 13:16+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
@@ -36,6 +36,20 @@ msgstr "<span>Pago</span>"
 #: model_terms:ir.ui.view,arch_db:l10n_latam_check.l10n_latam_check_view_form
 msgid "<span>Reconciled move</span>"
 msgstr "<span>Asiento conciliado</span>"
+
+#. module: l10n_latam_check
+#. odoo-python
+#: code:addons/l10n_latam_check/models/account_payment.py:0
+msgid ""
+"A payment with any Third Party Check or Own Check payment methods needs an "
+"outstanding account"
+msgstr "Un pago con cualquiera de los métodos de pago Cheque de terceros o Cheque propio requiere una cuenta pendiente"
+
+#. module: l10n_latam_check
+#. odoo-python
+#: code:addons/l10n_latam_check/wizards/l10n_latam_payment_mass_transfer.py:0
+msgid "A second payment has been created: "
+msgstr "Se ha creado un segundo pago: "
 
 #. module: l10n_latam_check
 #: model:ir.model,name:l10n_latam_check.model_account_chart_template
@@ -504,6 +518,18 @@ msgstr ""
 "Se encontraron otros cheques con el mismo número, emisor y banco. Verifique "
 "que no esté codificando el mismo cheque más de una vez. Lista de otros "
 "pagos/cheques: %s"
+
+#. module: l10n_latam_check
+#. odoo-python
+#: code:addons/l10n_latam_check/models/account_chart_template.py:0
+msgid "Outstanding Payments"
+msgstr "Pagos pendientes"
+
+#. module: l10n_latam_check
+#. odoo-python
+#: code:addons/l10n_latam_check/models/account_chart_template.py:0
+msgid "Outstanding Receipts"
+msgstr "Ingresos pendientes"
 
 #. module: l10n_latam_check
 #: model:account.payment.method,name:l10n_latam_check.account_payment_method_own_checks

--- a/addons/l10n_latam_check/i18n/l10n_latam_check.pot
+++ b/addons/l10n_latam_check/i18n/l10n_latam_check.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.4alpha1+e\n"
+"Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-14 09:30+0000\n"
-"PO-Revision-Date: 2024-06-14 09:30+0000\n"
+"POT-Creation-Date: 2024-10-07 13:16+0000\n"
+"PO-Revision-Date: 2024-10-07 13:16+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -33,6 +33,20 @@ msgstr ""
 #. module: l10n_latam_check
 #: model_terms:ir.ui.view,arch_db:l10n_latam_check.l10n_latam_check_view_form
 msgid "<span>Reconciled move</span>"
+msgstr ""
+
+#. module: l10n_latam_check
+#. odoo-python
+#: code:addons/l10n_latam_check/models/account_payment.py:0
+msgid ""
+"A payment with any Third Party Check or Own Check payment methods needs an "
+"outstanding account"
+msgstr ""
+
+#. module: l10n_latam_check
+#. odoo-python
+#: code:addons/l10n_latam_check/wizards/l10n_latam_payment_mass_transfer.py:0
+msgid "A second payment has been created: "
 msgstr ""
 
 #. module: l10n_latam_check
@@ -485,6 +499,18 @@ msgid ""
 "Other checks were found with same number, issuer and bank. Please double "
 "check you are not encoding the same check more than once. List of other "
 "payments/checks: %s"
+msgstr ""
+
+#. module: l10n_latam_check
+#. odoo-python
+#: code:addons/l10n_latam_check/models/account_chart_template.py:0
+msgid "Outstanding Payments"
+msgstr ""
+
+#. module: l10n_latam_check
+#. odoo-python
+#: code:addons/l10n_latam_check/models/account_chart_template.py:0
+msgid "Outstanding Receipts"
 msgstr ""
 
 #. module: l10n_latam_check

--- a/addons/l10n_latam_check/models/account_chart_template.py
+++ b/addons/l10n_latam_check/models/account_chart_template.py
@@ -21,12 +21,18 @@ class AccountChartTemplate(models.AbstractModel):
                     'outbound_payment_method_line_ids': [
                         Command.create({
                             'payment_method_id': self.env.ref('l10n_latam_check.account_payment_method_out_third_party_checks').id,
-                            'payment_account_id': 'outstanding_check_out',
+                            'payment_account_id': 'base_outstanding_payments',
                         }),
                     ],
                     'inbound_payment_method_line_ids': [
-                        Command.create({'payment_method_id': self.env.ref('l10n_latam_check.account_payment_method_new_third_party_checks').id}),
-                        Command.create({'payment_method_id': self.env.ref('l10n_latam_check.account_payment_method_in_third_party_checks').id}),
+                        Command.create({
+                            'payment_method_id': self.env.ref('l10n_latam_check.account_payment_method_new_third_party_checks').id,
+                            'payment_account_id': 'base_outstanding_receipts',
+                        }),
+                        Command.create({
+                            'payment_method_id': self.env.ref('l10n_latam_check.account_payment_method_in_third_party_checks').id,
+                            'payment_account_id': 'base_outstanding_receipts',
+                        }),
                     ],
                 },
                 "rejected_third_party_check": {
@@ -35,12 +41,18 @@ class AccountChartTemplate(models.AbstractModel):
                     'outbound_payment_method_line_ids': [
                         Command.create({
                             'payment_method_id': self.env.ref('l10n_latam_check.account_payment_method_out_third_party_checks').id,
-                            'payment_account_id': 'outstanding_check_out',
+                            'payment_account_id': 'base_outstanding_payments',
                         }),
                     ],
                     'inbound_payment_method_line_ids': [
-                        Command.create({'payment_method_id': self.env.ref('l10n_latam_check.account_payment_method_new_third_party_checks').id}),
-                        Command.create({'payment_method_id': self.env.ref('l10n_latam_check.account_payment_method_in_third_party_checks').id}),
+                        Command.create({
+                            'payment_method_id': self.env.ref('l10n_latam_check.account_payment_method_new_third_party_checks').id,
+                            'payment_account_id': 'base_outstanding_receipts',
+                        }),
+                        Command.create({
+                            'payment_method_id': self.env.ref('l10n_latam_check.account_payment_method_in_third_party_checks').id,
+                            'payment_account_id': 'base_outstanding_receipts',
+                        }),
                     ],
                 },
             }
@@ -49,9 +61,15 @@ class AccountChartTemplate(models.AbstractModel):
     def _get_latam_check_outstanding_account_account(self, template_code):
         if self.env.company.country_id.code in self._get_third_party_checks_country_codes():
             return {
-                'outstanding_check_out': {
-                    'name': _("Outstanding Check Out"),
-                    'code': 'OC',
+                'base_outstanding_receipts': {
+                    'name': _("Outstanding Receipts"),
+                    'code': '1.1.1.02.003',
+                    'reconcile': True,
+                    'account_type': 'asset_current',
+                },
+                'base_outstanding_payments': {
+                    'name': _("Outstanding Payments"),
+                    'code': '1.1.1.02.004',
                     'reconcile': True,
                     'account_type': 'asset_current',
                 },

--- a/addons/l10n_latam_check/models/account_journal.py
+++ b/addons/l10n_latam_check/models/account_journal.py
@@ -6,8 +6,14 @@ class AccountJournal(models.Model):
 
     def _default_outbound_payment_methods(self):
         res = super()._default_outbound_payment_methods()
-        if self.company_id.country_id.code == "AR" and self._is_payment_method_available('own_checks'):
+        if self.company_id.country_id.code != "AR":
+            return res
+        if self._is_payment_method_available('own_checks'):
             res |= self.env.ref('l10n_latam_check.account_payment_method_own_checks')
+        if self._is_payment_method_available('out_third_party_checks'):
+            res |= self.env.ref('l10n_latam_check.account_payment_method_out_third_party_checks')
+        if self._is_payment_method_available('return_third_party_checks'):
+            res |= self.env.ref('l10n_latam_check.account_payment_method_return_third_party_checks')
         return res
 
     @api.model
@@ -16,3 +22,31 @@ class AccountJournal(models.Model):
         res = super()._get_reusable_payment_methods()
         res.add("own_checks")
         return res
+
+    def create(self, vals_list):
+        journals = super().create(vals_list)
+        inbound_payment_accounts = self.env['account.account'].search([
+            ('code', '=', '1.1.1.02.003'),
+            ('company_ids', 'in', journals.company_id.ids)
+        ]).grouped('company_ids')
+
+        outbound_payment_accounts = self.env['account.account'].search([
+            ('code', '=', '1.1.1.02.004'),
+            ('company_ids', 'in', journals.company_id.ids)
+        ]).grouped('company_ids')
+
+        for journal in journals:
+            if journal.country_code != 'AR' or journal.type not in ('bank', 'cash'):
+                continue
+
+            for payment_method_line in journal.inbound_payment_method_line_ids:
+                if payment_method_line.payment_account_id:
+                    continue
+                payment_method_line.payment_account_id = inbound_payment_accounts.get(journal.company_id)
+
+            for payment_method_line in journal.outbound_payment_method_line_ids:
+                if payment_method_line.payment_account_id:
+                    continue
+                payment_method_line.payment_account_id = outbound_payment_accounts.get(journal.company_id)
+
+        return journals

--- a/addons/l10n_latam_check/models/account_payment_method.py
+++ b/addons/l10n_latam_check/models/account_payment_method.py
@@ -10,5 +10,6 @@ class AccountPaymentMethod(models.Model):
         res['new_third_party_checks'] = {'mode': 'multi', 'type': ('cash',)}
         res['in_third_party_checks'] = {'mode': 'multi', 'type': ('cash',)}
         res['out_third_party_checks'] = {'mode': 'multi', 'type': ('cash',)}
+        res['return_third_party_checks'] = {'mode': 'multi', 'type': ('bank',)}
         res['own_checks'] = {'mode': 'multi', 'type': ('bank',)}
         return res

--- a/addons/l10n_latam_check/tests/__init__.py
+++ b/addons/l10n_latam_check/tests/__init__.py
@@ -1,3 +1,3 @@
 from . import common
 from . import test_own_checks
-# from . import test_third_party_checks  TODO WAN need to refactor the batch transfer wizard
+from . import test_third_party_checks

--- a/addons/l10n_latam_check/tests/common.py
+++ b/addons/l10n_latam_check/tests/common.py
@@ -16,12 +16,15 @@ class L10nLatamCheckTest(AccountTestInvoicingCommon):
         cls.company_data_3 = cls.setup_other_company(name='company_3_data', country_id=cls.env.ref('base.ar').id)
 
         cls.bank_journal = cls.company_data_3['default_journal_bank']
-        cls.bank_journal.outbound_payment_method_line_ids = [Command.create({'payment_method_id': cls.env.ref('l10n_latam_check.account_payment_method_own_checks').id, 'name': 'own checks'})]
+        cls.bank_journal.outbound_payment_method_line_ids = [
+            Command.create({'payment_method_id': cls.env.ref('l10n_latam_check.account_payment_method_own_checks').id, 'name': 'Own Checks'}),
+            Command.create({'payment_method_id': cls.env.ref('l10n_latam_check.account_payment_method_out_third_party_checks').id, 'name': 'Rejected Check'}),
+        ]
         # enable use electronic/deferred checks on bank journal
         third_party_checks_journals = cls.env['account.journal'].search([
             ('inbound_payment_method_line_ids.code', '=', 'in_third_party_checks'),
             ('inbound_payment_method_line_ids.code', '=', 'new_third_party_checks'),
-            ('outbound_payment_method_line_ids.code', '=', 'out_third_party_checks'),
+            ('outbound_payment_method_line_ids.code', 'in', ('out_third_party_checks', 'return_third_party_checks')),
         ])
         cls.third_party_check_journal = third_party_checks_journals[0]
         cls.rejected_check_journal = third_party_checks_journals[1]

--- a/addons/l10n_latam_check/views/account_payment_view.xml
+++ b/addons/l10n_latam_check/views/account_payment_view.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <group>
                 <notebook>
-                    <page name="latam_checks_page" string="Checks" invisible="payment_method_code not in ['in_third_party_checks', 'out_third_party_checks', 'new_third_party_checks', 'own_checks']">
+                    <page name="latam_checks_page" string="Checks" invisible="payment_method_code not in ['in_third_party_checks', 'out_third_party_checks', 'return_third_party_checks', 'new_third_party_checks', 'own_checks']">
                         <group name="latam_checks" colspan="2">
                             <field name="l10n_latam_new_check_ids" invisible="payment_method_code not in ['new_third_party_checks', 'own_checks']" nolabel="1" colspan="2" readonly="state != 'draft'">
                                 <list name="new_checks" editable="bottom">
@@ -18,10 +18,10 @@
                                     <field name="issuer_vat" column_invisible="parent.payment_method_code == 'own_checks'"/>
                                     <field name="payment_date"/>
                                     <field name="amount" />
-                                    <button type="object" name="get_formview_action" icon="fa-pencil-square-o" title="open" help="Open" column_invisible="parent.state != 'posted'"/>
+                                    <button type="object" name="get_formview_action" icon="fa-pencil-square-o" title="open" help="Open" column_invisible="parent.state == 'draft'"/>
                                 </list>
                             </field>
-                            <field name="l10n_latam_move_check_ids" invisible="payment_method_code not in ['in_third_party_checks', 'out_third_party_checks']"
+                            <field name="l10n_latam_move_check_ids" invisible="payment_method_code not in ['in_third_party_checks', 'out_third_party_checks', 'return_third_party_checks']"
                                 domain="
                                     [('payment_method_code', '=', 'new_third_party_checks'), ('current_journal_id', '=', journal_id), ('company_id', '=', company_id)]
                                         if payment_type == 'outbound' else

--- a/addons/l10n_latam_check/views/l10n_latam_check_view.xml
+++ b/addons/l10n_latam_check/views/l10n_latam_check_view.xml
@@ -211,7 +211,7 @@
         <field name="view_mode">list,form,calendar,graph,pivot</field>
         <field name="view_id" ref="view_account_third_party_check_tree"/>
         <field name="search_view_id" ref="l10n_latam_check.view_account_payment_third_party_checks_search"/>
-        <field name="domain">[('payment_method_code', '=', 'new_third_party_checks'), ('payment_id.state', '=', 'posted')]</field>
+        <field name="domain">[('payment_method_code', '=', 'new_third_party_checks'), ('payment_id.state', '!=', 'draft')]</field>
         <field name="context">{'search_default_checks_on_hand': 1}</field>
     </record>
 

--- a/addons/l10n_latam_check/wizards/account_payment_register.py
+++ b/addons/l10n_latam_check/wizards/account_payment_register.py
@@ -20,11 +20,11 @@ class AccountPaymentRegister(models.TransientModel):
 
     def _is_latam_check_payment(self, check_subtype=False):
         if check_subtype == 'move_check':
-            codes = ['in_third_party_checks', 'out_third_party_checks']
+            codes = ['in_third_party_checks', 'out_third_party_checks', 'return_third_party_checks']
         elif check_subtype == 'new_check':
             codes = ['new_third_party_checks', 'own_checks']
         else:
-            codes = ['in_third_party_checks', 'out_third_party_checks', 'new_third_party_checks', 'own_checks']
+            codes = ['in_third_party_checks', 'out_third_party_checks', 'return_third_party_checks', 'new_third_party_checks', 'own_checks']
         return self.payment_method_code in codes
 
     def _create_payment_vals_from_wizard(self, batch_result):

--- a/addons/l10n_latam_check/wizards/account_payment_register_views.xml
+++ b/addons/l10n_latam_check/wizards/account_payment_register_views.xml
@@ -8,7 +8,7 @@
         <field name="arch" type="xml">
             <group>
                 <notebook invisible="not can_edit_wizard or (can_group_payments and not group_payment)">
-                    <page name="latam_checks_page" string="Checks" invisible="payment_method_code not in ['in_third_party_checks', 'out_third_party_checks', 'new_third_party_checks', 'own_checks']">
+                    <page name="latam_checks_page" string="Checks" invisible="payment_method_code not in ['in_third_party_checks', 'out_third_party_checks', 'return_third_party_checks', 'new_third_party_checks', 'own_checks']">
                         <group name="latam_checks" colspan="2">
                             <field name="l10n_latam_new_check_ids" invisible="payment_method_code not in ['new_third_party_checks', 'own_checks']" nolabel="1" colspan="2" >
                                 <list editable="bottom">
@@ -21,7 +21,7 @@
                                     <field name="amount" />
                                 </list>
                             </field>
-                            <field name="l10n_latam_move_check_ids" invisible="payment_method_code not in ['in_third_party_checks', 'out_third_party_checks']"
+                            <field name="l10n_latam_move_check_ids" invisible="payment_method_code not in ['in_third_party_checks', 'out_third_party_checks', 'return_third_party_checks']"
                                 domain="
                                     [('payment_method_code', '=', 'new_third_party_checks'), ('current_journal_id', '=', journal_id), ('company_id', '=', company_id)]
                                         if payment_type == 'outbound' else
@@ -43,7 +43,7 @@
             </group>
             <div role="alert" position="after">
                 <div role="alert" class="alert alert-info"
-                        invisible="payment_method_code not in ['new_third_party_checks', 'in_third_party_checks', 'out_third_party_checks', 'own_checks'] or can_edit_wizard and (not can_group_payments or can_group_payments and group_payment)">
+                        invisible="payment_method_code not in ['new_third_party_checks', 'in_third_party_checks', 'out_third_party_checks', 'return_third_party_checks', 'own_checks'] or can_edit_wizard and (not can_group_payments or can_group_payments and group_payment)">
                     <p>You can't use checks when paying invoices of different partners or same partner without grouping</p>
                 </div>
             </div>


### PR DESCRIPTION
In this commit: https://github.com/odoo/odoo/commit/2609fc2e38b8a82c773f27f910f2030b5d704633
We made the journal entry optional for payments. But this pr broke some flows
for l10n_ar. This commit will correct the following issues:

- Domain where we check the posted state, the posted state don't exist anymore,
we will adapt this by checking for in_progress and paid status.
- Adding outstanding accounts on argentinian bank and cash journals.
- Adding back the synchronisation of payment -> move for withholdings
- Adding a check that we can't have a payment with a checks payment method that
has no outstanding accounts
- Fixing a traceback when the check has no name
- When being in the payment wizard with check and withholding, a commit (https://github.com/odoo/odoo/commit/774d76682a72a786986bbcb70099c2a3be7a09d6)
removed a dependency on the compute net amount which made the warning
to never be displayed.
- Check transfer wizard was not working anymore cause internal_transfer logic
was removed. This commit reintroduce it, when being on a third party check and
making a transfer it will create a first payment to reverse the check and a new
one on the destination journal.
- Correct the payment receipt traceback when trying to print it.

task: 4204366



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
