### PR TITLE
[IMP] l10n_uy: Type of doc based on type of ID

### DIFF
--- a/addons/l10n_uy/models/account_move.py
+++ b/addons/l10n_uy/models/account_move.py
@@ -48,3 +48,15 @@ class AccountMove(models.Model):
                 allowed_codes = set(codes).intersection(set(matching_subtype_codes[0]))
                 domain += [("code", "in", tuple(allowed_codes))]
         return domain
+
+    def _compute_l10n_latam_document_type(self):
+        """
+        The following considerations apply for determining document types based on the partner's identification:
+        RUT/RUC (Uruguay): Automatically select e-factura.
+        Other documents (Example: CI, PAS, NIE, NIFE, etc.): Automatically select e-ticket
+        """
+        super()._compute_l10n_latam_document_type()
+        self.filtered(lambda x: x.company_id.country_code == 'UY' and
+            x.partner_id.l10n_latam_identification_type_id == self.env.ref('l10n_uy.it_rut')).write({
+            'l10n_latam_document_type_id': self.env.ref('l10n_uy.dc_e_inv').id
+        })

--- a/addons/l10n_uy/tests/test_doc_types.py
+++ b/addons/l10n_uy/tests/test_doc_types.py
@@ -61,3 +61,17 @@ class TestDocTypes(AccountTestInvoicingCommon):
         self.assertEqual(debit_note.l10n_latam_document_type_id.code, "123", "Not Export e-Invoice Debit Note")
         expected_docs = ["123"] if self.env['ir.module.module']._get('l10n_uy_edi').state == 'installed' else ['123', '223']
         self.assertEqual(debit_note.l10n_latam_available_document_type_ids.mapped("code"), expected_docs, "Bad Domain")
+
+    def test_default_doc_type_by_id(self):
+
+        expected_doc = self.env.ref('l10n_uy.dc_e_ticket') if self.env['ir.module.module']._get('l10n_uy_edi').state == 'installed'\
+            else self.env.ref('l10n_uy.dc_inv')
+        dc_e_inv = self.env.ref('l10n_uy.dc_e_inv')
+        move = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+        })
+        self.assertFalse(move.l10n_latam_document_type_id)
+        move.write({'partner_id': self.env.ref('l10n_uy.partner_cfu').id})
+        self.assertEqual(move.l10n_latam_document_type_id, expected_doc, "The document type is not being set correctly.")
+        move.write({'partner_id': self.env.ref('l10n_uy.partner_dgi').id})
+        self.assertEqual(move.l10n_latam_document_type_id, dc_e_inv, "The expected document should be e-invoice")


### PR DESCRIPTION
Description of the Issue/Feature Addressed by This PR:
The current system sets the default document type to e-Ticket, regardless of the partner's identification type. However, for usability purposes, if the identification type is RUT/RUC, the document type should default to e-Factura, as this is the correct choice in 95% of cases.

Current Behavior Before PR:
The default document type is always set to e-Ticket, irrespective of the identification type.

Desired Behavior After PR:
The system will automatically select the appropriate document type (either e-Factura or e-Ticket) in the account.move module, based on the partner's identification type (RUT/RUC or other). This will reduce the need for manual adjustments. Users will still have the flexibility to select other document types to account for any exceptions.

Latam-task: 1273
Adhoc-side-task: 44194

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
