### PR TITLE
[FIX] html_editor: dynamic field added at next line

### DIFF
--- a/addons/html_editor/static/src/others/qweb_plugin.js
+++ b/addons/html_editor/static/src/others/qweb_plugin.js
@@ -1,5 +1,5 @@
 import { Plugin } from "@html_editor/plugin";
-import { closestElement } from "@html_editor/utils/dom_traversal";
+import { closestElement, selectElements } from "@html_editor/utils/dom_traversal";
 import { leftPos, rightPos } from "@html_editor/utils/position";
 import { QWebPicker } from "./qweb_picker";
 import { isElement } from "@html_editor/utils/dom_info";
@@ -89,7 +89,7 @@ export class QWebPlugin extends Plugin {
     normalize(root) {
         this.normalizeInline(root);
 
-        for (const element of root.querySelectorAll("[t-esc], [t-raw], [t-out], [t-field]")) {
+        for (const element of selectElements(root, "[t-esc], [t-raw], [t-out], [t-field]")) {
             element.setAttribute("contenteditable", "false");
         }
         this.applyGroupQwebBranching(root);
@@ -109,7 +109,7 @@ export class QWebPlugin extends Plugin {
     }
 
     normalizeInline(root) {
-        for (const el of root.querySelectorAll("t")) {
+        for (const el of selectElements(root, "t")) {
             if (this.checkAllInline(el)) {
                 el.setAttribute("data-oe-t-inline", "true");
             }
@@ -164,7 +164,7 @@ export class QWebPlugin extends Plugin {
     }
 
     applyGroupQwebBranching(root) {
-        const tNodes = root.querySelectorAll("[t-if], [t-elif], [t-else]");
+        const tNodes = selectElements(root, "[t-if], [t-elif], [t-else]");
         const groupsEncounter = new Set();
         for (const node of tNodes) {
             const prevNode = node.previousElementSibling;
@@ -189,10 +189,11 @@ export class QWebPlugin extends Plugin {
             // If there is no element in groupId activated, activate the first
             // one.
             if (!isOneElementActive) {
-                root.querySelector(`[data-oe-t-group='${groupId}']`).setAttribute(
-                    "data-oe-t-group-active",
-                    "true"
-                );
+                const firstElementToActivate = selectElements(
+                    root,
+                    `[data-oe-t-group='${groupId}']`
+                ).next().value;
+                firstElementToActivate.setAttribute("data-oe-t-group-active", "true");
             }
         }
     }

--- a/addons/html_editor/static/tests/dynamic_placeholder.test.js
+++ b/addons/html_editor/static/tests/dynamic_placeholder.test.js
@@ -1,0 +1,59 @@
+import { expect, test } from "@odoo/hoot";
+import { animationFrame } from "@odoo/hoot-mock";
+import { click, manuallyDispatchProgrammaticEvent, press } from "@odoo/hoot-dom";
+import { DYNAMIC_PLACEHOLDER_PLUGINS, MAIN_PLUGINS } from "@html_editor/plugin_sets";
+import { defineModels, models, onRpc, serverState } from "@web/../tests/web_test_helpers";
+import { setupEditor } from "./_helpers/editor";
+import { insertText } from "./_helpers/user_actions";
+
+class ResUsers extends models.Model {
+    _name = "res.users";
+    _records = [
+        {
+            id: serverState.userId,
+        },
+    ];
+}
+
+onRpc("has_group", () => true);
+onRpc("mail_allowed_qweb_expressions", () => []);
+defineModels([ResUsers]);
+
+test("inserted value from dynamic placeholder should contain the data-oe-t-inline attribute", async () => {
+    const { editor } = await setupEditor("<p>test[]</p>", {
+        config: {
+            Plugins: [...MAIN_PLUGINS, ...DYNAMIC_PLACEHOLDER_PLUGINS],
+            dynamicPlaceholderResModel: "res.users",
+        },
+    });
+
+    await insertText(editor, "/dynamicplaceholder");
+    await press("Enter");
+    await animationFrame();
+
+    const popover_search_input = document.querySelector(
+        ".o_model_field_selector_popover_search .o_input"
+    );
+    popover_search_input.value = "displayname";
+    await manuallyDispatchProgrammaticEvent(popover_search_input, "input", {
+        inputType: "insertText",
+    });
+    await press("Enter");
+    await animationFrame();
+
+    const default_value_input = document.querySelector(
+        ".o_model_field_selector_default_value_input .o_input"
+    );
+    await click(default_value_input);
+    await manuallyDispatchProgrammaticEvent(default_value_input, "input", {
+        inputType: "insertText",
+    });
+    default_value_input.value = "Test";
+    await manuallyDispatchProgrammaticEvent(default_value_input, "input", {
+        inputType: "insertText",
+    });
+    await press("Enter");
+    await animationFrame();
+
+    expect("t[data-oe-t-inline]").toHaveCount(1);
+});


### PR DESCRIPTION
**Current behavior before PR:**

- When adding a dynamic field next to text nodes, the dynamic field would be inserted on the following line.

**Desired behavior after PR is merged:**

- The dynamic field is now added on the same line as the text.

task:4220919
