### PR TITLE
[PERF] base_vat: avoid vies check on child partner with same vat

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -202,6 +202,9 @@ class ResPartner(models.Model):
             if not partner.vies_vat_to_check:
                 partner.vies_valid = False
                 continue
+            if partner.parent_id and partner.parent_id.vies_vat_to_check == partner.vies_vat_to_check:
+                partner.vies_valid = partner.parent_id.vies_valid
+                continue
             try:
                 _logger.info('Calling VIES service to check VAT for validation: %s', partner.vies_vat_to_check)
                 vies_valid = check_vies(partner.vies_vat_to_check, timeout=10)


### PR DESCRIPTION
Follow up of https://github.com/odoo/odoo/pull/178219

The vies check service may limit ip addresses when:
- checking too many vat numbers per day
- checking the same vat number multiple times
- checking too many invalid number

This is to avoid the second case
