### PR TITLE
[FIX] base: don't use python's default ssl context

### DIFF
--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -329,6 +329,12 @@ class IrMailServer(models.Model):
                  _("Please define at least one SMTP server, "
                    "or provide the SMTP parameters explicitly.")))
 
+        if ssl_context is None:
+            ssl_context = ssl.create_default_context()
+            # default behavior of python until 3.13, scary
+            ssl_context.check_hostname = False
+            ssl_context.verify_mode = ssl.CERT_NONE
+
         if smtp_encryption == 'ssl':
             if 'SMTP_SSL' not in smtplib.__all__:
                 raise UserError(


### PR DESCRIPTION
The `SMTP` and `SMTP_SSL` classes create their own `ssl_context` on-the-fly when none is given. That default `ssl_context` doesn't verify nor the server's certificate nor the hostname. That behavior changed with py3.13 where the `ssl_context` created on-the-fly *does* verify the server's certificate and hostname.

Too many customers are using their own (broken) postfix servers and it just works because Odoo doesn't validate their (broken) certificate. It would be too disruptive if over night their emails are not delivered anymore.

Make it explicits that the `ssl_context` is unsafe until we find a better solution.

Task-2861790