### PR TITLE
[16.0][IMP]: Enhanced numpad decimal usage

### DIFF
--- a/addons/web/static/src/views/fields/float_time/float_time_field.js
+++ b/addons/web/static/src/views/fields/float_time/float_time_field.js
@@ -8,7 +8,7 @@ import { useInputField } from "../input_field_hook";
 import { standardFieldProps } from "../standard_field_props";
 import { useNumpadDecimal } from "../numpad_decimal_hook";
 
-import { Component } from "@odoo/owl";
+import { Component,  onMounted, onWillUnmount } from "@odoo/owl";
 
 export class FloatTimeField extends Component {
     setup() {
@@ -18,6 +18,34 @@ export class FloatTimeField extends Component {
             parse: (v) => parseFloatTime(v),
         });
         useNumpadDecimal();
+        onMounted(this.onMounted);
+        onWillUnmount(this.onWillUnmount);
+    }
+
+    // checks for "." in keyboard event and
+    // replaces with ":" in float_time fields
+    async onKeydownListener(ev) {
+        var decimalPoint = ":";
+
+        if (!([".", ","].includes(ev.key))) {
+            return;
+        }
+        ev.preventDefault();
+        ev.originalTarget.setRangeText(
+            decimalPoint,
+            ev.originalTarget.selectionStart,
+            ev.originalTarget.selectionEnd,
+            "end"
+        );
+    }
+
+    onMounted() {
+        this.keydownListenerCallback = this.onKeydownListener.bind(this);
+        this.__owl__.bdom.parentEl.addEventListener('keydown', this.keydownListenerCallback);
+    }
+
+    onWillUnmount() {
+        this.__owl__.bdom.parentEl.removeEventListener('keydown', this.keydownListenerCallback);
     }
 
     get formattedValue() {


### PR DESCRIPTION
 Description of the issue/feature this PR addresses:
        Migration to 16.0 of web_numpad, missed to include numpad decimal to be
used for fields which uses time to differentiate hours from minutes.

Current behavior before PR:
      Numpad decimal usage is not allowed for float_time fields to differentiate time from hour to minutes
      
Desired behavior after PR is merged:
      User can use numpad decimal for entering time input which would differentiate time using ":" between hour and minutes



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
