### PR TITLE
[FIX] website: fix table of content hidden on mobile

### DIFF
--- a/addons/website/static/src/snippets/s_table_of_content/000.js
+++ b/addons/website/static/src/snippets/s_table_of_content/000.js
@@ -62,7 +62,6 @@ const TableOfContent = publicWidget.Widget.extend({
      */
     async start() {
         this._stripNavbarStyles();
-        await this._super(...arguments);
         this._scrollElement = this.$target.closest(".s_table_of_content").closestScrollable()[0];
         this._scrollTarget = $().getScrollingTarget(this._scrollElement)[0];
         this._tocElement = this.el.querySelector('.s_table_of_content_navbar');
@@ -71,6 +70,7 @@ const TableOfContent = publicWidget.Widget.extend({
         this._updateTableOfContentNavbarPositionBound = this._updateTableOfContentNavbarPosition.bind(this);
         extraMenuUpdateCallbacks.push(this._updateTableOfContentNavbarPositionBound);
         this._scrollTarget.addEventListener("scroll", this._onScrollBound);
+        await this._super(...arguments);
     },
     /**
      * @override


### PR DESCRIPTION
Steps to reproduce the bug:

- Enter edit mode.
- Drag and drop 2 "Table of Content" snippets onto the page.
- For both snippets, enable the "Hide on mobile" option.
- Save the page.
- Click on "switch to mobile view" button.
- Enter edit mode again.
- Bug: there is a traceback.

or also

- Drop a "Table of Content" snippet.
- Hide it on desktop.
- Display the snippet by clicking on it in the "Invisible Elements"
section.
- Click again on hide on desktop.

The bug occurs starting from commit [1], where a listener was added to
the scroll element in the "Table of Contents" public widget. When this
listener is removed in the destroy function, a traceback occurs if
multiple "Table of Contents" widgets are hidden. This happens because we
try to remove the listener while the widget's start function has not
finished yet, which means the listener we try to remove has not been
instantiated.

To fix this, we now await properly for the end of the start function.

[1]: https://github.com/odoo/odoo/commit/178825649fdb6fdd66ebc65732b5e903c2fca694

task-4160033
opw-4228666
opw-4226783