### PR TITLE
[REF/IMP] mail: refactor image actions and improve video attachment display

### DIFF
--- a/addons/mail/static/src/core/common/attachment_actions.js
+++ b/addons/mail/static/src/core/common/attachment_actions.js
@@ -1,0 +1,24 @@
+import { Component } from "@odoo/owl";
+import { isMobileOS } from "@web/core/browser/feature_detection";
+
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+
+/**
+ * @typedef {Object} Props
+ * @property {Object[]} actions
+ * @property {number} maxHeight
+ * @extends {Component<Props, Env>}
+ */
+export class AttachmentActions extends Component {
+    static components = { Dropdown, DropdownItem };
+    static props = ["actions", "maxHeight"];
+    static template = "mail.AttachmentActions";
+
+    setup() {
+        super.setup();
+        this.actionsMenuState = useDropdownState();
+        this.isMobileOS = isMobileOS;
+    }
+}

--- a/addons/mail/static/src/core/common/attachment_actions.xml
+++ b/addons/mail/static/src/core/common/attachment_actions.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="mail.AttachmentActions">
+        <div class="position-absolute top-0 bottom-0 start-0 end-0 p-1 text-white o-opacity-hoverable opacity-100-hover d-flex align-items-end flax-wrap flex-column" t-att-class="{ 'opacity-0': !actionsMenuState.isOpen }">
+            <button t-if="props.actions.length === 1 and props.maxHeight gt 75" class="btn btn-sm btn-light rounded px-1 py-0" t-att-class="{ 'opacity-75 opacity-100-hover': !isMobileOS }" tabindex="0" t-att-aria-label="props.actions[0].label" t-att-title="props.actions[0].label" role="menuitem" t-on-click.stop="props.actions[0].onSelect">
+                <i t-att-class="props.actions[0].icon"/>
+            </button>
+            <Dropdown t-else="" menuClass="'d-flex flex-column py-0' + (props.actions.length gt 1 ? ' py-0' : '')" state="actionsMenuState" position="'right-start'">
+                <button class="btn btn-sm btn-light rounded px-1 py-0" t-att-class="{ 'opacity-75 opacity-100-hover': !isMobileOS }" tabindex="0" aria-label="Actions" title="Actions" role="menuitem">
+                    <i class="oi oi-chevron-down"/>
+                </button>
+                <t t-set-slot="content">
+                    <DropdownItem t-foreach="props.actions" t-as="action" t-key="action_index" class="'px-2 py-1 d-flex align-items-center rounded-0'" onSelected="action.onSelect">
+                        <i class="fa-fw" t-att-class="action.icon"/>
+                        <span class="mx-2" t-esc="action.label"/>
+                    </DropdownItem>
+                </t>
+            </Dropdown>
+        </div>
+    </t>
+
+</templates>

--- a/addons/mail/static/src/core/common/attachment_list.js
+++ b/addons/mail/static/src/core/common/attachment_list.js
@@ -2,25 +2,12 @@ import { Component, useState } from "@odoo/owl";
 import { isMobileOS } from "@web/core/browser/feature_detection";
 
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
-import { Dropdown } from "@web/core/dropdown/dropdown";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
-import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { useFileViewer } from "@web/core/file_viewer/file_viewer_hook";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { url } from "@web/core/utils/urls";
-
-class ImageActions extends Component {
-    static components = { Dropdown, DropdownItem };
-    static props = ["actions", "imagesHeight"];
-    static template = "mail.ImageActions";
-
-    setup() {
-        super.setup();
-        this.actionsMenuState = useDropdownState();
-        this.isMobileOS = isMobileOS;
-    }
-}
+import { AttachmentActions } from "@mail/core/common/attachment_actions";
 
 /**
  * @typedef {Object} Props
@@ -31,7 +18,7 @@ class ImageActions extends Component {
  * @extends {Component<Props, Env>}
  */
 export class AttachmentList extends Component {
-    static components = { ImageActions };
+    static components = { AttachmentActions };
     static props = ["attachments", "unlinkAttachment", "imagesHeight", "messageSearch?"];
     static template = "mail.AttachmentList";
 

--- a/addons/mail/static/src/core/common/attachment_list.scss
+++ b/addons/mail/static/src/core/common/attachment_list.scss
@@ -25,16 +25,6 @@
     }
 }
 
-.o-mail-AttachmentImage {
-    min-width: 75px;
-    min-height: 75px;
-    background-color: $gray-200;
-
-    img {
-        object-fit: contain;
-    }
-}
-
 .o-viewable {
     cursor: zoom-in;
 }

