### PR TITLE
[FIX] point_of_sale/saas~17.4: fix share trusted pos feature

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -61,6 +61,7 @@ export class ProductScreen extends Component {
             if (this.pos.config.iface_start_categ_id) {
                 this.pos.setSelectedCategory(this.pos.config.iface_start_categ_id.id);
             }
+            this.pos.addPendingOrder([this.pos.get_order().id]);
 
             // Call `reset` when the `onMounted` callback in `numberBuffer.use` is done.
             // We don't do this in the `mounted` lifecycle method because it is called before


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

 - The feature of shared trusted PoS is not working in saas~17.4 
![image](https://github.com/user-attachments/assets/0ba4a40a-1374-42b0-8554-f5e83a63eb8b)

 - This is due to fact, the current order is never added to the pendingOrder object. so when [syncAllOrders](https://github.com/odoo/odoo/blob/saas-17.4/addons/point_of_sale/static/src/app/store/pos_store.js#L981) is called from [_setOrder](https://github.com/odoo/odoo/blob/saas-17.4/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js#L600-L605) is called, [no orders](https://github.com/odoo/odoo/blob/saas-17.4/addons/point_of_sale/static/src/app/store/pos_store.js#L989) are returned and  function [exits early
](https://github.com/odoo/odoo/blob/saas-17.4/addons/point_of_sale/static/src/app/store/pos_store.js#L998)

Desired behavior after PR is merged:
- Feature works as intended.


Steps to reproduce:
- install point_of_sale in saas-17.4 version
- from setting, add a trusted pos B  for  Pos A
- open both pos in two different tabs/browsers.
- Create one order from PoS A,
- on opening orders page from pos B, that order should be loaded but it does not.
![image](https://github.com/user-attachments/assets/d47f2fb2-d745-4cb4-949f-d15bca46f723)

opw-4160166


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
