### PR TITLE
[FIX] l10n_cl: include parent when checking tax group in a branch

### DIFF
--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -264,7 +264,6 @@ class AccountMove(models.Model):
         :return:
         """
         self.ensure_one()
-        cid = self.company_id.id
         tax = [{'tax_code': line.tax_line_id.l10n_cl_sii_code,
                 'tax_name': line.tax_line_id.name,
                 'tax_base': abs(sum(self.invoice_line_ids.filtered(
@@ -273,8 +272,8 @@ class AccountMove(models.Model):
                 'tax_percent': abs(line.tax_line_id.amount),
                 'tax_amount_currency': self.currency_id.round(abs(line.amount_currency)),
                 'tax_amount': self.currency_id.round(abs(line.balance))} for line in self.line_ids.filtered(
-            lambda x: x.tax_group_id.id in [self.env.ref(f'account.{cid}_tax_group_ila').id,
-                                            self.env.ref(f'account.{cid}_tax_group_retenciones').id])]
+            lambda x: x.tax_group_id.id in [self.env['account.chart.template'].ref('tax_group_ila').id,
+                                            self.env['account.chart.template'].ref('tax_group_retenciones').id])]
         return tax
 
     def _float_repr_float_round(self, value, decimal_places):


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting, POS and l10n_cl
- Switch to a Chilean company (e.g. CL Company)
- Create a branch company for it
- Create a product with a tax from "ILA" group
- Switch to the branch company
- Open a POS session
- Sell the created product
- When processing payment, select a Chilean customer and the invoice option

**Issue:**
A traceback is raised while trying to fetch some tax groups:
- self.env.ref(f'account.{cid}_tax_group_ila')
- self.env.ref(f'account.{cid}_tax_group_retenciones') where {cid} is the id of the branch company.

**Cause:**
There is no tax group defined in the branch company. The taxes and the tax groups are defined in the parent company.

**Solution:**
Do not raise an error if the XMLID cannot be found and also check tax groups from parent companies as the taxes could come from them.
Use the "ref" method defined in "account.chart.template" model that is doing it.

opw-4227241


Related enterprise PR: https://github.com/odoo/enterprise/pull/71476

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
