### PR TITLE
FIX trim=False not working for config_parameters

### DIFF
--- a/doc/cla/individual/Lightprohvet.md
+++ b/doc/cla/individual/Lightprohvet.md
@@ -1,0 +1,11 @@
+Estonia, 2024-10-07
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Mihkel Marten Rüütli LightProhvet@gmail.com https://github.com/LightProhvet

--- a/odoo/addons/base/models/res_config.py
+++ b/odoo/addons/base/models/res_config.py
@@ -552,9 +552,9 @@ class ResConfigSettings(models.TransientModel, ResConfigModuleInstallationMixin)
             value = self[name]
             current_value = IrConfigParameter.get_param(icp)
 
-            if field.type == 'char':
+            if field.type == 'char' and field.trim:
                 # storing developer keys as ir.config_parameter may lead to nasty
-                # bugs when users leave spaces around them
+                # bugs when users leave spaces around them, but trim=False should still work
                 value = (value or "").strip() or False
             elif field.type in ('integer', 'float'):
                 value = repr(value) if value else False


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Allow creating config_parameters in res.config setting, with trailing whitespace, by using the 'trim' attribute already existing in Char fields. This problem may also exist in other versions, but has currently only been tested in Odoo 17.

Current behavior before PR: When creating a config_parameter all trailing whitespaces are removed even when the field specifies trim=False, which is meant to allow trailing whitespaces. This restricts the creation of separator config_parameters e.g for name computations, qweb reports, etc. 

Desired behavior after PR is merged: When creating a config_parameter all trailing whitespaces are removed by default, to avoid bugs. However when the field has specified trim=False, the whitespace is not removed as per the original intention of the attribute.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
