### PR TITLE
[IMP] website, html_editor: allow images in social media sections

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_tool_option.js
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option.js
@@ -22,6 +22,7 @@ export class ImageToolOption extends BaseOptionComponent {
         this.state = useDomState((editingElement) => ({
             isImageAnimated: editingElement.classList.contains("o_animate"),
             isGridMode: editingElement.closest(".o_grid_mode, .o_grid"),
+            isSocialMediaImg: editingElement.classList.contains("social_media_img"),
         }));
     }
 }

--- a/addons/html_builder/static/src/plugins/image/image_tool_option.xml
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option.xml
@@ -2,29 +2,31 @@
 <templates xml:space="preserve">
 
 <t t-name="html_builder.ImageToolOption">
-    <ImageShapeOption />
-    <BuilderRow label.translate="Description"
-        tooltip.translate="'Alt tag' specifies an alternate text for an image, if the image cannot be displayed (slow connection, missing image, screen reader ...).">
-        <BuilderTextInput
-            action="'alt'"
-            placeholder.translate="Alt tag"
-            />
-    </BuilderRow>
-    <BuilderRow label.translate="Tooltip"
-        tooltip.translate="'Title tag' is shown as a tooltip when you hover the picture.">
-        <BuilderTextInput
-            attributeAction="'title'"
-            placeholder.translate="Title tag" />
-    </BuilderRow>
+    <t t-if="!state.isSocialMediaImg">
+        <ImageShapeOption />
+        <BuilderRow label.translate="Description"
+            tooltip.translate="'Alt tag' specifies an alternate text for an image, if the image cannot be displayed (slow connection, missing image, screen reader ...).">
+            <BuilderTextInput
+                action="'alt'"
+                placeholder.translate="Alt tag"
+                />
+        </BuilderRow>
+        <BuilderRow label.translate="Tooltip"
+            tooltip.translate="'Title tag' is shown as a tooltip when you hover the picture.">
+            <BuilderTextInput
+                attributeAction="'title'"
+                placeholder.translate="Title tag" />
+        </BuilderRow>
+    </t>
     <BuilderRow label.translate="Transform" preview="false">
         <div class="btn-group o-hb-button-group">
             <BuilderButton title.translate="Crop image" action="'cropImage'" icon="'fa-crop'" id="'cropImage'" />
             <BuilderButton title.translate="Reset crop" action="'resetCrop'" t-if="this.isActiveItem('cropImage')" icon="'oi-close'" className="'btn-danger-color-hover rounded-start-0 m-0 py-0 flex-grow-0'" />
         </div>
-        <ImageTransformOption t-if="!state.isImageAnimated" />
+        <ImageTransformOption t-if="!state.isImageAnimated and !state.isSocialMediaImg" />
     </BuilderRow>
     <ImageFilterOption />
-    <t t-if="!state.isGridMode">
+    <t t-if="!state.isGridMode and !state.isSocialMediaImg">
         <MediaSizeOption/>
     </t>
     <ImageFormatOption />

--- a/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
@@ -10,7 +10,11 @@ import {
     IMAGE_TOOL,
     ALIGNMENT_STYLE_PADDING,
 } from "@html_builder/utils/option_sequence";
-import { ReplaceMediaOption, searchSupportedParentLinkEl } from "./replace_media_option";
+import {
+    ReplaceMediaOption,
+    searchSupportedParentLinkEl,
+    socialMediaElementsSelector,
+} from "./replace_media_option";
 import { computeMaxDisplayWidth } from "@html_builder/plugins/image/image_format_option";
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { selectElements } from "@html_editor/utils/dom_traversal";
@@ -21,8 +25,7 @@ import { BaseOptionComponent } from "@html_builder/core/utils";
 export class ImageAndFaOption extends BaseOptionComponent {
     static template = "html_builder.ImageAndFaOption";
     static selector = "span.fa, i.fa, img";
-    static exclude =
-        "[data-oe-type='image'] > img, [data-oe-xpath], .s_social_media i.fa, .s_share i.fa";
+    static exclude = `[data-oe-type='image'] > img, [data-oe-xpath], ${socialMediaElementsSelector}`;
     static name = "imageAndFaOption";
 }
 class ImageToolOptionPlugin extends Plugin {

--- a/addons/html_builder/static/src/plugins/image/replace_media_option.js
+++ b/addons/html_builder/static/src/plugins/image/replace_media_option.js
@@ -1,11 +1,12 @@
 import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
 import { _t } from "@web/core/l10n/translation";
 
+export const socialMediaElementsSelector = ".s_social_media i.fa, .s_share i.fa, .social_media_img";
+
 export class ReplaceMediaOption extends BaseOptionComponent {
     static template = "html_builder.ReplaceMediaOption";
     static selector = "img, .media_iframe_video, span.fa, i.fa";
-    static exclude =
-        "[data-oe-xpath], a[href^='/website/social/'] > i.fa, a[class*='s_share_'] > i.fa";
+    static exclude = `[data-oe-xpath], ${socialMediaElementsSelector}`;
     static name = "replaceMediaOption";
     setup() {
         super.setup();

--- a/addons/html_editor/static/src/main/media/media_dialog/media_dialog.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/media_dialog.js
@@ -261,6 +261,9 @@ export class MediaDialog extends Component {
                     })
                 );
             }
