### PR TITLE
[FIX] payment_razorpay: fix an error when update the payment method

### DIFF
--- a/addons/payment_razorpay/models/payment_transaction.py
+++ b/addons/payment_razorpay/models/payment_transaction.py
@@ -389,7 +389,7 @@ class PaymentTransaction(models.Model):
         # Update the payment method.
         payment_method_type = entity_data.get('method', '')
         if payment_method_type == 'card':
-            payment_method_type = entity_data.get('card', {}).get('network').lower()
+            payment_method_type = entity_data.get('card', {}).get('network', '').lower()
         payment_method = self.env['payment.method']._get_from_code(
             payment_method_type, mapping=const.PAYMENT_METHODS_MAPPING
         )


### PR DESCRIPTION
Fix the code at [1], Where the system tries to update the payment method, Modify the code to handle this issue where the network value might not exist. This can be done by providing a default value for ```payment_method_type``` if the network value is not present.

Link [1]: https://github.com/odoo/odoo/blob/d30f41a49f614456c71a0a6974325030f552a0db/addons/payment_razorpay/models/payment_transaction.py#L391-L392

Sentry-5950544641

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
