### PR TITLE
[FIX] sale_pdf_quote_builder: prevent error when upload pdf for quotation

### DIFF
--- a/addons/sale_pdf_quote_builder/i18n/sale_pdf_quote_builder.pot
+++ b/addons/sale_pdf_quote_builder/i18n/sale_pdf_quote_builder.pot
@@ -114,6 +114,12 @@ msgid "Download examples"
 msgstr ""
 
 #. module: sale_pdf_quote_builder
+#. odoo-python
+#: code:addons/sale_pdf_quote_builder/utils.py:0
+msgid "Error when reading the pdf file: %s"
+msgstr ""
+
+#. module: sale_pdf_quote_builder
 #: model:ir.model.fields,field_description:sale_pdf_quote_builder.field_res_company__sale_footer
 #: model:ir.model.fields,field_description:sale_pdf_quote_builder.field_res_config_settings__sale_footer
 #: model:ir.model.fields,field_description:sale_pdf_quote_builder.field_sale_order_template__sale_footer

--- a/addons/sale_pdf_quote_builder/utils.py
+++ b/addons/sale_pdf_quote_builder/utils.py
@@ -7,6 +7,11 @@ from odoo import _
 from odoo.exceptions import ValidationError
 from odoo.tools import pdf
 
+try:
+    from PyPDF2.errors import PdfReadError
+except ImportError:
+    from PyPDF2.utils import PdfReadError
+
 
 def _ensure_document_not_encrypted(document):
     if pdf.PdfFileReader(io.BytesIO(document), strict=False).isEncrypted:
@@ -24,6 +29,9 @@ def _get_form_fields_from_pdf(pdf_data):
     :return: set of form fields that are in the pdf.
     :rtype: set
     """
-    reader = pdf.PdfFileReader(io.BytesIO(base64.b64decode(pdf_data)))
+    try:
+        reader = pdf.PdfFileReader(io.BytesIO(base64.b64decode(pdf_data)))
+    except PdfReadError as e:
+        raise ValidationError(_('Error when reading the pdf file: %s', e))
 
     return set(reader.getFields() or '')


### PR DESCRIPTION
Currently, an error occurs when uploading a corrupted PDF as a quotation header or footer pages.

Step to produce:

- Install the ```sale_pdf_quote_builder``` module.
- Navigate to Sales / Products / Product Variants.
- Click on the Documents button, And create a new product document.
- Add a name and upload a corrupted pdf file.
- Click on 'Configure dynamic fields'.

```PdfReadError: Broken xref table```

An error occurs when the system tries to read file content through the PDF file reader at [1]. But the xref table of the pdf file is corrupted or broken.

Link [1]:  https://github.com/odoo/odoo/blob/1b1de50729c741d03b11d0fdc24cebf3df4b083a/addons/sale_pdf_quote_builder/utils.py#L27

To handle this issue, Add a try-except block to ensure that if an error occurs during the pdf file read it raises a validation error,

Sentry-5879869841

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
