### PR TITLE
[FIX] website_sale_wishlist: Synchronising the wish list counter betw…

### DIFF
--- a/addons/website_sale_wishlist/static/src/js/website_sale_wishlist.js
+++ b/addons/website_sale_wishlist/static/src/js/website_sale_wishlist.js
@@ -25,6 +25,13 @@ publicWidget.registry.ProductWishlist = publicWidget.Widget.extend(VariantMixin,
     init: function (parent) {
         this._super.apply(this, arguments);
         this.wishlistProductIDs = JSON.parse(sessionStorage.getItem('website_sale_wishlist_product_ids') || '[]');
+        if (!this.wishlistProductIDs.length) {
+            // Set a placeholder that will be recomputed on willStart method because
+            // the length of this.wishlistProductIDs will be the same that showed on
+            // screen.
+            const wishCount = parseInt($('.my_wish_quantity').text(), 10);
+            this.wishlistProductIDs = new Array(wishCount).fill(null);
+        }
     },
     /**
      * Gets the current wishlist items.


### PR DESCRIPTION
Steps to reproduce the error:
- Log in to odoo as a registered user.
- Log in again in an incognito window or from another device with the same user account.
- In one of the sessions go to /shop and add products to the wish list. The value of the wishlist counter will increase.
- Refresh the browser in the other session (F5). The counter of the wish list will appear as 0 although the products are in the list.

Behaviour before the change:
The system was retrieving the wishlist value directly from sessionStorage, which caused inconsistencies when opening the website in a new window or on another device. If the key ‘website_sale_wishlist_product_ids’ was empty in sessionStorage, the wishlist counter remained at 0, even though there were actually products added.

![wishlist](https://github.com/user-attachments/assets/17070d8a-957a-4742-b2c4-66d06f61b175)

Solution implemented:
If the key ‘website_sale_wishlist_product_ids’ is empty when starting the component, the value of the counter visible on the page (element <sup> with class my_wish_quantity) is picked up, which is set correctly from the server view when loading the page. This value is used as a placeholder to hold the correct length of wishlistProductIDs until it is updated in the willStart method.

![wishlistfix](https://github.com/user-attachments/assets/f957fa60-23aa-43fa-99f5-0f906c88c921)

Objective:
To ensure that even when the key in sessionStorage is empty, the visual counter of the wishlist correctly reflects the number of products as indicated by the view before this value is modified or re-synchronised.

cc @Tecnativa TT51120

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
