### PR TITLE
[FIX] website: fix position of "Card" snippet cover video

### DIFF
--- a/addons/website/static/src/snippets/s_card/000.scss
+++ b/addons/website/static/src/snippets/s_card/000.scss
@@ -21,8 +21,14 @@
         }
     }
 
-    .o_card_img_wrapper.ratio > a > .o_card_img {
-        height: 100%;
+    .o_card_img_wrapper.ratio {
+        > a > .o_card_img {
+            height: 100%;
+        }
+
+        .media_iframe_video {
+            position: absolute;
+        }
     }
 
     // Options


### PR DESCRIPTION
In the "Card" snippet, if the cover image is replaced by a video, and if it has a ratio (i.e. the "Ratio" option is not set on "Image default"), the video is not placed correctly. This happens because the videos have a rule setting their position to `relative`, overriding the `absolute` position set and needed by the `ratio` class.

This commit fixes that by setting the position of card cover videos as `absolute`, to be placed correctly according to the ratio.

Steps to reproduce:
- Drop a "Card" inner snippet.
- Click on the cover image and replace it by a video. => The video is shifted and does not fill the wrapper properly.

Related to task-3674888
