### PR TITLE
[FIX] point_of_sale: shipping date on the receipt accounts for user's TZ

### DIFF
--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -1658,7 +1658,7 @@ export class Order extends PosModel {
             footer: this.pos.config.receipt_footer,
             // FIXME: isn't there a better way to handle this date?
             shippingDate:
-                this.shippingDate && formatDate(DateTime.fromJSDate(new Date(this.shippingDate))),
+                this.shippingDate && formatDate(DateTime.fromSQL(this.shippingDate)),
             headerData: {
                 ...this.pos.getReceiptHeaderData(this),
                 trackingNumber: this.trackingNumber,

--- a/addons/point_of_sale/static/tests/tours/ReceiptScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/ReceiptScreen.tour.js
@@ -29,6 +29,7 @@ registry.category("web_tour.tours").add("ReceiptScreenTour", {
             ReceiptScreen.receiptIsThere(),
             //receipt had expected delivery printed
             ReceiptScreen.shippingDateExists(),
+            ReceiptScreen.shippingDateIsToday(),
             // letter tray has 10% tax (search SRC)
             ReceiptScreen.totalAmountContains("55.0"),
             ReceiptScreen.clickNextOrder(),

--- a/addons/point_of_sale/static/tests/tours/helpers/ReceiptScreenTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/ReceiptScreenTourMethods.js
@@ -108,3 +108,19 @@ export function shippingDateExists() {
         }
     ]
 }
+
+export function shippingDateIsToday() {
+    // format the date in US, the language used by the tests
+    const expectedDelivery = new Date().toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit'
+    });
+
+    return [
+        {
+            content: 'Shipping date must be today',
+            trigger: '.pos-receipt-order-data:contains("Expected delivery: ' + expectedDelivery + '")'
+        },
+    ]
+}


### PR DESCRIPTION
## Steps to reproduce
- Go into point of sale app
- Enable delivery later from the settings
- Sell a product with a shipping later set in the future
- See the expected delivery date on the printed receipt.

Note that, normally you will be able to reproduce on any device running in a timezone GMT-, however, for GMT+ timezones, I think there's no good way to reproduce this (please see explanation below)

----

When creating the date with `DateTime.fromJSDate(new Date(yyyy-mm-dd))` , javascript will create it at time 00:00 in the UTC timezone, so for users with negative timezone offset (GMT-x), `formatDate` will print the the date as one day behind. It’s the case for American users for instance.

Now, we create the date using `DateTime.fromSQL(yyyy-mm-dd)`, it will be created at 00:00 in the local time zone (not the UTC timezone anymore), and printing it with `formatDate` will therefore yield the correct value expected by the user.

opw-4116982