### PR TITLE
[FIX] account: force entry on payments in community edition

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -10255,6 +10255,12 @@ msgid ""
 msgstr ""
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_payment.py:0
+msgid "No outstanding account could be found to make the payment"
+msgstr ""
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_journal_form
 msgid "No payment journal entries"
 msgstr ""
@@ -10900,8 +10906,20 @@ msgid "Outstanding Account"
 msgstr ""
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/chart_template.py:0
+msgid "Outstanding Payments"
+msgstr ""
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_journal_form
 msgid "Outstanding Payments accounts"
+msgstr ""
+
+#. module: account
+#. odoo-python
+#: code:addons/account/models/chart_template.py:0
+msgid "Outstanding Receipts"
 msgstr ""
 
 #. module: account

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -792,6 +792,34 @@ class AccountChartTemplate(models.AbstractModel):
             for company_attr_name, account in zip(accounts_data.keys(), accounts):
                 company[company_attr_name] = account
 
+        # No fields on company
+        is_accounting_installed_next = self.env["ir.module.module"].search([('name', '=', 'accountant')]).state in ('to install', 'installed')
+        if not company.parent_id and not is_accounting_installed_next:
+            accounts_data_no_fields = {
+                'account_journal_payment_debit_account_id': {
+                    'name': _("Outstanding Receipts"),
+                    'prefix': bank_prefix,
+                    'code_digits': code_digits,
+                    'account_type': 'asset_current',
+                    'reconcile': True,
+                },
+                'account_journal_payment_credit_account_id': {
+                    'name': _("Outstanding Payments"),
+                    'prefix': bank_prefix,
+                    'code_digits': code_digits,
+                    'account_type': 'asset_current',
+                    'reconcile': True,
+                },
+            }
+            self.env['account.account']._load_records([
+                {
+                    'xml_id': f"account.{company.id}_{xml_id}",
+                    'values': values,
+                    'noupdate': True,
+                }
+                for xml_id, values in accounts_data_no_fields.items()
+            ])
+
     @api.model
     def _instantiate_foreign_taxes(self, country, company):
         """Create and configure foreign taxes from the provided country.


### PR DESCRIPTION
In Odoo Community, bank reconciliation is not available. For that reason, when recording a Payment, this should be enough to fully recognize the payment of the invoice, as there is no second "reconciliation step". In this case, we always want a "behind-the-scene" entry to be created to compute the amount_residual and the status of the invoice accordingly.

After the Payments rework, the problem is that by default, no Outstanding account is set up on basic Payment Methods, not triggering any entry and messing up the computation of the invoice status. On top of that, the user shouldn't even have to configure accounts on journals, as this is a pure Accounting work.

task-4224553

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
