### PR TITLE
[FIX] l10n_din5008: header shows Shipping address instead of Invoicing address

### DIFF
--- a/addons/l10n_din5008/report/din5008_report.xml
+++ b/addons/l10n_din5008/report/din5008_report.xml
@@ -221,9 +221,9 @@
 
                 <t t-set="din5008_address_block">
                     <t t-if="o and o._name=='account.move'">
-                        <t t-set="commercial_partner_id" t-value=""/>
-                        <t t-set="fact_partner_id" t-value="o.partner_id"/>
-                        <t t-set="delivery_partner_id" t-value="o.partner_shipping_id"/>
+                        <t t-set="commercial_partner" t-value="o.commercial_partner_id"/>
+                        <t t-set="invoice_partner" t-value="o.partner_id"/>
+                        <t t-set="delivery_partner" t-value="o.partner_shipping_id"/>
 
                         <t t-set="different_partner_count" t-value="len({partner.id for partner in [o.partner_id.commercial_partner_id, o.partner_id, o.partner_shipping_id] if partner})"/>
                         <tr t-if="different_partner_count > 1">


### PR DESCRIPTION
The invoice prints the "Shipping address" instead of the "Invoicing and shipping address."

Commit 6d36b38 moved `l10n_din5008` formatting logic from Python to XML, but the values were not set properly. Setting the `t-value` will resolve this issue.

To reproduce:
1. Create an invoice.
2. Assign an individual customer that has its company set.
3. Print it.

<details>
    <summary>Click here to see</summary>
    Before:
    <img src="https://github.com/user-attachments/assets/4eb54685-f906-4c29-87b3-70015ca84b9a"/>
    After:
    <img src="https://github.com/user-attachments/assets/1889a202-420f-4128-aeb6-a47fc9cd3a2e"/>
</details>

upg-2092611
opw-4209922


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
