### PR TITLE
[FIX] web: fix menus and user language mismatch

### DIFF
--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -122,7 +122,7 @@ class Http(models.AbstractModel):
             # but is still included in some other calls (e.g. '/web/session/authenticate')
             # to avoid access errors and unnecessary information, it is only included for users
             # with access to the backend ('internal'-type users)
-            menus = self.env['ir.ui.menu'].load_menus(request.session.debug)
+            menus = self.env['ir.ui.menu'].with_context(lang=request.session.context['lang']).load_menus(request.session.debug)
             ordered_menus = {str(k): v for k, v in menus.items()}
             menu_json_utf8 = json.dumps(ordered_menus, default=ustr, sort_keys=True).encode()
             session_info['cache_hashes'].update({


### PR DESCRIPTION
Steps to reproduce the issue:
- Have 2 different authenticated browser (one as `admin` and one as `demo`)
- With the `demo browser`, change your own language to French -> Reload the main menu page
- With the `admin browser`, update the demo user language from the Settings to English
- Reload the page on the `demo browser`, the menus will have stayed in French while the rest of the page is translated in English

Details:
- Only the first query after the following step will have an issue, the problem corrects itself on the second refresh.
- Could not reproduce on the runbot but could do it locally and on Odoo.SH (in 16.0) and on `odoo.com` free database (18.0).

This issue was already discussed more than a year ago (https://github.com/odoo/odoo/pull/110207) but was finally closed without being merged. The problem can now be fully reproduced while previously, it was a bit blurry.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
