### PR TITLE
[FIX] ir_ui_view: fix empty view arch

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -892,7 +892,7 @@ actual arch.
         queue = collections.deque(sorted(hierarchy[self], key=lambda v: v.mode))
         while queue:
             view = queue.popleft()
-            arch = etree.fromstring(view.arch)
+            arch = etree.fromstring(view.arch or '<data/>')
             if view.env.context.get('inherit_branding'):
                 view.inherit_branding(arch)
             self._add_validation_flag(combined_arch, view, arch)


### PR DESCRIPTION
the arch is not mandatory in the view, but in the
_combine method we are assuming that there is at
least a node in the arch.

This commit fix the issue by adding a data node if the arch is empty to ensure the ability to combine the archs.

task-4241455
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr