### PR TITLE
[FIX] pos: traceback when printing bill and validating payment

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1487,7 +1487,11 @@ export class PosStore extends Reactive {
         const baseUrl = this.session._base_url;
         return order.export_for_printing(baseUrl, headerData);
     }
-    async printReceipt({ basic = false, order = this.get_order() } = {}) {
+    async printReceipt({
+        basic = false,
+        order = this.get_order(),
+        printBillActionTriggered = false,
+    } = {}) {
         await this.printer.print(
             OrderReceipt,
             {
@@ -1497,8 +1501,10 @@ export class PosStore extends Reactive {
             },
             { webPrintFallback: true }
         );
-        const nbrPrint = order.nb_print;
-        await this.data.write("pos.order", [order.id], { nb_print: nbrPrint + 1 });
+        if (!printBillActionTriggered) {
+            const nbrPrint = order.nb_print;
+            await this.data.write("pos.order", [order.id], { nb_print: nbrPrint + 1 });
+        }
         return true;
     }
     getOrderChanges(skipped = false, order = this.get_order()) {

--- a/addons/pos_restaurant/static/src/app/bill_screen/bill_screen.js
+++ b/addons/pos_restaurant/static/src/app/bill_screen/bill_screen.js
@@ -15,6 +15,8 @@ export class BillScreen extends Component {
         this.printer = useState(useService("printer"));
     }
     async print() {
-        await this.pos.printReceipt();
+        await this.pos.printReceipt({
+            printBillActionTriggered: true,
+        });
     }
 }


### PR DESCRIPTION

Steps:

- Open the restaurant interface.
- Add items to any table order.
- Print the bill using the action button.
- Attempt to validate a payment.
- An error message appears.

Issue:
- A traceback occurs when printing the bill from the action button.
- After printing the bill via the action button, adding a payment line to the order becomes restricted.

Cause:
- An error occurs due to an increment in the bill print count.

Fix:
- Prevent incrementing the bill print count when using the action button.

task-4231943
