### PR TITLE
[16.0] google_gmail: avoid SMTPServerDisconnected errors

### DIFF
--- a/addons/google_gmail/tests/__init__.py
+++ b/addons/google_gmail/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_google_gmail

--- a/addons/google_gmail/tests/test_google_gmail.py
+++ b/addons/google_gmail/tests/test_google_gmail.py
@@ -1,0 +1,73 @@
+from odoo.tests.common import TransactionCase
+from unittest import mock
+from datetime import datetime
+from freezegun import freeze_time
+
+
+class TestIrMailServer(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.mail_server = cls.env["ir.mail_server"].create(
+            {
+                "name": "Gmail",
+                "smtp_host": "fake.host",
+                "google_gmail_access_token": "fake_access_token",
+            }
+        )
+
+    def test_generate_oauth2_string_token(self):
+        """Testing the generation of the oauth2 token
+        should take care of google_gmail_mixin.GMAIL_TOKEN_VALIDITY_THRESHOLD
+        """
+        current_token_expiry = int(datetime(2021, 12, 15, 11, 0, 0).timestamp())
+        new_token_expiry = int(datetime(2021, 12, 15, 12, 0, 1).timestamp())
+        cases = [
+            (
+                "2021-12-15 10:59:50",
+                False,
+                "fake_access_token",
+                ("Google Gmail: reuse existing access token. Expire in %i minutes", 0),
+            ),
+            (
+                "2021-12-15 10:59:55",
+                True,
+                "new-access-token",
+                ("Google Gmail: fetch new access token. Expires in %i minutes", 60),
+            ),
+            (
+                "2021-12-15 11:00:01",
+                True,
+                "new-access-token",
+                ("Google Gmail: fetch new access token. Expires in %i minutes", 60),
+            ),
+        ]
+
+        for (
+            current_datetime,
+            assert_new_token_generation_called,
+            expected_token,
+            expected_log,
+        ) in cases:
+            with self.subTest(currenct_datetime=current_datetime), \
+                freeze_time(current_datetime), \
+                mock.patch("odoo.addons.google_gmail.models.google_gmail_mixin._logger.info") as mock_logger, \
+                mock.patch(
+                    "odoo.addons.google_gmail.models.google_gmail_mixin.GoogleGmailMixin._fetch_gmail_access_token",
+                    return_value=("new-access-token", new_token_expiry),
+                ) as mock_fetch_gmail_access_token:
+                self.mail_server.google_gmail_access_token_expiration = current_token_expiry
+                oauth2_string = self.mail_server._generate_oauth2_string(
+                    "user-account", "refresh-token"
+                )
+                self.assertEqual(
+                    f"user=user-account\1auth=Bearer {expected_token}\1\1",
+                    oauth2_string,
+                )
+                if assert_new_token_generation_called:
+                    mock_fetch_gmail_access_token.assert_called_once()
+                else:
+                    mock_fetch_gmail_access_token.assert_not_called()
+
+                mock_logger.assert_called_once_with(*expected_log)

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -450,7 +450,12 @@ class MailMail(models.Model):
                     len(batch_ids), mail_server_id)
             finally:
                 if smtp_session:
-                    smtp_session.quit()
+                    try:
+                        smtp_session.quit()
+                    except smtplib.SMTPServerDisconnected:
+                        _logger.info(
+                            "Ignoring SMTPServerDisconnected while trying to quit non open session"
+                        )
 
     def _send(self, auto_commit=False, raise_exception=False, smtp_session=None):
         IrMailServer = self.env['ir.mail_server']

--- a/addons/mail/tests/__init__.py
+++ b/addons/mail/tests/__init__.py
@@ -8,6 +8,7 @@ from . import test_mail_channel_as_guest
 from . import test_mail_channel_member
 from . import test_mail_composer
 from . import test_mail_full_composer
+from . import test_mail_mail
 from . import test_mail_mail_stable_selection
 from . import test_mail_render
 from . import test_mail_template

--- a/addons/mail/tests/test_mail_mail.py
+++ b/addons/mail/tests/test_mail_mail.py
@@ -1,0 +1,35 @@
+from odoo.tests import TransactionCase
+from unittest import mock
+import smtplib
+
+
+class MailCase(TransactionCase):
+
+    def test_mail_send_non_connected_smtp_session(self):
+        """Check to avoid SMTPServerDisconnected error while trying to
+        disconnect smtp session that is not connected.
+
+        This used to happens while trying to connect to a
+        google smtp server with an expired token.
+
+        Or here testing non recipients emails with non connected
+        smtp session, we won't get SMTPServerDisconnected that would
+        hide the other error that is raised earlier.
+        """
+        disconnected_smtpsession = mock.MagicMock()
+        disconnected_smtpsession.quit.side_effect = smtplib.SMTPServerDisconnected
+        mail = self.env["mail.mail"].create({})
+        with mock.patch("odoo.addons.base.models.ir_mail_server.IrMailServer.connect", return_value=disconnected_smtpsession):
+            with mock.patch("odoo.addons.mail.models.mail_mail._logger.info") as mock_logging_info:
+                mail.send()
+        disconnected_smtpsession.quit.assert_called_once()
+        mock_logging_info.assert_any_call(
+            "Ignoring SMTPServerDisconnected while trying to quit non open session"
+        )
+        # if we get here SMTPServerDisconnected was not raised
+        self.assertEqual(mail.state, "exception")
+        self.assertEqual(
+            mail.failure_reason,
+            "Error without exception. Probably due to sending "
+            "an email without computed recipients."
+        )


### PR DESCRIPTION
## Description of the issue/feature this PR addresses:

This PR is about fixing this issue: https://github.com/odoo/odoo/issues/182777 to avoid SMTPServerDisconnected

## Current behavior before PR:

With some race condition got SMTPServerDisconnected

## Desired behavior after PR is merged:
Do not get SMTPServerDisconnected while quitting non connect session and avoid to get non connected session using google oauth2 connection.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
