### PR TITLE
[IMP] delivery: display shipping pickup point name

### DIFF
--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -151,7 +151,7 @@ class SaleOrder(models.Model):
                 continue
 
             # Retrieve all the data : name, street, city, state, zip, country.
-            name = order.partner_shipping_id.name
+            name = order_location.get('name') or order.partner_shipping_id.name
             street = order_location['street']
             city = order_location['city']
             zip_code = order_location['zip_code']


### PR DESCRIPTION
### Issue: 

When a sale order made from the website with a pickup point (for instance using a sendcloud delivery method) is confirmed, a new partner is created to mix the data of the partner making the order and the address of the pickup point. If the partner is named Bob, this new partner will be named Bob, Bob. It woul dbe much clearer if he was named: Bob, pickup point name.

opw-4181787
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
