### PR TITLE
[IMP] web: remove target inline

### DIFF
--- a/addons/account/data/account_data.xml
+++ b/addons/account/data/account_data.xml
@@ -12,7 +12,6 @@
             <field name="name">Settings</field>
             <field name="res_model">res.config.settings</field>
             <field name="view_mode">form</field>
-            <field name="target">inline</field>
             <field name="context">{'module': 'general_settings', 'bin_size': False}</field>
         </record>
 

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -385,7 +385,6 @@
             <field name="name">Settings</field>
             <field name="res_model">res.config.settings</field>
             <field name="view_mode">form</field>
-            <field name="target">inline</field>
             <field name="context">{'module' : 'account', 'bin_size': False}</field>
         </record>
 

--- a/addons/base_setup/views/res_config_settings_views.xml
+++ b/addons/base_setup/views/res_config_settings_views.xml
@@ -205,7 +205,6 @@
             <field name="path">settings</field>
             <field name="res_model">res.config.settings</field>
             <field name="view_mode">form</field>
-            <field name="target">inline</field>
             <field name="context">{'module' : 'general_settings', 'bin_size': False}</field>
         </record>
 

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -460,7 +460,6 @@
         <field name="name">Settings</field>
         <field name="res_model">res.config.settings</field>
         <field name="view_mode">form</field>
-        <field name="target">inline</field>
         <field name="context">{'module' : 'calendar', 'bin_size': False}</field>
     </record>
 

--- a/addons/crm/views/res_config_settings_views.xml
+++ b/addons/crm/views/res_config_settings_views.xml
@@ -104,7 +104,6 @@
         <field name="res_model">res.config.settings</field>
         <field name="view_id" ref="res_config_settings_view_form"/>
         <field name="view_mode">form</field>
-        <field name="target">inline</field>
         <field name="context">{'module' : 'crm', 'bin_size': False}</field>
     </record>
 

--- a/addons/event/views/res_config_settings_views.xml
+++ b/addons/event/views/res_config_settings_views.xml
@@ -85,7 +85,6 @@
             <field name="name">Settings</field>
             <field name="res_model">res.config.settings</field>
             <field name="view_mode">form</field>
-            <field name="target">inline</field>
             <field name="context">{'module' : 'event', 'bin_size': False}</field>
         </record>
 

--- a/addons/fleet/views/res_config_settings_views.xml
+++ b/addons/fleet/views/res_config_settings_views.xml
@@ -27,7 +27,6 @@
             <field name="name">Settings</field>
             <field name="res_model">res.config.settings</field>
             <field name="view_mode">form</field>
-            <field name="target">inline</field>
             <field name="context">{'module' : 'fleet', 'bin_size': False}</field>
         </record>
 

--- a/addons/hr/views/res_config_settings_views.xml
+++ b/addons/hr/views/res_config_settings_views.xml
@@ -80,7 +80,6 @@
         <field name="name">Settings</field>
         <field name="res_model">res.config.settings</field>
         <field name="view_mode">form</field>
-        <field name="target">inline</field>
         <field name="context">{'module' : 'hr', 'bin_size': False}</field>
     </record>
 

--- a/addons/hr_attendance/views/res_config_settings_views.xml
+++ b/addons/hr_attendance/views/res_config_settings_views.xml
@@ -81,7 +81,6 @@
         <field name="name">Settings</field>
         <field name="res_model">res.config.settings</field>
         <field name="view_mode">form</field>
-        <field name="target">inline</field>
         <field name="context">{'module' : 'hr_attendance', 'bin_size': False}</field>
     </record>
 

--- a/addons/hr_expense/views/res_config_settings_views.xml
+++ b/addons/hr_expense/views/res_config_settings_views.xml
@@ -62,7 +62,6 @@
             <field name="name">Settings</field>
             <field name="res_model">res.config.settings</field>
             <field name="view_mode">form</field>
-            <field name="target">inline</field>
             <field name="context">{'module' : 'hr_expense', 'bin_size': False}</field>
         </record>
 

--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -386,20 +386,6 @@ class Job(models.Model):
         }
         return action
 
-    def close_dialog(self):
-        return {'type': 'ir.actions.act_window_close'}
-
-    def edit_dialog(self):
-        form_view = self.env.ref('hr.view_hr_job_form')
-        return {
-            'name': _('Job'),
-            'res_model': 'hr.job',
-            'res_id': self.id,
-            'views': [(form_view.id, 'form')],
-            'type': 'ir.actions.act_window',
-            'target': 'inline'
-        }
-
     @api.model
     def _action_load_recruitment_scenario(self):
 

