### PR TITLE
[FIX] pos_sale: traceback while pressing backspace

### DIFF
--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -173,7 +173,7 @@ patch(PosStore.prototype, {
             buttons: enhancedButtons(),
             formatDisplayedValue: (x) => (isPercentage ? `% ${x}` : x),
             feedback: (buffer) =>
-                isPercentage
+                isPercentage && buffer
                     ? `(${this.env.utils.formatCurrency(
                           (sale_order.amount_total * parseFloat(buffer)) / 100
                       )})`


### PR DESCRIPTION
Steps to reproduce :
---------------------------
- Install the point_of_sale and sales module.
- Set downpayment on the shop and open session.
- Press quotation/orders action button.
- Open any quotation try apply percentage downpayment.
- Try to press backspace twice.

Issue :
---------
The number buffer would be "" at starting but when we again press backspace it will become null as mentioned from number buffer services which was directly passed to parseFloat function.

Cause :
----------
The parse float function applies startsWith function which won't be there if value is null.

Fix :
------
Instead of passing buffer directly now just send buffer to parse if it exist else send "" instead of null.
