### PR TITLE
[FIX] l10n_de: Don't raise if account code not changed

### DIFF
--- a/addons/l10n_de/models/account_account.py
+++ b/addons/l10n_de/models/account_account.py
@@ -6,7 +6,11 @@ class AccountAccount(models.Model):
     _inherit = ['account.account']
 
     def write(self, vals):
-        if 'code' in vals and 'DE' in self.company_id.account_fiscal_country_id.mapped('code'):
+        if (
+            'code' in vals
+            and 'DE' in self.company_id.account_fiscal_country_id.mapped('code')
+            and any(a.code != vals['code'] for a in self)
+        ):
             if self.env['account.move.line'].search_count([('account_id', 'in', self.ids)], limit=1):
                 raise UserError(_("You can not change the code of an account."))
         return super().write(vals)


### PR DESCRIPTION
In #171244, we prevented users from modifying account codes on German CoAs, as part of changes for GoBD compliance.

However, when the user exports and re-imports an entire CoA in Excel, `write` is still called on the account code, even if it doesn't change.

With this commit, we don't raise if the code doesn't actually change.

Back-port of #181234

task-4192627