### PR TITLE
[FIX] calendar: fix traceback when user gives maximum duration value

### DIFF
--- a/addons/calendar/i18n/calendar.pot
+++ b/addons/calendar/i18n/calendar.pot
@@ -2254,6 +2254,13 @@ msgstr ""
 
 #. module: calendar
 #. odoo-python
+#: code:addons/calendar/models/calendar_event.py:0
+#, python-format
+msgid "The given duration creates a date too far into the future."
+msgstr ""
+
+#. module: calendar
+#. odoo-python
 #: code:addons/calendar/models/calendar_recurrence.py:0
 #, python-format
 msgid "The interval cannot be negative."

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -366,7 +366,10 @@ class Meeting(models.Model):
         for event in self:
             # Round the duration (in hours) to the minute to avoid weird situations where the event
             # stops at 4:19:59, later displayed as 4:19.
-            event.stop = event.start and event.start + timedelta(minutes=round((event.duration or 1.0) * 60))
+            try:
+                event.stop = event.start and event.start + timedelta(minutes=round((event.duration or 1.0) * 60))
+            except OverflowError:
+                raise UserError(_("The given duration creates a date too far into the future."))
             if event.allday:
                 event.stop -= timedelta(seconds=1)
 


### PR DESCRIPTION
A traceback occurs when the user gives a maximum duration value while creating a new 
calendar event.

To reproduce this issue:

1) Install appointment
2) Create a new appointment from the Gantt view
3) Give the maximum duration value

Error:- 
```
OverflowError: Python int too large to convert to C int
```

This is because when the user gives a maximum duration value it is used to calculate the time from the below.

https://github.com/odoo/odoo/blob/a4c46f358401077a65106a6172b2a636755d41aa/addons/calendar/models/calendar_event.py#L369

This leads to the above traceback because of the duration value

sentry-5926537828

