### PR TITLE
[FIX] website: fix google search label in options

### DIFF
--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -4209,7 +4209,7 @@ msgstr ""
 
 #. module: website
 #: model:ir.model.fields,field_description:website.field_res_config_settings__has_google_search_console
-msgid "Console Google Search"
+msgid "Google Search Console"
 msgstr ""
 
 #. module: website
@@ -6896,7 +6896,7 @@ msgstr ""
 #. module: website
 #: model:ir.model.fields,field_description:website.field_res_config_settings__google_search_console
 #: model:ir.model.fields,field_description:website.field_website__google_search_console
-msgid "Google Search Console"
+msgid "Google Search Console Key"
 msgstr ""
 
 #. module: website

--- a/addons/website/models/res_config_settings.py
+++ b/addons/website/models/res_config_settings.py
@@ -66,7 +66,7 @@ class ResConfigSettings(models.TransientModel):
         related='website_id.google_analytics_key',
         readonly=False)
     google_search_console = fields.Char(
-        'Google Search Console',
+        'Google Search Console Key',
         related='website_id.google_search_console',
         readonly=False)
     plausible_shared_key = fields.Char(
@@ -109,7 +109,7 @@ class ResConfigSettings(models.TransientModel):
         compute='_compute_has_google_analytics',
         inverse='_inverse_has_google_analytics')
     has_google_search_console = fields.Boolean(
-        "Console Google Search",
+        "Google Search Console",
         compute='_compute_has_google_search_console',
         inverse='_inverse_has_google_search_console')
     has_default_share_image = fields.Boolean(


### PR DESCRIPTION
Before this commit, the Google Search Console label in the settings
was wrongly displayed as "Console Google Search".

This commit replaces this field label with "Google Search Console".

task-3839274