### PR TITLE
[FIX] hr_holidays: Fix user error for same requires_allocation

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -182,6 +182,11 @@ class HolidaysType(models.Model):
             else:
                 holiday_type.has_valid_allocation = True
 
+    def _load_records_write(self, values):
+        if 'requires_allocation' in values and self.requires_allocation == values['requires_allocation']:
+            values.pop('requires_allocation')
+        return super()._load_records_write(values)
+
     @api.constrains('requires_allocation')
     def check_allocation_requirement_edit_validity(self):
         if self.env['hr.leave'].search_count([('holiday_status_id', 'in', self.ids)], limit=1):


### PR DESCRIPTION
Steps to reproduce the error
1.create a db in odoo 15.0 install hr_holiday and l10n_be_hr_payroll
2.create a leave with existing leave type from l10n_be_hr_payroll module 
3.upgrade db to 16.0 the below mentioned traceback will raise

traceback
```py
Traceback (most recent call last):
  File "/home/odoo/src/odoo/16.0/odoo/tools/convert.py", line 698, in _tag_root
    f(rec)
  File "/home/odoo/src/odoo/16.0/odoo/tools/convert.py", line 599, in _tag_record
    record = model._load_records([data], self.mode == 'update')
  File "/home/odoo/src/odoo/16.0/odoo/models.py", line 4393, in _load_records
    data['record']._load_records_write(data['values'])
  File "/home/odoo/src/odoo/16.0/odoo/models.py", line 4324, in _load_records_write
    self.write(values)
  File "/home/odoo/src/odoo/16.0/odoo/models.py", line 3806, in write
    real_recs._validate_fields(vals, inverse_fields)
  File "/home/odoo/src/odoo/16.0/odoo/models.py", line 1365, in _validate_fields
    check(self)
  File "/home/odoo/src/odoo/16.0/addons/hr_holidays/models/hr_leave_type.py", line 188, in check_allocation_requirement_edit_validity
    raise UserError(_("The allocation requirement of a time off type cannot be changed once leaves of that type have been taken. You should create a new time off type instead."))
odoo.exceptions.UserError: The allocation requirement of a time off type cannot be changed once leaves of that type have been taken. You should create a new time off type instead.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/odoo/src/odoo/16.0/odoo/service/server.py", line 1310, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "<decorator-gen-16>", line 2, in new
  File "/home/odoo/src/odoo/16.0/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "/home/odoo/src/odoo/16.0/odoo/modules/registry.py", line 91, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/odoo/src/odoo/16.0/odoo/modules/loading.py", line 484, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/home/odoo/src/odoo/16.0/odoo/modules/loading.py", line 372, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/home/odoo/src/odoo/16.0/odoo/modules/loading.py", line 231, in load_module_graph
    load_data(cr, idref, mode, kind='data', package=package)
  File "/home/odoo/src/odoo/16.0/odoo/modules/loading.py", line 71, in load_data
    tools.convert_file(cr, package.name, filename, idref, mode, noupdate, kind)
  File "/home/odoo/src/odoo/16.0/odoo/tools/convert.py", line 763, in convert_file
    convert_xml_import(cr, module, fp, idref, mode, noupdate)
  File "/home/odoo/src/odoo/16.0/odoo/tools/convert.py", line 829, in convert_xml_import
    obj.parse(doc.getroot())
  File "/home/odoo/src/odoo/16.0/odoo/tools/convert.py", line 749, in parse
    self._tag_root(de)
  File "/home/odoo/src/odoo/16.0/odoo/tools/convert.py", line 711, in _tag_root
    raise ParseError('while parsing %s:%s, somewhere inside\n%s' % (
odoo.tools.convert.ParseError: while parsing /home/odoo/src/enterprise/16.0/l10n_be_hr_payroll/data/hr_leave_type_data.xml:14, somewhere inside
<record id="holiday_type_maternity" model="hr.leave.type">
        <field name="name">Maternity Time Off</field>
        <field name="requires_allocation">no</field>
        <field name="leave_validation_type">no_validation</field>
        <field name="request_unit">half_day</field>
        <field name="color_name">lavender</field>
        <field name="leave_notif_subtype_id" ref="hr_holidays.mt_leave"/>
        <field name="work_entry_type_id" ref="work_entry_type_maternity"/>
        <field name="icon_id" ref="hr_holidays.icon_11"/>
        <field name="company_id" eval="False"/>
    </record>
```

why this traceback is raised because while loading ``l10n_be_hr_payroll`` moduel this data file will load during that if record is noupdate false then it will go for write call so in that requires_allocation will also go for write call even the value is same. So, the newly introduced [``constraints``](https://github.com/odoo/odoo/commit/33da34b842f2fe700efaf55915d4cb9828e139d7) will trigger and check if any record
of leave is present with the that leavetype constraint will trigger .For fixing this issue pop the value of ``requires_allocation`` if the values are same otherwise record is modified by user.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
