### PR TITLE
[FIX] web_editor: remove ufeff characters when copying

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -3685,8 +3685,8 @@ export class OdooEditor extends EventTarget {
         }
         const dataHtmlElement = document.createElement('data');
         dataHtmlElement.append(rangeContent);
-        const odooHtml = dataHtmlElement.innerHTML;
-        const odooText = selection.toString();
+        const odooHtml = dataHtmlElement.innerHTML.replace(/\uFEFF/g, "");
+        const odooText = selection.toString().replace(/\uFEFF/g, "");
         clipboardEvent.clipboardData.setData('text/plain', odooText);
         clipboardEvent.clipboardData.setData('text/html', odooHtml);
         clipboardEvent.clipboardData.setData('text/odoo-editor', odooHtml);

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
@@ -123,7 +123,7 @@ describe('Copy', () => {
                     window.chai.expect(clipboardData.getData('text/odoo-editor')).to.be.equal('<span style="font-size: 48px;"><font style="color: rgb(255, 0, 0);">First</font></span>');
                 },
             });
-        })
+        });
         it('should copy the selection as a list with multiple list items', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<ul><li>[First</li><li>Second]</li>',
@@ -133,6 +133,18 @@ describe('Copy', () => {
                     window.chai.expect(clipboardData.getData('text/plain')).to.be.equal('First\nSecond');
                     window.chai.expect(clipboardData.getData('text/html')).to.be.equal('<ul><li>First</li><li>Second</li></ul>');
                     window.chai.expect(clipboardData.getData('text/odoo-editor')).to.be.equal('<ul><li>First</li><li>Second</li></ul>');
+                },
+            });
+        });
+        it('should remove uFEFF characters from selection', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>[content\ufeff]</p>',
+                stepFunction: async editor => {
+                    const clipboardData = new DataTransfer();
+                    triggerEvent(editor.editable, 'copy', { clipboardData });
+                    window.chai.expect(clipboardData.getData('text/plain')).to.be.equal('content');
+                    window.chai.expect(clipboardData.getData('text/html')).to.be.equal('<p>content</p>');
+                    window.chai.expect(clipboardData.getData('text/odoo-editor')).to.be.equal('<p>content</p>');
                 },
             });
         });


### PR DESCRIPTION
Issue:
======
clipboard data has ufeff characters in it.

Steps to reproduce the issue:
=============================
- Create a new note/todo
- Add a link
- Copy it
- Visualise the data copied
- It contains ufeff characters of the link

Solution:
=========
We remove the characters fron the text and html we put in the clipboard data.

opw-4029722