### PR TITLE
[IMP] sale,website_sale_*: improve/fix combo logic

### DIFF
--- a/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.js
+++ b/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.js
@@ -43,8 +43,7 @@ export class ComboConfiguratorDialog extends Component {
             basePrice: this.props.price,
             isLoading: false,
         });
-        if (this.props.edit) this._initSelectedComboItems();
-        this._selectSingleComboItems();
+        this._initSelectedComboItems();
         this.getPriceUrl = '/sale/combo_configurator/get_price';
         useSubEnv({ currency: { id: this.props.currency_id } });
     }
@@ -124,17 +123,12 @@ export class ComboConfiguratorDialog extends Component {
     }
 
     /**
-     * Return the total price, formatted using the provided currency.
-     *
-     * The total price is the sum of:
-     * - The combo product's price,
-     * - The selected combo items' extra price,
-     * - The selected `no_variant` attributes' extra price.
+     * Return the total price for all units, formatted using the provided currency.
      *
      * @return {String} The formatted total price.
      */
     get formattedTotalPrice() {
-        return formatCurrency(this._totalPrice, this.props.currency_id);
+        return formatCurrency(this.state.quantity * this._comboPrice, this.props.currency_id);
     }
 
     /**
@@ -166,7 +160,7 @@ export class ComboConfiguratorDialog extends Component {
      */
     _initSelectedComboItems() {
         for (const combo of this.props.combos) {
-            const comboItem = combo.selectedComboItem;
+            const comboItem = combo.selectedComboItem ?? combo.preselectedComboItem;
             if (comboItem) {
                 this.state.selectedComboItems.set(combo.id, comboItem.deepCopy());
             }
@@ -174,24 +168,20 @@ export class ComboConfiguratorDialog extends Component {
     }
 
     /**
-     * Automatically select the single combo item in each combo that has a single, non-configurable
-     * combo item.
+     * Return the total price per unit.
+     *
+     * The total price is the sum of:
+     * - The combo product's price,
+     * - The selected combo items' extra price,
+     * - The selected `no_variant` attributes' extra price.
+     *
+     * @return {Number} The total price.
      */
-    _selectSingleComboItems() {
-        for (const combo of this.props.combos) {
-            const comboItem = combo.combo_items[0];
-            if (combo.combo_items.length === 1 && !comboItem.product.hasNoVariantPtals) {
-                this.state.selectedComboItems.set(combo.id, comboItem.deepCopy());
-            }
-        }
-    }
-
-    get _totalPrice() {
-        const extraPrice = Array.from(
-            this.state.selectedComboItems.values(),
-            comboItem => comboItem.extra_price + comboItem.product.selectedNoVariantPtavsPriceExtra,
-        ).reduce((price, comboItemExtraPrice) => price + comboItemExtraPrice, 0);
-        return this.state.quantity * (this.state.basePrice + extraPrice);
+    get _comboPrice() {
+        const extraPrice = Array.from(this.state.selectedComboItems.values()).reduce(
+            (price, item) => price + item.totalExtraPrice, 0
+        );
+        return this.state.basePrice + extraPrice;
     }
 
     /**
@@ -204,12 +194,17 @@ export class ComboConfiguratorDialog extends Component {
     }
 
     /**
-     * Return the selected combo items.
+     * Return the selected combo items, in the same order as the combos given as props.
      *
-     * @return {ProductComboItem[]} The selected combo items.
+     * @return {ProductComboItem[]} The sorted selected combo items.
      */
     get _selectedComboItems() {
-        return Array.from(this.state.selectedComboItems.values());
+        const sortedItems = new Map([...this.state.selectedComboItems.entries()].sort(
+            (entry1, entry2) =>
+                this.props.combos.findIndex(combo => combo.id === entry1[0])
+                - this.props.combos.findIndex(combo => combo.id === entry2[0])
+        ));
+        return Array.from(sortedItems.values());
     }
 
     /**

--- a/addons/sale/static/src/js/models/product_combo.js
+++ b/addons/sale/static/src/js/models/product_combo.js
@@ -20,4 +20,13 @@ export class ProductCombo {
     get selectedComboItem() {
         return this.combo_items.find(item => item.is_selected);
     }
+
+    /**
+     * Return the preselected combo item, if any.
+     *
+     * @return {ProductComboItem|undefined} The preselected combo item, if any.
+     */
+    get preselectedComboItem() {
+        return this.combo_items.find(item => item.is_preselected);
+    }
 }

--- a/addons/sale/static/src/js/models/product_combo_item.js
+++ b/addons/sale/static/src/js/models/product_combo_item.js
@@ -5,13 +5,28 @@ export class ProductComboItem {
      * @param {number} id
      * @param {number} extra_price
      * @param {boolean} is_selected
+     * @param {boolean} is_preselected
      * @param {ProductProduct|object} product
      */
-    constructor({id, extra_price, is_selected, product}) {
+    constructor({id, extra_price, is_selected, is_preselected, product}) {
         this.id = id;
         this.extra_price = extra_price;
         this.is_selected = is_selected;
+        this.is_preselected = is_preselected;
         this.product = new ProductProduct(product);
+    }
+
+    /**
+     * Return the combo item's "total" extra price.
+     *
+     * The total extra price is the sum of:
+     * - The combo item's extra price,
+     * - The extra price of the selected `no_variant` PTAVs of the combo item's product.
+     *
+     * @return {Number} The combo item's "total" extra price.
+     */
+    get totalExtraPrice() {
+        return this.extra_price + this.product.selectedNoVariantPtavsPriceExtra;
     }
 
     /**

--- a/addons/website_sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.js
+++ b/addons/website_sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.js
@@ -27,7 +27,7 @@ patch(ComboConfiguratorDialog.prototype, {
     get _comboProductData() {
         const comboProductData = super._comboProductData;
         if (this.props.isFrontend) {
-            Object.assign(comboProductData, { 'price': this._totalPrice });
+            Object.assign(comboProductData, { 'price': this._comboPrice });
         }
         return comboProductData;
     },

--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -5,14 +5,17 @@
         <xpath expr="//div[hasclass('o_wsale_product_btn')]" position="inside">
             <t t-set="in_wish" t-value="product in products_in_wishlist"/>
             <t t-set="product_variant_id" t-value="in_wish or product._get_first_possible_variant_id()"/>
-            <button t-if="product_variant_id"
-                    type="button"
-                    role="button"
-                    class="btn btn btn-light o_add_wishlist"
-                    t-att-disabled='in_wish or None' title="Add to Wishlist"
-                    t-att-data-product-template-id="product.id"
-                    t-att-data-product-product-id="product_variant_id"
-                    data-action="o_wishlist">
+            <button
+                t-if="product_variant_id and product.type != 'combo'"
+                type="button"
+                role="button"
+                class="btn btn-light o_add_wishlist"
+                t-att-disabled="in_wish"
+                t-att-data-product-template-id="product.id"
+                t-att-data-product-product-id="product_variant_id"
+                data-action="o_wishlist"
+                title="Add to Wishlist"
+            >
                 <span class="fa fa-heart" role="img" aria-label="Add to wishlist"/>
             </button>
         </xpath>
@@ -20,7 +23,10 @@
 
     <template id="product_cart_lines" inherit_id="website_sale.cart_lines" active="True">
         <div name="o_wsale_cart_line_button_container" position="inside">
-            <span class="d-none d-md-inline-block ms-1">
+            <span
+                t-if="line.product_id.type != 'combo'"
+                class="d-none d-md-inline-block ms-1"
+            >
                 <a
                     href="#"
                     class="small o_add_wishlist js_delete_product px-2 border-start"
@@ -32,6 +38,7 @@
                 </a>
             </span>
             <button
+                t-if="line.product_id.type != 'combo'"
                 class="o_add_wishlist js_delete_product btn btn-light d-inline-block d-md-none"
                 t-att-data-product-template-id="line.product_id.product_tmpl_id.id"
                 t-att-data-product-product-id="line.product_id.id"
@@ -48,7 +55,20 @@
             <t t-nocache="The wishlist depends on the user and must not be shared with other users. The product come from the controller.">
                 <t t-set="product_variant" t-value="product_variant or product._create_first_product_variant()"/>
                 <t t-set="in_wish" t-value="product_variant and product_variant._is_in_wishlist()"/>
-                <button t-if="product_variant" type="button" role="button" class="btn btn-link px-0 pe-3 o_add_wishlist_dyn" t-att-disabled='in_wish or None' t-att-data-product-template-id="product.id" t-att-data-product-product-id="product_variant.id" data-action="o_wishlist" title="Add to wishlist"><i class="fa fa-heart-o me-2" role="img" aria-label="Add to wishlist"/>Add to wishlist</button>
+                <button
+                    t-if="product_variant and product.type != 'combo'"
+                    type="button"
+                    role="button"
+                    class="btn btn-link px-0 pe-3 o_add_wishlist_dyn"
+                    t-att-disabled="in_wish"
+                    t-att-data-product-template-id="product.id"
+                    t-att-data-product-product-id="product_variant.id"
+                    data-action="o_wishlist"
+                    title="Add to wishlist"
+                >
+                    <i class="fa fa-heart-o me-2" role="img" aria-label="Add to wishlist"/>
+                    Add to wishlist
+                </button>
             </t>
         </xpath>
     </template>


### PR DESCRIPTION
- Don't open the combo configurator in eCommerce if there's nothing to configure,
- Don't allow combo products in the wishlist,
- Order combo items by combo sequence instead of by selection order,
- Fix the Google Analytics tracking price for combos.

task-4264135

Closes https://github.com/odoo/odoo/issues/182464