### PR TITLE
[FIX] stock_account: Use correct UOM for correction svl quantity

### DIFF
--- a/addons/stock_account/models/stock_move_line.py
+++ b/addons/stock_account/models/stock_move_line.py
@@ -20,9 +20,9 @@ class StockMoveLine(models.Model):
             analytic_move_to_recompute.add(move.id)
             if move_line.state != 'done':
                 continue
-            rounding = move.product_id.uom_id.rounding
-            diff = move.product_uom._compute_quantity(move_line.qty_done, move.product_id.uom_id)
-            if float_is_zero(diff, precision_rounding=rounding):
+            product_uom = move_line.product_id.uom_id
+            diff = move_line.product_uom_id._compute_quantity(move_line.qty_done, product_uom)
+            if float_is_zero(diff, precision_rounding=product_uom.rounding):
                 continue
             self._create_correction_svl(move, diff)
         if analytic_move_to_recompute:
@@ -40,14 +40,11 @@ class StockMoveLine(models.Model):
             for move_line in self:
                 if move_line.state != 'done':
                     continue
-                move = move_line.move_id
-                if float_compare(vals['qty_done'], move_line.qty_done, precision_rounding=move.product_uom.rounding) == 0:
+                product_uom = move_line.product_id.uom_id
+                diff = move_line.product_uom_id._compute_quantity(vals['qty_done'] - move_line.qty_done, product_uom, rounding_method='HALF-UP')
+                if float_is_zero(diff, precision_rounding=product_uom.rounding):
                     continue
-                rounding = move.product_id.uom_id.rounding
-                diff = move.product_uom._compute_quantity(vals['qty_done'] - move_line.qty_done, move.product_id.uom_id, rounding_method='HALF-UP')
-                if float_is_zero(diff, precision_rounding=rounding):
-                    continue
-                self._create_correction_svl(move, diff)
+                self._create_correction_svl(move_line.move_id, diff)
         res = super(StockMoveLine, self).write(vals)
         if analytic_move_to_recompute:
             self.env['stock.move'].browse(analytic_move_to_recompute)._account_analytic_entry_move()


### PR DESCRIPTION
How to reproduce:
- Create a product P, storable, uom=Units
- Create Receipt for 12 units of P, Confirm
- Change the operation line from 12 Units to 1 Dozen
- Validate Receipt => Valuation layer for 12 Units created (OK)
- Unlock Receipt
- Change the operation line from 1 to 2 Dozens
- Save Receipt => Valuation layer for 1 Unit created (Should be 12)

OPW-4204420

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
