### PR TITLE
[FIX] product: force deepcopy of domain when searching in product.product

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -3,6 +3,7 @@
 import itertools
 import logging
 from collections import defaultdict
+import copy
 
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import UserError, ValidationError
@@ -538,7 +539,7 @@ class ProductTemplate(models.Model):
         Product = self.env['product.product']
         templates = self.browse()
 
-        product_domain = domain.copy()
+        product_domain = copy.deepcopy(domain)
         if search_pp:
             for term in product_domain:  # Replace id related leaf to product_tmpl_id
                 if term[0] == 'id':


### PR DESCRIPTION
### Context :
The changes introduced in https://github.com/odoo/odoo/pull/111575 seems to not have accounted for two things:

1) Running `.copy()` on the domain list object will create a shallow copy of the object. Thus, the sub-lists in the domain list are still assigned by reference. This means that when `id` gets replaced by `product_tmpl_id` (https://github.com/odoo/odoo/blob/ffcff5a784f40522ef9e3051ca3605465b99c718/addons/product/models/product_template.py#L543-L546), it actually also mutates the original `domain` variable.

2) Downstream when the conditional logic from https://github.com/odoo/odoo/pull/143543/files, i.e.  
https://github.com/odoo/odoo/blob/ffcff5a784f40522ef9e3051ca3605465b99c718/addons/product/models/product_template.py#L579C1-L580C93
gets triggered, it will create an invalid domain for the `product.template` model, because it tries to search based on `product_tmp_id` instead of `id`.

In practice, when a DB is in a state that triggers the conditional logic, the user will face a non-descript traceback about an unresolved promise when trying to search for alternative products in the  product From view (“Sales” tab).
Checking the back-end, we will actually find a traceback similar to:
```
Invalid field product.template.product_tmpl_id in leaf ('product_tmpl_id', '!=', 215)
```

### Proposed solution:
Since the original intent seems to be to create a deep copy of the original domain, as to not mutate it, we explicitly import the `copy` library and run the `deepcopy` method to achieve the original intent.

OPW-4232858

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
