### PR TITLE
[FIX] link_tracker: fix traceback when creating new link tracker

### DIFF
--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -74,7 +74,7 @@ class LinkTracker(models.Model):
     @api.depends('code')
     def _compute_short_url(self):
         for tracker in self:
-            tracker.short_url = urls.url_join(tracker.short_url_host, '%(code)s' % {'code': tracker.code})
+            tracker.short_url = urls.url_join(tracker.short_url_host or '', tracker.code or '')
 
     def _compute_short_url_host(self):
         for tracker in self:


### PR DESCRIPTION
A traceback occurs from version 18.0 when the user creates a new link tracker.

To reproduce this issue in 18.0:

1) Install website, link tracker and enable debug mode
2) Tries to create a new link tracker record from the link tracker

Error:- 
```
TypeError: Cannot mix str and bytes arguments (got (False, 'False'))
```

The onchange sets computes to False by default when they're requested,
and apparently does not recompute them if they don't depend on anything.

Because of that the `short_url_host` value will be False and this leads to a traceback
when the compute method of `short_url` triggers.

Ref of the breaking commit:- 

https://github.com/odoo/odoo/pull/170548/commits/20d2f122568feead98df18706ca0a4691c8393c5

sentry-5969318187

