### PR TITLE
[IMP] website: make cookie watcher container list custo-friendly

### DIFF
--- a/addons/website/models/ir_qweb.py
+++ b/addons/website/models/ir_qweb.py
@@ -137,13 +137,7 @@ class IrQWeb(models.AbstractModel):
             # are/could be built on the fly client-side for some reason.
             cookies_watchlist = {
                 'domains': website.blocked_third_party_domains.split('\n'),
-                'classes': {
-                    's_map',
-                    's_instagram_page',
-                    'o_facebook_page',
-                    'o_background_video',
-                    'media_iframe_video',
-                },
+                'classes': website._get_blocked_iframe_containers_classes(),
             }
             remove_src = False
             if tagName in ('iframe', 'script'):

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -252,6 +252,15 @@ class Website(models.Model):
     def _get_blocked_third_party_domains_list(self):
         return self.blocked_third_party_domains.split('\n')
 
+    def _get_blocked_iframe_containers_classes(self):
+        return {
+            's_map',
+            's_instagram_page',
+            'o_facebook_page',
+            'o_background_video',
+            'media_iframe_video',
+        }
+
     # self.env.uid for ir.rule groups on menu
     @tools.ormcache('self.env.uid', 'self.id', cache='templates')
     def _get_menu_ids(self):


### PR DESCRIPTION
Commit [958b41c4] added support to prevent 3rd-party iframes from loading without proper consent. As some iframes are built client-side, preventing them from loading required getting their container by their class. Those classes are stored in a set.
Allowing any user to update that set does not make sense, but to make it possible for developers to update it through custos, this commit retrieves it from a method on the Website model instead of hard-coding it in the middle of a function.

[958b41c4]: https://github.com/odoo/odoo/commit/958b41c4acec7e1700ca4d6e0b25ee0ad2aac9f1

task-4045932