### PR TITLE
[FIX] spreadsheet,tools: don't translate pivot titles

### DIFF
--- a/addons/spreadsheet/static/src/list/plugins/list_core_plugin.js
+++ b/addons/spreadsheet/static/src/list/plugins/list_core_plugin.js
@@ -182,7 +182,7 @@ export class ListCorePlugin extends OdooCorePlugin {
      * @returns {string}
      */
     getListName(id) {
-        return _t(this.lists[id].definition.name);
+        return this.lists[id].definition.name;
     }
 
     /**

--- a/odoo/addons/test_translation_import/i18n/test_translation_import.pot
+++ b/odoo/addons/test_translation_import/i18n/test_translation_import.pot
@@ -142,18 +142,6 @@ msgstr ""
 #. module: test_translation_import
 #. odoo-javascript
 #: code:addons/test_translation_import/data/files/test_spreadsheet_dashboard.json:0
-msgid "Pipeline"
-msgstr ""
-
-#. module: test_translation_import
-#. odoo-javascript
-#: code:addons/test_translation_import/data/files/test_spreadsheet_dashboard.json:0
-msgid "Pipeline Analysis"
-msgstr ""
-
-#. module: test_translation_import
-#. odoo-javascript
-#: code:addons/test_translation_import/data/files/test_spreadsheet_dashboard.json:0
 msgid "Scorecard chart"
 msgstr ""
 

--- a/odoo/addons/test_translation_import/tests/test_term_count.py
+++ b/odoo/addons/test_translation_import/tests/test_term_count.py
@@ -397,8 +397,6 @@ class TestTranslationFlow(common.TransactionCase):
             'Scorecard description',
             'Scorecard chart',
             'Opportunities',
-            'Pipeline',
-            'Pipeline Analysis',
             'link label',
             'aa (\\"inside\\") bb',
             'with spaces',

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -1114,11 +1114,6 @@ def extract_spreadsheet_terms(fileobj, keywords, comment_tags, options):
                         terms.append(axes.get('title', {}).get('text', ''))
                 if 'baselineDescr' in figure['data']:
                     terms.append(figure['data']['baselineDescr'])
-    pivots = data.get('pivots', {}).values()
-    lists = data.get('lists', {}).values()
-    for data_source in itertools.chain(lists, pivots):
-        if 'name' in data_source:
-            terms.append(data_source['name'])
     for global_filter in data.get('globalFilters', []):
         terms.append(global_filter['label'])
     return (


### PR DESCRIPTION
In standards dashboards, pivot titles are currently extracted from the json files to be translated. But those titles are not visible in dashboard mode (only in edit mode, in the side panels and menus). The cost of translating those titles is not worth it.

.pot files will be re-exported later, when TIC is back. She already warned
the translators to skip those translation anyway.

Task 4239967


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
