### PR TITLE
[FIX] spreadsheet_dashboard_pos_restaurant: Fix dashboard chart

### DIFF
--- a/addons/spreadsheet_dashboard_pos_restaurant/data/files/pos_restaurant_dashboard.json
+++ b/addons/spreadsheet_dashboard_pos_restaurant/data/files/pos_restaurant_dashboard.json
@@ -762,7 +762,7 @@
                 "label": "Revenue"
               },
               {
-                "dataRange": "Data!D14:D38",
+                "dataRange": "Data!D13:D37",
                 "label": "Average per order",
                 "yAxisId": "y1",
                 "trend": { "type": "polynomial", "order": 2, "display": false }

--- a/addons/spreadsheet_dashboard_pos_restaurant/data/files/pos_restaurant_sample_dashboard.json
+++ b/addons/spreadsheet_dashboard_pos_restaurant/data/files/pos_restaurant_sample_dashboard.json
@@ -475,7 +475,7 @@
                               "label": "Revenue"
                           },
                           {
-                              "dataRange": "Data!D14:D38",
+                              "dataRange": "Data!D13:D37",
                               "label": "Average per order",
                               "yAxisId": "y1",
                               "trend": {


### PR DESCRIPTION
the ranges of the first chart were not properly aligned but since we activated the "dataSets have title" option, the 2 datasets were offset from each other.

Task-4236146

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
