### PR TITLE
[FIX] point_of_sale: Correct price in product card with pricelist

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -274,7 +274,8 @@ export class ProductScreen extends Component {
     }
 
     getProductPrice(product) {
-        return this.pos.getProductPriceFormatted(product, product.list_price);
+        const price = product.list_price === product.lst_price ? false : product.list_price;
+        return this.pos.getProductPriceFormatted(product, price);
     }
 
     getProductImage(product) {


### PR DESCRIPTION
Following the commit https://github.com/odoo/odoo/commit/236120ad5de2c87494c662dc3149457d68e887da, which aimed to prevent displaying a variant's price as the product template price to avoid confusion, an issue arose where the pricelist was not considered for products without variants. This commit resolves the issue by ensuring the pricelist is applied correctly, especially when the variant's price matches the product template's price.

opw-4205688

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
