### PR TITLE
[FIX] stock: resupply from a warehouse between branches

### DIFF
--- a/addons/stock/views/stock_warehouse_views.xml
+++ b/addons/stock/views/stock_warehouse_views.xml
@@ -40,7 +40,9 @@
                                         <field name="delivery_steps" widget='radio'/>
                                     </group>
                                     <group name="group_resupply" string="Resupply" groups="stock.group_stock_multi_warehouses">
-                                        <field name="resupply_wh_ids" domain="[('id', '!=', id), ('company_id', '=', company_id)]" widget="many2many_checkboxes" groups="stock.group_stock_multi_warehouses"/>
+                                        <field name="resupply_wh_ids"
+                                               domain="[('id', '!=', id), '|', ('company_id', 'parent_of', company_id), ('company_id', 'child_of', company_id)]"
+                                               widget="many2many_checkboxes" groups="stock.group_stock_multi_warehouses"/>
                                     </group>
                                 </group>
                             </page>


### PR DESCRIPTION
Steps to reproduce the bug:

1. Enable “multi steps routes” in inventory settings
2. Have two company `A` and `B`, A is the parent company of B
3. Create another warehouse in company A
3. Refresh the page

Problem:
We cannot select a parent company warehouse or subsidiary warehouse. If user wants to use this option, they can enable 'Inter-Company Transactions' in settings and have to configure very complicated route, which can complicate operations if the correct configuration is not known

Solution:
Allow selecting the subsidiary warehouse or the parent company warehouse to automatically generate the route




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
