### PR TITLE
[FIX] web_editor: force the grid images maximum width to 100%

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.frontend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.frontend.scss
@@ -65,6 +65,10 @@
                 // mobile view, otherwise, force it to 15px.
                 --mobile-grid-item-padding-x: clamp(0px, calc(var(--grid-item-padding-x) * 100000), calc(0.5 * var(--gutter-x)));
                 padding: var(--grid-item-padding-y) var(--mobile-grid-item-padding-x) !important;
+
+                > img {
+                    max-width: 100%;
+                }
             }
         }
     }


### PR DESCRIPTION
In some theme customizations, images were replaced by new ones without specifying the usual image classes `img img-fluid mx-auto`. While two of them could be ignored, this is not the case of `img-fluid`, which limits the maximum width of an image to 100%. Without it, grid images in mobile view are overflowing, because the rule forcing their width to 100% has been moved in commit [1], to be applied on the desktop view only.

This commit fixes this issue by adding a rule for grid images, limiting their width to 100%. The problematic themes will also be fixed in the associated design PR.

[1]: https://github.com/odoo/odoo/commit/710d000f1872fd99b41d52ec3d6923756bba7cba
