### PR TITLE
[FIX] l10n_it_edi_doi: add condition to delcaration info on invoice

### DIFF
--- a/addons/l10n_it_edi_doi/views/report_invoice.xml
+++ b/addons/l10n_it_edi_doi/views/report_invoice.xml
@@ -2,7 +2,7 @@
 <odoo>
     <template id="report_invoice_document" inherit_id="account.report_invoice_document">
         <div name="comment" position="before">
-            <div>
+            <div t-if="o.l10n_it_edi_doi_id">
                 <span>Your Declaration of Intent number <span t-field="o.l10n_it_edi_doi_id"/> from <span t-field="o.l10n_it_edi_doi_id.issue_date"/>.</span>
             </div>
         </div>

--- a/addons/l10n_it_edi_doi/views/sale_ir_actions_report_templates.xml
+++ b/addons/l10n_it_edi_doi/views/sale_ir_actions_report_templates.xml
@@ -2,7 +2,7 @@
 <odoo>
     <template id="report_saleorder_document" inherit_id="sale.report_saleorder_document">
         <p id="fiscal_position_remark" position="after">
-            <div>
+            <div t-if="doc.l10n_it_edi_doi_id">
                 <span>Your Declaration of Intent number <span t-field="doc.l10n_it_edi_doi_id"/> from <span t-field="doc.l10n_it_edi_doi_id.issue_date"/>.</span>
             </div>
         </p>


### PR DESCRIPTION
Currently we always try to add a string informing about the used
declaration of intent to the invoice / sale order PDF.
I.e. it also happens when no declaration of intent is selected.

After this commit the string is only added in case there is
actually a declaration of intent selected.

opw-4237368