### PR TITLE
[IMP] point_of_sale: cross button behavior on close session popup

### DIFF
--- a/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.js
+++ b/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.js
@@ -248,6 +248,7 @@ export class ClosePosPopup extends Component {
                     this.closeSession();
                 }
             },
+            dismiss: async () => {},
         });
 
         if (response.redirect) {


### PR DESCRIPTION
Before this commit:
==
- When we have open orders, and pressing the "close" (cross) button while closing a session currently closes the session.

After this commit:
==
- The session should not be closed when the cross button is pressed. it only dismiss the current dialog.

Task-4243380


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
