### PR TITLE
[FIX] base_import: active_model as query parameter

### DIFF
--- a/addons/base_import/static/src/import_action/import_action.js
+++ b/addons/base_import/static/src/import_action/import_action.js
@@ -28,7 +28,11 @@ export class ImportAction extends Component {
         this.notification = useService("notification");
         this.orm = useService("orm");
         this.env.config.setDisplayName(this.props.action.name || _t("Import a File"));
-        this.resModel = this.props.action.params.model;
+        // this.props.action.params.model is there for retro-compatiblity issues
+        this.resModel = this.props.action.params.model || this.props.action.params.active_model;
+        if (this.resModel) {
+            this.props.updateActionState({ active_model: this.resModel });
+        }
         this.model = useImportModel({
             env: this.env,
             resModel: this.resModel,

--- a/addons/base_import/static/src/import_records/import_records.js
+++ b/addons/base_import/static/src/import_records/import_records.js
@@ -33,7 +33,7 @@ export class ImportRecords extends Component {
         this.action.doAction({
             type: "ir.actions.client",
             tag: "import",
-            params: { model: resModel, context },
+            params: { active_model: resModel, context },
         });
     }
 }

--- a/addons/mass_mailing/wizard/mailing_contact_import.py
+++ b/addons/mass_mailing/wizard/mailing_contact_import.py
@@ -123,6 +123,6 @@ class MailingContactImport(models.TransientModel):
             'name': _('Import Mailing Contacts'),
             'params': {
                 'context': self.env.context,
-                'model': 'mailing.contact',
+                'active_model': 'mailing.contact',
             }
         }


### PR DESCRIPTION
- In any APP (We would use CRM for the example);
- On a multi-record view (Kanban, List, or other);
- Click the action menu;
- Click on “Import records” dropdown;
- Reload the view (either reload the browser, or activate the debug, or change to dark mode on the user menu).

Before this commit, an exception was raised, and the default multi-record view was loaded. This occurs because, the client action base import required a model (found in the context) that was lost when reloading.

Now, the model is put in the query string of the URL (as active_model), in that way, when reloading, the client action base import will have the needed model. Note that, this is also the behavior of the stock TraceabilityReport client action [1].

opw-3959254

[1] : https://github.com/odoo/odoo/commit/8b3deab679bfee844ccd84c7f4f6f831921365d3
