### PR TITLE
[FIX] auth_signup: Password reset email template translation

### DIFF
--- a/addons/auth_signup/models/res_users.py
+++ b/addons/auth_signup/models/res_users.py
@@ -225,10 +225,12 @@ class ResUsers(models.Model):
                         user.id, force_send=True,
                         raise_exception=True, email_values=email_values)
                 else:
-                    body = self.env['mail.render.mixin']._render_template(
+                    user_lang = user.lang or self.env.lang or 'en_US'
+                    body = self.env['mail.render.mixin'].with_context(lang=user_lang)._render_template(
                         self.env.ref('auth_signup.reset_password_email'),
                         model='res.users', res_ids=user.ids,
                         engine='qweb_view', options={'post_process': True})[user.id]
+                    context = {'lang': user_lang}   # noqa: F841
                     mail = self.env['mail.mail'].sudo().create({
                         'subject': _('Password reset'),
                         'email_from': user.company_id.email_formatted or user.email_formatted,


### PR DESCRIPTION
The password reset email was not being translated according to the receiver's language. This caused the template to render in the website language, leading to confusion for receivers with different language.

The problem came form Convert the "Reset Password" template into QWeb view in https://github.com/odoo/odoo/pull/125874,    Before, to sent the email  `mail.send_mail()`  function was used, and it has a check for the receiver language. and after  https://github.com/odoo/odoo/pull/125874 the function wasnt used any more. it replaces with `mail.send()` that send the rendered content directly.

To resolve this issue, the language of the receiver user is explicitly set in the context before rendering the email template. This ensures the email content is translated based on the user's preferred language then calling the function that send it. 

Now the template is rendered using the receiver's language (`user.lang`), or falls back to the website language `self.env.lang` if the receiver's language is not set. Or falls back to  'en_US' if the language is not set.

owp-4149894


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
