### PR TITLE
[FIX] web: model: do not generate update command on virtual ids

### DIFF
--- a/addons/web/static/src/model/relational_model/static_list.js
+++ b/addons/web/static/src/model/relational_model/static_list.js
@@ -782,7 +782,8 @@ export class StaticList extends DataPoint {
         const options = {
             parentRecord: this._parent,
             onUpdate: async ({ withoutParentUpdate }) => {
-                if (!this.currentIds.includes(record.isNew ? record._virtualId : record.resId)) {
+                const id = record.isNew ? record._virtualId : record.resId;
+                if (!this.currentIds.includes(id)) {
                     // the record hasn't been added to the list yet (we're currently creating it
                     // from a dialog)
                     return;

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -802,9 +802,7 @@ export function useX2ManyCrud(getList, isMany2Many) {
                 return list.addAndRemove({ add: object });
             } else {
                 // object instanceof Record
-                if (!object.resId || object.isDirty) {
-                    await object.save();
-                }
+                await object.save({ reload: false });
                 return list.linkTo(object.resId);
             }
         };


### PR DESCRIPTION
This commit fixes an issue that requires a very specific scenario to be reproduced:

Go to Settings > Technical > Server Actions
Add a Server Action on the "Contact" model with type "Execute Existing Actions" Add a child action on the "Contact" model and set a domain using the "country" field
Save the dialog and save the record.

Before this commit, it crashed. Indeed, we generated an update command (1) with a virtualId as record id. This happened because of the ReferenceField that was used in the dialog. When the record was saved, it was also reloaded (via web_save), and the `update_related_model_id` field was unset (the business logic unsets it, I don't know why). This field being the `modelField` for the reference field (`resource_ref`), the latter was unset by the ReferenceField (via useRecordObserver), which called record.update. This produced an update command on a record that had been saved meanwhile but was still referenced as a new record (hence the virtual_id).

This commit fixes the issue by not reloading the record with web_save, as we're closing the dialog anyway, and that record is loaded for the x2many list view anyway. Moreover, we also ensure that if an update occurs on a record that was initially new but that has been saved meanwhile, the command is associated with the correct resId, not the virtualId.

Closes #178541

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
