### PR TITLE
[IMP] product,_*: packaging button in catalog

### DIFF
--- a/addons/product/static/src/product_catalog/kanban_record.js
+++ b/addons/product/static/src/product_catalog/kanban_record.js
@@ -31,7 +31,8 @@ export class ProductCatalogKanbanRecord extends KanbanRecord {
             increaseQuantity: this.increaseQuantity.bind(this),
             setQuantity: this.setQuantity.bind(this),
             decreaseQuantity: this.decreaseQuantity.bind(this),
-            childField: this.props.record.context?.child_field
+            childField: this.props.record.context?.child_field,
+            updatePackagingQuantity: this.updatePackagingQuantity.bind(this),
         });
     }
 
@@ -76,6 +77,12 @@ export class ProductCatalogKanbanRecord extends KanbanRecord {
             res_model: this.env.orderResModel,
             child_field: this.env.childField,
         }
+    }
+
+    async updatePackagingQuantity(packaging) {
+        const productPackagingQty =
+            Math.floor(this.productCatalogData.quantity / packaging.qty) + 1;
+        this.updateQuantity(productPackagingQty * packaging.qty)
     }
 
     //--------------------------------------------------------------------------

--- a/addons/product/static/src/product_catalog/order_line/order_line.js
+++ b/addons/product/static/src/product_catalog/order_line/order_line.js
@@ -9,6 +9,7 @@ export class ProductCatalogOrderLine extends Component {
         quantity: Number,
         price: Number,
         productType: String,
+        packaging: { type: Object, optional: true },
         readOnly: { type: Boolean, optional: true },
         warning: { type: String, optional: true},
     };
@@ -19,6 +20,10 @@ export class ProductCatalogOrderLine extends Component {
      */
     _onFocus(ev) {
         ev.target.select();
+    }
+
+    addPackagingQty() {
+        this.env.updatePackagingQuantity(this.props.packaging);
     }
 
     //--------------------------------------------------------------------------

--- a/addons/product/static/src/product_catalog/order_line/order_line.xml
+++ b/addons/product/static/src/product_catalog/order_line/order_line.xml
@@ -37,6 +37,11 @@
                         t-on-click.stop="(ev) => this.env.increaseQuantity()">
                     <i class="fa fa-plus"/>
                 </button>
+                <button t-if="props.packaging"
+                        class="o_product_catalog_package_quantity btn btn-primary border"
+                        t-on-click.stop="addPackagingQty">
+                    <i class="fa fa-cube"/>
+                </button>
             </div>
             <t t-elif="props.warning">
                 <i class="fa fa-warning text-warning" t-att-title="props.warning"/>

--- a/addons/purchase/static/src/product_catalog/kanban_record.js
+++ b/addons/purchase/static/src/product_catalog/kanban_record.js
@@ -1,18 +1,13 @@
 /** @odoo-module */
 import { ProductCatalogKanbanRecord } from "@product/product_catalog/kanban_record";
 import { ProductCatalogPurchaseOrderLine } from "./purchase_order_line/purchase_order_line";
-import { rpc } from "@web/core/network/rpc";
 import { patch } from "@web/core/utils/patch";
 import { useService } from "@web/core/utils/hooks";
-import { useSubEnv } from "@odoo/owl";
 
 patch(ProductCatalogKanbanRecord.prototype, {
     setup() {
         super.setup();
         this.orm = useService("orm");
-        useSubEnv({
-            updatePackagingQuantity: this.updatePackagingQuantity.bind(this),
-        });
     },
 
     get orderLineComponent() {
@@ -28,19 +23,5 @@ patch(ProductCatalogKanbanRecord.prototype, {
         } else {
             super.addProduct(...arguments);
         }
-    },
-
-    async updatePackagingQuantity(packaging) {
-        const productPackagingQty =
-            Math.floor(this.productCatalogData.quantity / packaging.qty) + 1;
-        this.productCatalogData.quantity = productPackagingQty * packaging.qty;
-        const price = await rpc("/product/catalog/update_order_line_info", {
-            order_id: this.env.orderId,
-            product_id: this.env.productId,
-            product_packaging_id: packaging.id,
-            product_packaging_qty: productPackagingQty,
-            res_model: this.env.orderResModel,
-        });
-        this.productCatalogData.price = parseFloat(price);
     },
 });

--- a/addons/purchase/static/src/product_catalog/purchase_order_line/purchase_order_line.js
+++ b/addons/purchase/static/src/product_catalog/purchase_order_line/purchase_order_line.js
@@ -14,8 +14,4 @@ export class ProductCatalogPurchaseOrderLine extends ProductCatalogOrderLine {
     get highlightUoM() {
         return true;
     }
-
-    addPackagingQty() {
-        this.env.updatePackagingQuantity(this.props.packaging);
-    }
 }

--- a/addons/purchase/static/src/product_catalog/purchase_order_line/purchase_order_line.xml
+++ b/addons/purchase/static/src/product_catalog/purchase_order_line/purchase_order_line.xml
@@ -15,12 +15,5 @@
                 </span>
             </span>
         </xpath>
-        <xpath expr="//div[hasclass('o_product_catalog_quantity')]" position="inside">
-            <button t-if="props.packaging"
-                    class="o_product_catalog_package_quantity btn btn-primary border"
-                    t-on-click.stop="addPackagingQty">
-                <i class="fa fa-cube"/>
-            </button>
-        </xpath>
     </t>
 </templates>

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -2101,6 +2101,12 @@ class SaleOrder(models.Model):
                 res[product.id]['warning'] = product.sale_line_warn_msg
             if product.sale_line_warn == "block":
                 res[product.id]['readOnly'] = True
+            packaging = product.packaging_ids.filtered('sales')[:1]
+            if packaging:
+                res[product.id]['packaging'] = {
+                        'id': packaging.id,
+                        'qty': packaging.product_uom_id._compute_quantity(packaging.qty, product.uom_po_id),
+                    }
         return res
 
     def _get_product_catalog_record_lines(self, product_ids, **kwargs):
@@ -2137,8 +2143,13 @@ class SaleOrder(models.Model):
         """
         request.update_context(catalog_skip_tracking=True)
         sol = self.order_line.filtered(lambda line: line.product_id.id == product_id)
+        product_packaging_id = kwargs.get('product_packaging_id', False)
+        product_packaging_qty = kwargs.get('product_packaging_qty', False)
         if sol:
-            if quantity != 0:
+            if product_packaging_id:
+                sol.product_packaging_id = product_packaging_id
+                sol.product_packaging_qty = product_packaging_qty
+            elif quantity != 0:
                 sol.product_uom_qty = quantity
             elif self.state in ['draft', 'sent']:
                 price_unit = self.pricelist_id._get_product_price(

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1424,6 +1424,12 @@ class SaleOrderLine(models.Model):
                     or bool(self.combo_item_id)
                 ),
             }
+            packaging = self.product_packaging_id
+            if packaging:
+                res['packaging'] = {
+                    'id': packaging.id,
+                    'qty': packaging.product_uom_id._compute_quantity(packaging.qty, self.product_uom),
+                }
             if self.product_id.sale_line_warn != 'no-message' and self.product_id.sale_line_warn_msg:
                 res['warning'] = self.product_id.sale_line_warn_msg
             return res


### PR DESCRIPTION
_* : sale, purchase
Prior this commit
- Packaging button in catalog was only availabe in purchase

Post this commit
- Moved the packaging button logic to product
- Now we can add packaging button to a model inheriting catalog by passing `packaging` to `_get_product_catalog_order_data` and `_get_product_catalog_lines_data` and handling the return in `_update_order_line_info`

task-4200918

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
