### PR TITLE
[FIX] base: assets performance

### DIFF
--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -296,6 +296,9 @@ class AssetsBundle(object):
                FROM ir_attachment
               WHERE create_uid = %s
                 AND url like %s
+                AND res_model = 'ir.ui.view'
+                AND res_id = 0
+                AND public = true
            GROUP BY name
            ORDER BY name
          """, [SUPERUSER_ID, url_pattern])


### PR DESCRIPTION
Versions affected: 15.0, 16.0

In a database with a large ir_attachment table, the performance of the query for gathering asset attachments is poor. We're backporting the query conditions from commit 1b9ac0e100501e09c9e5900f5184db392cf5e0e0, which resulted in a 30x speed improvement on a database with approximately 1M ir_attachment records.

In a real db we went from 150ms per query to 5ms

cc @Tecnativa @carlosdauden TT51109

Before:

![image](https://github.com/user-attachments/assets/8f410cd4-87d6-437f-a03c-2c454a3f68e9)

After:

![image](https://github.com/user-attachments/assets/e009c0f4-02ce-4120-b156-82aa6273903c)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
