### PR TITLE
[IMP] tests: add an environment variable for undeterminisms

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1979,7 +1979,7 @@ class HttpCase(TransactionCase):
 
         return session
 
-    def browser_js(self, url_path, code, ready='', login=None, timeout=60, cookies=None, error_checker=None, watch=False, success_signal=DEFAULT_SUCCESS_SIGNAL, debug=False, **kw):
+    def browser_js(self, url_path, code, ready='', login=None, timeout=60, cookies=None, error_checker=None, watch=False, success_signal=DEFAULT_SUCCESS_SIGNAL, debug=False, check=0, **kw):
         """ Test js code running in the browser
         - optionnally log as 'login'
         - load page given by url_path
@@ -2003,6 +2003,13 @@ class HttpCase(TransactionCase):
             timeout = 1e6
         if watch:
             self._logger.warning('watch mode is only suitable for local testing')
+
+        odoo_tour_delay = os.getenv("ODOO_TOUR_DELAY")
+        if odoo_tour_delay:
+            check = int(odoo_tour_delay)
+        if check > 0:
+            # Add a delay to timeout based arbitrary on max steps viewed in a tour
+            timeout = timeout + 1000 * check
 
         browser = ChromeBrowser(self, headless=not watch, success_signal=success_signal, debug=debug)
         try:
@@ -2059,8 +2066,11 @@ class HttpCase(TransactionCase):
             'stepDelay': step_delay or 0,
             'keepWatchBrowser': kwargs.get('watch', False),
             'debug': kwargs.get('debug', False),
+            'check': kwargs.get('check', os.getenv("ODOO_TOUR_DELAY") or 0),
             'startUrl': url_path,
         }
+        if int(options["check"]) > 0:
+            _logger.runbot("Tour %s is launched with mode check to try catch undeterminisms.", tour_name)
         code = kwargs.pop('code', f"odoo.startTour({tour_name!r}, {json.dumps(options)})")
         ready = kwargs.pop('ready', f"odoo.isTourReady({tour_name!r})")
         return self.browser_js(url_path=url_path, code=code, ready=ready, success_signal="tour succeeded", **kwargs)


### PR DESCRIPTION
In commit, we add an environment variable to launch a tour in which we will look for undeterministic errors. The environment variable is a delay (in seconds).
You can then launch a tour with "check" parameter or set the environment variable ODOO_TOUR_DELAY to search for undeterminisms.

The search for the undeterministic error in a tour is not yet implemented. This commit comes before this implementation. But here is how it will work:
When the trigger of a step of a tour has been found, we wait this delay and then, we look again for the trigger in the DOM. If the element found is different from the first, then it triggers an error.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
