### PR TITLE
[FIX] base: give a fallback value to icon_flag field

### DIFF
--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -249,6 +249,7 @@ class Module(models.Model):
     @api.depends('icon')
     def _get_icon_image(self):
         self.icon_image = ''
+        self.icon_flag = ''
         for module in self:
             if not module.id:
                 continue


### PR DESCRIPTION
Currently, a traceback will occur when the module id is NewId.

The `icon_flag` field is a readonly and nonstorable field. 
If we get module id as `NewId` the compute method of `icon_flag` fails to assign a value to the `icon_flag` field.

https://github.com/odoo/odoo/blob/775b6818f37496f85defc1c76a894c03fe2c8a00/odoo/addons/base/models/ir_module.py#L250-L254

Error:-
```
ValueError: Compute method failed to assign ir.module.module(<NewId 0x72edfa22ba00>,).icon_flag
```

Which leads to the above traceback from the below line
https://github.com/odoo/odoo/blob/775b6818f37496f85defc1c76a894c03fe2c8a00/odoo/fields.py#L1215-L1216

sentry-5175358979

