### PR TITLE
[FIX] sale_project: copy SO doesn't copy project

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -25,7 +25,7 @@ class SaleOrder(models.Model):
     show_task_button = fields.Boolean(compute='_compute_show_project_and_task_button', groups='project.group_project_user', export_string_translation=False)
     closed_task_count = fields.Integer(compute='_compute_tasks_ids', export_string_translation=False)
     completed_task_percentage = fields.Float(compute="_compute_completed_task_percentage", export_string_translation=False)
-    project_id = fields.Many2one('project.project', domain=[('allow_billable', '=', True)], help="A task will be created for the project upon sales order confirmation. The analytic distribution of this project will also serve as a reference for newly created sales order items.")
+    project_id = fields.Many2one('project.project', domain=[('allow_billable', '=', True)], copy=False, help="A task will be created for the project upon sales order confirmation. The analytic distribution of this project will also serve as a reference for newly created sales order items.")
     project_account_id = fields.Many2one('account.analytic.account', related='project_id.account_id')
 
     def _compute_milestone_count(self):

--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -173,6 +173,13 @@ class SaleOrderLine(models.Model):
                     line.task_id.write({'allocated_hours': allocated_hours})
         return result
 
+    def copy_data(self, default=None):
+        data = super().copy_data(default)
+        for origin, datum in zip(self, data):
+            if origin.analytic_distribution == origin.order_id.project_id.sudo()._get_analytic_distribution():
+                datum['analytic_distribution'] = False
+        return data
+
     ###########################################
     # Service : Project and task generation
     ###########################################


### PR DESCRIPTION
Steps:
Activate analytic accounting.
Create a SO with a service that creates a project. Confirm. The project that has just been created is now set on the SO. Duplicate.

Issue:
The project is duplicated too.
Yet is doesn't correspond to the the one that
will be created upon confirmation.

Solution:
Simply not duplicated the project upon SO duplication.

task-4207182




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
