### PR TITLE
[FIX] account: amount_currency update in bank statement line sync

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -686,7 +686,7 @@ class AccountBankStatementLine(models.Model):
             st_line_vals_to_write = {}
 
             if 'line_ids' in changed_fields:
-                liquidity_lines, suspense_lines, _other_lines = st_line._seek_for_lines()
+                liquidity_lines, suspense_lines, other_lines = st_line._seek_for_lines()
                 company_currency = st_line.journal_id.company_id.currency_id
                 journal_currency = st_line.journal_id.currency_id if st_line.journal_id.currency_id != company_currency\
                     else False
@@ -739,7 +739,7 @@ class AccountBankStatementLine(models.Model):
                             'foreign_currency_id': False,
                         })
 
-                    else:
+                    elif not other_lines:
 
                         # Update the statement line regarding the foreign currency of the suspense line.
 


### PR DESCRIPTION
When changing the move associated with the bank statement line we i.e. update the `amount_currency` field on the bank statement line. But currently we just set it to the `amount_currency` value of the suspense line.
This may not be correct in case we also have other lines on the move: We should have (liquidity = suspense + other) and the `amount_currency` on the bank statement line expresses the liquidity (total amount) and not the suspense (residual amount). After this commit we also include the other lines in the computation.

(Note: We cannot just use the liquidity line
It is in journal currency / company currency but the `amount_currency` of the bank statement line may be in a foreign currency that is neither the company nor the journal currency.)

enterprise PR which needs the change: https://github.com/odoo/enterprise/pull/71243