### PR TITLE
[FIX] im_livechat: im_livechat_history_back_and_forth tour

### DIFF
--- a/addons/im_livechat/static/tests/tours/im_livechat_history_back_and_forth.js
+++ b/addons/im_livechat/static/tests/tours/im_livechat_history_back_and_forth.js
@@ -4,8 +4,9 @@ registry.category("web_tour.tours").add("im_livechat_history_back_and_forth_tour
     test: true,
     steps: () => [
         {
-            trigger: "body",
-            run: "press ctrl+k",
+            content: "open command palette",
+            trigger: ".o_home_menu",
+            run: "click && press ctrl+k",
         },
         {
             trigger: ".o_command_palette_search input",


### PR DESCRIPTION
In this commit, we click on element to set the focus on window before press ctrl+k. This fix an undeterministic error.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
