### PR TITLE
[FIX] website: restore table's transparent background

### DIFF
--- a/addons/web/static/src/scss/bootstrap_overridden_frontend.scss
+++ b/addons/web/static/src/scss/bootstrap_overridden_frontend.scss
@@ -57,6 +57,8 @@ $link-decoration: none !default;
 // colors are a color close to the body text color: the text becomes invisible.
 // We disable this behavior by not forcing a text color for tables.
 $table-color: inherit !default;
+// With BS5.3, $table-bg is set $body-bg by default, and we want it transparent.
+$table-bg: transparent !default;
 
 // Forms
 


### PR DESCRIPTION
Since [1] when Bootstrap was upgraded to version 5.3, the `$table-bg` variable is obtained from `$body-bg` instead of being transparent as it was previously. Because of this, when a "Boxed", "Frame" or "Postcard" layout is used, and a background color is specified, that color is used as table background, even if they are nested within cards that have a white background.

This commit restores the transparent table background.

Steps to reproduce:
- Install eCommerce
- Set a "Postcard" layout
- Specify a non-white background color
- Add a product to the card
- Proceed to the checkout page

=> The total area used the body background instead of the card background.

[1]: https://github.com/odoo/odoo/commit/058212e12b5079eba870bde9775fe98f27928935#diff-b037a8f5f304da130ba183549bf6abf5126d1bc118033211aa865ae74d3bca51R739

opw-4203976
