### PR TITLE
[FIX] stock: prevent needless write on picking

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -797,10 +797,11 @@ class Picking(models.Model):
     def _onchange_picking_type(self):
         if self.picking_type_id and self.state == 'draft':
             self = self.with_company(self.company_id)
-            (self.move_ids | self.move_ids_without_package).update({
-                "picking_type_id": self.picking_type_id,  # The compute store doesn't work in case of One2many inverse (move_ids_without_package)
-                "company_id": self.company_id,
-            })
+            # The compute store doesn't work in case of One2many inverse (move_ids_without_package)
+            (self.move_ids | self.move_ids_without_package).filtered(
+                lambda m: m.picking_type_id != self.picking_type_id
+            ).picking_type_id = self.picking_type_id
+            (self.move_ids | self.move_ids_without_package).company_id = self.company_id
             for move in (self.move_ids | self.move_ids_without_package):
                 if not move.product_id:
                     continue


### PR DESCRIPTION
**Current behavior:**
Creating a new picking, adding some moves, then adding/changing the partner_id field all without saving will remove the added moves.

**Expected behavior:**
Changing the partner shouldn't affect the moves.

**Steps to reproduce:**
1. Create a new picking, add some moves, then add a partner (all without saving)

2. Observe the moves disappear after adding the partner

**Cause of the issue:**
In the onchange handling partner_id changes, we overwrite the new virtual moves with values and mark them as modified. This causes them to eventually get invalidated and they aren't saved once the update (overwrite) resolves.

**Fix:**
Don't update virtual moves (records without an _origin).

opw-4120108