### PR TITLE
[FIX] base: use parent_id in company order

### DIFF
--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -17,7 +17,7 @@ _logger = logging.getLogger(__name__)
 class Company(models.Model):
     _name = "res.company"
     _description = 'Companies'
-    _order = 'sequence, name'
+    _order = 'parent_id desc, sequence, name'
     _inherit = ['format.address.mixin', 'format.vat.label.mixin']
     _parent_store = True
 


### PR DESCRIPTION
The natural company order should return main companies first then sub companies.
This is useful when updating charts of accounts so we always update the parent first.


How to reproduce an issue:
1- Create a company with a sub company having a name such that the sub company is alphabetically < main company
2- Add a *New* account to the account chart used by those companies
3- update the chart using the usual code:
```py
    for company in env['res.company'].search([('chart_template', '=', code)]):
        env['account.chart.template'].try_loading(code, company)
```
This will result in the branch loading the chart first, it will not find the new account so it will be created using the branch company id, then the parent will load and will also try to add the account -> account unique code violation

ref PR https://github.com/odoo/odoo/pull/182361


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
