### PR TITLE
[FIX] web_editor: fix popup with invisible elements

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -730,15 +730,18 @@ var SnippetEditor = Widget.extend({
         this.selectorLockWithin = new Set();
         const selectorExcludeAncestor = new Set();
 
-        var $element = this.$target.parent();
-        while ($element.length) {
-            var parentEditor = $element.data('snippet-editor');
-            if (parentEditor) {
-                this._customize$Elements = this._customize$Elements
-                    .concat(parentEditor._customize$Elements);
-                break;
+        if (this.options.allowParentsEditors) {
+            // TODO Should not rely on .data('snippet-editor') but ask parents
+            var $element = this.$target.parent();
+            while ($element.length) {
+                var parentEditor = $element.data('snippet-editor');
+                if (parentEditor) {
+                    this._customize$Elements = this._customize$Elements
+                        .concat(parentEditor._customize$Elements);
+                    break;
+                }
+                $element = $element.parent();
             }
-            $element = $element.parent();
         }
 
         var $optionsSection = $(renderToElement('web_editor.customize_block_options_section', {
@@ -3282,7 +3285,8 @@ class SnippetsMenu extends Component {
         }
 
         var def;
-        if (this._allowParentsEditors($snippet)) {
+        const allowParentsEditors = this._allowParentsEditors($snippet);
+        if (allowParentsEditors) {
             var $parent = globalSelector.closest($snippet.parent());
             if ($parent.length) {
                 def = this._createSnippetEditor($parent);
@@ -3300,7 +3304,13 @@ class SnippetsMenu extends Component {
             }
 
             let editableArea = self.getEditableArea();
-            snippetEditor = new SnippetEditor(parentEditor || self, $snippet, self.templateOptions, $snippet.closest('[data-oe-type="html"], .oe_structure').add(editableArea), self.options);
+            snippetEditor = new SnippetEditor(
+                parentEditor || self,
+                $snippet,
+                self.templateOptions,
+                $snippet.closest('[data-oe-type="html"], .oe_structure').add(editableArea),
+                Object.assign({}, self.options, {allowParentsEditors: allowParentsEditors})
+            );
             self.snippetEditors.push(snippetEditor);
             // Keep parent below its child inside the DOM as its `o_handle`
             // needs to be (visually) on top of the child ones.


### PR DESCRIPTION
Steps to reproduce the bug:

- In Website edit mode.
- Drag and drop a "Popup" into the page.
- Drag and drop a "Text" block into the page (note that the "Text" block must be dropped after the "Popup" for the bug to occur).
- Enable the "Hide on desktop" option for the "Text" block.
- There are now 2 elements in the "Invisible Elements" list of the snippet menu. They should be ordered as follows: "Popup" and below "Text".
- Save the page.
- Enter edit mode.
- Click on "Popup" in the "Invisible Elements" list of the snippet menu.
- Bug: a traceback occurs.

When we add options for a snippet, we also add the options of its parent snippets. But for "Popup" snippets, since commit [2], we don’t want to add their parent options. So, we don’t create an editor for the parents of a "Popup."

However, when adding the "Popup" options to the snippet menu, we still check if an editor exists for its parents to decide whether to add parent options. The problem is that an editor for one of the parents might have started being created for another snippet that shares the same parent, but the creation is not finished yet, which causes the bug.

To fix this, this commit stops adding parent options for snippets that shouldn’t have a parent editor (as required by commit [2]).

Note that commit [2] was introduced in version 15, but the bug only appears in version 17.4, following commit [1], which converted the snippet menu to OWL.

[1]: https://github.com/odoo/odoo/commit/91293fe4a8125f65cd7e5f487aacbc62c35c0f74
[2]: https://github.com/odoo/odoo/commit/1acc2420d839b443d31ba63b546bcce9ea5dc237

opw-4217635
opw-4217256
opw-4190303
opw-4151866
opw-4221894
opw-4206875
opw-4127338