### PR TITLE
[FIX] website: properly allow using named colors for navbar text

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -789,6 +789,11 @@ options.Class.include({
                 await this._customizeWebsiteData(widgetValue, params, true);
                 break;
             case 'variable':
+                // Color values (e.g. "header-text-color") must be saved as
+                // string. TODO: Color values should be added to the color map.
+                if (params.colorNames?.includes(widgetValue)) {
+                    widgetValue =`'${widgetValue}'`;
+                }
                 await this._customizeWebsiteVariable(widgetValue, params);
                 break;
             case "variables":

--- a/addons/website/static/src/scss/primary_variables.scss
+++ b/addons/website/static/src/scss/primary_variables.scss
@@ -2043,7 +2043,7 @@ $o-base-website-values-palette: (
 
     'header-template': 'default', // 'default' / 'hamburger' / 'vertical' / 'sidebar'
     'header-font-size': null, // Default to BS (normal font-size)
-    'header-text-color': null,
+    'header-text-color': null, // TODO: should have been put in the color map
     'header-links-style': 'default', // 'default' / 'fill' / 'outline' / 'pills' / 'block' / 'border-bottom'
     'logo-height': null, // Default to navbar height (see portal)
     'hamburger-position': 'left', // 'left' / 'center' / 'right'

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -346,7 +346,14 @@ $-seen-urls: ();
 // bootstrap if possible.
 #wrapwrap:not(.o_header_overlay) header, header.o_header_is_scrolled {
     .nav-item > .nav-link > *, .nav-item > .nav-link::after, .js_language_selector span, .badge {
-        color: o-website-value('header-text-color') !important;
+        $header-text-color: o-website-value('header-text-color');
+        // Check if the value is wrapped in quotes (initially it wasn't, and it
+        // didn't work) because we don't want the text color of the navbar to
+        // change once the fix is applied for users who tried the option when it
+        // wasn't working.
+        color: if(str-index(inspect($header-text-color), '"') == 1 or str-index(inspect($header-text-color), "'") == 1,
+            o-color($header-text-color),
+            $header-text-color) !important;
     }
 }
 


### PR DESCRIPTION
Steps to reproduce the bug:

- In Website edit mode.
- click on the navbar.
- For the "Format" option of the navbar, open the
color picker.
- Select any colors of the theme colors or any grayscale color.
- Bug: the color is not applied to the navbar links.

The bug has existed since commit [1], which added the feature to set a
custom text color for the header. Two problems were there from the
start:

- First, the variable wasn't saved inside quotes like it should have
been.
- Second, there was no function to convert theme colors (e.g.,
"o-color-1") into hexadecimal values when generating the CSS.

Because of this, only non-theme colors worked with this option. This
commit fixes the issue but ensures that it doesn't change anything for
users who already applied a color that didn’t work before. This way,
their navbar text color won't suddenly change after the fix without
them understanding why.

[1]: https://github.com/odoo/odoo/commit/d54028e5ed33a0258d3f2aeeaea338ac04f8d402

opw-4065019