### PR TITLE
[REM] web: Hoot - ":text" pseudo-class

### DIFF
--- a/addons/web/static/lib/hoot-dom/helpers/dom.js
+++ b/addons/web/static/lib/hoot-dom/helpers/dom.js
@@ -863,7 +863,6 @@ customPseudoClasses
             return node.shadowRoot || false;
         };
     })
-    .set("text", makePatternBasedPseudoClass("text", getNodeText))
     .set("value", makePatternBasedPseudoClass("value", getNodeValue))
     .set("visible", () => {
         return function visible(node) {


### PR DESCRIPTION
This commit removes the ":text" pseudo class as it is redundant with ":contains", and is a left-over from the development of Hoot-DOM.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
