### PR TITLE
[IMP] core: remove @api.returns and move call_kw to odoo.service.model

### DIFF
--- a/addons/hr_maintenance/models/equipment.py
+++ b/addons/hr_maintenance/models/equipment.py
@@ -80,7 +80,6 @@ class MaintenanceEquipment(models.Model):
 class MaintenanceRequest(models.Model):
     _inherit = 'maintenance.request'
 
-    @api.returns('self')
     def _default_employee_get(self):
         return self.env.user.employee_id
 

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -738,7 +738,6 @@ class DiscussChannel(models.Model):
     def _get_allowed_message_post_params(self):
         return super()._get_allowed_message_post_params() | {"special_mentions", "parent_id"}
 
-    @api.returns('mail.message', lambda value: value.id)
     def message_post(self, *, message_type='notification', **kwargs):
         if (not self.env.user or self.env.user._is_public()) and self.is_member:
             # sudo: discuss.channel - guests don't have access for creating mail.message

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -584,7 +584,6 @@ class MailTemplate(models.Model):
             email_layout_xmlid=email_layout_xmlid
         )[0].id  # TDE CLEANME: return mail + api.returns ?
 
-    @api.returns('self', lambda value: value.ids)
     def send_mail_batch(self, res_ids, force_send=False, raise_exception=False, email_values=None,
                   email_layout_xmlid=False):
         """ Generates new mail.mails. Batch version of 'send_mail'.'

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2071,7 +2071,6 @@ class MailThread(models.AbstractModel):
     # MESSAGE POST MAIN
     # ------------------------------------------------------------
 
-    @api.returns('mail.message', lambda value: value.id)
     def message_post(self, *,
                      body='', subject=None, message_type='notification',
                      email_from=None, author_id=None, parent_id=False,
@@ -2573,7 +2572,6 @@ class MailThread(models.AbstractModel):
                 )
         return messages_all
 
-    @api.returns('mail.message', lambda value: value.id)
     def message_notify(self, *,
                        body='', subject=False,
                        author_id=None, email_from=None,

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -86,7 +86,6 @@ class ResPartner(models.Model):
         return key + (self._context.get('force_email'),)
 
     @api.model
-    @api.returns('self', lambda value: value.id)
     def find_or_create(self, email, assert_valid_email=False):
         """ Override to use the email_normalized field. """
         if not email:

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -681,18 +681,18 @@ export async function mail_message_post(request) {
         }
     }
     const kwargs = makeKwArgs({ ...finalData, context });
-    let messageId;
+    let messageIds;
     if (thread_model === "discuss.channel") {
-        messageId = DiscussChannel.message_post(thread_id, kwargs);
+        messageIds = DiscussChannel.message_post(thread_id, kwargs);
     } else {
         const model = this.env[thread_model];
-        messageId = MailThread.message_post.call(model, [thread_id], {
+        messageIds = MailThread.message_post.call(model, [thread_id], {
             ...kwargs,
             model: thread_model,
         });
     }
     return new mailDataHelpers.Store(
-        MailMessage.browse(messageId),
+        MailMessage.browse(messageIds[0]),
         makeKwArgs({ for_current_user: true })
     ).get_result();
 }

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -827,7 +827,7 @@ export class DiscussChannel extends models.ServerModel {
             ]).map((member) => member.partner_id);
         }
         delete kwargs.special_mentions;
-        const messageId = MailThread.message_post.call(this, [id], kwargs);
+        const messageIds = MailThread.message_post.call(this, [id], kwargs);
         // simulate compute of message_unread_counter
         const memberOfCurrentUser = this._find_or_create_member_for_self(channel.id);
         const otherMembers = DiscussChannelMember._filter([
@@ -839,7 +839,7 @@ export class DiscussChannel extends models.ServerModel {
                 message_unread_counter: member.message_unread_counter + 1,
             });
         }
-        return messageId;
+        return messageIds;
     }
 
     /**

--- a/addons/mail/static/tests/mock_server/mock_models/mail_thread.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_thread.js
@@ -157,7 +157,7 @@ export class MailThread extends models.ServerModel {
             });
         }
         MailThread._notify_thread.call(this, ids, messageId, kwargs.context?.temporary_id);
-        return messageId;
+        return [messageId];
     }
 
     /**

--- a/addons/mail_group/models/mail_group.py
+++ b/addons/mail_group/models/mail_group.py
@@ -267,7 +267,6 @@ class MailGroup(models.Model):
         """Add the method to make the mail gateway flow work with this model."""
         return
 
-    @api.returns('mail.message', lambda value: value.id)
     def message_post(self, body='', subject=None, email_from=None, author_id=None, **kwargs):
         """ Custom posting process. This model does not inherit from ``mail.thread``
         but uses the mail gateway so few methods should be defined.

