### PR TITLE
[FIX] hr_expense: proritize employee account in payment register wizard

### DIFF
--- a/addons/hr_expense/models/hr_expense_sheet.py
+++ b/addons/hr_expense/models/hr_expense_sheet.py
@@ -552,9 +552,12 @@ class HrExpenseSheet(models.Model):
         The default_partner_bank_id is set only if there is one available, if more than one the field is left empty.
         :return: An action opening the account.payment.register wizard.
         '''
-        return self.account_move_ids.with_context(default_partner_bank_id=(
-            self.employee_id.sudo().bank_account_id.id if len(self.employee_id.sudo().bank_account_id.ids) <= 1 else None
-        )).action_register_payment()
+        res = self.account_move_ids.action_register_payment()
+        if len(self.employee_id.sudo().bank_account_id.ids) <= 1:
+            res['context'].update({
+                'default_partner_bank_id': self.employee_id.sudo().bank_account_id.id,
+            })
+        return res
 
     def action_open_expense_view(self):
         self.ensure_one()


### PR DESCRIPTION
Have an employee with a trusted bank account [BNK1]
Set the corresponding partner parent company as the current company
Set the current company trusted back account to [BNK2]
Create an expense paid by the employee, create the report, post journal
entry and register payment

Issue: The default bank address is the one from the company [BNK2], but
it should be the employee's account [BNK1]

opw-3800134