### PR TITLE
[FIX] l10n_nl: Remap old tax btw_X0

### DIFF
--- a/addons/l10n_nl/migrations/3.3/post-migrate_update_taxes.py
+++ b/addons/l10n_nl/migrations/3.3/post-migrate_update_taxes.py
@@ -19,7 +19,10 @@ def _get_tax_ids_for_xml_id(cr, xml_id):
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
 
-    goods_taxes = env['account.tax'].browse(_get_tax_ids_for_xml_id(cr, 'btw_X0_producten'))
+    goods_tax_ids = [tax_id for xml_id in ['btw_X0_producten', 'btw_X0']
+                     for tax_id in _get_tax_ids_for_xml_id(cr, xml_id)]
+
+    goods_taxes = env['account.tax'].browse(goods_tax_ids)
     services_taxes = env['account.tax'].browse(_get_tax_ids_for_xml_id(cr, 'btw_X0_diensten'))
 
     old_3bl_tax_tags = env['account.account.tag']._get_tax_tags('3bl (omzet)', 'nl')


### PR DESCRIPTION
The **`btw_X0`** tax was updated [Here](https://github.com/odoo/odoo/commit/02ccb58401a45528adb77c768318c9f6dfdf05b6#diff-de6184d4eb5e7e2450afafb9d22046721e4931216a636ec6b945ea27a1488591L391). Despite this update, some customers are still using the original tax, which was mapped during migration [Here](https://github.com/odoo/odoo/blob/17.0/addons/l10n_nl/migrations/3.3/post-migrate_update_taxes.py#L22). As a result of these changes, the customers are unable to view the tax report correctly as it appeared in the production environment. To address this issue, I have added the XML ID of the tax to map the old tax.

opw-[4091389](https://www.odoo.com/odoo/project/70/tasks/4091389)
upg-[1874716](https://upgrade.odoo.com/web#id=1874716&cids=1&menu_id=107&action=150&model=upgrade.request&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
