### PR TITLE
[FIX] website: fix image distortion in megamenu using 'Images Subtitles'

### DIFF
--- a/addons/website/static/src/snippets/s_mega_menu_images_subtitles/000.scss
+++ b/addons/website/static/src/snippets/s_mega_menu_images_subtitles/000.scss
@@ -2,6 +2,7 @@
 .s_mega_menu_images_subtitles:not([data-vcss]) {
     .d-flex img {
         max-width: 64px;
+        align-self: start;
     }
 
     .nav-link {


### PR DESCRIPTION
Previously, the "Images Subtitles" template in the Megamenu had an issue where the images were stretching vertically to fill the container's height.

Adding an additional class to the container fixes the styling and maintains the images' correct aspect ratio.

task-4203427

![4203427-before-after](https://github.com/user-attachments/assets/d63c0308-0e83-4cde-9973-88f068c8f85a)