### PR TITLE
[PERF] stock, *: reduce queries when opening Replenishment View

### DIFF
--- a/addons/mrp/models/stock_orderpoint.py
+++ b/addons/mrp/models/stock_orderpoint.py
@@ -65,7 +65,12 @@ class StockWarehouseOrderpoint(models.Model):
 
     def _compute_days_to_order(self):
         res = super()._compute_days_to_order()
-        for orderpoint in self:
+        # Avoid computing rule_ids in case no manufacture rules.
+        if not self.env['stock.rule'].search([('action', '=', 'manufacture')]):
+            return res
+        # Compute rule_ids only for orderpoint with boms
+        orderpoints_with_bom = self.filtered(lambda orderpoint: orderpoint.product_id.variant_bom_ids or orderpoint.product_id.bom_ids)
+        for orderpoint in orderpoints_with_bom:
             if 'manufacture' in orderpoint.rule_ids.mapped('action'):
                 boms = (orderpoint.product_id.variant_bom_ids or orderpoint.product_id.bom_ids)
                 orderpoint.days_to_order = boms and boms[0].days_to_prepare_mo or 0

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -127,7 +127,12 @@ class Orderpoint(models.Model):
 
     def _compute_days_to_order(self):
         res = super()._compute_days_to_order()
-        for orderpoint in self:
+        # Avoid computing rule_ids if no stock.rules with the buy action
+        if not self.env['stock.rule'].search([('action', '=', 'buy')]):
+            return res
+        # Compute rule_ids only for orderpoint whose compnay_id.days_to_purchase != orderpoint.days_to_order
+        orderpoints_to_compute = self.filtered(lambda orderpoint: orderpoint.days_to_order != orderpoint.company_id.days_to_purchase)
+        for orderpoint in orderpoints_to_compute:
             if 'buy' in orderpoint.rule_ids.mapped('action'):
                 orderpoint.days_to_order = orderpoint.company_id.days_to_purchase
         return res

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -658,6 +658,17 @@ class Product(models.Model):
         or_domains = expression.OR(or_domains)
         return expression.AND([base_domain, or_domains])
 
+    def filter_has_routes(self):
+        """ Return products with route_ids
+            or whose categ_id has total_route_ids.
+        """
+        products_with_routes = self.env['product.product']
+        # retrieve products with route_ids
+        products_with_routes += self.search([('id', 'in', self.ids), ('route_ids', '!=', False)])
+        # retrive products with categ_ids having routes
+        products_with_routes += self.search([('id', 'in', (self - products_with_routes).ids), ('categ_id.total_route_ids', '!=', False)])
+        return products_with_routes
+
 
 class ProductTemplate(models.Model):
     _inherit = 'product.template'
