### PR TITLE
[FIX] web: model: re-evaluate required attrs on field update

### DIFF
--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -290,16 +290,12 @@ export class Record extends DataPoint {
 
     _applyChanges(changes, serverChanges = {}) {
         // We need to generate the undo function before applying the changes
-        const fieldNameChanges = [...Object.keys({ ...changes, ...serverChanges })];
         const initialTextValues = { ...this._textValues };
         const initialChanges = { ...this._changes };
         const initialData = { ...toRaw(this.data) };
-        const invalidFields = toRaw(this._invalidFields);
-        const invalidFieldNames = fieldNameChanges.filter((fieldName) =>
-            invalidFields.has(fieldName)
-        );
+        const invalidFields = [...toRaw(this._invalidFields)];
         const undoChanges = () => {
-            for (const fieldName of invalidFieldNames) {
+            for (const fieldName of invalidFields) {
                 this.setInvalidField(fieldName);
             }
             Object.assign(this.data, initialData);
@@ -329,7 +325,11 @@ export class Record extends DataPoint {
         Object.assign(this._textValues, this._getTextValues(serverChanges));
 
         this._setEvalContext();
-        this._removeInvalidFields(fieldNameChanges);
+
+        // mark changed fields as valid if they were not, and re-evaluate required attributes
+        // for all fields, as some of them might still be unset but become valid with those changes
+        this._removeInvalidFields(Object.keys({ ...changes, ...serverChanges }));
+        this._checkValidity({ removeInvalidOnly: true });
         return undoChanges;
     }
 
@@ -362,8 +362,8 @@ export class Record extends DataPoint {
         this._setEvalContext();
     }
 
-    _checkValidity({ silent, displayNotification } = {}) {
-        const unsetRequiredFields = [];
+    _checkValidity({ silent, displayNotification, removeInvalidOnly } = {}) {
+        const unsetRequiredFields = new Set();
         for (const fieldName in this.activeFields) {
             const fieldType = this.fields[fieldName].type;
             if (this._isInvisible(fieldName) || this.fields[fieldName].relatedPropertyField) {
@@ -377,7 +377,7 @@ export class Record extends DataPoint {
                     continue;
                 case "html":
                     if (this._isRequired(fieldName) && this.data[fieldName].length === 0) {
-                        unsetRequiredFields.push(fieldName);
+                        unsetRequiredFields.add(fieldName);
                     }
                     break;
                 case "one2many":
@@ -385,9 +385,11 @@ export class Record extends DataPoint {
                     const list = this.data[fieldName];
                     if (
                         (this._isRequired(fieldName) && !list.count) ||
-                        !list.records.every((r) => !r.dirty || r._checkValidity({ silent }))
+                        !list.records.every(
+                            (r) => !r.dirty || r._checkValidity({ silent, removeInvalidOnly })
+                        )
                     ) {
-                        unsetRequiredFields.push(fieldName);
+                        unsetRequiredFields.add(fieldName);
                     }
                     break;
                 }
@@ -402,7 +404,7 @@ export class Record extends DataPoint {
                                 propertyDefinition.string.length
                         );
                         if (!ok) {
-                            unsetRequiredFields.push(fieldName);
+                            unsetRequiredFields.add(fieldName);
                         }
                     }
                     break;
@@ -412,28 +414,37 @@ export class Record extends DataPoint {
                         this._isRequired(fieldName) &&
                         (!this.data[fieldName] || !Object.keys(this.data[fieldName]).length)
                     ) {
-                        unsetRequiredFields.push(fieldName);
+                        unsetRequiredFields.add(fieldName);
                     }
                     break;
                 }
                 default:
                     if (!this.data[fieldName] && this._isRequired(fieldName)) {
-                        unsetRequiredFields.push(fieldName);
+                        unsetRequiredFields.add(fieldName);
                     }
             }
         }
 
         if (silent) {
-            return !unsetRequiredFields.length;
+            return !unsetRequiredFields.size;
         }
 
-        for (const fieldName of Array.from(this._unsetRequiredFields)) {
-            this._invalidFields.delete(fieldName);
-        }
-        this._unsetRequiredFields.clear();
-        for (const fieldName of unsetRequiredFields) {
-            this._unsetRequiredFields.add(fieldName);
-            this._setInvalidField(fieldName);
+        if (removeInvalidOnly) {
+            for (const fieldName of Array.from(this._unsetRequiredFields)) {
+                if (!unsetRequiredFields.has(fieldName)) {
+                    this._unsetRequiredFields.delete(fieldName);
+                    this._invalidFields.delete(fieldName);
+                }
+            }
+        } else {
+            for (const fieldName of Array.from(this._unsetRequiredFields)) {
+                this._invalidFields.delete(fieldName);
+            }
+            this._unsetRequiredFields.clear();
+            for (const fieldName of unsetRequiredFields) {
+                this._unsetRequiredFields.add(fieldName);
+                this._setInvalidField(fieldName);
+            }
         }
         const isValid = !this._invalidFields.size;
         if (!isValid && displayNotification) {
@@ -990,7 +1001,11 @@ export class Record extends DataPoint {
         if (!this._checkValidity({ displayNotification: true })) {
             return false;
         }
-        if (this.model._urgentSave && this.model.useSendBeaconToSaveUrgently && !this.model.env.inDialog) {
+        if (
+            this.model._urgentSave &&
+            this.model.useSendBeaconToSaveUrgently &&
+            !this.model.env.inDialog
+        ) {
             // We are trying to save urgently because the user is closing the page. To
             // ensure that the save succeeds, we can't do a classic rpc, as these requests
             // can be cancelled (payload too heavy, network too slow, computer too fast...).

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -2319,6 +2319,39 @@ test(`two occurrences of invalid integer fields in form view`, async () => {
     expect(`.o_field_integer.o_field_invalid`).toHaveCount(0);
 });
 
+test(`mutually exclusive required fields in form view`, async () => {
+    delete Partner._fields.foo.default;
+
+    onRpc("web_save", () => expect.step("saved"));
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `
+            <form>
+                <group>
+                    <field name="foo" required="not name"/>
+                    <field name="name" required="not foo"/>
+                </group>
+            </form>
+        `,
+        resId: 1,
+    });
+
+    await contains(".o_field_widget[name=foo] input").edit("");
+    await contains(".o_field_widget[name=name] input").edit("");
+
+    await contains(`.o_form_button_save`).click();
+    expect(`.o_field_widget.o_field_invalid`).toHaveCount(2);
+    expect(`.o_form_button_save`).toHaveAttribute("disabled");
+
+    await contains(`.o_field_widget[name=foo] input`).edit("some value");
+    expect(`.o_field_widget.o_field_invalid`).toHaveCount(0);
+    expect(`.o_form_button_save`).not.toHaveAttribute("disabled");
+
+    await contains(`.o_form_button_save`).click();
+    expect.verifySteps(["saved"]);
+});
+
 test(`twice same field with different required attributes`, async () => {
     Partner._fields.foo = fields.Char();
 


### PR DESCRIPTION
Have a form view with two fields A and B, which are both required if the other one is unset:
```xml
<form>
    <field name="A" required="not B"/>
    <field name="B" required="not A"/>
</form>
```

Open a form view and unset A and B. Try to save: both fields are marked as invalid (highlighted in red). Fill one of them and click out.

Before this commit, the other field was still marked as invalid. Worse: the save button was still disabled. One thus had to fake a value in that field, then remove it, to be able to save the record.

The issue occurred because when a field changed, we only removed that field from the list of invalid field. We didn't considerer other invalid fields (unset, but required) that could become valid with the change because they are no longer required. With this commit, we remove from the list of invalid fields those that were unset and required, but are no longer required now.

The issue could be reproduced in the `studio.approval.rule` form view with fields `approver_ids` and `approval_group_id`.

Followup of task~4122644

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
