### PR TITLE
[FIX] website: disable view "Published" field in "Properties" menu

### DIFF
--- a/addons/website/models/website_page_properties.py
+++ b/addons/website/models/website_page_properties.py
@@ -77,6 +77,11 @@ class PagePropertiesBase(models.TransientModel):
                 # Check we are in a non-custom state to avoid messing with
                 # manually set values.
                 record.can_publish = self._is_ir_ui_view_published(target) or self._is_ir_ui_view_unpublished(target)
+
+                # FIXME disabled for the moment because it does not hide the url
+                # in the sitemap and it is difficult to find a fix that would be
+                # consistent. To revisit later.
+                record.can_publish = False
             elif 'can_publish' in target._fields:
                 record.can_publish = target.can_publish
             else:


### PR DESCRIPTION
Commit [1] introduced the possibility to publish/unpublish "any route"
by using the visibility and groups fields available on the rendered
view. This obviously had its limitations, indeed the route and the view
are independent (e.g. a same URL could lead to different views depending
on values in the database for example) but allowing to "unpublish" the
"current rendered page the user is seeing" seemed like a good first
improvement anyway.

However, the sitemap was forgotten... and it is proving difficult to fix
in a way that makes sense. It would mean saving the info of the URL
that was used to reach the "unpublished" *view* in the first place
somehow somewhere... and if it were to be possible, controllers with
parameters, or controllers that lead to different views depending on
some configuration would really be a problem.

We choose to disable the feature for now (keeping its code but just not
showing the possibility via the UI). We will revisit this later. In the
end [2] added the possibility to properly "unpublish the whole shop"
(not just one page), which is the main demand when it comes to
unpublishing controllers (funny enough, the sitemap was also forgotten
for that feature, before fixes [3] and [4]).

[1]: https://github.com/odoo/odoo/commit/e3b1ff6e25ecc71c9242d3826cee09c636bc465a
[2]: https://github.com/odoo/odoo/commit/5bde2e42c8ec5e943a779ad4b3e1b7142f2d2fcf
[3]: https://github.com/odoo/odoo/commit/0738e0210207397429826ab3c4b3760b3a4dff44
[4]: https://github.com/odoo/odoo/commit/eb14c1f401d5d09a1d906346a4a4cd494bb47628