### PR TITLE
[FIX] web: pivot: close header dropdowns on selection

### DIFF
--- a/addons/web/static/src/views/pivot/pivot_header.xml
+++ b/addons/web/static/src/views/pivot/pivot_header.xml
@@ -49,7 +49,6 @@
                                     </t>
                                     <CheckboxItem class="{ o_item_option: true, selected: option.isActive }"
                                         checked="option.isActive ? true : false"
-                                        closingMode="'none'"
                                         t-esc="option.description"
                                         onSelected="() => this.onGroupBySelected({ itemId: item.id, optionId: option.id})"
                                     />
@@ -61,7 +60,6 @@
                     <t t-else="">
                         <CheckboxItem class="{ o_menu_item: true, selected: item.isActive }"
                             checked="item.isActive"
-                            closingMode="'none'"
                             t-esc="item.description"
                             onSelected="() => this.onGroupBySelected({ itemId: item.id })"
                         />

--- a/addons/web/static/tests/legacy/views/pivot_view_tests.js
+++ b/addons/web/static/tests/legacy/views/pivot_view_tests.js
@@ -5805,4 +5805,51 @@ QUnit.module("Views", (hooks) => {
         });
         assert.verifySteps([`[]`, `["date:month"]`]);
     });
+
+    QUnit.test("Close header dropdown when a simple groupby is selected", async function (assert) {
+        const pivot = await makeView({
+            type: "pivot",
+            resModel: "partner",
+            serverData,
+            arch: `<pivot/>`,
+        });
+        assert.containsNone(target, ".o-overlay-container .dropdown-menu");
+        assert.deepEqual(pivot.model.getTable().headers[1].map((h) => h.title), ["Count"]);
+
+        await click(target.querySelector("thead .o_pivot_header_cell_closed"));
+        assert.containsOnce(target, ".o-overlay-container .dropdown-menu");
+
+        await click(target.querySelector(".o-overlay-container .o-dropdown--menu .dropdown-item"));
+        assert.containsNone(target, ".o-overlay-container .dropdown-menu");
+        assert.deepEqual(
+            pivot.model.getTable().headers[1].map((h) => h.title),
+            ["Company", "individual"]
+        );
+    });
+
+    QUnit.test("Close header dropdown when a simple date groupby option is selected", async function (assert) {
+        const pivot = await makeView({
+            type: "pivot",
+            resModel: "partner",
+            serverData,
+            arch: `<pivot/>`,
+        });
+        assert.containsNone(target, ".o-overlay-container .dropdown-menu");
+        assert.deepEqual(pivot.model.getTable().headers[1].map((h) => h.title), ["Count"]);
+
+        await click(target.querySelector("thead .o_pivot_header_cell_closed"));
+        assert.containsOnce(target, ".o-overlay-container .dropdown-menu");
+
+        // open the Date sub dropdown
+        await mouseEnter(target, ".o-dropdown--menu .dropdown-toggle.o_menu_item");
+        await nextTick();
+
+        const subDropdownMenu = getDropdownMenu(
+            target,
+            ".o-dropdown--menu .dropdown-toggle.o_menu_item"
+        );
+        await click(subDropdownMenu.querySelector(".dropdown-item"));
+        assert.containsNone(target, ".o-overlay-container .dropdown-menu");
+        assert.deepEqual(pivot.model.getTable().headers[1].map((h) => h.title), ["2016"]);
+    });
 });


### PR DESCRIPTION
Before https://github.com/odoo/odoo/pull/137691, select a groupby in the
dropdown of a pivot header would close the dropdown. Now the dropdown
stays open and it is possible to add several row/col groupbys at the same time
but the pivot model is not updated correctly because the update of the model is
based on the groupId of the header for which the dropdown was opened.
The simpler/best solution to that problem is to restore the previous behavior.

Task ID: 3985217