### PR TITLE
[FIX] account: update Invoice PDF on Invoice Modification

### DIFF
--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -574,6 +574,10 @@ class AccountMoveSend(models.TransientModel):
                                                  and not (allow_fallback_pdf and invoice_data.get('error_but_continue'))
                 invoice_data['error_but_continue'] = allow_fallback_pdf and invoice_data.get('error_but_continue')
 
+            if invoice.invoice_pdf_report_id.id and (not invoice_data.get('error') or allow_fallback_pdf):
+                content, _report_format = self.env['ir.actions.report'].with_company(invoice.company_id)._render('account.account_invoices', invoice.ids)
+                invoice.invoice_pdf_report_id.write({'raw': content})
+
         invoices_data_web_service = {
             invoice: invoice_data
             for invoice, invoice_data in invoices_data.items()


### PR DESCRIPTION
Before this **PR**:
When an invoice is modified and the "Print & Send" button is used again (after having previously sent or downloaded the invoice), the PDF attachment does not reflect the modifications.

After this **PR**:
The PDF attachment now gets updated with every modification of the invoice.

**task**-4228746