--- a/addons/hr_recruitment/views/res_config_settings_views.xml
+++ b/addons/hr_recruitment/views/res_config_settings_views.xml
@@ -38,7 +38,6 @@
             <field name="name">Settings</field>
             <field name="res_model">res.config.settings</field>
             <field name="view_mode">form</field>
-            <field name="target">inline</field>
             <field name="context">{'module' : 'hr_recruitment', 'bin_size': False}</field>
         </record>
     </data>

--- a/addons/hr_timesheet/views/res_config_settings_views.xml
+++ b/addons/hr_timesheet/views/res_config_settings_views.xml
@@ -41,7 +41,6 @@
         <field name="name">Settings</field>
         <field name="res_model">res.config.settings</field>
         <field name="view_mode">form</field>
-        <field name="target">inline</field>
         <field name="context">{'module' : 'hr_timesheet', 'bin_size': False}</field>
     </record>
 </odoo>

--- a/addons/lunch/views/res_config_settings.xml
+++ b/addons/lunch/views/res_config_settings.xml
@@ -34,7 +34,6 @@
         <field name="res_model">res.config.settings</field>
         <field name="view_id" ref="res_config_settings_view_form"/>
         <field name="view_mode">form</field>
-        <field name="target">inline</field>
         <field name="context">{'module' : 'lunch', 'bin_size': False}</field>
     </record>
 </odoo>

--- a/addons/maintenance/views/res_config_settings_views.xml
+++ b/addons/maintenance/views/res_config_settings_views.xml
@@ -24,7 +24,6 @@
             <field name="name">Settings</field>
             <field name="res_model">res.config.settings</field>
             <field name="view_mode">form</field>
-            <field name="target">inline</field>
             <field name="context">{'module' : 'maintenance', 'bin_size': False}</field>
         </record>
 

--- a/addons/mass_mailing/models/mailing_list.py
+++ b/addons/mass_mailing/models/mailing_list.py
@@ -263,9 +263,6 @@ class MassMailingList(models.Model):
         if archive:
             (src_lists - self).action_archive()
 
-    def close_dialog(self):
-        return {'type': 'ir.actions.act_window_close'}
-
     # ------------------------------------------------------
     # SUBSCRIPTION MANAGEMENT
     # ------------------------------------------------------

--- a/addons/mass_mailing/views/res_config_settings_views.xml
+++ b/addons/mass_mailing/views/res_config_settings_views.xml
@@ -43,7 +43,6 @@
             <field name="name">Settings</field>
             <field name="res_model">res.config.settings</field>
             <field name="view_mode">form</field>
-            <field name="target">inline</field>
             <field name="context">{'module' : 'mass_mailing', 'bin_size': False}</field>
         </record>
 </odoo>

--- a/addons/mrp/views/res_config_settings_views.xml
+++ b/addons/mrp/views/res_config_settings_views.xml
@@ -79,7 +79,6 @@
             <field name="name">Settings</field>
             <field name="res_model">res.config.settings</field>
             <field name="view_mode">form</field>
-            <field name="target">inline</field>
             <field name="context">{'module' : 'mrp', 'bin_size': False}</field>
         </record>
 

--- a/addons/point_of_sale/views/point_of_sale_view.xml
+++ b/addons/point_of_sale/views/point_of_sale_view.xml
@@ -48,7 +48,6 @@
         <field name="name">Settings</field>
         <field name="res_model">res.config.settings</field>
         <field name="view_mode">form</field>
-        <field name="target">inline</field>
         <field name="context">{'module' : 'point_of_sale', 'bin_size': False}</field>
     </record>
 

--- a/addons/project/views/res_config_settings_views.xml
+++ b/addons/project/views/res_config_settings_views.xml
@@ -51,7 +51,6 @@
             <field name="name">Settings</field>
             <field name="res_model">res.config.settings</field>
             <field name="view_mode">form</field>
-            <field name="target">inline</field>
             <field name="context">{'module' : 'project', 'bin_size': False}</field>
         </record>
 </odoo>

--- a/addons/purchase/views/res_config_settings_views.xml
+++ b/addons/purchase/views/res_config_settings_views.xml
@@ -81,7 +81,6 @@
         <field name="name">Settings</field>
         <field name="res_model">res.config.settings</field>
         <field name="view_mode">form</field>
-        <field name="target">inline</field>
         <field name="context">{'module' : 'purchase', 'bin_size': False}</field>
     </record>
 

