### PR TITLE
[FIX] mail: channel image not editable in form view

### DIFF
--- a/addons/mail/views/discuss_channel_views.xml
+++ b/addons/mail/views/discuss_channel_views.xml
@@ -53,7 +53,7 @@
                         <div class="oe_button_box" name="button_box"/>
                         <field name="avatar_128" invisible="1"/>
                         <field name="is_editable" invisible="1"/>
-                        <field name="image_128" widget="image" class="oe_avatar" options="{'size': [90, 90], 'preview_image':'avatar_128'}" readonly="is_editable != 'True'"/>
+                        <field name="image_128" widget="image" class="oe_avatar" options="{'size': [90, 90], 'preview_image':'avatar_128'}" readonly="not is_editable"/>
                         <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                         <div class="oe_title">
                             <label for="name" string="Group Name"/>


### PR DESCRIPTION
**Current behavior before PR:**

The pencil icon for editing the channel image was not visible on hover due to a
wrongly written condition, preventing users from updating the image in the form
view.

**Desired behavior after PR is merged:**

This PR fixes the issue by ensuring that the pencil icon now appears on hover,
allowing users to edit the channel image directly from the form view.

Task-4224182


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
