### PR TITLE
[FIX] web_editor: make columns added with powerbox have the same size

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/base_style.scss
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/base_style.scss
@@ -13,15 +13,31 @@ $sizes: 'xs', 'sm', 'md', 'lg', 'xl', 'xxl';
     max-width: 100% !important;
     padding: 0 !important;
 }
-.o_text_columns > .row {
-    margin: 0 !important;
-    @each $size in $sizes {
-        @for $i from 1 through 12 {
-            & > .col-#{$size}-#{$i}:first-of-type {
-                padding-left: 0;
-            }
-            & > .col-#{$size}-#{$i}:last-of-type {
-                padding-right: 0;
+// TODO adapt in master. Those following `.o_text_column` CSS rules were added
+// as an attempt to align those columns with the rest of the edited text in
+// backend form views, etc. It was not needed, something else fixed the issue.
+// But removing them would actually display an horizontal scrollbar in backend
+// html fields displayed in form views now... as somehow the edited text relies
+// on a combination of `overflow: auto` and `padding: 0` (or too small...
+// depends on the form view...)... this should be refactored to be possible to
+// remove. We keep the bug they introduce: the columns are not properly sized,
+// the first and last ones are bigger because of this. Also columns wrapping on
+// multiple rows is buggy. However, we allow to disable the rule with a variable
+// so that the bug can be fixed for the website, where this is more important
+// and can rely on the external paddings being right.
+// grep: FIXED_TEXT_COLUMNS
+$--enable-no-overflow-of-text-columns: true !default;
+@if $--enable-no-overflow-of-text-columns {
+    .o_text_columns > .row {
+        margin: 0 !important;
+        @each $size in $sizes {
+            @for $i from 1 through 12 {
+                & > .col-#{$size}-#{$i}:first-of-type {
+                    padding-left: 0;
+                }
+                & > .col-#{$size}-#{$i}:last-of-type {
+                    padding-right: 0;
+                }
             }
         }
     }

--- a/addons/web_editor/static/src/scss/web_editor.frontend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.frontend.scss
@@ -44,7 +44,8 @@
         // Adapt the horizontal margins of a direct row child of a grid item, to
         // make them compensate the grid item horizontal padding (to avoid an
         // overflow).
-        .o_grid_item > .row {
+        .o_grid_item > .row,
+        .o_grid_item > .o_text_columns > .row {
             --grid-inner-row-gutter-x: clamp(0px, 2 * var(--grid-item-padding-x), #{$grid-gutter-width});
             margin-left: calc(-0.5 * var(--grid-inner-row-gutter-x));
             margin-right: calc(-0.5 * var(--grid-inner-row-gutter-x));

--- a/addons/website/static/src/scss/bootstrap_overridden.scss
+++ b/addons/website/static/src/scss/bootstrap_overridden.scss
@@ -189,3 +189,7 @@ $o-navbar-nav-pills-link-border-radius: if(o-website-value('header-links-style')
 // Accordion
 $accordion-color: inherit !default;
 $accordion-bg: inherit !default;
+
+// TODO adapt in master: fix the text columns web_editor feature to use standard
+// Bootstrap paddings and margins. See FIXED_TEXT_COLUMNS.
+$--enable-no-overflow-of-text-columns: false !default;


### PR DESCRIPTION
Steps to reproduce:
- In edit mode, drop a "Text-Image" snippet.
- In the text column, add 4 columns with the powerbox (type "/" then "columns").
- In each column, add an image.
 => The two outer columns image have the same size, which is bigger than the inner ones.

This happens because in commit [1], in order for the columns to be well aligned with the rest of the content, the left padding of the first column and the right padding of the last one have been forced to 0px. This resulted in the columns content having different sizes depending on their position.

Moreover, this was not a good solution because if we added more columns (by duplicating them) such that they go on multiple lines, the last one of the first line would not be correctly aligned to the content, because it is not the last column so it would keep its right padding. This would also result in the columns being shifted compared to the first line.

This commit fixes that by removing the rules added by commit [1], as the columns were already aligned without them. The row margins are then set so they compensate the grid item padding, for the case when we are in grid mode, to avoid overflow. Note that if the padding is under 15px, the columns are not aligned anymore, but this is the compromise to have identical columns.

[1]: https://github.com/odoo/odoo/commit/fb55f688f6be2211ebeea4ba431a06230c40fb6b

opw-4172256