### PR TITLE
[ADD] product_warranty: add module for warranty

### DIFF
--- a/addons/product_warranty/__init__.py
+++ b/addons/product_warranty/__init__.py
@@ -1,0 +1,15 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models
+from . import report
+
+from odoo import Command
+
+
+def _enable_tracking_lots(env):
+    """ This hook ensures the tracking numbers are enabled when the module is installed since the
+    user can install `product_warranty` manually without enable `group_production_lot`.
+    """
+    group_production_lot = env.ref('stock.group_production_lot')
+    groups = env.ref('base.group_user') + env.ref('base.group_portal')
+    groups.write({'implied_ids': [Command.link(group_production_lot.id)]})

--- a/addons/product_warranty/__manifest__.py
+++ b/addons/product_warranty/__manifest__.py
@@ -1,0 +1,23 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'Lots/Serial Warranty Periods',
+    'category': 'Inventory/Inventory',
+    'depends': ['stock'],
+    'description': """
+Manage Warranty periods for Lots & Serial Numbers.
+======================================================
+
+Administrate Warranty periods in Inventory;
+Define warranty period for each product variant;
+Track warranty end date on Lot/Serial view per customer.
+""",
+    'data': [
+        'security/ir.model.access.csv',
+        'views/product_template_views.xml',
+        'views/product_warranty_views.xml',
+        'report/stock_lot_customer.xml',
+        'data/product_warranty_data.xml',
+    ],
+    'post_init_hook': '_enable_tracking_lots',
+    'license': 'LGPL-3',
+}

--- a/addons/product_warranty/data/product_warranty_data.xml
+++ b/addons/product_warranty/data/product_warranty_data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <record id="product_warranty_2year" model="product.warranty">
+        <field name="name">2-Year Warranty</field>
+        <field name="duration">2</field>
+        <field name="duration_unit">year</field>
+    </record>
+    <record id="product_warranty_6month" model="product.warranty">
+        <field name="name">6-Month Warranty</field>
+        <field name="duration">6</field>
+        <field name="duration_unit">month</field>
+    </record>
+</odoo>

--- a/addons/product_warranty/models/__init__.py
+++ b/addons/product_warranty/models/__init__.py
@@ -1,0 +1,6 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import product_template
+from . import product_warranty
+from . import res_config_settings
+from . import stock_lot

--- a/addons/product_warranty/models/product_template.py
+++ b/addons/product_warranty/models/product_template.py
@@ -1,0 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    default_warranty_id = fields.Many2one('product.warranty',
+        help="Warranty status based on delivery date can be tracked from the partner")

--- a/addons/product_warranty/models/product_warranty.py
+++ b/addons/product_warranty/models/product_warranty.py
@@ -1,0 +1,23 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class ProductWarranty(models.Model):
+    _name = "product.warranty"
+    _description = "Warranty"
+    _order = "sequence, id"
+
+    sequence = fields.Integer(default=10)
+    name = fields.Char(required=True)
+    active = fields.Boolean(default=True)
+    duration = fields.Integer(default=1)
+    duration_unit = fields.Selection(
+        [('month', "Months"), ('year', "Years")],
+        default='month',
+        string="Unit")
+
+    _sql_constraints = [
+        ('name_uniq', 'unique(name)', 'The warranty name must be unique.'),
+        ('name_uniq', 'CHECK(duration_unit IS NOT NULL)', 'The duration unit should be set'),
+    ]

--- a/addons/product_warranty/models/res_config_settings.py
+++ b/addons/product_warranty/models/res_config_settings.py
@@ -1,0 +1,13 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    @api.onchange('group_stock_production_lot')
+    def _onchange_group_stock_production_lot(self):
+        super()._onchange_group_stock_production_lot()
+        if self.group_stock_production_lot:
+            self.module_product_warranty = True

--- a/addons/product_warranty/models/stock_lot.py
+++ b/addons/product_warranty/models/stock_lot.py
@@ -1,0 +1,26 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+from odoo.tools import get_timedelta
+
+
+class StockLot(models.Model):
+    _inherit = 'stock.lot'
+
+    warranty_end_date = fields.Date(
+        compute='_compute_warranty_end_date', store=True, readonly=False,
+        help="This is the end date of the warranty for this tracked product.")
+    warranty_id = fields.Many2one('product.warranty', compute='_compute_warranty_id', store=True, readonly=False)
+
+    @api.depends('location_id')
+    def _compute_warranty_end_date(self):
+        to_compute = self.filtered(lambda lot: not lot.warranty_end_date and lot.warranty_id)
+        delivery_ids_by_lot = to_compute._find_delivery_ids_by_lot()
+        for lot in to_compute:
+            if len(delivery_ids_by_lot[lot.id]) > 0:
+                last_delivery = self.env['stock.picking'].browse(delivery_ids_by_lot[lot.id]).sorted(key='date_done', reverse=True)[0]
+                lot.warranty_end_date = last_delivery.date_done + get_timedelta(lot.warranty_id.duration, lot.warranty_id.duration_unit)
+
+    def _compute_warranty_id(self):
+        for lot in self:
+            lot.warranty_id = lot.product_id.default_warranty_id

--- a/addons/product_warranty/report/__init__.py
+++ b/addons/product_warranty/report/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import stock_lot_customer

--- a/addons/product_warranty/report/stock_lot_customer.py
+++ b/addons/product_warranty/report/stock_lot_customer.py
@@ -1,0 +1,23 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class StockLotReport(models.Model):
+    _inherit = "stock.lot.report"
+
+    warranty_end_date = fields.Date(readonly=True)
+
+    def _select(self):
+        select_str = super()._select()
+        return f"""
+            {select_str},
+            lot.warranty_end_date
+        """
+
+    def _group_by(self):
+        group_by_str = super()._group_by()
+        return f"""
+            {group_by_str},
+            lot.warranty_end_date
+        """