@@ -1041,7 +1052,7 @@ class ProductCategory(models.Model):
         tracking=True,
     )
     total_route_ids = fields.Many2many(
-        'stock.route', string='Total routes', compute='_compute_total_route_ids',
+        'stock.route', string='Total routes', compute='_compute_total_route_ids', search='_search_total_route_ids',
         readonly=True)
     putaway_rule_ids = fields.One2many('stock.putaway.rule', 'category_id', 'Putaway Rules')
     packaging_reserve_method = fields.Selection([
@@ -1050,6 +1061,10 @@ class ProductCategory(models.Model):
         help="Reserve Only Full Packagings: will not reserve partial packagings. If customer orders 2 pallets of 1000 units each and you only have 1600 in stock, then only 1000 will be reserved\n"
              "Reserve Partial Packagings: allow reserving partial packagings. If customer orders 2 pallets of 1000 units each and you only have 1600 in stock, then 1600 will be reserved")
     filter_for_stock_putaway_rule = fields.Boolean('stock.putaway.rule', store=False, search='_search_filter_for_stock_putaway_rule')
+
+    def _search_total_route_ids(self, operator, value):
+        categ_ids = self.filtered_domain([('total_route_ids', operator, value)]).ids
+        return [('id', 'in', categ_ids)]
 
     def _compute_total_route_ids(self):
         for category in self:

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -319,10 +319,9 @@ class StockWarehouseOrderpoint(models.Model):
 
     @api.depends('qty_multiple', 'qty_forecast', 'product_min_qty', 'product_max_qty', 'visibility_days')
     def _compute_qty_to_order_computed(self):
-        for orderpoint in self:
-            if not orderpoint.product_id or not orderpoint.location_id:
-                orderpoint.qty_to_order_computed = False
-                continue
+        orderpoints_to_compute = self.filtered(lambda orderpoint: orderpoint.product_id and orderpoint.location_id)
+        qty_in_progress_by_orderpoint = orderpoints_to_compute._quantity_in_progress()
+        for orderpoint in orderpoints_to_compute:
             qty_to_order = 0.0
             rounding = orderpoint.product_uom.rounding
             # The check is on purpose. We only want to consider the visibility days if the forecast is negative and
@@ -330,7 +329,7 @@ class StockWarehouseOrderpoint(models.Model):
             if float_compare(orderpoint.qty_forecast, orderpoint.product_min_qty, precision_rounding=rounding) < 0:
                 # We want to know how much we should order to also satisfy the needs that gonna appear in the next (visibility) days
                 product_context = orderpoint._get_product_context(visibility_days=orderpoint.visibility_days)
-                qty_forecast_with_visibility = orderpoint.product_id.with_context(product_context).read(['virtual_available'])[0]['virtual_available'] + orderpoint._quantity_in_progress()[orderpoint.id]
+                qty_forecast_with_visibility = orderpoint.product_id.with_context(product_context).read(['virtual_available'])[0]['virtual_available'] + qty_in_progress_by_orderpoint[orderpoint.id]
                 qty_to_order = max(orderpoint.product_min_qty, orderpoint.product_max_qty) - qty_forecast_with_visibility
                 remainder = orderpoint.qty_multiple > 0.0 and qty_to_order % orderpoint.qty_multiple or 0.0
                 if (float_compare(remainder, 0.0, precision_rounding=rounding) > 0
@@ -340,6 +339,7 @@ class StockWarehouseOrderpoint(models.Model):
                     else:
                         qty_to_order -= remainder
             orderpoint.qty_to_order_computed = qty_to_order
+        (self - orderpoints_to_compute).qty_to_order_computed = False
 
     def _get_qty_multiple_to_order(self):
         """ Calculates the minimum quantity that can be ordered according to the PO UoM or BoM

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -121,11 +121,25 @@ class StockWarehouseOrderpoint(models.Model):
 
     @api.depends('route_id', 'product_id', 'location_id', 'company_id', 'warehouse_id', 'product_id.route_ids')
     def _compute_rules(self):
-        for orderpoint in self:
-            if not orderpoint.product_id or not orderpoint.location_id:
-                orderpoint.rule_ids = False
-                continue
-            orderpoint.rule_ids = orderpoint.product_id._get_rules_from_location(orderpoint.location_id, route_ids=orderpoint.route_id)
+        orderpoints_to_compute = self.filtered(lambda orderpoint: orderpoint.product_id and orderpoint.location_id)
+        # Products without routes have no impact on _get_rules_from_location.
+        product_ids_with_routes = set(orderpoints_to_compute.product_id.filter_has_routes().ids)
+        # Small cache mapping (location_id, route_id) -> stock.rule.
+        # This reduces calls to _get_rules_from_location for products without routes.
+        rules_cache = {}
+        for orderpoint in orderpoints_to_compute:
+            if orderpoint.product_id.id not in product_ids_with_routes:
+                cache_key = (orderpoint.location_id, orderpoint.route_id)
+                rule_ids = rules_cache.get(cache_key) or orderpoint.product_id._get_rules_from_location(
+                    orderpoint.location_id, route_ids=orderpoint.route_id
+                )
+                orderpoint.rule_ids = rule_ids
+                rules_cache[cache_key] = rule_ids
+            else:
+                orderpoint.rule_ids = orderpoint.product_id._get_rules_from_location(
+                    orderpoint.location_id, route_ids=orderpoint.route_id
+                )
+        (self - orderpoints_to_compute).rule_ids = False
 
     @api.depends('route_id', 'product_id')
     def _compute_visibility_days(self):

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -110,14 +110,13 @@ class StockWarehouseOrderpoint(models.Model):
 
     @api.depends('rule_ids', 'product_id.seller_ids', 'product_id.seller_ids.delay')
     def _compute_lead_days(self):
-        for orderpoint in self.with_context(bypass_delay_description=True):
-            if not orderpoint.product_id or not orderpoint.location_id:
-                orderpoint.lead_days_date = False
-                continue
+        orderpoints_to_compute = self.filtered(lambda orderpoint: orderpoint.product_id and orderpoint.location_id)
+        for orderpoint in orderpoints_to_compute.with_context(bypass_delay_description=True):
             values = orderpoint._get_lead_days_values()
             lead_days, dummy = orderpoint.rule_ids._get_lead_days(orderpoint.product_id, **values)
             lead_days_date = fields.Date.today() + relativedelta.relativedelta(days=lead_days['total_delay'])
             orderpoint.lead_days_date = lead_days_date
+        (self - orderpoints_to_compute).lead_days_date = False
 
     @api.depends('route_id', 'product_id', 'location_id', 'company_id', 'warehouse_id', 'product_id.route_ids')
     def _compute_rules(self):

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
-from collections import defaultdict, namedtuple
+from collections import defaultdict, namedtuple, OrderedDict
 from dateutil.relativedelta import relativedelta
 
 from odoo import SUPERUSER_ID, _, api, fields, models, registry
@@ -524,6 +524,31 @@ class ProcurementGroup(models.Model):
         return True
 
     @api.model
+    def _search_rule_for_warehouses(self, route_ids, packaging_id, product_id, warehouse_ids, domain):
+        if warehouse_ids:
+            domain = expression.AND([['|', ('warehouse_id', 'in', warehouse_ids.ids), ('warehouse_id', '=', False)], domain])
+        valid_route_ids = set()
+        if route_ids:
+            valid_route_ids |= set(route_ids.ids)
+        if packaging_id:
+            packaging_routes = packaging_id.route_ids
+            valid_route_ids |= set(packaging_routes.ids)
+        valid_route_ids |= set((product_id.route_ids | product_id.categ_id.total_route_ids).ids)
+        if warehouse_ids:
+            valid_route_ids |= set(warehouse_ids.route_ids.ids)
+        if valid_route_ids:
+            domain = expression.AND([[('route_id', 'in', list(valid_route_ids))], domain])
+        res = self.env["stock.rule"]._read_group(
+            domain,
+            groupby=["location_dest_id", "warehouse_id", "route_id"],
+            aggregates=["id:recordset"],
+            order="route_sequence:min, sequence:min",
+        )
+        rule_dict = defaultdict(OrderedDict)
+        for group in res:
+            rule_dict[group[0].id, group[2].id][group[1].id] = group[3].sorted(lambda rule: (rule.route_sequence, rule.sequence))[0]
+        return rule_dict
+
     def _search_rule(self, route_ids, packaging_id, product_id, warehouse_id, domain):
         """ First find a rule among the ones defined on the procurement
         group, then try on the routes defined for the product, finally fallback
@@ -555,23 +580,88 @@ class ProcurementGroup(models.Model):
         locations if it could not be found.
         """
         result = self.env['stock.rule']
+        locations = location_id
+        # Get the location hierarchy, starting from location_id up to its root location.
+        while locations[-1].location_id:
+            locations |= locations[-1].location_id
+        domain = self._get_rule_domain(locations, values)
+        # Get a mapping (location_id, route_id) -> warehouse_id -> rule_id
+        rule_dict = self._search_rule_for_warehouses(
+            values.get("route_ids", False),
+            values.get("product_packaging_id", False),
+            product_id,
+            values.get("warehouse_id", locations.warehouse_id),
+            domain,
+        )
+
+        def extract_rule(rule_dict, route_ids, warehouse_id, location_dest_id):
+            rule = self.env['stock.rule']
+            for route_id in route_ids:
+                sub_dict = rule_dict.get((location_dest_id.id, route_id.id))
+                if not sub_dict:
+                    continue
+                if not warehouse_id:
+                    rule = sub_dict[next(iter(sub_dict))]
+                else:
+                    rule = sub_dict.get(warehouse_id.id)
+                    rule = rule or sub_dict[False]
+                if rule:
+                    break
+            return rule
+
+        def get_rule_for_routes(rule_dict, route_ids, packaging_id, product_id, warehouse_id, location_dest_id):
+            res = self.env['stock.rule']
+            if route_ids:
+                res = extract_rule(rule_dict, route_ids, warehouse_id, location_dest_id)
+            if not res and packaging_id:
+                res = extract_rule(rule_dict, packaging_id.route_ids, warehouse_id, location_dest_id)
+            if not res:
+                res = extract_rule(rule_dict, product_id.route_ids | product_id.categ_id.total_route_ids, warehouse_id, location_dest_id)
+            if not res and warehouse_id:
+                res = extract_rule(rule_dict, warehouse_id.route_ids, warehouse_id, location_dest_id)
+            return res
+
         location = location_id
+        # Go through the location hierarchy again, this time breaking at the first valid stock.rule found
+        # in rules_by_location.
+        inter_comp_location_checked = False
         while (not result) and location:
-            domain = self._get_rule_domain(location, values)
-            result = self._search_rule(values.get('route_ids', False), values.get('product_packaging_id', False), product_id, values.get('warehouse_id', location.warehouse_id), domain)
-            location = location.location_id
+            candidate_locations = location
+            if not inter_comp_location_checked and self._check_intercomp_location(location):
+                # Add the intercomp location to candidate_locations as the intercomp domain was added
+                # above in the call to _get_rule_domain.
+                inter_comp_location = self.env.ref('stock.stock_location_customers', raise_if_not_found=False)
+                candidate_locations |= inter_comp_location
+                inter_comp_location_checked = True
+            for candidate_location in candidate_locations:
+                result = get_rule_for_routes(
+                    rule_dict,
+                    values.get("route_ids", self.env['stock.route']),
+                    values.get("product_packaging_id", self.env['product.packaging']),
+                    product_id,
+                    values.get("warehouse_id", candidate_location.warehouse_id),
+                    candidate_location,
+                )
+                if result:
+                    break
+            else:
+                location = location.location_id
         return result
 
     @api.model
-    def _get_rule_domain(self, location, values):
-        domain = ['&', ('location_dest_id', '=', location.id), ('action', '!=', 'push')]
+    def _check_intercomp_location(self, locations):
+        if self.env.user.has_group('base.group_multi_company') and locations.filtered(lambda location: location.usage == 'transit'):
+            inter_comp_location = self.env.ref('stock.stock_location_inter_company', raise_if_not_found=False)
+            return inter_comp_location and inter_comp_location.id in locations.ids
+
+    @api.model
+    def _get_rule_domain(self, locations, values):
+        location_ids = locations.ids
         # If the method is called to find rules towards the Inter-company location, also add the 'Customer' location in the domain.
         # This is to avoid having to duplicate every rules that deliver to Customer to have the Inter-company part.
-        if self.env.user.has_group('base.group_multi_company') and location.usage == 'transit':
-            inter_comp_location = self.env.ref('stock.stock_location_inter_company', raise_if_not_found=False)
-            if inter_comp_location and location.id == inter_comp_location.id:
-                customers_location = self.env.ref('stock.stock_location_customers', raise_if_not_found=False)
-                domain = expression.OR([domain, ['&', ('location_dest_id', '=', customers_location.id), ('action', '!=', 'push')]])
+        if self._check_intercomp_location(locations):
+            location_ids.append(self.env.ref('stock.stock_location_customers', raise_if_not_found=False).id)
+        domain = ['&', ('location_dest_id', 'in', location_ids), ('action', '!=', 'push')]
         # In case the method is called by the superuser, we need to restrict the rules to the
         # ones of the company. This is not useful as a regular user since there is a record
         # rule to filter out the rules based on the company.


### PR DESCRIPTION
The aim of this PR is to reduce the number of queries executed when opening the Replenishment View of the Inventory module.

The following ideas were implemented

### Usage of `filtered` instead of a continue inside compute functions. 
`filtered` sets the _prefetch_ids to the records that matches the condition. This reduces the size of the expanded recordset whose computed field value needs to be recomputed.

### Batch `orderpoint._quantity_in_progress`
The method `_quantity_in_progress` is designed to be used on a recordset. Calling it once before the for loop in
`stock_orderpoint.py:_compute_qty_to_order_computed` speeds up the whole compute function.

### Introduce a rule cache in `orderpoint._compute_rules`
A product without stock.rules have no impact on the call to `product_id._get_rules_from_locations`. It's only used to search on stock.rule in `procurement.group._search_rule`. We can therefore partition the orderpoints between orderpoints whose products have and don't have route_ids. This saves calls to `product_id._get_rules_from_locations` because now it only depends on (orderpoint.location_id, orderpoint.route_id) which have more hits than (orderpoint.product_id, orderpoint.location_id, orderpoint.route_id).

### Add preliminary checks to `_compute_days_to_order`
In both mrp and purchase_stock, `_compute_days_to_order` does some computations when the rule_ids' action is 'manufacture' and 'buy' respectively. This forces the computation of rule_ids on all orderpoints in self. Adding some precheck and prefiltering on self reduces the size of the recordset that needs the value of rule_ids.

### Introduce `_search_rule_for_warehouses`
Introduce a new method, `_search_rule_for_warehouses`. It's kind of batched version of `_search_rule` that works for multiple
location_dest_ids and warehouse_ids. It is designed to be called by `_get_rule`.

This method uses a _read_group to group the stock.rules by (location_dest_id, warehouse_id, route_id). It then constructs
a dict mappin (location_dest_id, route_id) -> warehouse_id -> stock.rule. This is done because when bool(warehouse_id) in parameter is False, any existing rule matching the location_dest_id, route_id is fine. When bool(warehouse_id) in parameter is True, the candidate stock.rules.warehouse must be equal to the parameter or False.

`_get_rule` is also revamped to find the correct stock.rule among the candidates. It first goes through the location hierarchy, starting from location_id, to build the rule_domain. Then, using the result of `_search_rule_for_warehouses`, it goes through the hierarchy again in the while loop, breaking at the first valid stock.rule found.

`_search_rule` is kept as is in case of overriding.

----

### Benchmark:
  Customer saas-17.4 database with 10 000 active orderpoints and 140 active stock.rules.
  Requests when opening Replenishment: run + search_panel_select_range + web_search_read

  #### Before PR:
     Number of queries: 90569 + 90471 + 90497 = 271 352 queries
     Timings: 1min30 + 2min40 + 1min30 = 5min40

  #### After PR:
     Number of queries: 36819 + 36744 + 36767 = 110 330 queries
     Timings: 43s + 1min20s + 54s = 2min57

Queries reduction: 250%
Speedup: 192%

NB: Should this PR be merged, it will be backported to 17.0 with some modifications.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