--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -196,7 +196,6 @@ class MaintenanceRequest(models.Model):
     _order = "id desc"
     _check_company_auto = True
 
-    @api.returns('self')
     def _default_stage(self):
         return self.env['maintenance.stage'].search([], limit=1)
 

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -379,7 +379,6 @@ class PurchaseOrder(models.Model):
     # MAIL.THREAD
     # ------------------------------------------------------------
 
-    @api.returns('mail.message', lambda value: value.id)
     def message_post(self, **kwargs):
         if self.env.context.get('mark_rfq_as_sent'):
             self.filtered(lambda o: o.state == 'draft').write({'state': 'sent'})

--- a/addons/rating/models/mail_thread.py
+++ b/addons/rating/models/mail_thread.py
@@ -3,7 +3,7 @@
 import datetime
 import markupsafe
 
-from odoo import _, api, fields, models, tools
+from odoo import _, fields, models, tools
 
 
 class MailThread(models.AbstractModel):
@@ -161,7 +161,6 @@ class MailThread(models.AbstractModel):
                 )
         return rating
 
-    @api.returns('mail.message', lambda value: value.id)
     def message_post(self, **kwargs):
         rating_id = kwargs.pop('rating_id', False)
         rating_value = kwargs.pop('rating_value', False)

--- a/addons/rpc/tests/test_xmlrpc.py
+++ b/addons/rpc/tests/test_xmlrpc.py
@@ -1,17 +1,28 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import collections
 import datetime
 import time
 
-from odoo.exceptions import AccessDenied, AccessError
-from odoo.http import _request_stack
-
 import odoo
 import odoo.tools
+from odoo.addons.base.tests.common import SavepointCaseWithUserDemo
+from odoo.exceptions import AccessDenied, AccessError
+from odoo.http import _request_stack
+from odoo.service import common as auth
+from odoo.service import model
 from odoo.tests import common
-from odoo.service import common as auth, model
 from odoo.tools import DotDict
+
+
+class TestExternalAPI(SavepointCaseWithUserDemo):
+
+    def test_call_kw(self):
+        """kwargs is not modified by the execution of the call"""
+        partner = self.env['res.partner'].create({'name': 'MyPartner1'})
+        args = (partner.ids, ['name'])
+        kwargs = {'context': {'test': True}}
+        model.call_kw(self.env['res.partner'], 'read', args, kwargs)
+        self.assertEqual(kwargs, {'context': {'test': True}})
 
 
 @common.tagged('post_install', '-at_install')

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1666,7 +1666,6 @@ class SaleOrder(models.Model):
             return
         return super()._track_finalize()
 
-    @api.returns('mail.message', lambda value: value.id)
     def message_post(self, **kwargs):
         if self.env.context.get('mark_so_as_sent'):
             self.filtered(lambda o: o.state == 'draft').with_context(tracking_disable=True).write({'state': 'sent'})

--- a/addons/sms/models/mail_thread.py
+++ b/addons/sms/models/mail_thread.py
@@ -125,7 +125,6 @@ class MailThread(models.AbstractModel):
                 }
         return result
 
