### PR TITLE
[FIX] web_editor: remove translate button from image toolbar

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -2265,6 +2265,7 @@ export class Wysiwyg extends Component {
             '#colorInputButtonGroup',
             '#media-insert', // "Insert media" should be replaced with "Replace media".
             '#chatgpt', // Chatgpt should be removed when media is in selection.
+            '#translate' // Translate button should be removed when media is in selection.
         ].join(','))){
             el.classList.toggle('d-none', isInMedia);
         }


### PR DESCRIPTION
Current behavior before PR:

- The translate button was visible on the image toolbar.

Desired behavior after PR is merged:

- Now, translate button is no longer displayed on the image toolbar.

task:4224550
