### PR TITLE
[IMP] core: improve convert_to_column_update

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -122,7 +122,7 @@ class ProjectTask(models.Model):
 
     @api.model
     def _default_user_ids(self):
-        return self.env.context.keys() & {'default_personal_stage_type_ids', 'default_personal_stage_type_id'} and self.env.user
+        return self.env.user.ids if any(key in self.env.context for key in ('default_personal_stage_type_ids', 'default_personal_stage_type_id')) else ()
 
     @api.model
     def _default_company_id(self):

--- a/addons/web/static/src/views/fields/properties/property_definition.js
+++ b/addons/web/static/src/views/fields/properties/property_definition.js
@@ -45,6 +45,12 @@ export class PropertyDefinition extends Component {
         // prop needed by the popover service
         close: { type: Function, optional: true },
     };
+    static _propertyParametersMap = new Map([
+        ["comodel", ["many2one", "many2many"]],
+        ["domain", ["many2one", "many2many"]],
+        ["selection", ["selection"]],
+        ["tags", ["tags"]],
+    ]);
 
     setup() {
         this.orm = useService("orm");
@@ -218,12 +224,18 @@ export class PropertyDefinition extends Component {
             propertyDefinition.default = false;
         }
 
-        delete propertyDefinition.comodel;
+        PropertyDefinition._propertyParametersMap.forEach((types, param) => {
+            if (!types.includes(propertyDefinition.type)) {
+                delete propertyDefinition[param];
+            }
+        });
 
         this.props.onChange(propertyDefinition);
         this.state.propertyDefinition = propertyDefinition;
-        this.state.resModel = "";
-        this.state.resModelDescription = "";
+        if (!propertyDefinition.comodel) {
+            this.state.resModel = "";
+            this.state.resModelDescription = "";
+        }
         this.state.typeLabel = this._typeLabel(newType);
     }
 

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -966,10 +966,7 @@ class Field(MetaField('DummyField', (object,), {}), typing.Generic[T]):
         """
         if self.company_dependent:
             return PsycopgJson(value)
-        return self.convert_to_column_insert(
-            self.convert_to_write(value, record),
-            record,
-        )
+        return self.convert_to_column_insert(value, record, validate=False)
 
     def convert_to_cache(self, value, record, validate=True):
         """ Convert ``value`` to the cache format; ``value`` may come from an

--- a/odoo/orm/fields_binary.py
+++ b/odoo/orm/fields_binary.py
@@ -69,7 +69,7 @@ class Binary(Field):
         }
         if isinstance(value, str):
             value = value.encode()
-        if value[:1] in magic_bytes:
+        if validate and value[:1] in magic_bytes:
             try:
                 decoded_value = base64.b64decode(value.translate(None, delete=b'\r\n'), validate=True)
             except binascii.Error:

--- a/odoo/orm/fields_textual.py
+++ b/odoo/orm/fields_textual.py
@@ -90,7 +90,7 @@ class BaseString(Field[str | typing.Literal[False]]):
         else:
             s = str(value)
         value = s[:self.size]
-        if callable(self.translate):
+        if validate and callable(self.translate):
             # pylint: disable=not-callable
             value = self.translate(lambda t: None, value)
         return value
@@ -495,7 +495,7 @@ class Html(BaseString):
     _description_strip_classes = property(attrgetter('strip_classes'))
 
     def convert_to_column(self, value, record, values=None, validate=True):
-        value = self._convert(value, record, validate=True)
+        value = self._convert(value, record, validate=validate)
         return super().convert_to_column(value, record, values, validate=False)
 
     def convert_to_cache(self, value, record, validate=True):

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -1008,7 +1008,7 @@ class BaseModel(metaclass=MetaModel):
                         result.append(properties_field._dict_to_list(raw_properties, definition))
 
                 # FIXME: Far from optimal, it will fetch display_name for no reason
-                res_ids_per_model = properties_field._get_res_ids_per_model(self, result)
+                res_ids_per_model = properties_field._get_res_ids_per_model(self.env, result)
 
                 cache_properties[properties_fname] = record_map = {}
                 for properties, rec in zip(result, self):
@@ -5175,7 +5175,7 @@ class BaseModel(metaclass=MetaModel):
             if fname not in self or self._fields[fname].type != 'properties':
                 continue
             field_converter = self._fields[fname].convert_to_cache
-            to_write[fname] = dict(self[fname], **field_converter(values.pop(fname), self))
+            to_write[fname] = dict(self[fname], **field_converter(values.pop(fname), self, validate=False))
 
         self.write(values)
         if to_write:


### PR DESCRIPTION
`convert_to_column_update` can trust the data in cache and doesn't need
`convert_to_write` and `validate`

take more advantage of `validate` for converters to avoid validating trusted or
already validated data

For `Properties` fields, format data when `convert_to_cache` for write instead of
flush which also improves the data consistency. As a result, it is required to
update the property definition before update the property value.

upgrade: https://github.com/odoo/upgrade/pull/6906

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
