### PR TITLE
[FIX] mail: DiscussSidebar hover doesn't flicker on mouse-hovering

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
@@ -29,6 +29,7 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .1;
 
 .o-mail-DiscussSidebar-item {
     line-height: 2; // so that same height as actions
+    background-color: inherit !important;
 
     &:hover .o-mail-DiscussSidebarChannel-commands {
         display: flex !important;


### PR DESCRIPTION
Mouse-hovering items when discuss sidebar is compact result in some style flickering on im status icon.

This happens because the items are button and they need `bg-inherit`. Due to CSS specificity, however, the classname is not enough, so we need `!important` in CSS, which is what this commit does to fix the issue.

Before / After (see status of 3 items at the bottom while mouse-hovering)

![before](https://github.com/user-attachments/assets/f2ef3a89-d5b7-451c-92a5-5157c1283338) ![after](https://github.com/user-attachments/assets/0720aa65-948f-4131-8ca1-140aa899f58e)
