### PR TITLE
[FIX] pos_restaurant: allow edit plan only if floor exists

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.xml
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.xml
@@ -3,7 +3,7 @@
 
     <t t-name="pos_restaurant.Navbar" t-inherit="point_of_sale.Navbar" t-inherit-mode="extension">
         <xpath expr="//li[hasclass('backend-button')]" position="before">
-            <li t-if="pos.mainScreen.component.name == 'FloorScreen'" class="menu-item navbar-button edit-button" t-on-click="toggleEditMode">
+            <li t-if="pos.mainScreen.component.name == 'FloorScreen' and pos.floors.length" class="menu-item navbar-button edit-button" t-on-click="toggleEditMode">
                 <a class="dropdown-item py-2">Edit Plan</a>
             </li>
             <li t-if="pos.mainScreen.component.name == 'FloorScreen'" class="menu-item navbar-button" t-on-click="onSwitchButtonClick">


### PR DESCRIPTION
Steps to reproduce :
-------------------------
- Install the pos_restaurant module.
- Create a restaurant with no floors.
- Open Restaurant and click on edit plan button.
- Try to do anything from editing options.

Issue :
--------
As there are no floor exists neither of the options works and some will give tracebacks.

Cause :
---------
Without any floor we were trying to change properties of the floor.

Fix :
----
We will check if any floor exists for that config then only the edit plan button will be visible.