### PR TITLE
[FIX] resource, hr_work_entry_contract: split work intervals by type

### DIFF
--- a/addons/hr_work_entry_contract/models/hr_contract.py
+++ b/addons/hr_work_entry_contract/models/hr_contract.py
@@ -4,7 +4,6 @@
 import itertools
 from collections import defaultdict
 from datetime import datetime, date, time
-from math import floor
 import pytz
 
 from dateutil.relativedelta import relativedelta
@@ -103,34 +102,6 @@ class HrContract(models.Model):
             ))
         return result
 
-    def _postprocess_attendance_intervals(self, intervals):
-        # _attendance_intervals_batch combines the attendances regardless of work entry type if their date and time overlap.
-        # This makes a single attendance block with the work entry type of the first attendance only. This function undoes those
-        # undesirable merges
-        try:
-            multi_type_intervals = [interval for interval in intervals if len(interval[2].work_entry_type_id) > 1]
-        except AttributeError:
-            return intervals
-        for interval in multi_type_intervals:
-            attendances = interval[2]
-            current_work_entry_type = attendances[0].work_entry_type_id
-            attendances_of_type = self.env["resource.calendar.attendance"]
-            start_date = interval[0]
-            for attendance in attendances:
-                if attendance.work_entry_type_id == current_work_entry_type:
-                    end_date = interval[0].replace(hour=floor(attendance.hour_to), minute=int((attendance.hour_to % 1) * 60))
-                    attendances_of_type |= attendance
-                else:
-                    intervals._items.append((start_date, end_date, attendances_of_type))
-                    start_date = interval[0].replace(hour=floor(attendance.hour_from), minute=int((attendance.hour_from % 1) * 60))
-                    end_date = interval[0].replace(hour=floor(attendance.hour_to), minute=int((attendance.hour_to % 1) * 60))
-                    current_work_entry_type = attendance.work_entry_type_id
-                    attendances_of_type = attendance
-            intervals._items.append((start_date, end_date, attendances_of_type))
-            intervals._items.remove(interval)
-        intervals._items.sort()
-        return intervals
-
     def _get_lunch_intervals(self, start_dt, end_dt):
         # {resource: intervals}
         employees_by_calendar = defaultdict(lambda: self.env['hr.employee'])
@@ -211,7 +182,7 @@ class HrContract(models.Model):
             mapped_leaves = {r.id: WorkIntervals(result[r.id]) for r in resources_list}
             leaves = mapped_leaves[resource.id]
 
-            real_attendances = self._postprocess_attendance_intervals(attendances - leaves)
+            real_attendances = attendances - leaves
             if contract.has_static_work_entries() or not leaves:
                 # Empty leaves means empty real_leaves
                 real_leaves = attendances - real_attendances

--- a/addons/hr_work_entry_contract/tests/test_work_entry.py
+++ b/addons/hr_work_entry_contract/tests/test_work_entry.py
@@ -322,5 +322,5 @@ class TestWorkEntry(TestWorkEntryBase):
         employee.generate_work_entries(datetime(2024, 9, 2), datetime(2024, 9, 2))
         result_entries = self.env['hr.work.entry'].search([('employee_id', '=', employee.id)])
         work_entry_types = [entry.work_entry_type_id for entry in result_entries]
-        self.assertEqual(len(result_entries), 3, 'Afternoon attendances should be split by work entry type')
-        self.assertEqual(work_entry_types, [entry_type_1, entry_type_1, entry_type_2])
+        self.assertEqual(len(result_entries), 4, 'A shift should be created for each attendance')
+        self.assertEqual(work_entry_types, [entry_type_1, entry_type_1, entry_type_1, entry_type_2])

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -20,6 +20,7 @@ from odoo.tools.float_utils import float_round
 
 from odoo.tools import date_utils, float_utils
 from .utils import Intervals, float_to_time, make_aware, datetime_to_string, string_to_datetime
+from odoo.addons.hr_work_entry_contract.models.hr_work_intervals import WorkIntervals
 
 
 class ResourceCalendar(models.Model):
@@ -360,12 +361,12 @@ class ResourceCalendar(models.Model):
         result_per_resource_id = dict()
         for tz, resources in resources_per_tz.items():
             res = result_per_tz[tz]
-            res_intervals = Intervals(res)
+            res_intervals = WorkIntervals(res)
             for resource in resources:
                 if resource in per_resource_result:
                     resource_specific_result = [(max(bounds_per_tz[tz][0], tz.localize(val[0])), min(bounds_per_tz[tz][1], tz.localize(val[1])), val[2])
                         for val in per_resource_result[resource]]
-                    result_per_resource_id[resource.id] = Intervals(itertools.chain(res, resource_specific_result))
+                    result_per_resource_id[resource.id] = WorkIntervals(itertools.chain(res, resource_specific_result))
                 else:
                     result_per_resource_id[resource.id] = res_intervals
         return result_per_resource_id


### PR DESCRIPTION
Steps to reproduce:
- Payroll > Configuration > Working Schedules
- Edit Monday morning to have shifts as follows -- 8:00-10:00, Overtime Hours type, 0.25 days
-- 10:00-12:00, Attendance type, 0.25 days
- Employees > Any with that schedule > Time Off
- Take a day off on a Monday (Full day)
- Time Off app > Management > Time Off
- Try to validate this time off

An error occurs when trying to read the morning's work entry type because both shifts have been merged (and thus the resulting shift has 2 entry types). This happens because of the use of Intervals in resource_calendar's '_attendance_intervals_batch' method.

When dealing with attendances we prefer using WorkIntervals which, unlike Intervals, keeps adjacent shifts separate. This is necessary to properly handle the entry type of leaves and attendances over contiguous periods.

This also removes the need for fdd9247cb86a01cc8c0903e69b85aae311e7c1ad, as the attendances have already been separated (Shifts cannot overlap any more than at their bounds) according to their type.

opw-4193334

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
