### PR TITLE
[FIX] hr_work_entry: Check install mode in the constraint

### DIFF
--- a/addons/hr_work_entry/models/hr_work_entry.py
+++ b/addons/hr_work_entry/models/hr_work_entry.py
@@ -259,7 +259,7 @@ class HrWorkEntryType(models.Model):
     def _check_work_entry_type_country(self):
         if self.env.ref('hr_work_entry.work_entry_type_attendance') in self:
             raise UserError(_("You can't change the country of this specific work entry type."))
-        elif self.env['hr.work.entry'].sudo().search_count([('work_entry_type_id', 'in', self.ids)], limit=1):
+        elif not self.env.context.get('install_mode') and self.env['hr.work.entry'].sudo().search_count([('work_entry_type_id', 'in', self.ids)], limit=1):
             raise UserError(_("You can't change the Country of this work entry type cause it's currently used by the system. You need to delete related working entries first."))
 
     @api.constrains('code', 'country_id')


### PR DESCRIPTION
A new constraint on model `hr.work.entry.type` triggers an error while updating `country_id` if related work entries exist.

Since a lot of the data records from enterprise don't have the noupdate flag and they include the country as a field to update, the constraint is triggered just by upgrading the module.

Steps to reproduce:
- Install one of the affected modules (eg `l10n_au_hr_payroll`)
- Create a work entry from one of the types from the module
- Upgrade the module.
