### PR TITLE
[FIX] mail: prevent error on call toggle when camera/screen access is pending

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -978,7 +978,7 @@ export class Rtc extends Record {
             }
         }
         const updatedTrack = type === "camera" ? this.state.cameraTrack : this.state.screenTrack;
-        await this.network.updateUpload(type, updatedTrack);
+        await this.network?.updateUpload(type, updatedTrack);
         if (!this.selfSession) {
             return;
         }


### PR DESCRIPTION
Fixed an issue where an error is thrown if the call is ended before accepting/rejecting the camera or screen access.
After ending the call, accepting or rejecting access would trigger an error due to the absence of a check for whether the call is still active.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
