### PR TITLE
[FIX] html_editor: selection after delete on mobile

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -39,6 +39,7 @@ import {
 } from "../utils/position";
 import { CTYPES } from "../utils/content_types";
 import { withSequence } from "@html_editor/utils/resource";
+import { selectionsAreEqual } from "@html_editor/utils/selection";
 import { isAndroid, isBrowserChrome } from "@web/core/browser/feature_detection";
 
 /**
@@ -55,15 +56,13 @@ export class DeletePlugin extends Plugin {
     static dependencies = ["selection", "history"];
     static name = "delete";
     static shared = ["deleteRange", "isUnmergeable"];
-
-    isAndroidChrome = isAndroid() && isBrowserChrome();
-
     resources = {
         onBeforeInput: [
             withSequence(5, this.onBeforeInputInsertText.bind(this)),
             this.onBeforeInputDelete.bind(this),
         ],
-
+        onInput: this.onInput.bind(this),
+        onSelectionChange: withSequence(5, this.onSelectionChange.bind(this)),
         shortcuts: [
             { hotkey: "backspace", command: "DELETE_BACKWARD" },
             { hotkey: "delete", command: "DELETE_FORWARD" },
@@ -87,13 +86,6 @@ export class DeletePlugin extends Plugin {
             // Monetary field
             (element) => element.matches("[data-oe-type='monetary'] > span"),
         ],
-
-        ...(this.isAndroidChrome
-            ? {
-                  onInput: this.onInput.bind(this),
-                  onSelectionChange: withSequence(5, this.onSelectionChange.bind(this)),
-              }
-            : {}),
     };
 
     setup() {
@@ -1190,8 +1182,6 @@ export class DeletePlugin extends Plugin {
     // --------------------------------------------------------------------------
 
     onBeforeInputDelete(ev) {
-        console.log("beforeInput", ev);
-        // return;
         const handledInputTypes = {
             deleteContentBackward: ["backward", "character"],
             deleteContentForward: ["forward", "character"],
@@ -1203,10 +1193,11 @@ export class DeletePlugin extends Plugin {
         const argsForDelete = handledInputTypes[ev.inputType];
         if (argsForDelete) {
             this.log(`onBeforeInputDelete: ${serializeCurrentSelection()}`);
-            this.delete(...argsForDelete);
             ev.preventDefault();
-            if (this.isAndroidChrome) {
-                this.preventDefaultDeleteAndroidChrome(ev);
+            if (isAndroid()) {
+                this.handleBeforeInputAndroid(argsForDelete);
+            } else {
+                this.delete(...argsForDelete);
             }
         }
     }
@@ -1221,43 +1212,86 @@ export class DeletePlugin extends Plugin {
         }
     }
 
-    // ======== ANDROID CHROME =============
+    // ======== ANDROID =============
+
+    handleBeforeInputAndroid(argsForDelete) {
+        this.fixSelectionPreDelete();
+        this.delete(...argsForDelete);
+
+        // Record the resulting selection as trusted: it matters for fast sequential deletes.
+        this.recordSelection(this.shared.getEditableSelection(), { trusted: true });
+
+        if (isBrowserChrome()) {
+            this.preventDefaultDeleteAndroidChrome();
+        }
+    }
+
+    // Revert selection changes that happened right before delete.
+    fixSelectionPreDelete() {
+        // Restore selection to the last legit one.
+        const currentSelection = this.shared.getEditableSelection();
+        const lastRecodedSelection = this.getLastRecordedSelection();
+        if (lastRecodedSelection && !selectionsAreEqual(lastRecodedSelection, currentSelection)) {
+            this.shared.setSelection(lastRecodedSelection, { normalize: false });
+            console.log("selection fixed pre-delete");
+            this.dispatch("HISTORY_STAGE_SELECTION");
+        }
+    }
 
     // Beforeinput event of type deleteContentBackward cannot be default
     // prevented in Android Chrome. So we need to revert eventual mutations and
     // selection change.
-    preventDefaultDeleteAndroidChrome(ev) {
+    preventDefaultDeleteAndroidChrome() {
         const revertDomChanges = this.shared.makeSavePoint();
-        this.runOnceOnInput ??= {};
-        this.runOnceOnInput[ev.inputType] = () => {
+        this.runOnceOnInput = () => {
             revertDomChanges();
             // Chrome might change the selection *after* the input event.
             const { restore: revertSelectionChange } = this.shared.preserveSelection();
             this.runOnceOnSelectionChange = revertSelectionChange;
-            // But we don't want to interfere with it if it's followed by text
-            // input (eg. using dictionary)
-            this.runOnceOnInput["insertText"] = () => {
-                delete this.runOnceOnSelectionChange;
-            };
         };
     }
 
-    onInput(ev) {
-        console.log("input", ev);
-
-        if (this.runOnceOnInput?.[ev.inputType]) {
-            this.runOnceOnInput[ev.inputType]();
-            delete this.runOnceOnInput[ev.inputType];
+    onInput() {
+        if (this.runOnceOnInput) {
+            this.runOnceOnInput();
+            delete this.runOnceOnInput;
         }
     }
 
-    onSelectionChange() {
+    onSelectionChange({ editableSelection }) {
         this.log(`onSelectionChange: ${serializeCurrentSelection()}`);
+        this.recordSelection(editableSelection);
 
         if (this.runOnceOnSelectionChange) {
             this.runOnceOnSelectionChange();
             delete this.runOnceOnSelectionChange;
         }
+    }
+
+    recordSelection(editableSelection, { trusted = false } = {}) {
+        const SELECTION_HISTORY_SIZE = 10;
+        this.selectionHistory ??= [];
+
+        this.selectionHistory.push({ editableSelection, timestamp: Date.now(), trusted });
+
+        if (this.selectionHistory.length > SELECTION_HISTORY_SIZE) {
+            this.selectionHistory.shift();
+        }
+    }
+
+    // Get last **legit** selection. TODO: find a better way, not time-based?
+    getLastRecordedSelection() {
+        const DELTA = 100; // ms
+        const now = Date.now();
+
+        let lastSelection = this.selectionHistory?.at(-1);
+        while (lastSelection && !lastSelection.trusted && lastSelection.timestamp > now - DELTA) {
+            // Discard non-legit selection.
+            console.log("non-legit recorded selection discarded");
+            this.selectionHistory.pop();
+            lastSelection = this.selectionHistory.at(-1);
+        }
+        return lastSelection?.editableSelection;
     }
 
     // ======== AD-HOC STUFF ========

--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -114,6 +114,7 @@ export class HistoryPlugin extends Plugin {
         this.observer = new MutationObserver(this.handleNewRecords.bind(this));
         this._cleanups.push(() => this.observer.disconnect());
         this.clean();
+        window.HistoryPlugin = this;
     }
     handleCommand(command, payload) {
         switch (command) {
@@ -956,6 +957,7 @@ export class HistoryPlugin extends Plugin {
         for (let i = this.steps.length - 1; i > stepIndex; i--) {
             const currentStep = this.steps[i];
             this.revertMutations(currentStep.mutations, { forNewStep: true });
+            console.log("mutations reversed");
             // Process (filter, handle and stage) mutations so that the
             // attribute comparison for the state change is done with the
             // intermediate attribute value and not with the final value in the

--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -115,6 +115,15 @@ export class HistoryPlugin extends Plugin {
         this._cleanups.push(() => this.observer.disconnect());
         this.clean();
         window.HistoryPlugin = this;
+
+        const undoButton = document.createElement("button");
+        undoButton.textContent = "Undo";
+        undoButton.onclick = () => this.undo();
+        const redoButton = document.createElement("button");
+        redoButton.textContent = "Redo";
+        redoButton.onclick = () => this.redo();
+        this.document.querySelector(".o_main_navbar").prepend(redoButton);
+        this.document.querySelector(".o_main_navbar").prepend(undoButton);
     }
     handleCommand(command, payload) {
         switch (command) {

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -17,6 +17,7 @@ import {
     normalizeCursorPosition,
     normalizeDeepCursorPosition,
     normalizeFakeBR,
+    selectionsAreEqual,
 } from "../utils/selection";
 
 /**
@@ -121,6 +122,7 @@ export class SelectionPlugin extends Plugin {
         "modifySelection",
         "rectifySelection",
         "focusEditable",
+        "isSelectionInEditable",
         // "collapseIfZWS",
     ];
     resources = {
@@ -503,15 +505,16 @@ export class SelectionPlugin extends Plugin {
 
         return {
             restore: () => {
-                this.setSelection(
-                    {
-                        anchorNode: anchor.node,
-                        anchorOffset: anchor.offset,
-                        focusNode: focus.node,
-                        focusOffset: focus.offset,
-                    },
-                    { normalize: false }
-                );
+                const selectionToRestore = {
+                    anchorNode: anchor.node,
+                    anchorOffset: anchor.offset,
+                    focusNode: focus.node,
+                    focusOffset: focus.offset,
+                };
+                if (!selectionsAreEqual(this.getEditableSelection(), selectionToRestore)) {
+                    console.log("selection fixed post-delete");
+                }
+                this.setSelection(selectionToRestore, { normalize: false });
             },
             update(callback) {
                 callback(anchor);

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -504,14 +504,14 @@ export class SelectionPlugin extends Plugin {
         const focus = { node: selection.focusNode, offset: selection.focusOffset };
 
         return {
-            restore: () => {
+            restore: ({ log = false } = {}) => {
                 const selectionToRestore = {
                     anchorNode: anchor.node,
                     anchorOffset: anchor.offset,
                     focusNode: focus.node,
                     focusOffset: focus.offset,
                 };
-                if (!selectionsAreEqual(this.getEditableSelection(), selectionToRestore)) {
+                if (log && !selectionsAreEqual(this.getEditableSelection(), selectionToRestore)) {
                     console.log("selection fixed post-delete");
                 }
                 this.setSelection(selectionToRestore, { normalize: false });

--- a/addons/html_editor/static/src/utils/selection.js
+++ b/addons/html_editor/static/src/utils/selection.js
@@ -268,9 +268,3 @@ export function getAdjacentCharacter(selection, side, editable) {
     }
     return adjacentCharacter;
 }
-
-export function selectionsAreEqual(selection1, selection2) {
-    return ["anchorNode", "anchorOffset", "focusNode", "focusOffset"].every(
-        (key) => selection1[key] === selection2[key]
-    );
-}

--- a/addons/html_editor/static/src/utils/selection.js
+++ b/addons/html_editor/static/src/utils/selection.js
@@ -268,3 +268,9 @@ export function getAdjacentCharacter(selection, side, editable) {
     }
     return adjacentCharacter;
 }
+
+export function selectionsAreEqual(selection1, selection2) {
+    return ["anchorNode", "anchorOffset", "focusNode", "focusOffset"].every(
+        (key) => selection1[key] === selection2[key]
+    );
+}


### PR DESCRIPTION
Steps:
1. On mobile Chrome, have two paragraphs with some text, and place the cursor at the beginning of the second paragraph. E.g.: ```<p>abc</p> <p>[]def</p>```

2. Press backspace on the device's virtual keyboard.

As a result, the paragraphs are merged (as expected), but the cursor is placed in the wrong position, e.g.:
        `<p>abcd[]ef</p>`, whilst `<p>abc[]def</p>` was expected.

The issue seems to be a bug in contenteditable in Android Chrome. The same issue happens in a contenteditable div, without Odoo's HTML editor.

This commit introduces a workaround for this issue. It stores the selection resulting from the delete operation, and on the following selectionchange event, it checks if the selection is different from the stored one, and if so, it reverts the selection to the stored one.

task-4243933

