### PR TITLE
[FIX] account: no tva recomputation on partner change

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -974,7 +974,6 @@ class AccountMoveLine(models.Model):
                     'analytic_distribution': ((tax['analytic'] or not tax['use_in_tax_closing']) and line.move_id.state == 'draft') and line.analytic_distribution,
                     'tax_ids': [(6, 0, tax['tax_ids'])],
                     'tax_tag_ids': [(6, 0, tax['tag_ids'])],
-                    'partner_id': line.move_id.partner_id.id or line.partner_id.id,
                     'move_id': line.move_id.id,
                     'display_type': line.display_type,
                 }): {

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -1060,8 +1060,8 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             {
                 **self.tax_line_vals_1,
                 'currency_id': self.currency_data['currency'].id,
-                'amount_currency': 24.001,
-                'debit': 8.0,
+                'amount_currency': 0,
+                'debit': 0.0,
             },
             {
                 **self.tax_line_vals_2,
@@ -1072,8 +1072,8 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             {
                 **self.term_line_vals_1,
                 'currency_id': self.currency_data['currency'].id,
-                'amount_currency': -208.006,
-                'credit': 69.33,
+                'amount_currency': -184.005,
+                'credit': 61.33,
                 'date_maturity': fields.Date.from_string('2016-01-01'),
             },
         ], {
@@ -1081,8 +1081,8 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             'currency_id': self.currency_data['currency'].id,
             'date': fields.Date.from_string('2016-01-01'),
             'amount_untaxed': 160.005,
-            'amount_tax': 48.001,
-            'amount_total': 208.006,
+            'amount_tax': 24.0,
+            'amount_total': 184.005,
         })
 
         # Exit the multi-currencies.


### PR DESCRIPTION
Steps to reproduce:

1. Install account
2. Create a new Vendor Bill, no partner, at least one line with tax. Save.
3. Modify the tax's amount in the subtotal section (click the pen). Save.
4. Assign a partner to the invoice.
5. The custom tax amount is reset to \<it's rate\> * \<the base amount\>

---

Description of the issue this commit addresses:

In an invoice's form view before confirmation, it is possible to edit the tax
amounts in the subtotals of the invoice but those amounts are recomputed when
the partner of the invoice is changed. The way it's currently makes it so that
we lose the custom amounts on such events. We don't want that.

This issue is produced by two sub-issues either of which produce the bug on
its own. Both have to be fixed.

1. When editing the form, the tax total widget gets the values of the lines and
updates itself. In its current form, the values are gathered from the
invoice_line_ids without checking if they have been manually changed.

2. When saving the form, a list of some attributes is made and if some are
different, a bunch of other attributes are recomputed. partner_id is among the
triggering attributes. The tax totals widget values among the recomputed ones.

---

Desired behavior after the commit is merged:

To fix the first of the two sub-issues, the tax amount doesn't change when the
base amount of the tax doesn't change and the new tax amount is not the
original. For the second sub-issue, partner_id is removed from the attributes
that trigger a recomputation of the tax totals during a synchronization of the
tax totals widget.

---

Note on the fix:

A bunch of variables are created which represent whether or not the old and the
new tax amounts, tax rates, base amounts for each tax groups are different and
then freezing the edited amount is decided based on which combinaison of
mismatches there is. This should help to change the behavior in the future.

A test had to be modified as the behavior of the recomputation changed. The
test was modifying the base amount of a taxed line which is now a trigger for
a recomputation of the tax's amount.

---

task-4134532

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
