### PR TITLE
[FIX] hw_drivers: remove usages of `_` translation helper

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/KeyboardUSBDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/KeyboardUSBDriver_L.py
@@ -16,7 +16,7 @@ import time
 import urllib3
 from usb import util
 
-from odoo import http, _
+from odoo import http
 from odoo.addons.hw_drivers.controllers.proxy import proxy_drivers
 from odoo.addons.hw_drivers.driver import Driver
 from odoo.addons.hw_drivers.event_manager import event_manager
@@ -122,7 +122,7 @@ class KeyboardUSBDriver(Driver):
             return re.sub(r"[^\w \-+/*&]", '', "%s - %s" % (manufacturer, product))
         except ValueError as e:
             _logger.warning(e)
-            return _('Unknown input device')
+            return 'Unknown input device'
 
     def run(self):
         try:

--- a/addons/hw_drivers/iot_handlers/drivers/SerialBaseDriver.py
+++ b/addons/hw_drivers/iot_handlers/drivers/SerialBaseDriver.py
@@ -9,7 +9,6 @@ from threading import Lock
 import time
 import traceback
 
-from odoo import _
 from odoo.addons.hw_drivers.event_manager import event_manager
 from odoo.addons.hw_drivers.driver import Driver
 
@@ -108,7 +107,7 @@ class SerialDriver(Driver):
                 self._actions[data['action']](data)
                 time.sleep(self._protocol.commandDelay)
         except Exception:
-            msg = _('An error occurred while performing action %s on %s', data, self.device_name)
+            msg = 'An error occurred while performing action %s on %s' % (data, self.device_name)
             _logger.exception(msg)
             self._status = {'status': self.STATUS_ERROR, 'message_title': msg, 'message_body': traceback.format_exc()}
             self._push_status()
@@ -141,7 +140,7 @@ class SerialDriver(Driver):
                 self._status['status'] = self.STATUS_DISCONNECTED
                 self._push_status()
         except Exception:
-            msg = _('Error while reading %s', self.device_name)
+            msg = 'Error while reading %s' % self.device_name
             _logger.exception(msg)
             self._status = {'status': self.STATUS_ERROR, 'message_title': msg, 'message_body': traceback.format_exc()}
             self._push_status()

--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -24,7 +24,7 @@ from threading import Thread, Lock
 import time
 import zipfile
 
-from odoo import _, http, release, service
+from odoo import http, release, service
 from odoo.tools.func import lazy_property
 from odoo.tools.misc import file_path
 
@@ -122,11 +122,11 @@ def check_certificate():
         if key[0] == b'CN':
             cn = key[1].decode('utf-8')
     if cn == 'OdooTempIoTBoxCertificate' or datetime.datetime.now() > cert_end_date:
-        message = _('Your certificate %s must be updated', cn)
+        message = 'Your certificate %s must be updated' % cn
         _logger.info(message)
         return {"status": CertificateStatus.NEED_REFRESH}
     else:
-        message = _('Your certificate %s is valid until %s', cn, cert_end_date)
+        message = 'Your certificate %s is valid until %s' % (cn, cert_end_date)
         _logger.info(message)
         return {"status": CertificateStatus.OK, "message": message}
 


### PR DESCRIPTION
On the IoT box, translations are not supported as
there is no language context and no po/pot files.
However, there were still some usages of the `_`
function which will now log a warning in version
18.0+.

In this PR we simply remove the usages of `_`, as
it was not translating anyway and removes the
warnings.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
