### PR TITLE
[FIX] web: hide notebook's vertical scrollbar

### DIFF
--- a/addons/web/static/src/core/notebook/notebook.scss
+++ b/addons/web/static/src/core/notebook/notebook.scss
@@ -9,6 +9,7 @@
     .o_notebook_headers {
         margin: 0 var(--notebook-margin-x, 0);
         overflow-x: auto;
+        overflow-y: hidden;
 
         @include media-breakpoint-down(md) {
             &::-webkit-scrollbar {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In certain configurations or at specific zoom levels (typically > 100%), a vertical scrollbar may appear unintentionally. This fix ensures that the scrollbar remains hidden, providing a cleaner user experience.

Current behavior before PR:
![Screenshot from 2024-10-09 17-09-53](https://github.com/user-attachments/assets/17a56670-cce6-48c1-a25a-07708561943d)

Desired behavior after PR is merged:
![Screenshot from 2024-10-09 17-10-20](https://github.com/user-attachments/assets/aa319ec7-592e-407d-be83-bb065d524849)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
