### PR TITLE
[FIX] web: avoid using iframe coordinates for drag-and-drop

### DIFF
--- a/addons/web/static/src/core/utils/draggable_hook_builder.js
+++ b/addons/web/static/src/core/utils/draggable_hook_builder.js
@@ -521,7 +521,11 @@ export function makeDraggableHook(hookParams) {
 
                 dom.addClass(document.body, "pe-none", "user-select-none");
                 if (params.iframeWindow) {
-                    dom.addClass(params.iframeWindow.body, "pe-none", "user-select-none");
+                    for (const iframe of document.getElementsByTagName("iframe")) {
+                        if (iframe.contentWindow === params.iframeWindow) {
+                            dom.addClass(iframe, "pe-none", "user-select-none");
+                        }
+                    }
                 }
                 // FIXME: adding pe-none and cursor on the same element makes
                 // no sense as pe-none prevents the cursor to be displayed.
@@ -773,6 +777,16 @@ export function makeDraggableHook(hookParams) {
              * @param {PointerEvent} ev
              */
             const updatePointerPosition = (ev) => {
+                if (ev.view === params.iframeWindow) {
+                    for (const iframe of document.getElementsByTagName("iframe")) {
+                        if (iframe.contentWindow === params.iframeWindow) {
+                            const boundingRect = iframe.getBoundingClientRect();
+                            ctx.pointer.x = ev.clientX + boundingRect.x;
+                            ctx.pointer.y = ev.clientY + boundingRect.y;
+                            return;
+                        }
+                    }
+                }
                 ctx.pointer.x = ev.clientX;
                 ctx.pointer.y = ev.clientY;
             };


### PR DESCRIPTION
- open "marketing automation"
- create a campaign
- add a mailing activity
- open the mailing inside the activity (in a modal)
- drag an item from the snippet menu
- yank the mouse FAST over the editor, such that the mouse overshoots the dragged snippet (editing the dragged element to be smaller may help)
- the dragged element does not follow the mouse until the mouse leaves the editor iframe

Drag and drop relies on `clientX` and `clientY` being in the coordinates of the viewport.

When entering an iframe, mouse event coordinates (other than screen-based) are given relative to the viewport of the iframe.

This means the position of the drag and drop does not match the position of the mouse.

The only way to avoid this is to either prevent the iframe from becoming the target of the event using style="pointer-event: none;" on the iframe itself.

Alternatively we can correct for the offset of the iframe.

task-4160857
