### PR TITLE
[FIX] account: Bank statement lines fixes

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -114,7 +114,8 @@ class AccountBankStatement(models.Model):
     @api.depends('line_ids.internal_index', 'line_ids.state')
     def _compute_date_index(self):
         for stmt in self:
-            sorted_lines = stmt.line_ids.sorted('internal_index')
+            # When we create lines manually from the form view, they don't have any `internal_index` set yet.
+            sorted_lines = stmt.line_ids.filtered("internal_index").sorted('internal_index')
             stmt.first_line_index = sorted_lines[:1].internal_index
             stmt.date = sorted_lines.filtered(lambda l: l.state == 'posted')[-1:].date
 

--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -227,6 +227,7 @@ class AccountBankStatementLine(models.Model):
                 """,
                 [max_index, journal.id] + extra_params,
             )
+            pending_items = self
             for st_line_id, amount, is_anchor, balance_start, state in self._cr.fetchall():
                 if is_anchor:
                     current_running_balance = balance_start
@@ -234,6 +235,10 @@ class AccountBankStatementLine(models.Model):
                     current_running_balance += amount
                 if record_by_id.get(st_line_id):
                     record_by_id[st_line_id].running_balance = current_running_balance
+                    pending_items -= record_by_id[st_line_id]
+            # Lines manually deleted from the form view still require to have a value set here, as the field is computed and non-stored.
+            for item in pending_items:
+                item.running_balance = item.running_balance
 
     @api.depends('date', 'sequence')
     def _compute_internal_index(self):


### PR DESCRIPTION
Bank statement lines created from the form view won't have an `internal_index` value set yet.

Running balance computation should set a value also on manually deleted lines from the form view as the balance is a computed non-stored field.

@Tecnativa TT50906

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
