### PR TITLE
[FIX] website: fix s_map in sanitized field

### DIFF
--- a/addons/website/static/src/snippets/s_map/000.js
+++ b/addons/website/static/src/snippets/s_map/000.js
@@ -19,8 +19,8 @@ publicWidget.registry.Map = publicWidget.Widget.extend(ObservingCookieWidgetMixi
             const dataset = this.el.dataset;
             if (dataset.mapAddress) {
                 const iframeEl = generateGMapIframe();
-                this._manageIframeSrc(this.el, generateGMapLink(dataset));
                 this.el.querySelector('.s_map_color_filter').before(iframeEl);
+                this._manageIframeSrc(this.el, generateGMapLink(dataset));
             }
         }
         return this._super(...arguments);


### PR DESCRIPTION
Since [1] when miscellaneous trackers were disabled until cookies are accepted, `s_map` generates its URL if the `iframe` is not inside the document. Unfortunately, it does it before adding the `iframe` to the element and this results in an error.

This commit reorders the operations so that the `iframe` source is set only once the element has an `iframe`.

Steps to reproduce:
- Edit an event
- Make sure to disable the event's sub-menu
- Drop an `s_map` into the event's `description` field
- Save

=> The `s_map` snippet failed upon `start`.

[1]: https://github.com/odoo/odoo/commit/958b41c4acec7e1700ca4d6e0b25ee0ad2aac9f1#diff-21d1f66e41f1c6b04a9c11edf6d4ff7d9773b0bf0b4f77c8cecea173f0c0db19R22

opw-4171564
