### PR TITLE
[FIX] html_editor: remove extended text style

### DIFF
--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -24,21 +24,21 @@ export const fontItems = [
         extraClass: "display-1",
     },
     // TODO @phoenix use them if showExtendedTextStylesOptions is true
-    {
-        name: _t("Header 1 Display 2"),
-        tagName: "h1",
-        extraClass: "display-2",
-    },
-    {
-        name: _t("Header 1 Display 3"),
-        tagName: "h1",
-        extraClass: "display-3",
-    },
-    {
-        name: _t("Header 1 Display 4"),
-        tagName: "h1",
-        extraClass: "display-4",
-    },
+    // {
+    //     name: _t("Header 1 Display 2"),
+    //     tagName: "h1",
+    //     extraClass: "display-2",
+    // },
+    // {
+    //     name: _t("Header 1 Display 3"),
+    //     tagName: "h1",
+    //     extraClass: "display-3",
+    // },
+    // {
+    //     name: _t("Header 1 Display 4"),
+    //     tagName: "h1",
+    //     extraClass: "display-4",
+    // },
     // ----
 
     { name: _t("Header 1"), tagName: "h1" },
@@ -51,16 +51,16 @@ export const fontItems = [
     { name: _t("Normal"), tagName: "p" },
 
     // TODO @phoenix use them if showExtendedTextStylesOptions is true
-    {
-        name: _t("Light"),
-        tagName: "p",
-        extraClass: "lead",
-    },
-    {
-        name: _t("Small"),
-        tagName: "p",
-        extraClass: "small",
-    },
+    // {
+    //     name: _t("Light"),
+    //     tagName: "p",
+    //     extraClass: "lead",
+    // },
+    // {
+    //     name: _t("Small"),
+    //     tagName: "p",
+    //     extraClass: "small",
+    // },
     // ----
 
     { name: _t("Code"), tagName: "pre" },


### PR DESCRIPTION
Currently, showExtendedTextStylesOptions are still displayed. Before the new editor (html_editor), it was only used by the website builder. The website builder still doesn't use html_editor, so we're going to disable them. We'll reintroduce them when the website builder uses html_editor.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
