### PR TITLE
[IMP] website_blog: allow changing the order of blog categories

### DIFF
--- a/addons/website_blog/controllers/main.py
+++ b/addons/website_blog/controllers/main.py
@@ -181,7 +181,7 @@ class WebsiteBlog(http.Controller):
     ], type='http', auth="public", website=True, sitemap=True)
     def blog(self, blog=None, tag=None, page=1, search=None, **opt):
         Blog = request.env['blog.blog']
-        blogs = tools.lazy(lambda: Blog.search(request.website.website_domain(), order="create_date asc, id asc"))
+        blogs = tools.lazy(lambda: Blog.search(request.website.website_domain(), order="sequence"))
 
         if not blog and len(blogs) == 1:
             url = QueryURL('/blog/%s' % request.env['ir.http']._slug(blogs[0]), search=search, **opt)()
@@ -246,7 +246,7 @@ class WebsiteBlog(http.Controller):
         date_begin, date_end = post.get('date_begin'), post.get('date_end')
 
         domain = request.website.website_domain()
-        blogs = blog.search(domain, order="create_date, id asc")
+        blogs = blog.search(domain, order="sequence")
 
         tag = None
         if tag_id:

--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -22,6 +22,10 @@ class BlogBlog(models.Model):
     ]
     _order = 'name'
 
+    def _default_sequence(self):
+        return (self.search([], order="sequence desc", limit=1).sequence or 0) + 1
+
+    sequence = fields.Integer("Sequence", default=_default_sequence)
     name = fields.Char('Blog Name', required=True, translate=True)
     subtitle = fields.Char('Blog Subtitle', translate=True)
     active = fields.Boolean('Active', default=True)

--- a/addons/website_blog/views/website_blog_views.xml
+++ b/addons/website_blog/views/website_blog_views.xml
@@ -6,6 +6,7 @@
             <field name="model">blog.blog</field>
             <field name="arch" type="xml">
                 <list string="Blogs">
+                    <field name="sequence" widget="handle"/>
                     <field name="name"/>
                     <field name="blog_post_count"/>
                     <field name="website_id" groups="website.group_multi_website"/>


### PR DESCRIPTION
Before this commit, users were unable to change the order of blog categories, which were sorted by default based on their create_date.

With this commit, users now have the option to choose the order in which blog categories are displayed.

task-4224591