### PR TITLE
[FIX] web_editor, mass_mailing: save image changes when switching tabs

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -102,7 +102,11 @@ export class MassMailingHtmlField extends HtmlField {
             const $editable = this.wysiwyg.getEditable();
             this.wysiwyg.odooEditor.historyPauseSteps();
             await this.wysiwyg.cleanForSave();
-            await super.commitChanges(...args);
+            if (args.length) {
+                await super.commitChanges({ ...args[0], urgent: true });
+            } else {
+                await super.commitChanges({ urgent: true });
+            }
 
             const $editorEnable = $editable.closest('.editor_enable');
             $editorEnable.removeClass('editor_enable');

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1384,7 +1384,10 @@ const Wysiwyg = Widget.extend({
             // Refocus again to save updates when calling `_onWysiwygBlur`
             this.odooEditor.editable.focus();
         } else {
-            return this.odooEditor.execCommand('insert', element);
+            const result = this.odooEditor.execCommand('insert', element);
+            // Refocus again to save updates when calling `_onWysiwygBlur`
+            this.odooEditor.editable.focus();
+            return result;
         }
 
         if (this.snippetsMenu) {


### PR DESCRIPTION
This fix is a continuation of this [commit].

Issue:
======
Inserting new image and image replacements don't get saved when switching tabs.

Steps to reproduce the issue:
=============================
- Create a mass mailing
- choose welcome message template
- add subject, mailing list and save
- Add image using /image and switch directly to another tab like `a/b testing`
- Go back to mail body =>  changes aren't saved.
- Same if you replace an existing image with another one

Origin of the issue:
====================
- For Newly inserted images we need to refocus in the editor like we did in the old commit.
- Now for both of them after the refocus fix we still have an issue because the `saveModifiedImagesPromise` will take so much time so that after it gets resolved the component is already destroyed and we will not save the changes.

Solution:
=========
We force the commitChanges coming from mass_mailing as urgent so it will save the value before resolving any promise to make sure we don't loose the content.

opw-3947516

[commit]: https://github.com/odoo/odoo/commit/146b0b9ff4b4c2cbabd5d71f869f31f4bbb649d2