### PR TITLE
[FIX] point_of_sale: ensures images are ready before using them (IOS)

### DIFF
--- a/addons/point_of_sale/static/src/app/utils/html-to-image.js
+++ b/addons/point_of_sale/static/src/app/utils/html-to-image.js
@@ -209,8 +209,11 @@ function canvasToBlob(canvas, options = {}) {
 function createImage(url) {
     return new Promise((resolve, reject) => {
         const img = new Image();
-        img.decode = () => resolve(img);
-        img.onload = () => resolve(img);
+        img.onload = () => {
+            img.decode().then(() => {
+                requestAnimationFrame(() => resolve(img));
+            });
+        };
         img.onerror = reject;
         img.crossOrigin = "anonymous";
         img.decoding = "async";


### PR DESCRIPTION
Currently, when using any browser on an Ipad, qr codes will not be shown on the printed receipt, when printed for the first time. When printing it a second time, it will appear.

Steps to reproduce:
-------------------
* Use an Ipad (or simulate one)
* Go to the **Point of sale** App
* Select **Configuration** > **Settings**
* Enable QR code on receipt
* Open shop session
* Make an order and pay it
* Print the receipt
> Observation: QR code does not appear, big white space where it should be

* Print it again
> Observation: QR code is printed

Why the fix:
------------
```js
function createImage(url) {
    return new Promise((resolve, reject) => {
        const img = new Image();
        img.onload = () => resolve(img);
        img.decode = () => resolve(img);
        img.onerror = reject;
        img.crossOrigin = "anonymous";
        img.decoding = "async";
        img.src = url;
    });
}
```

In this piece of code, `img.decode = () => resolve(img);` is supposed to ensure that the image is fully processed but is misused. Decode is not a setter, it's a method that returns a promise when the image is fully decoded. While this code wait for the image to load it does not wait for it to be fully ready (processed).

`img.decode()` ensures that the image has been fully decoded before continuing.

We go one step further with `requestAnimationFrame`. This defers the execution and will ensure that the resolved image is rendered in the next frame. It's more important in devices like Ipad because the broswers tend to handle image operations differently, thus creating rendering and timing issues.

With this fix, we now wait longer to make sure that the image is not only loaded but also fully processed and ready to be shown.

opw-4144049
