### PR TITLE
[FIX] l10n_br: prevent error when activating Portuguese (BR) language

### DIFF
--- a/addons/l10n_br/i18n/pt.po
+++ b/addons/l10n_br/i18n/pt.po
@@ -337,7 +337,7 @@ msgstr "Alagoa Nova"
 #: model:res.city,name:l10n_br.city_br_406
 #: model:res.city,name:l10n_br.city_br_407
 msgid "Alagoinha"
-msgstr "Alagoin"Alagoinha"
+msgstr "Alagoinha"
 
 #. module: l10n_br
 #: model:res.city,name:l10n_br.city_br_408


### PR DESCRIPTION
When the user tries to activate Portuguese (BR) language,
a traceback will appear.

Traceback:
```
OSError: Syntax error in po file (line 340): unescaped double quote found
  File "odoo/tools/translate.py", line 1757, in _get_code_translations
    p = CodeTranslations._read_code_translations_file(fileobj, filter_func)
  File "odoo/tools/translate.py", line 1744, in _read_code_translations_file
    reader = TranslationFileReader(fileobj, fileformat='po')
  File "odoo/tools/translate.py", line 735, in TranslationFileReader
    return PoFileReader(source)
  File "odoo/tools/translate.py", line 790, in __init__
    self.pofile = polib.pofile(source.read().decode())
  File "polib.py", line 130, in pofile
    return _pofile_or_mofile(pofile, 'pofile', **kwargs)
  File "polib.py", line 78, in _pofile_or_mofile
    instance = parser.parse()
  File "polib.py", line 1348, in parse
    raise IOError('Syntax error in po file %s(line %s): '
```

https://github.com/odoo/odoo/blob/11cbd44ada7526849f884b5b16c52a8965d10708/addons/l10n_br/i18n/pt.po#L340
Here, ``"Alagoin"Alagoinha"`` is used instead of ``"Alagoinha"`` as msgstr.
So, it will lead to the above traceback.

sentry-5963927752

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
