### PR TITLE
[FIX] mail: call icon in DiscussSidebar lack spacing with border

### DIFF
--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebarCallIndicator">
-        <div t-if="props.thread.rtcSessions.length > 0" class="fa fa-volume-up" title="Ongoing call" t-att-class="{ 'text-danger': props.thread.eq(rtc.state.channel), 'ms-1': !store.discuss.isSidebarCompact }"/>
+        <div t-if="props.thread.rtcSessions.length > 0" class="fa fa-volume-up" title="Ongoing call" t-att-class="{ 'text-danger': props.thread.eq(rtc.state.channel), 'mx-1': !store.discuss.isSidebarCompact }"/>
     </t>
 </templates>


### PR DESCRIPTION
Before / After
<img width="296" alt="Screenshot 2024-10-01 at 16 26 22" src="https://github.com/user-attachments/assets/b7b23378-b778-4610-ba8d-83f3219e7234">
<img width="299" alt="Screenshot 2024-10-01 at 16 25 57" src="https://github.com/user-attachments/assets/08cf20af-fb75-4ddf-ae25-3d5f5d1c241a">
