### PR TITLE
[IMP] discuss: send notifications for calls

### DIFF
--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -179,6 +179,7 @@ For more specific needs, you may also assign custom-defined actions
             'web/static/tests/legacy/utils.js',
             'mail/static/tests/tours/discuss_channel_public_tour.js',
             'mail/static/tests/tours/discuss_channel_as_guest_tour.js',
+            'mail/static/tests/tours/discuss_channel_call_action.js',
             'mail/static/tests/tours/discuss_channel_call_public_tour.js',
             'mail/static/tests/tours/discuss_sidebar_in_public_page_tour.js',
         ],

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 
 from odoo import api, fields, models, _
 from odoo.addons.mail.tools.discuss import Store
+from odoo.addons.mail.tools.web_push import PUSH_NOTIFICATION_ACTION, PUSH_NOTIFICATION_TYPE
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.osv import expression
 from ...tools import jwt, discuss
@@ -460,6 +461,47 @@ class DiscussChannelMember(models.Model):
                     ),
                 },
             )
+            devices, private_key, public_key = self.channel_id._get_web_push_parameters(members.partner_id.ids)
+            if devices:
+                if self.channel_id.channel_type != 'chat':
+                    icon = f"/web/image/discuss.channel/{self.channel_id.id}/avatar_128"
+                elif guest := self.env["mail.guest"]._get_guest_from_context():
+                    icon = f"/web/image/mail.guest/{guest.id}/avatar_128"
+                elif partner := self.env.user.partner_id:
+                    icon = f"/web/image/res.partner/{partner.id}/avatar_128"
+                languages = [partner.lang for partner in devices.partner_id]
+                payload_by_lang = {}
+                for lang in languages:
+                    env_lang = self.with_context(lang=lang).env
+                    payload_by_lang[lang] = {
+                        "title": env_lang._("Incoming call"),
+                        "options": {
+                            "body": env_lang._("Conference: %s", self.channel_id.display_name),
+                            "icon": icon,
+                            "vibrate": [100, 50, 100],
+                            "requireInteraction": True,
+                            "tag": self.channel_id._get_call_notification_tag(),
+                            "data": {
+                                "type": PUSH_NOTIFICATION_TYPE.CALL,
+                                "model": "discuss.channel",
+                                "action": "mail.action_discuss",
+                                "res_id": self.channel_id.id,
+                            },
+                            "actions": [
+                                {
+                                    "action": PUSH_NOTIFICATION_ACTION.DECLINE,
+                                    "type": "button",
+                                    "title": env_lang._("Decline"),
+                                },
+                                {
+                                    "action": PUSH_NOTIFICATION_ACTION.ACCEPT,
+                                    "type": "button",
+                                    "title": env_lang._("Accept"),
+                                },
+                            ]
+                        }
+                    }
+                self.channel_id._push_web_notification(devices, private_key, public_key, payload_by_lang=payload_by_lang)
         return members
 
     def _mark_as_read(self, last_message_id, sync=False):

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -310,6 +310,16 @@ export class Rtc extends Record {
                 this.sfuClient?.disconnect();
             }
         });
+        browser.navigator.serviceWorker?.addEventListener("message", ({ data: { action, id } }) => {
+            if (action === "JOIN_CALL") {
+                const channel = this.store.Thread.get({ model: "discuss.channel", id });
+                channel.open();
+                if (this.state.channel) {
+                    return;
+                }
+                this.joinCall(channel);
+            }
+        });
         /**
          * Call all sessions for which no peerConnection is established at
          * a regular interval to try to recover any connection that failed

--- a/addons/mail/static/src/discuss/call/public_web/discuss_client_action_patch.js
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_client_action_patch.js
@@ -1,0 +1,27 @@
+import { DiscussClientAction } from "@mail/core/public_web/discuss_client_action";
+import { useState } from "@odoo/owl";
+
+import { useService } from "@web/core/utils/hooks";
+import { patch } from "@web/core/utils/patch";
+
+patch(DiscussClientAction.prototype, {
+    setup() {
+        super.setup(...arguments);
+        this.rtc = useState(useService("discuss.rtc"));
+    },
+    /**
+     * Checks if we are in a client action and if we have a query parameter requesting to join a call,
+     * if so, the call is joined on the current discuss thread.
+     */
+    async restoreDiscussThread() {
+        await super.restoreDiscussThread(...arguments);
+        const action = this.props.action;
+        if (!action) {
+            return;
+        }
+        const call = action.context?.call || action.params?.call;
+        if (call === "accept") {
+            await this.rtc.joinCall(this.store.discuss.thread);
+        }
+    },
+});

