### PR TITLE
[FIX] web_editor: accept non-blank characters in input unit

### DIFF
--- a/addons/web_editor/static/src/js/common/utils.js
+++ b/addons/web_editor/static/src/js/common/utils.js
@@ -157,7 +157,7 @@ function _convertNumericToUnit(value, unitFrom, unitTo, cssProp, $target) {
  * @returns {Array|null}
  */
 function _getNumericAndUnit(value) {
-    const m = value.trim().match(/^(-?[0-9.]+(?:e[+|-]?[0-9]+)?)\s*([A-Za-z%-]*)$/);
+    const m = value.trim().match(/^(-?[0-9.]+(?:e[+|-]?[0-9]+)?)\s*([^\s]*)$/);
     if (!m) {
         return null;
     }


### PR DESCRIPTION
Before this commit, a regular expression was restricting the input units to `[A-Za-z%-]` characters. It made sense initially because those units were limited to technical terms with an untranslated name. But this makes "human" units such as "days" not recognized when using languages where the translated name either contains accents, or is not made of latin alphabet letters at all.

This commit adapts the regular expression to consider a sequence of non-blank characters as the unit instead.

Steps to reproduce:
- Install Website
- Drop a Popup inside the homepage
- Switch user to Spanish
- Edit the popup

=> The "Ocultar para" option did not display its value because "días" contains an accent.

- Switch user to Japanese
- Edit the popup

=> The "次のものに非表示" option did not display its value because "日" is not an alphabet letter.

opw-4200520
