### PR TITLE
[PERF] base_automation: Reduce high frequency cron on negative delay

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -255,7 +255,7 @@ class BaseAutomation(models.Model):
     def _get_cron_interval(self, actions=None):
         """ Return the expected time interval used by the cron, in minutes. """
         def get_delay(rec):
-            return rec.trg_date_range * DATE_RANGE_FACTOR[rec.trg_date_range_type]
+            return abs(rec.trg_date_range) * DATE_RANGE_FACTOR[rec.trg_date_range_type]
 
         if actions is None:
             actions = self.with_context(active_test=True).search([('trigger', '=', 'on_time')])


### PR DESCRIPTION
Currently, the cron job "Base Action Rule: check and execute" has its
frequency set dynamically based on the shortest delay of time based
automated actions. 

Nevertheless, when a time based automated action
has a negative delay, the frequency of the cron job is set to shortest
frequency. This causes load on the server more than needed.

This can be solved by adding an absolute and treating the negative
delay like the a normal delay which results in more representative
frequency.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
