### PR TITLE
[WIP] fields: allow related to traverse one2many or forbid it completly

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -696,7 +696,7 @@ class Field(MetaField('DummyField', (object,), {}), typing.Generic[T]):
         values = list(records)
         for name in self.related.split('.')[:-1]:
             try:
-                values = [first(value[name]) for value in values]
+                values = [value[name] for value in values]
             except AccessError as e:
                 description = records.env['ir.model']._get(records._name).name
                 env = records.env


### PR DESCRIPTION
Right now it is possible to express a related as

some_field = fields.One2many(related="first_one2many_ids.second_one2many_ids")

But the output is incorrect. The expected result would be to have

`self.some_field = self.first_one2many_ids.second_one2many_ids` (mapped) 

but the real result will be

`self.first_one2many_ids[0].second_one2many_ids`

The main reason being that all elements of the related path as considered to be many2one.

This commit proposes to make it work when following One

If not, this should be detected and display an error. 

Note that it only makes sense if the last field is relationnal, or we may have an error (should be detected too) 