-    @api.returns('mail.message', lambda value: value.id)
     def message_post(self, *args, body='', message_type='notification', **kwargs):
         # When posting an 'SMS' `message_type`, make sure that the body is used as-is in the sms,
         # and reformat the message body for the notification (mainly making URLs clickable).

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -1162,7 +1162,6 @@ class StockWarehouse(models.Model):
             name = self._get_route_name(route_type)
         return '%s: %s' % (self.name, name)
 
-    @api.returns('self')
     def _get_all_routes(self):
         routes = self.mapped('route_ids') | self.mapped('mto_pull_id').mapped('route_id')
         routes |= self.env["stock.route"].with_context(active_test=False).search([('supplied_wh_id', 'in', self.ids)])

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -15,7 +15,7 @@ from odoo.addons.mail.tests.common import mail_new_test_user, MailCommon
 from odoo.addons.test_mail.data.test_mail_data import MAIL_TEMPLATE_PLAINTEXT
 from odoo.addons.test_mail.models.test_mail_models import MailTestSimple
 from odoo.addons.test_mail.tests.common import TestRecipients
-from odoo.api import call_kw
+from odoo.service.model import call_kw
 from odoo.exceptions import AccessError
 from odoo.tests import tagged
 from odoo.tools import mute_logger, formataddr
@@ -1744,15 +1744,16 @@ class TestMessagePostGlobal(TestMessagePostCommon):
 
     @users('employee')
     def test_message_post_return(self):
-        """ Ensures calling message_post through RPC always return an ID. """
+        """ Ensures calling message_post through RPC always return a list with one ID. """
         test_record = self.env['mail.test.simple'].browse(self.test_record.ids)
 
         # Use call_kw as shortcut to simulate a RPC call.
-        message_id = call_kw(self.env['mail.test.simple'],
-                             'message_post',
-                             [test_record.id],
-                             {'body': 'test'})
-        self.assertTrue(isinstance(message_id, int))
+        result = call_kw(
+            self.env['mail.test.simple'],
+            'message_post',
+            [test_record.id],
+            {'body': 'test'})
+        self.assertTrue(tools.misc.has_list_types(result, (int,)))
 
 
 @tagged('mail_post', 'multi_lang')

--- a/addons/web/controllers/dataset.py
+++ b/addons/web/controllers/dataset.py
@@ -1,17 +1,13 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import logging
-import warnings
 from werkzeug.exceptions import NotFound
 
 from odoo import http
-from odoo.api import call_kw
 from odoo.http import request
 from odoo.models import check_method_name
+from odoo.service.model import call_kw
+
 from .utils import clean_action
