### PR TITLE
[FIX] pos_self_order: install the module

### DIFF
--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -346,10 +346,10 @@ class PosConfig(models.Model):
             return False
 
         journal, payment_methods_ids = self._create_journal_and_payment_methods()
-        restaurant_categories = [
-            self.env.ref('pos_restaurant.food').id,
-            self.env.ref('pos_restaurant.drinks').id,
-        ]
+        restaurant_categories = self.get_categories([
+            'pos_restaurant.food',
+            'pos_restaurant.drinks',
+        ])
         not_cash_payment_methods_ids = self.env['pos.payment.method'].search([
             ('is_cash_count', '=', False),
             ('id', 'in', payment_methods_ids),


### PR DESCRIPTION
If the company has a CoA, it's currently not possible to install the
module without the demo data.

When loading the data of the module, it will lead to
https://github.com/odoo/odoo/blob/3ad46fc7bbb7511efeb9e4861d9795844feec878/addons/pos_self_order/data/kiosk_demo_data.xml#L3-L5
https://github.com/odoo/odoo/blob/9511bacc89cc23ce162f93af4682a4806c45dfda/addons/pos_self_order/models/pos_config.py#L344-L352
Since the company has a CoA, we execute the `ref` but they target
demo data, cf how they are loaded:
https://github.com/odoo/odoo/blob/0bc90e7d74bd0792b9af7464256ba8770d894a25/addons/pos_restaurant/data/demo_data.xml#L4
https://github.com/odoo/odoo/blob/b9f9dbb7a1cd7d8812658c68daca89191c28eda7/addons/pos_restaurant/models/pos_config.py#L107-L111
https://github.com/odoo/odoo/blob/e2f08d58ff024228c3f472b35fd4aef7e60bdde4/addons/pos_restaurant/data/scenarios/restaurant_data.xml#L9-L12
Hence
`ValueError: External ID not found in the system: pos_restaurant.food`

OPW-4226855