### PR TITLE
[FIX] point_of_sale: traceback when try to cancel order

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -317,7 +317,7 @@ export class PosStore extends Reactive {
                 title: _t("Existing orderlines"),
                 body: _t(
                     "%s has a total amount of %s, are you sure you want to delete this order?",
-                    order.name,
+                    order.pos_reference,
                     this.env.utils.formatCurrency(order.get_total_with_tax())
                 ),
             });
@@ -330,6 +330,7 @@ export class PosStore extends Reactive {
             order.uiState.displayed = false;
             this.afterOrderDeletion();
         }
+        return orderIsDeleted;
     }
     afterOrderDeletion() {
         this.set_order(this.get_open_orders().at(-1) || this.createNewOrder());
@@ -341,7 +342,7 @@ export class PosStore extends Reactive {
             if (order && (await this._onBeforeDeleteOrder(order))) {
                 if (
                     typeof order.id === "number" &&
-                    Object.keys(order.last_order_preparation_change).length > 0
+                    Object.keys(order.last_order_preparation_change.lines).length > 0
                 ) {
                     await this.sendOrderInPreparation(order, true);
                 }

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -129,6 +129,13 @@ registry.category("web_tour.tours").add("ProductScreenTour", {
                 })
             ),
             ProductScreen.isShown(),
+
+            // Test Cancel Order from Actions
+            ProductScreen.clickReview(),
+            ProductScreen.clickControlButton("Cancel Order"),
+            Dialog.confirm(),
+            { ...ProductScreen.back(), isActive: ["mobile"] },
+            ProductScreen.orderIsEmpty(),
         ].flat(),
 });
 

--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -36,13 +36,15 @@ patch(PosStore.prototype, {
         return screen === "LoginScreen" ? "LoginScreen" : "FloorScreen";
     },
     async onDeleteOrder(order) {
+        const orderIsDeleted = await super.onDeleteOrder(...arguments);
         if (
             this.config.module_pos_restaurant &&
+            orderIsDeleted &&
             this.mainScreen.component.name !== "TicketScreen"
         ) {
             this.showScreen("FloorScreen");
         }
-        return super.onDeleteOrder(...arguments);
+        return orderIsDeleted;
     },
     // using the same floorplan.
     async ws_syncTableCount(data) {

--- a/addons/pos_restaurant/static/tests/tours/control_buttons_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/control_buttons_tour.js
@@ -51,6 +51,17 @@ registry.category("web_tour.tours").add("ControlButtonsTour", {
                 internalNote: "test note",
                 withClass: ".selected",
             }),
+
+            // Test Cancel Order
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("5"),
+            ProductScreen.addOrderline("Water", "5", "2", "10.0"),
+            ProductScreen.clickReview(),
+            ProductScreen.clickControlButton("Cancel Order"),
+            Dialog.confirm(),
+            FloorScreen.clickTable("5"),
+            ProductScreen.orderIsEmpty(),
+
             // Check that note is imported if come back to the table
             Chrome.clickPlanButton(),
             FloorScreen.clickTable("2"),


### PR DESCRIPTION
Steps to reproduce :
--------------------------
- Install the pos_restaurant module.
- Add some products to order don't order them.
- Try to cancel order from action button.

Issue :
--------
- There will be a traceback as it was trying to fetch & delete order from preparation display as well.
- If you have never visited floor screen the order won't be synced and have string id so at the time of cancellation at first try it can't get order's int id and we have to again click on cancel order to delete it.

Cause :
--------
- The condition applied was now not relevant as structure of data changed.
- The order was still not synced at backend so have temparary string id at time of action click.

Fix :
-----
- Changed condition as per the new structure.
- Fetched data from backend at time of getting id to remove it.

