### PR TITLE
[FIX] point_of_sale: ensure partners in draft orders are loaded

### DIFF
--- a/addons/point_of_sale/models/res_partner.py
+++ b/addons/point_of_sale/models/res_partner.py
@@ -16,7 +16,16 @@ class ResPartner(models.Model):
     @api.model
     def _load_pos_data_domain(self, data):
         config_id = self.env['pos.config'].browse(data['pos.config']['data'][0]['id'])
-        return [('id', 'in', config_id.get_limited_partners_loading() + [self.env.user.partner_id.id])]
+
+        # Collect partner IDs from loaded orders
+        loaded_order_partner_ids = {order['partner_id'] for order in data['pos.order']['data']}
+
+        # Extract partner IDs from the tuples returned by get_limited_partners_loading
+        limited_partner_ids = {partner[0] for partner in config_id.get_limited_partners_loading()}
+
+        limited_partner_ids.add(self.env.user.partner_id.id)  # Ensure current user is included
+        partner_ids = limited_partner_ids.union(loaded_order_partner_ids)
+        return [('id', 'in', list(partner_ids))]
 
     @api.model
     def _load_pos_data_fields(self, config_id):


### PR DESCRIPTION
Before this commit, there was an issue where a partner associated with a draft order might not be loaded. This could lead to users having to re-enter the customer's information if the page was refreshed.

opw-4207881

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
