### PR TITLE
[IMP] website: make the donation snippets options draggable

### DIFF
--- a/addons/website_payment/static/src/snippets/s_donation/options.js
+++ b/addons/website_payment/static/src/snippets/s_donation/options.js
@@ -203,7 +203,7 @@ options.registry.Donation = options.Class.extend({
         list.dataset.dependencies = "pre_filled_opt";
         list.dataset.addItemTitle = _t("Add new pre-filled option");
         list.dataset.renderListItems = '';
-        list.dataset.unsortable = 'true';
+        list.dataset.unsortable = '';
         list.dataset.inputType = 'number';
         list.dataset.defaultValue = 50;
         list.dataset.listChanged = '';
@@ -235,7 +235,7 @@ options.registry.Donation = options.Class.extend({
             const $descriptions = this.$target.find('#s_donation_description_inputs > input');
             const $tableEl = this.$el.find('we-list table');
             $tableEl.find("tr").toArray().forEach((trEl, i) => {
-                const $inputAmount = $(trEl).find('td').first();
+                const $inputAmount = $(trEl).find('td').eq(1);
                 $inputAmount.addClass('w-25');
                 const tdEl = document.createElement('td');
                 const inputEl = document.createElement('input');


### PR DESCRIPTION
Before this commit, it was not possible to reorder the options of a
donation snippet. To do so, you had to delete the options and rewrite
them in the order you wanted, which was not practical.

This commit make the donation snippet options sortable as already
implemented for social media snippets.

task-4224570