### PR TITLE
[FIX] sale_stock: open forecast for 'own documents' sales

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -34,7 +34,7 @@ class StockMove(models.Model):
 
     def _get_source_document(self):
         res = super()._get_source_document()
-        return self.sale_line_id.order_id or res
+        return self.sudo().sale_line_id.order_id or res
 
     def _assign_picking_post_process(self, new=False):
         super(StockMove, self)._assign_picking_post_process(new=new)

--- a/addons/sale_stock/report/stock_forecasted.py
+++ b/addons/sale_stock/report/stock_forecasted.py
@@ -31,7 +31,7 @@ class ReplenishmentReport(models.AbstractModel):
     def _compute_draft_quantity_count(self, product_template_ids, product_variant_ids, wh_location_ids):
         res = super()._compute_draft_quantity_count(product_template_ids, product_variant_ids, wh_location_ids)
         domain = self._product_sale_domain(product_template_ids, product_variant_ids)
-        so_lines = self.env['sale.order.line'].search(domain)
+        so_lines = self.env['sale.order.line'].sudo().search(domain)
         out_sum = 0
         if so_lines:
             product_uom = so_lines[0].product_id.uom_id


### PR DESCRIPTION
Steps to reproduce:
- Create a Sale Order for a storable product and confirm it
- Create another user with the following permissions:
  - Sales > User: Own Documents Only
  - Inventory > User
- With that user, create a new Sale Order for the same product and confirm it.
- Click the forecast icon and open the report.

Issue:
An AccessError will be triggered, as that user doesn't have the rights to access the SO lines of the first SO since it wasn't created by them.

While it's correct that this user shouldn't be able to access the sale order, we still want them to be able to access the forecast report and see their use, even though they can't click on them and see the SO content.

Same thing should apply for draft SO, as they indicate potential future state of the stock as well.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
