### PR TITLE
[FIX] http_routing: don't consider path prefixed by _ as a lang during match

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -349,6 +349,8 @@ class IrHttp(models.AbstractModel):
             return lang_code
 
         short = lang_code.partition('_')[0]
+        if not short:
+            return None
         return next((code for code in lang_codes if code.startswith(short)), None)
 
     @classmethod

--- a/addons/website/tests/test_lang_url.py
+++ b/addons/website/tests/test_lang_url.py
@@ -106,6 +106,11 @@ class TestLangUrl(HttpCase):
         res = self.url_open('/fr/path?привет=1')
         self.assertEqual(res.status_code, 404, "Rerouting didn't crash because of unicode query-string")
 
+    def test_07_nolang_prefix_underscore(self):
+        res = self.url_open('/_not_a_lang', allow_redirects=False)
+        self.assertEqual(res.status_code, 404, "Should not consider /_not_a_lang as a lang")
+        self.assertURLEqual(res.url, '/_not_a_lang', "Should use /_not_a_lang as the path and not a lang")
+
 
 @tagged('-at_install', 'post_install')
 class TestControllerRedirect(TestLangUrl):


### PR DESCRIPTION
Prior to this commit, when a URL started with an underscore (_) and didn’t match any existing controller, Odoo attempted to resolve the first part of the URL as a language code.

If the first segment started with an underscore and was not a valid language code, Odoo would split at the underscore and attempt to match the empty string (''), causing it to default to the first available language.

For example, accessing https://www.odoo.com/__NULL__ on odoo.com would result in the language being incorrectly set to Arabic, and a redirection to https://www.odoo.com/ar.
