### PR TITLE
[FIX] {sale_,}stock: decrease the SOL qty with MTO rule

### DIFF
--- a/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
+++ b/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
 from odoo.tests.common import TransactionCase, Form
 
 
@@ -83,3 +84,53 @@ class TestSalePurchaseStockFlow(TransactionCase):
 
         sm.move_line_ids.qty_done = 10
         self.assertEqual(so.order_line.qty_delivered, 10)
+
+    def test_mto_and_partial_cancel(self):
+        """
+        First, confirm a SO with two lines with the MTO + Buy routes (the products
+        should not be available in stock). Put the quantity of the first SOL to 0
+        then back to max. Then cancel the PO for the first product and decrease back
+        the quantity of the related SOL to 0:
+        - The delivery should be updated
+        - There should not be any return picking
+        """
+        product_1 = self.mto_product
+        vendor_2 = self.env['res.partner'].create({'name': 'Lovely Vendor'})
+        product_2 = self.env['product.product'].create({
+            'name': 'LovelyProduct',
+            'type': 'product',
+            'route_ids': [Command.set((self.mto_route + self.buy_route).ids)],
+            'seller_ids': [Command.create({
+                'partner_id': vendor_2.id,
+            })],
+        })
+        so = self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'order_line': [
+                Command.create({
+                    'name': product_1.name,
+                    'product_id': product_1.id,
+                    'product_uom_qty': 1,
+                    'product_uom': product_1.uom_id.id,
+                    'price_unit': 10,
+                }),
+                Command.create({
+                    'name': product_2.name,
+                    'product_id': product_2.id,
+                    'product_uom_qty': 1,
+                    'product_uom': product_2.uom_id.id,
+                    'price_unit': 20,
+                }),
+            ],
+        })
+        so.action_confirm()
+        delivery = so.picking_ids
+        po_2 = self.env['purchase.order'].search([('partner_id', '=', vendor_2.id)])
+        po_2.button_cancel()
+        line_2 = so.order_line.filtered(lambda sol: sol.product_id == product_2)
+        line_2.product_uom_qty = 0
+        self.assertEqual(delivery, so.picking_ids)
+        self.assertRecordValues(delivery.move_ids, [
+            {'product_id': product_1.id, 'product_uom_qty': 1.0},
+            {'product_id': product_2.id, 'product_uom_qty': 0.0},
+        ])

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -255,7 +255,9 @@ class StockRule(models.Model):
                 if float_compare(qty_needed, 0, precision_rounding=procurement.product_id.uom_id.rounding) <= 0:
                     procure_method = 'make_to_order'
                     for move in procurement.values.get('group_id', self.env['procurement.group']).stock_move_ids:
-                        if move.rule_id == rule and float_compare(move.product_uom_qty, 0, precision_rounding=move.product_uom.rounding) > 0:
+                        if move.product_id != procurement.product_id:
+                            continue
+                        elif move.rule_id == rule and float_compare(move.product_uom_qty, 0, precision_rounding=move.product_uom.rounding) > 0:
                             procure_method = move.procure_method
                             break
                     forecasted_qties_by_loc[rule.location_src_id][procurement.product_id.id] -= qty_needed


### PR DESCRIPTION
### Steps to reproduce:

- In Settings, enable "Multi-Step Routes"
- In the Routes, unarchive MTO
- Create 2 storable products P1, P2 with routes MTO + Buy
- Set a different vendor on P1/P2 and ensure you have 0 units in stock
- Create and confirm a sale order with 2 lines:
  - 1 x P1
  - 1 x P2
> A delivery and 2 purchase order were created (one for each product)
- Cancel the purchase orderfor P2 (it will not work with P1 hehe)
- Go back to the SO and decrease the qty of P2 to 0
#### > A return is created from patner to stock instead of updating the P2 move of the delivery

### Cause of the issue:

When the sale order was confirmed the moves created for the delivery were both used the same procurment group and their `procure_method` was set to `make_to_order`. When the purchase order for P2 is cancelled, the delivery move associated with the related sol is cancelled and its `procure_method` is set to `make_to_stock` here:
https://github.com/odoo/odoo/blob/c424fded8660de628bfcf3937806cc72c8410434/addons/purchase_stock/models/purchase.py#L148 Then, when you decrease the qty of the SOL from 0 to 1, a procurement for -1 unit of P2 will be created and run by the
`_action_launch_stock_rule`. A negative move will then be created and confirm with a `procure_method`: `make_to_stock` here: https://github.com/odoo/odoo/blob/c424fded8660de628bfcf3937806cc72c8410434/addons/stock/models/stock_rule.py#L275-L277 Because the `procure_method` used at the creation of the negative move is determined from the `procure_method` of the first move related to the procurement group with a positive qty (here the P1 move): https://github.com/odoo/odoo/blob/1fd336e5f321e5256accff6b5a4032b237dce528/addons/stock/models/stock_rule.py#L257-L260 As such, the negative P2 move will have a different `procure_method` than the positive P2 move and they will not be merged here: https://github.com/odoo/odoo/blob/1fd336e5f321e5256accff6b5a4032b237dce528/addons/stock/models/stock_move.py#L1384

### Fix:

The fix proposed in commit 65d5e7900f41aa7f65159f8f4cdb0c6638eaf8ca and introducing the lines:
https://github.com/odoo/odoo/blob/1fd336e5f321e5256accff6b5a4032b237dce528/addons/stock/models/stock_rule.py#L257-L260 works perfectly fine in most situtations but should considers only the moves related to the procurment group that concerns the same product to also work in the above case.

opw-4214369
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
