### PR TITLE
[FIX] account, l10n_vn_edi_viettel: prevent error when clicking on Send payment status to SInvoice

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -742,6 +742,8 @@ class ResCompany(models.Model):
 
         :param records: The records to lock.
         """
+        if not records.ids:
+            return
         self._cr.execute(f'SELECT * FROM {records._table} WHERE id IN %s FOR UPDATE SKIP LOCKED', [tuple(records.ids)])
         available_ids = {r[0] for r in self._cr.fetchall()}
         if available_ids != set(records.ids):

--- a/addons/l10n_vn_edi_viettel/models/account_move.py
+++ b/addons/l10n_vn_edi_viettel/models/account_move.py
@@ -295,10 +295,14 @@ class AccountMove(models.Model):
     def action_l10n_vn_edi_update_payment_status(self):
         """ Send a request to update the payment status of the invoice. """
 
-        # == Lock ==
-        self.env['res.company']._with_locked_records(self)
+        invoices = self.filtered(lambda i: i.l10n_vn_edi_invoice_state == 'payment_state_to_update')
+        if not invoices:
+            return
 
-        for invoice in self.filtered(lambda i: i.l10n_vn_edi_invoice_state == 'payment_state_to_update'):
+        # == Lock ==
+        self.env['res.company']._with_locked_records(invoices)
+
+        for invoice in invoices:
             sinvoice_status = 'unpaid'
 
             # SInvoice will return a NOT_FOUND_DATA error if the status in Odoo matches the one on their side.

--- a/addons/l10n_vn_edi_viettel/views/account_move_views.xml
+++ b/addons/l10n_vn_edi_viettel/views/account_move_views.xml
@@ -78,7 +78,6 @@
         <field name="state">code</field>
         <field name="code">
             if records:
-                records = records.filtered(lambda r: r.l10n_vn_edi_invoice_state == 'payment_state_to_update')
                 action = records.action_l10n_vn_edi_update_payment_status()
         </field>
     </record>


### PR DESCRIPTION
When User Clicks on Send payment status to SInvoice action,
a traceback will appear.

Steps to reproduce the error:
- Install ``l10n_vn_edi_viettel`` module
- Switch to VN Company
- Go to Invoicing > Customers > Invoices > Select any invoice > Actions >
  Send payment status to SInvoice

Traceback:
```
SyntaxError: syntax error at or near ")"
LINE 1: SELECT * FROM account_move WHERE id IN () FOR UPDATE SKIP LO...
                                                ^

  File "odoo/tools/safe_eval.py", line 391, in safe_eval
    return unsafe_eval(c, globals_dict, locals_dict)
  File "ir.actions.server(2134,)", line 3, in <module>
  File "addons/l10n_vn_edi_viettel/models/account_move.py", line 299, in action_l10n_vn_edi_update_payment_status
    self.env['res.company']._with_locked_records(self)
  File "addons/account/models/company.py", line 785, in _with_locked_records
    self._cr.execute(f'SELECT * FROM {records._table} WHERE id IN %s FOR UPDATE SKIP LOCKED', [tuple(records.ids)])
  File "odoo/sql_db.py", line 347, in execute
    res = self._obj.execute(query, params)
ValueError: <class 'psycopg2.errors.SyntaxError'>: "syntax error at or near ")"
LINE 1: SELECT * FROM account_move WHERE id IN () FOR UPDATE SKIP LO...
                                                ^
```

https://github.com/odoo/odoo/blob/072da22e72e66e6332d073502b987682f1b6e88b/addons/account/models/company.py#L745
Here, when there are no records for sending their payment status to SInvoice,
records.ids will be empty,
It will lead to the above traceback.

This commit will fix the above issue by preventing the execution of the query
when ``records.ids`` is empty.

sentry-5954926261

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
