### PR TITLE
[FIX] hw_drivers: Set a user-agent for the websocket connection

### DIFF
--- a/addons/hw_drivers/websocket_client.py
+++ b/addons/hw_drivers/websocket_client.py
@@ -95,6 +95,7 @@ class WebsocketClient(Thread):
 
     def run(self):
         self.ws = websocket.WebSocketApp(self.url,
+            header={"User-Agent": "OdooIoTBox/1.0"},
             on_open=self.on_open, on_message=on_message,
             on_error=on_error, on_close=on_close)
 


### PR DESCRIPTION
**This is a back-port of a hotfix done during the OXP. See the original commit message below:**

`websocket.WebSocketApp` doesn't set any fingerprint header, like no user-agent or origin, ...

It can lead to issues when using a proxy firewall, such as HAProxy, as it could lead to the
fingerpint to be 00000000-00000000-00000000-00000000, which can be seen as not legitimate, and the requests to be rejected for that reason.

By setting a user-agent, we overcome this limitation

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
