### PR TITLE
[FIX] core: raise for no sense selection attribute

### DIFF
--- a/odoo/orm/fields_selection.py
+++ b/odoo/orm/fields_selection.py
@@ -96,15 +96,17 @@ class Selection(Field[str | typing.Literal[False]]):
                 if self.related:
                     _logger.warning("%s: selection attribute will be ignored as the field is related", self)
                 selection = field.args['selection']
-                if isinstance(selection, list):
+                if isinstance(selection, (list, tuple)):
                     if values is not None and list(values) != [kv[0] for kv in selection]:
                         _logger.warning("%s: selection=%r overrides existing selection; use selection_add instead", self, selection)
                     values = dict(selection)
                     self.ondelete = {}
-                else:
-                    values = None
-                    self.selection = selection
+                elif callable(selection) or isinstance(selection, str):
                     self.ondelete = None
+                    self.selection = selection
+                    values = None
+                else:
+                    raise ValueError(f"{self!r}: selection={selection!r} should be a list, a callable or a method name")
 
             if 'selection_add' in field.args:
                 if self.related:


### PR DESCRIPTION
As https://github.com/odoo/odoo/pull/182667, no error is trigger when the selection is actually ignored. Also, accept tuple doesn't cost anything.