### PR TITLE
[FIX] base, tools: consider icons in is_html_empty

### DIFF
--- a/odoo/addons/base/tests/test_mail.py
+++ b/odoo/addons/base/tests/test_mail.py
@@ -382,6 +382,9 @@ class TestHtmlTools(BaseCase):
 
         void_html_samples = [
             '<section><br /> <b><i/></b></section>',
+            '<section><br /> <b><i/ ></b></section>',
+            '<section><br /> <b>< i/ ></b></section>',
+            '<section><br /> <b>< i / ></b></section>',
             '<p><br></p>', '<p><br> </p>', '<p><br /></p >',
             '<p style="margin: 4px"></p>',
             '<div style="margin: 4px"></div>',
@@ -395,6 +398,8 @@ class TestHtmlTools(BaseCase):
             '<p><br>1</p>', '<p>1<br > </p>', '<p style="margin: 4px">Hello World</p>',
             '<div style="margin: 4px"><p>Hello World</p></div>',
             '<p><span style="font-weight: bolder;"><font style="color: rgb(255, 0, 0);" class=" ">W</font></span><br></p>',
+            '<span class="fa fa-heart"></span>',
+            '<i class="fas fa-home"></i>'
         ]
         for content in valid_html_samples:
             self.assertFalse(is_html_empty(content))

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -327,8 +327,9 @@ def is_html_empty(html_content):
     """
     if not html_content:
         return True
-    tag_re = re.compile(r'\<\s*\/?(?:p|div|section|span|br|b|i|font)(?:(?=\s+\w*)[^/>]*|\s*)/?\s*\>')
-    return not bool(re.sub(tag_re, '', html_content).strip())
+    icon_re = r'<\s*(i|span)\b(\s+[A-Za-z_-][A-Za-z0-9-_]*(\s*=\s*[\'"][^"\']*[\'"])?)*\s*\bclass\s*=\s*["\'][^"\']*\b(fa|fab|fad|far|oi)\b'
+    tag_re = r'<\s*\/?(?:p|div|section|span|br|b|i|font)\b(?:(\s+[A-Za-z_-][A-Za-z0-9-_]*(\s*=\s*[\'"][^"\']*[\'"]))*)(?:\s*>|\s*\/\s*>)'
+    return not bool(re.sub(tag_re, '', html_content).strip()) and not re.search(icon_re, html_content)
 
 def html_keep_url(text):
     """ Transform the url into clickable link with <a/> tag """


### PR DESCRIPTION
Before this commit :
`is_html_empty` considers empty icons as empty html.

After this commit:
Empty icons are considered as non empty html

Note: changed the tag_re to more performant regex

task-4060037