### PR TITLE
[IMP] mail: 'start a call' thread action becomes green on hover

### DIFF
--- a/addons/mail/static/src/discuss/call/common/chat_window_patch.scss
+++ b/addons/mail/static/src/discuss/call/common/chat_window_patch.scss
@@ -1,0 +1,12 @@
+.o-mail-ChatWindow-command {
+    @media (hover: none) {
+        .fa-phone {
+            color: $success !important;
+        }
+    }
+    @media (hover: hover) {
+        &:hover .fa-phone {
+            color: $success !important;
+        }
+    }
+}

--- a/addons/mail/static/src/discuss/call/common/discuss_patch.scss
+++ b/addons/mail/static/src/discuss/call/common/discuss_patch.scss
@@ -1,0 +1,12 @@
+.o-mail-Discuss-headerActions button {
+    @media (hover: none) {
+        .fa-phone {
+            color: $success !important;
+        }
+    }
+    @media (hover: hover) {
+        &:hover .fa-phone {
+            color: $success !important;
+        }
+    }
+}


### PR DESCRIPTION
This makes it more obvious that clicking on this button will start the call immediately, compared to all other thread actions that have a significantly lower level of commitment.

![Oct-01-2024 17-14-03](https://github.com/user-attachments/assets/459641f4-5707-4825-9660-bb8e4f4223b7)
