### PR TITLE
[FIX] analytic : returning analytic plan creation rights

### DIFF
--- a/addons/analytic/models/analytic_plan.py
+++ b/addons/analytic/models/analytic_plan.py
@@ -250,7 +250,7 @@ class AccountAnalyticPlan(models.Model):
         domain = [('name', 'in', [plan._strict_column_name() for plan in self])]
         if model:
             domain.append(('model', '=', model))
-        return self.env['ir.model.fields'].search(domain)
+        return self.env['ir.model.fields'].sudo().search(domain)
 
     def _sync_all_plan_column(self):
         model_names = self.env.registry.descendants(['analytic.plan.fields.mixin'], '_inherit') - {'analytic.plan.fields.mixin'}

--- a/addons/analytic/tests/test_analytic_account.py
+++ b/addons/analytic/tests/test_analytic_account.py
@@ -197,3 +197,13 @@ class TestAnalyticAccount(AnalyticCommon):
             'amount': 100,
             'company_id': self.company_b_branch.id,
         })
+
+    def test_create_analytic_with_minimal_access(self):
+        analyst_partner = self.env['res.partner'].create({'name': 'analyst'})
+        analyst = self.env['res.users'].create({
+            'login': 'analyst',
+            'groups_id': [Command.set(self.env.ref('analytic.group_analytic_accounting').ids)],
+            'partner_id': analyst_partner.id
+        })
+        plan = self.env['account.analytic.plan'].with_user(analyst).create({'name': 'test plan'})
+        self.assertEqual(plan.create_uid, analyst)


### PR DESCRIPTION
### Steps to reproduce the issue:

1. Give user full accounting access rights and no administrative access rights
2. With said user, create analytic plan
3. Following access error is shown:

>     You are not allowed to modify 'Fields' (ir.model.fields) records.
>
>     This operation is allowed for the following groups:
>     - Administration/Access Rights

### Explanation:

With commit odoo/odoo@0fe0246b0d5a0e372e69fbae2b5a2f61143eb93f, a `sudo` has been mistakenly removed in `_find_plan_column`.

### Fix reasoning:

Adding `sudo` back and a test to make sure it does not happen again.

opw-4201314