### PR TITLE
[FIX] pos_sale: show correct value when paying through downpayment(percentage)

### DIFF
--- a/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js
+++ b/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js
@@ -275,20 +275,11 @@ export class SaleOrderManagementScreen extends ControlButtonsMixin(Component) {
                             this.pos.config.down_payment_product_id[0]
                         );
                     }
-                    const down_payment_tax =
-                        this.pos.taxes_by_id[down_payment_product.taxes_id] || false;
-                    let down_payment;
-                    if (down_payment_tax) {
-                        down_payment = down_payment_tax.price_include
-                            ? sale_order.amount_total
-                            : sale_order.amount_untaxed;
-                    } else {
-                        down_payment = sale_order.amount_total;
-                    }
 
+                    let down_payment;
                     let popupTitle = "";
                     let popupInputSuffix = "";
-                    const popupTotalDue = sale_order.amount_total;
+                    const popupTotalDue = sale_order.amount_unpaid;
                     let getInputBufferReminder = () => false;
                     const popupSubtitle = _t("Due balance: %s");
                     if (selectedOption == "dpAmount") {
@@ -315,7 +306,7 @@ export class SaleOrderManagementScreen extends ControlButtonsMixin(Component) {
                         title: popupTitle,
                         subtitle: sprintf(
                             popupSubtitle,
-                            this.env.utils.formatCurrency(sale_order.amount_unpaid)
+                            this.env.utils.formatCurrency(popupTotalDue)
                         ),
                         inputSuffix: popupInputSuffix,
                         startingValue: 0,
@@ -328,7 +319,7 @@ export class SaleOrderManagementScreen extends ControlButtonsMixin(Component) {
                     if (selectedOption == "dpAmount") {
                         down_payment = parseFloat(payload);
                     } else {
-                        down_payment = (down_payment * parseFloat(payload)) / 100;
+                        down_payment = (popupTotalDue * parseFloat(payload)) / 100;
                     }
 
                     if (down_payment > sale_order.amount_unpaid) {


### PR DESCRIPTION
Steps to reproduce:
====
- Create a quotation and confirm it.
- Open Point of Sale.
- Load the order in POS.
- Choose option Apply a down payment(percentage).
- Insert 50.
- Do payment and again place new order.
- Select the same Quotation and do same 50% down payment.

Issue:
====
- Next time value should be calculated from due balance not from initial total amount of the quotation.

Fix:
====
- Instead of total_amount , now amount_unpaid is used.

task- 4231244
