### PR TITLE
[FIX] hw_posbox_homepage: allow old IoT connection tokens

### DIFF
--- a/addons/hw_posbox_homepage/controllers/main.py
+++ b/addons/hw_posbox_homepage/controllers/main.py
@@ -257,8 +257,15 @@ class IoTboxHomepage(Home):
     def connect_to_server(self, token, iotname):
         if token:
             try:
-                configuration = helpers.parse_url(token)
-                helpers.save_conf_server(**configuration)
+                if len(token.split('|')) == 4:
+                    # Old style token with pipe separators (pre v18 DB)
+                    url, token, db_uuid, enterprise_code = token.split('|')
+                    configuration = helpers.parse_url(url)
+                    helpers.save_conf_server(configuration["url"], token, db_uuid, enterprise_code)
+                else:
+                    # New token using query params (v18+ DB)
+                    configuration = helpers.parse_url(token)
+                    helpers.save_conf_server(**configuration)
             except ValueError:
                 _logger.warning("Wrong server token: %s", token)
                 return 'Invalid URL provided.'


### PR DESCRIPTION
In v18, a new format was given to the connection
token as shown below:

v17: `http://1.2.3.4|12345678|aaaa-bbbb-cccc|M123`
v18: `http://1.2.3.4?token=12345678&db_uuid=aaaa-bbbb-cccc&enterprise_code=M123`

However these formats are not compatible. Currently you cannot connect a v17 database to a v18 IoT box.

After this PR both formats are compatible.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
