### PR TITLE
[FIX] point_of_sale: correctly load last order after refresh

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1070,9 +1070,9 @@ export class PosStore extends Reactive {
     }
     set_start_order() {
         if (this.orders.length && !this.selectedOrder) {
-            this.selectedOrder = this.orders[0];
+            this.selectedOrder = this.orders[this.orders.length - 1];
             if (this.isOpenOrderShareable()) {
-                this.ordersToUpdateSet.add(this.orders[0]);
+                this.ordersToUpdateSet.add(this.orders[this.orders.length - 1]);
             }
         } else {
             this.add_new_order();

--- a/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
@@ -14,6 +14,7 @@ import {
     inLeftSide,
     scan_barcode,
     selectButton,
+    refresh,
 } from "@point_of_sale/../tests/tours/helpers/utils";
 
 registry.category("web_tour.tours").add("ProductScreenTour", {
@@ -290,5 +291,22 @@ registry.category("web_tour.tours").add("PosCustomerAllFieldsDisplayed", {
             ProductScreenPartnerList.searchCustomerValueAndClear("0987654321"),
             ProductScreen.clickPartnerButton(),
             PartnerList.searchCustomerValue("john@doe.com"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("ParkOrderTour", {
+    test: true,
+    url: "/pos/ui",
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+
+            ProductScreen.clickShowProductsMobile(),
+            ProductScreen.clickDisplayedProduct("Test Product"),
+            ProductScreen.clickReview(),
+            ProductScreen.controlButtonMore(),
+            ProductScreen.controlButton("Park Order"),
+            refresh(),
+            ProductScreen.orderIsEmpty(),
         ].flat(),
 });

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1382,6 +1382,16 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'CashRoundingPayment', login="accountman")
 
+    def test_park_order_reload(self):
+
+        self.env['product.product'].create({
+            'name': 'Test Product',
+            'list_price': 110,
+            'available_in_pos': True,
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'ParkOrderTour', login="pos_user")
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
After parking an order, if you refresh the page the parked order would be selected as the current order.

Steps to reproduce:
-------------------
* Setup a PoS with atleast one trusted PoS
* Open the PoS and add some products to the order
* Park the order
* Refresh the page
> Observation: The parked order is selected

Why the fix:
------------
When setting the start order we take the last order saved instead of the first one.

opw-4104298
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
