### PR TITLE
[FIX] payment: make _disableButton act only within the current widget

### DIFF
--- a/addons/payment/static/src/js/payment_form_mixin.js
+++ b/addons/payment/static/src/js/payment_form_mixin.js
@@ -45,7 +45,7 @@ odoo.define('payment.payment_form_mixin', require => {
          * @param {boolean} showLoadingAnimation - Whether a spinning loader should be shown
          * @return {undefined}
          */
-        _disableButton: (showLoadingAnimation = true) => {
+        _disableButton: function (showLoadingAnimation = true) {
             const $submitButton = this.$('button[name="o_payment_submit_button"]');
             const iconClass = $submitButton.data('icon-class');
             $submitButton.attr('disabled', true);


### PR DESCRIPTION
The function _disableButton is defined as an arrow function (args) => {body;}. This assigns the `this` keyword to the global document instead of the class instance.

As a result the jQuery results for
```
const $submitButton = this.$('button[name="o_payment_submit_button"]');
```
are inconsistent between _enableButton and _disableButton. This could result in buttons being disabled and, in principle, never re-enabled.

**Current behavior before PR**:
Having the same widget call _disableButton and _enableButton might disable a button outside the widget and never re-enable it

**Desired behavior after PR is merged**:
If a button is disabled by a widget calling _disableButton it will get re-enabled too when _enableButton is applied.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
