### PR TITLE
[FIX] sale_pdf_quote_builder: prevent error when uploading document

### DIFF
--- a/addons/sale_pdf_quote_builder/static/src/js/quotation_document_kanban/quotation_document_kanban_widget.js
+++ b/addons/sale_pdf_quote_builder/static/src/js/quotation_document_kanban/quotation_document_kanban_widget.js
@@ -6,6 +6,7 @@ import {
 import { UploadButton } from '@product/js/product_document_kanban/upload_button/upload_button';
 import { registry } from '@web/core/registry';
 import { X2ManyField, x2ManyField } from '@web/views/fields/x2many/x2many_field';
+import { onWillRender } from "@odoo/owl";
 
 export class QuotationDocumentX2ManyField extends X2ManyField {
     static template = 'sale_pdf_quote_builder.QuotationDocumentX2ManyField';
@@ -18,10 +19,12 @@ export class QuotationDocumentX2ManyField extends X2ManyField {
     setup() {
         super.setup();
         this.uploadRoute = '/sale_pdf_quote_builder/quotation_document/upload';
-        this.formData = {
-            'sale_order_template_id': this.props.record.resId,
-        };
         this.allowedMIMETypes='application/pdf';
+        onWillRender(() => {
+            this.formData = {
+                'sale_order_template_id': this.props.record.resId,
+            };
+        });
     }
 }
 

--- a/addons/sale_pdf_quote_builder/static/src/js/quotation_document_kanban/quotation_document_kanban_widget.xml
+++ b/addons/sale_pdf_quote_builder/static/src/js/quotation_document_kanban/quotation_document_kanban_widget.xml
@@ -7,6 +7,7 @@
     >
         <xpath expr="//div[hasclass('o_cp_buttons')]" position="inside">
             <UploadButton
+                t-if="formData.sale_order_template_id"
                 formData="formData"
                 allowedMIMETypes="allowedMIMETypes"
                 load.bind="() => this.props.record.load()"


### PR DESCRIPTION
When attempting to upload a file in the ``Quotation Templates`` without saving the template first, an error occurs in the terminal.

Steps to reproduce:
---
- Install the ``sale_management`` module
- Sales > Configuration > Sales Order > Quotation Templates
- Create New > Quote Builder > Click on Upload
- Try to upload a file

Traceback:
---
``ValueError: invalid literal for int() with base 10: 'false'``

Previous Behaviour:
---
When attempting to upload a file in the ``Quotation Templates`` without first saving the template, the template ID is not generated at [1]. As a result, at [2], we encounter an issue where ``int(sale_order_template_id) = 'false'``. This happens because the template tries to access its name in the uploaded file. If the template name is not available and we attempt to upload the file, ``resId`` at [1] will be returned as false.

Solution:
---
Until the template is saved, the upload button will remain hidden. Once the template is saved, the upload button will be displayed. This ensures that when a file is uploaded, the template name will be properly associated with it.

[1]- https://github.com/odoo/odoo/blob/c5ce138697d7c5ebe200566dfb8b7ba55365f100/addons/sale_pdf_quote_builder/static/src/js/quotation_document_kanban/quotation_document_kanban_widget.js#L21-L23

[2]- https://github.com/odoo/odoo/blob/c5ce138697d7c5ebe200566dfb8b7ba55365f100/addons/sale_pdf_quote_builder/controllers/quotation_document.py#L24-L26

sentry-5963406254

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