--- a/addons/product_warranty/report/stock_lot_customer.xml
+++ b/addons/product_warranty/report/stock_lot_customer.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="warranty_stock_lot_customer_report_view_list" model="ir.ui.view">
+        <field name="name">stock.lot.report.view.list.inherit</field>
+        <field name="model">stock.lot.report</field>
+        <field name="inherit_id" ref="stock.stock_lot_customer_report_view_list"/>
+        <field name="arch" type="xml">
+            <field name="delivery_date" position="after">
+                <field name="warranty_end_date"/>
+            </field>
+            <field name="address" position="attributes">
+                <attribute name="optional">hide</attribute>
+            </field>
+        </field>
+    </record>
+    <record id="search_customer_lot_filter" model="ir.ui.view">
+        <field name="name">Customer Lots Filter</field>
+        <field name="model">stock.lot.report</field>
+        <field name="inherit_id" ref="stock.search_customer_lot_filter"/>
+        <field name="arch" type="xml">
+            <filter name="delivery_date" position="before">
+                <filter string="Under Warranty" name="under_warranty"
+                    domain="[('warranty_end_date', '&gt;=', datetime.datetime.combine(context_today(), datetime.time(0,0,0)))]"/>
+                <filter string="Warranty Date" name="warranty_end_date" date="warranty_end_date"/>
+            </filter>
+            <filter name="group_by_delivery_date" position="after">
+                <filter name="group_by_warranty_end_date" string="Warranty date" domain="[]" context="{'group_by': 'warranty_end_date'}"/>
+            </filter>
+        </field>
+    </record>
+</odoo>

--- a/addons/product_warranty/security/ir.model.access.csv
+++ b/addons/product_warranty/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+"access_product_warranty_user","access.product.warranty.user","model_product_warranty","stock.group_stock_user",1,1,1,0
+"access_product_warranty_manager","access.product.warranty.manager","model_product_warranty","stock.group_stock_manager",1,1,1,1

--- a/addons/product_warranty/views/product_template_views.xml
+++ b/addons/product_warranty/views/product_template_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<odoo>
+    <record id="view_product_form_warranty" model="ir.ui.view">
+        <field name="name">product.template.inherit.form</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="stock.view_template_property_form" />
+        <field name="arch" type="xml">
+            <group name="traceability" position="after">
+                <group name="warranty" string="Warranty" invisible="tracking == 'none'">
+                    <field name="default_warranty_id"/>
+                </group>
+            </group>
+        </field>
+    </record>
+</odoo>

--- a/addons/product_warranty/views/product_warranty_views.xml
+++ b/addons/product_warranty/views/product_warranty_views.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="product_warranty_view_list" model="ir.ui.view">
+        <field name="name">product.warranty.view.list</field>
+        <field name="model">product.warranty</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="sequence" widget="handle"/>
+                <field name="name"/>
+                <field name="duration"/>
+                <field name="duration_unit"/>
+            </list>
+        </field>
+    </record>
+    <record id="product_warranty_view_form" model="ir.ui.view">
+        <field name="name">product.warranty.view.form</field>
+        <field name="model">product.warranty</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <div class="oe_title">
+                        <label for="name"/>
+                        <h1>
+                            <field name="name" placeholder="e.g. 1-Year Warranty"/>
+                        </h1>
+                    </div>
+                    <group>
+                        <field name="duration"/>
+                        <field name="duration_unit"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+    <record id="product_warranty_action_list" model="ir.actions.act_window">
+        <field name="name">Warranties</field>
+        <field name="res_model">product.warranty</field>
+        <field name="view_id" ref="product_warranty_view_list"/>
+    </record>
+
+    <menuitem
+        action="product_warranty_action_list" id="menu_warranty_action"
+        parent="stock.menu_product_in_config_stock" sequence="8"/>
+</odoo>

--- a/addons/stock/models/res_config_settings.py
+++ b/addons/stock/models/res_config_settings.py
@@ -52,6 +52,7 @@ class ResConfigSettings(models.TransientModel):
         "Separator", config_parameter='stock.barcode_separator',
         help="Character(s) used to separate data contained within an aggregate barcode (i.e. a barcode containing multiple barcode encodings)")
     module_stock_fleet = fields.Boolean("Dispatch Management System")
+    module_product_warranty = fields.Boolean("Warranty")
 
     @api.onchange('group_stock_multi_locations')
     def _onchange_group_stock_multi_locations(self):

--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -155,6 +155,9 @@
                             <setting help="Lots &amp; Serial numbers will appear on the delivery slip" invisible="not group_stock_production_lot" id="group_lot_on_delivery_slip">
                                 <field name="group_lot_on_delivery_slip"/>
                             </setting>
+                            <setting id="product_warranty" help="Warranty dates will appear on products and lots" invisible="not group_stock_production_lot">
+                                <field name="module_product_warranty"/>
+                            </setting>
                             <setting id="owner_stored_products" help="Set owner on stored products" documentation="/applications/inventory_and_mrp/inventory/management/misc/owned_stock.html">
                                 <field name="group_stock_tracking_owner"/>
                             </setting>


### PR DESCRIPTION
In Odoo, there is not enough to help users managing the warranties, maintenance and tracked serial numbers. 
This commit adds a new product warranty module to track the warranty of delivered lots.

This will centralize the link with Tasks and serial numbers for history overview by adding a specific view on the customer.

task-4100027