+
+            element.classList.add(...this.extraClassesToAdd());
+
             element.classList.remove(...this.initialIconClasses);
             element.classList.remove("o_modified_image_to_save");
             element.classList.remove("oe_edited_link");
@@ -269,6 +272,10 @@ export class MediaDialog extends Component {
             );
         });
         return elements;
+    }
+
+    extraClassesToAdd() {
+        return [];
     }
 
     selectMedia(media, tabId, multiSelect) {

--- a/addons/website/static/src/builder/plugins/font_awesome_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/font_awesome_option_plugin.js
@@ -27,7 +27,7 @@ export class FaResizeAction extends ClassAction {
 }
 export class FontAwesomeOptionComponent extends BaseOptionComponent {
     static template = "website.FontAwesomeOption";
-    static selector = "span.fa, i.fa";
+    static selector = "span.fa, i.fa, .social_media_img";
     static exclude = "[data-oe-xpath]";
     static components = { BorderConfigurator };
     setup() {

--- a/addons/website/static/src/builder/plugins/options/animate_option.js
+++ b/addons/website/static/src/builder/plugins/options/animate_option.js
@@ -3,8 +3,10 @@ import {
     useDomState,
     SPECIAL_BLOCKQUOTE_SELECTOR,
 } from "@html_builder/core/utils";
-
-import { isImageSupportedForStyle } from "@html_builder/plugins/image/replace_media_option";
+import {
+    isImageSupportedForStyle,
+    socialMediaElementsSelector,
+} from "@html_builder/plugins/image/replace_media_option";
 
 /**
  * @typedef {((el: HTMLElement) => Promise<boolean>)[]} hover_effect_allowed_predicates
@@ -14,7 +16,7 @@ export class AnimateOption extends BaseOptionComponent {
     static template = "website.AnimateOption";
     static dependencies = ["animateOption"];
     static selector = ".o_animable, section .row > div, img, .fa, .btn";
-    static exclude = `[data-oe-xpath], .o_not-animable, .s_col_no_resize.row > div, .s_col_no_resize, .s_social_media i.fa, .s_share i.fa, ${SPECIAL_BLOCKQUOTE_SELECTOR}`;
+    static exclude = `[data-oe-xpath], .o_not-animable, .s_col_no_resize.row > div, .s_col_no_resize, ${socialMediaElementsSelector}, ${SPECIAL_BLOCKQUOTE_SELECTOR}`;
     static props = {
         dropdownClass: { type: String, optional: true, default: "o-hb-select-dropdown" },
         requireAnimation: { type: Boolean, optional: true },

--- a/addons/website/static/src/builder/plugins/options/social_media_option.xml
+++ b/addons/website/static/src/builder/plugins/options/social_media_option.xml
@@ -11,7 +11,7 @@
     </BuilderRow>
 
     <BuilderRow label.translate="Layout">
-        <BuilderSelect applyTo="'.fa'">
+        <BuilderSelect applyTo="'.fa, .social_media_img'">
             <BuilderSelectItem classAction="'rounded shadow-sm'">Square</BuilderSelectItem>
             <BuilderSelectItem classAction="'rounded-empty-circle shadow-sm'">Circle</BuilderSelectItem>
             <BuilderSelectItem classAction="'rounded-circle shadow-sm'">Disk</BuilderSelectItem>
@@ -20,7 +20,7 @@
     </BuilderRow>
 
     <BuilderRow label.translate="Size">
-        <BuilderSelect applyTo="'.fa'">
+        <BuilderSelect applyTo="'.fa, .social_media_img'">
             <BuilderSelectItem classAction="'small_social_icon'">Small</BuilderSelectItem>
             <BuilderSelectItem classAction="''">Medium</BuilderSelectItem>
             <BuilderSelectItem classAction="'fa-2x'">Large</BuilderSelectItem>

--- a/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
@@ -11,6 +11,7 @@ import { SNIPPET_SPECIFIC, TITLE_LAYOUT_SIZE, ANIMATE } from "@html_builder/util
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { AnimateOption } from "./animate_option";
 import { BaseOptionComponent } from "@html_builder/core/utils";
+import { socialMediaElementsSelector } from "@html_builder/plugins/image/replace_media_option";
 
 /**
  * @typedef { Object } SocialMediaOptionShared
@@ -128,7 +129,7 @@ export class SocialMediaOption extends BaseOptionComponent {
 
 export class SocialMediaAnimateOption extends AnimateOption {
     static selector = ".s_social_media, .s_share";
-    static applyTo = ".s_social_media i.fa, .s_share i.fa";
+    static applyTo = socialMediaElementsSelector;
 }
 
 class SocialMediaOptionPlugin extends Plugin {

--- a/addons/website/static/src/components/media_dialog/image_selector.js
+++ b/addons/website/static/src/components/media_dialog/image_selector.js
@@ -9,3 +9,7 @@ patch(HtmlImageSelector.prototype, {
         return domain;
     },
 });
+
+patch(HtmlImageSelector, {
+    mediaExtraClasses: [...HtmlImageSelector.mediaExtraClasses, "social_media_img"],
+});

--- a/addons/website/static/src/components/media_dialog/media_dialog.js
+++ b/addons/website/static/src/components/media_dialog/media_dialog.js
@@ -1,0 +1,21 @@
+import { patch } from "@web/core/utils/patch";
+import { MediaDialog, TABS } from "@html_editor/main/media/media_dialog/media_dialog";
+
+patch(MediaDialog.prototype, {
+    extraClassesToAdd() {
+        const classes = super.extraClassesToAdd();
+        const closestDivEl = this.props.node?.parentElement.closest("div");
+        if (
+            this.state.activeTab == TABS.IMAGES.id &&
+            closestDivEl?.matches(".s_social_media, .s_share")
+        ) {
+            classes.push("social_media_img");
+            for (const element of this.props.node.classList) {
+                if (element.match(/fa-\d{1}x/) || element == "small_social_icon") {
+                    classes.push(element);
+                }
+            }
+        }
+        return classes;
+    },
+});

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -679,11 +679,16 @@ font[class*='bg-'] {
     padding: MAX($-base-padding, 1px) 0 MAX(($-bottom-factor * $-base-padding), ($-bottom-factor * 1px));
 }
 
+// Images as Icons
+.social_media_img {
+    object-fit: cover;
+}
 // Icons
 .fa {
-    $-size: map-get($spacers, 5);
-
     font-family: "FontAwesome" !important;
+}
+.fa, .social_media_img {
+    $-size: map-get($spacers, 5);
 
     &.rounded-circle,
     &.rounded,

--- a/addons/website/static/src/snippets/s_share/000.scss
+++ b/addons/website/static/src/snippets/s_share/000.scss
@@ -10,7 +10,7 @@
         margin: 0 .4rem 0 0;
     }
     a {
-        i.fa {
+        i.fa, .social_media_img {
             display: flex;
             justify-content: center;
             align-items: center;

--- a/addons/website/static/src/snippets/s_social_media/000.scss
+++ b/addons/website/static/src/snippets/s_social_media/000.scss
@@ -10,7 +10,7 @@
         margin: 0 .4rem 0 0;
     }
     a {
-        i.fa, span.fa {
+        i.fa, span.fa, .social_media_img {
             display: flex;
             justify-content: center;
             align-items: center;


### PR DESCRIPTION
Before this commit, it was possible to replace social media icons with
any image. However, the image was not targetted by the options as
expected. For example, changing the "Layout" option of social media
(circle, disque, square) would only change the icons, not the images.

The options for the images are also different from the one for icons,
making the customization harder.

This commit allows the use of images as icons by using the same options
for icons.

task-3609071