### PR TITLE
[FIX] mrp_account: compute price from BoM with total OP duration

### DIFF
--- a/addons/mrp_account/tests/test_bom_price.py
+++ b/addons/mrp_account/tests/test_bom_price.py
@@ -4,6 +4,7 @@
 from odoo.exceptions import UserError
 from odoo.tests import common, Form
 from odoo.tools.float_utils import float_round, float_compare
+from odoo import Command
 
 
 class TestBomPriceCommon(common.TransactionCase):
@@ -254,3 +255,40 @@ class TestBomPrice(TestBomPriceCommon):
         self.assertEqual(self.dining_table.standard_price, 137.5, "After computing price from BoM price should be 137.5")
         scrap_wood.button_bom_cost()
         self.assertEqual(scrap_wood.standard_price, 20.63, "After computing price from BoM price should be 20.63")
+
+    def test_compute_price_from_bom_with_operation(self):
+        """
+        Test that the cost of the product is calculated correctly based on the total work order duration.
+        BoM:
+            Qty: 651
+            component: $3 * 651 units
+            operation: 60 min by unit with cost of 30
+
+            workcenter capacity = 2
+            cycle = 651 % capacity (2) = 326
+            cost = ((30 * 326) + (3 * 651) = 11733.0 / 651 → $18.02
+        """
+        uom_gram = self.env.ref('uom.product_uom_gram')
+        uom_kgm = self.env.ref('uom.product_uom_kgm')
+        self.bolt.uom_id = uom_gram
+        workcenter = self.env['mrp.workcenter'].create({
+            'name': 'Workcenter',
+            'costs_hour': 30,
+            'default_capacity': 2,
+        })
+        self.bolt.standard_price = 10
+        self.glass.standard_price = 3
+        self.env['mrp.bom'].create({
+            'product_tmpl_id': self.bolt.product_tmpl_id.id,
+            'product_qty': 651,
+            'product_uom_id': uom_kgm.id,
+            'bom_line_ids': [
+                Command.create({'product_id': self.glass.id, 'product_qty': 651}),
+            ],
+            'operation_ids': [
+                Command.create({'name': 'op1', 'workcenter_id': workcenter.id}),
+            ]
+        })
+        self.assertEqual(self.bolt.standard_price, 10)
+        self.bolt.button_bom_cost()
+        self.assertEqual(self.bolt.standard_price, 18.02)


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Create a storable product P1 with the following BoM:
    - Quantity: 650
    - Components:
         - 650 units of C1 (price: $3 per unit)
    - Operations:
         - OP1 → Duration: 60 minutes, workcenter cost: $30

- Go to the product form of P1
- Click on "Compute Price from BoM"

**Problem:**
The unit cost of P1 is calculated as:

(30) + (3 * 650) = 1980 / 650 → $3.05

Instead of:

(30 * 650) + (3 * 650) = 21450 / 650 → $33

The operation cost is not being multiplied by the number of finished products to produce.

opw-4178820
