### PR TITLE
[FIX] html_editor: size selection issue in radial gradient

### DIFF
--- a/addons/html_editor/static/src/main/font/gradient_picker.js
+++ b/addons/html_editor/static/src/main/font/gradient_picker.js
@@ -57,7 +57,7 @@ export class GradientPicker extends Component {
         } else {
             this.state.type = "radial";
             const sizeMatch = gradient.match(/(closest|farthest)-(side|corner)/);
-            const size = sizeMatch ? sizeMatch[0] : "closest-side";
+            const size = sizeMatch ? sizeMatch[0] : "farthest-corner";
             this.state.size = size;
 
             const position = gradient.match(/ at ([0-9]+)% ([0-9]+)%/) || ["", "50", "50"];

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -367,6 +367,23 @@ test("clicking on the angle input does not close the dropdown", async () => {
     expect("input[name='angle'").toHaveCount(1);
 });
 
+test("should be able to select farthest-corner option in radial gradient", async () => {
+    await setupEditor(`<p>a[bcd]e</p>`);
+    await waitFor(".o-we-toolbar");
+    await click(".o-we-toolbar .o-select-color-foreground");
+    await animationFrame();
+    expect(".btn:contains('Gradient')").toHaveCount(1);
+    await click(".btn:contains('Gradient')");
+    await animationFrame();
+    expect("button:contains('Radial')").toHaveCount(1);
+    await click(".btn:contains('Radial')");
+    await animationFrame();
+    expect("button[title='Extend to the farthest corner']").toHaveCount(1);
+    await click("button[title='Extend to the farthest corner']");
+    await animationFrame();
+    expect("button[title='Extend to the farthest corner']").toHaveClass("active");
+});
+
 describe.tags("desktop")("color preview", () => {
     test("preview color should work and be reverted", async () => {
         await setupEditor("<p>[test]</p>");


### PR DESCRIPTION
**Behaviour before PR:**

Steps to reproduce issue:

- Add some text, select it.
- Open color picker to apply text or background color.
- Switch the gradient tab, select radial gradient type.
- Try to select 4th option of size (extend to the farthest corner).
- Selected option is deselected and gets switched to first option.
- If we try to select it again then it gets selected.

The issue happens because `fathest-corner` is the default size parameter for radial gradient. When we apply background-image property for farthest-corner it gets simplified later and rendered without keyword `'farthest-size'`.
E.g.` radial-gradient(circle farthest-corner at 50% 50%, rgb(255,..` will be simplified to `radial-gradient(circle at 50% 50%, rgb(255,..`

Due to this reason when we get background-image property using `style['background-image']` we get simplified value. As result in `setGradientFromString` method regex fails to extract the value of `'farthest-corner'` and `state.size` is set to `'closest-side'` which is our first option.

**Desired behaviour after PR:**

Now, default size is set to `'farthest-corner'` and 4th option is selectable.

task-4240711



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
