### PR TITLE
[IMP] Move SUPERUSER_ID to odoo.api

### DIFF
--- a/addons/onboarding/tests/test_onboarding_concurrency.py
+++ b/addons/onboarding/tests/test_onboarding_concurrency.py
@@ -6,7 +6,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 import psycopg2.errors
 
-import odoo
+from odoo import api
 from odoo.modules.registry import Registry
 from odoo.tests.common import get_db_name, tagged, BaseCase
 from odoo.tools import mute_logger
@@ -22,7 +22,7 @@ class TestOnboardingConcurrency(BaseCase):
         cls.addClassCleanup(cls.cleanUpClass)
 
         with cls.registry.cursor() as cr:
-            env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
+            env = api.Environment(cr, api.SUPERUSER_ID, {})
             cls.onboarding_id = env['onboarding.onboarding'].create([
                 {
                     'name': 'Test Onboarding Concurrent',
@@ -34,7 +34,7 @@ class TestOnboardingConcurrency(BaseCase):
     @classmethod
     def cleanUpClass(cls):
         with cls.registry.cursor() as cr:
-            env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
+            env = api.Environment(cr, api.SUPERUSER_ID, {})
             env['onboarding.onboarding'].browse(cls.onboarding_id).unlink()
             env['onboarding.progress'].search([
                 ('onboarding_id', '=', cls.onboarding_id)
@@ -46,7 +46,7 @@ class TestOnboardingConcurrency(BaseCase):
 
         def run():
             with self.registry.cursor() as cr:
-                env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
+                env = api.Environment(cr, api.SUPERUSER_ID, {})
                 onboarding = env['onboarding.onboarding'].search([
                     ('id', '=', self.onboarding_id)
                 ])
@@ -69,7 +69,7 @@ class TestOnboardingConcurrency(BaseCase):
             raised_2 = future_2.result(timeout=3)
 
         with self.registry.cursor() as cr:
-            env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
+            env = api.Environment(cr, api.SUPERUSER_ID, {})
             self.assertEqual(
                 len(env['onboarding.progress'].search([('onboarding_id', '=', self.onboarding_id)])),
                 1,

--- a/addons/product_expiry/__init__.py
+++ b/addons/product_expiry/__init__.py
@@ -3,7 +3,8 @@
 from . import models
 from . import wizard
 
-from odoo import api, SUPERUSER_ID, Command
+from odoo import Command
+
 
 def _enable_tracking_numbers(env):
     """ This hook ensures the tracking numbers are enabled when the module is installed since the

--- a/addons/repair/__init__.py
+++ b/addons/repair/__init__.py
@@ -5,7 +5,6 @@ from . import models
 from . import wizard
 from . import report
 
-from odoo import api, SUPERUSER_ID
 
 def _create_warehouse_data(env):
     """ This hook is used to add default repair picking types on every warehouse.

--- a/addons/web/controllers/home.py
+++ b/addons/web/controllers/home.py
@@ -4,6 +4,7 @@ import json
 import logging
 import psycopg2
 
+import odoo.api
 import odoo.exceptions
 import odoo.modules.registry
 from odoo import http

--- a/odoo/__init__.py
+++ b/odoo/__init__.py
@@ -22,9 +22,6 @@ assert sys.version_info > MIN_PY_VERSION, f"Outdated python version detected, Od
 # ----------------------------------------------------------
 # Shortcuts
 # ----------------------------------------------------------
-# The hard-coded super-user id (a.k.a. administrator, or root user).
-SUPERUSER_ID = 1
-
 
 def registry(database_name=None):
     """
@@ -47,6 +44,9 @@ def registry(database_name=None):
 from . import _monkeypatches
 _monkeypatches.patch_all()
 
+# ----------------------------------------------------------
+# Export admin user constant
+from .orm.utils import SUPERUSER_ID
 
 # ----------------------------------------------------------
 # Imports

--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -20,7 +20,8 @@ except ImportError:
 
 from rjsmin import jsmin as rjsmin
 
-from odoo import release, SUPERUSER_ID, _
+from odoo import release, _
+from odoo.api import SUPERUSER_ID
 from odoo.http import request
 from odoo.tools import (func, misc, transpile_javascript,
     is_odoo_module, SourceMapGenerator, profiler, OrderedSet)

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -14,7 +14,7 @@ import werkzeug
 
 from collections import defaultdict
 
-from odoo import api, fields, models, SUPERUSER_ID, _
+from odoo import api, fields, models, _
 from odoo.exceptions import AccessError, ValidationError, UserError
 from odoo.fields import Domain
 from odoo.http import Stream, root, request
@@ -706,7 +706,7 @@ class IrAttachment(models.Model):
             ("url", "=like", "/web/assets/%"),
             ('res_model', '=', 'ir.ui.view'),
             ('res_id', '=', 0),
-            ('create_uid', '=', SUPERUSER_ID),
+            ('create_uid', '=', api.SUPERUSER_ID),
         ]).unlink()
         self.env.registry.clear_cache('assets')
 

--- a/odoo/addons/base/models/ir_default.py
+++ b/odoo/addons/base/models/ir_default.py
@@ -4,7 +4,8 @@
 import json
 from datetime import date
 
-from odoo import api, fields, models, tools, _, SUPERUSER_ID
+from odoo import api, fields, models, tools, _
+from odoo.api import SUPERUSER_ID
 from odoo.exceptions import ValidationError
 from odoo.tools import SQL
 

--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -27,7 +27,8 @@ except ImportError:
     slugify_lib = None
 
 import odoo
-from odoo import api, http, models, tools, SUPERUSER_ID
+from odoo import api, http, models, tools
+from odoo.api import SUPERUSER_ID
 from odoo.exceptions import AccessDenied
 from odoo.http import request, Response, ROUTING_KEYS, SAFE_HTTP_METHODS
 from odoo.modules.registry import Registry

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -6,7 +6,8 @@ import logging
 import threading
 import warnings
 
-from odoo import api, fields, models, tools, _, Command, SUPERUSER_ID
+from odoo import api, fields, models, tools, _, Command
+from odoo.api import SUPERUSER_ID
 from odoo.exceptions import ValidationError, UserError
 from odoo.osv import expression
 from odoo.tools import html2plaintext, file_open, ormcache

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -14,7 +14,7 @@ from collections import defaultdict
 from random import randint
 from werkzeug import urls
 
-from odoo import api, fields, models, tools, SUPERUSER_ID, _, Command
+from odoo import api, fields, models, tools, _, Command
 from odoo.exceptions import RedirectWarning, UserError, ValidationError
 
 import typing
@@ -392,7 +392,7 @@ class ResPartner(models.Model):
 
     @api.depends('user_ids.share', 'user_ids.active')
     def _compute_partner_share(self):
-        super_partner = self.env['res.users'].browse(SUPERUSER_ID).partner_id
+        super_partner = self.env['res.users'].browse(api.SUPERUSER_ID).partner_id
         if super_partner in self:
             super_partner.partner_share = False
         for partner in self - super_partner:

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -23,8 +23,9 @@ from lxml import etree
 from lxml.builder import E
 from passlib.context import CryptContext as _CryptContext
 
-from odoo import api, fields, models, tools, SUPERUSER_ID, _, Command
+from odoo import api, fields, models, tools, _, Command
 from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
+from odoo.api import SUPERUSER_ID
 from odoo.exceptions import AccessDenied, AccessError, UserError, ValidationError
 from odoo.fields import Domain
 from odoo.http import request, DEFAULT_LANG

--- a/odoo/addons/base/tests/test_db_cursor.py
+++ b/odoo/addons/base/tests/test_db_cursor.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import psycopg2
 from psycopg2.extensions import ISOLATION_LEVEL_REPEATABLE_READ
 
-import odoo
+from odoo import api
 from odoo.modules.registry import Registry
 from odoo.sql_db import db_connect, TestCursor
 from odoo.tests import common
@@ -132,7 +132,7 @@ class TestTestCursor(common.TransactionCase):
         # now we make a test cursor for self.cr
         self.cr = self.registry.cursor()
         self.addCleanup(self.cr.close)
-        self.env = odoo.api.Environment(self.cr, odoo.SUPERUSER_ID, {})
+        self.env = api.Environment(self.cr, api.SUPERUSER_ID, {})
         self.record = self.env['res.partner'].create({'name': 'Foo'})
 
     def write(self, record, value):

--- a/odoo/addons/base/tests/test_ir_attachment.py
+++ b/odoo/addons/base/tests/test_ir_attachment.py
@@ -7,7 +7,7 @@ import os
 
 from PIL import Image
 
-import odoo
+from odoo.api import SUPERUSER_ID
 from odoo.exceptions import AccessError
 from odoo.addons.base.models.ir_attachment import IrAttachment
 from odoo.addons.base.tests.common import TransactionCaseWithUserDemo
@@ -317,14 +317,14 @@ class TestPermissions(TransactionCaseWithUserDemo):
         # Check the user can access his own attachment
         attachment_user.datas
         # Create an attachment as superuser without res_model/res_id
-        attachment_admin = self.Attachments.with_user(odoo.SUPERUSER_ID).create({'name': 'foo'})
+        attachment_admin = self.Attachments.with_user(SUPERUSER_ID).create({'name': 'foo'})
         # Check the record cannot be accessed by a regular user
         with self.assertRaises(AccessError):
             attachment_admin.with_user(self.env.user).datas
         # Check the record can be accessed by an admin (other than superuser)
         admin_user = self.env.ref('base.user_admin')
         # Safety assert that base.user_admin is not the superuser, otherwise the test is useless
-        self.assertNotEqual(odoo.SUPERUSER_ID, admin_user.id)
+        self.assertNotEqual(SUPERUSER_ID, admin_user.id)
         attachment_admin.with_user(admin_user).datas
 
     def test_with_write_permissions(self):

--- a/odoo/addons/base/tests/test_res_users.py
+++ b/odoo/addons/base/tests/test_res_users.py
@@ -1,12 +1,12 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from odoo import Command, SUPERUSER_ID
 from odoo.addons.base.models.res_users import is_selection_groups, get_selection_groups, name_selection_groups
+from odoo.api import SUPERUSER_ID
 from odoo.exceptions import AccessError, UserError, ValidationError
+from odoo.fields import Command
 from odoo.http import _request_stack
 from odoo.tests import Form, TransactionCase, new_test_user, tagged, HttpCase, users, warmup
 from odoo.tools import mute_logger

--- a/odoo/addons/base/tests/test_uninstall.py
+++ b/odoo/addons/base/tests/test_uninstall.py
@@ -6,7 +6,7 @@
 from contextlib import contextmanager
 import unittest
 
-from odoo import api, SUPERUSER_ID
+from odoo import api
 from odoo.tests import common
 from odoo.tests.common import BaseCase
 
@@ -20,7 +20,7 @@ def environment():
     """
     reg = Registry(common.get_db_name())
     with reg.cursor() as cr:
-        yield api.Environment(cr, SUPERUSER_ID, {})
+        yield api.Environment(cr, api.SUPERUSER_ID, {})
 
 
 MODULE = 'test_uninstall'

--- a/odoo/addons/test_access_rights/tests/test_feedback.py
+++ b/odoo/addons/test_access_rights/tests/test_feedback.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8 -*-
-from odoo import SUPERUSER_ID, Command
+from odoo.api import SUPERUSER_ID
 from odoo.exceptions import AccessError
+from odoo.fields import Command
 from odoo.tests import TransactionCase
 from odoo.tools.misc import mute_logger
 

--- a/odoo/addons/test_assetsbundle/controllers/main.py
+++ b/odoo/addons/test_assetsbundle/controllers/main.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import SUPERUSER_ID
+from odoo.api import SUPERUSER_ID
 from odoo.http import Controller, request, route
 
 class TestAssetsBundleController(Controller):

--- a/odoo/addons/test_http/tests/test_static.py
+++ b/odoo/addons/test_http/tests/test_static.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 from freezegun import freeze_time
 from urllib3.util import parse_url
 
-import odoo
+from odoo import api, http
 from odoo.tests import new_test_user, tagged, RecordCapturer
 from odoo.tools import config, file_open, image_process
 from odoo.tools.misc import submap
@@ -456,7 +456,7 @@ class TestHttpStaticLogo(TestHttpStaticCommon):
             'Content-Type': 'image/png',
             'Content-Disposition': 'inline; filename=nologo.png'
         }
-        super_user = cls.env['res.users'].browse([odoo.SUPERUSER_ID])
+        super_user = cls.env['res.users'].browse([api.SUPERUSER_ID])
         companies = ResCompany.browse([super_user.company_id.id]) | ResCompany.create(
             {
                 'name': 'Company 2',
@@ -646,7 +646,7 @@ class TestHttpStaticUpload(TestHttpStaticCommon):
                 f'{self.base_url()}/web/binary/upload_attachment',
                 files={'ufile': file},
                 data={
-                    'csrf_token': odoo.http.Request.csrf_token(self),
+                    'csrf_token': http.Request.csrf_token(self),
                     'model': 'test_http.stargate',
                     'id': self.env.ref('test_http.earth').id,
                 },
@@ -692,7 +692,7 @@ class TestHttpStaticUpload(TestHttpStaticCommon):
                 f'{self.base_url()}/web/binary/upload_attachment',
                 files={'ufile': file},
                 data={
-                    'csrf_token': odoo.http.Request.csrf_token(self),
+                    'csrf_token': http.Request.csrf_token(self),
                     'model': 'test_http.stargate',
                     'id': self.env.ref('test_http.earth').id,
                     'callback': 'callmemaybe',

--- a/odoo/addons/test_lint/__init__.py
+++ b/odoo/addons/test_lint/__init__.py
@@ -1,4 +1,1 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
-from odoo import api, SUPERUSER_ID

--- a/odoo/api/__init__.py
+++ b/odoo/api/__init__.py
@@ -14,5 +14,6 @@ from odoo.orm.decorators import (
     readonly,
 )
 from odoo.orm.environments import Environment
+from odoo.orm.utils import SUPERUSER_ID
 
 from odoo.orm.types import ContextType, DomainType, IdType, Self, ValuesType

--- a/odoo/cli/populate.py
+++ b/odoo/cli/populate.py
@@ -3,11 +3,12 @@ import optparse
 import sys
 import time
 
-from . import Command
 import odoo
+from odoo import api
 from odoo.modules.registry import Registry
 from odoo.tools.populate import populate_models
-from odoo.api import Environment
+
+from . import Command
 
 DEFAULT_FACTOR = '10000'
 DEFAULT_SEPARATOR = '_'
@@ -56,11 +57,11 @@ class Populate(Command):
             sys.exit("-d/--database/db_name has multiple database, please provide a single one")
         registry = Registry(dbnames[0])
         with registry.cursor() as cr:
-            env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {'active_test': False})
+            env = api.Environment(cr, api.SUPERUSER_ID, {'active_test': False})
             self.populate(env, model_factors, separator_code)
 
     @classmethod
-    def populate(cls, env: Environment, modelname_factors: dict[str, int], separator_code: int):
+    def populate(cls, env: api.Environment, modelname_factors: dict[str, int], separator_code: int):
         model_factors = {
             model: factor
             for model_name, factor in modelname_factors.items()

--- a/odoo/cli/shell.py
+++ b/odoo/cli/shell.py
@@ -6,7 +6,8 @@ import signal
 import sys
 import threading
 
-import odoo
+import odoo  # to expose in the shell
+from odoo import api
 from odoo.modules.registry import Registry
 from odoo.service import server
 from odoo.tools import config
@@ -135,9 +136,9 @@ class Shell(Command):
             threading.current_thread().dbname = dbname
             registry = Registry(dbname)
             with registry.cursor() as cr:
-                uid = odoo.SUPERUSER_ID
-                ctx = odoo.api.Environment(cr, uid, {})['res.users'].context_get()
-                env = odoo.api.Environment(cr, uid, ctx)
+                uid = api.SUPERUSER_ID
+                ctx = api.Environment(cr, uid, {})['res.users'].context_get()
+                env = api.Environment(cr, uid, ctx)
                 local_vars['env'] = env
                 local_vars['self'] = env.user
                 self.console(local_vars)

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -17,7 +17,7 @@ import traceback
 import odoo.sql_db
 import odoo.tools.sql
 import odoo.tools.translate
-from odoo import SUPERUSER_ID, api, tools
+from odoo import api, tools
 from odoo.tools.misc import SENTINEL
 
 from . import db as modules_db
@@ -466,7 +466,7 @@ def load_modules(registry: Registry, force_demo: bool = False, status: None = No
         # processed_modules: for cleanup step after install
         # loaded_modules: to avoid double loading
         report = registry._assertion_report
-        env = api.Environment(cr, SUPERUSER_ID, {})
+        env = api.Environment(cr, api.SUPERUSER_ID, {})
         loaded_modules, processed_modules = load_module_graph(
             env,
             graph,

--- a/odoo/orm/environments.py
+++ b/odoo/orm/environments.py
@@ -13,7 +13,6 @@ from contextlib import contextmanager
 from pprint import pformat
 from weakref import WeakSet
 
-from odoo import SUPERUSER_ID
 from odoo.exceptions import AccessError, UserError, CacheMiss
 from odoo.sql_db import BaseCursor
 from odoo.tools import clean_context, frozendict, lazy_property, OrderedSet, Query, SQL
@@ -21,6 +20,7 @@ from odoo.tools.translate import get_translation, get_translated_module, LazyGet
 from odoo.tools.misc import StackMap, SENTINEL
 
 from .registry import Registry
+from .utils import SUPERUSER_ID
 
 if typing.TYPE_CHECKING:
     from collections.abc import Collection, Iterable, Iterator

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -48,7 +48,7 @@ import psycopg2.extensions
 from psycopg2.extras import Json
 
 import odoo
-from odoo import SUPERUSER_ID, tools
+from odoo import tools
 from odoo.exceptions import AccessError, MissingError, ValidationError, UserError
 from odoo.tools import (
     clean_context, config, date_utils, discardattr,
@@ -76,6 +76,7 @@ from .utils import (
     OriginIds, check_pg_name, check_object_name, origin_ids, parse_field_expr,
     COLLECTION_TYPES, SQL_OPERATORS,
     READ_GROUP_ALL_TIME_GRANULARITY, READ_GROUP_TIME_GRANULARITY, READ_GROUP_NUMBER_GRANULARITY,
+    SUPERUSER_ID,
 )
 
 if typing.TYPE_CHECKING:
@@ -4483,7 +4484,7 @@ class BaseModel(metaclass=MetaModel):
         bad_names = {'id', 'parent_path'}
         if self._log_access:
             # the superuser can set log_access fields while loading registry
-            if not(self.env.uid == SUPERUSER_ID and not self.pool.ready):
+            if not (self.env.uid == SUPERUSER_ID and not self.pool.ready):
                 bad_names.update(LOG_ACCESS_COLUMNS)
 
         # set magic fields
@@ -4858,7 +4859,7 @@ class BaseModel(metaclass=MetaModel):
         bad_names = ['id', 'parent_path']
         if self._log_access:
             # the superuser can set log_access fields while loading registry
-            if not(self.env.uid == SUPERUSER_ID and not self.pool.ready):
+            if not (self.env.uid == SUPERUSER_ID and not self.pool.ready):
                 bad_names.extend(LOG_ACCESS_COLUMNS)
 
         # also discard precomputed readonly fields (to force their computation)

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -21,7 +21,6 @@ from operator import attrgetter
 import psycopg2.sql
 
 import odoo
-from odoo import SUPERUSER_ID
 from odoo.modules.db import FunctionStatus
 from odoo.sql_db import TestCursor
 from odoo.tools import (
@@ -36,6 +35,8 @@ from odoo.tools import (
 from odoo.tools.func import locked
 from odoo.tools.lru import LRU
 from odoo.tools.misc import Collector, format_frame
+
+from .utils import SUPERUSER_ID
 
 if typing.TYPE_CHECKING:
     from collections.abc import Callable, Collection, Iterable, Iterator, MutableMapping
@@ -319,7 +320,8 @@ class Registry(Mapping[str, type["BaseModel"]]):
         """ Complete the setup of models.
             This must be called after loading modules and before using the ORM.
         """
-        env = odoo.api.Environment(cr, SUPERUSER_ID, {})
+        from .environments import Environment  # noqa: PLC0415
+        env = Environment(cr, SUPERUSER_ID, {})
         env.invalidate_all()
 
         # Uninstall registry hooks. Because of the condition, this only happens
@@ -604,7 +606,8 @@ class Registry(Mapping[str, type["BaseModel"]]):
         elif context.get('models_to_check', False):
             _logger.info("verifying fields for every extended model")
 
-        env = odoo.api.Environment(cr, SUPERUSER_ID, context)
+        from .environments import Environment  # noqa: PLC0415
+        env = Environment(cr, SUPERUSER_ID, context)
         models = [env[model_name] for model_name in model_names]
 
         try:
@@ -756,7 +759,8 @@ class Registry(Mapping[str, type["BaseModel"]]):
         """
         Verify that all tables are present and try to initialize those that are missing.
         """
-        env = odoo.api.Environment(cr, SUPERUSER_ID, {})
+        from .environments import Environment  # noqa: PLC0415
+        env = Environment(cr, SUPERUSER_ID, {})
         table2model = {
             model._table: name
             for name, model in env.registry.items()

--- a/odoo/orm/utils.py
+++ b/odoo/orm/utils.py
@@ -14,6 +14,8 @@ regex_private = re.compile(r'^(_.*|init)$')
 
 # types handled as collections
 COLLECTION_TYPES = (list, tuple, AbstractSet)
+# The hard-coded super-user id (a.k.a. root user, or OdooBot).
+SUPERUSER_ID = 1
 
 # read_group stuff
 READ_GROUP_TIME_GRANULARITY = {

--- a/odoo/service/db.py
+++ b/odoo/service/db.py
@@ -14,12 +14,11 @@ from psycopg2.extensions import quote_ident
 from decorator import decorator
 from pytz import country_timezones
 
-import odoo
+import odoo.api
 import odoo.modules.neutralize
 import odoo.release
 import odoo.sql_db
 import odoo.tools
-from odoo import SUPERUSER_ID
 from odoo.exceptions import AccessDenied
 from odoo.release import version_info
 from odoo.sql_db import db_connect
@@ -72,7 +71,7 @@ def _initialize_db(id, db_name, demo, lang, user_password, login='admin', countr
         registry = odoo.modules.registry.Registry.new(db_name, demo, update_module=True)
 
         with closing(registry.cursor()) as cr:
-            env = odoo.api.Environment(cr, SUPERUSER_ID, {})
+            env = odoo.api.Environment(cr, odoo.api.SUPERUSER_ID, {})
 
             if lang:
                 modules = env['ir.module.module'].search([('state', '=', 'installed')])
@@ -174,7 +173,7 @@ def exp_duplicate_database(db_original_name, db_name, neutralize_database=False)
     registry = odoo.modules.registry.Registry.new(db_name)
     with registry.cursor() as cr:
         # if it's a copy of a database, force generation of a new dbuuid
-        env = odoo.api.Environment(cr, SUPERUSER_ID, {})
+        env = odoo.api.Environment(cr, odoo.api.SUPERUSER_ID, {})
         env['ir.config_parameter'].init(force=True)
         if neutralize_database:
             odoo.modules.neutralize.neutralize_database(cr)
@@ -342,7 +341,7 @@ def restore_db(db, dump_file, copy=False, neutralize_database=False):
 
         registry = odoo.modules.registry.Registry.new(db)
         with registry.cursor() as cr:
-            env = odoo.api.Environment(cr, SUPERUSER_ID, {})
+            env = odoo.api.Environment(cr, odoo.api.SUPERUSER_ID, {})
             if copy:
                 # if it's a copy of a database, force generation of a new dbuuid
                 env['ir.config_parameter'].init(force=True)

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -52,6 +52,7 @@ except ImportError:
     setproctitle = lambda x: None
 
 import odoo
+from odoo import api
 from odoo.modules import get_modules
 from odoo.modules.registry import Registry
 from odoo.release import nt_service_name
@@ -1311,7 +1312,7 @@ def preload_registries(dbnames):
                 post_install_suite = loader.make_suite(module_names, 'post_install')
                 if post_install_suite.has_http_case():
                     with registry.cursor() as cr:
-                        env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
+                        env = api.Environment(cr, api.SUPERUSER_ID, {})
                         env['ir.qweb']._pregenerate_assets_bundles()
                 result = loader.run_suite(post_install_suite)
                 registry._assertion_report.update(result)

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -120,7 +120,7 @@ def __getattr__(name):
 # The odoo library is supposed already configured.
 HOST = '127.0.0.1'
 # Useless constant, tests are aware of the content of demo data
-ADMIN_USER_ID = odoo.SUPERUSER_ID
+ADMIN_USER_ID = api.SUPERUSER_ID
 
 CHECK_BROWSER_SLEEP = 0.1 # seconds
 CHECK_BROWSER_ITERATIONS = 100
@@ -846,7 +846,7 @@ class TransactionCase(BaseCase):
         # since cron are not running during tests, we need to gc manually
         # We need to check the status of the file system outside of the test cursor
         with Registry(get_db_name()).cursor() as cr:
-            gc_env = api.Environment(cr, odoo.SUPERUSER_ID, {})
+            gc_env = api.Environment(cr, api.SUPERUSER_ID, {})
             gc_env['ir.attachment']._gc_file_store_unsafe()
 
     @classmethod
@@ -902,8 +902,7 @@ class TransactionCase(BaseCase):
         cls.close_patcher = patch.object(cls.cr, 'close', forbidden)
         cls.startClassPatcher(cls.close_patcher)
 
-
-        cls.env = api.Environment(cls.cr, odoo.SUPERUSER_ID, {})
+        cls.env = api.Environment(cls.cr, api.SUPERUSER_ID, {})
 
         # speedup CryptContext. Many user an password are done during tests, avoid spending time hasing password with many rounds
         def _crypt_context(self):  # noqa: ARG001
@@ -981,7 +980,7 @@ class SingleTransactionCase(BaseCase):
         cls.cr = cls.registry.cursor()
         cls.addClassCleanup(cls.cr.close)
 
-        cls.env = api.Environment(cls.cr, odoo.SUPERUSER_ID, {})
+        cls.env = api.Environment(cls.cr, api.SUPERUSER_ID, {})
 
     def setUp(self):
         super(SingleTransactionCase, self).setUp()

--- a/odoo/tests/test_module_operations.py
+++ b/odoo/tests/test_module_operations.py
@@ -8,7 +8,7 @@ import time
 
 sys.path.append(os.path.abspath(os.path.join(__file__,'../../../')))
 
-import odoo
+from odoo import api
 from odoo.tools import config, topological_sort, unique
 from odoo.modules.registry import Registry
 from odoo.netsvc import init_logger
@@ -30,7 +30,7 @@ INSTALL_BLACKLIST = {
 
 def install(db_name, module_id, module_name):
     with Registry(db_name).cursor() as cr:
-        env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
+        env = api.Environment(cr, api.SUPERUSER_ID, {})
         module = env['ir.module.module'].browse(module_id)
         module.button_immediate_install()
     _logger.info('%s installed', module_name)
@@ -38,7 +38,7 @@ def install(db_name, module_id, module_name):
 
 def uninstall(db_name, module_id, module_name):
     with Registry(db_name).cursor() as cr:
-        env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
+        env = api.Environment(cr, api.SUPERUSER_ID, {})
         module = env['ir.module.module'].browse(module_id)
         module.button_immediate_uninstall()
     _logger.info('%s uninstalled', module_name)
@@ -125,7 +125,7 @@ class StandaloneAction(argparse.Action):
 def test_cycle(args):
     """ Test full install/uninstall/reinstall cycle for all modules """
     with Registry(args.database).cursor() as cr:
-        env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
+        env = odoo.api.Environment(cr, odoo.api.SUPERUSER_ID, {})
 
         def valid(module):
             return not (
@@ -160,7 +160,7 @@ def test_uninstall(args):
     """ Tries to uninstall/reinstall one ore more modules"""
     for module_name in args.uninstall.split(','):
         with Registry(args.database).cursor() as cr:
-            env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
+            env = odoo.api.Environment(cr, odoo.api.SUPERUSER_ID, {})
             module = env['ir.module.module'].search([('name', '=', module_name)])
             module_id, module_state = module.id, module.state
 
@@ -193,7 +193,7 @@ def test_standalone(args):
     start_time = time.time()
     for index, func in enumerate(funcs, start=1):
         with Registry(args.database).cursor() as cr:
-            env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
+            env = odoo.api.Environment(cr, odoo.api.SUPERUSER_ID, {})
             _logger.info("Executing standalone script: %s (%d / %d)",
                          func.__name__, index, len(funcs))
             try:

--- a/odoo/tools/cloc.py
+++ b/odoo/tools/cloc.py
@@ -6,8 +6,9 @@ import os
 import re
 import shutil
 
-import odoo
-from odoo.tools.config import config
+import odoo.modules
+from odoo import api
+from .config import config
 
 VERSION = 1
 DEFAULT_EXCLUDE = [
@@ -289,8 +290,8 @@ class Cloc(object):
     def count_database(self, database):
         registry = odoo.modules.registry.Registry(database)
         with registry.cursor() as cr:
-            uid = odoo.SUPERUSER_ID
-            env = odoo.api.Environment(cr, uid, {})
+            uid = api.SUPERUSER_ID
+            env = api.Environment(cr, uid, {})
             self.count_env(env)
 
     #------------------------------------------------------

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -569,7 +569,8 @@ def _get_lang(frame, default_lang='') -> str:
     cr = _get_cr(frame)
     uid = _get_uid(frame)
     if cr and uid:
-        env = odoo.api.Environment(cr, uid, {})
+        from odoo import api  # noqa: PLC0415
+        env = api.Environment(cr, uid, {})
         if lang := env['res.users'].context_get().get('lang'):
             return lang
     # fallback
@@ -1121,7 +1122,8 @@ class TranslationReader:
     def __init__(self, cr, lang=None):
         self._cr = cr
         self._lang = lang or 'en_US'
-        self.env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
+        from odoo import api  # noqa: PLC0415
+        self.env = api.Environment(cr, api.SUPERUSER_ID, {})
         self._to_translate = []
 
     def __iter__(self):
@@ -1442,7 +1444,8 @@ class TranslationImporter:
     def __init__(self, cr, verbose=True):
         self.cr = cr
         self.verbose = verbose
-        self.env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
+        from odoo import api  # noqa: PLC0415
+        self.env = api.Environment(cr, api.SUPERUSER_ID, {})
 
         # {model_name: {field_name: {xmlid: {lang: value}}}}
         self.model_translations = DeepDefaultDict()
@@ -1676,7 +1679,8 @@ def load_language(cr, lang):
     :param str lang: language ISO code with optional underscore (``_``) and
         l10n flavor (ex: 'fr', 'fr_BE', but not 'fr-BE')
     """
-    env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
+    from odoo import api  # noqa: PLC0415
+    env = api.Environment(cr, api.SUPERUSER_ID, {})
     lang_ids = env['res.lang'].with_context(active_test=False).search([('code', '=', lang)]).ids
     installer = env['base.language.install'].create({'lang_ids': [(6, 0, lang_ids)]})
     installer.lang_install()


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Move `odoo.SUPERUSER_ID` to `odoo.api.SUPERUSER_ID`.
In order to become a namespace package, `odoo` package should not contain any variables, only modules.

odoo/upgrade-util#144
task-4069446

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
