### PR TITLE
[IMP] *: cleaning after big changes in tours

### DIFF
--- a/addons/account/static/tests/tours/tax_group_tests.js
+++ b/addons/account/static/tests/tours/tax_group_tests.js
@@ -5,7 +5,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add('account_tax_group', {
-    test: true,
     url: "/odoo",
     steps: () => [
     ...accountTourSteps.goToAccountMenu("Go to Invoicing"),

--- a/addons/account/static/tests/tours/tour_tests_shared_js_python.js
+++ b/addons/account/static/tests/tours/tour_tests_shared_js_python.js
@@ -3,7 +3,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('tests_shared_js_python', {
-    test: true,
     url: "/account/init_tests_shared_js_python",
     steps: () => [
     {

--- a/addons/auth_totp/static/tests/totp_flow.js
+++ b/addons/auth_totp/static/tests/totp_flow.js
@@ -73,7 +73,6 @@ function closeProfileDialog({content, totp_state}) {
 }
 
 registry.category("web_tour.tours").add('totp_tour_setup', {
-    test: true,
     url: '/odoo',
     steps: () => [...openUserProfileAtSecurityTab(), {
     content: "Open totp wizard",
@@ -132,7 +131,6 @@ registry.category("web_tour.tours").add('totp_tour_setup', {
 ]});
 
 registry.category("web_tour.tours").add('totp_login_enabled', {
-    test: true,
     url: '/',
     steps: () => [{
     content: "check that we're on the login page or go to it",
@@ -172,7 +170,6 @@ registry.category("web_tour.tours").add('totp_login_enabled', {
 }]});
 
 registry.category("web_tour.tours").add('totp_login_device', {
-    test: true,
     url: '/',
     steps: () => [{
     content: "check that we're on the login page or go to it",
@@ -271,7 +268,6 @@ registry.category("web_tour.tours").add('totp_login_device', {
 ]});
 
 registry.category("web_tour.tours").add('totp_login_disabled', {
-    test: true,
     url: '/',
     steps: () => [{
     content: "check that we're on the login page or go to it",
@@ -301,7 +297,6 @@ registry.category("web_tour.tours").add('totp_login_disabled', {
 
 const columns = {};
 registry.category("web_tour.tours").add('totp_admin_disables', {
-    test: true,
     url: '/odoo',
     steps: () => [stepUtils.showAppsMenuItem(), {
     content: 'Go to settings',

--- a/addons/auth_totp_mail/static/tests/totp_flow.js
+++ b/addons/auth_totp_mail/static/tests/totp_flow.js
@@ -39,7 +39,6 @@ function openAccountSettingsTab() {
 }
 
 registry.category("web_tour.tours").add('totp_admin_self_invite', {
-    test: true,
     url: '/odoo',
     steps: () => [stepUtils.showAppsMenuItem(), ...openAccountSettingsTab(), {
     content: "open the user's form",
@@ -64,7 +63,6 @@ registry.category("web_tour.tours").add('totp_admin_self_invite', {
 }]});
 
 registry.category("web_tour.tours").add('totp_admin_invite', {
-    test: true,
     url: '/odoo',
     steps: () => [stepUtils.showAppsMenuItem(), ...openAccountSettingsTab(), {
     content: "open the user's form",

--- a/addons/auth_totp_portal/static/tests/totp_portal.js
+++ b/addons/auth_totp_portal/static/tests/totp_portal.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import { rpc } from "@web/core/network/rpc";
 
 registry.category("web_tour.tours").add('totportal_tour_setup', {
-    test: true,
     url: '/my/security',
     steps: () => [{
     content: "Open totp wizard",
@@ -43,7 +42,6 @@ registry.category("web_tour.tours").add('totportal_tour_setup', {
 }]});
 
 registry.category("web_tour.tours").add('totportal_login_enabled', {
-    test: true,
     url: '/',
     steps: () => [{
     content: "check that we're on the login page or go to it",
@@ -103,7 +101,6 @@ registry.category("web_tour.tours").add('totportal_login_enabled', {
 }]});
 
 registry.category("web_tour.tours").add('totportal_login_disabled', {
-    test: true,
     url: '/',
     steps: () => [{
     content: "check that we're on the login page or go to it",

--- a/addons/calendar/static/tests/tours/calendar_tour.js
+++ b/addons/calendar/static/tests/tours/calendar_tour.js
@@ -15,7 +15,6 @@ const todayDate = function () {
 
 registry.category("web_tour.tours").add("calendar_appointments_hour_tour", {
     url: "/odoo",
-    test: true,
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {
@@ -95,7 +94,6 @@ const clickOnTheEvent = {
 };
 
 registry.category("web_tour.tours").add("test_calendar_delete_tour", {
-    test: true,
     steps: () => [
         {
             content: "Select filter (everybody)",
@@ -120,7 +118,6 @@ registry.category("web_tour.tours").add("test_calendar_delete_tour", {
 });
 
 registry.category("web_tour.tours").add("test_calendar_decline_tour", {
-    test: true,
     steps: () => [
         clickOnTheEvent,
         {
@@ -136,7 +133,6 @@ registry.category("web_tour.tours").add("test_calendar_decline_tour", {
 });
 
 registry.category("web_tour.tours").add("test_calendar_decline_with_everybody_filter_tour", {
-    test: true,
     steps: () => [
         {
             content: "Select filter (everybody)",

--- a/addons/contacts/static/tests/tours/debug_menu_set_defaults.js
+++ b/addons/contacts/static/tests/tours/debug_menu_set_defaults.js
@@ -4,7 +4,6 @@
     import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
     registry.category("web_tour.tours").add('debug_menu_set_defaults', {
-        test: true,
         url: '/odoo?debug=1',
         steps: () => [
             ...stepUtils.goToAppSteps('contacts.menu_contacts', "Open the contacts menu"),

--- a/addons/crm/static/tests/tours/create_crm_team_tour.js
+++ b/addons/crm/static/tests/tours/create_crm_team_tour.js
@@ -5,7 +5,6 @@ import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add('create_crm_team_tour', {
     url: "/odoo",
-    test: true,
     steps: () => [
     ...stepUtils.goToAppSteps('crm.crm_menu_root'),
 {
@@ -36,6 +35,6 @@ registry.category("web_tour.tours").add('create_crm_team_tour', {
 }, {
     trigger: 'button.o_select_button',
     run: "click",
-}, 
+},
     ...stepUtils.saveForm()
 ]});

--- a/addons/crm/static/tests/tours/crm_email_and_phone_propagation.js
+++ b/addons/crm/static/tests/tours/crm_email_and_phone_propagation.js
@@ -1,10 +1,9 @@
 /** @odoo-module **/
-    
+
     import { registry } from "@web/core/registry";
     import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
     registry.category("web_tour.tours").add('crm_email_and_phone_propagation_edit_save', {
-        test: true,
         url: '/odoo',
         steps: () => [
         stepUtils.showAppsMenuItem(),

--- a/addons/crm/static/tests/tours/crm_forecast_tour.js
+++ b/addons/crm/static/tests/tours/crm_forecast_tour.js
@@ -5,7 +5,6 @@ import { stepUtils } from "@web_tour/tour_service/tour_utils";
 const today = luxon.DateTime.now();
 
 registry.category("web_tour.tours").add('crm_forecast', {
-    test: true,
     url: "/odoo",
     steps: () => [
     stepUtils.showAppsMenuItem(),
@@ -39,7 +38,7 @@ registry.category("web_tour.tours").add('crm_forecast', {
     }, {
         trigger: "button.o_kanban_edit",
         content: "edit lead",
-        run: "click",        
+        run: "click",
     }, {
         trigger: "div[name=date_deadline] input",
         content: "complete expected closing",

--- a/addons/crm/static/tests/tours/crm_rainbowman.js
+++ b/addons/crm/static/tests/tours/crm_rainbowman.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add("crm_rainbowman", {
-    test: true,
     url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),

--- a/addons/event_sale/static/tests/tours/event_configurator_ui.js
+++ b/addons/event_sale/static/tests/tours/event_configurator_ui.js
@@ -6,7 +6,6 @@ import tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add("event_configurator_tour", {
     url: "/odoo",
-    test: true,
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
         ...tourUtils.createNewSalesOrder(),

--- a/addons/hr/static/tests/tours/hr_employee_flow.js
+++ b/addons/hr/static/tests/tours/hr_employee_flow.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add('hr_employee_tour', {
-    test: true,
     url: '/odoo',
     steps: () => [
     stepUtils.showAppsMenuItem(),

--- a/addons/hr_expense/static/src/js/tours/show_expense_receipt_tour.js
+++ b/addons/hr_expense/static/src/js/tours/show_expense_receipt_tour.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add("show_expense_receipt_tour", {
-    test: true,
     url: "/odoo",
     steps: () => [
         ...stepUtils.goToAppSteps("hr_expense.menu_hr_expense_root", "Go to the Expenses app"),

--- a/addons/hr_expense/static/tests/tours/expense_form_in_sheet_tours.js
+++ b/addons/hr_expense/static/tests/tours/expense_form_in_sheet_tours.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add("do_not_create_zero_amount_expense_in_sheet", {
-    test: true,
     url: "/odoo",
     steps: () => [
         ...stepUtils.goToAppSteps("hr_expense.menu_hr_expense_root", "Go to the Expenses app"),

--- a/addons/hr_expense/static/tests/tours/expense_form_tours.js
+++ b/addons/hr_expense/static/tests/tours/expense_form_tours.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add('create_expense_no_employee_access_tour', {
-    test: true,
     url: "/odoo",
     steps: () => [
     ...stepUtils.goToAppSteps('hr_expense.menu_hr_expense_root', "Go to the Expenses app"),

--- a/addons/hr_expense/static/tests/tours/expense_upload_tours.js
+++ b/addons/hr_expense/static/tests/tours/expense_upload_tours.js
@@ -1,10 +1,9 @@
 /** @odoo-module **/
-    
+
     import { registry } from "@web/core/registry";
     import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
     registry.category("web_tour.tours").add('hr_expense_test_tour', {
-        test: true,
         url: "/odoo",
         steps: () => [stepUtils.showAppsMenuItem(),
         {
@@ -124,7 +123,6 @@
     ]});
 
     registry.category("web_tour.tours").add('hr_expense_access_rights_test_tour', {
-        test: true,
         url: "/odoo",
         steps: () => [stepUtils.showAppsMenuItem(),
         {

--- a/addons/hr_holidays/static/tests/tours/time_off_request_calendar_view.js
+++ b/addons/hr_holidays/static/tests/tours/time_off_request_calendar_view.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add("time_off_request_calendar_view", {
-    test: true,
     url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),

--- a/addons/hr_skills/static/tests/tours/skills_tour.js
+++ b/addons/hr_skills/static/tests/tours/skills_tour.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add('hr_skills_tour', {
-    test: true,
     url: '/odoo',
     steps: () => [
     stepUtils.showAppsMenuItem(),

--- a/addons/im_livechat/static/tests/tours/im_livechat_channel_creation_tour.js
+++ b/addons/im_livechat/static/tests/tours/im_livechat_channel_creation_tour.js
@@ -11,12 +11,10 @@ const requestChatSteps = [
 ];
 
 registry.category("web_tour.tours").add("im_livechat_request_chat", {
-    test: true,
     steps: () => requestChatSteps,
 });
 
 registry.category("web_tour.tours").add("im_livechat_request_chat_and_send_message", {
-    test: true,
     steps: () => [
         ...requestChatSteps,
         {

--- a/addons/im_livechat/static/tests/tours/im_livechat_chatbot_steps_sequence_tour.js
+++ b/addons/im_livechat/static/tests/tours/im_livechat_chatbot_steps_sequence_tour.js
@@ -60,7 +60,6 @@ const commonSteps = [
  * Simply create a few steps in order to check the sequences.
  */
 registry.category("web_tour.tours").add("im_livechat_chatbot_steps_sequence_tour", {
-    test: true,
     url: "/odoo",
     steps: () => [
         ...commonSteps,
@@ -79,7 +78,6 @@ registry.category("web_tour.tours").add("im_livechat_chatbot_steps_sequence_tour
  * Same as above, with an extra drag&drop at the end.
  */
 registry.category("web_tour.tours").add("im_livechat_chatbot_steps_sequence_with_move_tour", {
-    test: true,
     url: "/odoo",
     steps: () => [
         ...commonSteps,

--- a/addons/im_livechat/static/tests/tours/im_livechat_history_back_and_forth.js
+++ b/addons/im_livechat/static/tests/tours/im_livechat_history_back_and_forth.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("im_livechat_history_back_and_forth_tour", {
-    test: true,
     steps: () => [
         {
             isActive: ["enterprise"],

--- a/addons/l10n_be_pos_sale/static/tests/tours/l10n_be_pos_sale_tour.js
+++ b/addons/l10n_be_pos_sale/static/tests/tours/l10n_be_pos_sale_tour.js
@@ -8,7 +8,6 @@ import * as Order from "@point_of_sale/../tests/tours/utils/generic_components/o
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("PosSettleOrderIsInvoice", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -25,7 +24,6 @@ registry.category("web_tour.tours").add("PosSettleOrderIsInvoice", {
 });
 
 registry.category("web_tour.tours").add("PosSettleOrderTryInvoice", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/l10n_br_website_sale/static/tests/tours/brazilian_address.js
+++ b/addons/l10n_br_website_sale/static/tests/tours/brazilian_address.js
@@ -19,7 +19,6 @@ function assertCityAndState(expectedCity, expectedState) {
 }
 
 registry.category("web_tour.tours").add("test_brazilian_address", {
-    test: true,
     url: '/shop?search=Brazilian test product',
     steps: () => [
         ...tourUtils.addToCart({productName: "Brazilian test product", search: false}),

--- a/addons/l10n_ec_website_sale/static/tests/tours/website_sale_checkout_address.js
+++ b/addons/l10n_ec_website_sale/static/tests/tours/website_sale_checkout_address.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add("shop_checkout_address_ec", {
-    test: true,
     url: "/shop",
     steps: () => [
         ...tourUtils.addToCart({ productName: "Test Product" }),

--- a/addons/l10n_es_pos/static/tests/tours/spanish_pos_tour.js
+++ b/addons/l10n_es_pos/static/tests/tours/spanish_pos_tour.js
@@ -10,7 +10,6 @@ import { checkSimplifiedInvoiceNumber, pay } from "./utils/receipt_util";
 const SIMPLIFIED_INVOICE_LIMIT = 1000;
 
 registry.category("web_tour.tours").add("spanish_pos_tour", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/l10n_id_pos/static/tests/test_pos_qris_payment.tour.js
+++ b/addons/l10n_id_pos/static/tests/test_pos_qris_payment.tour.js
@@ -34,7 +34,6 @@ function addProductandPay() {
 }
 
 registry.category("web_tour.tours").add("PaymentScreenQRISPaymentFail", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -46,7 +45,6 @@ registry.category("web_tour.tours").add("PaymentScreenQRISPaymentFail", {
 });
 
 registry.category("web_tour.tours").add("PaymentScreenQRISPaymentSuccess", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -58,7 +56,6 @@ registry.category("web_tour.tours").add("PaymentScreenQRISPaymentSuccess", {
 });
 
 registry.category("web_tour.tours").add("PayementScreenQRISFetchQR", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -75,7 +72,6 @@ registry.category("web_tour.tours").add("PayementScreenQRISFetchQR", {
 });
 
 registry.category("web_tour.tours").add("PayementScreenQRISChangeAmount", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/l10n_it_edi_website_sale/static/tests/tours/website_sale_checkout_address.js
+++ b/addons/l10n_it_edi_website_sale/static/tests/tours/website_sale_checkout_address.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('shop_checkout_address', {
-    test: true,
     url: '/shop',
     steps: () => [
         {

--- a/addons/l10n_test_pos_qr_payment/static/tests/test_pos_payment_tour.js
+++ b/addons/l10n_test_pos_qr_payment/static/tests/test_pos_payment_tour.js
@@ -43,7 +43,6 @@ function addProductandPay() {
  */
 
 registry.category("web_tour.tours").add("PaymentScreenWithQRPaymentFailure", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -55,7 +54,6 @@ registry.category("web_tour.tours").add("PaymentScreenWithQRPaymentFailure", {
 });
 
 registry.category("web_tour.tours").add("PaymentScreenWithQRPayment", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -80,7 +78,6 @@ registry.category("web_tour.tours").add("PaymentScreenWithQRPayment", {
 });
 
 registry.category("web_tour.tours").add("PaymentScreenWithQRPaymentSwiss", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/lunch/static/tests/tours/order_lunch.js
+++ b/addons/lunch/static/tests/tours/order_lunch.js
@@ -5,7 +5,6 @@ import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('order_lunch_tour', {
     url: "/odoo",
-    test: true,
     steps: () => [{
     trigger: 'a[data-menu-xmlid="lunch.menu_lunch"]',
     content: _t("Start by accessing the lunch app."),

--- a/addons/mail/static/tests/tours/activity_date_format_tour.js
+++ b/addons/mail/static/tests/tours/activity_date_format_tour.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("mail_activity_date_format", {
-    test: true,
     steps: () => [
         {
             trigger: "button:contains('Activities')",

--- a/addons/mail/static/tests/tours/discuss_channel_as_guest_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_as_guest_tour.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("discuss_channel_as_guest_tour.js", {
-    test: true,
     steps: () => [
         {
             content: "Channel secret token has been hidden on welcome page",

--- a/addons/mail/static/tests/tours/discuss_channel_call_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_call_public_tour.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("discuss_channel_call_public_tour.js", {
-    test: true,
     steps: () => [
         {
             content: "The call does not start on the welcome page",

--- a/addons/mail/static/tests/tours/discuss_channel_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_public_tour.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { click, contains, inputFiles } from "@web/../tests/utils";
 
 registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
-    test: true,
     steps: () => [
         {
             trigger: ".o-mail-Discuss",

--- a/addons/mail/static/tests/tours/discuss_channel_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_tour.js
@@ -5,7 +5,6 @@ import { markup } from "@odoo/owl";
 
 registry.category("web_tour.tours").add("discuss_channel_tour", {
     url: "/odoo/action-mail.action_discuss",
-    sequence: 80,
     steps: () => [
         {
             trigger: ".o-mail-DiscussSidebarCategory-channel .o-mail-DiscussSidebarCategory-add",

--- a/addons/mail/static/tests/tours/discuss_configuration_tour.js
+++ b/addons/mail/static/tests/tours/discuss_configuration_tour.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add("discuss_configuration_tour", {
-    test: true,
     url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),

--- a/addons/mail/static/tests/tours/discuss_sidebar_in_public_page_tour.js
+++ b/addons/mail/static/tests/tours/discuss_sidebar_in_public_page_tour.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("sidebar_in_public_page_tour", {
-    test: true,
     steps: () => [
         {
             trigger: ".o-mail-Discuss-header [title='Channel 1']",

--- a/addons/mail/static/tests/tours/discuss_sub_channel_search_tour.js
+++ b/addons/mail/static/tests/tours/discuss_sub_channel_search_tour.js
@@ -2,7 +2,6 @@ import { contains, scroll } from "@web/../tests/utils";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("test_discuss_sub_channel_search", {
-    test: true,
     steps: () => [
         {
             trigger: "button[title='Threads']",

--- a/addons/mail/static/tests/tours/mail_activity_schedule_from_chatter.js
+++ b/addons/mail/static/tests/tours/mail_activity_schedule_from_chatter.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("mail_activity_schedule_from_chatter", {
-    test: true,
     steps: () => [
         {
             trigger: "button:contains('Activities')",

--- a/addons/mail/static/tests/tours/mail_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_composer_test_tour.js
@@ -8,7 +8,6 @@ import { contains, inputFiles } from "@web/../tests/utils";
  * @see mail/tests/test_mail_composer.py
  */
 registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_test_tour.js", {
-    test: true,
     steps: () => [
         {
             content: "Wait for the chatter to be fully loaded",

--- a/addons/mail/static/tests/tours/mail_message_load_order_tour.js
+++ b/addons/mail/static/tests/tours/mail_message_load_order_tour.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { contains, scroll } from "@web/../tests/utils";
 
 registry.category("web_tour.tours").add("mail_message_load_order_tour", {
-    test: true,
     steps: () => [
         {
             trigger: ".o-mail-DiscussSidebarChannel:contains(MyTestChannel)",

--- a/addons/mail/static/tests/tours/mail_template_dynamic_placeholder_tour.js
+++ b/addons/mail/static/tests/tours/mail_template_dynamic_placeholder_tour.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add("mail_template_dynamic_placeholder_tour", {
-    test: true,
     url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),

--- a/addons/mail/static/tests/tours/user_modify_own_profile_tour.js
+++ b/addons/mail/static/tests/tours/user_modify_own_profile_tour.js
@@ -5,7 +5,6 @@ import { contains, insertText } from "@web/../tests/utils";
  * Verify that a user can modify their own profile information.
  */
 registry.category("web_tour.tours").add("mail/static/tests/tours/user_modify_own_profile_tour.js", {
-    test: true,
     steps: () => [
         {
             content: "Open user account menu",

--- a/addons/maintenance/static/tests/tours/tour_calendar_with_recurrence.js
+++ b/addons/maintenance/static/tests/tours/tour_calendar_with_recurrence.js
@@ -3,7 +3,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("test_dblclick_event_from_calendar", {
-    test: true,
     steps: () => [
         {
             content: "Enter event form",
@@ -52,7 +51,6 @@ registry.category("web_tour.tours").add("test_dblclick_event_from_calendar", {
 });
 
 registry.category("web_tour.tours").add("test_drag_and_drop_event_in_calendar", {
-    test: true,
     steps: () => [
         {
             content: "Move event to Wednesday 1 PM",

--- a/addons/mass_mailing/static/tests/tours/mailing_campaign.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_campaign.js
@@ -3,7 +3,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registry.category('web_tour.tours').add('mailing_campaign', {
-    test: true,
     url: '/odoo',
     steps: () => [
         stepUtils.showAppsMenuItem(),

--- a/addons/mass_mailing/static/tests/tours/mailing_editor.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_editor.js
@@ -1,11 +1,10 @@
 /** @odoo-module **/
-    
+
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add('mailing_editor', {
     url: '/odoo',
-    test: true,
     steps: () => [stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="mass_mailing.mass_mailing_menu_root"]',
     run: "click",

--- a/addons/mass_mailing/static/tests/tours/mailing_editor_theme.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_editor_theme.js
@@ -5,7 +5,6 @@ import { stepUtils } from "@web_tour/tour_service/tour_utils";
 import { boundariesIn, setSelection } from "@web_editor/js/editor/odoo-editor/src/utils/utils";
 
 registry.category("web_tour.tours").add('mailing_editor_theme', {
-    test: true,
     url: '/odoo',
     steps: () => [
         stepUtils.showAppsMenuItem(),

--- a/addons/mass_mailing/static/tests/tours/mailing_portal_unsubscribe_from_document.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_portal_unsubscribe_from_document.js
@@ -7,7 +7,6 @@ import { registry } from "@web/core/registry";
  * mailing lists). We assume email is not member of any mailing list in this test.
  */
 registry.category("web_tour.tours").add('mailing_portal_unsubscribe_from_document', {
-    test: true,
     steps: () => [
         {
             content: "Confirmation unsubscribe is done",
@@ -69,7 +68,6 @@ registry.category("web_tour.tours").add('mailing_portal_unsubscribe_from_documen
  * mailing lists). We assume email is member of mailing lists in this test.
  */
 registry.category("web_tour.tours").add('mailing_portal_unsubscribe_from_document_with_lists', {
-    test: true,
     steps: () => [
         {
             content: "Confirmation unsubscribe is done",

--- a/addons/mass_mailing/static/tests/tours/mailing_portal_unsubscribe_from_list.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_portal_unsubscribe_from_list.js
@@ -7,7 +7,6 @@ import { registry } from "@web/core/registry";
  * instead of directly blocking emails).
  */
 registry.category("web_tour.tours").add("mailing_portal_unsubscribe_from_list", {
-    test: true,
     steps: () => [
         {
             content: "Confirmation unsubscribe is done",
@@ -61,7 +60,6 @@ registry.category("web_tour.tours").add("mailing_portal_unsubscribe_from_list", 
  * hereabove, easing debug and splitting checks.
  */
 registry.category("web_tour.tours").add("mailing_portal_unsubscribe_from_list_with_update", {
-    test: true,
     steps: () => [
         {
             content: "Confirmation unsubscribe is done",

--- a/addons/mass_mailing/static/tests/tours/mailing_portal_unsubscribe_from_my.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_portal_unsubscribe_from_my.js
@@ -7,7 +7,6 @@ import { registry } from "@web/core/registry";
  * as well as manage blocklist (add / remove my own email from block list).
  */
 registry.category("web_tour.tours").add("mailing_portal_unsubscribe_from_my", {
-    test: true,
     steps: () => [
         {
             content: "List1 is present, opt-in member",

--- a/addons/mass_mailing/static/tests/tours/mass_mailing_code_view.js
+++ b/addons/mass_mailing/static/tests/tours/mass_mailing_code_view.js
@@ -6,7 +6,6 @@ import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add('mass_mailing_code_view_tour', {
     url: '/odoo?debug=tests',
-    test: true,
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {

--- a/addons/mass_mailing/static/tests/tours/snippets_mailing_menu_tabs.js
+++ b/addons/mass_mailing/static/tests/tours/snippets_mailing_menu_tabs.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add('snippets_mailing_menu_tabs', {
-    test: true,
     url: '/odoo',
     steps: () => [
     stepUtils.showAppsMenuItem(), {

--- a/addons/mass_mailing/static/tests/tours/snippets_mailing_menu_toolbar.js
+++ b/addons/mass_mailing/static/tests/tours/snippets_mailing_menu_toolbar.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add('snippets_mailing_menu_toolbar', {
-    test: true,
     url: '/odoo',
     steps: () => [
     stepUtils.showAppsMenuItem(), {

--- a/addons/mass_mailing/static/tests/tours/snippets_mailing_menu_toolbar_mobile.js
+++ b/addons/mass_mailing/static/tests/tours/snippets_mailing_menu_toolbar_mobile.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add('snippets_mailing_menu_toolbar_mobile', {
-    test: true,
     url: '/odoo',
     steps: () => [
     stepUtils.showAppsMenuItem(), {

--- a/addons/mass_mailing_sms/static/tests/tours/mailing_activities_split.js
+++ b/addons/mass_mailing_sms/static/tests/tours/mailing_activities_split.js
@@ -4,7 +4,6 @@ import { queryAll } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('mailing_activities_split', {
-    test: true,
     url: '/odoo',
     steps: () => [
         {

--- a/addons/mrp/static/tests/tours/mrp_manual_consumption.js
+++ b/addons/mrp/static/tests/tours/mrp_manual_consumption.js
@@ -3,7 +3,6 @@
 import { registry } from "@web/core/registry";
 import { stepUtils } from '@web_tour/tour_service/tour_utils';
 registry.category("web_tour.tours").add('test_mrp_manual_consumption_02', {
-    test: true,
     steps: () => [
         {
             trigger: 'div[name=move_raw_ids] td[name="quantity"]:last:contains("0.00")',

--- a/addons/mrp/static/tests/tours/mrp_manufacture_from_bom.js
+++ b/addons/mrp/static/tests/tours/mrp_manufacture_from_bom.js
@@ -3,7 +3,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("test_manufacture_from_bom", {
-    test: true,
     steps: () => [
         {
             trigger: '[name="product_tmpl_id"]',

--- a/addons/mrp/static/tests/tours/mrp_product_catalog.js
+++ b/addons/mrp/static/tests/tours/mrp_product_catalog.js
@@ -3,7 +3,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('test_mrp_bom_product_catalog', {
-    test: true,
     steps: () => [
         {
             trigger: 'button[name=action_add_from_catalog]',
@@ -27,7 +26,6 @@ registry.category("web_tour.tours").add('test_mrp_bom_product_catalog', {
 ]});
 
 registry.category("web_tour.tours").add('test_mrp_production_product_catalog', {
-    test: true,
     steps: () => [
         {
             trigger: 'button[name=action_add_from_catalog_raw]',
@@ -49,4 +47,3 @@ registry.category("web_tour.tours").add('test_mrp_production_product_catalog', {
             trigger: 'div.o_field_widget:contains("WH/MO/")',
         },
 ]});
-

--- a/addons/mrp/static/tests/tours/mrp_sm_sml_synchronization.js
+++ b/addons/mrp/static/tests/tours/mrp_sm_sml_synchronization.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from '@web_tour/tour_service/tour_utils';
 
 registry.category("web_tour.tours").add('test_manufacturing_and_byproduct_sm_to_sml_synchronization', {
-    test: true,
     steps: () => [
         {
             trigger: ".btn-primary[name=action_confirm]",

--- a/addons/mrp_subcontracting/static/tests/tours/subcontracting_portal_tour.js
+++ b/addons/mrp_subcontracting/static/tests/tours/subcontracting_portal_tour.js
@@ -3,7 +3,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('subcontracting_portal_tour', {
-    test: true,
     url: '/my/productions',
     steps: () => [
         {

--- a/addons/point_of_sale/static/tests/tours/acceptance_tour.js
+++ b/addons/point_of_sale/static/tests/tours/acceptance_tour.js
@@ -7,7 +7,6 @@ import * as PaymentScreen from "@point_of_sale/../tests/tours/utils/payment_scre
 import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
 
 registry.category("web_tour.tours").add("pos_basic_order_01_multi_payment_and_change", {
-    test: true,
     steps: () =>
         [
             waitForLoading(),
@@ -30,7 +29,6 @@ registry.category("web_tour.tours").add("pos_basic_order_01_multi_payment_and_ch
 });
 
 registry.category("web_tour.tours").add("pos_basic_order_02_decimal_order_quantity", {
-    test: true,
     steps: () =>
         [
             waitForLoading(),
@@ -49,7 +47,6 @@ registry.category("web_tour.tours").add("pos_basic_order_02_decimal_order_quanti
 });
 
 registry.category("web_tour.tours").add("pos_basic_order_03_tax_position", {
-    test: true,
     steps: () =>
         [
             waitForLoading(),

--- a/addons/point_of_sale/static/tests/tours/barcode_scanning_tour.js
+++ b/addons/point_of_sale/static/tests/tours/barcode_scanning_tour.js
@@ -5,7 +5,6 @@ import { registry } from "@web/core/registry";
 import { scan_barcode } from "@point_of_sale/../tests/tours/utils/common";
 
 registry.category("web_tour.tours").add("BarcodeScanningTour", {
-    test: true,
     steps: () =>
         [
             // The following step is to make sure that the Chrome widget initialization ends
@@ -37,7 +36,6 @@ registry.category("web_tour.tours").add("BarcodeScanningTour", {
 });
 
 registry.category("web_tour.tours").add("BarcodeScanningProductPackagingTour", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -59,7 +57,6 @@ registry.category("web_tour.tours").add("BarcodeScanningProductPackagingTour", {
 });
 
 registry.category("web_tour.tours").add("GS1BarcodeScanningTour", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -87,7 +84,6 @@ registry.category("web_tour.tours").add("GS1BarcodeScanningTour", {
 });
 
 registry.category("web_tour.tours").add("BarcodeScanPartnerTour", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/point_of_sale/static/tests/tours/chrome_tour.js
+++ b/addons/point_of_sale/static/tests/tours/chrome_tour.js
@@ -7,7 +7,6 @@ import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("ChromeTour", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [
@@ -111,7 +110,6 @@ registry.category("web_tour.tours").add("ChromeTour", {
 });
 
 registry.category("web_tour.tours").add("OrderModificationAfterValidationError", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [

--- a/addons/point_of_sale/static/tests/tours/chrome_without_cash_move_permission_tour.js
+++ b/addons/point_of_sale/static/tests/tours/chrome_without_cash_move_permission_tour.js
@@ -3,7 +3,6 @@ import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("chrome_without_cash_move_permission", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/point_of_sale/static/tests/tours/customer_display_tour.js
+++ b/addons/point_of_sale/static/tests/tours/customer_display_tour.js
@@ -23,7 +23,6 @@ const NEW_ORDER =
     '{"lines":[],"finalized":false,"amount":"0.00","paymentLines":[],"change":0,"onlinePaymentData":{}}';
 
 registry.category("web_tour.tours").add("CustomerDisplayTour", {
-    test: true,
     steps: () =>
         [
             {

--- a/addons/point_of_sale/static/tests/tours/fixed_price_negative_qty_tour.js
+++ b/addons/point_of_sale/static/tests/tours/fixed_price_negative_qty_tour.js
@@ -6,7 +6,6 @@ import { registry } from "@web/core/registry";
 import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
 
 registry.category("web_tour.tours").add("FixedTaxNegativeQty", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/point_of_sale/static/tests/tours/payment_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/payment_screen_tour.js
@@ -6,7 +6,6 @@ import * as ReceiptScreen from "@point_of_sale/../tests/tours/utils/receipt_scre
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("PaymentScreenTour", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -63,7 +62,6 @@ registry.category("web_tour.tours").add("PaymentScreenTour", {
 });
 
 registry.category("web_tour.tours").add("PaymentScreenTour2", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -81,7 +79,6 @@ registry.category("web_tour.tours").add("PaymentScreenTour2", {
 });
 
 registry.category("web_tour.tours").add("PaymentScreenRoundingUp", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -104,7 +101,6 @@ registry.category("web_tour.tours").add("PaymentScreenRoundingUp", {
 });
 
 registry.category("web_tour.tours").add("PaymentScreenRoundingDown", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -127,7 +123,6 @@ registry.category("web_tour.tours").add("PaymentScreenRoundingDown", {
 });
 
 registry.category("web_tour.tours").add("PaymentScreenRoundingHalfUp", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -172,7 +167,6 @@ registry.category("web_tour.tours").add("PaymentScreenRoundingHalfUp", {
 });
 
 registry.category("web_tour.tours").add("PaymentScreenRoundingHalfUpCashAndBank", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -213,7 +207,6 @@ registry.category("web_tour.tours").add("PaymentScreenRoundingHalfUpCashAndBank"
 });
 
 registry.category("web_tour.tours").add("PaymentScreenTotalDueWithOverPayment", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -230,7 +223,6 @@ registry.category("web_tour.tours").add("PaymentScreenTotalDueWithOverPayment", 
 });
 
 registry.category("web_tour.tours").add("InvoiceShipLaterAccessRight", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -248,7 +240,6 @@ registry.category("web_tour.tours").add("InvoiceShipLaterAccessRight", {
 });
 
 registry.category("web_tour.tours").add("CashRoundingPayment", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/point_of_sale/static/tests/tours/pos_combo_tour.js
+++ b/addons/point_of_sale/static/tests/tours/pos_combo_tour.js
@@ -9,7 +9,6 @@ import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("ProductComboPriceTaxIncludedTour", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -75,7 +74,6 @@ registry.category("web_tour.tours").add("ProductComboPriceTaxIncludedTour", {
 });
 
 registry.category("web_tour.tours").add("ProductComboPriceCheckTour", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -94,7 +92,6 @@ registry.category("web_tour.tours").add("ProductComboPriceCheckTour", {
 });
 
 registry.category("web_tour.tours").add("ProductComboChangeFP", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/point_of_sale/static/tests/tours/pricelist_tour.js
+++ b/addons/point_of_sale/static/tests/tours/pricelist_tour.js
@@ -7,7 +7,6 @@ import * as Pricelist from "@point_of_sale/../tests/tours/utils/pricelist_util";
 import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
 
 registry.category("web_tour.tours").add("pos_pricelist", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/point_of_sale/static/tests/tours/product_configurator_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_configurator_tour.js
@@ -5,7 +5,6 @@ import * as ProductConfigurator from "@point_of_sale/../tests/tours/utils/produc
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("ProductConfiguratorTour", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -16,7 +16,6 @@ import {
 import * as ProductConfiguratorPopup from "@point_of_sale/../tests/tours/utils/product_configurator_util";
 
 registry.category("web_tour.tours").add("ProductScreenTour", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [
@@ -134,7 +133,6 @@ registry.category("web_tour.tours").add("ProductScreenTour", {
 });
 
 registry.category("web_tour.tours").add("FiscalPositionNoTax", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [
@@ -153,7 +151,6 @@ registry.category("web_tour.tours").add("FiscalPositionNoTax", {
 });
 
 registry.category("web_tour.tours").add("FiscalPositionIncl", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [
@@ -175,7 +172,6 @@ registry.category("web_tour.tours").add("FiscalPositionIncl", {
 });
 
 registry.category("web_tour.tours").add("FiscalPositionExcl", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [
@@ -194,7 +190,6 @@ registry.category("web_tour.tours").add("FiscalPositionExcl", {
 });
 
 registry.category("web_tour.tours").add("CashClosingDetails", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [
@@ -218,7 +213,6 @@ registry.category("web_tour.tours").add("CashClosingDetails", {
 });
 
 registry.category("web_tour.tours").add("ShowTaxExcludedTour", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [
@@ -232,7 +226,6 @@ registry.category("web_tour.tours").add("ShowTaxExcludedTour", {
 });
 
 registry.category("web_tour.tours").add("limitedProductPricelistLoading", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [
@@ -255,7 +248,6 @@ registry.category("web_tour.tours").add("limitedProductPricelistLoading", {
 });
 
 registry.category("web_tour.tours").add("MultiProductOptionsTour", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [
@@ -272,7 +264,6 @@ registry.category("web_tour.tours").add("MultiProductOptionsTour", {
 });
 
 registry.category("web_tour.tours").add("TranslateProductNameTour", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [
@@ -284,7 +275,6 @@ registry.category("web_tour.tours").add("TranslateProductNameTour", {
 });
 
 registry.category("web_tour.tours").add("DecimalCommaOrderlinePrice", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [
@@ -298,7 +288,6 @@ registry.category("web_tour.tours").add("DecimalCommaOrderlinePrice", {
 });
 
 registry.category("web_tour.tours").add("CheckProductInformation", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [
@@ -324,7 +313,6 @@ registry.category("web_tour.tours").add("CheckProductInformation", {
 });
 
 registry.category("web_tour.tours").add("PosCustomerAllFieldsDisplayed", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [
@@ -358,7 +346,6 @@ registry.category("web_tour.tours").add("PosCustomerAllFieldsDisplayed", {
 });
 
 registry.category("web_tour.tours").add("PosCategoriesOrder", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/point_of_sale/static/tests/tours/receipt_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/receipt_screen_tour.js
@@ -9,7 +9,6 @@ import { registry } from "@web/core/registry";
 import { inLeftSide } from "@point_of_sale/../tests/tours/utils/common";
 
 registry.category("web_tour.tours").add("ReceiptScreenTour", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [
@@ -76,7 +75,6 @@ registry.category("web_tour.tours").add("ReceiptScreenTour", {
 });
 
 registry.category("web_tour.tours").add("ReceiptScreenDiscountWithPricelistTour", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [
@@ -93,7 +91,6 @@ registry.category("web_tour.tours").add("ReceiptScreenDiscountWithPricelistTour"
 });
 
 registry.category("web_tour.tours").add("OrderPaidInCash", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [
@@ -119,7 +116,6 @@ registry.category("web_tour.tours").add("OrderPaidInCash", {
 });
 
 registry.category("web_tour.tours").add("ReceiptTrackingMethodTour", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [

--- a/addons/point_of_sale/static/tests/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/ticket_screen_tour.js
@@ -11,7 +11,6 @@ import { inLeftSide } from "@point_of_sale/../tests/tours/utils/common";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("TicketScreenTour", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [
@@ -160,7 +159,6 @@ registry.category("web_tour.tours").add("TicketScreenTour", {
 });
 
 registry.category("web_tour.tours").add("FiscalPositionNoTaxRefund", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [
@@ -186,7 +184,6 @@ registry.category("web_tour.tours").add("FiscalPositionNoTaxRefund", {
 });
 
 registry.category("web_tour.tours").add("LotRefundTour", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [
@@ -212,7 +209,6 @@ registry.category("web_tour.tours").add("LotRefundTour", {
 });
 
 registry.category("web_tour.tours").add("RefundFewQuantities", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [

--- a/addons/portal/static/tests/tours/portal.js
+++ b/addons/portal/static/tests/tours/portal.js
@@ -3,7 +3,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('portal_load_homepage', {
-    test: true,
     url: '/my',
     steps: () => [
         {

--- a/addons/portal/static/tests/tours/skip_to_content.js
+++ b/addons/portal/static/tests/tours/skip_to_content.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("skip_to_content", {
-    test: true,
     url: "/",
     steps: () => [
         {

--- a/addons/pos_event/static/tests/tours/pos_event_tour.js
+++ b/addons/pos_event/static/tests/tours/pos_event_tour.js
@@ -8,7 +8,6 @@ import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("SellingEventInPos", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_hr/static/tests/tours/pos_hr_tour.js
+++ b/addons/pos_hr/static/tests/tours/pos_hr_tour.js
@@ -8,7 +8,6 @@ import * as SelectionPopup from "@point_of_sale/../tests/tours/utils/selection_p
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("PosHrTour", {
-    test: true,
     steps: () =>
         [
             Chrome.clickBtn("Open Register"),
@@ -87,7 +86,6 @@ registry.category("web_tour.tours").add("PosHrTour", {
 });
 
 registry.category("web_tour.tours").add("CashierStayLogged", {
-    test: true,
     steps: () =>
         [
             Chrome.clickBtn("Open Register"),
@@ -110,7 +108,6 @@ registry.category("web_tour.tours").add("CashierStayLogged", {
 });
 
 registry.category("web_tour.tours").add("CashierCanSeeProductInfo", {
-    test: true,
     steps: () =>
         [
             Chrome.clickBtn("Open Register"),

--- a/addons/pos_loyalty/static/tests/tours/e_wallet_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/e_wallet_program_tour.js
@@ -7,7 +7,6 @@ import * as PartnerList from "@point_of_sale/../tests/tours/utils/partner_list_u
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("EWalletProgramTour1", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [
@@ -34,7 +33,6 @@ registry.category("web_tour.tours").add("EWalletProgramTour1", {
 
 const getEWalletText = (suffix) => "eWallet" + (suffix !== "" ? ` ${suffix}` : "");
 registry.category("web_tour.tours").add("EWalletProgramTour2", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [
@@ -101,7 +99,6 @@ registry.category("web_tour.tours").add("EWalletProgramTour2", {
 });
 
 registry.category("web_tour.tours").add("ExpiredEWalletProgramTour", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [
@@ -118,7 +115,6 @@ registry.category("web_tour.tours").add("ExpiredEWalletProgramTour", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyPointsEwallet", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [

--- a/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
@@ -7,7 +7,6 @@ import * as TicketScreen from "@point_of_sale/../tests/tours/utils/ticket_screen
 import * as Order from "@point_of_sale/../tests/tours/utils/generic_components/order_widget_util";
 
 registry.category("web_tour.tours").add("GiftCardProgramTour1", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -19,7 +18,6 @@ registry.category("web_tour.tours").add("GiftCardProgramTour1", {
 });
 
 registry.category("web_tour.tours").add("GiftCardProgramTour2", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -31,7 +29,6 @@ registry.category("web_tour.tours").add("GiftCardProgramTour2", {
 });
 
 registry.category("web_tour.tours").add("GiftCardWithRefundtTour", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -56,7 +53,6 @@ registry.category("web_tour.tours").add("GiftCardWithRefundtTour", {
 });
 
 registry.category("web_tour.tours").add("GiftCardProgramPriceNoTaxTour", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -72,7 +68,6 @@ registry.category("web_tour.tours").add("GiftCardProgramPriceNoTaxTour", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyPointsGiftcard", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -92,7 +87,6 @@ registry.category("web_tour.tours").add("PosLoyaltyPointsGiftcard", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyGiftCardTaxes", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -109,7 +103,6 @@ registry.category("web_tour.tours").add("PosLoyaltyGiftCardTaxes", {
 });
 
 registry.category("web_tour.tours").add("PhysicalGiftCardProgramSaleTour", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_loyalty/static/tests/tours/loyalty_history_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/loyalty_history_tour.js
@@ -5,7 +5,6 @@ import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("LoyaltyHistoryTour", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_loyalty/static/tests/tours/multiple_gift_wallet_programs_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/multiple_gift_wallet_programs_tour.js
@@ -7,7 +7,6 @@ import { registry } from "@web/core/registry";
 
 const getEWalletText = (suffix) => "eWallet" + (suffix !== "" ? ` ${suffix}` : "");
 registry.category("web_tour.tours").add("MultipleGiftWalletProgramsTour", {
-    test: true,
     steps: () =>
         [
             // One card for gift_card_1.

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
@@ -8,7 +8,6 @@ import { inLeftSide } from "@point_of_sale/../tests/tours/utils/common";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram1", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -66,7 +65,6 @@ registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram1", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram2", {
-    test: true,
     steps: () =>
         [
             // Order1: Immediately set the customer to Test Partner AAA which has 4 points.
@@ -136,7 +134,6 @@ registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram2", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyChangeRewardQty", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -153,7 +150,6 @@ registry.category("web_tour.tours").add("PosLoyaltyChangeRewardQty", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram3", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -176,7 +172,6 @@ registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram3", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyPromotion", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -189,7 +184,6 @@ registry.category("web_tour.tours").add("PosLoyaltyPromotion", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyDontGrantPointsForRewardOrderLines", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -209,7 +203,6 @@ registry.category("web_tour.tours").add("PosLoyaltyDontGrantPointsForRewardOrder
 });
 
 registry.category("web_tour.tours").add("PosComboCheapestRewardProgram", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_reward_button_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_reward_button_tour.js
@@ -6,7 +6,6 @@ import * as SelectionPopup from "@point_of_sale/../tests/tours/utils/selection_p
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [
@@ -129,7 +128,6 @@ registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour2", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [
@@ -148,7 +146,6 @@ registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour2", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltySpecificDiscountTour", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [
@@ -174,7 +171,6 @@ registry.category("web_tour.tours").add("PosLoyaltySpecificDiscountTour", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltySpecificDiscountWithFreeProductTour", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [
@@ -191,7 +187,6 @@ registry.category("web_tour.tours").add("PosLoyaltySpecificDiscountWithFreeProdu
 });
 
 registry.category("web_tour.tours").add("PosLoyaltySpecificDiscountWithRewardProductDomainTour", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [
@@ -209,7 +204,6 @@ registry.category("web_tour.tours").add("PosLoyaltySpecificDiscountWithRewardPro
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyRewardProductTag", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
@@ -8,7 +8,6 @@ import { registry } from "@web/core/registry";
 import { scan_barcode } from "@point_of_sale/../tests/tours/utils/common";
 
 registry.category("web_tour.tours").add("PosLoyaltyTour1", {
-    test: true,
     steps: () =>
         [
             // --- PoS Loyalty Tour Basic Part 1 ---
@@ -80,7 +79,6 @@ registry.category("web_tour.tours").add("PosLoyaltyTour1", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyTour2", {
-    test: true,
     steps: () =>
         [
             // --- PoS Loyalty Tour Basic Part 2 ---
@@ -166,7 +164,6 @@ registry.category("web_tour.tours").add("PosLoyaltyTour2", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyTour3", {
-    test: true,
     steps: () =>
         [
             // --- PoS Loyalty Tour Basic Part 3 ---
@@ -189,7 +186,6 @@ registry.category("web_tour.tours").add("PosLoyaltyTour3", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyTour4", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -206,7 +202,6 @@ registry.category("web_tour.tours").add("PosLoyaltyTour4", {
 });
 
 registry.category("web_tour.tours").add("PosCouponTour5", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -220,7 +215,6 @@ registry.category("web_tour.tours").add("PosCouponTour5", {
 
 //transform the last tour to match the new format
 registry.category("web_tour.tours").add("PosLoyaltyTour6", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -237,7 +231,6 @@ registry.category("web_tour.tours").add("PosLoyaltyTour6", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyTour7", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -251,7 +244,6 @@ registry.category("web_tour.tours").add("PosLoyaltyTour7", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyTour8", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -264,7 +256,6 @@ registry.category("web_tour.tours").add("PosLoyaltyTour8", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltySpecificDiscountCategoryTour", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -279,7 +270,6 @@ registry.category("web_tour.tours").add("PosLoyaltySpecificDiscountCategoryTour"
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyTour9", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -297,7 +287,6 @@ registry.category("web_tour.tours").add("PosLoyaltyTour9", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyTour10", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -322,7 +311,6 @@ registry.category("web_tour.tours").add("PosLoyaltyTour10", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyTour11.1", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -338,7 +326,6 @@ registry.category("web_tour.tours").add("PosLoyaltyTour11.1", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyTour11.2", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -359,7 +346,6 @@ registry.category("web_tour.tours").add("PosLoyaltyTour11.2", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyMinAmountAndSpecificProductTour", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -380,7 +366,6 @@ registry.category("web_tour.tours").add("PosLoyaltyMinAmountAndSpecificProductTo
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyTour12", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -419,22 +404,18 @@ function createOrderCoupon(totalAmount, couponName, couponAmount, loyaltyPoints)
 }
 
 registry.category("web_tour.tours").add("PosLoyaltyPointsDiscountNoDomainProgramNoDomain", {
-    test: true,
     steps: () => [createOrderCoupon("135.00", "10% on your order", "-15.00", "135")].flat(),
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyPointsDiscountNoDomainProgramDomain", {
-    test: true,
     steps: () => [createOrderCoupon("135.00", "10% on your order", "-15.00", "100")].flat(),
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyPointsDiscountWithDomainProgramDomain", {
-    test: true,
     steps: () => [createOrderCoupon("140.00", "10% on food", "-10.00", "90")].flat(),
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyPointsGlobalDiscountProgramNoDomain", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -450,7 +431,6 @@ registry.category("web_tour.tours").add("PosLoyaltyPointsGlobalDiscountProgramNo
 });
 
 registry.category("web_tour.tours").add("ChangeRewardValueWithLanguage", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -468,7 +448,6 @@ registry.category("web_tour.tours").add("ChangeRewardValueWithLanguage", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyArchivedRewardProductsInactive", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -484,7 +463,6 @@ registry.category("web_tour.tours").add("PosLoyaltyArchivedRewardProductsInactiv
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyArchivedRewardProductsActive", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -498,7 +476,6 @@ registry.category("web_tour.tours").add("PosLoyaltyArchivedRewardProductsActive"
 });
 
 registry.category("web_tour.tours").add("CustomerLoyaltyPointsDisplayed", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -519,7 +496,6 @@ registry.category("web_tour.tours").add("CustomerLoyaltyPointsDisplayed", {
 });
 
 registry.category("web_tour.tours").add("PosRewardProductScan", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -534,7 +510,6 @@ registry.category("web_tour.tours").add("PosRewardProductScan", {
 });
 
 registry.category("web_tour.tours").add("PosRewardProductScanGS1", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_validity_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_validity_tour.js
@@ -5,7 +5,6 @@ import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("PosLoyaltyValidity1", {
-    test: true,
     steps: () =>
         [
             // First tour should not get any automatic rewards
@@ -22,7 +21,6 @@ registry.category("web_tour.tours").add("PosLoyaltyValidity1", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyValidity2", {
-    test: true,
     steps: () =>
         [
             // Second tour

--- a/addons/pos_online_payment/static/tests/tours/online_payment_tour.js
+++ b/addons/pos_online_payment/static/tests/tours/online_payment_tour.js
@@ -5,7 +5,6 @@ import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("OnlinePaymentErrorsTour", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_online_payment_self_order/static/tests/tours/pos_online_payment_self_order_after_each_cart_tour.js
+++ b/addons/pos_online_payment_self_order/static/tests/tours/pos_online_payment_self_order_after_each_cart_tour.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { PosSelf } from "@pos_self_order/../tests/tours/tour_utils";
 
 registry.category("web_tour.tours").add("pos_online_payment_self_order_after_each_cart_tour", {
-    test: true,
     steps: () => [
         // Check that the self is open
         PosSelf.isNotNotification(),

--- a/addons/pos_online_payment_self_order/static/tests/tours/pos_online_payment_self_order_after_meal_cart_tour.js
+++ b/addons/pos_online_payment_self_order/static/tests/tours/pos_online_payment_self_order_after_meal_cart_tour.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { PosSelf } from "@pos_self_order/../tests/tours/tour_utils";
 
 registry.category("web_tour.tours").add("pos_online_payment_self_order_after_meal_cart_tour", {
-    test: true,
     steps: () => [
         // Check that the self is open
         PosSelf.isNotNotification(),

--- a/addons/pos_restaurant/static/tests/tours/control_buttons_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/control_buttons_tour.js
@@ -13,7 +13,6 @@ const Chrome = { ...ChromePos, ...ChromeRestaurant };
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("ControlButtonsTour", {
-    test: true,
     steps: () =>
         [
             // Test merging table, transfer is already tested in pos_restaurant_sync_second_login.

--- a/addons/pos_restaurant/static/tests/tours/floor_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/floor_screen_tour.js
@@ -13,7 +13,6 @@ const ProductScreen = { ...ProductScreenPos, ...ProductScreenResto };
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("FloorScreenTour", {
-    test: true,
     steps: () =>
         [
             // check floors if they contain their corresponding tables

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -54,7 +54,6 @@ function checkOrderChanges(expected_changes) {
 }
 
 registry.category("web_tour.tours").add("pos_restaurant_sync", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -179,7 +178,6 @@ registry.category("web_tour.tours").add("pos_restaurant_sync", {
  * This tour should be run after the first tour is done.
  */
 registry.category("web_tour.tours").add("pos_restaurant_sync_second_login", {
-    test: true,
     steps: () =>
         [
             // There is one draft synced order from the previous tour
@@ -220,7 +218,6 @@ registry.category("web_tour.tours").add("pos_restaurant_sync_second_login", {
 });
 
 registry.category("web_tour.tours").add("SaveLastPreparationChangesTour", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -239,7 +236,6 @@ const billScreenQRCode = {
 };
 
 registry.category("web_tour.tours").add("BillScreenTour", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -258,7 +254,6 @@ registry.category("web_tour.tours").add("BillScreenTour", {
 });
 
 registry.category("web_tour.tours").add("OrderTrackingTour", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -284,7 +279,6 @@ registry.category("web_tour.tours").add("OrderTrackingTour", {
         ].flat(),
 });
 registry.category("web_tour.tours").add("CategLabelCheck", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_restaurant/static/tests/tours/refund_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/refund_tour.js
@@ -11,7 +11,6 @@ import * as Order from "@point_of_sale/../tests/tours/utils/generic_components/o
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("RefundStayCurrentTableTour", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_restaurant/static/tests/tours/split_bill_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/split_bill_screen_tour.js
@@ -15,7 +15,6 @@ import * as combo from "@point_of_sale/../tests/tours/utils/combo_popup_util";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("SplitBillScreenTour", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -82,7 +81,6 @@ registry.category("web_tour.tours").add("SplitBillScreenTour", {
 });
 
 registry.category("web_tour.tours").add("SplitBillScreenTour2", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -116,7 +114,6 @@ registry.category("web_tour.tours").add("SplitBillScreenTour2", {
 });
 
 registry.category("web_tour.tours").add("SplitBillScreenTour3", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -152,7 +149,6 @@ registry.category("web_tour.tours").add("SplitBillScreenTour3", {
 });
 
 registry.category("web_tour.tours").add("SplitBillScreenTour4ProductCombo", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
@@ -8,7 +8,6 @@ import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("PosResTicketScreenTour", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [
@@ -37,7 +36,6 @@ registry.category("web_tour.tours").add("PosResTicketScreenTour", {
 });
 
 registry.category("web_tour.tours").add("OrderNumberConflictTour", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [

--- a/addons/pos_restaurant/static/tests/tours/tip_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/tip_screen_tour.js
@@ -12,7 +12,6 @@ import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("PosResTipScreenTour", {
-    test: true,
     checkDelay: 50,
     steps: () =>
         [

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -10,7 +10,6 @@ import * as Utils from "@point_of_sale/../tests/tours/utils/common";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("PosSettleOrder", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -28,7 +27,6 @@ registry.category("web_tour.tours").add("PosSettleOrder", {
 });
 
 registry.category("web_tour.tours").add("PosSettleOrderIncompatiblePartner", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -48,7 +46,6 @@ registry.category("web_tour.tours").add("PosSettleOrderIncompatiblePartner", {
 });
 
 registry.category("web_tour.tours").add("PosSettleOrder2", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -67,7 +64,6 @@ registry.category("web_tour.tours").add("PosSettleOrder2", {
 });
 
 registry.category("web_tour.tours").add("PosRefundDownpayment", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -96,7 +92,6 @@ registry.category("web_tour.tours").add("PosRefundDownpayment", {
 });
 
 registry.category("web_tour.tours").add("PosSettleOrderRealTime", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -111,7 +106,6 @@ registry.category("web_tour.tours").add("PosSettleOrderRealTime", {
 });
 
 registry.category("web_tour.tours").add("PosSettleOrder3", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -126,7 +120,6 @@ registry.category("web_tour.tours").add("PosSettleOrder3", {
 });
 
 registry.category("web_tour.tours").add("PosSettleOrderNotGroupable", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -139,7 +132,6 @@ registry.category("web_tour.tours").add("PosSettleOrderNotGroupable", {
 });
 
 registry.category("web_tour.tours").add("PosSettleOrderWithNote", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -160,7 +152,6 @@ registry.category("web_tour.tours").add("PosSettleOrderWithNote", {
 });
 
 registry.category("web_tour.tours").add("PosSettleAndInvoiceOrder", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -175,7 +166,6 @@ registry.category("web_tour.tours").add("PosSettleAndInvoiceOrder", {
 });
 
 registry.category("web_tour.tours").add("PosOrderDoesNotRemainInList", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -190,7 +180,6 @@ registry.category("web_tour.tours").add("PosOrderDoesNotRemainInList", {
 });
 
 registry.category("web_tour.tours").add("PosSettleDraftOrder", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -201,7 +190,6 @@ registry.category("web_tour.tours").add("PosSettleDraftOrder", {
 });
 
 registry.category("web_tour.tours").add("PosSettleCustomPrice", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -215,7 +203,6 @@ registry.category("web_tour.tours").add("PosSettleCustomPrice", {
 });
 
 registry.category("web_tour.tours").add("PoSSaleOrderWithDownpayment", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -227,7 +214,6 @@ registry.category("web_tour.tours").add("PoSSaleOrderWithDownpayment", {
 });
 
 registry.category("web_tour.tours").add("PoSDownPaymentLinesPerTax", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -257,7 +243,6 @@ registry.category("web_tour.tours").add("PoSDownPaymentLinesPerTax", {
 });
 
 registry.category("web_tour.tours").add("PoSApplyDownpayment", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -270,7 +255,6 @@ registry.category("web_tour.tours").add("PoSApplyDownpayment", {
 });
 
 registry.category("web_tour.tours").add("PosShipLaterNoDefault", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -283,7 +267,6 @@ registry.category("web_tour.tours").add("PosShipLaterNoDefault", {
 });
 
 registry.category("web_tour.tours").add("PosSaleTeam", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -297,7 +280,6 @@ registry.category("web_tour.tours").add("PosSaleTeam", {
 });
 
 registry.category("web_tour.tours").add("PosOrdersListDifferentCurrency", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_sale_loyalty/static/tests/tours/pos_sale_loyalty_tour.js
+++ b/addons/pos_sale_loyalty/static/tests/tours/pos_sale_loyalty_tour.js
@@ -7,7 +7,6 @@ import * as PosSale from "@pos_sale/../tests/tours/utils/pos_sale_utils";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("PosSaleLoyaltyTour1", {
-    test: true,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
@@ -4,7 +4,6 @@ import * as CartPage from "@pos_self_order/../tests/tours/utils/cart_page_util";
 import * as ProductPage from "@pos_self_order/../tests/tours/utils/product_page_util";
 
 registry.category("web_tour.tours").add("self_attribute_selector", {
-    test: true,
     steps: () => [
         Utils.clickBtn("Order Now"),
         ProductPage.clickProduct("Desk Organizer"),
@@ -40,7 +39,6 @@ registry.category("web_tour.tours").add("self_attribute_selector", {
 });
 
 registry.category("web_tour.tours").add("self_multi_attribute_selector", {
-    test: true,
     steps: () => [
         Utils.clickBtn("Order Now"),
         ProductPage.clickProduct("Multi Check Attribute Product"),

--- a/addons/pos_self_order/static/tests/tours/self_order_combo_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_combo_tour.js
@@ -4,7 +4,6 @@ import * as CartPage from "@pos_self_order/../tests/tours/utils/cart_page_util";
 import * as ProductPage from "@pos_self_order/../tests/tours/utils/product_page_util";
 
 registry.category("web_tour.tours").add("self_combo_selector", {
-    test: true,
     steps: () => [
         Utils.clickBtn("Order Now"),
         ProductPage.clickProduct("Office Combo"),

--- a/addons/pos_self_order/static/tests/tours/self_order_common_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_common_tour.js
@@ -4,7 +4,6 @@ import * as LandingPage from "@pos_self_order/../tests/tours/utils/landing_page_
 import * as ProductPage from "@pos_self_order/../tests/tours/utils/product_page_util";
 
 registry.category("web_tour.tours").add("self_order_is_close", {
-    test: true,
     steps: () => [
         LandingPage.isClosed(),
         Utils.clickBtn("Order Now"),
@@ -14,7 +13,6 @@ registry.category("web_tour.tours").add("self_order_is_close", {
 });
 
 registry.category("web_tour.tours").add("self_order_is_open_consultation", {
-    test: true,
     steps: () => [
         Utils.clickBtn("Order Now"),
         LandingPage.isOpened(),
@@ -24,7 +22,6 @@ registry.category("web_tour.tours").add("self_order_is_open_consultation", {
 });
 
 registry.category("web_tour.tours").add("self_order_pos_closed", {
-    test: true,
     steps: () => [
         LandingPage.isClosed(),
         // Normal product

--- a/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
@@ -7,7 +7,6 @@ import * as ProductPage from "@pos_self_order/../tests/tours/utils/product_page_
 import * as Numpad from "@point_of_sale/../tests/tours/utils/numpad_util";
 
 registry.category("web_tour.tours").add("self_kiosk_each_table_takeaway_in", {
-    test: true,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -28,7 +27,6 @@ registry.category("web_tour.tours").add("self_kiosk_each_table_takeaway_in", {
 });
 
 registry.category("web_tour.tours").add("self_kiosk_each_table_takeaway_out", {
-    test: true,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -46,7 +44,6 @@ registry.category("web_tour.tours").add("self_kiosk_each_table_takeaway_out", {
 });
 
 registry.category("web_tour.tours").add("self_kiosk_each_counter_takeaway_in", {
-    test: true,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -64,7 +61,6 @@ registry.category("web_tour.tours").add("self_kiosk_each_counter_takeaway_in", {
 });
 
 registry.category("web_tour.tours").add("self_kiosk_each_counter_takeaway_out", {
-    test: true,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -82,7 +78,6 @@ registry.category("web_tour.tours").add("self_kiosk_each_counter_takeaway_out", 
 });
 
 registry.category("web_tour.tours").add("self_order_kiosk_cancel", {
-    test: true,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -101,7 +96,6 @@ registry.category("web_tour.tours").add("self_order_kiosk_cancel", {
 });
 
 registry.category("web_tour.tours").add("self_simple_order", {
-    test: true,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -115,7 +109,6 @@ registry.category("web_tour.tours").add("self_simple_order", {
 });
 
 registry.category("web_tour.tours").add("self_order_price_null", {
-    test: true,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -129,7 +122,6 @@ registry.category("web_tour.tours").add("self_order_price_null", {
 });
 
 registry.category("web_tour.tours").add("self_order_language_changes", {
-    test: true,
     steps: () => [
         LandingPage.checkLanguageSelected("English"),
         LandingPage.checkCountryFlagShown("us"),

--- a/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
@@ -6,7 +6,6 @@ import * as ProductPage from "@pos_self_order/../tests/tours/utils/product_page_
 import * as ConfirmationPage from "@pos_self_order/../tests/tours/utils/confirmation_page_util";
 
 registry.category("web_tour.tours").add("self_mobile_each_table_takeaway_in", {
-    test: true,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -26,7 +25,6 @@ registry.category("web_tour.tours").add("self_mobile_each_table_takeaway_in", {
 });
 
 registry.category("web_tour.tours").add("self_mobile_each_table_takeaway_out", {
-    test: true,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -45,7 +43,6 @@ registry.category("web_tour.tours").add("self_mobile_each_table_takeaway_out", {
 });
 
 registry.category("web_tour.tours").add("self_mobile_each_counter_takeaway_in", {
-    test: true,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -64,7 +61,6 @@ registry.category("web_tour.tours").add("self_mobile_each_counter_takeaway_in", 
 });
 
 registry.category("web_tour.tours").add("self_mobile_each_counter_takeaway_out", {
-    test: true,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -83,7 +79,6 @@ registry.category("web_tour.tours").add("self_mobile_each_counter_takeaway_out",
 });
 
 registry.category("web_tour.tours").add("self_mobile_meal_table_takeaway_in", {
-    test: true,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -109,7 +104,6 @@ registry.category("web_tour.tours").add("self_mobile_meal_table_takeaway_in", {
 });
 
 registry.category("web_tour.tours").add("self_mobile_meal_table_takeaway_out", {
-    test: true,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -135,7 +129,6 @@ registry.category("web_tour.tours").add("self_mobile_meal_table_takeaway_out", {
 });
 
 registry.category("web_tour.tours").add("self_mobile_meal_counter_takeaway_in", {
-    test: true,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -161,7 +154,6 @@ registry.category("web_tour.tours").add("self_mobile_meal_counter_takeaway_in", 
 });
 
 registry.category("web_tour.tours").add("self_mobile_meal_counter_takeaway_out", {
-    test: true,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -187,7 +179,6 @@ registry.category("web_tour.tours").add("self_mobile_meal_counter_takeaway_out",
 });
 
 registry.category("web_tour.tours").add("self_order_mobile_meal_cancel", {
-    test: true,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -217,7 +208,6 @@ registry.category("web_tour.tours").add("self_order_mobile_meal_cancel", {
 });
 
 registry.category("web_tour.tours").add("self_order_mobile_each_cancel", {
-    test: true,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -243,7 +233,6 @@ registry.category("web_tour.tours").add("self_order_mobile_each_cancel", {
 });
 
 registry.category("web_tour.tours").add("SelfOrderOrderNumberTour", {
-    test: true,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),

--- a/addons/project/static/tests/tours/personal_stage_tour.js
+++ b/addons/project/static/tests/tours/personal_stage_tour.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add('personal_stage_tour', {
-    test: true,
     url: '/odoo',
     steps: () => [stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="project.menu_main_pm"]',

--- a/addons/project/static/tests/tours/project_burndown_chart_tour.js
+++ b/addons/project/static/tests/tours/project_burndown_chart_tour.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add('burndown_chart_tour', {
-    test: true,
     url: '/odoo',
     steps: () => [stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="project.menu_main_pm"]',

--- a/addons/project/static/tests/tours/project_sharing_tour.js
+++ b/addons/project/static/tests/tours/project_sharing_tour.js
@@ -126,7 +126,6 @@ const projectSharingSteps = [...stepUtils.goToAppSteps("project.menu_main_pm", '
 }];
 
 registry.category("web_tour.tours").add('project_sharing_tour', {
-    test: true,
     url: '/odoo',
     steps: () => {
         return projectSharingSteps;
@@ -134,7 +133,6 @@ registry.category("web_tour.tours").add('project_sharing_tour', {
 });
 
 registry.category("web_tour.tours").add("portal_project_sharing_tour", {
-    test: true,
     url: "/my/projects",
     steps: () => {
         // The begining of the project sharing feature
@@ -144,7 +142,6 @@ registry.category("web_tour.tours").add("portal_project_sharing_tour", {
 });
 
 registry.category("web_tour.tours").add("project_sharing_with_blocked_task_tour", {
-    test: true,
     url: "/my/projects",
     steps: () => [{
         trigger: 'table > tbody > tr a:has(span:contains("Project Sharing"))',
@@ -165,7 +162,6 @@ registry.category("web_tour.tours").add("project_sharing_with_blocked_task_tour"
 ]});
 
 registry.category("web_tour.tours").add("portal_project_sharing_tour_with_disallowed_milestones", {
-    test: true,
     url: "/my/projects",
     steps: () => [
         {
@@ -210,4 +206,3 @@ registry.category("web_tour.tours").add("portal_project_sharing_tour_with_disall
         },
     ],
 });
-

--- a/addons/project/static/tests/tours/project_tags_filter_tour_tests.js
+++ b/addons/project/static/tests/tours/project_tags_filter_tour_tests.js
@@ -23,7 +23,6 @@ function changeFilter(filterName) {
 }
 
 registry.category("web_tour.tours").add("project_tags_filter_tour", {
-    test: true,
     url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),

--- a/addons/project/static/tests/tours/project_task_history.js
+++ b/addons/project/static/tests/tours/project_task_history.js
@@ -32,7 +32,6 @@ function changeDescriptionContentAndSave(newContent) {
 }
 
 registry.category("web_tour.tours").add("project_task_history_tour", {
-    test: true,
     url: "/odoo",
     steps: () => [stepUtils.showAppsMenuItem(), {
         content: "Open the project app",

--- a/addons/project/static/tests/tours/project_tour.js
+++ b/addons/project/static/tests/tours/project_tour.js
@@ -4,13 +4,12 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add('project_test_tour', {
-    test: true,
     url: '/odoo',
     steps: () => [
     stepUtils.showAppsMenuItem(), {
         trigger: '.o_app[data-menu-xmlid="project.menu_main_pm"]',
         run: "click",
-    }, 
+    },
     {
         trigger: '.o_project_kanban',
     },
@@ -31,7 +30,7 @@ registry.category("web_tour.tours").add('project_test_tour', {
         isActive: ["auto"],
         trigger: ".o_kanban_project_tasks .o_column_quick_create .o_kanban_add",
         run: "click",
-    }, 
+    },
     {
         trigger: ".o_kanban_group",
     },
@@ -42,14 +41,14 @@ registry.category("web_tour.tours").add('project_test_tour', {
         isActive: ["auto"],
         trigger: ".o_kanban_project_tasks .o_column_quick_create .o_kanban_add",
         run: "click",
-    }, 
+    },
     {
         trigger: ".o_kanban_group:eq(0)",
     },
     {
         trigger: '.o-kanban-button-new',
         run: "click",
-    }, 
+    },
     {
         trigger: ".o_kanban_project_tasks",
     },
@@ -83,7 +82,7 @@ registry.category("web_tour.tours").add('project_test_tour', {
         trigger: ".o_kanban_record .o_widget_subtask_counter .subtask_list_button",
         content: 'open sub-tasks from kanban card',
         run: "click",
-    }, 
+    },
     {
         trigger: ".o_widget_subtask_kanban_list .subtask_list",
     },
@@ -91,7 +90,7 @@ registry.category("web_tour.tours").add('project_test_tour', {
         trigger: ".o_kanban_record .o_widget_subtask_kanban_list .subtask_create",
         content: 'Create a new sub-task',
         run: "click",
-    }, 
+    },
     {
         trigger: ".subtask_create_input",
     },
@@ -103,7 +102,7 @@ registry.category("web_tour.tours").add('project_test_tour', {
         trigger: ".o_kanban_record .o_widget_subtask_kanban_list .subtask_list_row:first-child .o_field_project_task_state_selection button",
         content: 'Change the subtask state',
         run: "click",
-    }, 
+    },
     {
         trigger: ".dropdown-menu",
     },
@@ -140,7 +139,7 @@ registry.category("web_tour.tours").add('project_test_tour', {
         trigger: '.o_field_subtasks_one2many div[name="name"] input',
         content: 'Set subtask name',
         run: "edit new subtask",
-    }, 
+    },
     {
         trigger: '.o_field_many2many_tags_avatar .o_m2m_avatar',
     },

--- a/addons/project/static/tests/tours/project_update_tour_tests.js
+++ b/addons/project/static/tests/tours/project_update_tour_tests.js
@@ -4,12 +4,11 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add('project_update_tour', {
-    test: true,
     url: '/odoo',
     steps: () => [stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="project.menu_main_pm"]',
     run: "click",
-}, 
+},
 {
     trigger: ".o_project_kanban",
 },
@@ -29,7 +28,7 @@ registry.category("web_tour.tours").add('project_update_tour', {
     isActive: ["auto"],
     trigger: ".o_kanban_project_tasks .o_column_quick_create .o_kanban_add",
     run: "click",
-}, 
+},
 {
     trigger: ".o_kanban_group",
 },
@@ -40,42 +39,42 @@ registry.category("web_tour.tours").add('project_update_tour', {
     isActive: ["auto"],
     trigger: ".o_kanban_project_tasks .o_column_quick_create .o_kanban_add",
     run: "click",
-}, 
+},
 {
     trigger: ".o_kanban_group:eq(0)",
 },
 {
     trigger: '.o-kanban-button-new',
     run: "click",
-}, 
+},
 {
     trigger: ".o_kanban_project_tasks",
 },
 {
     trigger: '.o_kanban_quick_create div.o_field_char[name=display_name] input',
     run: "edit New task",
-}, 
+},
 {
     trigger: ".o_kanban_project_tasks",
 },
 {
     trigger: '.o_kanban_quick_create .o_kanban_add',
     run: "click",
-}, 
+},
 {
     trigger: ".o_kanban_group:eq(0)",
 },
 {
     trigger: '.o-kanban-button-new',
     run: "click",
-}, 
+},
 {
     trigger: ".o_kanban_project_tasks",
 },
 {
     trigger: '.o_kanban_quick_create div.o_field_char[name=display_name] input',
     run: "edit Second task",
-}, 
+},
 {
     trigger: ".o_kanban_project_tasks",
 },
@@ -133,7 +132,7 @@ registry.category("web_tour.tours").add('project_update_tour', {
 }, {
     trigger: ".modal-footer .o_form_button_save",
     run: "click",
-}, 
+},
 {
     trigger: "body:not(:has(.modal))",
 },
@@ -149,7 +148,7 @@ registry.category("web_tour.tours").add('project_update_tour', {
 }, {
     trigger: ".modal-footer .o_form_button_save",
     run: "click",
-}, 
+},
 {
     trigger: "body:not(:has(.modal))",
 },
@@ -190,7 +189,7 @@ registry.category("web_tour.tours").add('project_update_tour', {
     trigger: '.o_switch_view.o_list',
     content: 'Open List View of Dashboard',
     run: "click",
-}, 
+},
 {
     trigger: '.o_list_view',
 },

--- a/addons/project_todo/static/tests/tours/project_task_activities_split.js
+++ b/addons/project_todo/static/tests/tours/project_task_activities_split.js
@@ -3,7 +3,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('project_task_activities_split', {
-    test: true,
     url: '/odoo',
     steps: () => [
         {

--- a/addons/project_todo/static/tests/tours/project_todo_main_functions.js
+++ b/addons/project_todo/static/tests/tours/project_todo_main_functions.js
@@ -5,7 +5,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add('project_todo_main_functions', {
-    test: true,
     url: '/odoo',
     steps: () => [stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="project_todo.menu_todo_todos"]',
@@ -14,7 +13,7 @@ registry.category("web_tour.tours").add('project_todo_main_functions', {
     trigger: ".o_project_task_kanban_view .o_column_quick_create .o_kanban_add_column",
     content: "Create a personal stage from the To-do kanban view",
     run: "click",
-}, 
+},
 {
     trigger: ".o_kanban_group",
 },
@@ -26,7 +25,7 @@ registry.category("web_tour.tours").add('project_todo_main_functions', {
     trigger: ".o_project_task_kanban_view .o_column_quick_create .o_kanban_add",
     content: "Save the personal stage",
     run: "click",
-}, 
+},
 {
     trigger: ".o_kanban_group",
 },
@@ -38,7 +37,7 @@ registry.category("web_tour.tours").add('project_todo_main_functions', {
     trigger: ".o_project_task_kanban_view .o_column_quick_create .o_kanban_add",
     content: "Save the personal stage",
     run: "click",
-}, 
+},
 {
     trigger: ".o_kanban_group:eq(1)",
 },
@@ -46,7 +45,7 @@ registry.category("web_tour.tours").add('project_todo_main_functions', {
     trigger: '.o-kanban-button-new',
     content: "Create a task in the first stage",
     run: "click",
-}, 
+},
 {
     trigger: ".o_project_task_kanban_view",
 },
@@ -54,7 +53,7 @@ registry.category("web_tour.tours").add('project_todo_main_functions', {
     trigger: '.o_kanban_quick_create div.o_field_char[name=name] input',
     content: "Create a personal task from the To-do kanban view",
     run: "edit Personal Task 1",
-}, 
+},
 {
     trigger: ".o_project_task_kanban_view",
 },
@@ -62,7 +61,7 @@ registry.category("web_tour.tours").add('project_todo_main_functions', {
     trigger: '.o_kanban_quick_create .o_kanban_add',
     content: "Save the personal task",
     run: "click",
-}, 
+},
 {
     trigger: ".o_project_task_kanban_view",
 },
@@ -70,7 +69,7 @@ registry.category("web_tour.tours").add('project_todo_main_functions', {
     trigger: ".o_kanban_record",
     content: "Drag &amp; drop the card to change the personal task from personal stage.",
     run: "drag_and_drop(.o_kanban_group:eq(1))",
-}, 
+},
 {
     trigger: ".o_project_task_kanban_view",
 },
@@ -83,7 +82,7 @@ registry.category("web_tour.tours").add('project_todo_main_functions', {
     trigger: ".o_kanban_record:first",//:contains(Send message)
     content: "Open the first todo record",
     run: "click",
-}, 
+},
 {
     trigger: ".o_todo_form_view",
 },
@@ -96,7 +95,7 @@ registry.category("web_tour.tours").add('project_todo_main_functions', {
     trigger: ".o-mail-Chatter-topbar button.o-mail-Chatter-sendMessage",
     content: "A 'send message' button should be present in the chatter",
     run: "click",
-}, 
+},
 {
     trigger: ".o_todo_form_view",
 },
@@ -104,7 +103,7 @@ registry.category("web_tour.tours").add('project_todo_main_functions', {
     trigger: ".o-mail-Chatter-topbar button.o-mail-Chatter-logNote",
     content: "A 'log note' button should be present in the chatter",
     run: "click",
-}, 
+},
 {
     trigger: ".o_todo_form_view",
 },
@@ -116,7 +115,7 @@ registry.category("web_tour.tours").add('project_todo_main_functions', {
     trigger: "button[name=action_schedule_activities]",
     content: "Schedule an activity",
     run: "click",
-}, 
+},
 {
     trigger: ".o_todo_form_view",
 },
@@ -137,7 +136,7 @@ registry.category("web_tour.tours").add('project_todo_main_functions', {
     trigger: '.o_todo_done_button',
     content: 'Mark the task as done',
     run: "click",
-}, 
+},
 {
     trigger: ".o_todo_form_view .o_form_dirty",
 },

--- a/addons/purchase_product_matrix/static/tests/tours/purchase_product_matrix_tour.js
+++ b/addons/purchase_product_matrix/static/tests/tours/purchase_product_matrix_tour.js
@@ -5,11 +5,10 @@ import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add('purchase_matrix_tour', {
     url: "/odoo",
-    test: true,
     steps: () => [stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="purchase.menu_purchase_root"]',
     run: "click",
-}, 
+},
 {
     trigger: ".o_purchase_order",
 },
@@ -66,7 +65,7 @@ registry.category("web_tour.tours").add('purchase_matrix_tour', {
 }, {
     trigger: ".modal button:contains(Confirm)",
     run: 'click' // apply the matrix
-}, 
+},
 {
     trigger: '.o_field_cell.o_data_cell.o_list_number:contains("4.00")',
 },

--- a/addons/sale/static/tests/tours/product_attribute_value_tour.js
+++ b/addons/sale/static/tests/tours/product_attribute_value_tour.js
@@ -40,7 +40,6 @@ const deletePAV = (product_attribute_value, message) => [
 // This tour relies on data created on the Python test.
 registry.category("web_tour.tours").add('delete_product_attribute_value_tour', {
     url: '/odoo',
-    test: true,
     steps: () => [
         ...openProductAttribute("PA"),
         // Test error message on a used attribute value

--- a/addons/sale/static/tests/tours/sale_signature.js
+++ b/addons/sale/static/tests/tours/sale_signature.js
@@ -5,7 +5,6 @@ import { redirect } from "@web/core/utils/urls";
 
 // This tour relies on data created on the Python test.
 registry.category("web_tour.tours").add('sale_signature', {
-    test: true,
     url: '/my/quotes',
     steps: () => [
     {

--- a/addons/sale_pdf_quote_builder/static/tests/tours/custom_content_kanban_like_tests.js
+++ b/addons/sale_pdf_quote_builder/static/tests/tours/custom_content_kanban_like_tests.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add('custom_content_kanban_like_tour', {
-    test: true,
     steps: () => [
         {
             trigger: "ul.nav a:contains(Quote Builder)",

--- a/addons/sale_project/static/tests/tours/project_create_sol_tour.js
+++ b/addons/sale_project/static/tests/tours/project_create_sol_tour.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add('project_create_sol_tour', {
-    test: true,
     url: "/odoo",
     steps: () => [
     stepUtils.showAppsMenuItem(), {
@@ -26,7 +25,7 @@ registry.category("web_tour.tours").add('project_create_sol_tour', {
         trigger: ".ui-autocomplete > li > a:not(:has(i.fa))",
         content: "Select the customer in the autocomplete dropdown",
         run: "click",
-    }, 
+    },
     {
         trigger: 'div.o_notebook_headers',
     },

--- a/addons/sale_project/static/tests/tours/task_create_sol_tour.js
+++ b/addons/sale_project/static/tests/tours/task_create_sol_tour.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add("task_create_sol_tour", {
-    test: true,
     url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),

--- a/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
+++ b/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
@@ -8,7 +8,6 @@ import { markup } from "@odoo/owl";
 import { queryText } from "@odoo/hoot-dom";
 
 registry.category("web_tour.tours").add('sale_timesheet_tour', {
-    test: true,
     url: '/odoo',
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),

--- a/addons/stock/static/tests/tours/stock_picking_tour.js
+++ b/addons/stock/static/tests/tours/stock_picking_tour.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add('test_detailed_op_no_save_1', { test: true, steps: () => [
+registry.category("web_tour.tours").add('test_detailed_op_no_save_1', {  steps: () => [
     {
         trigger: '.o_field_x2many_list_row_add > a',
         run: "click",
@@ -71,7 +71,7 @@ registry.category("web_tour.tours").add('test_detailed_op_no_save_1', { test: tr
     },
 ]});
 
-registry.category("web_tour.tours").add('test_generate_serial_1', { test: true, steps: () => [
+registry.category("web_tour.tours").add('test_generate_serial_1', {  steps: () => [
     {
         trigger: '.o_field_x2many_list_row_add > a',
         run: "click",
@@ -166,7 +166,7 @@ registry.category("web_tour.tours").add('test_generate_serial_1', { test: true, 
     },
 ]});
 
-registry.category("web_tour.tours").add('test_generate_serial_2', { test: true, steps: () => [
+registry.category("web_tour.tours").add('test_generate_serial_2', {  steps: () => [
     {
         trigger: '.o_field_x2many_list_row_add > a',
         run: "click",
@@ -307,7 +307,7 @@ registry.category("web_tour.tours").add('test_generate_serial_2', { test: true, 
     },
 ]});
 
-registry.category('web_tour.tours').add('test_inventory_adjustment_apply_all', { test: true, steps: () => [
+registry.category('web_tour.tours').add('test_inventory_adjustment_apply_all', {  steps: () => [
     {
         trigger: '.o_list_button_add',
         run: "click",
@@ -368,7 +368,6 @@ registry.category('web_tour.tours').add('test_inventory_adjustment_apply_all', {
 ]});
 
 registry.category("web_tour.tours").add('test_add_new_line', {
-    test: true,
     steps: () => [
         {
             trigger: ".o_form_editable",
@@ -419,7 +418,6 @@ registry.category("web_tour.tours").add('test_add_new_line', {
 });
 
 registry.category("web_tour.tours").add("test_edit_existing_line", {
-    test: true,
     steps: () => [
         {
             trigger: ".o_data_cell[name=quantity]",
@@ -464,7 +462,6 @@ registry.category("web_tour.tours").add("test_edit_existing_line", {
 });
 
 registry.category("web_tour.tours").add('test_edit_existing_lines_2', {
-    test: true,
     steps: () => [
         { trigger: ".o_data_row:has(.o_data_cell[data-tooltip='Product a']) .fa-list", run: 'click'},
         { trigger: ".o_data_cell[name=lot_name]", run: 'click' },
@@ -482,7 +479,6 @@ registry.category("web_tour.tours").add('test_edit_existing_lines_2', {
 });
 
 registry.category("web_tour.tours").add('test_onchange_twice_lot_ids', {
-    test: true,
     steps: () => [
         {
             trigger: ".o_optional_columns_dropdown_toggle",

--- a/addons/stock/static/tests/tours/stock_report_tests.js
+++ b/addons/stock/static/tests/tours/stock_report_tests.js
@@ -1,9 +1,8 @@
 /** @odoo-module **/
-    
+
     import { registry } from "@web/core/registry";
 
     registry.category("web_tour.tours").add('test_stock_route_diagram_report', {
-        test: true,
         steps: () => [
         {
             trigger: ".o_breadcrumb",
@@ -27,7 +26,6 @@
 
 
 registry.category("web_tour.tours").add('test_multiple_warehouses_filter', {
-    test: true,
     steps: () => [
         // Add (Warehouse A or Warehouse B) to the filter
         {

--- a/addons/stock_picking_batch/static/tests/tours/stock_picking_batch_tour.js
+++ b/addons/stock_picking_batch/static/tests/tours/stock_picking_batch_tour.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from '@web_tour/tour_service/tour_utils';
 
 registry.category("web_tour.tours").add('test_stock_picking_batch_sm_to_sml_synchronization', {
-    test: true,
     steps: () => [
         {
             trigger: ".btn-primary[name=action_confirm]",

--- a/addons/survey/static/tests/tours/certification_failure.js
+++ b/addons/survey/static/tests/tours/certification_failure.js
@@ -129,6 +129,5 @@ var lastSteps = [{
 }];
 
 registry.category("web_tour.tours").add('test_certification_failure', {
-    test: true,
     url: '/survey/start/4ead4bc8-b8f2-4760-a682-1fde8daaaaac',
     steps: () => [].concat(patch, failSteps, retrySteps, failSteps, lastSteps) });

--- a/addons/survey/static/tests/tours/certification_success.js
+++ b/addons/survey/static/tests/tours/certification_success.js
@@ -16,7 +16,6 @@ function patchSurveyWidget() {
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('test_certification_success', {
-    test: true,
     url: '/survey/start/4ead4bc8-b8f2-4760-a682-1fde8daaaaac',
     steps: () => [{
         content: "Patching Survey Widget",

--- a/addons/survey/static/tests/tours/survey.js
+++ b/addons/survey/static/tests/tours/survey.js
@@ -3,7 +3,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('test_survey', {
-    test: true,
     url: '/survey/start/b137640d-14d4-4748-9ef6-344caaaaaae',
     steps: () => [
     // Page-1

--- a/addons/survey/static/tests/tours/survey_chained_conditional_questions.js
+++ b/addons/survey/static/tests/tours/survey_chained_conditional_questions.js
@@ -4,7 +4,6 @@ import { queryAll } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('test_survey_chained_conditional_questions', {
-    test: true,
     url: '/survey/start/3cfadce3-3f7e-41da-920d-10fa0eb19527',
     steps: () => [
     {
@@ -15,7 +14,7 @@ registry.category("web_tour.tours").add('test_survey_chained_conditional_questio
         content: 'Answer Q1 with Answer 1',
         trigger: 'div.js_question-wrapper:contains("Q1") label:contains("Answer 1")',
         run: "click",
-    }, 
+    },
     {
         trigger: 'div.js_question-wrapper:contains("Q4")',
     },

--- a/addons/survey/static/tests/tours/survey_conditional_questions_on_different_page.js
+++ b/addons/survey/static/tests/tours/survey_conditional_questions_on_different_page.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import { expectHiddenQuestion } from "@survey/../tests/tours/survey_chained_conditional_questions";
 
 registry.category("web_tour.tours").add('test_survey_conditional_question_on_different_page', {
-    test: true,
     url: '/survey/start/1cb935bd-2399-4ed1-9e10-c649318fb4dc',
     steps: () => [
         {

--- a/addons/survey/static/tests/tours/survey_form.js
+++ b/addons/survey/static/tests/tours/survey_form.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add('survey_tour_test_survey_form_triggers', {
-    test: true,
     url: '/odoo',
     steps: () => [
     stepUtils.showAppsMenuItem(),

--- a/addons/survey/static/tests/tours/survey_prefill.js
+++ b/addons/survey/static/tests/tours/survey_prefill.js
@@ -4,7 +4,6 @@ import { queryFirst, queryOne } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('test_survey_prefill', {
-    test: true,
     url: '/survey/start/b137640d-14d4-4748-9ef6-344caaaaaae',
     steps: () => [{      // Page-1
         trigger: 'button.btn.btn-primary.btn-lg:contains("Start Survey")',

--- a/addons/survey/static/tests/tours/survey_roaming_mandatory_questions.js
+++ b/addons/survey/static/tests/tours/survey_roaming_mandatory_questions.js
@@ -3,7 +3,6 @@
 import { registry } from '@web/core/registry';
 
 registry.category('web_tour.tours').add('test_survey_roaming_mandatory_questions', {
-    test: true,
     url: '/survey/start/853ebb30-40f2-43bf-a95a-bbf0e367a365',
     steps: () => [{
         content: 'Click on Start',
@@ -13,7 +12,7 @@ registry.category('web_tour.tours').add('test_survey_roaming_mandatory_questions
         content: 'Skip question Q1',
         trigger: 'button.btn:contains("Continue")',
         run: "click",
-    }, 
+    },
     {
         trigger: 'div.js_question-wrapper:contains("Q2")',
     },

--- a/addons/survey/static/tests/tours/survey_tour_session_manage.js
+++ b/addons/survey/static/tests/tours/survey_tour_session_manage.js
@@ -135,7 +135,6 @@ const checkAnswersCount = (chartData, expectedCount) => {
  */
 registry.category("web_tour.tours").add('test_survey_session_manage_tour', {
     url: "/odoo",
-    test: true,
     steps: () => [].concat(accessSurveysteps, [{
     trigger: 'button[name="action_open_session_manager"]',
     run: "click",
@@ -251,7 +250,7 @@ registry.category("web_tour.tours").add('test_survey_session_manage_tour', {
             {value: 0, type: "regular"},
         ]);
         nextScreen();
-    }, 
+    },
 },
 {
     trigger: "h1:contains(  Scored Simple Choice)",

--- a/addons/survey/static/tests/tours/survey_tour_session_start.js
+++ b/addons/survey/static/tests/tours/survey_tour_session_start.js
@@ -10,7 +10,6 @@ import { accessSurveysteps } from "./survey_tour_session_tools";
  */
 registry.category("web_tour.tours").add('test_survey_session_start_tour', {
     url: "/odoo",
-    test: true,
     steps: () => [].concat(accessSurveysteps, [{
     trigger: 'button[name="action_open_session_manager"]',
     run: "click",

--- a/addons/test_base_automation/static/tests/tour/base_automation_tour.js
+++ b/addons/test_base_automation/static/tests/tour/base_automation_tour.js
@@ -37,7 +37,6 @@ function observeOrmCalls() {
 }
 
 registry.category("web_tour.tours").add("test_base_automation", {
-    test: true,
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {
@@ -120,7 +119,6 @@ registry.category("web_tour.tours").add("test_base_automation", {
 });
 
 registry.category("web_tour.tours").add("test_base_automation_on_tag_added", {
-    test: true,
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {
@@ -285,7 +283,6 @@ registry.category("web_tour.tours").add("test_base_automation_on_tag_added", {
 });
 
 registry.category("web_tour.tours").add("test_open_automation_from_grouped_kanban", {
-    test: true,
     steps: () => [
         {
             trigger: ".o_kanban_view .o_kanban_config button.dropdown-toggle",
@@ -321,7 +318,6 @@ registry.category("web_tour.tours").add("test_open_automation_from_grouped_kanba
 });
 
 registry.category("web_tour.tours").add("test_kanban_automation_view_stage_trigger", {
-    test: true,
     steps: () => [
         {
             trigger: ".o_base_automation_kanban_view",
@@ -340,7 +336,6 @@ registry.category("web_tour.tours").add("test_kanban_automation_view_stage_trigg
 });
 
 registry.category("web_tour.tours").add("test_kanban_automation_view_time_trigger", {
-    test: true,
     steps: () => [
         {
             trigger: ".o_base_automation_kanban_view",
@@ -365,7 +360,6 @@ registry.category("web_tour.tours").add("test_kanban_automation_view_time_trigge
 });
 
 registry.category("web_tour.tours").add("test_kanban_automation_view_time_updated_trigger", {
-    test: true,
     steps: () => [
         {
             trigger: ".o_base_automation_kanban_view",
@@ -386,7 +380,6 @@ registry.category("web_tour.tours").add("test_kanban_automation_view_time_update
 });
 
 registry.category("web_tour.tours").add("test_kanban_automation_view_create_action", {
-    test: true,
     steps: () => [
         {
             trigger: ".o_base_automation_kanban_view",
@@ -402,7 +395,6 @@ registry.category("web_tour.tours").add("test_kanban_automation_view_create_acti
 });
 
 registry.category("web_tour.tours").add("test_resize_kanban", {
-    test: true,
     steps: () => [
         {
             trigger: ".o_base_automation_kanban_view",
@@ -425,7 +417,6 @@ registry.category("web_tour.tours").add("test_resize_kanban", {
 });
 
 registry.category("web_tour.tours").add("test_form_view_resequence_actions", {
-    test: true,
     steps: () => [
         {
             trigger:
@@ -497,7 +488,6 @@ registry.category("web_tour.tours").add("test_form_view_resequence_actions", {
 
 let waitOrmCalls;
 registry.category("web_tour.tours").add("test_form_view_model_id", {
-    test: true,
     steps: () => [
         {
             trigger: ".o_field_widget[name='model_id'] input",
@@ -565,7 +555,6 @@ registry.category("web_tour.tours").add("test_form_view_model_id", {
 });
 
 registry.category("web_tour.tours").add("test_form_view_custom_reference_field", {
-    test: true,
     steps: () => [
         {
             trigger: ".o_field_widget[name='model_id'] input",
@@ -623,7 +612,6 @@ registry.category("web_tour.tours").add("test_form_view_custom_reference_field",
 });
 
 registry.category("web_tour.tours").add("test_form_view_mail_triggers", {
-    test: true,
     steps: () => [
         {
             trigger: ".o_field_widget[name='model_id'] input",
@@ -685,7 +673,6 @@ registry.category("web_tour.tours").add("test_form_view_mail_triggers", {
 });
 
 registry.category("web_tour.tours").add("base_automation.on_change_rule_creation", {
-    test: true,
     url: "/odoo/action-base_automation.base_automation_act",
     steps: () => [
         {

--- a/addons/test_event_full/static/src/js/tours/wevent_performance_tour.js
+++ b/addons/test_event_full/static/src/js/tours/wevent_performance_tour.js
@@ -48,7 +48,7 @@ var registerSteps = [{
             document.querySelector("textarea[name*='question_answer']").textContent =
                 "Random answer from random guy";
     },
-}, 
+},
 {
     trigger: "input[name*='1-name'], input[name*='2-name'], input[name*='3-name']",
 },
@@ -70,7 +70,6 @@ wsTourUtils.fillAdressForm({
 
 
 registry.category("web_tour.tours").add('wevent_performance_register', {
-    test: true,
     steps: () => [].concat(
         registerSteps,
     )

--- a/addons/test_event_full/static/src/js/tours/wevent_register_tour.js
+++ b/addons/test_event_full/static/src/js/tours/wevent_register_tour.js
@@ -187,7 +187,6 @@ var browseMeetSteps = [{
 
 registry.category("web_tour.tours").add('wevent_register', {
     url: '/event',
-    test: true,
     steps: () => [].concat(
         initTourSteps('Online Reveal'),
         browseTalksSteps,

--- a/addons/test_mail/static/tests/tours/mail_activity_view_tour.js
+++ b/addons/test_mail/static/tests/tours/mail_activity_view_tour.js
@@ -37,7 +37,6 @@ const checkRows = values => {
 }
 
 registry.category("web_tour.tours").add("mail_activity_view", {
-    test: true,
     steps: () => [
         {
             content: "Open the debug menu",

--- a/addons/test_sale_product_configurators/static/tests/tours/event_sale_with_product_configurator_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/event_sale_with_product_configurator_ui.js
@@ -7,7 +7,6 @@ import tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add("event_sale_with_product_configurator_tour", {
     url: "/odoo",
-    test: true,
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
         ...tourUtils.createNewSalesOrder(),

--- a/addons/test_sale_product_configurators/static/tests/tours/product_attribute_with_multi_type.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_attribute_with_multi_type.js
@@ -7,7 +7,6 @@ import tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add("product_attribute_multi_type", {
     url: "/odoo",
-    test: true,
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
         ...tourUtils.createNewSalesOrder(),

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_advanced_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_advanced_ui.js
@@ -9,7 +9,6 @@ let optionVariantImage;
 
 registry.category("web_tour.tours").add('sale_product_configurator_advanced_tour', {
     url: '/odoo',
-    test: true,
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
         ...tourUtils.createNewSalesOrder(),

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_custom_value_update_tour.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_custom_value_update_tour.js
@@ -7,7 +7,6 @@ import tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('sale_product_configurator_custom_value_update_tour', {
     url: '/odoo',
-    test: true,
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
         ...tourUtils.createNewSalesOrder(),

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_edition_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_edition_ui.js
@@ -7,7 +7,6 @@ import tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('sale_product_configurator_edition_tour', {
     url: '/odoo',
-    test: true,
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
         ...tourUtils.createNewSalesOrder(),

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_optional_products_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_optional_products_ui.js
@@ -6,7 +6,6 @@ import tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('sale_product_configurator_optional_products_tour', {
     url: '/odoo',
-    test: true,
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
         ...tourUtils.createNewSalesOrder(),

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_pricelist_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_pricelist_ui.js
@@ -7,7 +7,6 @@ import tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('sale_product_configurator_pricelist_tour', {
     url: '/odoo',
-    test: true,
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
         ...tourUtils.createNewSalesOrder(),

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_recursive_optional_products.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_recursive_optional_products.js
@@ -7,7 +7,6 @@ import tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('sale_product_configurator_recursive_optional_products_tour', {
     url: '/odoo',
-    test: true,
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
         ...tourUtils.createNewSalesOrder(),

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_single_custom_attribute_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_single_custom_attribute_ui.js
@@ -8,7 +8,6 @@ import tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('sale_product_configurator_single_custom_attribute_tour', {
     url: '/odoo',
-    test: true,
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
         ...tourUtils.createNewSalesOrder(),

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_ui.js
@@ -10,7 +10,6 @@ import tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('sale_product_configurator_tour', {
     url: '/odoo',
-    test: true,
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
         ...tourUtils.createNewSalesOrder(),

--- a/addons/test_sale_product_configurators/static/tests/tours/product_matrix_tour.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_matrix_tour.js
@@ -21,7 +21,6 @@ for (let no of ['PAV41', 'PAV42']) {
 
 registry.category("web_tour.tours").add('sale_matrix_tour', {
     url: '/odoo',
-    test: true,
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
         ...tourUtils.createNewSalesOrder(),

--- a/addons/test_website/static/tests/tours/custom_snippets.js
+++ b/addons/test_website/static/tests/tours/custom_snippets.js
@@ -24,7 +24,6 @@ import { insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tou
 registerWebsitePreviewTour('test_custom_snippet', {
     url: '/',
     edition: true,
-    test: true,
 }, () => [
     ...insertSnippet({
         id: 's_banner',

--- a/addons/test_website/static/tests/tours/error_views.js
+++ b/addons/test_website/static/tests/tours/error_views.js
@@ -3,7 +3,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('test_error_website', {
-    test: true,
     url: '/test_error_view',
     steps: () => [
     // RPC ERROR

--- a/addons/test_website/static/tests/tours/form.js
+++ b/addons/test_website/static/tests/tours/form.js
@@ -9,7 +9,6 @@ registerWebsitePreviewTour(
     {
         url: "/test_website/model_item/1",
         edition: true,
-        test: true,
     },
     () => [
         {

--- a/addons/test_website/static/tests/tours/image_link.js
+++ b/addons/test_website/static/tests/tours/image_link.js
@@ -18,7 +18,6 @@ const selectImageSteps = [{
 }];
 
 registerWebsitePreviewTour('test_image_link', {
-    test: true,
     url: '/',
     edition: true,
 }, () => [

--- a/addons/test_website/static/tests/tours/image_upload_progress.js
+++ b/addons/test_website/static/tests/tours/image_upload_progress.js
@@ -17,7 +17,7 @@ const patchMediaDialog = () => patch(FileSelectorControlPanel.prototype, {
             }
             return new File([arr], fileData[1], {type: fileData[0]});
         };
-        
+
         let files = [
             getFileFromB64(['image/vnd.microsoft.icon', 'icon.ico', "AAABAAEAAQEAAAEAIAAwAAAAFgAAACgAAAABAAAAAgAAAAEAIAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAA=="]),
             getFileFromB64(['image/webp', 'image.webp', "UklGRhwAAABXRUJQVlA4TBAAAAAvE8AEAAfQhuh//wMR0f8A"]),
@@ -64,7 +64,6 @@ const formatErrorMsg = "format is not supported. Try with: .gif, .jpe, .jpeg, .j
 
 registerWebsitePreviewTour('test_image_upload_progress', {
     url: '/test_image_progress',
-    test: true,
     edition: true,
 }, () => [
     ...setupSteps(),
@@ -195,7 +194,6 @@ registerWebsitePreviewTour('test_image_upload_progress', {
 
 registerWebsitePreviewTour('test_image_upload_progress_unsplash', {
     url: '/test_image_progress',
-    test: true,
     edition: true,
 }, () => [
     ...setupSteps(),
@@ -216,7 +214,7 @@ registerWebsitePreviewTour('test_image_upload_progress_unsplash', {
         content: "click on unsplash result", // note that unsplash is mocked
         trigger: "img[alt~=fox]",
         run: "click",
-    }, 
+    },
     {
         trigger: ".o_notification_close",
     },

--- a/addons/test_website/static/tests/tours/json_auth.js
+++ b/addons/test_website/static/tests/tours/json_auth.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import { rpc } from "@web/core/network/rpc";
 
 registry.category("web_tour.tours").add('test_json_auth', {
-    test: true,
     steps: () => [{
     trigger: 'body',
     run: async function () {

--- a/addons/test_website/static/tests/tours/page_manager.js
+++ b/addons/test_website/static/tests/tours/page_manager.js
@@ -3,7 +3,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('test_website_page_manager', {
-    test: true,
     url: '/odoo/action-test_website.action_test_model_multi_website',
     steps: () => [
 // Part 1: check that the website filter is working
@@ -45,7 +44,7 @@ registry.category("web_tour.tours").add('test_website_page_manager', {
     content: "Click on Kanban View",
     trigger: '.o_cp_switch_buttons .o_kanban',
     run: "click",
-}, 
+},
 {
     trigger: ".o_kanban_renderer",
 },
@@ -60,7 +59,6 @@ registry.category("web_tour.tours").add('test_website_page_manager', {
 });
 
 registry.category("web_tour.tours").add('test_website_page_manager_js_class_bug', {
-    test: true,
     url: '/odoo/action-test_website.action_test_model_multi_website_js_class_bug',
     steps: () => [
 {
@@ -74,7 +72,6 @@ registry.category("web_tour.tours").add('test_website_page_manager_js_class_bug'
 });
 
 registry.category("web_tour.tours").add('test_website_page_manager_no_website_id', {
-    test: true,
     url: '/odoo/action-test_website.action_test_model',
     steps: () => [
 {

--- a/addons/test_website/static/tests/tours/replace_media.js
+++ b/addons/test_website/static/tests/tours/replace_media.js
@@ -15,7 +15,6 @@ const VIDEO_URL = 'https://www.youtube.com/watch?v=Dpq87YCHmJc';
  */
 registerWebsitePreviewTour('test_replace_media', {
     url: '/',
-    test: true,
     edition: true,
 }, () => [
     {

--- a/addons/test_website/static/tests/tours/reset_views.js
+++ b/addons/test_website/static/tests/tours/reset_views.js
@@ -14,7 +14,6 @@ var BROKEN_STEP = {
 registerWebsitePreviewTour(
     "test_reset_page_view_complete_flow_part1",
     {
-        test: true,
         url: "/test_page_view",
         // 1. Edit the page through Edit Mode, it will COW the view
         edition: true,
@@ -67,7 +66,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "test_reset_page_view_complete_flow_part2",
     {
-        test: true,
         url: "/test_page_view",
     },
     () => [

--- a/addons/test_website/static/tests/tours/restricted_editor.js
+++ b/addons/test_website/static/tests/tours/restricted_editor.js
@@ -50,7 +50,6 @@ const goToMenuItem = [
 ];
 
 registerWebsitePreviewTour('test_restricted_editor_only', {
-    test: true,
     url: '/',
 }, () => [
     // Home
@@ -79,7 +78,6 @@ registerWebsitePreviewTour('test_restricted_editor_only', {
 ]);
 
 registerWebsitePreviewTour('test_restricted_editor_test_admin', {
-    test: true,
     url: '/',
 }, () => [
     // Home

--- a/addons/test_website/static/tests/tours/website_controller_page.js
+++ b/addons/test_website/static/tests/tours/website_controller_page.js
@@ -9,7 +9,6 @@ function assertEqual(actual, expected) {
 }
 
 registerWebsitePreviewTour('website_controller_page_listing_layout', {
-    test: true,
     url: '/model/exposed-model',
     edition: true,
 }, () => [
@@ -59,7 +58,6 @@ registerWebsitePreviewTour('website_controller_page_listing_layout', {
 ]);
 
 registerWebsitePreviewTour('website_controller_page_default_page_check', {
-    test: true,
     url: '/model/exposed-model',
 }, () => [
     {

--- a/addons/test_website/static/tests/tours/website_page_properties.js
+++ b/addons/test_website/static/tests/tours/website_page_properties.js
@@ -334,7 +334,6 @@ function testWebsitePageProperties() {
 registerWebsitePreviewTour(
     "website_page_properties_common",
     {
-        test: true,
         url: "/test_view",
     },
     () => [...testCommonProperties("/test_view", false).finalize()],
@@ -343,7 +342,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "website_page_properties_can_publish",
     {
-        test: true,
         url: "/test_website/model_item/1",
     },
     () => [...testCommonProperties("/test_website/model_item/1", true).finalize()],
@@ -352,7 +350,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "website_page_properties_website_page",
     {
-        test: true,
         url: "/",
     },
     () => [

--- a/addons/test_website/static/tests/tours/website_settings.js
+++ b/addons/test_website/static/tests/tours/website_settings.js
@@ -6,7 +6,6 @@ import { stepUtils } from "@web_tour/tour_service/tour_utils";
 const websiteName = "Website Test Settings";
 
 registry.category("web_tour.tours").add("website_settings_m2o_dirty", {
-    test: true,
     url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),

--- a/addons/test_website_modules/static/tests/tours/configurator_flow.js
+++ b/addons/test_website_modules/static/tests/tours/configurator_flow.js
@@ -4,7 +4,6 @@ import { queryAll } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('configurator_flow', {
-    test: true,
     url: '/odoo/action-website.action_website_configuration',
     steps: () => [
     {
@@ -59,7 +58,7 @@ registry.category("web_tour.tours").add('configurator_flow', {
         content: "select Pricing",
         trigger: '.card:contains("Pricing")',
         run: "click",
-    }, 
+    },
     {
         trigger: '.card.border-success:contains("Pricing")',
     },
@@ -69,7 +68,7 @@ registry.category("web_tour.tours").add('configurator_flow', {
     }, {
         content: "Slides should be selected (module already installed)",
         trigger: '.card.card_installed:contains("eLearning")',
-    }, 
+    },
     {
         trigger: '.card.card_installed:contains("Success Stories")',
     },

--- a/addons/test_website_slides_full/static/tests/tours/slides_certification_member.js
+++ b/addons/test_website_slides_full/static/tests/tours/slides_certification_member.js
@@ -167,7 +167,6 @@ var profileSteps = [{
 
 registry.category("web_tour.tours").add('certification_member', {
     url: '/slides',
-    test: true,
     steps: () => [].concat(
         initTourSteps,
         buyCertificationSteps,

--- a/addons/web/static/tests/tours/user_switch_tour.js
+++ b/addons/web/static/tests/tours/user_switch_tour.js
@@ -16,7 +16,6 @@ function logout() {
 }
 
 registry.category("web_tour.tours").add("test_user_switch", {
-    test: true,
     url: "/odoo",
     steps: () => [
         ...logout(),

--- a/addons/web_tour/static/src/tour_service/tour_service.js
+++ b/addons/web_tour/static/src/tour_service/tour_service.js
@@ -45,10 +45,7 @@ const TourSchema = {
     checkDelay: { type: Number, optional: true },
     name: { type: String, optional: true },
     saveAs: { type: String, optional: true },
-    rainbowManMessage: { type: [String, Boolean, Function], optional: true },
-    sequence: { type: Number, optional: true },
     steps: Function,
-    test: { type: Boolean, optional: true },
     url: { type: String, optional: true },
     wait_for: { type: [Function, Object], optional: true },
 };

--- a/addons/web_tour/static/tests/tour_service.test.js
+++ b/addons/web_tour/static/tests/tour_service.test.js
@@ -115,7 +115,6 @@ test("Step Tour validity", async () => {
         },
     ];
     tourRegistry.add("tour1", {
-        sequence: 10,
         steps: () => steps,
     });
     await makeMockEnv({});
@@ -549,7 +548,6 @@ test("registering test tour after service is started doesn't auto-start the tour
     await mountWithCleanup(Root);
     expect(".o_tour_pointer").toHaveCount(0);
     registry.category("web_tour.tours").add("tour1", {
-        test: true,
         steps: () => [
             {
                 content: "content",
@@ -859,7 +857,6 @@ test("automatic tour with invisible element", async () => {
 
     await mountWithCleanup(Root);
     registry.category("web_tour.tours").add("tour_de_wallonie", {
-        test: true,
         steps: () => [
             {
                 trigger: ".button0",
@@ -912,7 +909,6 @@ test("automatic tour with invisible element but use :not(:visible))", async () =
 
     await mountWithCleanup(Root);
     registry.category("web_tour.tours").add("tour_de_wallonie", {
-        test: true,
         steps: () => [
             {
                 trigger: ".button0",
@@ -1021,8 +1017,6 @@ test("automatic tour with alternative trigger", async () => {
         },
     });
     registry.category("web_tour.tours").add("tour_des_flandres", {
-        test: true,
-        sequence: 17,
         steps: () => [
             {
                 trigger: ".interval, .button1",
@@ -1397,7 +1391,6 @@ test("check rainbowManMessage", async () => {
 
 test("check alternative trigger that appear after the initial trigger", async () => {
     registry.category("web_tour.tours").add("rainbow_tour", {
-        sequence: 87,
         steps: () => [
             {
                 trigger: ".button0, .button1",

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -453,9 +453,7 @@ export function registerThemeHomepageTour(name, steps) {
     }
     return registerWebsitePreviewTour(name, {
         url: '/',
-        sequence: 50,
-        saveAs: "homepage",
-        test: true, // disable manual mode for theme homepage tours - FIXME
+        saveAs: "homepage", // disable manual mode for theme homepage tours - FIXME
         },
         () => [
             ...clickOnEditAndWaitEditMode(),

--- a/addons/website/static/tests/tours/carousel_content_removal.js
+++ b/addons/website/static/tests/tours/carousel_content_removal.js
@@ -3,7 +3,6 @@
 import { insertSnippet, registerWebsitePreviewTour } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour("carousel_content_removal", {
-    test: true,
     url: '/',
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/client_action_iframe_fallback.js
+++ b/addons/website/static/tests/tours/client_action_iframe_fallback.js
@@ -3,7 +3,6 @@
 import { registerWebsitePreviewTour } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour('client_action_iframe_fallback', {
-    test: true,
     url: '/',
 },
 () => [

--- a/addons/website/static/tests/tours/client_action_redirect.js
+++ b/addons/website/static/tests/tours/client_action_redirect.js
@@ -38,7 +38,6 @@ const checkEditorSteps = [{
 }];
 
 registry.category("web_tour.tours").add('client_action_redirect', {
-    test: true,
     url: testUrl,
     steps: () => [
     // Case 1: From frontend, click on `enable_editor=1` link without `/@/` in it

--- a/addons/website/static/tests/tours/conditional_visibility.js
+++ b/addons/website/static/tests/tours/conditional_visibility.js
@@ -53,7 +53,6 @@ function checkEyesIconAfterSave(footerIsHidden = true) {
 registerWebsitePreviewTour('conditional_visibility_1', {
     edition: true,
     url: '/',
-    test: true,
 }, () => [
 ...insertSnippet(snippets[0]),
 ...clickOnSnippet(snippets[0]),
@@ -107,7 +106,6 @@ changeOption('ConditionalVisibility', 'we-toggler'),
 
 registerWebsitePreviewTour("conditional_visibility_3", {
     edition: true,
-    test: true,
     url: "/",
 },
 () => [
@@ -156,7 +154,6 @@ checkEyeIcon("Banner", false),
 
 registerWebsitePreviewTour("conditional_visibility_4", {
     edition: true,
-    test: true,
     url: "/",
 },
 () => [
@@ -197,7 +194,6 @@ registerWebsitePreviewTour("conditional_visibility_4", {
 
 registerWebsitePreviewTour("conditional_visibility_5", {
     edition: true,
-    test: true,
     url: "/",
 }, () => [
     {

--- a/addons/website/static/tests/tours/conditional_visibility_frontend.js
+++ b/addons/website/static/tests/tours/conditional_visibility_frontend.js
@@ -3,7 +3,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('conditional_visibility_2', {
-    test: true,
     url: '/?utm_medium=Email',
     steps: () => [{
     content: 'The content previously hidden should now be visible',

--- a/addons/website/static/tests/tours/configurator_translation.js
+++ b/addons/website/static/tests/tours/configurator_translation.js
@@ -6,7 +6,6 @@ import { registry } from "@web/core/registry";
 import { clickOnEditAndWaitEditMode } from "@website/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('configurator_translation', {
-    test: true,
     url: '/website/configurator',
     steps: () => [
     // Configurator first screen

--- a/addons/website/static/tests/tours/default_shape_gets_palette_colors.js
+++ b/addons/website/static/tests/tours/default_shape_gets_palette_colors.js
@@ -9,7 +9,6 @@ import {
 } from "@website/js/tours/tour_utils";
 
 registerWebsitePreviewTour("default_shape_gets_palette_colors", {
-    test: true,
     url: '/',
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/drag_and_drop_on_non_editable.js
+++ b/addons/website/static/tests/tours/drag_and_drop_on_non_editable.js
@@ -3,7 +3,6 @@
 import { insertSnippet, goBackToBlocks, registerWebsitePreviewTour } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour("test_drag_and_drop_on_non_editable", {
-    test: true,
     url: "/",
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/drop_404_ir_attachment_url.js
+++ b/addons/website/static/tests/tours/drop_404_ir_attachment_url.js
@@ -7,7 +7,6 @@ import {
 } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour('drop_404_ir_attachment_url', {
-    test: true,
     url: '/',
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/dropdowns_and_header_hide_on_scroll.js
+++ b/addons/website/static/tests/tours/dropdowns_and_header_hide_on_scroll.js
@@ -34,7 +34,6 @@ const scrollDownToMediaList = function () {
 };
 
 registerWebsitePreviewTour("dropdowns_and_header_hide_on_scroll", {
-    test: true,
     url: "/",
     edition: true,
     checkDelay: 100,

--- a/addons/website/static/tests/tours/edit_link_popover.js
+++ b/addons/website/static/tests/tours/edit_link_popover.js
@@ -29,7 +29,6 @@ const clickEditLink = [{
 }];
 
 registerWebsitePreviewTour('edit_link_popover_1', {
-    test: true,
     url: '/',
     edition: true,
 }, () => [
@@ -147,7 +146,6 @@ registerWebsitePreviewTour('edit_link_popover_1', {
 ]);
 
 registerWebsitePreviewTour('edit_link_popover_2', {
-    test: true,
     url: '/',
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/edit_megamenu.js
+++ b/addons/website/static/tests/tours/edit_megamenu.js
@@ -20,7 +20,6 @@ const toggleMegaMenu = (stepOptions) => Object.assign({}, {
 }, stepOptions);
 
 registerWebsitePreviewTour('edit_megamenu', {
-    test: true,
     url: '/',
     edition: true,
 }, () => [
@@ -126,7 +125,6 @@ registerWebsitePreviewTour('edit_megamenu', {
     },
 ]);
 registerWebsitePreviewTour('edit_megamenu_big_icons_subtitles', {
-    test: true,
     url: '/',
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -9,7 +9,6 @@ import {
 } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour('edit_menus', {
-    test: true,
     url: '/',
 }, () => [
     // Add a megamenu item from the menu.
@@ -353,7 +352,6 @@ registerWebsitePreviewTour('edit_menus', {
 registerWebsitePreviewTour(
     "edit_menus_delete_parent",
     {
-        test: true,
         url: "/",
     },
     () => [

--- a/addons/website/static/tests/tours/edit_translated_page.js
+++ b/addons/website/static/tests/tours/edit_translated_page.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import { clickOnEditAndWaitEditModeInTranslatedPage } from "@website/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('edit_translated_page_redirect', {
-    test: true,
     url: '/nl/contactus',
     steps: () => [
     {

--- a/addons/website/static/tests/tours/editable_root_as_custom_snippet.js
+++ b/addons/website/static/tests/tours/editable_root_as_custom_snippet.js
@@ -10,7 +10,6 @@ import {
 } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour("editable_root_as_custom_snippet", {
-    test: true,
     edition: true,
     url: '/custom-page',
 }, () => [

--- a/addons/website/static/tests/tours/focus_blur_snippets.js
+++ b/addons/website/static/tests/tours/focus_blur_snippets.js
@@ -50,7 +50,6 @@ function clickAndCheck(blockID, expected) {
 window.focusBlurSnippetsResult = [];
 
 registerWebsitePreviewTour("focus_blur_snippets", {
-    test: true,
     url: "/",
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/gray_color_palette.js
+++ b/addons/website/static/tests/tours/gray_color_palette.js
@@ -21,7 +21,6 @@ function waitForCSSReload() {
 }
 
 registerWebsitePreviewTour('website_gray_color_palette', {
-    test: true,
     url: '/',
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/grid_layout.js
+++ b/addons/website/static/tests/tours/grid_layout.js
@@ -15,7 +15,6 @@ const snippet = {
 };
 
 registerWebsitePreviewTour('website_replace_grid_image', {
-    test: true,
     url: '/',
     edition: true,
 }, () => [
@@ -60,7 +59,6 @@ registerWebsitePreviewTour('website_replace_grid_image', {
 ]);
 
 registerWebsitePreviewTour("scroll_to_new_grid_item", {
-    test: true,
     url: "/",
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/html_editor.js
+++ b/addons/website/static/tests/tours/html_editor.js
@@ -9,7 +9,6 @@ const demoCssModif = '// demo_edition';
 registerWebsitePreviewTour('html_editor_multiple_templates', {
     url: '/generic',
     edition: true,
-    test: true,
 },
     () => [
         {
@@ -87,7 +86,6 @@ registerWebsitePreviewTour('html_editor_multiple_templates', {
 
 registerWebsitePreviewTour('test_html_editor_scss', {
     url: '/contactus',
-    test: true,
 },
     () => [
         // 1. Open Html Editor and select a scss file
@@ -186,7 +184,6 @@ registerWebsitePreviewTour('test_html_editor_scss', {
 
 registerWebsitePreviewTour('test_html_editor_scss_2', {
     url: '/',
-    test: true,
 },
     () => [
         // This part of the test ensures that a restricted user can still use
@@ -261,7 +258,6 @@ registerWebsitePreviewTour(
     {
         // TODO: enable debug mode when failing tests have been fixed (props validation)
         url: "/",
-        test: true,
     },
     () => [
         {

--- a/addons/website/static/tests/tours/link_to_document.js
+++ b/addons/website/static/tests/tours/link_to_document.js
@@ -7,7 +7,6 @@ registerWebsitePreviewTour(
     "test_link_to_document",
     {
         url: "/",
-        test: true,
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/link_tools.js
+++ b/addons/website/static/tests/tours/link_tools.js
@@ -17,7 +17,6 @@ const clickOnImgStep = {
 };
 
 registerWebsitePreviewTour('link_tools', {
-    test: true,
     url: '/',
     edition: true,
     checkDelay: 200,
@@ -151,7 +150,7 @@ registerWebsitePreviewTour('link_tools', {
     {
         content: "Set URL.",
         trigger: '.o_we_customize_panel we-input:contains("Your URL") input',
-        // TODO: remove && click 
+        // TODO: remove && click
         run: "edit odoo.com && click(we-title:contains(Your URL))",
     },
     {
@@ -229,7 +228,7 @@ registerWebsitePreviewTour('link_tools', {
             return helpers.drag_and_drop(".oe_menu_editor li:contains('Home') .fa-bars", {
                 position : {
                     top: 20,
-                }, 
+                },
                 relative: true,
             });
         },
@@ -303,8 +302,8 @@ registerWebsitePreviewTour('link_tools', {
         trigger: "#o_link_dialog_url_input",
         run() {
             // TODO: update the tour to use helpers.edit("https://odoo.com")
-            // To see what happens with edit, add `pause:true` to the previous step 
-            // and type yourself https://odoo.com in #o_link_dialog_url_input  
+            // To see what happens with edit, add `pause:true` to the previous step
+            // and type yourself https://odoo.com in #o_link_dialog_url_input
             // The label will be ohttps://
             this.anchor.value = "https://odoo.com";
             this.anchor.dispatchEvent(new InputEvent("input", { bubbles: true }));

--- a/addons/website/static/tests/tours/media_dialog.js
+++ b/addons/website/static/tests/tours/media_dialog.js
@@ -8,7 +8,6 @@ import {
 } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour("website_media_dialog_undraw", {
-    test: true,
     url: '/',
     edition: true,
 }, () => [
@@ -32,7 +31,6 @@ registerWebsitePreviewTour("website_media_dialog_undraw", {
 ]);
 
 registerWebsitePreviewTour("website_media_dialog_external_library", {
-    test: true,
     url: "/",
     edition: true,
 }, () => [
@@ -82,7 +80,6 @@ registerWebsitePreviewTour("website_media_dialog_external_library", {
 ]);
 
 registerWebsitePreviewTour('website_media_dialog_icons', {
-    test: true,
     url: '/',
     edition: true,
 }, () => [
@@ -122,7 +119,6 @@ registerWebsitePreviewTour('website_media_dialog_icons', {
 ]);
 
 registerWebsitePreviewTour("website_media_dialog_image_shape", {
-    test: true,
     url: "/",
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/multi_edition.js
+++ b/addons/website/static/tests/tours/multi_edition.js
@@ -3,7 +3,6 @@
 import { clickOnSave, insertSnippet, registerWebsitePreviewTour } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour('website_multi_edition', {
-    test: true,
     url: '/',
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/page_manager.js
+++ b/addons/website/static/tests/tours/page_manager.js
@@ -166,7 +166,6 @@ const duplicateMultiplePage = [
 ];
 
 registerWebsitePreviewTour('website_page_manager', {
-    test: true,
     url: '/',
 }, () => [
     {
@@ -204,7 +203,6 @@ registerWebsitePreviewTour('website_page_manager', {
 ]);
 
 registerWebsitePreviewTour('website_page_manager_session_forced', {
-    test: true,
     url: '/',
 }, () => [...switchWebsite(2, 'My Website 2'), {
     content: "Click on Site",
@@ -228,7 +226,6 @@ registerWebsitePreviewTour('website_page_manager_session_forced', {
 }]);
 
 registry.category("web_tour.tours").add('website_page_manager_direct_access', {
-    test: true,
     url: '/odoo/action-website.action_website_pages_list',
     steps: () => [{
     content: "Check that the homepage is the one of My Website 2",
@@ -246,7 +243,6 @@ registry.category("web_tour.tours").add('website_page_manager_direct_access', {
 registerWebsitePreviewTour(
     "website_clone_pages",
     {
-        test: true,
         url: "/",
     },
     () => [

--- a/addons/website/static/tests/tours/parallax.js
+++ b/addons/website/static/tests/tours/parallax.js
@@ -12,7 +12,6 @@ import {
 const coverSnippet = {id: "s_cover", name: "Cover", groupName: "Intro"};
 
 registerWebsitePreviewTour("test_parallax", {
-    test: true,
     url: "/",
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/powerbox_snippet.js
+++ b/addons/website/static/tests/tours/powerbox_snippet.js
@@ -2,7 +2,6 @@ import {clickOnSnippet, insertSnippet, registerWebsitePreviewTour } from "@websi
 
 registerWebsitePreviewTour("website_powerbox_snippet",{
     edition: true,
-    test: true,
 },
 () => [
 ...insertSnippet({

--- a/addons/website/static/tests/tours/public_user_editor.js
+++ b/addons/website/static/tests/tours/public_user_editor.js
@@ -3,7 +3,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('public_user_editor', {
-    test: true,
     steps: () => [{
     trigger: '.note-editable',
 }]});

--- a/addons/website/static/tests/tours/reset_password.js
+++ b/addons/website/static/tests/tours/reset_password.js
@@ -3,7 +3,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('website_reset_password', {
-    test: true,
     steps: () => [
     {
         content: "fill new password",

--- a/addons/website/static/tests/tours/restricted_editor.js
+++ b/addons/website/static/tests/tours/restricted_editor.js
@@ -3,7 +3,6 @@
 import { clickOnEditAndWaitEditMode, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
 
 registerWebsitePreviewTour("restricted_editor", {
-    test: true,
     url: "/",
 }, () => [
     ...clickOnEditAndWaitEditMode(),

--- a/addons/website/static/tests/tours/rte.js
+++ b/addons/website/static/tests/tours/rte.js
@@ -10,7 +10,6 @@ import {
 import { whenReady } from "@odoo/owl";
 
 registerWebsitePreviewTour('rte_translator', {
-    test: true,
     url: '/',
     edition: true,
     wait_for: whenReady(),

--- a/addons/website/static/tests/tours/skip_website_configurator.js
+++ b/addons/website/static/tests/tours/skip_website_configurator.js
@@ -3,7 +3,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('skip_website_configurator', {
-    test: true,
     url: '/odoo/action-website.action_website_configuration',
     steps: () => [
     {

--- a/addons/website/static/tests/tours/snippet_background_edition.js
+++ b/addons/website/static/tests/tours/snippet_background_edition.js
@@ -103,7 +103,6 @@ function updateAndCheckCustomGradient({updateStep, checkGradient}) {
 registerWebsitePreviewTour('snippet_background_edition', {
     url: '/',
     edition: true,
-    test: true,
     checkDelay: 100,
 },
 () => [

--- a/addons/website/static/tests/tours/snippet_cache_across_websites.js
+++ b/addons/website/static/tests/tours/snippet_cache_across_websites.js
@@ -9,7 +9,6 @@ import {
 
 registerWebsitePreviewTour('snippet_cache_across_websites', {
     edition: true,
-    test: true,
     url: '/@/'
 }, () => [
     {

--- a/addons/website/static/tests/tours/snippet_countdown.js
+++ b/addons/website/static/tests/tours/snippet_countdown.js
@@ -8,7 +8,6 @@ import {
 } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour('snippet_countdown', {
-    test: true,
     url: '/',
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/snippet_editor_panel_options.js
+++ b/addons/website/static/tests/tours/snippet_editor_panel_options.js
@@ -10,7 +10,6 @@ import {
 import { browser } from '@web/core/browser/browser';
 
 registerWebsitePreviewTour('snippet_editor_panel_options', {
-    test: true,
     url: '/',
     edition: true,
     checkDelay: 100,

--- a/addons/website/static/tests/tours/snippet_empty_parent_autoremove.js
+++ b/addons/website/static/tests/tours/snippet_empty_parent_autoremove.js
@@ -16,7 +16,6 @@ function removeSelectedBlock() {
 }
 
 registerWebsitePreviewTour('snippet_empty_parent_autoremove', {
-    test: true,
     url: '/',
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/snippet_image.js
+++ b/addons/website/static/tests/tours/snippet_image.js
@@ -3,7 +3,6 @@
 import {insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
 
 registerWebsitePreviewTour("snippet_image", {
-    test: true,
     url: "/",
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/snippet_image_gallery.js
+++ b/addons/website/static/tests/tours/snippet_image_gallery.js
@@ -10,7 +10,6 @@ import {
 } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour('snippet_image_gallery', {
-    test: true,
     url: '/',
     edition: true,
 }, () => [
@@ -28,7 +27,6 @@ registerWebsitePreviewTour('snippet_image_gallery', {
 ]);
 
 registerWebsitePreviewTour("snippet_image_gallery_remove", {
-    test: true,
     url: "/",
     edition: true,
 }, () => [
@@ -36,7 +34,7 @@ registerWebsitePreviewTour("snippet_image_gallery_remove", {
         id: "s_image_gallery",
         name: "Image Gallery",
         groupName: "Images",
-}), 
+}),
 ...clickOnSnippet({
     id: 's_image_gallery',
     name: 'Image Gallery',
@@ -75,7 +73,6 @@ registerWebsitePreviewTour("snippet_image_gallery_remove", {
 }]);
 
 registerWebsitePreviewTour("snippet_image_gallery_reorder", {
-    test: true,
     url: "/",
     edition: true,
 }, () => [
@@ -132,7 +129,6 @@ registerWebsitePreviewTour("snippet_image_gallery_reorder", {
 }]);
 
 registerWebsitePreviewTour("snippet_image_gallery_thumbnail_update", {
-    test: true,
     url: "/",
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/snippet_image_quality.js
+++ b/addons/website/static/tests/tours/snippet_image_quality.js
@@ -3,7 +3,6 @@
 import { insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
 
 registerWebsitePreviewTour('website_image_quality', {
-    test: true,
     url: '/',
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/snippet_images_wall.js
+++ b/addons/website/static/tests/tours/snippet_images_wall.js
@@ -50,7 +50,6 @@ const reselectSignImageSteps = [
 ];
 
 registerWebsitePreviewTour("snippet_images_wall", {
-    test: true,
     url: "/",
     edition: true,
 }, () => [
@@ -58,7 +57,7 @@ registerWebsitePreviewTour("snippet_images_wall", {
         id: "s_images_wall",
         name: "Images Wall",
         groupName: "Images",
-}), 
+}),
 ...clickOnSnippet({
     id: "s_image_gallery",
     name: "Images Wall",

--- a/addons/website/static/tests/tours/snippet_popup_add_remove.js
+++ b/addons/website/static/tests/tours/snippet_popup_add_remove.js
@@ -6,7 +6,6 @@ import {
 } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour('snippet_popup_add_remove', {
-    test: true,
     url: '/',
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/snippet_popup_and_animations.js
+++ b/addons/website/static/tests/tours/snippet_popup_and_animations.js
@@ -37,7 +37,6 @@ const setOnScrollAnim = function () {
 };
 
 registerWebsitePreviewTour("snippet_popup_and_animations", {
-    test: true,
     url: "/",
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/snippet_popup_and_scrollbar.js
+++ b/addons/website/static/tests/tours/snippet_popup_and_scrollbar.js
@@ -40,7 +40,6 @@ const toggleBackdrop = function () {
 };
 
 registerWebsitePreviewTour("snippet_popup_and_scrollbar", {
-    test: true,
     url: "/",
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/snippet_popup_display_on_click.js
+++ b/addons/website/static/tests/tours/snippet_popup_display_on_click.js
@@ -11,7 +11,6 @@ import {
 import { browser } from "@web/core/browser/browser";
 
 registerWebsitePreviewTour("snippet_popup_display_on_click", {
-    test: true,
     url: "/",
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/snippet_rating.js
+++ b/addons/website/static/tests/tours/snippet_rating.js
@@ -7,7 +7,6 @@ import {
 } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour("snippet_rating", {
-    test: true,
     url: "/",
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/snippet_social_media.js
+++ b/addons/website/static/tests/tours/snippet_social_media.js
@@ -85,7 +85,6 @@ const addNewSocialNetwork = function (optionIndex, linkIndex, url, replaceIcon =
 };
 
 registerWebsitePreviewTour('snippet_social_media', {
-    test: true,
     url: '/',
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/snippet_table_of_content.js
+++ b/addons/website/static/tests/tours/snippet_table_of_content.js
@@ -26,7 +26,6 @@ const checkTOCNavBar = function (tocPosition, activeHeaderPosition) {
 };
 
 registerWebsitePreviewTour('snippet_table_of_content', {
-    test: true,
     url: '/',
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/snippet_translation.js
+++ b/addons/website/static/tests/tours/snippet_translation.js
@@ -12,7 +12,6 @@ import {
 
 registerWebsitePreviewTour('snippet_translation', {
     url: '/',
-    test: true,
 }, () => [
     {
         content: "Wait for website preview and check language",
@@ -38,7 +37,6 @@ registerWebsitePreviewTour('snippet_translation', {
 ]);
 registerWebsitePreviewTour('snippet_translation_changing_lang', {
     url: '/',
-    test: true,
 }, () => [
     {
         content: "Change language to Parseltongue",

--- a/addons/website/static/tests/tours/snippet_version.js
+++ b/addons/website/static/tests/tours/snippet_version.js
@@ -9,7 +9,6 @@ import {
 registerWebsitePreviewTour("snippet_version_1", {
     edition: true,
     url: "/",
-    test: true,
 }, () => [
     ...insertSnippet({
         id: 's_test_snip',
@@ -40,13 +39,12 @@ registerWebsitePreviewTour("snippet_version_1", {
 registerWebsitePreviewTour("snippet_version_2", {
     edition: true,
     url: "/",
-    test: true,
 }, () => [
 {
     content: "Edit s_test_snip",
     trigger: ':iframe #wrap.o_editable .s_test_snip',
     run: "click",
-}, 
+},
 {
     trigger:
         "we-customizeblock-options:contains(Test snip) .snippet-option-VersionControl > we-alert",
@@ -55,7 +53,7 @@ registerWebsitePreviewTour("snippet_version_2", {
     content: "Edit text_image",
     trigger: ':iframe #wrap.o_editable .s_text_image',
     run: "click",
-}, 
+},
 {
     trigger:
         "we-customizeblock-options:contains(Text - Image) .snippet-option-VersionControl  > we-alert",
@@ -64,7 +62,7 @@ registerWebsitePreviewTour("snippet_version_2", {
     content: "Edit s_share",
     trigger: ':iframe #wrap.o_editable .s_share',
     run: "click",
-}, 
+},
 {
     trigger:
         "we-customizeblock-options:contains(Share) .snippet-option-VersionControl > we-alert",

--- a/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
+++ b/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
@@ -68,7 +68,7 @@ for (let snippet of snippetsNames) {
         content: `Remove the ${snippet.name} snippet`, // Avoid bad perf if many snippets
         trigger: "we-button.oe_snippet_remove:last",
         run: "click",
-    }, 
+    },
     {
         trigger: "body[test-dd-snippet-removed]",
     },
@@ -114,7 +114,6 @@ for (let snippet of snippetsNames) {
 }
 
 registry.category("web_tour.tours").add("snippets_all_drag_and_drop", {
-    test: true,
     // To run the tour locally, you need to insert the URL sent by the python
     // tour here. There is currently an issue with tours which don't have an URL
     // url: '/?enable_editor=1&snippets_names=s_process_steps:columns,s_website_form:,s_...',

--- a/addons/website/static/tests/tours/specific_website_editor.js
+++ b/addons/website/static/tests/tours/specific_website_editor.js
@@ -7,7 +7,6 @@ import {
 } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour("generic_website_editor", {
-    test: true,
     edition: true,
 }, () => [{
     trigger: ':iframe body:not([data-hello="world"])',
@@ -19,7 +18,6 @@ registerWebsitePreviewTour("generic_website_editor", {
 // mode. Unfortunately this breaks the page and therefore the test fails for
 // unknown reason.
 registry.category("web_tour.tours").add('specific_website_editor', {
-    test: true,
     steps: () => [
     ...clickOnEditAndWaitEditMode(),
 {

--- a/addons/website/static/tests/tours/start_cloned_snippet.js
+++ b/addons/website/static/tests/tours/start_cloned_snippet.js
@@ -7,7 +7,6 @@ import {
 
 registerWebsitePreviewTour('website_start_cloned_snippet', {
     edition: true,
-    test: true,
     url: '/',
 }, () => {
     const countdownSnippet = {
@@ -38,6 +37,6 @@ registerWebsitePreviewTour('website_start_cloned_snippet', {
                 }
             },
         },
-        
+
     ]
 });

--- a/addons/website/static/tests/tours/text_animations.js
+++ b/addons/website/static/tests/tours/text_animations.js
@@ -6,7 +6,6 @@ import {
 } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour("text_animations", {
-    test: true,
     url: "/",
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/text_highlights.js
+++ b/addons/website/static/tests/tours/text_highlights.js
@@ -7,7 +7,6 @@ import {
 } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour("text_highlights", {
-    test: true,
     url: "/",
     edition: true,
 }, () => [
@@ -55,7 +54,7 @@ registerWebsitePreviewTour("text_highlights", {
             const secondLine = document.createElement("i");
             secondLine.textContent = "Text content line B";
             this.anchor.replaceChildren(firstLine, document.createElement("br"), secondLine);
-            // Select the whole content.            
+            // Select the whole content.
             const range = iframeDOC.createRange();
             const selection = iframeDOC.getSelection();
             range.selectNodeContents(this.anchor);

--- a/addons/website/static/tests/tours/translate_menu_name.js
+++ b/addons/website/static/tests/tours/translate_menu_name.js
@@ -8,7 +8,6 @@ import {
 
 registerWebsitePreviewTour('translate_menu_name', {
     url: '/pa_GB',
-    test: true,
     edition: false,
 }, () => [
     {

--- a/addons/website/static/tests/tours/unsplash_beacon.js
+++ b/addons/website/static/tests/tours/unsplash_beacon.js
@@ -3,7 +3,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("test_unsplash_beacon", {
-    test: true,
     url: "/",
     steps: () => [{
         content: "Verify whether beacon was sent.",

--- a/addons/website/static/tests/tours/website_backend_menus_redirect.js
+++ b/addons/website/static/tests/tours/website_backend_menus_redirect.js
@@ -3,7 +3,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('website_backend_menus_redirect', {
-    test: true,
     url: '/',
     steps: () => [
 {

--- a/addons/website/static/tests/tours/website_click_tests.js
+++ b/addons/website/static/tests/tours/website_click_tests.js
@@ -17,7 +17,6 @@ const cover = {
 };
 
 registerWebsitePreviewTour('website_click_tour', {
-    test: true,
     url: '/',
 }, () => [
     stepUtils.waitIframeIsReady(),

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -144,7 +144,6 @@ const addExistingField = function (name, type, label, required, display) {
 registerWebsitePreviewTour("website_form_editor_tour", {
     url: '/',
     edition: true,
-    test: true,
     checkDelay: 100,
 }, () => [
     // Drop a form builder snippet and configure it
@@ -730,7 +729,6 @@ return [
 registerWebsitePreviewTour('website_form_contactus_edition_with_email', {
     url: '/contactus',
     edition: true,
-    test: true,
 }, () => editContactUs([
     {
         content: 'Change the Recipient Email',
@@ -742,7 +740,6 @@ registerWebsitePreviewTour('website_form_contactus_edition_with_email', {
 registerWebsitePreviewTour('website_form_contactus_edition_no_email', {
     url: '/contactus',
     edition: true,
-    test: true,
 }, () => editContactUs([
     {
         content: "Change a random option",
@@ -755,7 +752,6 @@ registerWebsitePreviewTour('website_form_contactus_edition_no_email', {
 ]));
 
 registerWebsitePreviewTour('website_form_conditional_required_checkboxes', {
-    test: true,
     url: '/',
     edition: true,
 }, () => [
@@ -894,7 +890,6 @@ registerWebsitePreviewTour('website_form_conditional_required_checkboxes', {
 ]);
 
 registerWebsitePreviewTour('website_form_contactus_change_random_option', {
-    test: true,
     url: '/contactus',
     edition: true,
 }, () => editContactUs([
@@ -908,7 +903,6 @@ registerWebsitePreviewTour('website_form_contactus_change_random_option', {
 
 // Check that the editable form content is actually editable.
 registerWebsitePreviewTour("website_form_editable_content", {
-    test: true,
     url: "/",
     edition: true,
 }, () => [
@@ -973,7 +967,6 @@ registerWebsitePreviewTour("website_form_editable_content", {
 ]);
 
 registerWebsitePreviewTour("website_form_special_characters", {
-    test: true,
     url: "/",
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/website_form_editor_frontend.js
+++ b/addons/website/static/tests/tours/website_form_editor_frontend.js
@@ -3,7 +3,6 @@ import { rpc } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_form_editor_tour_submit", {
-    test: true,
     steps: () => [
     {
         trigger:  "form[data-model_name='mail.mail']" +
@@ -176,7 +175,6 @@ registry.category("web_tour.tours").add("website_form_editor_tour_submit", {
 ]});
 
 registry.category("web_tour.tours").add("website_form_editor_tour_results", {
-    test: true,
     steps: () => [
     {
         content: "Check mail.mail records have been created",
@@ -210,7 +208,6 @@ registry.category("web_tour.tours").add("website_form_editor_tour_results", {
     }
 ]});
 registry.category("web_tour.tours").add('website_form_contactus_submit', {
-    test: true,
     url: '/contactus',
     steps: () => [
     // As the demo portal user, only two inputs needs to be filled to send
@@ -236,7 +233,6 @@ registry.category("web_tour.tours").add('website_form_contactus_submit', {
     },
 ]});
 registry.category("web_tour.tours").add('website_form_contactus_check_changed_email', {
-    test: true,
     url: '/contactus',
     steps: () => [
         {

--- a/addons/website/static/tests/tours/website_navbar_menu.js
+++ b/addons/website/static/tests/tours/website_navbar_menu.js
@@ -3,7 +3,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_navbar_menu", {
-    test: true,
     url: "/",
     steps: () => [
     {

--- a/addons/website/static/tests/tours/website_no_dirty_page.js
+++ b/addons/website/static/tests/tours/website_no_dirty_page.js
@@ -61,13 +61,11 @@ const makeSteps = (steps = []) => [
 ];
 
 registerWebsitePreviewTour('website_no_action_no_dirty_page', {
-    test: true,
     url: '/',
     edition: true,
 }, () => makeSteps());
 
 registerWebsitePreviewTour('website_no_dirty_page', {
-    test: true,
     url: '/',
     edition: true,
 }, () => makeSteps([
@@ -102,7 +100,6 @@ registerWebsitePreviewTour('website_no_dirty_page', {
 ]));
 
 registerWebsitePreviewTour('website_no_dirty_lazy_image', {
-    test: true,
     url: '/',
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/website_page_options.js
+++ b/addons/website/static/tests/tours/website_page_options.js
@@ -10,7 +10,6 @@ import {
 
 
 registerWebsitePreviewTour('website_page_options', {
-    test: true,
     url: '/',
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/website_snippets_menu_tabs.js
+++ b/addons/website/static/tests/tours/website_snippets_menu_tabs.js
@@ -6,7 +6,6 @@ import {
 } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour("website_snippets_menu_tabs", {
-    test: true,
     url: "/",
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/website_style_edition.js
+++ b/addons/website/static/tests/tours/website_style_edition.js
@@ -48,7 +48,6 @@ const checkBodyColor = function () {
 };
 
 registerWebsitePreviewTour("website_style_edition", {
-    test: true,
     url: '/',
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/website_text_edition.js
+++ b/addons/website/static/tests/tours/website_text_edition.js
@@ -10,7 +10,6 @@ import {
 const WEBSITE_MAIN_COLOR = '#ABCDEF';
 
 registerWebsitePreviewTour('website_text_edition', {
-    test: true,
     url: '/',
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/website_text_font_size.js
+++ b/addons/website/static/tests/tours/website_text_font_size.js
@@ -128,7 +128,6 @@ function getAllFontSizesTestSteps() {
 }
 
 registerWebsitePreviewTour("website_text_font_size", {
-    test: true,
     url: "/",
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/website_update_column_count.js
+++ b/addons/website/static/tests/tours/website_update_column_count.js
@@ -39,7 +39,6 @@ const checkIfNoMobileOrder = (snippetRowSelector) => {
 };
 
 registerWebsitePreviewTour("website_update_column_count", {
-    test: true,
     url: "/",
     edition: true,
 }, () => [
@@ -119,7 +118,7 @@ registerWebsitePreviewTour("website_update_column_count", {
     content: "Change the orders of the 2nd and 3rd items",
     trigger: ":iframe .o_overlay_move_options [data-name='move_right_opt']",
     run: "click",
-}, 
+},
 {
     trigger: `${columnsSnippetRow}:has([style*='order: 2;'].order-lg-0:nth-child(2) + [style*='order: 1;'].order-lg-0:nth-child(3))`,
 },
@@ -162,7 +161,6 @@ registerWebsitePreviewTour("website_update_column_count", {
 ]);
 
 registerWebsitePreviewTour("website_mobile_order_with_drag_and_drop", {
-    test: true,
     url: "/",
     edition: true,
 }, () => [

--- a/addons/website/static/tests/tours/widget_lifecycle.js
+++ b/addons/website/static/tests/tours/widget_lifecycle.js
@@ -15,7 +15,6 @@ import {
 const localStorageKey = 'widgetAndWysiwygLifecycle';
 
 registerWebsitePreviewTour("widget_lifecycle", {
-    test: true,
     url: "/",
     edition: true,
 }, () => [

--- a/addons/website_blog/static/tests/tours/blog_search_with_date.js
+++ b/addons/website_blog/static/tests/tours/blog_search_with_date.js
@@ -6,13 +6,12 @@ import { registry } from "@web/core/registry";
  * Makes sure that blog search can be used with the date filtering.
  */
 registry.category("web_tour.tours").add("blog_autocomplete_with_date", {
-    test: true,
     url: '/blog',
     steps: () => [{
     content: "Select first month",
     trigger: 'select[name=archive]',
     run: "selectByIndex 1",
-}, 
+},
 {
     trigger: '#o_wblog_posts_loop span:has(i.fa-calendar-o):has(a[href="/blog"])',
 },
@@ -20,7 +19,7 @@ registry.category("web_tour.tours").add("blog_autocomplete_with_date", {
     content: "Enter search term",
     trigger: '.o_searchbar_form input',
     run: "edit a",
-}, 
+},
 {
     trigger: ".o_searchbar_form .o_dropdown_menu .o_search_result_item",
 },

--- a/addons/website_blog/static/tests/tours/blog_tags_tour.js
+++ b/addons/website_blog/static/tests/tours/blog_tags_tour.js
@@ -13,7 +13,6 @@ import { stepUtils } from "@web_tour/tour_service/tour_utils";
  * Makes sure that blog tags can be created and removed.
  */
 registerWebsitePreviewTour('blog_tags', {
-    test: true,
     url: '/blog',
 }, () => [
     stepUtils.waitIframeIsReady(),

--- a/addons/website_crm/static/tests/tours/website_crm.js
+++ b/addons/website_crm/static/tests/tours/website_crm.js
@@ -7,7 +7,6 @@ import {
 } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour('website_crm_pre_tour', {
-    test: true,
     url: '/contactus',
     edition: true,
 }, () => [{
@@ -34,7 +33,6 @@ registerWebsitePreviewTour('website_crm_pre_tour', {
 }]);
 
 registry.category("web_tour.tours").add('website_crm_tour', {
-    test: true,
     url: '/contactus',
     steps: () => [{
     content: "Complete name",
@@ -70,7 +68,6 @@ registry.category("web_tour.tours").add('website_crm_tour', {
 }]});
 
 registry.category("web_tour.tours").add('website_crm_catch_logged_partner_info_tour', {
-    test: true,
     url: '/contactus',
     steps: () => [{
     content: "Complete Subject",

--- a/addons/website_event/static/tests/tours/tickets_questions.js
+++ b/addons/website_event/static/tests/tours/tickets_questions.js
@@ -2,7 +2,6 @@
 
 import { registry } from "@web/core/registry";
 registry.category("web_tour.tours").add('test_tickets_questions', {
-    test: true,
     url: '/event',
     steps: () => [{
     content: "Click on the Design Fair event",

--- a/addons/website_event/static/tests/tours/website_event.js
+++ b/addons/website_event/static/tests/tours/website_event.js
@@ -9,7 +9,6 @@ import {
 import { markup } from "@odoo/owl";
 
 registerWebsitePreviewTour("website_event_tour", {
-    test: true,
     url: "/",
 }, () => [{
     content: _t("Click here to add new content to your website."),

--- a/addons/website_event/static/tests/tours/website_event_pages_seo.js
+++ b/addons/website_event/static/tests/tours/website_event_pages_seo.js
@@ -3,7 +3,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_event_pages_seo", {
-    test: true,
     // The tour must start on an event's custom page (not register page)
     // url: `/event/openwood-collection-online-reveal-8/page/introduction-openwood-collection-online-reveal`,
     steps: () => [

--- a/addons/website_event_booth_exhibitor/static/tests/tours/website_event_booth_exhibitor.js
+++ b/addons/website_event_booth_exhibitor/static/tests/tours/website_event_booth_exhibitor.js
@@ -5,7 +5,6 @@
 
 
     registry.category("web_tour.tours").add("webooth_exhibitor_register", {
-        test: true,
         url: "/event",
         steps: () => [{
         content: 'Go on "Online Reveal" page',
@@ -40,7 +39,7 @@
             document.querySelector("input[name='sponsor_slogan']").value = "Patrick is Your Sponsor";
             document.querySelector("textarea[name='sponsor_description']").textContent = "Really eager to meet you !";
         },
-    }, 
+    },
     {
         trigger: "input[name='sponsor_name'], input[name='sponsor_email'], input[name='sponsor_phone']",
     },

--- a/addons/website_event_booth_sale/static/tests/tours/website_event_booth.js
+++ b/addons/website_event_booth_sale/static/tests/tours/website_event_booth.js
@@ -5,7 +5,6 @@ import * as wsTourUtils from '@website_sale/js/tours/tour_utils';
 
 
 registry.category("web_tour.tours").add('website_event_booth_tour', {
-    test: true,
     url: '/event',
     steps: () => [
 {

--- a/addons/website_event_booth_sale/static/tests/tours/website_event_booth_sale_pricelists.js
+++ b/addons/website_event_booth_sale/static/tests/tours/website_event_booth_sale_pricelists.js
@@ -5,7 +5,6 @@ import { getPriceListChecksSteps } from '@website_event_booth_sale/../tests/tour
 import * as wsTourUtils from '@website_sale/js/tours/tour_utils';
 
 registry.category("web_tour.tours").add('event_booth_sale_pricelists_different_currencies', {
-    test: true,
     url: '/event',
     steps: () => [
     // Init: registering the booth

--- a/addons/website_event_sale/static/tests/tours/website_event_sale.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import * as wsTourUtils from "@website_sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add("event_buy_tickets", {
-    test: true,
     url: "/event",
     steps: () => [
         {

--- a/addons/website_event_sale/static/tests/tours/website_event_sale_last_ticket.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale_last_ticket.js
@@ -3,12 +3,10 @@
 import { registry } from "@web/core/registry";
 import * as wsTourUtils from "@website_sale/js/tours/tour_utils";
 
-registry.category("web_tour.tours").add("event_buy_last_ticket", {
-    test: true,
-    url: "/event",
+registry.category("web_tour.tours").add('event_buy_last_ticket', {
+    url: '/event',
     checkDelay: 100,
-    steps: () => [
-    {
+    steps: () => [{
         content: "Open the Last ticket test event page",
         trigger: '.o_wevent_events_list a:contains("Last ticket test")',
         run: "click",

--- a/addons/website_event_sale/static/tests/tours/website_event_sale_pricelists.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale_pricelists.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import { getPriceListChecksSteps } from "@website_event_sale/../tests/tours/helpers/WebsiteEventSaleTourMethods";
 
 registry.category("web_tour.tours").add("event_sale_pricelists_different_currencies", {
-    test: true,
     url: "/event",
     steps: () => [
         // Register for tickets

--- a/addons/website_forum/static/tests/tours/website_forum_question.js
+++ b/addons/website_forum/static/tests/tours/website_forum_question.js
@@ -3,7 +3,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('forum_question', {
-    test: true,
     url: '/forum/help-1',
     steps: () => [
     {

--- a/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
+++ b/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
@@ -49,7 +49,6 @@ function applyForAJob(jobName, application) {
 }
 
 registry.category("web_tour.tours").add('website_hr_recruitment_tour', {
-    test: true,
     url: '/jobs',
     steps: () => [
     ...applyForAJob('Guru', {
@@ -74,7 +73,6 @@ registry.category("web_tour.tours").add('website_hr_recruitment_tour', {
 ]});
 
 registerWebsitePreviewTour('website_hr_recruitment_tour_edit_form', {
-    test: true,
     url: '/jobs',
 }, () => [
     stepUtils.waitIframeIsReady(),
@@ -152,7 +150,6 @@ registerWebsitePreviewTour('website_hr_recruitment_tour_edit_form', {
 // field is selected, the alert message should not display an undefined
 // action name.
 registerWebsitePreviewTour('model_required_field_should_have_action_name', {
-    test: true,
     url: '/jobs',
 }, () => [{
     content: "Select Job",

--- a/addons/website_links/static/tests/tours/website_links.js
+++ b/addons/website_links/static/tests/tours/website_links.js
@@ -33,7 +33,6 @@ const mediumValue = 'Super Specific Medium';
 const sourceValue = 'Super Specific Source';
 
 registry.category("web_tour.tours").add('website_links_tour', {
-    test: true,
     url: '/r',
     steps: () => [
         // 1. Create a tracked URL

--- a/addons/website_livechat/static/tests/tours/lazy_frontend_bus_tour.js
+++ b/addons/website_livechat/static/tests/tours/lazy_frontend_bus_tour.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_livechat.lazy_frontend_bus", {
-    test: true,
     url: "/",
     steps: () => [
         {

--- a/addons/website_livechat/static/tests/tours/website_livechat_as_portal.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_as_portal.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_livechat_as_portal_tour", {
-    test: true,
     steps: () => [
         {
             trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_after_reload.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_after_reload.js
@@ -4,7 +4,6 @@ import { closeChat } from "./website_livechat_common";
 const messagesContain = (text) => `.o-livechat-root:shadow .o-mail-Message:contains("${text}")`;
 
 registry.category("web_tour.tours").add("website_livechat_chatbot_after_reload_tour", {
-    test: true,
     steps: () => [
         {
             trigger: messagesContain("Hello! I'm a bot!"),

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
@@ -4,7 +4,6 @@ import { contains } from "@web/../tests/utils";
 const messagesContain = (text) => `.o-livechat-root:shadow .o-mail-Message:contains("${text}")`;
 
 registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
-    test: true,
     checkDelay: 50,
     steps: () => [
         {

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_redirect.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_redirect.js
@@ -3,7 +3,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_livechat.chatbot_redirect", {
-    test: true,
     url: "/contactus",
     steps: () => [
         {

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_trigger_selection_tour.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_trigger_selection_tour.js
@@ -19,7 +19,6 @@ const answerBothQuestions = [
     },
 ];
 registry.category("web_tour.tours").add("website_livechat.chatbot_trigger_selection", {
-    test: true,
     url: "/contactus",
     steps: () => [
         {

--- a/addons/website_livechat/static/tests/tours/website_livechat_rating.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_rating.js
@@ -12,37 +12,31 @@ import {
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_livechat_complete_flow_tour", {
-    test: true,
     url: "/",
     steps: () => [].concat(start, closeChat, confirmnClose, okRating, feedback, transcript, close),
 });
 
 registry.category("web_tour.tours").add("website_livechat_happy_rating_tour", {
-    test: true,
     url: "/",
     steps: () => [].concat(start, closeChat, confirmnClose, goodRating, feedback),
 });
 
 registry.category("web_tour.tours").add("website_livechat_ok_rating_tour", {
-    test: true,
     url: "/",
     steps: () => [].concat(start, closeChat, confirmnClose, okRating, feedback),
 });
 
 registry.category("web_tour.tours").add("website_livechat_sad_rating_tour", {
-    test: true,
     url: "/",
     steps: () => [].concat(start, closeChat, confirmnClose, sadRating, feedback),
 });
 
 registry.category("web_tour.tours").add("website_livechat_no_rating_tour", {
-    test: true,
     url: "/",
     steps: () => [].concat(start, closeChat, confirmnClose, transcript, close),
 });
 
 registry.category("web_tour.tours").add("website_livechat_no_rating_no_close_tour", {
-    test: true,
     url: "/",
     steps: () => [].concat(start),
 });

--- a/addons/website_livechat/static/tests/tours/website_livechat_request.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_request.js
@@ -46,13 +46,11 @@ const chatRequest = [
 ];
 
 registry.category("web_tour.tours").add("website_livechat_chat_request_part_1_no_close_tour", {
-    test: true,
     url: "/",
     steps: () => [].concat(chatRequest),
 });
 
 registry.category("web_tour.tours").add("website_livechat_chat_request_part_2_end_session_tour", {
-    test: true,
     url: "/",
     steps: () => [].concat(closeChat, confirmnClose, okRating, feedback, transcript),
 });

--- a/addons/website_livechat/static/tests/tours/website_livechat_session_user_changes.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_session_user_changes.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_livechat_login_after_chat_start", {
-    test: true,
     url: "/",
     steps: () => [
         {
@@ -51,7 +50,6 @@ registry.category("web_tour.tours").add("website_livechat_login_after_chat_start
 });
 
 registry.category("web_tour.tours").add("website_livechat_logout_after_chat_start", {
-    test: true,
     url: "/",
     steps: () => [
         {

--- a/addons/website_livechat/static/tests/tours/website_livechat_user_known_after_reload.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_user_known_after_reload.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_livechat_user_known_after_reload", {
-    test: true,
     steps: () => [
         {
             trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",

--- a/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_block_with_edit.js
+++ b/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_block_with_edit.js
@@ -8,7 +8,6 @@ import {
 } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour('snippet_newsletter_block_with_edit', {
-    test: true,
     url: '/',
     edition: true,
 }, () => [

--- a/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_popup_edition.js
+++ b/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_popup_edition.js
@@ -8,7 +8,6 @@ import {
 import snippetNewsletterPopupUseTour from "@website_mass_mailing/../tests/tours/snippet_newsletter_popup_use";
 
 registerWebsitePreviewTour("snippet_newsletter_popup_edition", {
-    test: true,
     url: "/",
     edition: true,
 }, () => [

--- a/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_popup_use.js
+++ b/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_popup_use.js
@@ -19,7 +19,6 @@ function ensurePopupNotVisible() {
 }
 
 registry.category("web_tour.tours").add('snippet_newsletter_popup_use', {
-    test: true,
     url: '/',
     steps: () => [
     {

--- a/addons/website_payment/static/tests/tours/donation.js
+++ b/addons/website_payment/static/tests/tours/donation.js
@@ -7,7 +7,6 @@ import {
 } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour('donation_snippet_edition', {
-    test: true,
     url: '/',
     edition: true,
 }, () => [

--- a/addons/website_profile/static/tests/tours/tour_website_profile_description.js
+++ b/addons/website_profile/static/tests/tours/tour_website_profile_description.js
@@ -3,7 +3,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('website_profile_description', {
-    test: true,
     url: "/profile/users",
     steps: () => [{
         content: "Click on one user profile card",

--- a/addons/website_sale/static/tests/tours/website_free_delivery.js
+++ b/addons/website_sale/static/tests/tours/website_free_delivery.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add("check_free_delivery", {
-    test: true,
     url: "/shop",
     steps: () => [
         // Part 1: Check free delivery

--- a/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
@@ -14,7 +14,6 @@ function editAddToCartSnippet() {
 registerWebsitePreviewTour('add_to_cart_snippet_tour', {
         url: '/',
         edition: true,
-        test: true,
     },
     () => [
         ...insertSnippet({name: 'Add to Cart Button'}),

--- a/addons/website_sale/static/tests/tours/website_sale_buy.js
+++ b/addons/website_sale/static/tests/tours/website_sale_buy.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('shop_buy_product', {
-    test: true,
     url: '/shop',
     steps: () => [
         ...tourUtils.searchProduct("Storage Box"),

--- a/addons/website_sale/static/tests/tours/website_sale_cart_notification.js
+++ b/addons/website_sale/static/tests/tours/website_sale_cart_notification.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add("website_sale_cart_notification", {
-    test: true,
     url: "/shop",
     checkDelay: 100,
     steps: () => [

--- a/addons/website_sale/static/tests/tours/website_sale_category_page_and_products_snippet.js
+++ b/addons/website_sale/static/tests/tours/website_sale_category_page_and_products_snippet.js
@@ -6,7 +6,6 @@ import { registry } from "@web/core/registry";
 const PRODUCT_CATEGORY_ID = 2;
 
 registerWebsitePreviewTour('category_page_and_products_snippet_edition', {
-    test: true,
     url: `/shop/category/${PRODUCT_CATEGORY_ID}`,
     edition: true,
 }, () => [
@@ -43,7 +42,6 @@ registerWebsitePreviewTour('category_page_and_products_snippet_edition', {
 ]);
 
 registry.category("web_tour.tours").add('category_page_and_products_snippet_use', {
-    test: true,
     url: `/shop/category/${PRODUCT_CATEGORY_ID}`,
     steps: () => [
     {

--- a/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
+++ b/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
@@ -5,7 +5,6 @@
     import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
     registry.category("web_tour.tours").add('website_sale_tour_1', {
-        test: true,
         checkDelay: 150,
         url: '/shop?search=Storage Box Test',
         steps: () => [
@@ -445,7 +444,6 @@
     }]});
 
     registry.category("web_tour.tours").add('website_sale_tour_2', {
-        test: true,
         url: '/shop/cart',
         checkDelay: 150,
         steps: () => [

--- a/addons/website_sale/static/tests/tours/website_sale_complete_flow_backend.js
+++ b/addons/website_sale/static/tests/tours/website_sale_complete_flow_backend.js
@@ -3,7 +3,6 @@
 import { clickOnSave, registerWebsitePreviewTour } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour('website_sale_tour_backend', {
-    test: true,
     url: '/shop/cart',
     edition: true,
 }, () => [

--- a/addons/website_sale/static/tests/tours/website_sale_fiscal_position_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_fiscal_position_tour.js
@@ -3,7 +3,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('website_sale_fiscal_position_portal_tour', {
-    test: true,
     url: '/shop?search=Super%20Product',
     steps: () => [
         {
@@ -13,7 +12,6 @@ registry.category("web_tour.tours").add('website_sale_fiscal_position_portal_tou
 ]});
 
 registry.category("web_tour.tours").add('website_sale_fiscal_position_public_tour', {
-    test: true,
     url: '/shop?search=Super%20Product',
     steps: () => [
         {

--- a/addons/website_sale/static/tests/tours/website_sale_google_analytics.js
+++ b/addons/website_sale/static/tests/tours/website_sale_google_analytics.js
@@ -22,7 +22,6 @@ let itemId;
 
 
 registry.category("web_tour.tours").add('google_analytics_view_item', {
-    test: true,
     url: '/shop?search=Customizable Desk',
     steps: () => [
     {
@@ -56,7 +55,6 @@ registry.category("web_tour.tours").add('google_analytics_view_item', {
 ]});
 
 registry.category("web_tour.tours").add('google_analytics_add_to_cart', {
-    test: true,
     url: '/shop?search=Acoustic Bloc Screens',
     steps: () => [
     ...tourUtils.addToCart({productName: 'Acoustic Bloc Screens', search: false}),

--- a/addons/website_sale/static/tests/tours/website_sale_preconfigured_variant_price.js
+++ b/addons/website_sale/static/tests/tours/website_sale_preconfigured_variant_price.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import configuratorTourUtils from "@sale/js/tours/product_configurator_tour_utils";
 
 registry.category("web_tour.tours").add('website_sale_product_configurator_optional_products_tour', {
-    test: true,
     steps: () => [
         {
             trigger: 'ul.js_add_cart_variants span:contains("Aluminium") ~ span.badge:contains("50.40")',

--- a/addons/website_sale/static/tests/tours/website_sale_product_configurator_hide_dialog.js
+++ b/addons/website_sale/static/tests/tours/website_sale_product_configurator_hide_dialog.js
@@ -6,7 +6,6 @@ import * as wsTourUtils from '@website_sale/js/tours/tour_utils';
 registry
     .category('web_tour.tours')
     .add('website_sale_product_configurator_hide_dialog', {
-        test: true,
         url: '/shop?search=Main product',
         steps: () => [
             {

--- a/addons/website_sale/static/tests/tours/website_sale_product_configurator_shop_hide_dialog.js
+++ b/addons/website_sale/static/tests/tours/website_sale_product_configurator_shop_hide_dialog.js
@@ -6,7 +6,6 @@ import * as wsTourUtils from '@website_sale/js/tours/tour_utils';
 registry
     .category('web_tour.tours')
     .add('website_sale_product_configurator_shop_hide_dialog', {
-        test: true,
         url: '/shop?search=Main product',
         steps: () => [
             {

--- a/addons/website_sale/static/tests/tours/website_sale_product_configurator_shop_show_dialog.js
+++ b/addons/website_sale/static/tests/tours/website_sale_product_configurator_shop_show_dialog.js
@@ -5,7 +5,6 @@ import { registry } from '@web/core/registry';
 registry
     .category('web_tour.tours')
     .add('website_sale_product_configurator_shop_show_dialog', {
-        test: true,
         url: '/shop?search=Main product',
         steps: () => [
             {

--- a/addons/website_sale/static/tests/tours/website_sale_product_configurator_show_dialog.js
+++ b/addons/website_sale/static/tests/tours/website_sale_product_configurator_show_dialog.js
@@ -5,7 +5,6 @@ import { registry } from '@web/core/registry';
 registry
     .category('web_tour.tours')
     .add('website_sale_product_configurator_show_dialog', {
-        test: true,
         url: '/shop?search=Main product',
         steps: () => [
             {

--- a/addons/website_sale/static/tests/tours/website_sale_product_configurator_strikethrough_price.js
+++ b/addons/website_sale/static/tests/tours/website_sale_product_configurator_strikethrough_price.js
@@ -7,7 +7,6 @@ import websiteConfiguratorTourUtils from '@website_sale/js/tours/product_configu
 registry
     .category('web_tour.tours')
     .add('website_sale_product_configurator_strikethrough_price', {
-        test: true,
         url: '/shop?search=Main product',
         steps: () => [
             {

--- a/addons/website_sale/static/tests/tours/website_sale_product_configurator_taxes.js
+++ b/addons/website_sale/static/tests/tours/website_sale_product_configurator_taxes.js
@@ -6,7 +6,6 @@ import configuratorTourUtils from '@sale/js/tours/product_configurator_tour_util
 registry
     .category('web_tour.tours')
     .add('website_sale_product_configurator_taxes', {
-        test: true,
         url: '/shop?search=Main product',
         steps: () => [
             {

--- a/addons/website_sale/static/tests/tours/website_sale_product_configurator_zero_priced.js
+++ b/addons/website_sale/static/tests/tours/website_sale_product_configurator_zero_priced.js
@@ -7,7 +7,6 @@ import websiteConfiguratorTourUtils from '@website_sale/js/tours/product_configu
 registry
     .category('web_tour.tours')
     .add('website_sale_product_configurator_zero_priced', {
-        test: true,
         url: '/shop?search=Main product',
         steps: () => [
             {

--- a/addons/website_sale/static/tests/tours/website_sale_remove_product_image.js
+++ b/addons/website_sale/static/tests/tours/website_sale_remove_product_image.js
@@ -44,7 +44,6 @@ const removeImg = [
 
 registerWebsitePreviewTour("add_and_remove_main_product_image_no_variant", {
     url: "/shop?search=Test Remove Image",
-    test: true,
 }, () => [
     ...enterEditModeOfTestProduct(),
     {
@@ -65,7 +64,6 @@ registerWebsitePreviewTour("add_and_remove_main_product_image_no_variant", {
 ]);
 registerWebsitePreviewTour("remove_main_product_image_with_variant", {
     url: "/shop?search=Test Remove Image",
-    test: true,
 }, () => [
     ...enterEditModeOfTestProduct(),
     ...clickOnImgAndWaitForLoad,

--- a/addons/website_sale/static/tests/tours/website_sale_reorder_from_portal.js
+++ b/addons/website_sale/static/tests/tours/website_sale_reorder_from_portal.js
@@ -5,7 +5,6 @@ import { assertCartContains } from '@website_sale/js/tours/tour_utils';
 import { clickOnElement } from '@website/js/tours/tour_utils';
 
 registry.category("web_tour.tours").add('website_sale_reorder_from_portal', {
-        test: true,
         url: '/my/orders',
         steps: () => [
         // Initial reorder, nothing in cart

--- a/addons/website_sale/static/tests/tours/website_sale_restricted_editor_ui.js
+++ b/addons/website_sale/static/tests/tours/website_sale_restricted_editor_ui.js
@@ -4,7 +4,6 @@ import { registerWebsitePreviewTour } from '@website/js/tours/tour_utils';
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registerWebsitePreviewTour('website_sale_restricted_editor_ui', {
-    test: true,
     url: `/shop`,
 }, () => [
     {

--- a/addons/website_sale/static/tests/tours/website_sale_shop_archived_variant_multi.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_archived_variant_multi.js
@@ -14,7 +14,6 @@ function assert(current, expected, info) {
 }
 
 registry.category("web_tour.tours").add('tour_shop_archived_variant_multi', {
-    test: true,
     url: '/shop?search=Test Product 2',
     steps: () => [
     {
@@ -65,7 +64,6 @@ registry.category("web_tour.tours").add('tour_shop_archived_variant_multi', {
 ]});
 
 registry.category("web_tour.tours").add('test_09_pills_variant', {
-    test: true,
     url: '/shop?search=Test Product 2',
     steps: () => [
     {

--- a/addons/website_sale/static/tests/tours/website_sale_shop_cart_recovery.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_cart_recovery.js
@@ -9,7 +9,6 @@ var orderIdKey = 'website_sale.tour_shop_cart_recovery.orderId';
 var recoveryLinkKey = 'website_sale.tour_shop_cart_recovery.recoveryLink';
 
 registry.category("web_tour.tours").add('shop_cart_recovery', {
-    test: true,
     url: '/shop',
     steps: () => [
         ...tourUtils.addToCart({productName: "Acoustic Bloc Screens"}),

--- a/addons/website_sale/static/tests/tours/website_sale_shop_compare_list_price_pricelist.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_compare_list_price_pricelist.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import * as tourUtils from '@website_sale/js/tours/tour_utils';
 
 registry.category("web_tour.tours").add('compare_list_price_price_list_display', {
-        test: true,
         url: '/shop?search=test_product',
         steps: () => [
         tourUtils.assertProductPrice("price_reduce", "1,000", "test_product_default"),

--- a/addons/website_sale/static/tests/tours/website_sale_shop_custom_attribute_value.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_custom_attribute_value.js
@@ -4,7 +4,6 @@
 
     registry.category("web_tour.tours").add("shop_custom_attribute_value", {
         url: "/shop?search=Customizable Desk",
-        test: true,
         steps: () => [{
         content: "click on Customizable Desk",
         trigger: '.oe_product_cart a:contains("Customizable Desk (TEST)")',

--- a/addons/website_sale/static/tests/tours/website_sale_shop_custom_attributes_value.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_custom_attributes_value.js
@@ -8,7 +8,6 @@ let optionVariantImage;
 
 registry.category("web_tour.tours").add("a_shop_custom_attribute_value", {
     url: "/shop?search=Customizable Desk",
-    test: true,
     steps: () => [{
         content: "click on Customizable Desk",
         trigger: '.oe_product_cart a:contains("Customizable Desk (TEST)")',

--- a/addons/website_sale/static/tests/tours/website_sale_shop_customize.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_customize.js
@@ -11,7 +11,6 @@ import {
 registerWebsitePreviewTour('shop_customize', {
     url: '/shop',
     edition: true,
-    test: true,
 },
     () => [
         ...clickOnSave(),

--- a/addons/website_sale/static/tests/tours/website_sale_shop_deleted_archived_variants.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_deleted_archived_variants.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 
 // This tour relies on a data created from the python test.
 registry.category("web_tour.tours").add('tour_shop_deleted_archived_variants', {
-    test: true,
     url: '/shop?search=Test Product 2',
     steps: () => [
     {

--- a/addons/website_sale/static/tests/tours/website_sale_shop_dynamic_variants.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_dynamic_variants.js
@@ -5,7 +5,6 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
 // This tour relies on a data created from the python test.
 registry.category("web_tour.tours").add('tour_shop_dynamic_variants', {
-    test: true,
     url: '/shop?search=Dynamic Product',
     steps: () => [
     {

--- a/addons/website_sale/static/tests/tours/website_sale_shop_editor_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_editor_tour.js
@@ -3,14 +3,13 @@
 import { clickOnSave, registerWebsitePreviewTour } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour("shop_editor", {
-    test: true,
     url: "/shop",
     edition: true,
 }, () => [{
     content: "Click on pricelist dropdown",
     trigger: ":iframe div.o_pricelist_dropdown a[data-bs-toggle=dropdown]",
     run: "click",
-}, 
+},
 {
     trigger: ":iframe div.o_pricelist_dropdown a[data-bs-toggle=dropdown][aria-expanded=true]",
 },
@@ -18,7 +17,7 @@ registerWebsitePreviewTour("shop_editor", {
     trigger: ":iframe input[name=search]",
     content: "Click somewhere else in the shop.",
     run: "click",
-}, 
+},
 {
     trigger: ":iframe div.o_pricelist_dropdown a[data-bs-toggle=dropdown][aria-expanded=false]",
 },
@@ -32,7 +31,6 @@ registerWebsitePreviewTour("shop_editor", {
 }]);
 
 registerWebsitePreviewTour("shop_editor_set_product_ribbon", {
-    test: true,
     url: "/shop",
     edition: true,
 }, () => [{

--- a/addons/website_sale/static/tests/tours/website_sale_shop_list_view_b2c.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_list_view_b2c.js
@@ -9,7 +9,6 @@ import {
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registerWebsitePreviewTour('shop_list_view_b2c', {
-    test: true,
     url: '/shop?search=Test Product',
 },
     () => [

--- a/addons/website_sale/static/tests/tours/website_sale_shop_mail.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_mail.js
@@ -5,7 +5,6 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
 import { redirect } from "@web/core/utils/urls";
 
 registry.category("web_tour.tours").add('shop_mail', {
-    test: true,
     url: '/shop?search=Acoustic Bloc Screens',
     steps: () => [
         ...tourUtils.addToCart({productName: 'Acoustic Bloc Screens', search: false}),

--- a/addons/website_sale/static/tests/tours/website_sale_shop_multi_checkbox.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_multi_checkbox.js
@@ -5,7 +5,6 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
 // This tour relies on a data created from the python test.
 registry.category("web_tour.tours").add('tour_shop_multi_checkbox', {
-    test: true,
     url: '/shop?search=Product Multi',
     steps: () => [
     {
@@ -64,7 +63,6 @@ registry.category("web_tour.tours").add('tour_shop_multi_checkbox', {
 ]});
 
 registry.category("web_tour.tours").add('tour_shop_multi_checkbox_single_value', {
-    test: true,
     url: '/shop?search=Burger',
     steps: () => [
     {

--- a/addons/website_sale/static/tests/tours/website_sale_shop_no_variant_attribute.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_no_variant_attribute.js
@@ -5,7 +5,6 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
 // This tour relies on a data created from the python test.
 registry.category("web_tour.tours").add('tour_shop_no_variant_attribute', {
-    test: true,
     url: '/shop?search=Test Product 3',
     steps: () => [
     {

--- a/addons/website_sale/static/tests/tours/website_sale_shop_pricelist_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_pricelist_tour.js
@@ -5,7 +5,6 @@ import { registry } from "@web/core/registry";
 registry.category("web_tour.tours").add(
     "website_sale.website_sale_shop_pricelist_tour",
     {
-        test: true,
         url: '/shop',
         steps: () => [
             {

--- a/addons/website_sale/static/tests/tours/website_sale_shop_zoom.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_zoom.js
@@ -8,7 +8,6 @@ var nameGreen = "Forest Green";
 
 // This tour relies on a data created from the python test.
 registry.category("web_tour.tours").add('shop_zoom', {
-    test: true,
     url: '/shop?debug=1&search=' + imageName,
     steps: () => [
     {

--- a/addons/website_sale/static/tests/tours/website_sale_snippet_products.js
+++ b/addons/website_sale/static/tests/tours/website_sale_snippet_products.js
@@ -40,7 +40,6 @@ function changeTemplate(templateKey) {
 }
 
 registerWebsitePreviewTour('website_sale.snippet_products', {
-    test: true,
     url: '/',
     edition: true,
 },
@@ -64,7 +63,6 @@ registerWebsitePreviewTour('website_sale.snippet_products', {
 });
 
 registerWebsitePreviewTour('website_sale.products_snippet_recently_viewed', {
-    test: true,
     url: '/',
     edition: true,
 },

--- a/addons/website_sale/static/tests/tours/website_sale_update_address.js
+++ b/addons/website_sale/static/tests/tours/website_sale_update_address.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('update_billing_shipping_address', {
-    test: true,
     url: '/shop',
     steps: () => [
         ...tourUtils.addToCart({productName: "Office Chair Black TEST"}),

--- a/addons/website_sale/static/tests/tours/website_sale_update_cart.js
+++ b/addons/website_sale/static/tests/tours/website_sale_update_cart.js
@@ -4,7 +4,6 @@ import {registry} from '@web/core/registry';
 import * as tourUtils from '@website_sale/js/tours/tour_utils';
 
 registry.category('web_tour.tours').add('shop_update_cart', {
-    test: true,
     url: '/shop',
     steps: () => [
         ...tourUtils.searchProduct("conference chair"),

--- a/addons/website_sale/static/tests/tours/website_sale_variants_modal_window.js
+++ b/addons/website_sale/static/tests/tours/website_sale_variants_modal_window.js
@@ -4,7 +4,6 @@
 
     // This tour relies on a data created from the python test.
     registry.category("web_tour.tours").add('tour_variants_modal_window', {
-        test: true,
         url: '/shop?search=Short (TEST)',
         steps: () => [
         {

--- a/addons/website_sale_autocomplete/static/tests/autocomplete_tour.js
+++ b/addons/website_sale_autocomplete/static/tests/autocomplete_tour.js
@@ -9,7 +9,6 @@ function fail (errorMessage) {
 }
 
 registry.category("web_tour.tours").add('autocomplete_tour', {
-    test: true,
     url: '/shop', // /shop/address is redirected if no sales order
     steps: () => [
     ...tourUtils.addToCart({productName: "A test product"}),

--- a/addons/website_sale_comparison/static/tests/tours/website_sale_comparison.js
+++ b/addons/website_sale_comparison/static/tests/tours/website_sale_comparison.js
@@ -4,7 +4,6 @@
     import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
     registry.category("web_tour.tours").add('product_comparison', {
-        test: true,
         url: "/shop",
         steps: () => [
     // test from shop page

--- a/addons/website_sale_loyalty/static/tests/tours/test_apply_discount_code.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_apply_discount_code.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import * as tourUtils from '@website_sale/js/tours/tour_utils';
 
 registry.category("web_tour.tours").add('apply_discount_code_program_multi_rewards', {
-    test: true,
     url: '/shop?search=Super%20Chair',
     checkDelay: 100,
     steps: () => [

--- a/addons/website_sale_loyalty/static/tests/tours/test_ewallet_tour.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_ewallet_tour.js
@@ -6,7 +6,6 @@ import { TourError } from "@web_tour/tour_service/tour_utils";
 
 
 registry.category("web_tour.tours").add('shop_sale_ewallet', {
-    test: true,
     url: '/shop',
     steps: () => [
         // Add a $50 gift card to the order

--- a/addons/website_sale_loyalty/static/tests/tours/test_gift_card_tour.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_gift_card_tour.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import * as tourUtils from '@website_sale/js/tours/tour_utils';
 
 registry.category("web_tour.tours").add('shop_sale_gift_card', {
-    test: true,
     url: '/shop',
     steps: () => [
         // Add a small drawer to the order (50$)

--- a/addons/website_sale_loyalty/static/tests/tours/test_promo_main_tour.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_promo_main_tour.js
@@ -5,7 +5,6 @@ import { registry } from "@web/core/registry";
 import * as tourUtils from '@website_sale/js/tours/tour_utils';
 
 registry.category("web_tour.tours").add('shop_sale_loyalty', {
-    test: true,
     url: '/shop?search=Small%20Cabinet',
     steps: () => [
         /* 1. Buy 1 Small Cabinet, enable coupon code & insert 10% code */

--- a/addons/website_sale_loyalty/static/tests/tours/test_website_sale_free_shipping_discount_line.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_website_sale_free_shipping_discount_line.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import * as wsTourUtils from '@website_sale/js/tours/tour_utils';
 
 registry.category("web_tour.tours").add('check_shipping_discount', {
-    test: true,
     url: '/shop?search=Plumbus',
     checkDelay: 50,
     steps: () => [

--- a/addons/website_sale_loyalty/static/tests/tours/website_sale_delivery_gift_card.js
+++ b/addons/website_sale_loyalty/static/tests/tours/website_sale_delivery_gift_card.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import * as wsTourUtils from "@website_sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('shop_sale_loyalty_delivery', {
-    test: true,
     url: '/shop',
     steps: () => [
         ...wsTourUtils.addToCart({productName: "Acoustic Bloc Screens"}),

--- a/addons/website_sale_slides/static/tests/tours/slides_course_member_invited_logged.js
+++ b/addons/website_sale_slides/static/tests/tours/slides_course_member_invited_logged.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("invited_on_payment_course_logged", {
-    test: true,
     steps: () => [
         {
             trigger: 'a:contains("Add to Cart")',

--- a/addons/website_sale_slides/static/tests/tours/slides_course_member_invited_public.js
+++ b/addons/website_sale_slides/static/tests/tours/slides_course_member_invited_public.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("invited_on_payment_course_public", {
-    test: true,
     steps: () => [
         {
             trigger: '.o_wslides_identification_banner a:contains("Log in")',

--- a/addons/website_sale_stock/static/src/js/tours/website_sale_stock_reorder_from_portal.js
+++ b/addons/website_sale_stock/static/src/js/tours/website_sale_stock_reorder_from_portal.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import { clickOnElement } from '@website/js/tours/tour_utils';
 
 registry.category("web_tour.tours").add('website_sale_stock_reorder_from_portal', {
-        test: true,
         url: '/my/orders',
     steps: () => [
         {
@@ -24,4 +23,3 @@ registry.category("web_tour.tours").add('website_sale_stock_reorder_from_portal'
         },
     ]
 });
-

--- a/addons/website_sale_stock/static/tests/tours/website_sale_stock_message_after_close_configurator_modal.js
+++ b/addons/website_sale_stock/static/tests/tours/website_sale_stock_message_after_close_configurator_modal.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('website_sale_stock_message_after_close_onfigurator_modal_with_optional_products', {
     // This tour relies on a data created from the python test.
-    test: true,
     url: '/shop?search=Product With Optional (TEST)',
     steps: () => [{
         content: "Select Customizable Desk",
@@ -34,7 +33,6 @@ registry.category("web_tour.tours").add('website_sale_stock_message_after_close_
 
 registry.category("web_tour.tours").add('website_sale_stock_message_after_close_onfigurator_modal_without_optional_products', {
     // This tour relies on a data created from the python test.
-    test: true,
     url: '/shop?search=Product Without Optional (TEST)',
     steps: () => [{
         content: "Select Office Lamp",

--- a/addons/website_sale_stock/static/tests/tours/website_sale_stock_multilang.js
+++ b/addons/website_sale_stock/static/tests/tours/website_sale_stock_multilang.js
@@ -3,7 +3,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('website_sale_stock_multilang', {
-    test: true,
     url: '/fr/shop?search=unavailable',
     steps: () => [{
         content: "Open unavailable product page",

--- a/addons/website_sale_stock/static/tests/tours/website_sale_stock_product_configurator.js
+++ b/addons/website_sale_stock/static/tests/tours/website_sale_stock_product_configurator.js
@@ -6,7 +6,6 @@ import configuratorTourUtils from '@sale/js/tours/product_configurator_tour_util
 registry
     .category('web_tour.tours')
     .add('website_sale_stock_product_configurator', {
-        test: true,
         url: '/shop?search=Main product',
         steps: () => [
             {

--- a/addons/website_sale_stock/static/tests/tours/website_sale_stock_product_configurator_out_of_stock.js
+++ b/addons/website_sale_stock/static/tests/tours/website_sale_stock_product_configurator_out_of_stock.js
@@ -7,7 +7,6 @@ import stockConfiguratorTourUtils from '@website_sale_stock/js/tours/product_con
 registry
     .category('web_tour.tours')
     .add('website_sale_stock_product_configurator_out_of_stock', {
-        test: true,
         url: '/shop?search=Main product',
         steps: () => [
             {

--- a/addons/website_sale_stock/static/tests/tours/website_sale_stock_stock_notification.js
+++ b/addons/website_sale_stock/static/tests/tours/website_sale_stock_stock_notification.js
@@ -3,7 +3,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('back_in_stock_notification_product', {
-        test: true,
         url: '/shop?search=Macbook%20Pro',
     steps: () => [
         {

--- a/addons/website_sale_stock_wishlist/static/tests/tours/website_sale_stock_wishlist_stock_notification.js
+++ b/addons/website_sale_stock_wishlist/static/tests/tours/website_sale_stock_wishlist_stock_notification.js
@@ -3,7 +3,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('stock_notification_wishlist', {
-        test: true,
         url: '/shop/wishlist',
     steps: () => [
         {

--- a/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist.js
+++ b/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import { rpc } from "@web/core/network/rpc";
 
 registry.category("web_tour.tours").add('shop_wishlist', {
-    test: true,
     checkDelay: 250,
     url: '/shop?search=Customizable Desk',
     steps: () => [

--- a/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist_admin.js
+++ b/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist_admin.js
@@ -8,7 +8,6 @@ import {
 
 registerWebsitePreviewTour('shop_wishlist_admin', {
     url: '/shop?search=Rock',
-    test: true,
 },
     () => [
         {

--- a/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
+++ b/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
@@ -12,7 +12,6 @@ import { clickOnEditAndWaitEditMode, registerWebsitePreviewTour } from '@website
  */
 registerWebsitePreviewTour('course_publisher_standard', {
     url: '/slides',
-    test: true,
 }, () => [{
     content: 'eLearning: click on New (top-menu)',
     trigger: 'div.o_new_content_container a',
@@ -62,7 +61,7 @@ registerWebsitePreviewTour('course_publisher_standard', {
     content: 'eLearning: add a bioutifoul URL',
     trigger: 'input.o_we_url_input',
     run: "edit https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/ThreeTimeAKCGoldWinnerPembrookeWelshCorgi.jpg/800px-ThreeTimeAKCGoldWinnerPembrookeWelshCorgi.jpg",
-}, 
+},
 {
     trigger: ".o_we_url_success",
 },
@@ -78,7 +77,7 @@ registerWebsitePreviewTour('course_publisher_standard', {
     content: 'eLearning: save course edition',
     trigger: 'button[data-action="save"]',
     run: "click",
-}, 
+},
 {
     trigger: ":iframe body:not(.editor_enable)", // wait for editor to close
 },

--- a/addons/website_slides/static/tests/tours/slide_portal_chatter_bunddle.js
+++ b/addons/website_slides/static/tests/tours/slide_portal_chatter_bunddle.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("portal_chatter_bundle", {
-    test: true,
     steps: () => [
         {
             trigger: 'a:contains("Gardening: The Know-How")',

--- a/addons/website_slides/static/tests/tours/slides_course_member.js
+++ b/addons/website_slides/static/tests/tours/slides_course_member.js
@@ -11,7 +11,6 @@ import { registry } from "@web/core/registry";
  */
 registry.category("web_tour.tours").add("course_member", {
     url: "/slides",
-    test: true,
     steps: () => [
         // eLearning: go on free course and join it
         {

--- a/addons/website_slides/static/tests/tours/slides_course_member_invited_logged.js
+++ b/addons/website_slides/static/tests/tours/slides_course_member_invited_logged.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("invite_check_channel_preview_as_logged", {
-    test: true,
     steps: () => [
         {
             trigger: 'a:contains("Gardening: The Know-How")',

--- a/addons/website_slides/static/tests/tours/slides_course_member_invited_public.js
+++ b/addons/website_slides/static/tests/tours/slides_course_member_invited_public.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("invite_check_channel_preview_as_public", {
-    test: true,
     steps: () => [
         {
             trigger: ".o_wslides_identification_banner",

--- a/addons/website_slides/static/tests/tours/slides_course_member_yt.js
+++ b/addons/website_slides/static/tests/tours/slides_course_member_yt.js
@@ -33,7 +33,6 @@ function patchFullScreen() {
  */
 registry.category("web_tour.tours").add('course_member_youtube', {
     url: '/slides',
-    test: true,
     steps: () => [
 {
     content: "Patching FullScreen",

--- a/addons/website_slides/static/tests/tours/slides_course_publisher.js
+++ b/addons/website_slides/static/tests/tours/slides_course_publisher.js
@@ -12,8 +12,7 @@ import slidesTourTools from '@website_slides/../tests/tours/slides_tour_tools';
  */
 registerWebsitePreviewTour('course_publisher', {
     // TODO: replace by getClientActionURL when it's added
-    url: '/slides',
-    test: true
+    url: '/slides'
 }, () => [{
     content: 'eLearning: click on New (top-menu)',
     trigger: 'div.o_new_content_container a',
@@ -60,7 +59,7 @@ registerWebsitePreviewTour('course_publisher', {
     content: 'eLearning: add a bioutifoul URL',
     trigger: 'input.o_we_url_input',
     run: "edit https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/ThreeTimeAKCGoldWinnerPembrookeWelshCorgi.jpg/800px-ThreeTimeAKCGoldWinnerPembrookeWelshCorgi.jpg",
-}, 
+},
 {
     trigger: ".o_we_url_success",
 },

--- a/addons/website_slides/static/tests/tours/slides_course_reviews.js
+++ b/addons/website_slides/static/tests/tours/slides_course_reviews.js
@@ -9,7 +9,6 @@ import { registry } from "@web/core/registry";
  */
 registry.category("web_tour.tours").add("course_reviews", {
     url: "/slides",
-    test: true,
     steps: () => [
         {
             trigger: "a:contains(Basics of Gardening - Test)",

--- a/addons/website_slides/static/tests/tours/slides_full_screen_web_editor.js
+++ b/addons/website_slides/static/tests/tours/slides_full_screen_web_editor.js
@@ -15,7 +15,6 @@ import { stepUtils } from "@web_tour/tour_service/tour_utils";
  */
 registerWebsitePreviewTour('full_screen_web_editor', {
     url: '/slides',
-    test: true,
 }, () => [
     stepUtils.waitIframeIsReady(),
     {

--- a/odoo/addons/base/static/tests/test_ir_model_fields_translation.js
+++ b/odoo/addons/base/static/tests/test_ir_model_fields_translation.js
@@ -24,25 +24,21 @@ function checkLoginColumn(translation) {
 }
 
 registry.category("web_tour.tours").add('ir_model_fields_translation_en_tour', {
-    test: true,
     url: '/odoo',
     steps: () => checkLoginColumn('Login')
 });
 
 registry.category("web_tour.tours").add('ir_model_fields_translation_en_tour2', {
-    test: true,
     url: '/odoo',
     steps: () => checkLoginColumn('Login2')
 });
 
 registry.category("web_tour.tours").add('ir_model_fields_translation_fr_tour', {
-    test: true,
     url: '/odoo',
     steps: () => checkLoginColumn('Identifiant')
 });
 
 registry.category("web_tour.tours").add('ir_model_fields_translation_fr_tour2', {
-    test: true,
     url: '/odoo',
     steps: () => checkLoginColumn('Identifiant2')
 });

--- a/odoo/addons/test_apikeys/static/tests/apikey_flow.js
+++ b/odoo/addons/test_apikeys/static/tests/apikey_flow.js
@@ -5,7 +5,6 @@ import { rpc } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('apikeys_tour_setup', {
-    test: true,
     url: '/odoo?debug=1', // Needed as API key part is now only displayed in debug mode
     steps: () => [{
     content: 'Open user account menu',
@@ -56,7 +55,7 @@ registry.category("web_tour.tours").add('apikeys_tour_setup', {
             kwargs: {},
         });
     }
-}, 
+},
 {
     trigger: "button:contains(Done)",
     run: "click",
@@ -87,7 +86,6 @@ registry.category("web_tour.tours").add('apikeys_tour_setup', {
 
 // deletes the previously created key
 registry.category("web_tour.tours").add('apikeys_tour_teardown', {
-    test: true,
     url: '/odoo?debug=1', // Needed as API key part is now only displayed in debug mode
     steps: () => [{
     content: 'Open preferences',

--- a/odoo/addons/test_assetsbundle/static/tests/test_css_error.js
+++ b/odoo/addons/test_assetsbundle/static/tests/test_css_error.js
@@ -3,7 +3,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('css_error_tour', {
-    test: true,
     url: '/odoo',
     steps: () => [
     {
@@ -20,7 +19,6 @@ registry.category("web_tour.tours").add('css_error_tour', {
 
 
 registry.category("web_tour.tours").add('css_error_tour_frontend', {
-    test: true,
     url: '/',
     steps: () => [
     {

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -8,7 +8,6 @@ import { markup } from "@odoo/owl";
 import { queryFirst } from "@odoo/hoot-dom";
 
 registry.category("web_tour.tours").add('main_flow_tour', {
-    test: true,
     url: "/odoo",
     steps: () => [
 ...stepUtils.toggleHomeMenu().map(step => {

--- a/odoo/addons/test_main_flows/static/tests/tours/switch_company_access_error_tour.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/switch_company_access_error_tour.js
@@ -11,7 +11,6 @@ function assertEqual(actual, expected, msg = "") {
 }
 
 registry.category("web_tour.tours").add("test_company_switch_access_error", {
-    test: true,
     steps: () => [
         {
             trigger: ".o_list_view",

--- a/odoo/addons/test_main_flows/static/tests/tours/test_company_access_error_redirect_tour.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/test_company_access_error_redirect_tour.js
@@ -9,7 +9,6 @@ function assertEqual(actual, expected) {
 }
 
 registry.category("web_tour.tours").add("test_company_access_error_redirect", {
-    test: true,
     steps: () => [
         {
             trigger: ".o_form_view .o_last_breadcrumb_item:contains(p2)",

--- a/odoo/addons/test_new_api/static/tests/tours/constraint.js
+++ b/odoo/addons/test_new_api/static/tests/tours/constraint.js
@@ -5,7 +5,6 @@
 
     registry.category("web_tour.tours").add('sql_constaint', {
         url: '/odoo/action-test_new_api.action_categories?debug=1',
-        test: true,
         steps: () => [
     {
         content: "wait web client",

--- a/odoo/addons/test_new_api/static/tests/tours/x2many.js
+++ b/odoo/addons/test_new_api/static/tests/tours/x2many.js
@@ -6,7 +6,6 @@
 
     registry.category("web_tour.tours").add('widget_x2many', {
         url: '/odoo/action-test_new_api.action_discussions?debug=tests',
-        test: true,
         steps: () => [
     /////////////////////////////////////////////////////////////////////////////////////////////
     // Discussions


### PR DESCRIPTION
After this commit: https://github.com/odoo/odoo/commit/37b35f18bd9138a9a8717d17268f375607b9482e Some attributes were useless in the registry of the tour. They have been deleted.

TASK-ID: 4070659

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
