### PR TITLE
[IMP] website: skip outdated theme preview on theme switch screen

### DIFF
--- a/addons/website/static/src/components/views/theme_preview_form.js
+++ b/addons/website/static/src/components/views/theme_preview_form.js
@@ -6,7 +6,7 @@ import { formView } from "@web/views/form/form_view";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { ViewButton } from "@web/views/view_button/view_button";
-import { useSubEnv, useEnv } from "@odoo/owl";
+import { useSubEnv, onMounted, useEnv } from "@odoo/owl";
 
 /*
 * Common code for theme installation/update handler.
@@ -59,6 +59,13 @@ class ThemePreviewFormController extends FormController {
     setup() {
         super.setup();
         useLoaderOnClick();
+
+        // TODO adapt theme previews then remove this
+        onMounted(() => {
+            setTimeout(() => {
+                document.querySelector('button[name="button_choose_theme"]')?.click();
+            }, 0);
+        });
     }
     /**
      * @override

--- a/addons/website/static/src/scss/website.backend.scss
+++ b/addons/website/static/src/scss/website.backend.scss
@@ -140,3 +140,11 @@
         }
     }
 }
+
+// TODO adapt theme previews then remove this
+.o_preview_frame::after {
+    content: "";
+    position: absolute;
+    inset: 0 0 0 0;
+    background-color: white;
+}


### PR DESCRIPTION
The theme previews on `themes.odoo.com` website are not up-to-date. While waiting for them, skipping the preview screen if you were to reach the switch theme screen (it is not the main flow: using the configurator the preview is a SVG with user-related colors, text and images and those are up-to-date).

