### PR TITLE
[IMP] portal: add state/province validation

### DIFF
--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -386,6 +386,21 @@ class CustomerPortal(Controller):
             error["email"] = 'error'
             error_message.append(_('Invalid Email! Please enter a valid email address.'))
 
+        # state_id and country_id validation
+        country_id = request.env['res.country'].browse(int(data.get("country_id")))
+        if not country_id:
+            error["country_id"] = 'error'
+            error_message.append(_('Invalid Country! Please select a valid country.'))
+
+        try:
+            state_id = int(data.get("state_id"))
+            if state_id not in country_id.state_ids.ids:
+                error["state_id"] = 'error'
+                error_message.append(_('Invalid State / Province. Please select a valid State or Province.'))
+        except ValueError as e:
+            error["state_id"] = 'error'
+            error_message.append(e.args[0])
+
         # vat validation
         partner = request.env.user.partner_id
         if data.get("vat") and partner and partner.vat != data.get("vat"):

--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -386,19 +386,33 @@ class CustomerPortal(Controller):
             error["email"] = 'error'
             error_message.append(_('Invalid Email! Please enter a valid email address.'))
 
-        # state_id and country_id validation
-        country_id = request.env['res.country'].browse(int(data.get("country_id")))
-        if not country_id:
-            error["country_id"] = 'error'
-            error_message.append(_('Invalid Country! Please select a valid country.'))
-
+        # country and state validation
         try:
-            state_id = int(data.get("state_id"))
-            if state_id not in country_id.state_ids.ids:
+            country_id = data.get("country_id")
+            if not country_id.isdigit():
+                raise ValueError(_('Country ID must be a valid integer.'))
+
+            country = request.env['res.country'].browse(int(country_id))
+
+            if not country.exists():
+                error["country_id"] = 'error'
+                error_message.append(_('Invalid Country! Please select a valid country.'))
+
+            state_id = data.get("state_id")
+
+            if state_id and not state_id.isdigit():
+                raise ValueError(_('State ID must be a valid integer.'))
+
+            if state_id and int(state_id) not in country.state_ids.ids:
                 error["state_id"] = 'error'
                 error_message.append(_('Invalid State / Province. Please select a valid State or Province.'))
+
+            if country and not state_id and country.state_required:
+                error["state_id"] = 'error'
+                error_message.append(_('Some required fields are empty.'))
+
         except ValueError as e:
-            error["state_id"] = 'error'
+            error['common'] = 'Unknown error'
             error_message.append(e.args[0])
 
         # vat validation

--- a/doc/cla/individual/elierwclik.md
+++ b/doc/cla/individual/elierwclik.md
@@ -1,0 +1,11 @@
+Canada, 2024-10-04
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Elier Ayala Bernal elier@wclik.com https://github.com/elierwclik


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This PR addresses the lack of validation for selected states/provinces in the portal module UI. Currently, users can register states or provinces that do not correspond to the selected country, which can lead to errors in the database and user experience.

Current behavior before PR:

Prior to this PR, there are no validations that check the correspondence between states/provinces and the selected country. This allows incorrect data to be registered, which could cause confusion and operational issues.

Desired behavior after PR is merged:

After this PR is merged, a validation will be implemented that will check that the submitted states or provinces are valid and belong to the region corresponding to the selected country. This will improve data quality, ensure a better user experience, and reduce the risk of errors in the system.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
