### PR TITLE
[FIX] l10n_in_edi_ewaybill: fix credential verification traceback

### DIFF
--- a/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
+++ b/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
@@ -373,7 +373,7 @@ class AccountEdiFormat(models.Model):
         return res
 
     def _l10n_in_edi_ewaybill_get_error_message(self, code):
-        error_message = self.env._(ERROR_CODES.get(code), '')  # pylint: disable=gettext-variable
+        error_message = self.env._(ERROR_CODES.get(code, ''))  # pylint: disable=gettext-variable
         return error_message or _("We don't know the error message for this error code. Please contact support.")
 
     def _get_l10n_in_edi_saler_buyer_party(self, move):


### PR DESCRIPTION
Before this PR, if the E-waybill credentials are wrong, the user gets a traceback in the production environment due to 61a85754800. Instead we introduce a `ValidationError`.

Steps to reproduce:
- Turn On (✓) "Production Environment" and "Indian Electronic Waybill" from accounting configuration settings.
- Click "Verify Username and Password" in "Indian Electronic Waybill".