### PR TITLE
[FIX] spreadsheet_dashboard: Edit non-active dashboard

### DIFF
--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
@@ -86,7 +86,7 @@
                         </div>
                         <t t-set="comp" t-value="dashboardButton"/>
                         <t t-if="comp">
-                            <t t-component="comp" t-props="{ onClick: () => this.editDashboard(dashboard.id) }"/>
+                            <t t-component="comp" t-props="{ dashboardId: dashboard.id, onClick: this.editDashboard.bind(this) }"/>
                         </t>
                     </li>
                 </ul>


### PR DESCRIPTION
The newly added button shortcut to edit a dashboard would only always open the active dashboard edition and not the one we clicked on.

Task-4236307

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
