### PR TITLE
[FIX] discuss: prevent call public page test race condition

### DIFF
--- a/addons/mail/static/tests/tours/discuss_channel_call_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_call_public_tour.js
@@ -22,11 +22,10 @@ registry.category("web_tour.tours").add("discuss_channel_call_public_tour.js", {
         {
             content: "Check that the call has started",
             trigger: ".o-discuss-Call",
-            run() {
-                if (!odoo.__WOWL_DEBUG__.root.env.services["discuss.rtc"]?.selfSession) {
-                    console.error("The call should have started.");
-                }
-            },
+        },
+        {
+            content: "Check that current user is in call ('disconnect' button visible)",
+            trigger: "button[title='Disconnect']",
         },
     ],
 });


### PR DESCRIPTION
Before this commit, it was possible that a bus message containing a `mail.message.rtc.session` record update reached the client before the response to the `/mail/rtc/channel/join_call` route.

Since the condition for the test step is that there is a call (triggered by the presence of a rtc session) while the condition for the error thrown is that there is no `selfSession` (which is obtained as the response of the http request), one condition could be satisfied without the other.


