### PR TITLE
[FIX] sale_stock: allow sendcloud picking validation

### DIFF
--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -175,21 +175,19 @@ class SaleOrder(models.Model):
                 ('type', '=', 'delivery'),
             ], limit=1)
 
-            if existing_partner:
-                order.partner_shipping_id = existing_partner
-            else:
-                order.partner_shipping_id = order.env['res.partner'].create({
-                    'parent_id': parent_id,
-                    'type': 'delivery',
-                    'name': name,
-                    'street': street,
-                    'city': city,
-                    'state_id': state,
-                    'zip': zip_code,
-                    'country_id': country,
-                    'email': email,
-                    'phone': phone,
-                })
+            shipping_partner = existing_partner or order.env['res.partner'].create({
+                'parent_id': parent_id,
+                'type': 'delivery',
+                'name': name,
+                'street': street,
+                'city': city,
+                'state_id': state,
+                'zip': zip_code,
+                'country_id': country,
+                'email': email,
+                'phone': phone,
+            })
+            order.with_context(update_delivery_shipping_partner=True).write({'partner_shipping_id': shipping_partner})
         return super()._action_confirm()
 
     def _prepare_delivery_line_vals(self, carrier, price_unit):

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -103,7 +103,10 @@ class SaleOrder(models.Model):
             for order in self:
                 pre_order_line_qty = {order_line: order_line.product_uom_qty for order_line in order.mapped('order_line') if not order_line.is_expense}
 
-        if values.get('partner_shipping_id'):
+        if values.get('partner_shipping_id') and self._context.get('update_delivery_shipping_partner'):
+            for order in self:
+                order.picking_ids.partner_id = values.get('partner_shipping_id')
+        elif values.get('partner_shipping_id'):
             new_partner = self.env['res.partner'].browse(values.get('partner_shipping_id'))
             for record in self:
                 picking = record.mapped('picking_ids').filtered(lambda x: x.state not in ('done', 'cancel'))


### PR DESCRIPTION
### Issue:

When validating a stock picking created with a sendcloud picking method the partner assocaited with the delivery has no parent_id, so that the code will raise an error the one raised by:
https://github.com/odoo/enterprise/blob/070a780db047d849db268a40f1b488dce0a80c6a/delivery_sendcloud/models/sendcloud_service.py#L556-L560 see commit fbeefb5f7d1e429b22d8fd6fc06b7c28b9c236a6

### Steps to reproduce:
- Create a sendcloud delivery method
- go to website and order a product, go to checkout
- pick sendcloud delivery method
- select a relay location
- go to odoo backend, go the sale order created by the website
- click the SO deliveries smart button
- Validate the delivery

#### > Invalid operation

### Cause of the issue:

When the customer checkouts, it confirms the sale order and generate a delivery linked to that SO via the `_action_launch_stock_rule`:
https://github.com/odoo/odoo/blob/a91da6a5e835c11f59a4847026ffc79ba97969c5/addons/sale_stock/models/sale_order.py#L153-L155 
Later in this confirm, the `partner_shipping_id` of the SO is changed to be associated with a `res.partner` of type `delivery`:
https://github.com/odoo/odoo/blob/a91da6a5e835c11f59a4847026ffc79ba97969c5/addons/delivery/models/sale_order.py#L178-L183
but the partner of the picking is not changed accordingly. However, the `delivery_sendcloud` module expects ti receive this delivery partner as a `partner_id` which raises.

### Note: 

The error is only reproducible after 17.4 even though the only change is that the piece of code creating the partner was moved from `website_sale` to `delivery` by commit 6a28ecf201acaa1e09d3f02184b49f9b3f17486a

HOWEVER, this change has a huge impact as it change the inheritance chain of the  `sale.order` model: more precisely, the overrides of the `_action_confirm` in which the stock move is created happens before the overrides creating the partner of type delivery while the flow use to be generated in the opposite order so that the picking was created with the updated partner data !

opw-4181787
opw-4188628

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
