### PR TITLE
[FIX] pos_restaurant: release table after order is completed

### DIFF
--- a/addons/pos_restaurant/static/src/app/models/restaurant_table.js
+++ b/addons/pos_restaurant/static/src/app/models/restaurant_table.js
@@ -71,10 +71,11 @@ export class RestaurantTable extends Base {
         );
     }
     getOrder() {
-        return this.parent_id?.getOrder?.() || this["<-pos.order.table_id"][0];
+        return (
+            this.parent_id?.getOrder?.() || this["<-pos.order.table_id"].find((o) => !o.finalized)
+        );
     }
     setPositionAsIfLinked(parent, side) {
-        // console.log("132")
         this.parent_id = parent;
         this.parent_side = side;
         this.position_h = this.getX();


### PR DESCRIPTION
Before this commit:
====================
The table remained occupied after the order was completed (payment done)

After this commit:
===================
Tables are now released once the order is fully completed, ensuring they are available for future use.

Task- 4228671