--- a/addons/mail/static/src/core/common/attachment_list.xml
+++ b/addons/mail/static/src/core/common/attachment_list.xml
@@ -34,7 +34,7 @@
                     <div t-if="attachment.uploading" class="position-absolute top-0 bottom-0 start-0 end-0 d-flex align-items-center justify-content-center" title="Uploading">
                         <i class="fa fa-circle-o-notch fa-spin"/>
                     </div>
-                    <ImageActions actions="getActions(attachment)" imagesHeight="props.imagesHeight"/>
+                    <AttachmentActions actions="getActions(attachment)" maxHeight="props.imagesHeight"/>
                 </div>
             </div>
             <div class="d-flex flex-wrap mt-1 mx-1">
@@ -89,25 +89,6 @@
                     </div>
                 </div>
             </div>
-        </div>
-    </t>
-
-    <t t-name="mail.ImageActions">
-        <div class="position-absolute top-0 bottom-0 start-0 end-0 p-1 text-white o-opacity-hoverable opacity-100-hover d-flex align-items-end flax-wrap flex-column" t-att-class="{ 'opacity-0': !actionsMenuState.isOpen }">
-            <button t-if="props.actions.length === 1 and props.imagesHeight gt 75" class="btn btn-sm btn-light rounded px-1 py-0" t-att-class="{ 'opacity-75 opacity-100-hover': !isMobileOS }" tabindex="0" t-att-aria-label="props.actions[0].label" t-att-title="props.actions[0].label" role="menuitem" t-on-click.stop="props.actions[0].onSelect">
-                <i t-att-class="props.actions[0].icon"/>
-            </button>
-            <Dropdown t-else="" menuClass="'d-flex flex-column py-0' + (props.actions.length gt 1 ? ' py-0' : '')" state="actionsMenuState" position="'right-start'">
-                <button class="btn btn-sm btn-light rounded px-1 py-0" t-att-class="{ 'opacity-75 opacity-100-hover': !isMobileOS }" tabindex="0" aria-label="Actions" title="Actions" role="menuitem">
-                    <i class="oi oi-chevron-down"/>
-                </button>
-                <t t-set-slot="content">
-                    <DropdownItem t-foreach="props.actions" t-as="action" t-key="action_index" class="'px-2 py-1 d-flex align-items-center rounded-0'" onSelected="action.onSelect">
-                        <i class="fa-fw" t-att-class="action.icon"/>
-                        <span class="mx-2" t-esc="action.label"/>
-                    </DropdownItem>
-                </t>
-            </Dropdown>
         </div>
     </t>
 

--- a/addons/mail/static/src/core/common/attachment_list.xml
+++ b/addons/mail/static/src/core/common/attachment_list.xml
@@ -15,7 +15,7 @@
                         }" role="menu" >
                 <div t-foreach="images" t-as="attachment" t-key="attachment.id"
                      t-att-aria-label="attachment.name"
-                     class="o-mail-AttachmentImage d-flex position-relative flex-shrink-0 mw-100 mb-1 me-1 rounded o-viewable"
+                     class="o-mail-AttachmentImage o-mail-mediaAttachment d-flex position-relative flex-shrink-0 mw-100 mb-1 me-1 rounded o-viewable"
                      t-att-title="attachment.name"
                      t-att-class="{ 'o-isUploading': attachment.uploading }"
                      tabindex="0"
@@ -36,6 +36,18 @@
                     </div>
                     <AttachmentActions actions="getActions(attachment)" maxHeight="props.imagesHeight"/>
                 </div>
+            </div>
+            <div class="d-flex flex-grow-1 flex-wrap mx-1 align-items-center" t-att-class="{
+                'justify-content-end': isInChatWindowAndIsAlignedRight and !env.inComposer,
+            }" role="menu" >
+                <AttachmentVideo
+                    t-foreach="videos" t-as="attachment" t-key="attachment.id"
+                    attachment="attachment"
+                    maxWidth="imagesWidth"
+                    maxHeight="props.imagesHeight"
+                    showDelete="showDelete"
+                    unlinkAttachment="props.unlinkAttachment"
+                />
             </div>
             <div class="d-flex flex-wrap mt-1 mx-1">
                 <!-- t-attf-class overridden in extensions -->

