### PR TITLE
[FIX] repair: wrong color on state badge

### DIFF
--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -48,7 +48,13 @@
                 <field name="sale_order_id" optional="show"/>
                 <field name="location_id" optional="hide"/>
                 <field name="company_id" groups="base.group_multi_company" readonly="1" optional="show"/>
-                <field name="state" optional="show" widget='badge' decoration-success="state == 'done'" decoration-info="state not in ('done', 'cancel')"/>
+                <field name="state" optional="show" widget='badge'
+                    decoration-success="state == 'done'"
+                    decoration-info="state == 'confirmed'"
+                    decoration-warning="state == 'under_repair'"
+                    decoration-danger="state == 'cancel'"
+                    decoration-muted="state == 'draft'"
+                />
                 <field name="activity_exception_decoration" widget="activity_exception"/>
             </list>
         </field>


### PR DESCRIPTION
Before:
In list view, repair orders state badge is green when the state is 'done'.
Otherwise, it is always blue.

After:
No change for state 'done'.
Badge color is more adapted to other states:
 - blue remain for 'confirmed'
 - yellow is used for 'under_repair'
 - white/black is used for 'draft'
 - red is used for 'cancel'

Task 4237694

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
