### PR TITLE
[FIX] web_editor: avoid error when updating ImageTools UI

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -6654,7 +6654,7 @@ registry.ImageTools = ImageHandlerOption.extend({
         restoreCursor();
         this.trigger_up("enable_loading_effect");
         if (!widgetValue) {
-            this._onImageCropped();
+            await this._onImageCropped();
         }
         this.options.wysiwyg.odooEditor.historyUnpauseSteps();
     },
@@ -6817,7 +6817,7 @@ registry.ImageTools = ImageHandlerOption.extend({
         // Re-rendering the options after selecting a "cropping" shape.
         if (this.isImageCropped && previewMode === "reset") {
             delete this.isImageCropped;
-            this._onImageCropped();
+            await this._onImageCropped();
         }
 
         const saveData = previewMode === false;


### PR DESCRIPTION
Since [1] when the "Stretch" option was added on shape, upon changing that option the ImageTools XML is re-rendered to make sure the available widths in the "Format" option are up to date, but that operation is not awaited.  Because of this, the widgets might not be available yet during `updateUI`, which leads to an error.

This commit fixes this by awaiting the calls to `_onImageCropped`. No problem was identified for the second call, but the missing `await` is added by this commit anyway.

Steps to reproduce:
- Edit a website page
- Drop a "Columns" block
- Select first image
- Apply shape on image (e.g. Tear)
- Activate "Stretch"
- Set "Animation" to "On hover"
- Save
- Edit
- Disable "Stretch"

=> An error dialog was displayed

[1]: https://github.com/odoo/odoo/commit/c66ae88eaa275d1b87693f329d3b2622c0534c33#diff-ffb61e86e6b8297ef8997f9c605de14de896b54161c032d88a80bbaeac4f89beR6657

opw-4192761
