### PR TITLE
[FIX] repair: don't show warning if all moves are not picked

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -317,7 +317,7 @@ class Repair(models.Model):
     @api.depends('move_ids.quantity', 'move_ids.product_uom_qty', 'move_ids.product_uom.rounding')
     def _compute_has_uncomplete_moves(self):
         for repair in self:
-            repair.has_uncomplete_moves = any(not move.picked or float_compare(move.quantity, move.product_uom_qty, precision_rounding=move.product_uom.rounding) < 0 for move in repair.move_ids)
+            repair.has_uncomplete_moves = any(float_compare(move.quantity, move.product_uom_qty, precision_rounding=move.product_uom.rounding) < 0 for move in repair.move_ids)
 
     @api.depends('move_ids', 'state', 'move_ids.product_uom_qty')
     def _compute_unreserve_visible(self):


### PR DESCRIPTION
This commit makes the behavior of the warning on repair order confirmation more similar to stock pickings. The warning now doesn't show if all the moves are not picked, since they'll be all picked during the validation process.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
