### PR TITLE
[FIX] link_tracker: fix traceback when opening a link tracker in website 

### DIFF
--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -55,7 +55,7 @@ class LinkTracker(models.Model):
             if url.scheme:
                 tracker.absolute_url = tracker.url
             else:
-                tracker.absolute_url = tracker.get_base_url().join(url).to_url()
+                tracker.absolute_url = urls.url_join(tracker.get_base_url(), url)
 
     @api.depends('link_click_ids.link_id')
     def _compute_count(self):

--- a/addons/link_tracker/tests/test_link_tracker.py
+++ b/addons/link_tracker/tests/test_link_tracker.py
@@ -14,6 +14,24 @@ class TestLinkTracker(common.TransactionCase, MockLinkTracker):
         self._web_base_url = 'https://test.odoo.com'
         self.env['ir.config_parameter'].sudo().set_param('web.base.url', self._web_base_url)
 
+    def test_absolute_url(self):
+        """
+        Test the absolute url of a link tracker having scheme in url and then removing the
+        scheme to give the absolute_url as a combination of the system parameter and tracker's url
+        """
+        # Creating a link tracker with url having the scheme
+        link_tracker = self.env['link.tracker'].create({
+            'url': 'https://odoo.com',
+            'title': 'Odoo',
+        })
+        # Validate the absolute url
+        self.assertEqual(link_tracker.absolute_url, link_tracker.url)
+
+        # Make the scheme as an empty string by removing the http:// from the url
+        link_tracker.write({'url': "odoo"})
+        # Validate the absolute url is the combination of system parameter and link tracker's url
+        self.assertEqual(link_tracker.absolute_url, f'{self._web_base_url}/odoo')
+
     def test_create(self):
         link_trackers = self.env['link.tracker'].create([
             {


### PR DESCRIPTION
Currently, a traceback occurs when the user creates a link tracker having no scheme in the URL.

To reproduce this issue:

1) Install website_link, email marketing
2) Create a new link tracker with a target URL from email marketing/configuration
3) Now remove the `http://` from the target URL
4) Navigate to  website/site/link tracker

Error:- 
```
AttributeError: 'str' object has no attribute 'to_url'
```

This is because when the target URL has no `http://` the URL scheme will be an empty string. 
So it executes the else block in the below line.

https://github.com/odoo/odoo/blob/8a1e6bef82fdaa98c60ef1e3fa519a03206a6788/addons/link_tracker/models/link_tracker.py#L54-L58

Clearly in the else block the value of `tracker.get_base_url()` is the string, when joining the `url` and `tracker.get_base_url()` it becomes a string.

which leads to a traceback when `to_url()` is accessed from the string.

sentry-5925121505
