### PR TITLE
[FIX] website_sale_loyalty: tours

### DIFF
--- a/addons/website_sale_loyalty/static/tests/tours/test_apply_discount_code.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_apply_discount_code.js
@@ -6,6 +6,7 @@ import * as tourUtils from '@website_sale/js/tours/tour_utils';
 registry.category("web_tour.tours").add('apply_discount_code_program_multi_rewards', {
     test: true,
     url: '/shop?search=Super%20Chair',
+    checkDelay: 100,
     steps: () => [
         {
             trigger: ".oe_search_found",
@@ -21,6 +22,9 @@ registry.category("web_tour.tours").add('apply_discount_code_program_multi_rewar
             run: "click",
         },
         tourUtils.goToCart(),
+        {
+            trigger: "h3:contains(order overview)",
+        },
         {
             trigger: 'form[name="coupon_code"]',
         },
@@ -44,8 +48,9 @@ registry.category("web_tour.tours").add('apply_discount_code_program_multi_rewar
             run: "click",
         },
         {
-            content: 'check claimed reward',
-            trigger: 'div>strong:contains("10% on Super Chair")',
+            content: "check claimed reward",
+            trigger:
+                "#cart_products.js_cart_lines .o_cart_product strong:contains(10% on Super Chair)",
         },
         // Try to reapply the same promo code
         {

--- a/addons/website_sale_loyalty/static/tests/tours/test_website_sale_free_shipping_discount_line.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_website_sale_free_shipping_discount_line.js
@@ -6,6 +6,7 @@ import * as wsTourUtils from '@website_sale/js/tours/tour_utils';
 registry.category("web_tour.tours").add('check_shipping_discount', {
     test: true,
     url: '/shop?search=Plumbus',
+    checkDelay: 50,
     steps: () => [
         {
             content: "select Plumbus",
@@ -43,7 +44,13 @@ registry.category("web_tour.tours").add('check_shipping_discount', {
             run: "click",
         },
         {
-            trigger: ".accordion-button",
+            trigger: ".oe_cart:contains(confirm order)",
+        },
+        {
+            trigger: ".o_total_card:contains(order summary)",
+        },
+        {
+            trigger: ".o_total_card button.accordion-button",
             run: "click",
         },
         {


### PR DESCRIPTION
In this commit, we decrease checkDelay to make the tours faster. We add intermediate steps to ensure elements are in DOM before to continue the tour.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