-
-
-_logger = logging.getLogger(__name__)
 
 
 class DataSet(http.Controller):

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -515,9 +515,9 @@ export class SearchModel extends EventBus {
     }
 
     async _createIrFilters(irFilter) {
-        const serverSideId = await this.orm.call("ir.filters", "create_or_replace", [irFilter]);
+        const serverSideIds = await this.orm.call("ir.filters", "create_or_replace", [irFilter]);
         this.env.bus.trigger("CLEAR-CACHES");
-        return serverSideId;
+        return serverSideIds[0];
     }
 
     /**

--- a/addons/web/static/tests/search/custom_favorite_item.test.js
+++ b/addons/web/static/tests/search/custom_favorite_item.test.js
@@ -107,7 +107,7 @@ test("save filter", async () => {
         expect.step(route);
         const irFilter = args[0];
         expect(irFilter.context).toEqual({ group_by: [], someKey: "foo" });
-        return 7; // fake serverSideId
+        return [7]; // fake serverSideId
     });
 
     const component = await mountWithSearch(TestComponent, {
@@ -134,7 +134,7 @@ test("dynamic filters are saved dynamic", async () => {
         expect(irFilter.domain).toBe(
             `[("date_field", ">=", (context_today() + relativedelta()).strftime("%Y-%m-%d"))]`
         );
-        return 7; // fake serverSideId
+        return [7]; // fake serverSideId
     });
 
     await mountWithSearch(SearchBar, {
@@ -163,7 +163,7 @@ test("save filters created via autocompletion works", async () => {
         expect.step(route);
         const irFilter = args[0];
         expect(irFilter.domain).toBe(`[("foo", "ilike", "a")]`);
-        return 7; // fake serverSideId
+        return [7]; // fake serverSideId
     });
 
     await mountWithSearch(SearchBar, {
@@ -209,7 +209,7 @@ test("favorites have unique descriptions (the submenus of the favorite menu are 
             embedded_parent_res_id: false,
             user_id: 7,
         });
-        return 2; // fake serverSideId
+        return [2]; // fake serverSideId
     });
 
     await mountWithSearch(SearchBar, {
@@ -257,7 +257,7 @@ test("undefined name for filter shows notification and not error", async () => {
         },
     });
 
-    onRpc("create_or_replace", () => 7); // fake serverSideId
+    onRpc("create_or_replace", () => [7]); // fake serverSideId
 
     await mountWithSearch(SearchBarMenu, {
         resModel: "foo",

--- a/addons/web/static/tests/search/search_bar_menu/favorite_menu.test.js
+++ b/addons/web/static/tests/search/search_bar_menu/favorite_menu.test.js
@@ -246,7 +246,7 @@ test("shared favorites are grouped under a dropdown if there are more than 10", 
         expect.step(route);
         const irFilter = args[0];
         expect(irFilter.domain).toBe(`[]`);
-        return 10; // fake serverSideId
+        return [10]; // fake serverSideId
     });
     const irFilters = [];
     for (let i = 1; i < 11; i++) {

--- a/addons/web/static/tests/views/graph/graph_view.test.js
+++ b/addons/web/static/tests/views/graph/graph_view.test.js
@@ -1320,7 +1320,7 @@ test("save params succeeds", async () => {
     let serverId = 1;
     onRpc("create_or_replace", ({ args }) => {
         expect(args[0].context).toEqual(expectedContexts.shift());
-        return serverId++;
+        return [serverId++];
     });
 
     await mountView({

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -2618,7 +2618,7 @@ test(`ordered target, sort attribute in context`, async () => {
     onRpc("create_or_replace", ({ args }) => {
         const favorite = args[0];
         expect.step(favorite.sort);
-        return 7;
+        return [7];
     });
 
     await mountView({

--- a/addons/web/static/tests/views/pivot_view.test.js
+++ b/addons/web/static/tests/views/pivot_view.test.js
@@ -3227,7 +3227,7 @@ test("pivot_row_groupby should be also used after first load", async () => {
 
     onRpc("create_or_replace", ({ args }) => {
         expect(args[0].context).toEqual(expectedContexts.shift());
-        return ids.shift();
+        return [ids.shift()];
     });
 
     await mountView({
@@ -3397,7 +3397,7 @@ test("favorite pivot_measures should be used even if found also in global contex
             pivot_measures: ["computed_field"],
             pivot_row_groupby: [],
         });
-        return 1;
+        return [1];
     });
 
     await mountView({

--- a/addons/web/static/tests/views/view_dialogs/select_create_dialog.test.js
+++ b/addons/web/static/tests/views/view_dialogs/select_create_dialog.test.js
@@ -563,7 +563,7 @@ test("SelectCreateDialog: save current search on desktop", async () => {
             expect(irFilter.context).toEqual(expectedContext, {
                 message: "should save the correct context",
             });
-            return 7; // fake serverSideId
+            return [7]; // fake serverSideId
         }
     });
 

--- a/addons/web/static/tests/webclient/actions/embedded_action.test.js
+++ b/addons/web/static/tests/webclient/actions/embedded_action.test.js
@@ -323,7 +323,7 @@ test("a view coming from a embedded can be saved in the embedded actions", async
         expect(args[0].domain).toBe(`[["name", "=", "Applejack"]]`);
         expect(args[0].embedded_action_id).toBe(4);
         expect(args[0].user_id).toBe(false);
-        return 5; // Fake new filter id
+        return [5]; // Fake new filter id
     });
     await mountWithCleanup(WebClient);
     await getService("action").doAction(1);

--- a/addons/web/static/tests/webclient/actions/window_action.test.js
+++ b/addons/web/static/tests/webclient/actions/window_action.test.js
@@ -1693,7 +1693,7 @@ test("save current search", async () => {
             group_by: [],
             shouldBeInFilterContext: true,
         });
-        return 3; // fake filter id
+        return [3]; // fake filter id
     });
 
     await mountWithCleanup(WebClient);

--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -738,7 +738,7 @@ export class Configurator extends Component {
         useSubEnv({ store });
 
         onWillStart(async () => {
-            this.websiteId = (await this.orm.call('website', 'get_current_website')).match(/\d+/)[0];
+            this.websiteId = (await this.orm.call('website', 'get_current_website'))[0];
 
             await store.start(() => this.getInitialState());
             this.updateStorage(store);

--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -7,7 +7,6 @@ import { redirect } from "@web/core/utils/urls";
 import { ResourceEditor } from '../../components/resource_editor/resource_editor';
 import { WebsiteEditorComponent } from '../../components/editor/editor';
 import { WebsiteTranslator } from '../../components/translator/translator';
-import { unslugHtmlDataObject } from '../../services/website_service';
 import {OptimizeSEODialog} from '@website/components/dialog/seo';
 import { WebsiteDialog } from "@website/components/dialog/dialog";
 import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
@@ -69,12 +68,12 @@ export class WebsitePreview extends Component {
         useExternalListener(window, "keydown", this._onKeydownRefresh.bind(this));
 
         onWillStart(async () => {
-            const [backendWebsiteRepr] = await Promise.all([
+            const [backendCurrentWebsite] = await Promise.all([
                 this.orm.call('website', 'get_current_website'),
                 this.websiteService.fetchWebsites(),
                 this.websiteService.fetchUserGroups(),
             ]);
-            this.backendWebsiteId = unslugHtmlDataObject(backendWebsiteRepr).id;
+            this.backendWebsiteId = backendCurrentWebsite[0];
 
             const encodedPath = encodeURIComponent(this.path);
             if (this.websiteDomain && !wUtils.isHTTPSorNakedDomainRedirection(this.websiteDomain, window.location.origin)) {

--- a/addons/website/static/src/components/views/page_search_model.js
+++ b/addons/website/static/src/components/views/page_search_model.js
@@ -91,9 +91,9 @@ export class PageSearchModel extends SearchModel {
      * @returns {Object} The current website.
      */
     async getCurrentWebsite() {
-        const currentWebsite = (await this.orm.call('website', 'get_current_website')).match(/\d+/);
+        const currentWebsite = await this.orm.call('website', 'get_current_website');
         if (currentWebsite) {
-            return this.website.websites.find(w => w.id === parseInt(currentWebsite[0]));
+            return this.website.websites.find(w => w.id === currentWebsite[0]);
         }
         return this.website.websites[0];
     }

