### PR TITLE
[FIX] account: make sure that rounding issues is distributed on base …

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3473,9 +3473,9 @@ class AccountMove(models.Model):
                             - sum(x['balance'] for x in res['base_lines'][payment_term_line].values()) \
                             - sum(x['balance'] for x in res['tax_lines'][payment_term_line].values())
 
-            last_tax_line = (list(res['tax_lines'][payment_term_line].values()) or list(res['base_lines'][payment_term_line].values()))[-1]
-            last_tax_line['amount_currency'] += delta_amount_currency
-            last_tax_line['balance'] += delta_balance
+            biggest_base_line = max(list(res['base_lines'][payment_term_line].values()), key=lambda x: x['amount_currency'])
+            biggest_base_line['amount_currency'] += delta_amount_currency
+            biggest_base_line['balance'] += delta_balance
 
         else:
             grouping_dict = {'account_id': cash_discount_account.id}

--- a/addons/account/tests/test_early_payment_discount.py
+++ b/addons/account/tests/test_early_payment_discount.py
@@ -1048,3 +1048,84 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
 
         for line in payments.line_ids.filtered(lambda line: line.tax_repartition_line_id or line.tax_ids):
             self.assertTrue(line.tax_tag_invert)
+
+    def test_epd_multiple_repartition_lines(self):
+        """
+        In the case of multi repartition lines tax definition with an early payment discount
+        We want to make sure that the EPD lines are correct.
+        We want the rounding difference to be added to the "biggest" base line.
+        """
+        # Taxes.
+        common_values = {
+            'amount': 17.0,
+            'invoice_repartition_line_ids': [
+                Command.create({'repartition_type': 'base'}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': -100.0}),
+            ],
+            'refund_repartition_line_ids': [
+                Command.create({'repartition_type': 'base'}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': -100.0}),
+            ],
+        }
+
+        tax1, tax2 = self.env['account.tax'].create([
+            {'name': "tax1", **common_values},
+            {'name': "tax2", **common_values},
+        ])
+
+        # Early payment.
+        payment_term = self.env['account.payment.term'].create({
+            'name': "10% discount if paid within 10 days",
+            'early_discount': True,
+            'early_pay_discount_computation': 'included',
+            'discount_percentage': 2,
+            'discount_days': 10,
+            'line_ids': [Command.create({
+                'value': 'percent',
+                'nb_days': 0,
+                'value_amount': 100,
+            })]
+        })
+
+        # Invoice.
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_payment_term_id': payment_term.id,
+            'invoice_date': '2017-01-01',
+            'invoice_line_ids': [
+                Command.create({
+                    'name': "Line One",
+                    'price_unit': 739.95,
+                    'tax_ids': [Command.set(tax1.ids)],
+                }),
+                Command.create({
+                    'name': "Line Two",
+                    'price_unit': 37.80,
+                    'tax_ids': [Command.set(tax2.ids)],
+                }),
+            ],
+        })
+        invoice.action_post()
+
+        # Payment.
+        payment = self.env['account.payment.register']\
+            .with_context(active_model='account.move', active_ids=invoice.ids)\
+            .create({'payment_date': '2017-01-01'})\
+            ._create_payments()
+
+        self.assertRecordValues(payment.move_id.line_ids.sorted('amount_currency'), [
+            # Invoice's total:
+            {'amount_currency': -777.75},
+            # Base / tax lines:
+            {'amount_currency': -2.51},
+            {'amount_currency': -0.13},
+            {'amount_currency': 0.13},
+            {'amount_currency': 0.76},
+            {'amount_currency': 2.51},
+            {'amount_currency': 14.79},
+            # Discounted amount:
+            {'amount_currency': 762.2},
+        ])


### PR DESCRIPTION
…line

Steps to reproduce:
- Create two taxes T1 and T2 of 17% with two tax grids lines (+) and (-)
- Configure a payment term of 2% discount
- Create a payment of `-762.20` for a partner with a reference 'ref123'
- Create and confirm a bill for the same partner, with a ref 'ref123', with the payment term and two lines; L1{'amount': 739.95 , 'tax': T1} L2{'amount': 37.8, 'tax':T2}
- In Dashboard > Bank > select the transaction

Issue:
The last line tax will be 0.14 (difference of one 1)

Cause:
The rounding issues sum up and we arbitrarily assign it to the last tax line (which can result in an unbalance).

Solution:
Instead, we assign this difference to the "biggest" base line (as the change will proportionnaly be smaller). While doing so, we keep consistencies between the tax lines.

opw-3966041
