### PR TITLE
[FIX] pos_self_order: exclude special products from self-order menu

### DIFF
--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -254,6 +254,7 @@ class PosConfig(models.Model):
             }
         }
         response['pos.config']['data'][0]['_self_ordering_image_home_ids'] = self._get_self_ordering_attachment(self.self_ordering_image_home_ids)
+        response['pos.config']['data'][0]['_pos_special_products_ids'] = self._get_special_products().ids
         self.env['pos.session']._load_pos_data_relations('pos.config', response)
 
         # Classic data loading

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -406,8 +406,14 @@ export class SelfOrder extends Reactive {
     initData() {
         this.productCategories = this.models["pos.category"].getAll();
         this.productByCategIds = this.models["product.product"].getAllBy("pos_categ_ids");
+        const isSpecialProduct = (p) => this.config._pos_special_products_ids.includes(p.id);
+        for (const category_id in this.productByCategIds) {
+            this.productByCategIds[category_id] = this.productByCategIds[category_id].filter(
+                (p) => !isSpecialProduct(p)
+            );
+        }
         const productWoCat = this.models["product.product"].filter(
-            (p) => p.pos_categ_ids.length === 0
+            (p) => p.pos_categ_ids.length === 0 && !isSpecialProduct(p)
         );
 
         if (productWoCat.length) {


### PR DESCRIPTION
Before this commit, special products, such as discount, could appear in the self-order menu. This commit ensures that such special products are not displayed, maintaining a cleaner and more relevant product selection for customers.

opw-4200540

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
