### PR TITLE
[FIX] event: don't block setup with demo cron

### DIFF
--- a/addons/event/data/ir_cron_data.xml
+++ b/addons/event/data/ir_cron_data.xml
@@ -11,5 +11,6 @@
         <field name="interval_type">hours</field>
         <field name="numbercall">-1</field>
         <field name="doall" eval="False" />
+        <field name="nextcall" eval="(DateTime.now() + timedelta(minutes=15)).strftime('%Y-%m-%d %H:%M:%S')" />
     </record>
 </data></odoo>


### PR DESCRIPTION
When installing Event via the Apps menu, you actually install
website_event (and therefore Website). This means that the next action
the user has to take is installing a theme.

In the case of a demo setup, the cron for the mail scheduler of Event
will launch immediately post-install and will run for a rather long
time, preventing any other module from installing (because module
installations are blocked whilst a cron is running). This means that
after installing the Website event in a demo setup, the user is the
prevented from finishing the website setup until the cron is finished.

This commit introduces a 'grace period' of 15min until the cron first
runs, making it possible to finish the website setup right away.
