### PR TITLE
[IMP] hr_recruitment: Improved applicant analysis reports

### DIFF
--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -193,8 +193,9 @@
         <field name="model">hr.applicant</field>
         <field name="arch" type="xml">
             <pivot string="Job Applications" sample="1">
-                <field name="create_date" type="row"/>
-                <field name="stage_id" type="col"/>
+                <field name="create_date" type="col" interval="month"/>
+                <field name="job_id" type="col"/>
+                <field name="stage_id" type="row"/>
                 <field name="color" invisible="1"/>
             </pivot>
         </field>


### PR DESCRIPTION
This PR improves the `Applicant Analysis` report as well as the pivot view of applicants. For the `Applicant analysis` report it adds `applicant`,`hired`, and `refused` sub columns for each stage. For the pivot view, it was previously displaying the same information on both axes making the default information useless. Now it displays by default each stage on one axis, and each job position grouped by month on the other. The improved pivot view aims for a similar results as the `Applicant Analysis` report, but as it is not a dedicated reporting model it cannot display the `applicant`, `hired`, and `refused` sub columns simultaneously. These improvements will hopefully give a more comprehensive overview of applicant flow throughout the recruitment process.

task-4146657

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