--- a/addons/sale/wizard/res_config_settings_views.xml
+++ b/addons/sale/wizard/res_config_settings_views.xml
@@ -175,7 +175,6 @@
         <field name="res_model">res.config.settings</field>
         <field name="view_id" ref="res_config_settings_view_form"/>
         <field name="view_mode">form</field>
-        <field name="target">inline</field>
         <field name="context">{'module' : 'sale_management', 'bin_size': False}</field>
     </record>
 

--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -196,7 +196,6 @@
             <field name="name">Settings</field>
             <field name="res_model">res.config.settings</field>
             <field name="view_mode">form</field>
-            <field name="target">inline</field>
             <field name="context">{'module' : 'stock', 'bin_size': False}</field>
         </record>
 

--- a/addons/web/static/tests/legacy/webclient/helpers.js
+++ b/addons/web/static/tests/legacy/webclient/helpers.js
@@ -204,7 +204,6 @@ export function getActionManagerServerData() {
             name: "Partner",
             res_id: 2,
             res_model: "partner",
-            target: "inline",
             type: "ir.actions.act_window",
             views: [[false, "form"]],
         },

--- a/addons/web/static/tests/webclient/actions/effect.test.js
+++ b/addons/web/static/tests/webclient/actions/effect.test.js
@@ -78,7 +78,6 @@ defineActions([
         name: "Partner",
         res_id: 2,
         res_model: "partner",
-        target: "inline",
         type: "ir.actions.act_window",
         views: [[false, "form"]],
     },

--- a/addons/website/views/res_config_settings_views.xml
+++ b/addons/website/views/res_config_settings_views.xml
@@ -218,7 +218,6 @@
         <field name="name">Settings</field>
         <field name="res_model">res.config.settings</field>
         <field name="view_mode">form</field>
-        <field name="target">inline</field>
         <field name="context">{'module' : 'website', 'bin_size': False}</field>
     </record>
 

--- a/addons/website_slides/views/res_config_settings_views.xml
+++ b/addons/website_slides/views/res_config_settings_views.xml
@@ -50,7 +50,6 @@
         <field name="name">Settings</field>
         <field name="res_model">res.config.settings</field>
         <field name="view_mode">form</field>
-        <field name="target">inline</field>
         <field name="context">{'module': 'website_slides', 'bin_size': False}</field>
     </record>
 </odoo>

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -308,7 +308,7 @@ class IrActionsActWindow(models.Model):
     res_id = fields.Integer(string='Record ID', help="Database ID of record to open in form view, when ``view_mode`` is set to 'form' only")
     res_model = fields.Char(string='Destination Model', required=True,
                             help="Model name of the object to open in the view window")
-    target = fields.Selection([('current', 'Current Window'), ('new', 'New Window'), ('inline', 'Inline Edit'), ('fullscreen', 'Full Screen'), ('main', 'Main action of Current Window')], default="current", string='Target Window')
+    target = fields.Selection([('current', 'Current Window'), ('new', 'New Window'), ('fullscreen', 'Full Screen'), ('main', 'Main action of Current Window')], default="current", string='Target Window')
     view_mode = fields.Char(required=True, default='list,form',
                             help="Comma-separated list of allowed view modes, such as 'form', 'list', 'calendar', etc. (Default: list,form)")
     mobile_view_mode = fields.Char(default="kanban", help="First view mode in mobile and small screen environments (default='kanban'). If it can't be found among available view modes, the same mode as for wider screens is used)")

--- a/odoo/addons/base/views/res_config_settings_views.xml
+++ b/odoo/addons/base/views/res_config_settings_views.xml
@@ -13,7 +13,6 @@
             <field name="name">Settings</field>
             <field name="res_model">res.config.settings</field>
             <field name="view_mode">form</field>
-            <field name="target">inline</field>
         </record>
     </data>
 </odoo>


### PR DESCRIPTION
The model IrActionsActWindow has a target selection field. Its value can be
"current", "new", "main", "fullscreen" or "inline". The latter value is useless.
It is only used on settings actions. Historically, it forced the form view mode
to "edit", which is now always the case. It also ensures that we don't load
dynamic filters and we don't have a search view, since it is set on actions that
only have a form view (no multi record views).

In this commit, we remove the value inline from the target selection and remove
that value in every actions that used to have that target. This means that the
default "current" will be used. For the model "res.config.settings" on which
all inline actions were defined, we hard code that loadActionMenus should be
false, since for the settigs actions we do not have the cog menu anyway.

Task ID: 3245566