### PR TITLE
[FIX] account: early payment discount reconciliation

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2493,11 +2493,12 @@ class AccountMove(models.Model):
     # -------------------------------------------------------------------------
     def _is_eligible_for_early_payment_discount(self, currency, reference_date):
         self.ensure_one()
+        payment_terms = self.line_ids.filtered(lambda line: line.display_type == 'payment_term')
         return self.currency_id == currency \
             and self.move_type in ('out_invoice', 'out_receipt', 'in_invoice', 'in_receipt') \
             and self.invoice_payment_term_id.early_discount \
             and (not reference_date or reference_date <= self.invoice_payment_term_id._get_last_discount_date(self.invoice_date)) \
-            and self.payment_state == 'not_paid'
+            and not (payment_terms.matched_debit_ids + payment_terms.matched_credit_ids)
 
     # -------------------------------------------------------------------------
     # BUSINESS MODELS SYNCHRONIZATION


### PR DESCRIPTION
Steps to reproduce:
 - Create an invoice with early payment discount applicable
 - Register a payment on the invoice (must be without a journal entry associated, done by default)
 - Open the bank reconciliation widget
 - Create a statement line with the discounted amount (invoice total - epd amount)
 - The suggested reconciliation doesn't include a new line with the write-off of the early payment discount

 Cause of the issue:
 When registering a payment on the invoice, the invoice payment state switch from 'not_paid' to 'in_payment', which makes this invoice not eligible anymore for early payment discount.

 task-4237657


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
