### PR TITLE
[IMP] sale: don't group SO with different delivery addresses

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1406,7 +1406,7 @@ class SaleOrder(models.Model):
         return action
 
     def _get_invoice_grouping_keys(self):
-        return ['company_id', 'partner_id', 'currency_id']
+        return ['company_id', 'partner_id', 'partner_shipping_id', 'currency_id']
 
     def _nothing_to_invoice_error_message(self):
         return _(
@@ -1513,7 +1513,7 @@ class SaleOrder(models.Model):
         if not invoice_vals_list and self._context.get('raise_if_nothing_to_invoice', True):
             raise UserError(self._nothing_to_invoice_error_message())
 
-        # 2) Manage 'grouped' parameter: group by (partner_id, currency_id).
+        # 2) Manage 'grouped' parameter: group by (partner_id, partner_shipping_id, currency_id).
         if not grouped:
             new_invoice_vals_list = []
             invoice_grouping_keys = self._get_invoice_grouping_keys()

--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -54,7 +54,8 @@ class SaleAdvancePaymentInv(models.TransientModel):
     display_draft_invoice_warning = fields.Boolean(compute="_compute_display_draft_invoice_warning")
     consolidated_billing = fields.Boolean(
         string="Consolidated Billing", default=True,
-        help="Create one invoice for all orders related to same customer and same invoicing address"
+        help="Create one invoice for all orders related to same customer, same invoicing address"
+             " and same delivery address."
     )
 
     #=== COMPUTE METHODS ===#


### PR DESCRIPTION
Before this commit:
Quotations with different delivery addresses for the same customer are combined when creating invoices, resulting in the loss of one delivery address. This can lead to inconsistencies as the delivery address is crucial information on the invoice.

After this commit:
Quotations will be grouped for the same customer only if they have the same delivery address.

task-3037272
