### PR TITLE
[FIX] point_of_sale: display product template image instead of variant

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -190,6 +190,14 @@ export class ProductProduct extends Base {
         );
     }
 
+    getTemplateImageUrl() {
+        return (
+            (this.image_128 &&
+                `/web/image?model=product.template&field=image_128&id=${this.raw.product_tmpl_id}&unique=${this.write_date}`) ||
+            ""
+        );
+    }
+
     get searchString() {
         const fields = ["display_name", "description_sale", "description"];
         return fields

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -278,7 +278,7 @@ export class ProductScreen extends Component {
     }
 
     getProductImage(product) {
-        return product.getImageUrl();
+        return product.getTemplateImageUrl();
     }
 
     get searchWord() {


### PR DESCRIPTION
Before this commit, the product screen displayed an image of one of the product's variants, contrary to the expectation of showing the product template image. This commit corrects the behavior to ensure the product template image is displayed.

opw-4234351

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
