### PR TITLE
[PERF] base: avoid prefetching all fields when exporting

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -933,8 +933,7 @@ class BaseModel(metaclass=MetaModel):
         if not _is_toplevel_call:
             splittor = lambda rs: rs
 
-        # memory stable but ends up prefetching 275 fields (???)
-        for record in splittor(self):
+        for record in splittor(self.with_context(prefetch_fields=False)):
             # main line of record, initially empty
             current = [''] * len(fields)
             lines.append(current)


### PR DESCRIPTION
## Description
When exporting a *wide* model, the process may face an out-of-memory error and be killed, even though that the large recordset is split into small batches of 1000 records via `splittor`. This is happening due to the field's prefetcher, on a model that is heavily extended, the reading of the first field to export, which happens at
https://github.com/odoo/odoo/blob/04a827e553cd6389a366c02d3a556de8c657ee22/odoo/models.py#L960 will read all fields (w/o those marked as `prefetch=False`) and put them into cache. On models that have some really large fields (like HTML descriptions), the limit can be quickly reached, even on the first split.

## Solution
Disable the field's prefetcher for the main loop during exporting. This way we avoid the OOM error, at the cost of doing a bit more queries (one foreach field we are exporting per batch of 1k records).

## Reference
opw-4202748

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
