### PR TITLE
[FIX] web: include postgresql server testing in health route

### DIFF
--- a/addons/web/controllers/home.py
+++ b/addons/web/controllers/home.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import psycopg2
 
 
 import odoo
@@ -147,10 +148,18 @@ class Home(http.Controller):
         return request.redirect(self._login_redirect(uid))
 
     @http.route('/web/health', type='http', auth='none', save_session=False)
-    def health(self):
-        data = json.dumps({
-            'status': 'pass',
-        })
+    def health(self, db_server_status=False):
+        health_info = {'status': 'pass'}
+        status = 200
+        if db_server_status:
+            try:
+                odoo.sql_db.db_connect('postgres').cursor().close()
+                health_info['db_server_status'] = True
+            except psycopg2.Error:
+                health_info['db_server_status'] = False
+                health_info['status'] = 'fail'
+                status = 500
+        data = json.dumps(health_info)
         headers = [('Content-Type', 'application/json'),
                    ('Cache-Control', 'no-store')]
-        return request.make_response(data, headers)
+        return request.make_response(data, headers, status=status)

--- a/addons/web/tests/test_health.py
+++ b/addons/web/tests/test_health.py
@@ -1,4 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import psycopg2
+from unittest.mock import patch
 
 from odoo.tests import HttpCase
 
@@ -10,3 +12,21 @@ class TestWebController(HttpCase):
         payload = response.json()
         self.assertEqual(payload['status'], 'pass')
         self.assertFalse(response.cookies.get('session_id'))
+
+    def test_health_db_server_status(self):
+        response = self.url_open('/web/health?db_server_status=1')
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload['status'], 'pass')
+        self.assertEqual(payload['db_server_status'], True)
+        self.assertFalse(response.cookies.get('session_id'))
+
+        def _raise_psycopg2_error(*args):
+            raise psycopg2.Error('boom')
+
+        with patch('odoo.sql_db.db_connect', new=_raise_psycopg2_error):
+            response = self.url_open('/web/health?db_server_status=1')
+            self.assertEqual(response.status_code, 500)
+            payload = response.json()
+            self.assertEqual(payload['status'], 'fail')
+            self.assertEqual(payload['db_server_status'], False)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses:

Prior to this commit, the health route is responding with a 200 status even when the database server is down or unreachable.

In deployment scenario (CI/CD), this route (/web/health) is (can be) used in order to get the deployement state. This is actually the only one that can be used in order to check it without an active session or credentials or master password.

Including the optional db_server_status arg will allow integrating the postgresql server state without breaking any eventual existing overrides.

## Current behavior before PR:

When the postgresql database is not up / not reachable the route is returning a 200 code.

## Desired behavior after PR is merged:

When the postgresql database is not up / not reachable the route is returning a 500 code. As we are in stable, an optional argument has been added to the route in order not to break any potential existing overrides.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
