### PR TITLE
[FIX] web: fix translation button alignment

### DIFF
--- a/addons/web/static/src/views/fields/char/char_field.xml
+++ b/addons/web/static/src/views/fields/char/char_field.xml
@@ -20,7 +20,7 @@
                 t-on-blur="onBlur"
                 t-ref="input"
             />
-            <div class="o_field_char_buttons position-absolute d-inline">
+            <div class="o_field_char_buttons d-inline">
                 <t t-if="isTranslatable">
                     <TranslationButton
                         fieldName="props.name"


### PR DESCRIPTION
Version:
- 18.0

Steps to Reproduce:
- Install the sign, project, and web_editor modules.
 - Enable multi-language support.

Issue:
- The translation button is misaligned.

Cause:
- The button is positioned using absolute within a div tag, which causes the alignment issue.

Solution:
- Remove the absolute positioning to fix the alignment.

task-4244696