--- a/addons/mail/static/src/core/common/attachment_utils.js
+++ b/addons/mail/static/src/core/common/attachment_utils.js
@@ -1,0 +1,83 @@
+import { Component } from "@odoo/owl";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { _t } from "@web/core/l10n/translation";
+import { useService } from "@web/core/utils/hooks";
+
+/**
+ * @typedef {Object} Props
+ * @property {function} unlinkAttachment
+ * @extends {Component<Props, Env>}
+ */
+export class AttachmentUtils extends Component {
+    static template = "";
+    static props = ["unlinkAttachment"];
+
+    setup() {
+        super.setup();
+        this.dialog = useService("dialog");
+    }
+
+    /**
+     * @param {import("models").Attachment} attachment
+     */
+    canDownload(attachment) {
+        return !attachment.uploading && !this.env.inComposer;
+    }
+
+    getActions(attachment) {
+        const res = [];
+        if (this.showDelete ?? this.props.showDelete) {
+            res.push({
+                label: _t("Remove"),
+                icon: "fa fa-trash",
+                onSelect: () => this.onClickUnlink(attachment),
+            });
+        }
+        if (this.canDownload(attachment)) {
+            res.push({
+                label: _t("Download"),
+                icon: "fa fa-download",
+                onSelect: () => this.onClickDownload(attachment),
+            });
+        }
+        return res;
+    }
+
+    /**
+     * @param {import("models").Attachment} attachment
+     */
+    onClickDownload(attachment) {
+        const downloadLink = document.createElement("a");
+        downloadLink.setAttribute("href", attachment.downloadUrl);
+        // Adding 'download' attribute into a link prevents open a new
+        // tab or change the current location of the window. This avoids
+        // interrupting the activity in the page such as rtc call.
+        downloadLink.setAttribute("download", "");
+        downloadLink.click();
+    }
+
+    /**
+     * @param {import("models").Attachment} attachment
+     */
+    onClickUnlink(attachment) {
+        if (this.env.inComposer) {
+            return this.props.unlinkAttachment(attachment);
+        }
+        this.dialog.add(ConfirmationDialog, {
+            body: _t('Do you really want to delete "%s"?', attachment.name),
+            cancel: () => {},
+            confirm: () => this.onConfirmUnlink(attachment),
+        });
+    }
+
+    onClickAttachment(attachment) {
+        this.fileViewer.open(attachment, this.props.attachments);
+    }
+
+    /**
+     * @param {import("models").Attachment} attachment
+     */
+    onConfirmUnlink(attachment) {
+        this.props.unlinkAttachment(attachment);
+    }
+}

--- a/addons/mail/static/src/core/common/attachment_utils.scss
+++ b/addons/mail/static/src/core/common/attachment_utils.scss
@@ -1,0 +1,9 @@
+.o-mail-mediaAttachment {
+    min-width: 75px;
+    min-height: 75px;
+    background-color: $gray-200;
+
+    img, video {
+        object-fit: contain;
+    }
+}

--- a/addons/mail/static/src/core/common/attachment_video.js
+++ b/addons/mail/static/src/core/common/attachment_video.js
@@ -1,0 +1,61 @@
+import { useRef, useState } from "@odoo/owl";
+import { AttachmentUtils } from "@mail/core/common/attachment_utils";
+import { AttachmentActions } from "@mail/core/common/attachment_actions";
+
+/**
+ * @typedef {Object} Props
+ * @property {import("models").Attachment} attachment
+ * @property {number} maxHeight
+ * @property {number} maxWidth
+ * @property {boolean} showDelete
+ * @extends {AttachmentUtils<Props, Env>}
+ */
+export class AttachmentVideo extends AttachmentUtils {
+    static template = "mail.AttachmentVideo";
+    static components = { AttachmentActions };
+    static props = [...AttachmentUtils.props, "attachment", "maxHeight", "maxWidth", "showDelete"];
+
+    setup() {
+        super.setup();
+        this.state = useState({ paused: true });
+        this.videoRefEl = useRef("videoRef");
+        this.seeking = false;
+    }
+
+    onClickPlay(ev) {
+        if (this.videoRefEl.el && this.canPlay) {
+            ev.stopPropagation();
+            this.state.paused = false;
+            this.videoRefEl.el.play();
+            this.videoRefEl.el.setAttribute("controls", "controls");
+        }
+    }
+
+    /**
+     * @param {MouseEvent} ev
+     */
+    onClickAttachment(ev) {
+        if (!this.props.attachment.uploading && this.env.inComposer) {
+            ev.stopPropagation();
+            ev.preventDefault();
+            this.env.onClickAttachment(this.props.attachment);
+        }
+    }
+
+    onPause() {
+        if (this.videoRefEl.el) {
+            // Need to wait for the seeking event to be triggered
+            setTimeout(() => {
+                if (this.seeking) {
+                    return;
+                }
+                this.state.paused = true;
+                this.videoRefEl.el.removeAttribute("controls");
+            }, 1);
+        }
+    }
+
+    get canPlay() {
+        return !this.props.attachment.uploading && !this.env.inComposer;
+    }
+}

