### PR TITLE
[FIX] web: open form view in multi-company (doAction)

### DIFF
--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -223,6 +223,7 @@ export class FormController extends Component {
         onError((error) => {
             const suggestedCompany = error.cause?.data?.context?.suggested_company;
             if (error.cause?.data?.name === "odoo.exceptions.AccessError" && suggestedCompany) {
+                this.env.pushStateBeforeReload();
                 const activeCompanyIds = this.companyService.activeCompanyIds;
                 activeCompanyIds.push(suggestedCompany.id);
                 this.companyService.setCompanies(activeCompanyIds, true);

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -633,18 +633,6 @@ export function makeActionManager(env, router = _router) {
                 }
             },
         });
-        const currentState = {
-            resId: viewProps.resId,
-            active_id: action.context.active_id || false,
-        };
-        viewProps.updateActionState = (controller, patchState) => {
-            const oldState = { ...currentState };
-            Object.assign(currentState, patchState);
-            const changed = !shallowEqual(currentState, oldState);
-            if (changed && target !== "new" && controller.isMounted) {
-                pushState();
-            }
-        };
         if (view.type === "form") {
             if (target === "new") {
                 viewProps.mode = "edit";
@@ -684,6 +672,19 @@ export function makeActionManager(env, router = _router) {
         if (!viewProps.resId) {
             viewProps.resId = action.res_id || false;
         }
+
+        const currentState = {
+            resId: viewProps.resId,
+            active_id: action.context.active_id || false,
+        };
+        viewProps.updateActionState = (controller, patchState) => {
+            const oldState = { ...currentState };
+            Object.assign(currentState, patchState);
+            const changed = !shallowEqual(currentState, oldState);
+            if (changed && target !== "new" && controller.isMounted) {
+                pushState();
+            }
+        };
 
         viewProps.noBreadcrumbs =
             "no_breadcrumbs" in action.context ? action.context.no_breadcrumbs : target === "new";
@@ -821,6 +822,12 @@ export function makeActionManager(env, router = _router) {
                 useDebugCategory("action", { action });
                 useChildSubEnv({
                     config: controller.config,
+                    pushStateBeforeReload: () => {
+                        if (this.isMounted) {
+                            return;
+                        }
+                        pushState(nextStack);
+                    },
                 });
                 if (action.target !== "new") {
                     this.__beforeLeave__ = new CallbackRecorder();
@@ -1558,11 +1565,11 @@ export function makeActionManager(env, router = _router) {
         }
     }
 
-    function pushState() {
-        if (!controllerStack.length) {
+    function pushState(cStack = controllerStack) {
+        if (!cStack.length) {
             return;
         }
-        const actions = controllerStack.map((controller) => {
+        const actions = cStack.map((controller) => {
             const { action, props, displayName } = controller;
             const actionState = { displayName };
             if (action.path || action.id) {
@@ -1595,7 +1602,7 @@ export function makeActionManager(env, router = _router) {
             actionStack: actions,
         };
         const stateKeys = [...PATH_KEYS];
-        const { action, props, currentState } = controllerStack.at(-1);
+        const { action, props, currentState } = cStack.at(-1);
         if (props.type !== "form" && props.type !== action.views?.[0][1]) {
             // add view_type only when it's not already known implicitly
             stateKeys.push("view_type");
@@ -1605,7 +1612,7 @@ export function makeActionManager(env, router = _router) {
         }
         Object.assign(newState, pick(newState.actionStack.at(-1), ...stateKeys));
 
-        controllerStack.at(-1).state = newState;
+        cStack.at(-1).state = newState;
         router.pushState(newState, { replace: true });
     }
     return {

--- a/addons/web/static/tests/web_test_helpers.js
+++ b/addons/web/static/tests/web_test_helpers.js
@@ -1,3 +1,4 @@
+import { WebClient } from "@web/webclient/webclient";
 import * as _fields from "./_framework/mock_server/mock_fields";
 import * as _models from "./_framework/mock_server/mock_model";
 import { IrAttachment } from "./_framework/mock_server/mock_models/ir_attachment";
@@ -13,6 +14,8 @@ import { ResGroups } from "./_framework/mock_server/mock_models/res_groups";
 import { ResPartner } from "./_framework/mock_server/mock_models/res_partner";
 import { ResUsers } from "./_framework/mock_server/mock_models/res_users";
 import { defineModels } from "./_framework/mock_server/mock_server";
+import { animationFrame } from "@odoo/hoot-dom";
+import { mountWithCleanup } from "./_framework/component_test_helpers";
 
 /**
  * @typedef {import("./_framework/mock_server/mock_fields").FieldType} FieldType
@@ -164,3 +167,16 @@ export const webModels = {
     ResPartner,
     ResUsers,
 };
+
+/**
+ * @param {{ env: import("@web/env").OdooEnv }} [options]
+ */
+export async function mountWebClient(options) {
+    await mountWithCleanup(WebClient, options);
+    // Wait for visual changes caused by a potential loadState
+    await animationFrame();
+    // wait for BlankComponent
+    await animationFrame();
+    // wait for the regular rendering
+    await animationFrame();
+}

--- a/addons/web/static/tests/webclient/actions/load_state.test.js
+++ b/addons/web/static/tests/webclient/actions/load_state.test.js
@@ -10,6 +10,7 @@ import {
     getService,
     makeMockEnv,
     models,
+    mountWebClient,
     mountWithCleanup,
     onRpc,
     patchWithCleanup,
@@ -51,19 +52,6 @@ function logHistoryInteractions() {
             return super.pushState(state, _, url);
         },
     });
-}
-
-/**
- * @param {{ env: import("@web/env").OdooEnv }} [options]
- */
-async function mountWebClient(options) {
-    await mountWithCleanup(WebClient, options);
-    // Wait for visual changes caused by a potential loadState
-    await animationFrame();
-    // wait for BlankComponent
-    await animationFrame();
-    // wait for the regular rendering
-    await animationFrame();
 }
 
 defineActions([

--- a/addons/web/static/tests/webclient/actions/multi_company_action.test.js
+++ b/addons/web/static/tests/webclient/actions/multi_company_action.test.js
@@ -1,0 +1,96 @@
+import { beforeEach, expect, test } from "@odoo/hoot";
+import { cookie } from "@web/core/browser/cookie";
+import { redirect } from "@web/core/utils/urls";
+import {
+    defineModels,
+    fields,
+    getService,
+    makeServerError,
+    models,
+    mountWebClient,
+    onRpc,
+    patchWithCleanup,
+    serverState,
+} from "@web/../tests/web_test_helpers";
+import { animationFrame } from "@odoo/hoot-dom";
+import { browser } from "@web/core/browser/browser";
+
+class Partner extends models.Model {
+    _name = "res.partner";
+
+    name = fields.Char();
+
+    _records = [{ id: 1, name: "First record" }];
+    _views = {
+        form: `
+            <form>
+                <group>
+                    <field name="display_name"/>
+                </group>
+            </form>
+        `,
+        search: `<search></search>`,
+    };
+}
+
+defineModels([Partner]);
+
+beforeEach(() => {
+    serverState.companies = [
+        { id: 1, name: "Company 1", sequence: 1, parent_id: false, child_ids: [] },
+        { id: 2, name: "Company 2", sequence: 2, parent_id: false, child_ids: [] },
+        { id: 3, name: "Company 3", sequence: 3, parent_id: false, child_ids: [] },
+    ];
+    patchWithCleanup(browser.location, {
+        reload() {
+            expect.step("reload");
+        },
+    });
+    patchWithCleanup(browser.location, {
+        origin: "http://example.com",
+    });
+});
+
+test("open record withtout the correct company (load state)", async () => {
+    cookie.set("cids", "1");
+    onRpc("web_read", () => {
+        throw makeServerError({
+            type: "AccessError",
+            message: "Wrong Company",
+            context: { suggested_company: { id: 2, display_name: "Company 2" } },
+        });
+    });
+
+    redirect("/odoo/res.partner/1");
+    await mountWebClient();
+    expect(cookie.get("cids")).toBe("1-2");
+    expect.verifySteps(["reload"]);
+    expect(browser.location.href).toBe("http://example.com/odoo/res.partner/1", {
+        message: "url did not change",
+    });
+});
+
+test("open record withtout the correct company (doAction)", async () => {
+    cookie.set("cids", "1");
+    onRpc("web_read", () => {
+        throw makeServerError({
+            type: "AccessError",
+            message: "Wrong Company",
+            context: { suggested_company: { id: 2, display_name: "Company 2" } },
+        });
+    });
+
+    await mountWebClient();
+    getService("action").doAction({
+        type: "ir.actions.act_window",
+        res_id: 1,
+        res_model: "res.partner",
+        views: [[false, "form"]],
+    });
+    await animationFrame();
+    expect(cookie.get("cids")).toBe("1-2");
+    expect.verifySteps(["reload"]);
+    expect(browser.location.href).toBe("http://example.com/odoo/res.partner/1", {
+        message: "url should contain the information of the doAction",
+    });
+});


### PR DESCRIPTION
- Have access to multiple companies (A and B for instance);
- Be connected to only one company (company A);
- In the profile, have notifications handled in Odoo;
- Open Discuss;
- Got to History;
- Click on the origin of a thread, it should be a record from the second
  company (company B in this case);

Before this commit, we will connect to the second company (as expected),
but the record will not be open. This issue happens because we open the
record through a doAction. Before the form view is mounted, an
AccessError is raised and the correct company is added to the cookies
(see [1]). As the form view is not already mounted, the action service
didn't push the new state into the URL. When reloading (after adding the
company into the cookies), the state loaded will not contain the action
to open the record.

Now, we will connect to the second company, and the record will be open.

opw-4240778

[1]: https://github.com/odoo/odoo/commit/6213c40932236101b529b82f0ea9fce1829c8c24