### PR TITLE
[FIX] odoo: enable ir_logging prior to registry creation

### DIFF
--- a/odoo/addons/base/data/base_data.sql
+++ b/odoo/addons/base/data/base_data.sql
@@ -115,6 +115,23 @@ CREATE TABLE res_partner (
     primary key(id)
 );
 
+CREATE TABLE ir_logging (
+    id serial,
+    create_uid integer,
+    write_uid integer,
+    name varchar NOT NULL,
+    type varchar NOT NULL,
+    dbname varchar,
+    level varchar,
+    path varchar NOT NULL,
+    func varchar NOT NULL,
+    line varchar NOT NULL,
+    message text NOT NULL,
+    create_date timestamp without time zone,
+    write_date timestamp without time zone,
+    primary key(id)
+);
+
 
 ---------------------------------
 -- Default data

--- a/odoo/modules/db.py
+++ b/odoo/modules/db.py
@@ -33,6 +33,8 @@ def initialize(cr):
 
     with odoo.tools.misc.file_open(f) as base_sql_file:
         cr.execute(base_sql_file.read())  # pylint: disable=sql-injection
+        # commiting as some table must be writeable during the rest of the initialization (e.g.: ir_logging)
+        cr.commit()
 
     for i in odoo.modules.get_modules():
         mod_path = odoo.modules.get_module_path(i)

--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -60,7 +60,7 @@ class PostgreSQLHandler(logging.Handler):
             # we do not use record.levelname because it may have been changed by ColoredFormatter.
             levelname = logging.getLevelName(record.levelno)
 
-            val = ('server', ct_db, record.name, levelname, msg, record.pathname, record.lineno, record.funcName)
+            val = ('server', dbname, record.name, levelname, msg, record.pathname, record.lineno, record.funcName)
             cr.execute("""
                 INSERT INTO ir_logging(create_date, type, dbname, name, level, message, path, line, func)
                 VALUES (NOW() at time zone 'UTC', %s, %s, %s, %s, %s, %s, %s, %s)


### PR DESCRIPTION
1) The db tracker is only set at the creation of the registry. Meaning
   that `PostgreSQLHandler` cannot properly track the concerned database
   with `threading.current_thread()`. Before the registry created, we
   should track the dbname with `tools.config['log_db']` (if specified)
2) Before the registry is created, the `ir_logging` table is not
   created. Yet, some `ERROR` or `WARNING` must be logged into the
   database (e.g.: `Missing `license` key in manifest`). This problem
   was harder to spot in earlier versions than 16.0 because this check was
   done multiple times (and at one point, the `current_thread.dbname` was
   defined --> you could see multiple ). As from 16.0, a LRU was assigned to the manifest loading (and
   checking the license) which is loaded first BEFORE the registry creation
   --> The table `ir_logging` does not exist at that point. The table must
   be created with the `base_data.sql` script.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
