### PR TITLE
[FIX] purchase: fix traceback when user removes company value while creating PO

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -222,6 +222,9 @@ class PurchaseOrder(models.Model):
     @api.depends('order_line.taxes_id', 'order_line.price_subtotal', 'amount_total', 'amount_untaxed')
     def _compute_tax_totals(self):
         for order in self:
+            if not order.company_id:
+                order.tax_totals = False
+                continue
             order_lines = order.order_line.filtered(lambda x: not x.display_type)
             order.tax_totals = self.env['account.tax']._prepare_tax_totals(
                 [x._convert_to_tax_base_line_dict() for x in order_lines],


### PR DESCRIPTION
Currently, a traceback occurs when the user removes the company 
while creating a PO with a multi-company environment.

To reproduce this issue:

1) Install Purchase order
2) Switch to multi-company environment
3) Create a PO and remove the company value from other information

Error:- 
```
ValueError: Expected singleton: res.currency()
```

When the user removes the company, its value becomes False. 
This leads to an empty currency record set as the currency fetches from the company.

https://github.com/odoo/odoo/blob/97de468e6943b1a13998503deb436eaa38cdaafe/addons/purchase/models/purchase_order.py#L226-L230

It leads to the above traceback

sentry-5939949508

