### PR TITLE
[FIX] point_of_sale: show full product name on kitchen receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.scss
+++ b/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.scss
@@ -7,14 +7,18 @@
     object-fit: contain;
 }
 
+.pos-receipt {
+    .product-name {
+        -webkit-line-clamp: unset;
+    }
+}
+
 .product-name {
 
     box-sizing: border-box;
     display: -webkit-box;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;
-    text-overflow: ellipsis;
-    overflow: hidden;
 
     &.no-image {
         -webkit-line-clamp: 7;


### PR DESCRIPTION
Product with long names where not shown completely on the kitchen receipt

Steps to reproduce:
-------------------
* Add a kitchen printer to your PoS setup
* Create a product with a really long name
* Open PoS and complete an order with the product
> Observation: The kithen receipt doesn't show the full name

opw-4221336
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
