### PR TITLE
[IMP] purchase: purchase feedbacks

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -115,9 +115,11 @@ class ProductTemplate(models.Model):
         default=_get_default_uom_id, required=True,
         help="Default unit of measure used for all stock operations.")
     uom_name = fields.Char(string='Unit of Measure Name', related='uom_id.name', readonly=True)
+    uom_category_id = fields.Many2one('uom.category', string='UoM Category', related="uom_id.category_id")
     uom_po_id = fields.Many2one(
         'uom.uom', 'Purchase Unit',
         default=_get_default_uom_po_id, required=True,
+        domain="[('category_id', '=', uom_category_id)]",
         help="Default unit of measure used for purchase orders. It must be in the same category as the default unit of measure.")
     company_id = fields.Many2one(
         'res.company', 'Company', index=True)

--- a/addons/product_matrix/static/src/scss/product_matrix.scss
+++ b/addons/product_matrix/static/src/scss/product_matrix.scss
@@ -25,4 +25,11 @@
             border-bottom: $o-black 1px solid;
         }
     }
+    // Sticky header styles
+    thead {
+        position: sticky;
+        top: 0;
+        z-index: 10; // Ensure it stays on top of other content
+        background-color: $o-view-background-color; // Background for visibility
+    }
 }

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -221,7 +221,7 @@
                                 mode="list,kanban"
                                 context="{'default_state': 'draft'}"
                                 readonly="state in ('done', 'cancel')">
-                                <list string="Purchase Order Lines" editable="bottom">
+                                <list string="Purchase Order Lines" editable="bottom" limit="200">
                                     <control>
                                         <create name="add_product_control" string="Add a product"/>
                                         <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>


### PR DESCRIPTION
In this commit:
===================
- Set the domain on Purchase UOM selection based on the selected Sales UOM to ensure consistency across transactions.
- Removed the limit on the number of Purchase Order lines, aligning with the behavior observed in Sales Orders.
- Implemented a freeze header feature on the variant grid selection for improved user experience.

task-4213738
