### PR TITLE
[FIX] point_of_sale: ensure values are cleared when switching away from terminal payment method

### DIFF
--- a/addons/point_of_sale/models/pos_payment_method.py
+++ b/addons/point_of_sale/models/pos_payment_method.py
@@ -86,6 +86,9 @@ class PosPaymentMethod(models.Model):
         selection_options = self.env['res.partner.bank'].get_available_qr_methods_in_sequence()
         if len(selection_options) == 1:
             self.qr_code_method = selection_options[0][0]
+        # Unset the use_payment_terminal field when switching to a payment method that doesn't use it
+        if self.payment_method_type != 'terminal':
+            self.use_payment_terminal = None
 
     @api.onchange('use_payment_terminal')
     def _onchange_use_payment_terminal(self):

--- a/doc/cla/individual/ncharlie.md
+++ b/doc/cla/individual/ncharlie.md
@@ -1,0 +1,11 @@
+Thailand, 2024-10-05
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Chanuwat na Chiengmai chanuwat555@hotmail.com https://github.com/ncharlie


### PR DESCRIPTION
[FIX] point_of_sale: ensure values are cleared when switching away from terminal payment method

Problem:
After a terminal provider is selected in "Integrate with" option, if the user change "Integration" option away from 'Terminal', the fields from terminal are still visible and getting validate. This makes record's changes cannot be saved if the fields are empty or do not pass validations.

Steps to Reproduce:
1. Install Point of Sale app.
2. Go to Configuration > Settings. Enable any "Payment Terminals".
3. Go to Configuration > Payment Methods. Click new or edit a record.
4. Select a journal
5. Select an "Integration" option "Terminal"
6. Select a terminal in "Integrate with" option
7. Switch an "Integration" option to None
8. Observe that the added fields does not disappear and is still getting validate when you save the record.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