--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -50,7 +50,6 @@ class BlogBlog(models.Model):
                 blog_post.active = vals['active']
         return res
 
-    @api.returns('mail.message', lambda value: value.id)
     def message_post(self, *, parent_id=False, subtype_id=False, **kwargs):
         """ Temporary workaround to avoid spam. If someone replies on a channel
         through the 'Presentation Published' email, it should be considered as a

--- a/addons/website_forum/models/forum_post.py
+++ b/addons/website_forum/models/forum_post.py
@@ -753,7 +753,6 @@ class ForumPost(models.Model):
 
         return groups
 
-    @api.returns('mail.message', lambda value: value.id)
     def message_post(self, *, message_type='notification', **kwargs):
         if self.ids and message_type == 'comment':  # user comments have a restriction on karma
             # add followers of comments on the parent post

--- a/addons/website_livechat/models/discuss_channel.py
+++ b/addons/website_livechat/models/discuss_channel.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, _
+from odoo import fields, models, _
 from odoo.addons.mail.tools.discuss import Store
 from odoo.exceptions import AccessError
 
@@ -76,7 +76,6 @@ class DiscussChannel(models.Model):
             operator=operator or _("an operator"),
         )
 
-    @api.returns('mail.message', lambda value: value.id)
     def message_post(self, **kwargs):
         """Override to mark the visitor as still connected.
         If the message sent is not from the operator (so if it's the visitor or

--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -792,7 +792,6 @@ class SlideChannel(models.Model):
         to_activate.with_context(active_test=False).slide_ids.action_unarchive()
         return super(SlideChannel, to_activate).action_unarchive()
 
-    @api.returns('mail.message', lambda value: value.id)
     def message_post(self, *, parent_id=False, subtype_id=False, **kwargs):
         """ Temporary workaround to avoid spam. If someone replies on a channel
         through the 'Presentation Published' email, it should be considered as a

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -715,7 +715,6 @@ class SlideSlide(models.Model):
     # Mail/Rating
     # ---------------------------------------------------------
 
-    @api.returns('mail.message', lambda value: value.id)
     def message_post(self, *, message_type='notification', **kwargs):
         self.ensure_one()
         if message_type == 'comment' and not self.channel_id.can_comment:  # user comments have a restriction on karma

--- a/odoo/addons/base/models/ir_filters.py
+++ b/odoo/addons/base/models/ir_filters.py
@@ -145,7 +145,6 @@ class IrFilters(models.Model):
         raise UserError(self.env._("There is already a shared filter set as default for %(model)s, delete or change it before setting a new default", model=vals.get('model_id')))
 
     @api.model
-    @api.returns('self', lambda value: value.id)
     def create_or_replace(self, vals):
         action_id = vals.get('action_id')
         embedded_action_id = vals.get('embedded_action_id')

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -493,7 +493,6 @@ class IrModuleModule(models.Model):
         orphans = self.env['ir.ui.view'].with_context(**{'active_test': False, MODULE_UNINSTALL_FLAG: True}).search(domain)
         orphans.unlink()
 
-    @api.returns('self')
     def downstream_dependencies(self, known_deps=None,
                                 exclude_states=('uninstalled', 'uninstallable', 'to remove')):
         """ Return the modules that directly or indirectly depend on the modules
@@ -519,7 +518,6 @@ class IrModuleModule(models.Model):
             known_deps |= missing_mods.downstream_dependencies(known_deps, exclude_states)
         return known_deps
 
-    @api.returns('self')
     def upstream_dependencies(self, known_deps=None,
                               exclude_states=('installed', 'uninstallable', 'to remove')):
         """ Return the dependency tree of modules of the modules in `self`, and

--- a/odoo/addons/base/models/ir_ui_menu.py
+++ b/odoo/addons/base/models/ir_ui_menu.py
@@ -198,7 +198,6 @@ class IrUiMenu(models.Model):
         return new_menus
 
     @api.model
-    @api.returns('self')
     def get_user_roots(self):
         """ Return all root menu ids visible for the user.
 

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -263,7 +263,6 @@ class ResCompany(models.Model):
         return expression.AND([domain, constraint])
 
     @api.model
-    @api.returns('self', lambda value: value.id)
     def _company_default_get(self, object=False, field=False):
         """ Returns the user's company
             - Deprecated

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -902,7 +902,6 @@ class ResPartner(models.Model):
         return partner.id, partner.display_name
 
     @api.model
-    @api.returns('self', lambda value: value.id)
     def find_or_create(self, email, assert_valid_email=False):
         """ Find a partner with the given ``email`` or use :py:method:`~.name_create`
         to create a new one.

--- a/odoo/addons/base/tests/test_api.py
+++ b/odoo/addons/base/tests/test_api.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, models, Command
+from odoo import models, Command
 from odoo.addons.base.tests.common import SavepointCaseWithUserDemo
 from odoo.tools import mute_logger, unique, lazy
 from odoo.tools.constants import PREFETCH_MAX
@@ -710,14 +710,3 @@ class TestAPI(SavepointCaseWithUserDemo):
             # group), so should be nothing here
             with self.assertQueries([]):
                 _ = byfn['host'].name
-
-
-class TestExternalAPI(SavepointCaseWithUserDemo):
-
-    def test_call_kw(self):
-        """kwargs is not modified by the execution of the call"""
-        partner = self.env['res.partner'].create({'name': 'MyPartner1'})
-        args = (partner.ids, ['name'])
-        kwargs = {'context': {'test': True}}
-        api.call_kw(self.env['res.partner'], 'read', args, kwargs)
-        self.assertEqual(kwargs, {'context': {'test': True}})

--- a/odoo/addons/base/wizard/base_module_upgrade.py
+++ b/odoo/addons/base/wizard/base_module_upgrade.py
@@ -11,7 +11,6 @@ class BaseModuleUpgrade(models.TransientModel):
     _description = "Upgrade Module"
 
     @api.model
-    @api.returns('ir.module.module')
     def get_module_list(self):
         states = ['to upgrade', 'to remove', 'to install']
         return self.env['ir.module.module'].search([('state', 'in', states)])

--- a/odoo/api/__init__.py
+++ b/odoo/api/__init__.py
@@ -4,7 +4,6 @@
 from odoo.orm.identifiers import NewId
 from odoo.orm.decorators import (
     autovacuum,
-    call_kw,
     constrains,
     depends,
     depends_context,
@@ -13,7 +12,6 @@ from odoo.orm.decorators import (
     onchange,
     ondelete,
     readonly,
-    returns,
 )
 from odoo.orm.environments import Environment
 

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -200,7 +200,7 @@ def check_companies_domain_parent_of(self, companies):
     ])]
 
 
