### PR TITLE
[IMP] web: enable eslint for stock_barcode modules

### DIFF
--- a/addons/web/tooling/_eslintignore
+++ b/addons/web/tooling/_eslintignore
@@ -203,6 +203,26 @@ addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet.js
 !whatsapp
 !whatsapp/**/*
 
+# Whitelist stock_barcode modules
+!stock_barcode
+!stock_barcode/**/*
+!stock_barcode_barcodelookup
+!stock_barcode_barcodelookup/**/*
+!stock_barcode_mrp
+!stock_barcode_mrp/**/*
+!stock_barcode_mrp_subcontracting
+!stock_barcode_mrp_subcontracting/**/*
+!stock_barcode_picking_batch
+!stock_barcode_picking_batch/**/*
+!stock_barcode_product_expiry
+!stock_barcode_product_expiry/**/*
+!stock_barcode_quality_control
+!stock_barcode_quality_control/**/*
+!stock_barcode_quality_control_picking_batch
+!stock_barcode_quality_control_picking_batch/**/*
+!stock_barcode_quality_mrp
+!stock_barcode_quality_mrp/**/*
+
 # Whitelist point_of_sale
 !addons/point_of_sale
 !addons/point_of_sale/**/*


### PR DESCRIPTION
Adds `stock_barcode` and children modules on the *not-to-ignore* list for the eslint.

Enterprise PR: odoo/enterprise#71556