### PR TITLE
[FIX] pos_self_order: Include 'account.cash.rounding' to prevent error

### DIFF
--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -242,7 +242,7 @@ class PosConfig(models.Model):
         return ['pos.session', 'pos.order', 'pos.order.line', 'pos.payment', 'pos.payment.method', 'res.currency', 'pos.category', 'product.product', 'pos.combo', 'pos.combo.line',
             'res.company', 'account.tax', 'pos.printer', 'res.country', 'product.pricelist', 'product.pricelist.item', 'account.fiscal.position', 'account.fiscal.position.tax',
             'res.lang', 'product.attribute', 'product.attribute.custom.value', 'product.template.attribute.line', 'product.template.attribute.value',
-            'decimal.precision', 'uom.uom', 'pos.printer', 'pos_self_order.custom_link', 'restaurant.floor', 'restaurant.table']
+            'decimal.precision', 'uom.uom', 'pos.printer', 'pos_self_order.custom_link', 'restaurant.floor', 'restaurant.table', 'account.cash.rounding']
 
     def load_self_data(self):
         # Init our first record, in case of self_order is pos_config


### PR DESCRIPTION
Before this commit, attempting to create an order with a configuration that included a rounding method resulted in an error due to the absence of the necessary rounding data. This was caused by the omission of 'account.cash.rounding' during the loading process.

opw-4217844

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
