### PR TITLE
[FIX] hw_drivers: fix browser refresh

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
@@ -45,6 +45,7 @@ class DisplayDriver(Driver):
         if self.device_identifier != 'distant_display':
             # helpers.get_version returns a string formatted as: <L|W><version> (L: Linux, W: Windows)
             self.browser = 'chromium-browser' if float(helpers.get_version()[1:]) >= 24.08 else 'firefox'
+            self.browser_process_name = 'chromium' if self.browser == 'chromium-browser' else self.browser
             self._x_screen = device.get('x_screen', '0')
             self.load_url()
 
@@ -120,7 +121,7 @@ class DisplayDriver(Driver):
                 '--screen',
                 self._x_screen,
                 '--class',
-                self.browser,
+                self.browser_process_name,
                 'key',
                 keystroke,
             ], check=False)


### PR DESCRIPTION
The DisplayDriver class uses the `xdotool`
command to send keypresses to the browser.
However for Chromium, it is using the wrong
process name causing the keystrokes not to
be received.

The symptom of this is the Pairing Code does
not disappear after 5 minutes as intended,
leaving an invalid code on the screen.

This PR fixes the issue by using the correct
process name for Chromium.

Related PR for 18.0+: https://github.com/odoo/odoo/pull/180286
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