-class MetaModel(api.Meta):
+class MetaModel(type):
     """ The metaclass of all model classes.
         Its main purpose is to register the models per module.
     """
@@ -1620,7 +1620,6 @@ class BaseModel(metaclass=MetaModel):
 
     @api.model
     @api.readonly
-    @api.returns('self')
     def search(self, domain: DomainType, offset=0, limit=None, order=None) -> Self:
         """ search(domain[, offset=0][, limit=None][, order=None])
 
@@ -1642,7 +1641,6 @@ class BaseModel(metaclass=MetaModel):
 
     @api.model
     @api.readonly
-    @api.returns('self')
     def search_fetch(self, domain: DomainType, field_names: Sequence[str], offset=0, limit=None, order=None) -> Self:
         """ search_fetch(domain, field_names[, offset=0][, limit=None][, order=None])
 
@@ -5723,7 +5721,6 @@ class BaseModel(metaclass=MetaModel):
                             translations[lang][from_lang_term] = to_lang_term
                     new.update_field_translations(name, translations)
 
-    @api.returns('self')
     def copy(self, default: ValuesType | None = None) -> Self:
         """ copy(default=None)
 
@@ -5740,7 +5737,6 @@ class BaseModel(metaclass=MetaModel):
             old_record.copy_translations(new_record, excluded=default or ())
         return new_records
 
-    @api.returns('self')
     def exists(self) -> Self:
         """  exists() -> records
 

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -185,7 +185,7 @@ def _eval_xml(self, node, env):
         # merge current context with context in kwargs
         kwargs['context'] = {**env.context, **kwargs.get('context', {})}
         # invoke method
-        return odoo.api.call_kw(model, method_name, args, kwargs)
+        return odoo.service.model.call_kw(model, method_name, args, kwargs)
     elif node.tag == "test":
         return node.text
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

`call_kw` is a function that is specific to external calls and should be in the model service.

The `@api.returns` decorator logically gives two signatures to a single function. In that case, it is better to have 2 different functions: for testing and conceptually to avoid having a function which result type depends on the context. Moreover, from an architecture point of view, the type of the result for external calls should be handled by the controller/service.

Only some of the `mail` functions really used this feature and removing it simplifies the api module.


Current behavior before PR:
- `call_kw` inside `odoo.api`
- `@api.returns` not often used, basically to return a record.id depending on the context of the call

Desired behavior after PR is merged:
- `call_kw` inside `odoo.service.model` (where it makes sense with other dispatch functions)
- functions have one return type


odoo/enterprise#71424
odoo/documentation#11156
task-4155860

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
