### PR TITLE
[FIX] base: make image directive work in manifest desc just like in odoo app store

### DIFF
--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -193,6 +193,13 @@ class Module(models.Model):
 
     @api.depends('name', 'description')
     def _get_desc(self):
+        def _apply_description_images(doc):
+            html = lxml.html.document_fromstring(doc)
+            for element, attribute, link, pos in html.iterlinks():
+                if element.get('src') and not '//' in element.get('src') and not 'static/' in element.get('src'):
+                    element.set('src', "/%s/static/description/%s" % (module.name, element.get('src')))
+            return tools.html_sanitize(lxml.html.tostring(html))
+
         for module in self:
             if not module.name:
                 module.description_html = False
@@ -208,11 +215,7 @@ class Module(models.Model):
                             doc = doc.decode('utf-8')
                         except UnicodeDecodeError:
                             pass
-                    html = lxml.html.document_fromstring(doc)
-                    for element, attribute, link, pos in html.iterlinks():
-                        if element.get('src') and not '//' in element.get('src') and not 'static/' in element.get('src'):
-                            element.set('src', "/%s/static/description/%s" % (module.name, element.get('src')))
-                    module.description_html = tools.html_sanitize(lxml.html.tostring(html))
+                    module.description_html = _apply_description_images(doc)
             else:
                 overrides = {
                     'embed_stylesheet': False,
@@ -222,7 +225,7 @@ class Module(models.Model):
                     'file_insertion_enabled': False,
                 }
                 output = publish_string(source=module.description if not module.application and module.description else '', settings_overrides=overrides, writer=MyWriter())
-                module.description_html = tools.html_sanitize(output)
+                module.description_html = _apply_description_images(output)
 
     @api.depends('name')
     def _get_latest_version(self):


### PR DESCRIPTION
* Before this commit, if you have .. image in manifest description like .. image:: image.png (image.png stay in static/description) , it will only work on odoo app store but in module info it isn't
* After this commit, make it work in module info of Apps (base module) by replace 'src' (image.png) with static/description resource (/module_name/static/description/image.png)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
