### PR TITLE
[FIX] spreadsheet_dashboard_account: Fix dashboard domain

### DIFF
--- a/addons/spreadsheet_dashboard_account/data/files/invoicing_dashboard.json
+++ b/addons/spreadsheet_dashboard_account/data/files/invoicing_dashboard.json
@@ -1568,6 +1568,15 @@
                 "state"
             ],
             "domain": [
+                "&",
+                [
+                    "state",
+                    "not in",
+                    [
+                        "draft",
+                        "cancel"
+                    ]
+                ],
                 [
                     "move_type",
                     "=",


### PR DESCRIPTION
The domain set on the list datasource did not exclude the draft and cancelled invoices as it was for the other datasources.

task-3999225

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
