### PR TITLE
[FIX] website: restore website domain switcher

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -95,7 +95,7 @@ export class WebsitePreview extends Component {
                     showSecondaryButton: false,
                 }, {
                     onClose: () => {
-                        redirect(`${encodeURI(this.websiteDomain)}/odoo/action-website.website_preview?path=${encodedPath}&website_id=${encodeURIComponent(this.websiteId)}`);
+                        window.location.href = `${encodeURI(this.websiteDomain)}/odoo/action-website.website_preview?path=${encodedPath}&website_id=${encodeURIComponent(this.websiteId)}`;
                     }
                 });
             } else {

--- a/addons/website/static/src/systray_items/website_switcher.js
+++ b/addons/website/static/src/systray_items/website_switcher.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { browser } from "@web/core/browser/browser";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
-import { redirect } from "@web/core/utils/urls";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import wUtils from '@website/js/utils';
@@ -32,7 +31,7 @@ export class WebsiteSwitcherSystray extends Component {
                 if (website.domain && !wUtils.isHTTPSorNakedDomainRedirection(website.domain, window.location.origin)) {
                     const { location: { pathname, search, hash } } = this.websiteService.contentWindow;
                     const path = pathname + search + hash;
-                    redirect(`${encodeURI(website.domain)}/odoo/action-website.website_preview?path=${encodeURIComponent(path)}&website_id=${encodeURIComponent(website.id)}`);
+                    window.location.href = `${encodeURI(website.domain)}/odoo/action-website.website_preview?path=${encodeURIComponent(path)}&website_id=${encodeURIComponent(website.id)}`;
                 } else {
                     this.websiteService.goToWebsite({ websiteId: website.id, path: "", lang: "default" });
                     if (!website.domain) {


### PR DESCRIPTION
When the URL domain you are currently using to access the Odoo backend is different from:
- The website's one you are trying to switch to using the switcher
- The website's one you are trying to preview

=> the user is redirected to that website's domain (and potentially have to re-login).

This is buggy since [1] which really wanted to use the framework util for redirections, while it could not work in those cases as that util is explicitly preventing to switch to a different domain which is exactly what is trying to be done in those cases.

[1]: https://github.com/odoo/odoo/commit/2cdc3a8c36233a9bdadea1957c9c5414c511b29e
