### PR TITLE
[FIX] web: improve display of RGBA in colorpicker

### DIFF
--- a/addons/web/static/src/core/colorpicker/colorpicker.xml
+++ b/addons/web/static/src/core/colorpicker/colorpicker.xml
@@ -25,7 +25,7 @@
             <div class="o_rgba_div px-1 d-flex align-items-baseline">
                 <input type="text" t-attf-class="o_red_input {{input_classes}}" data-color-method="rgb" size="1"/>
                 <input type="text" t-attf-class="o_green_input {{input_classes}}" data-color-method="rgb" size="1"/>
-                <input type="text" t-attf-class="o_blue_input me-0 {{input_classes}}" data-color-method="rgb" size="1"/>
+                <input type="text" t-attf-class="o_blue_input {{input_classes}}" data-color-method="rgb" size="1"/>
                 <t t-if="!props.noTransparency">
                     <input type="text" t-attf-class="o_opacity_input {{input_classes}}" data-color-method="opacity" size="1"/>
                     <label class="flex-grow-0 ms-1 mb-0">


### PR DESCRIPTION
Before this commit, the value of the RGBA in the colorpicker display
was missing a spacing after the value for blue.

This commit add the spacing after this value to make the text more
readable by the user.

task-4242209