### PR TITLE
[FIX] product: stop displaying erroneous discount in foreign currency

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -799,6 +799,7 @@ class ProductProduct(models.Model):
             pricelist.currency_id,
             self.env.company,
             fields.Datetime.now(),
+            round=False
         )
         if lst_price:
             return (lst_price - self._get_contextual_price()) / lst_price

--- a/addons/product/tests/__init__.py
+++ b/addons/product/tests/__init__.py
@@ -10,3 +10,4 @@ from . import test_product_attribute_value_config
 from . import test_product_pricelist
 from . import test_seller
 from . import test_variants
+from . import test_product_rounding

--- a/addons/product/tests/test_product_rounding.py
+++ b/addons/product/tests/test_product_rounding.py
@@ -1,0 +1,87 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import time
+
+from odoo.fields import Command
+from odoo.tests import tagged
+
+from odoo.addons.product.tests.common import ProductCommon
+
+
+@tagged('post_install', '-at_install')
+class TestProductRounding(ProductCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # test-specific currencies
+        cls.currency_jpy = cls.env['res.currency'].create({
+            'name': 'JPX',
+            'symbol': '¥',
+            'rounding': 1.0,
+            'rate_ids': [Command.create({'rate': 133.6200, 'name': time.strftime('%Y-%m-%d')})],
+        })
+
+        cls.currency_cad = cls.env['res.currency'].create({
+            'name': 'CXD',
+            'symbol': '$',
+            'rounding': 0.01,
+            'rate_ids': [Command.create({'rate': 1.338800, 'name': time.strftime('%Y-%m-%d')})],
+        })
+
+        cls.pricelist_usd = cls.pricelist
+
+        cls.pricelist_jpy = cls.env['product.pricelist'].create({
+            'name': 'Pricelist Testing JPY',
+            'currency_id': cls.currency_jpy.id,
+        })
+
+        cls.pricelist_cad = cls.env['product.pricelist'].create({
+            'name': 'Pricelist Testing CAD',
+            'currency_id': cls.currency_cad.id,
+        })
+
+        cls.product_1_dollar = cls.env['product.product'].create({
+            'name': 'Test Product $1',
+            'list_price': 1.00,
+            'categ_id': cls.product_category.id,
+        })
+
+        cls.product_100_dollars = cls.env['product.product'].create({
+            'name': 'Test Product $100',
+            'list_price': 100.00,
+            'categ_id': cls.product_category.id,
+        })
+
+    def test_no_discount_1_dollar_product(self):
+        """Ensure that no discount is applied when there shouldn't be, even for very small amounts."""
+        product = self.product_1_dollar
+
+        product_in_jpy = product.with_context(pricelist=self.pricelist_jpy.id)
+        discount_jpy = product_in_jpy._get_contextual_discount()
+        self.assertAlmostEqual(discount_jpy, 0.0, places=6, msg="No discount should be applied for $1 product in Testing JPY.")
+
+        product_in_usd = product.with_context(pricelist=self.pricelist_usd.id)
+        discount_usd = product_in_usd._get_contextual_discount()
+        self.assertAlmostEqual(discount_usd, 0.0, places=6, msg="No discount should be applied for $1 product in USD.")
+
+        product_in_cad = product.with_context(pricelist=self.pricelist_cad.id)
+        discount_cad = product_in_cad._get_contextual_discount()
+        self.assertAlmostEqual(discount_cad, 0.0, places=6, msg="No discount should be applied for $1 product in Testing CAD.")
+
+    def test_no_discount_100_dollars_product(self):
+        """Ensure that no discount is applied when there shouldn't be, even for very small amounts."""
+        product = self.product_100_dollars
+
+        product_in_jpy = product.with_context(pricelist=self.pricelist_jpy.id)
+        discount_jpy = product_in_jpy._get_contextual_discount()
+        self.assertAlmostEqual(discount_jpy, 0.0, places=6, msg="No discount should be applied for $100 product in Testing JPY.")
+
+        product_in_usd = product.with_context(pricelist=self.pricelist_usd.id)
+        discount_usd = product_in_usd._get_contextual_discount()
+        self.assertAlmostEqual(discount_usd, 0.0, places=6, msg="No discount should be applied for $100 product in USD.")
+
+        product_in_cad = product.with_context(pricelist=self.pricelist_cad.id)
+        discount_cad = product_in_cad._get_contextual_discount()
+        self.assertAlmostEqual(discount_cad, 0.0, places=6, msg="No discount should be applied for $100 product in Testing CAD.")


### PR DESCRIPTION
When purchasing event tickets in foreign currencies such as JPY or CAD, Odoo was incorrectly applying small discounts to products even when no discount was intended. This behavior affected the Event Sales module, where the wrong price was shown on the product page.

For Odoo 17.4+, this issue displayed as a strikethrough on the correct price next to a mistakenly discounted price. For versions prior to 17.4, only the incorrect discounted price was displayed without a strikethrough. This bug only occurred when the Event Registration product price was set to a value different from the price defined in the Event record.

While this bug is present in 16.0 onwards, the logic causing the issue has been refactored and will require a separate fix.

Steps to reproduce the issue:
1. Create Pricelists for additional currencies (CAD, JPY) with empty rules and enable the “Selectable” checkbox for Ecommerce.
2. Set currency rates to 133.6200 for JPY and 1.338800 for CAD to replicate the conditions when the bug was found.
3. Create an Event.
4. Create an Event Registration Ticket, ensuring the linked Event Registration product price is $1.00 and the price in the event view is set to $30.00.
5. Visit the Event page on the website and attempt to purchase a ticket. Switch between currencies (JPY, CAD) to observe the issue.
6. Using JPY at the conversion rate of 133.6200, the expected converted price for a $30.00 ticket should be ¥4009, but Odoo calculates the price as discounted to ¥3997.
7. With CAD at 1.338800, the correct converted price should be $40.16 CAD, but the price is instead calculated as $40.12 CAD.
8. On 17.4+, the original and correct prices will display as a strikethrough discount.

Cause of the issue:
The method _get_contextual_discount in product_product.py was comparing a rounded lst_price to an unrounded contextual price, leading to a tiny discrepancy being mistaken as a discount. The bug occurred because the rounding of the lst_price did not match the rounding of the contextual price. While this method is defined in the product module, it only is used by the event_booth and event_booth_sale modules.

Solution:
The fix ensures that both operands are not rounded before comparison. Now, the _get_contextual_discount method does not round both the lst_price and the contextual price, preventing the calculation of an erroneous discount.

opw-4213704