### PR TITLE
[FIX] web_editor: ignore buggy MSO nested comments

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -1597,7 +1597,7 @@ export function isUnbreakable(node) {
 
 export function isUnremovable(node) {
     return (
-        (node.nodeType !== Node.ELEMENT_NODE && node.nodeType !== Node.TEXT_NODE) ||
+        (node.nodeType !== Node.COMMENT_NODE && node.nodeType !== Node.ELEMENT_NODE && node.nodeType !== Node.TEXT_NODE) ||
         node.oid === 'root' ||
         (node.nodeType === Node.ELEMENT_NODE &&
             (node.classList.contains('o_editable') || node.getAttribute('t-set') || node.getAttribute('t-call'))) ||


### PR DESCRIPTION
Maybe not the right approach, but to put the issue over the table at least.


Users can copy paste their html signatures from whatever source, and that can lead to buggy behaviors when that signatures are used in the editor.

For this case, users copy-pasted from outlook their html signature containing nested comments like this

```
<!--<![endif]-->
```

This lead to a buggy behavior of the web_editor whenever those signatures were loaded in the template. For example, in the invoice sending template.

In that case, the web_editor will rollback any attemped change in the mail composer when that code is loaded into the composer body editor.

The issue is that those nested comments are detected incorrectly. So better simply ignore them as they don't add up any value.

cc @Tecnativa TT51068


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
