### PR TITLE
[FIX] mail: Correct bg-color on Discuss sidebar item

### DIFF
--- a/addons/mail/static/src/core/public_web/discuss_sidebar.scss
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.scss
@@ -27,7 +27,7 @@
     outline: 1px solid transparent !important;
 
     &.o-active, &:hover {
-        background-color: var(--mail-DiscussSidebar-itemActiveBgColor, mix($o-view-background-color, $o-action, 90%));
+        background-color: var(--mail-DiscussSidebar-itemActiveBgColor, mix($o-view-background-color, $o-action, 90%)) !important;
         outline-color: var(--mail-DiscussSidebar-itemActiveOutlineColor, rgba($o-action, .25)) !important;
     }
 }


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/182394

PR above fixed an issue where mouse-hovering IM status lead to buggy background color. This happens because the IM status requires `bg-inherit` in order to determine the right background color to crop the avatar. Buttons have specific bg-color that cannot simply be overidden with `bg-inherit`, so this was defined in SCSS with higher specificity.

A consequence of increasing the specificity of this rule was that it became more specific than the one for active item, so the active item in discuss sidebar had no background color but only the outline.

This commit fixes the issue by increasing the stylerule specificity of active item background color, so that this is higher than the `bg-inherit`. The specific bg-inherit is still important to fix the issue in PR above.

Before / After
![Screenshot 2024-10-08 at 12 53 44](https://github.com/user-attachments/assets/0e6a43cd-2029-4c2a-a2e2-e50a53a44bcf) ![Screenshot 2024-10-08 at 12 53 25](https://github.com/user-attachments/assets/0e93d8a1-492c-42f4-9454-f30e1906cfdc)

