### PR TITLE
[FIX] {spreadsheet_dashboard_,}stock_account: get value from quants

### DIFF
--- a/addons/spreadsheet_dashboard_stock_account/data/files/inventory_on_hand_dashboard.json
+++ b/addons/spreadsheet_dashboard_stock_account/data/files/inventory_on_hand_dashboard.json
@@ -741,7 +741,7 @@
                     "field": "value"
                 }
             ],
-            "model": "stock.valuation.layer",
+            "model": "stock.quant",
             "rowGroupBys": [],
             "name": "total inventory value",
             "sortedColumn": null
@@ -880,7 +880,7 @@
             "defaultsToCurrentPeriod": false,
             "pivotFields": {
                 "1": {
-                    "field": "stock_move_id.location_dest_id",
+                    "field": "location_id",
                     "type": "many2one"
                 },
                 "2": {
@@ -950,7 +950,7 @@
             "defaultsToCurrentPeriod": false,
             "pivotFields": {
                 "1": {
-                    "field": "stock_move_id.lot_ids",
+                    "field": "lot_id",
                     "type": "many2many"
                 },
                 "2": {


### PR DESCRIPTION
**Current behavior:**
Calling `read_group` on the SVL model with the following
parameters:
A) Domain includes 'stock_move_id.location_dest_id' and,
B) Fields includes 'value:aggregate'

Will not yield an up-to-date `value` result.

**Expected behavior:**
The value should be current.

**Steps to reproduce:**
1. Create some product a category having manual
`property_valuation` and standard `property_cost_method`,
set it's `standard_price` (cost) to zero.

2. Create a receipt for 1 unit of that product to WH/Stock and
validate it

3. Change the product `standard_price` to 1000

4. Go to the `Dashboard` app, select the 'Inventory On Hand'
report

5. Filter on the created product, and WH/Stock -> see that the
valuation is 0 when it should be 1000

**Cause of the issue:**
The SVL for the price change and new valuation does not have a
stock move associated with it. The dashboard calls `read_group`
on SVLs with the domain leaf:
`('stock_move_id.location_dest_id', 'in', [...])`
Thus, the SVL for the price change is not found here.

**Fix:**
Instead of getting the valuation from SVL records, use quants
which already have some amended `read_group` behavior to do so.

opw-4180394