### PR TITLE
[FIX] sale_project: fixed SOL not recomputing on changing partner

### DIFF
--- a/addons/sale_timesheet/models/project_task.py
+++ b/addons/sale_timesheet/models/project_task.py
@@ -57,18 +57,17 @@ class ProjectTask(models.Model):
     def _search_remaining_hours_so(self, operator, value):
         return [('sale_line_id.remaining_hours', operator, value)]
 
+    # TODO remove me in master
     def _inverse_partner_id(self):
         super()._inverse_partner_id()
-        for task in self:
-            if task.allow_billable and not task.sale_line_id:
-                task.sale_line_id = task.sudo()._get_last_sol_of_customer()
+        pass
 
     @api.depends('sale_line_id.order_partner_id', 'parent_id.sale_line_id', 'project_id.sale_line_id', 'allow_billable')
     def _compute_sale_line(self):
         super()._compute_sale_line()
         for task in self:
             if task.allow_billable and not task.sale_line_id:
-                task.sale_line_id = task._get_last_sol_of_customer()
+                task.sale_line_id = task.sudo()._get_last_sol_of_customer()
 
     @api.depends('project_id.sale_line_employee_ids')
     def _compute_is_project_map_empty(self):


### PR DESCRIPTION
_* = project, timesheet

Steps to reproduce:

- Open any task which is linked to a SOL.
- Change the Customer.

Issue:

- SOL linked must be set to Non-Billable.

Reason;

- In the PR https://github.com/odoo/odoo/pull/132320. Changing of SOL is removed
depends api decorator and added into a inverse function of partner_id field.
- Inverse function is only executed when we save a record.

Fix:

- Directly adding partner_id back into dependencies leads to circular dependency

- Implementing this mentioned PR alternatively to make sure we don't have neither
missing dependencies not circular dependencies.

Fields in circular dependency are
```
+---------------+                 +---------------+                  +---------------+
| sale_line_id  | ---->           | sale_order_id | ---->            |  partner_id   |
+---------------+                 +---------------+                  +---------------+
       ^                                  |                                     
       |________________________________________________________________________|
```

task-4221046