### PR TITLE
[FIX] website, website_form_project: prevent removal of e-mail field

### DIFF
--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -167,6 +167,20 @@ const wSnippetMenu = weSnippetEditor.SnippetsMenu.extend({
     _patchForComputeSnippetTemplates($html) {
         this._super(...arguments);
 
+        // TODO adapt in master: as a stable fix the controller required fields
+        // cannot be deleted.
+        const websiteFormFieldRequiredEl = $html.find("[data-js='WebsiteFormFieldRequired'][data-selector='.s_website_form .s_website_form_model_required']")[0];
+        if (websiteFormFieldRequiredEl) {
+            websiteFormFieldRequiredEl.dataset.selector = ".s_website_form .s_website_form_model_required, .s_website_form .s_website_form_controller_required";
+        }
+
+        // TODO adapt in master: as a stable fix the controller required fields
+        // cannot be duplicated.
+        const websiteFormFieldModelEl = $html.find("[data-js='WebsiteFormFieldModel'][data-selector='.s_website_form .s_website_form_field:not(.s_website_form_custom)']")[0];
+        if (websiteFormFieldModelEl) {
+            websiteFormFieldModelEl.dataset.selector = ".s_website_form .s_website_form_field:not(.s_website_form_custom:not(.s_website_form_controller_required))";
+        }
+
         // TODO adapt in master: as a stable fix we corrected the behavior of
         // the logo button that led to an error when switching from Text to
         // Logo. Remove me in master.

--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -211,6 +211,10 @@ const FormEditor = options.Class.extend({
         template.content.querySelectorAll("[data-name]").forEach(el => {
             el.dataset.name = this._getQuotesEncodedName(el.dataset.name);
         });
+        // TODO In master handle in fields templates ?
+        if (field.controllerRequired) {
+            template.content.firstElementChild.classList.add("s_website_form_controller_required");
+        }
         return template.content.firstElementChild;
     },
 });
@@ -366,6 +370,7 @@ const FieldEditor = FormEditor.extend({
         field.rows = textarea && textarea.rows;
         field.required = classList.contains('s_website_form_required');
         field.modelRequired = classList.contains('s_website_form_model_required');
+        field.controllerRequired = classList.contains("s_website_form_controller_required");
         field.hidden = classList.contains('s_website_form_field_hidden');
         field.formatInfo = this._getFieldFormat();
     },

--- a/addons/website_form_project/static/src/js/website_form_project_editor.js
+++ b/addons/website_form_project/static/src/js/website_form_project_editor.js
@@ -13,6 +13,7 @@ FormEditorRegistry.add('create_task', {
         type: 'email',
         custom: true,
         required: true,
+        controllerRequired: true,
         fillWith: 'email',
         name: 'email_from',
         string: _t('Your Email'),


### PR DESCRIPTION
Since [1] when the e-mail field of the "Create Task" forms have been turned into a required custom field, nothing prevents the user from removing it from the form.
However this field is still required by the controller that receives the form's submit. This leads to errors when such a form is submitted and no e-mail field was present.

This commit introduces a `requiredController` attribute on fields, which marks the field with the same class as `modelRequired` fields so that its deletion is prevented.

[1]: https://github.com/odoo/odoo/commit/dede76bd5c898c7b68b1b70c44bb73588c2f594e

opw-4243770
