### PR TITLE
[IMP] website_editor: autosave custom snippet when drag and drap

### DIFF
--- a/addons/test_website/static/tests/tours/custom_snippets.js
+++ b/addons/test_website/static/tests/tours/custom_snippets.js
@@ -10,7 +10,8 @@ const wTourUtils = require('website.tour_utils');
  * -> drag a banner into page content
  * -> customize banner (set text)
  * -> save banner as custom snippet
- * -> confirm save
+ * -> rename custom snippet
+ * -> check if auto save works and rename snippet
  * -> ensure custom snippet is available
  * -> drag custom snippet
  * -> ensure block appears as banner
@@ -61,13 +62,17 @@ wTourUtils.registerWebsitePreviewTour('test_custom_snippet', {
         extra_trigger: ".oe_snippet[name='Custom Banner'] .oe_snippet_thumbnail:not(.o_we_already_dragging)",
     },
     {
-        content: "set name",
+        content: "set name of custom snippet",
         trigger: ".oe_snippet[name='Custom Banner'] input",
-        run: "text Bruce Banner",
+        run: function () {
+            const inputEl = document.querySelector("input.text-start");
+            inputEl.value = "Bruce Banner";
+            inputEl.dispatchEvent(new Event("focusout"));
+        },
     },
     {
-        content: "confirm rename",
-        trigger: ".oe_snippet[name='Custom Banner'] we-button.o_we_confirm_btn",
+        content: "check if the snippet is auto-saved when the focus is removed from the input field",
+        trigger: ".oe_snippet[name='Bruce Banner']",
     },
     {
         content: "drop custom snippet",
@@ -92,7 +97,6 @@ wTourUtils.registerWebsitePreviewTour('test_custom_snippet', {
     {
         content: "delete custom snippet",
         trigger: ".oe_snippet[name='Bruce Banner'] we-button.o_delete_btn",
-        extra_trigger: ".oe_snippet[name='Bruce Banner'] .oe_snippet_thumbnail:not(.o_we_already_dragging)",
     },
     {
         content: "confirm delete",


### PR DESCRIPTION
Specification:
When a user is renaming a custom snippet and tried to drag and drop another snippet, all unsaved changes to the name gets lost.

This PR introduces a feature to autosave the name of the custom snippet. It allows both custom and other snippets to be dragged and dropped, with automatic saving of changes. Additionally, it prevents saving null names to custom snippets.

task-3581814
