### PR TITLE
[FIX] l10n_*: try loading the coa using parent company first

### DIFF
--- a/addons/l10n_ar_withholding/__init__.py
+++ b/addons/l10n_ar_withholding/__init__.py
@@ -12,7 +12,7 @@ _logger = logging.getLogger(__name__)
 def _l10n_ar_withholding_post_init(env):
     """ Existing companies that have the Argentinean Chart of Accounts set """
     template_codes = ['ar_ri', 'ar_ex', 'ar_base']
-    ar_companies = env['res.company'].search([('chart_template', 'in', template_codes)])
+    ar_companies = env['res.company'].search([('chart_template', 'in', template_codes)], order="parent_path")
     used_template_codes = set(ar_companies.mapped('chart_template'))
     for template_code in used_template_codes:
         data = {

--- a/addons/l10n_ch/migrations/11.1/post-migrate_update_taxes.py
+++ b/addons/l10n_ch/migrations/11.1/post-migrate_update_taxes.py
@@ -4,7 +4,7 @@ from odoo import api, SUPERUSER_ID
 
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    for company in env['res.company'].search([('chart_template', '=', 'ch')]):
+    for company in env['res.company'].search([('chart_template', '=', 'ch')], order="parent_path"):
         # We had corrupted data, handle the correction so the tax update can proceed.
         # See https://github.com/odoo/odoo/commit/7b07df873535446f97abc1de9176b9332de5cb07
         taxes_to_check = (f'{company.id}_vat_purchase_81_reverse', f'{company.id}_vat_77_purchase_reverse')

--- a/addons/l10n_ch/migrations/11.3/post-migrate.py
+++ b/addons/l10n_ch/migrations/11.3/post-migrate.py
@@ -4,5 +4,5 @@ from odoo import api, SUPERUSER_ID
 
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    for company in env["res.company"].search([("chart_template", "=", "ch")]):
+    for company in env["res.company"].search([("chart_template", "=", "ch")], order="parent_path"):
         env["account.chart.template"].try_loading("ch", company)

--- a/addons/l10n_cz/migrations/1.1/end-migrate_update_taxes.py
+++ b/addons/l10n_cz/migrations/1.1/end-migrate_update_taxes.py
@@ -4,5 +4,5 @@ from odoo import api, SUPERUSER_ID
 
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    for company in env['res.company'].search([('chart_template', '=', 'cz')]):
+    for company in env['res.company'].search([('chart_template', '=', 'cz')], order="parent_path"):
         env['account.chart.template'].try_loading('cz', company)

--- a/addons/l10n_dk/migrations/1.2/post-migrate.py
+++ b/addons/l10n_dk/migrations/1.2/post-migrate.py
@@ -3,5 +3,5 @@ from odoo import api, SUPERUSER_ID
 
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    for company in env['res.company'].search([('chart_template', '=', 'dk')]):
+    for company in env['res.company'].search([('chart_template', '=', 'dk')], order="parent_path"):
         env['account.chart.template'].try_loading('dk', company)

--- a/addons/l10n_ee/migrations/1.1/post-migrate_update_taxes.py
+++ b/addons/l10n_ee/migrations/1.1/post-migrate_update_taxes.py
@@ -3,5 +3,5 @@ from odoo import api, SUPERUSER_ID
 
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    for company in env['res.company'].search([('chart_template', '=', 'ee')]):
+    for company in env['res.company'].search([('chart_template', '=', 'ee')], order="parent_path"):
         env['account.chart.template'].try_loading('ee', company)

--- a/addons/l10n_es/migrations/5.3/post-migrate_update_taxes.py
+++ b/addons/l10n_es/migrations/5.3/post-migrate_update_taxes.py
@@ -4,7 +4,7 @@ from odoo import api, SUPERUSER_ID
 
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    for company in env['res.company'].search([('chart_template', 'like', 'es_%')]):
+    for company in env['res.company'].search([('chart_template', 'like', 'es_%')], order="parent_path"):
         taxes_to_disable = (
             f'{company.id}_account_tax_template_p_iva5_ic_bc',
             f'{company.id}_account_tax_template_p_iva5_ic_sc',

--- a/addons/l10n_fi/migrations/13.0.2/end-migrate_update_taxes.py
+++ b/addons/l10n_fi/migrations/13.0.2/end-migrate_update_taxes.py
@@ -4,5 +4,5 @@ from odoo import api, SUPERUSER_ID
 
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    for company in env['res.company'].search([('chart_template', '=', 'fi')]):
+    for company in env['res.company'].search([('chart_template', '=', 'fi')], order="parent_path"):
         env['account.chart.template'].try_loading('fi', company)

--- a/addons/l10n_fr/migrations/2.1/post-migrate_update_taxes.py
+++ b/addons/l10n_fr/migrations/2.1/post-migrate_update_taxes.py
@@ -4,5 +4,5 @@ from odoo import api, SUPERUSER_ID
 
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    for company in env['res.company'].search([('chart_template', '=', 'fr')]):
+    for company in env['res.company'].search([('chart_template', '=', 'fr')], order="parent_path"):
         env['account.chart.template'].try_loading('fr', company)

--- a/addons/l10n_hu_edi/__init__.py
+++ b/addons/l10n_hu_edi/__init__.py
@@ -12,7 +12,7 @@ _logger = logging.getLogger(__name__)
 
 
 def post_init(env):
-    for company in env['res.company'].search([('chart_template', '=', 'hu')]):
+    for company in env['res.company'].search([('chart_template', '=', 'hu')], order="parent_path"):
         # Apply default cash rounding configuration
         company._l10n_hu_edi_configure_company()
 

--- a/addons/l10n_it/migrations/0.6/post-migrate_update_taxes.py
+++ b/addons/l10n_it/migrations/0.6/post-migrate_update_taxes.py
@@ -3,5 +3,5 @@ from odoo import api, SUPERUSER_ID
 
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    for company in env['res.company'].search([('chart_template', '=', 'it')]):
+    for company in env['res.company'].search([('chart_template', '=', 'it')], order="parent_path"):
         env['account.chart.template'].try_loading('it', company)

--- a/addons/l10n_it_edi_doi/__init__.py
+++ b/addons/l10n_it_edi_doi/__init__.py
@@ -4,7 +4,7 @@ from . import models
 
 
 def _l10n_it_edi_doi_post_init(env):
-    for company in env['res.company'].search([('chart_template', '=', 'it')]):
+    for company in env['res.company'].search([('chart_template', '=', 'it')], order="parent_path"):
         template = env['account.chart.template'].with_company(company)
         template._load_data({
             'account.tax': template._get_it_edi_doi_account_tax(),

--- a/addons/l10n_it_edi_withholding/__init__.py
+++ b/addons/l10n_it_edi_withholding/__init__.py
@@ -7,7 +7,7 @@ _logger = logging.getLogger(__name__)
 
 def _l10n_it_edi_withholding_post_init(env):
     """ Existing companies that have the Italian Chart of Accounts set """
-    for company in env['res.company'].search([('chart_template', '=', 'it')]):
+    for company in env['res.company'].search([('chart_template', '=', 'it')], order="parent_path"):
         _logger.info("Company %s already has the Italian localization installed, updating...", company.name)
         ChartTemplate = env['account.chart.template'].with_company(company)
         ChartTemplate._load_data({

--- a/addons/l10n_lu/migrations/2.1/post-migrate_update_taxes.py
+++ b/addons/l10n_lu/migrations/2.1/post-migrate_update_taxes.py
@@ -3,5 +3,5 @@ from odoo import api, SUPERUSER_ID
 
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    for company in env['res.company'].search([('chart_template', '=', 'lu')]):
+    for company in env['res.company'].search([('chart_template', '=', 'lu')], order="parent_path"):
         env['account.chart.template'].try_loading('lu', company)

--- a/addons/l10n_lu/migrations/2.2/end-migrate_update_taxes.py
+++ b/addons/l10n_lu/migrations/2.2/end-migrate_update_taxes.py
@@ -3,5 +3,5 @@ from odoo import api, SUPERUSER_ID
 
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    for company in env['res.company'].search([('chart_template', '=', 'lu')]):
+    for company in env['res.company'].search([('chart_template', '=', 'lu')], order="parent_path"):
         env['account.chart.template'].try_loading('lu', company)

--- a/addons/l10n_mx/migrations/2.2/post-migrate.py
+++ b/addons/l10n_mx/migrations/2.2/post-migrate.py
@@ -3,5 +3,5 @@ from odoo import api, SUPERUSER_ID
 
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    for company in env['res.company'].search([('chart_template', '=', 'mx')]):
+    for company in env['res.company'].search([('chart_template', '=', 'mx')], order="parent_path"):
         env['account.chart.template'].try_loading('mx', company)

--- a/addons/l10n_my/migrations/1.1/post-migrate_update_taxes.py
+++ b/addons/l10n_my/migrations/1.1/post-migrate_update_taxes.py
@@ -5,5 +5,5 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     """ Update taxes for existing companies, in order to apply the new tags to them. """
     env = api.Environment(cr, SUPERUSER_ID, {})
-    for company in env['res.company'].search([('chart_template', '=', 'my')]):
+    for company in env['res.company'].search([('chart_template', '=', 'my')], order="parent_path"):
         env['account.chart.template'].try_loading('my', company)

--- a/addons/l10n_nl/migrations/3.1/end-migrate_update_taxes.py
+++ b/addons/l10n_nl/migrations/3.1/end-migrate_update_taxes.py
@@ -4,5 +4,5 @@ from odoo import api, SUPERUSER_ID
 
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    for company in env['res.company'].search([('chart_template', '=', 'nl')]):
+    for company in env['res.company'].search([('chart_template', '=', 'nl')], order="parent_path"):
         env['account.chart.template'].try_loading('nl', company)

--- a/addons/l10n_no/migrations/2.1/post-migrate_update_taxes.py
+++ b/addons/l10n_no/migrations/2.1/post-migrate_update_taxes.py
@@ -4,5 +4,5 @@ from odoo import api, SUPERUSER_ID
 
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    for company in env['res.company'].search([('chart_template', '=', 'no')]):
+    for company in env['res.company'].search([('chart_template', '=', 'no')], order="parent_path"):
         env['account.chart.template'].try_loading('no', company)

--- a/addons/l10n_ph/migrations/1.1/post-migrate_update_taxes.py
+++ b/addons/l10n_ph/migrations/1.1/post-migrate_update_taxes.py
@@ -4,5 +4,5 @@ from odoo import api, SUPERUSER_ID
 
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    for company in env['res.company'].search([('chart_template', '=', 'ph')]):
+    for company in env['res.company'].search([('chart_template', '=', 'ph')], order="parent_path"):
         env['account.chart.template'].try_loading('ph', company)

--- a/addons/l10n_pk/migrations/1.1/post-migrate_update_taxes.py
+++ b/addons/l10n_pk/migrations/1.1/post-migrate_update_taxes.py
@@ -4,5 +4,5 @@ from odoo import api, SUPERUSER_ID
 
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    for company in env['res.company'].search([('chart_template', '=', 'pk')]):
+    for company in env['res.company'].search([('chart_template', '=', 'pk')], order="parent_path"):
         env['account.chart.template'].try_loading('pk', company)

--- a/addons/l10n_se/migrations/1.1/end-migrate.py
+++ b/addons/l10n_se/migrations/1.1/end-migrate.py
@@ -3,5 +3,5 @@ from odoo import api, SUPERUSER_ID
 
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    for company in env['res.company'].search([('chart_template', '=', 'se')]):
+    for company in env['res.company'].search([('chart_template', '=', 'se')], order="parent_path"):
         env['account.chart.template'].try_loading('se', company)

--- a/addons/l10n_sg/migrations/2.1/post-migrate_update_tax.py
+++ b/addons/l10n_sg/migrations/2.1/post-migrate_update_tax.py
@@ -4,5 +4,5 @@ from odoo import api, SUPERUSER_ID
 
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    for company in env['res.company'].search([('chart_template', '=', 'sg')]):
+    for company in env['res.company'].search([('chart_template', '=', 'sg')], order="parent_path"):
         env['account.chart.template'].try_loading('sg', company)

--- a/addons/l10n_sg/migrations/2.2/post-migrate_update_taxes.py
+++ b/addons/l10n_sg/migrations/2.2/post-migrate_update_taxes.py
@@ -4,5 +4,5 @@ from odoo import api, SUPERUSER_ID
 
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    for company in env['res.company'].search([('chart_template', '=', 'sg')]):
+    for company in env['res.company'].search([('chart_template', '=', 'sg')], order="parent_path"):
         env['account.chart.template'].try_loading('sg', company)

--- a/addons/l10n_tr/migrations/1.1/end-migrate_update_taxes.py
+++ b/addons/l10n_tr/migrations/1.1/end-migrate_update_taxes.py
@@ -4,5 +4,5 @@ from odoo import api, SUPERUSER_ID
 
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    for company in env['res.company'].search([('chart_template', '=', 'tr')]):
+    for company in env['res.company'].search([('chart_template', '=', 'tr')], order="parent_path"):
         env['account.chart.template'].try_loading('tr', company)

--- a/addons/l10n_tr/migrations/1.2/end-migrate_update_package.py
+++ b/addons/l10n_tr/migrations/1.2/end-migrate_update_package.py
@@ -4,5 +4,5 @@ from odoo import api, SUPERUSER_ID
 
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    for company in env['res.company'].search([('chart_template', '=', 'tr')]):
+    for company in env['res.company'].search([('chart_template', '=', 'tr')], order="parent_path"):
         env['account.chart.template'].try_loading('tr', company)

--- a/addons/l10n_uk/migrations/1.1/end-migrate.py
+++ b/addons/l10n_uk/migrations/1.1/end-migrate.py
@@ -3,5 +3,5 @@ from odoo import api, SUPERUSER_ID
 
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    for company in env['res.company'].search([('chart_template', '=', 'uk')]):
+    for company in env['res.company'].search([('chart_template', '=', 'uk')], order="parent_path"):
         env['account.chart.template'].try_loading('uk', company)

--- a/addons/l10n_vn/migrations/2.0.3/post-migrate_update_taxes.py
+++ b/addons/l10n_vn/migrations/2.0.3/post-migrate_update_taxes.py
@@ -3,5 +3,5 @@ from odoo import api, SUPERUSER_ID
 
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    for company in env['res.company'].search([('chart_template', '=', 'vn')]):
+    for company in env['res.company'].search([('chart_template', '=', 'vn')], order="parent_path"):
         env['account.chart.template'].try_loading('vn', company)

--- a/addons/mrp_account/__init__.py
+++ b/addons/mrp_account/__init__.py
@@ -6,7 +6,7 @@ from . import report
 
 def _configure_journals(env):
     # if we already have a coa installed, create journal and set property field
-    for company in env['res.company'].search([('chart_template', '!=', False)]):
+    for company in env['res.company'].search([('chart_template', '!=', False)], order="parent_path"):
         ChartTemplate = env['account.chart.template'].with_company(company)
         template_code = company.chart_template
         template_data = ChartTemplate._get_chart_template_data(template_code)['template_data']

--- a/addons/stock_account/__init__.py
+++ b/addons/stock_account/__init__.py
@@ -8,7 +8,7 @@ from . import wizard
 
 def _configure_journals(env):
     # if we already have a coa installed, create journal and set property field
-    for company in env['res.company'].search([('chart_template', '!=', False)]):
+    for company in env['res.company'].search([('chart_template', '!=', False)], order="parent_path"):
         ChartTemplate = env['account.chart.template'].with_company(company)
         template_code = company.chart_template
         full_data = ChartTemplate._get_chart_template_data(template_code)


### PR DESCRIPTION
In migration and init scripts, when loading the chart of accounts or parts of it, we should always start with the parent companies to avoid creating duplicate chart records

Description of the issue/feature this PR addresses:
When a new account is added and the chart is loaded for the child company before the parent, the account will be created for both companies

Current behavior before PR:

Desired behavior after PR is merged:

see also https://github.com/odoo/enterprise/pull/71421




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
