### PR TITLE
[FIX] website_sale_loyalty: reward points if public user signed a quote

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -988,7 +988,7 @@ class SaleOrder(models.Model):
                     )
                 elif not product_qty_matched:
                     program_result['error'] = _("You don't have the required product quantities on your sales order.")
-            elif not self._allow_nominative_programs():
+            elif self.partner_id.is_public and not self._allow_nominative_programs():
                 program_result['error'] = _("This program is not available for public users.")
             if 'error' not in program_result:
                 points_result = [points] + rule_points

--- a/addons/website_sale_loyalty/tests/test_shop_sale_coupon.py
+++ b/addons/website_sale_loyalty/tests/test_shop_sale_coupon.py
@@ -429,3 +429,50 @@ class TestWebsiteSaleCoupon(TransactionCase):
         msg = "All coupon lines should have been removed from the order."
         self.assertEqual(len(order.applied_coupon_ids), 0, msg=msg)
         self.assertEqual(len(order.order_line), 4, msg=msg)
+
+    def test_confirm_points_as_public_user(self):
+        test_product = self.env['product.product'].create({
+            'name': "Test Product",
+            'list_price': 100,
+            'sale_ok': True,
+        })
+        test_partner = self.env['res.partner'].create({
+            'name': 'Test Partner'
+        })
+
+        loyalty_program = self.env['loyalty.program'].create({
+            'name': "Loyalty Program",
+            'program_type': 'loyalty',
+            'trigger': 'auto',
+            'applies_on': 'both',
+            'rule_ids': [Command.create({
+                'reward_point_mode': 'unit',
+                'reward_point_amount': 1,
+                'product_ids': [test_product.id],
+            })],
+            'reward_ids': [Command.create({
+                'reward_type': 'discount',
+                'discount': 1.5,
+                'discount_mode': 'per_point',
+                'discount_applicability': 'order',
+                'required_points': 3,
+            })],
+        })
+
+        order = self.env['sale.order'].create({
+            'partner_id': test_partner.id,
+            'order_line': [Command.create({
+                'product_id': test_product.id,
+                'product_uom_qty': 1,
+            })]
+        })
+
+        loyalty_card = self.env['loyalty.card'].create({
+            'program_id': loyalty_program.id,
+            'partner_id': test_partner.id,
+            'points': 0,
+        })
+        public_user = self.env.ref('base.public_user')
+        order.action_quotation_send()
+        order.with_context(access_token=order.access_token, user=public_user).action_confirm()
+        self.assertEqual(loyalty_card.points, 1)


### PR DESCRIPTION
Problem: A loyalty rewards points member don't receive their points for their confirmed order if they don't sign into their account when signing their quotation online from a link they received in their email. This bug only occurs if the quotation is set to "online signature" only. The bug is not reproducible when the quotation is set to both "online signature" and "online payment" or if website_sale_loyalty is not installed.

Purpose: It is expected that customers should receive their reward points for their order without needing to sign in because they accessed the link to sign the quotation from their email. It should be consistent with the behavior exhibited from having "online payment" set for the quotation or without website_sale_loyalty installed.

Steps to Reproduce on Runbot:
1. Install Sales app,  website_sale_loyalty, loyalty, sale_loyalty
2. Create a loyalty program that reward points based on orders
3. Create a quotation for a partner, set "online signature" in Other info, and click "Send by email"
4. Access the email in Settings > Technical > Emails
5. Copy the "Accept & sign" link and paste into incognito window
6. Sign the quote as a public user
7. Observe that the loyalty card  for the partner did not update the points

opw-4205826

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
