### PR TITLE
[IMP] account: add constraint on availability condition

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -13220,6 +13220,15 @@ msgstr ""
 
 #. module: account
 #. odoo-python
+#: code:addons/account/models/account_report.py:0
+#, python-format
+msgid ""
+"The Availability is set to 'Country Matches' but the field Country is not "
+"set."
+msgstr ""
+
+#. module: account
+#. odoo-python
 #: code:addons/account/models/account_move.py:0
 #, python-format
 msgid "The Bill/Refund date is required to validate this document."

--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -151,6 +151,12 @@ class AccountReport(models.Model):
                       'The parent must always come first.', line.name, line.parent_id.name))
             previous_lines |= line
 
+    @api.constrains('availability_condition', 'country_id')
+    def _validate_availability_condition(self):
+        for record in self:
+            if record.availability_condition == 'country' and not record.country_id:
+                raise ValidationError(_("The Availability is set to 'Country Matches' but the field Country is not set."))
+
     @api.onchange('availability_condition')
     def _onchange_availability_condition(self):
         if self.availability_condition != 'country':


### PR DESCRIPTION
This commit adds a constraint on the availability_condition, checking that if the availability_condition is set to country, the field country_id is set.

task-4160643 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
