### PR TITLE
[FIX] point_of_sale: enable search by `default_code` in PoS interface

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -199,7 +199,7 @@ export class ProductProduct extends Base {
     }
 
     get searchString() {
-        const fields = ["display_name", "description_sale", "description"];
+        const fields = ["display_name", "description_sale", "description", "default_code"];
         return fields
             .map((field) => this[field] || "")
             .filter(Boolean)


### PR DESCRIPTION
Problem:
In the PoS interface, searching for products using the `default_code` (internal reference) does not return any results, while this functionality was available in version 17.0.

Steps to reproduce:
- Open PoS.
- Attempt to search for any product using its `default_code` (internal reference).
- No results are displayed.

opw-4232415

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
