### PR TITLE
[FIX] phone_validation: oman phone numbers

### DIFF
--- a/addons/phone_validation/lib/phonenumbers_patch/__init__.py
+++ b/addons/phone_validation/lib/phonenumbers_patch/__init__.py
@@ -67,6 +67,10 @@ else:
         # https://github.com/daviddrysdale/python-phonenumbers/blob/v8.13.40/python/phonenumbers/data/region_KE.py
         phonenumbers.phonemetadata.PhoneMetadata.register_region_loader('KE', _local_load_region)
 
+    if parse_version(phonenumbers.__version__) < parse_version('8.13.47'):
+        # https://github.com/daviddrysdale/python-phonenumbers/blob/v8.13.47/python/phonenumbers/data/region_OM.py
+        phonenumbers.phonemetadata.PhoneMetadata.register_region_loader('OM', _local_load_region)
+
     # MONKEY PATCHING phonemetadata to fix Brazilian phonenumbers following 2016 changes
     def _hook_load_region(code):
         if parse_version(phonenumbers.__version__) < parse_version('8.13.39'):

--- a/addons/phone_validation/lib/phonenumbers_patch/region_OM.py
+++ b/addons/phone_validation/lib/phonenumbers_patch/region_OM.py
@@ -1,0 +1,13 @@
+"""Auto-generated file, do not edit by hand. OM metadata"""
+from ..phonemetadata import NumberFormat, PhoneNumberDesc, PhoneMetadata
+
+PHONE_METADATA_OM = PhoneMetadata(id='OM', country_code=968, international_prefix='00',
+    general_desc=PhoneNumberDesc(national_number_pattern='(?:1505|[279]\\d{3}|500)\\d{4}|800\\d{5,6}', possible_length=(7, 8, 9)),
+    fixed_line=PhoneNumberDesc(national_number_pattern='2[1-6]\\d{6}', example_number='23123456', possible_length=(8,)),
+    mobile=PhoneNumberDesc(national_number_pattern='(?:1505|90[1-9]\\d)\\d{4}|(?:7[126-9]|9[1-9])\\d{6}', example_number='92123456', possible_length=(8,)),
+    toll_free=PhoneNumberDesc(national_number_pattern='8007\\d{4,5}|(?:500|800[05])\\d{4}', example_number='80071234', possible_length=(7, 8, 9)),
+    premium_rate=PhoneNumberDesc(national_number_pattern='900\\d{5}', example_number='90012345', possible_length=(8,)),
+    number_format=[NumberFormat(pattern='(\\d{3})(\\d{4,6})', format='\\1 \\2', leading_digits_pattern=['[58]']),
+        NumberFormat(pattern='(\\d{2})(\\d{6})', format='\\1 \\2', leading_digits_pattern=['2']),
+        NumberFormat(pattern='(\\d{4})(\\d{4})', format='\\1 \\2', leading_digits_pattern=['[179]'])],
+    mobile_number_portable_region=True)

--- a/addons/phone_validation/tests/test_phonenumbers_patch.py
+++ b/addons/phone_validation/tests/test_phonenumbers_patch.py
@@ -159,6 +159,14 @@ class TestPhonenumbersPatch(BaseCase):
         )
         self._assert_parsing_phonenumbers(parse_test_lines_KE)
 
+    def test_region_OM_monkey_patch(self):
+        """Makes sure that patch for Oman phone numbers work"""
+        parse_test_lines_OM = (
+            self.PhoneInputOutputLine("76 123 456", "OM"),
+            self.PhoneInputOutputLine("+968 76 321 852"),
+        )
+        self._assert_parsing_phonenumbers(parse_test_lines_OM)
+
     def test_region_PA_monkey_patch(self):
         """Makes sure that patch for Panama's phone numbers work"""
         parse_test_lines_PA = (


### PR DESCRIPTION
Current behavior:
---
Omani numbers starting with 76 are not supported.

Steps to reproduce:
---
```py
parsed = phonenumbers.parse("76 123 456", "OM")
is_valid = phonenumbers.is_valid_number(parsed)
is_valid == False
```

Cause of the issue:
---
Old versions of phonenumbers (external library) are not up to date with the latest omani phone system changes 
Source 2024-08-13: https://www.itu.int/oth/T020200009F/en

Fix:
---
Monkey patched old versions of the library
Similar as: https://github.com/odoo/odoo/commit/b7878038e0aca885aa174ccd74be9ffd4b393a89

opw-4179042

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
