### PR TITLE
[FIX] hw_drivers: disable extensions in chromium

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
@@ -83,8 +83,12 @@ class DisplayDriver(Driver):
         # Kill browser instance (can't `instance.pkill()` as we can't keep the instance after Odoo service restarts)
         # We need to terminate it because Odoo will create a new instance each time it is restarted.
         subprocess.run(['pkill', self.browser.split('-')[0]], check=False)
-        # --log-level=3 to avoid useless log messages, --bwsi to use chromium without signing in
-        browser_args = ['--start-fullscreen', '--log-level=3', '--bwsi']
+        browser_args = [
+            '--start-fullscreen',
+            '--log-level=3',        # avoid useless log messages
+            '--bwsi',               # use chromium without signing in
+            '--disable-extensions'  # disable extensions as they fill up /tmp
+        ]
         subprocess.Popen([self.browser, self.url, *browser_args], env=browser_env)
 
         # To remove when everyone is on version >= 24.08: chromium has '--start-fullscreen' option


### PR DESCRIPTION
In the new IoT image we use Chromium instead of
Firefox, however it comes bundled with some
extensions, namely uBlock, which use up disk space in the background. This leads to the `/tmp`
directory getting full, which causes various
errors and instability.

After this change, the `/tmp` directory only
reaches around 50% capacity, even after many
restarts and webpage visits.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
