### PR TITLE
[FIX] hr_holidays: accrual start gain time granted immediately

### DIFF
--- a/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
@@ -330,3 +330,11 @@ class AccrualPlanLevel(models.Model):
                 return last_call + relativedelta(years=-1, month=month, day=self.yearly_day)
         else:
             return False
+
+    def _get_level_transition_date(self, allocation_start):
+        if self.start_type == 'day':
+            return allocation_start + relativedelta(days=self.start_count)
+        if self.start_type == 'month':
+            return allocation_start + relativedelta(months=self.start_count)
+        if self.start_type == 'year':
+            return allocation_start + relativedelta(years=self.start_count)

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -1,5 +1,6 @@
 import datetime
 from freezegun import freeze_time
+from datetime import date
 from dateutil.relativedelta import relativedelta
 from psycopg2 import IntegrityError
 
@@ -1584,7 +1585,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             })
             allocation.action_validate()
             allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 0, "Should accrue 0 days, days are added on 27th.")
+        self.assertAlmostEqual(allocation.number_of_days, 0.03, 2, "Should accrue 0.03 days, accrued_gain_time == start.")
 
         with freeze_time("2023-4-27"):
             allocation._update_accrual()
@@ -1596,7 +1597,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
 
         with freeze_time("2024-04-26"):
             allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 0, "Allocations not lost on 1st of January, but on allocation date.")
+        self.assertAlmostEqual(allocation.number_of_days, 0.0, 2, "Allocations not lost on 1st of January, but on allocation date.")
 
         with freeze_time("2024-04-27"):
             allocation._update_accrual()
@@ -2720,7 +2721,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
 
         with freeze_time('2026-9-01'):
             allocation._update_accrual()
-        self.assertAlmostEqual(allocation.number_of_days, 6.7, 1)
+        self.assertAlmostEqual(allocation.number_of_days, 10.7, 1)
 
         with freeze_time('2027-1-01'):
             allocation._update_accrual()
@@ -3311,3 +3312,49 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
         with freeze_time('2025-04-01'):
             allocation._update_accrual()
             self.assert_allocation_and_balance(allocation, 11, 5, "Only 5 days will carry over")
+
+    def test_start_accrual_gain_time_immediately(self):
+        accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
+            'name': '1.25 days each 1st of the month',
+            'transition_mode': 'immediately',
+            'carryover_date': 'year_start',
+            'accrued_gain_time': 'start',
+            'level_ids':
+                [(0, 0, {
+                    'start_type': 'day',
+                    'start_count': 0,
+                    'added_value_type': 'day',
+                    'added_value': 1.25,
+                    'frequency': 'monthly',
+                    'cap_accrued_time': False,
+                    'action_with_unused_accruals': 'all',
+                })],
+        })
+
+        with freeze_time('2024-09-02'):
+            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
+                'name': 'Accrual allocation',
+                'accrual_plan_id': accrual_plan.id,
+                'employee_id': self.employee_emp.id,
+                'holiday_status_id': self.leave_type.id,
+                'number_of_days': 0,
+                'allocation_type': 'accrual',
+            })
+
+            allocation.action_validate()
+            allocation._update_accrual()
+            self.assertAlmostEqual(allocation.number_of_days, 1.21, 2, 'Days for the current month should be granted immediately')
+
+            leave = self.env['hr.leave'].create({
+                'employee_id': self.employee_emp.id,
+                'holiday_status_id': self.leave_type.id,
+                'request_date_from': '2024-09-13 08:00:00',
+                'request_date_to': '2024-09-13 17:00:00',
+            })
+            leave.action_validate()
+            remaining_leaves = self.leave_type.get_allocation_data(self.employee_emp, date(2024, 9, 14))[self.employee_emp][0][1]['remaining_leaves']
+            self.assertAlmostEqual(remaining_leaves, 0.21, 2, 'Leave should be deducted from accrued days')
+
+        with freeze_time("2024-10-01"):
+            allocation._update_accrual()
+            self.assertAlmostEqual(allocation.number_of_days, 2.46, 2, 'Days for the upcoming month should be granted on the 1st')

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -246,13 +246,11 @@
                                         ('requires_allocation', '=', 'no'),
                                         '&amp;',
                                             ('has_valid_allocation', '=', True),
-                                            '&amp;',
-                                                ('max_leaves', '>', '0'),
-                                                '|',
-                                                    ('allows_negative', '=', True),
-                                                    '&amp;',
-                                                        ('virtual_remaining_leaves', '&gt;', 0),
-                                                        ('allows_negative', '=', False),
+                                            '|',
+                                                ('allows_negative', '=', True),
+                                                '&amp;',
+                                                    ('virtual_remaining_leaves', '&gt;', 0),
+                                                    ('allows_negative', '=', False),
                                 ]"
                                 context="{'employee_id': employee_id, 'default_date_from': date_from, 'default_date_to': date_to}"
                                 options="{'no_create': True, 'no_open': True, 'request_type': 'leave'}"


### PR DESCRIPTION
Steps to reproduce:
- Time off > Configuration > Accrual Plan > New
- Set 'Accrued Gain Time' to 'At the start'
- New Milestone > Set 'Milestone reached' to 0 days after...
- Accrue 1 day Monthly on the last day of the month > Save
- Management > Allocations > New
- Tick 'Accrual allocation' > Set the 'Accrual Plan' to your newly created plan
- Set the start date to today
- 0 days of allocation for 'Time off type' of your choice > Validate
- My time > Dashboard > Use 'Balance at the mm/dd/yyyy'

The accrual grants 1 day of leave for the upcoming month on the last day of each month, you will however notice that no leave is granted for the current month until we reach its last day. According to the logic of our accrual, 1 leave day should have been granted on the last day of the previous month so we should get our partial credit for the current month immediately instead.

The first step is to simply add the leave days of the corresponding period but this leads to other issues. When computing accruals that are granted at the start of start of the accrual period we use the already_accrued flag to avoid recomputations, but this flag can be raised by a call chain in the write method of hr.leave.allocation starting from _get_consumed_leaves.

This call chain passes through _process_accrual_plans, and invalidates the cache on its way out though _get_future_leaves_on. This notably happens when computing leaves_taken in _process_accrual_plans which can mess with the record's fields, including but not limited to the already_accrued flag which induces errors in the number_of_days we are trying to compute.

Also, the domain we use to restrict the leaves type that can be picked when asking for a leave prevents us from using allocations that start with 0 days. ('max_leaves', '>', 0) rules out these leaves, even after they have accrued enough time off to legitimately request a leave of this type. Disabling max_leaves = 0 does not seem to serve much purpose as a non-accrual leave starting with 0 days should only be able to fulfill the other conditions if it has 'allows_negative', in which case we would want it to show up anyway.

opw-4192703

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
