### PR TITLE
[FIX] hr: don't create work contact if no employee

### DIFF
--- a/addons/hr/models/hr_employee_base.py
+++ b/addons/hr/models/hr_employee_base.py
@@ -204,6 +204,8 @@ class HrEmployeeBase(models.AbstractModel):
                 employee.work_email = employee.work_contact_id.email
 
     def _create_work_contacts(self):
+        if not self:
+            return
         if any(employee.work_contact_id for employee in self):
             raise UserError(_('Some employee already have a work contact'))
         work_contacts = self.env['res.partner'].create([{


### PR DESCRIPTION
Method `_create_work_contacts` is called on employees having no work contact. However, it still creates contacts when no employee meets this condition.

This commit ensures at least one employee meets the condition before creating any new contact.

See a547162e2ec1400d508acb072729f61eee1188f3

TaskID: [4241255](https://www.odoo.com/odoo/project.task/4241255)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
