### PR TITLE
[FIX] point_of_sale,pos_sale: ignore fixed tax in downpayment

### DIFF
--- a/addons/point_of_sale/static/tests/tours/helpers/generic_components/OrderWidgetMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/generic_components/OrderWidgetMethods.js
@@ -98,3 +98,10 @@ export function hasTax(amount) {
         isCheck: true,
     };
 }
+
+export function hasNoTax() {
+    return {
+        content: 'order has not tax',
+        trigger: '.order-summary:not(:has(.tax))'
+    }
+}

--- a/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js
+++ b/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js
@@ -392,7 +392,7 @@ export class SaleOrderManagementScreen extends ControlButtonsMixin(Component) {
             const down_payment_line_price = total_down_payment * ratio;
 
             // We apply the taxes and keep the same price
-            const taxes_to_apply = group[0].tax_id.map((id) => {
+            const taxes_to_apply = group[0].tax_id.filter(id => this.pos.taxes_by_id[id].amount_type !== "fixed").map((id) => {
                 return { ...this.pos.taxes_by_id[id], price_include: true };
             });
             const tax_res = this.pos.compute_all(
@@ -416,7 +416,7 @@ export class SaleOrderManagementScreen extends ControlButtonsMixin(Component) {
                         price_type: "automatic",
                         sale_order_origin_id: clickedOrder,
                         down_payment_details: tab,
-                        tax_ids: group[0].tax_id,
+                        tax_ids: group[0].tax_id.filter(id => this.pos.taxes_by_id[id].amount_type !== "fixed"),
                     }
                 )
             );

--- a/addons/pos_sale/static/tests/tours/PosSaleTour.js
+++ b/addons/pos_sale/static/tests/tours/PosSaleTour.js
@@ -283,3 +283,20 @@ registry.category("web_tour.tours").add("PosShipLaterNoDefault", {
             negateStep(PaymentScreen.shippingLaterHighlighted()),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("PoSDownPaymentLinesPerFixedTax", {
+    test: true,
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.clickQuotationButton(),
+            ProductScreen.downPayment20PercentFirstOrder(),
+            Order.hasLine({
+                productName: "Down Payment",
+                quantity: "1.0",
+                price: "22",
+            }),
+            Order.hasNoTax(),
+            ProductScreen.totalAmountIs(22.0), 
+        ].flat(),
+});

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -5,7 +5,7 @@ import odoo
 
 from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
 from odoo.tests.common import Form
-from odoo import fields
+from odoo import fields, Command
 
 @odoo.tests.tagged('post_install', '-at_install')
 class TestPoSSale(TestPointOfSaleHttpCommon):
@@ -719,3 +719,44 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.main_pos_config.write({'ship_later': True})
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosShipLaterNoDefault', login="accountman")
+
+    def test_downpayment_with_fixed_taxed_product(self):
+        tax_1 = self.env['account.tax'].create({
+            'name': '10',
+            'amount_type': 'fixed',
+            'amount': 10,
+        })
+
+        product_a = self.env['product.product'].create({
+            'name': 'Product A',
+            'available_in_pos': True,
+            'type': 'product',
+            'lst_price': 100.0,
+            'taxes_id': [tax_1.id],
+        })
+
+        partner_test = self.env['res.partner'].create({'name': 'Test Partner'})
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': partner_test.id,
+            'order_line': [Command.create({
+                'product_id': product_a.id,
+                'name': product_a.name,
+                'product_uom_qty': 1,
+                'product_uom': product_a.uom_id.id,
+                'price_unit': product_a.lst_price,
+            })],
+        })
+        sale_order.action_confirm()
+
+        self.downpayment_product = self.env['product.product'].create({
+            'name': 'Down Payment',
+            'available_in_pos': True,
+            'type': 'service',
+            'taxes_id': [],
+        })
+        self.main_pos_config.write({
+            'down_payment_product_id': self.downpayment_product.id,
+        })
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PoSDownPaymentLinesPerFixedTax', login="accountman")


### PR DESCRIPTION
When you made a downpayment on an order that contained product with fixed amount taxes, the tax would be paid multiple times.

Steps to reproduce:
-------------------
* Create a tax T1 with a fixed amount of 10€
* Create a product P1 using the tax T1
* Make a sale order and add the product P1 to it
* Open PoS and make a downpayment for the sale order (e.g 50%)
* You will already pay the 10€ of tax
* Now if you make a second downpayment (e.g. 10%)
> Observation: You still have the 10€ tax to pay

Why the fix:
------------
We match the behavior of sales app, and ignore the fixed price taxes when creating the downpayment lines.

opw-4163579
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
