### PR TITLE
[FIX] web_editor: reset tranformatiom on click twice

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -3964,6 +3964,10 @@ export class OdooEditor extends EventTarget {
         if (selection.anchorNode && isProtected(selection.anchorNode)) {
             return;
         }
+        if (this.document.querySelector(".transfo-container")){
+            ev.preventDefault();
+            return;
+        }
         this.keyboardType =
             ev.key === 'Unidentified' ? KEYBOARD_TYPES.VIRTUAL : KEYBOARD_TYPES.PHYSICAL;
         this._currentKeyPress = ev.key;

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1942,8 +1942,6 @@ export class Wysiwyg extends Component {
         });
         $toolbar.find('#image-crop').click(() => this._showImageCrop());
         $toolbar.find('#image-transform').click(e => {
-            const sel = document.getSelection();
-            sel.removeAllRanges();
             if (!this.lastMediaClicked) {
                 return;
             }
@@ -2164,6 +2162,9 @@ export class Wysiwyg extends Component {
         if (!selection) return;
         const anchorNode = selection.anchorNode;
         if (isProtected(anchorNode)) {
+            return;
+        }
+        if (this.odooEditor.document.querySelector(".transfo-container")) {
             return;
         }
 

--- a/addons/web_editor/static/tests/html_field_tests.js
+++ b/addons/web_editor/static/tests/html_field_tests.js
@@ -1169,6 +1169,141 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
         assert.strictEqual(htmlField._isDirty(), false, 'should not be dirty as the content has not changed');
 
     });
+
+    QUnit.module("Image transform");
+
+    QUnit.test("Image transform should reset after click twice", async (assert) => {
+        assert.expect(8);
+
+        const isElementRotated = (element) => {
+            // Get the computed style of the element
+            const style = window.getComputedStyle(element);
+
+            // Get the transform property value
+            const transform = style.transform || style.mozTransform;
+
+            // If transform is 'none', the element is not rotated
+            if (transform === "none") {
+                return false;
+            }
+
+            // The matrix values will be in the form of matrix(a, b, c, d, e, f)
+            // For rotation, a and d will reflect the cosine of the angle, and b and c the sine.
+            const values = transform.split("(")[1].split(")")[0].split(",");
+
+            const a = parseFloat(values[0]);
+            const b = parseFloat(values[1]);
+
+            // Calculate the angle of rotation in degrees
+            const angle = Math.round(Math.atan2(b, a) * (180 / Math.PI));
+
+            // If the angle is not 0, the element is rotated
+            return angle !== 0;
+        };
+
+        serverData.models.partner.records.push({
+            id: 1,
+            txt: `<p class="content"><br></p>`,
+        });
+        let htmlField;
+        const wysiwygPromise = makeDeferred();
+        patchWithCleanup(HtmlField.prototype, {
+            async startWysiwyg() {
+                await super.startWysiwyg(...arguments);
+                htmlField = this;
+                wysiwygPromise.resolve();
+            },
+            // To prevent saving when calling onWillUnmount
+            async commitChanges() {},
+        });
+
+        await makeView({
+            type: "form",
+            resId: 1,
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <field name="txt" widget="html"/>
+                </form>`,
+        });
+        await wysiwygPromise;
+        const editor = htmlField.wysiwyg.odooEditor;
+
+        const paragraph = editor.editable.querySelector(".content");
+        setSelection(paragraph, 0, paragraph, 0);
+        await nextTick();
+
+        // Paste image.
+        const img = await pasteImage(editor, "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII");
+        // p.childnodes = [text, img]
+        setSelection(paragraph, 1, paragraph, 2);
+        await nextTick();
+
+        // we need to trigger a mousup event manually so the wysiwyg run `_updateEditorUI`
+        let mouseUpEvent = new MouseEvent("mouseup", {
+            view: window,
+            bubbles: true,
+            cancelable: true,
+        });
+        img.dispatchEvent(mouseUpEvent);
+
+        assert.ok(
+            document.querySelector('div#toolbar[style*="visibility: visible"]'),
+            "Toolbar should be visible"
+        );
+        assert.ok(document.querySelector("div#image-transform"), "Image toolbar is shown");
+
+        setSelection(paragraph, 0, paragraph, 0);
+        await nextTick();
+
+        assert.ok(
+            document.querySelector('div#toolbar[style*="visibility: hidden"]'),
+            "Toolbar should be hidden"
+        );
+
+        img.setAttribute(
+            "style",
+            "transform: rotate(20deg) translateX(-0.5%) translateY(1%); animation-play-state: paused; transition: none;"
+        );
+
+        // setSelection(paragraph, 1, paragraph, 2);
+        // await nextTick();
+        mouseUpEvent = new MouseEvent("mouseup", {
+            view: window,
+            bubbles: true,
+            cancelable: true,
+        });
+        img.dispatchEvent(mouseUpEvent);
+        await nextTick();
+
+        assert.ok(
+            document.querySelector('div#toolbar[style*="visibility: visible"]'),
+            "Toolbar should be visible"
+        );
+        assert.ok(document.querySelector("div#image-transform"), "Image toolbar is shown");
+        document.querySelector("div#image-transform").click();
+        await nextTick();
+        assert.ok(
+            document.querySelector("div.transfo-container"),
+            "Transform div should be visible around the image"
+        );
+        assert.ok(
+            document.querySelector('div#toolbar[style*="visibility: visible"]'),
+            "Toolbar should stay visible"
+        );
+        // click second time
+        // simply using click on the element doesn't trigger the mousedown event
+        const mouseDownEvent = new MouseEvent("mousedown", {
+            bubbles: true,
+            cancelable: true,
+            view: window,
+        });
+        document.querySelector("div#image-transform").dispatchEvent(mouseDownEvent);
+        await nextTick();
+        const isRotated = isElementRotated(img);
+        assert.notOk(isRotated, "The image should not be rotated");
+    });
 });
 
 export const mediaDialogServices = {


### PR DESCRIPTION
Issue:
======
We can't click twice on the transform button.

Steps to reproduce the issue:
=============================
- Create a todo
- Add an image
- Select it
- Click on the transform button in the toolbar
- The toolbar disappears so we can't click another time

Origin of the issue:
====================
The issue was introduced in [1]. Removing the selection will trigger a selectionChange which itself triggers updateToolbar but now we don't have any selection so we hide the toolbar.

Solution:
=========
Revert the old fix and instead we ignore any `keydown` event when the transform container is in the dom (which means we are currently transforming an image).

task-4235140

[1]: https://github.com/odoo/odoo/commit/463c248e291a53c80365ae606c7cf39e13cd290b