### PR TITLE
[FIX] product: hide price from catalog in case of mrp or repair orders

### DIFF
--- a/addons/mrp/static/src/product_catalog/order_line.js
+++ b/addons/mrp/static/src/product_catalog/order_line.js
@@ -1,0 +1,8 @@
+import { ProductCatalogOrderLine } from "@product/product_catalog/order_line/order_line";
+import { patch } from "@web/core/utils/patch";
+
+patch(ProductCatalogOrderLine.prototype, {
+    get showPrice() {
+        return super.showPrice && this.env.orderResModel !== "mrp.production";
+    }
+});

--- a/addons/product/static/src/product_catalog/order_line/order_line.js
+++ b/addons/product/static/src/product_catalog/order_line/order_line.js
@@ -47,4 +47,8 @@ export class ProductCatalogOrderLine extends Component {
         const options = { digits, decimalPoint: ".", thousandsSep: "" };
         return parseFloat(formatFloat(this.props.quantity, options));
     }
+
+    get showPrice() {
+        return true;
+    }
 }

--- a/addons/product/static/src/product_catalog/order_line/order_line.xml
+++ b/addons/product/static/src/product_catalog/order_line/order_line.xml
@@ -3,7 +3,7 @@
     <t t-name="product.ProductCatalogOrderLine">
         <!-- Replace the element found using the css selector by the content of the portalled
              template.  -->
-        <t t-portal="`#product-${props.productId}-price`">
+        <t t-portal="`#product-${props.productId}-price`" t-if="showPrice">
             <span class="o_product_catalog_price">Unit price: <t t-out="price"/></span>
         </t>
         <div 

--- a/addons/repair/static/src/components/product_catalog/order_line.js
+++ b/addons/repair/static/src/components/product_catalog/order_line.js
@@ -1,0 +1,8 @@
+import { ProductCatalogOrderLine } from "@product/product_catalog/order_line/order_line";
+import { patch } from "@web/core/utils/patch";
+
+patch(ProductCatalogOrderLine.prototype, {
+    get showPrice() {
+        return super.showPrice && this.env.orderResModel !== "repair.order";
+    }
+});


### PR DESCRIPTION
This commit hides the unit price of products in the catalog, in case that the catalog was opened from a manufacturing or a repair order. This is because the catalog in this case is used to add a component so the price information is irrelevant.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
