### PR TITLE
[IMP] account: narration below tax widget and qrcode

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -298,11 +298,11 @@
                                         <p>Scan this QR Code with<br/>your banking application</p>
                                     </div>
                                 </div>
+                            </div>
                                 <!--terms and conditions-->
                                 <div class="text-muted mb-3" t-attf-style="#{'text-align:justify;text-justify:inter-word;' if o.company_id.terms_type != 'html' else ''}" t-if="not is_html_empty(o.narration)" name="comment">
                                     <span t-field="o.narration"/>
                                 </div>
-                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
The aim of this commit is to avoid having the narration field to be displayed next to the widget tax getting some of its text line break next to the widget and not below it.

task-id: None