### PR TITLE
[FIX] point_of_sale: align attribute display behavior with sale module

### DIFF
--- a/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.js
@@ -33,12 +33,14 @@ export class BaseProductAttribute extends Component {
                 return val.name;
             })
             .join(", ");
+        const hasCustom = attribute_value_ids.some((val) => val.is_custom);
 
         return {
             value,
             valueIds,
             custom_value: this.state.custom_value,
             extra,
+            hasCustom,
         };
     }
 
@@ -130,10 +132,10 @@ export class ProductConfiguratorPopup extends Component {
         var price_extra = 0.0;
 
         this.state.payload.forEach((attribute_component) => {
-            const { valueIds, extra, custom_value } = attribute_component.getValue();
+            const { valueIds, extra, custom_value, hasCustom } = attribute_component.getValue();
             attribute_value_ids.push(valueIds);
 
-            if (custom_value) {
+            if (hasCustom) {
                 // for custom values, it will never be a multiple attribute
                 attribute_custom_values[valueIds[0]] = custom_value;
             }

--- a/addons/point_of_sale/static/src/utils.js
+++ b/addons/point_of_sale/static/src/utils.js
@@ -41,7 +41,7 @@ export function constructFullProductName(line) {
                         cus.custom_product_template_attribute_value_id?.id == parseInt(value.id)
                 );
                 if (customValue) {
-                    attributeString += `${value.attribute_id.name}: ${customValue.custom_value}, `;
+                    attributeString += `${value.attribute_id.name}: ${value.name}: ${customValue.custom_value}, `;
                 }
             } else {
                 attributeString += `${value.name}, `;

--- a/addons/point_of_sale/static/tests/tours/product_configurator_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_configurator_tour.js
@@ -37,7 +37,7 @@ registry.category("web_tour.tours").add("ProductConfiguratorTour", {
 
             // Check that the product has been added to the order with correct attributes and price
             ProductScreen.selectedOrderlineHas(
-                "Configurable Chair (Red, Metal, Fabrics: Custom Fabric)",
+                "Configurable Chair (Red, Metal, Fabrics: Other: Custom Fabric)",
                 "1.0",
                 "11.0"
             ),
@@ -50,7 +50,7 @@ registry.category("web_tour.tours").add("ProductConfiguratorTour", {
             ProductConfigurator.fillCustomAttribute("Custom Fabric"),
             Dialog.confirm(),
             ProductScreen.selectedOrderlineHas(
-                "Configurable Chair (Red, Metal, Fabrics: Custom Fabric)",
+                "Configurable Chair (Red, Metal, Fabrics: Other: Custom Fabric)",
                 "2.0",
                 "22.0"
             ),


### PR DESCRIPTION
Before this commit, attribute values marked as "Free text" would not appear on the orderline unless text was added to them. This behavior was inconsistent with the Sale module, where such attributes are displayed regardless.

opw-4218992

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