--- a/addons/mail/static/src/core/common/attachment_video.xml
+++ b/addons/mail/static/src/core/common/attachment_video.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="mail.AttachmentVideo">
+        <div
+            t-att-aria-label="props.attachment.name"
+            class="o-mail-AttachmentVideo o-mail-mediaAttachment d-flex position-relative flex-shrink-0 mw-100 mb-1 me-1"
+            t-att-title="props.attachment.name"
+            t-att-class="{ 'o-isUploading': props.attachment.uploading }"
+            tabindex="0"
+            t-att-data-mimetype="props.attachment.mimetype"
+            role="menuitem"
+            t-on-click="onClickAttachment"
+        >
+            <video
+                t-ref="videoRef"
+                class="my-0 mx-auto rounded"
+                t-att-class="{ 'cursor-pointer': canPlay }"
+                t-att-src="props.attachment.defaultSource"
+                t-on-pause="onPause"
+                t-on-seeking="() => this.seeking = true"
+                t-on-seeked="() => this.seeking = false"
+                t-attf-style="max-width: min(100%, {{ props.maxWidth }}px); max-height: {{ props.maxHeight }}px;"
+            />
+            <div t-if="props.attachment.uploading" class="position-absolute top-0 bottom-0 start-0 end-0 d-flex align-items-center justify-content-center" title="Uploading">
+                <i class="fa fa-spin fa-spinner"/>
+            </div>
+            <div t-if="state.paused" class="position-absolute flex-grow-1 cursor-pointer top-0 bottom-0 start-0 end-0 p-2 text-white d-flex flex-wrap align-content-center justify-content-center" t-on-click="onClickPlay">
+                <div t-if="canPlay" class="o-mail-AttachmentVideo-play btn btn-lg rounded opacity-75 bg-black">
+                    <i class="fa fa-play text-white"/>
+                </div>
+                <AttachmentActions actions="getActions(props.attachment)" maxHeight="props.maxHeight"/>
+            </div>
+        </div>
+    </t>
+
+</templates>

--- a/addons/mail/static/src/discuss/voice_message/common/attachment_list_patch.js
+++ b/addons/mail/static/src/discuss/voice_message/common/attachment_list_patch.js
@@ -5,3 +5,11 @@ import { patch } from "@web/core/utils/patch";
 patch(AttachmentList, {
     components: { ...AttachmentList.components, VoicePlayer },
 });
+
+patch(AttachmentList.prototype, {
+    openFileViewer(attachment) {
+        if (!attachment.voice) {
+            super.openFileViewer(attachment);
+        }
+    },
+});

--- a/addons/mail/static/tests/thread/attachment_list.test.js
+++ b/addons/mail/static/tests/thread/attachment_list.test.js
@@ -44,6 +44,36 @@ test("simplest layout", async () => {
     await contains(".o-mail-AttachmentCard-aside button[title='Download']");
 });
 
+test("layout with image, video and document files", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_type: "channel",
+        name: "channel1",
+    });
+    const attachmentIds = pyEnv["ir.attachment"].create(
+        [
+            ["text/plain", "text"],
+            ["image/png", "png"],
+            ["video/mp4", "mp4"],
+        ].map(([mimetype, ext]) => ({
+            name: `test.${ext}`,
+            mimetype,
+        }))
+    );
+    pyEnv["mail.message"].create({
+        attachment_ids: attachmentIds,
+        body: "<p>Test</p>",
+        model: "discuss.channel",
+        res_id: channelId,
+        message_type: "comment",
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-AttachmentList > div:eq(0) .o-mail-AttachmentImage");
+    await contains(".o-mail-AttachmentList > div:eq(1) .o-mail-AttachmentVideo");
+    await contains(".o-mail-AttachmentList > div:eq(2) .o-mail-AttachmentCard");
+});
+
 test("layout with card details and filename and extension", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({


### PR DESCRIPTION
This pull request includes two key changes:

1. **Refactor Image Actions**:
   - The `ImageActions` component has been separated from `AttachmentList` and renamed to `AttachmentActions`. 

2. **Enhance Video Attachment Display**:
   - Video attachments, previously displayed as simple cards, now include a preview, offering a more user-friendly experience.

**Task**-4244803

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