--- a/addons/mail/static/src/service_worker.js
+++ b/addons/mail/static/src/service_worker.js
@@ -1,20 +1,95 @@
 /* eslint-env serviceworker */
 /* eslint-disable no-restricted-globals */
+
+const PUSH_NOTIFICATION_TYPE = {
+    CALL: "CALL",
+    CANCEL: "CANCEL",
+};
+const PUSH_NOTIFICATION_ACTION = {
+    ACCEPT: "ACCEPT",
+    DECLINE: "DECLINE",
+};
+
 self.addEventListener("notificationclick", (event) => {
     event.notification.close();
     if (event.notification.data) {
-        const { action, model, res_id } = event.notification.data;
+        const { action, model, res_id, type } = event.notification.data;
         if (model === "discuss.channel") {
-            clients.openWindow(`/odoo/${res_id}/action-${action}`);
+            const route = `/odoo/${res_id}/action-${action}`;
+            if (type === PUSH_NOTIFICATION_TYPE.CALL) {
+                switch (event.action) {
+                    case PUSH_NOTIFICATION_ACTION.ACCEPT: {
+                        event.waitUntil(
+                            (async () => {
+                                const clientWindows = await clients.matchAll({
+                                    includeUncontrolled: true,
+                                    type: "window",
+                                });
+                                const clientWindow = clientWindows[0];
+                                if (clientWindow) {
+                                    clientWindow.focus();
+                                    clientWindow.postMessage({
+                                        action: "JOIN_CALL",
+                                        id: res_id,
+                                    });
+                                    return;
+                                }
+                                await clients.openWindow(route + "?call=accept");
+                            })()
+                        );
+                        return;
+                    }
+                    case PUSH_NOTIFICATION_ACTION.DECLINE:
+                        event.waitUntil(
+                            fetch("/mail/rtc/channel/leave_call", {
+                                headers: {
+                                    "Content-type": "application/json",
+                                },
+                                body: JSON.stringify({
+                                    id: 1,
+                                    jsonrpc: "2.0",
+                                    method: "call",
+                                    params: {
+                                        channel_id: res_id,
+                                    },
+                                }),
+                                method: "POST",
+                                mode: "cors",
+                                credentials: "include",
+                            })
+                        );
+                        return;
+                }
+            }
+            event.waitUntil(clients.openWindow(route));
         } else {
             const modelPath = model.includes(".") ? model : `m-${model}`;
-            clients.openWindow(`/odoo/${modelPath}/${res_id}`);
+            event.waitUntil(clients.openWindow(`/odoo/${modelPath}/${res_id}`));
         }
     }
 });
