### PR TITLE
[FIX] sale_timesheet: filter task SO without commercial partner id

### DIFF
--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -537,7 +537,7 @@ class ProjectTask(models.Model):
                 return related_project.sale_line_employee_ids.sale_line_id.order_partner_id[:1]
         return res
 
-    sale_order_id = fields.Many2one(domain="['|', '|', ('partner_id', '=', partner_id), ('partner_id', 'child_of', commercial_partner_id), ('partner_id', 'parent_of', partner_id)]")
+    sale_order_id = fields.Many2one(domain="['|', '|', ('partner_id', '=', partner_id), ('partner_id.commercial_partner_id.id', 'parent_of', partner_id), ('partner_id', 'parent_of', partner_id)]")
     so_analytic_account_id = fields.Many2one(related='sale_order_id.analytic_account_id', string='Sale Order Analytic Account')
     pricing_type = fields.Selection(related="project_id.pricing_type")
     is_project_map_empty = fields.Boolean("Is Project map empty", compute='_compute_is_project_map_empty')


### PR DESCRIPTION
Steps to reproduce:
- Project > Pick any task > Debug Mode
- Studio > View tab > Tick 'Show invisible elements'
- Scroll to 'Sales Order' and click it
- Untick 'Invisible' then tick and untick readonly
- Close > you should have a Sales Order field on the task
- Click to change it's value

An error occurs because the 'commercial_partner_id' field was removed from task in 17.0 in dcbdb6e690f29bc5327d7067688c93071d9a6b2d. Because of this the domain which filters 'Sales Order' (which contains this field) cannot be evaluated.

Since the field is still available on the sale_order model, we can simply invert the child_of relation:
from sale_order.partner_id child_of task.commercial_partner_id to sale_order.commercial_partner_id parent_of task.partner_id Which should serve essentially the same purpose.

opw-4199947

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