-self.addEventListener("push", (event) => {
+self.addEventListener("push", async (event) => {
     const notification = event.data.json();
-    self.registration.showNotification(notification.title, notification.options || {});
+    switch (notification.options?.data?.type) {
+        case PUSH_NOTIFICATION_TYPE.CALL:
+            if (notification.options.actions && navigator.userAgent.includes("Android")) {
+                // action "accept" is disabled on mobile until: https://issues.chromium.org/issues/40286493 is fixed.
+                delete notification.options.actions.accept;
+            }
+            break;
+        case PUSH_NOTIFICATION_TYPE.CANCEL: {
+            const notifications = await self.registration.getNotifications({
+                tag: notification.options?.tag,
+            });
+            for (const notification of notifications) {
+                notification.close();
+            }
+            return;
+        }
+    }
+    event.waitUntil(
+        self.registration.showNotification(notification.title, notification.options || {})
+    );
 });
 self.addEventListener("pushsubscriptionchange", async (event) => {
     const subscription = await self.registration.pushManager.subscribe(

--- a/addons/mail/static/tests/tours/discuss_channel_call_action.js
+++ b/addons/mail/static/tests/tours/discuss_channel_call_action.js
@@ -1,0 +1,14 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("discuss_channel_call_action.js", {
+    steps: () => [
+        {
+            content: "Check that the call has started",
+            trigger: ".o-discuss-Call",
+        },
+        {
+            content: "Check that current user is in call ('disconnect' button visible)",
+            trigger: "button[title='Disconnect']",
+        },
+    ],
+});

--- a/addons/mail/tests/discuss/test_discuss_action.py
+++ b/addons/mail/tests/discuss/test_discuss_action.py
@@ -2,11 +2,24 @@
 from odoo.tests import HttpCase, tagged
 
 
-@tagged("post_install", "-at_install")
+@tagged("post_install", "-at_install", "discuss_action")
 class TestDiscussAction(HttpCase):
     def test_go_back_to_thread_from_breadcrumbs(self):
         self.start_tour(
             "/odoo/discuss?active_id=mail.box_inbox",
             "discuss_go_back_to_thread_from_breadcrumbs.js",
             login="admin",
+        )
+
+    def test_join_call_with_client_action(self):
+        inviting_user = self.env['res.users'].sudo().create({'name': "Inviting User", 'login': 'inviting'})
+        invited_user = self.env['res.users'].sudo().create({'name': "Invited User", 'login': 'invited'})
+        channel = self.env['discuss.channel'].with_user(inviting_user).channel_get(partners_to=invited_user.partner_id.ids)
+        channel_member = channel.sudo().channel_member_ids.filtered(
+            lambda channel_member: channel_member.partner_id == inviting_user.partner_id)
+        channel_member._rtc_join_call()
+        self.start_tour(
+            f"/odoo/{channel.id}/action-mail.action_discuss?call=accept",
+            "discuss_channel_call_action.js",
+            login=invited_user.login,
         )

--- a/addons/mail/tools/web_push.py
+++ b/addons/mail/tools/web_push.py
@@ -19,6 +19,17 @@ from . import jwt
 
 MAX_PAYLOAD_SIZE = 4096
 
+
+class PUSH_NOTIFICATION_TYPE:
+    CALL = "CALL"
+    CANCEL = "CANCEL"
+
+
+class PUSH_NOTIFICATION_ACTION:
+    ACCEPT = "ACCEPT"
+    DECLINE = "DECLINE"
+
+
 _logger = logger.getLogger(__name__)
 
 


### PR DESCRIPTION
This commit implements the web push notification feature for the
call invitations.

This commit also adds support for the notification `action` feature:
https://developer.mozilla.org/en-US/docs/Web/API/Notification/actions

Behavior:

Click on notification: open the navigator to the right channel
Click on "Accept": open the channel and join the call
Click on "Decline": Decline the call without opening the navigator

task-4235046

examples:

Linux:
![image](https://github.com/user-attachments/assets/6b58f95d-590b-4c08-9f08-23ed798238d6)


Windows:
![image](https://github.com/user-attachments/assets/9274b2c2-6f88-4ac9-917b-1404f8a84a57)

Android ("accept" disabled until https://issues.chromium.org/issues/40286493 is fixed):
![image](https://github.com/user-attachments/assets/42a05f62-efc1-49b5-84f6-71ee004cb8ad)



