### PR TITLE
[16.0][SEC] point_of_sale: add multi company rule for pos order line

### DIFF
--- a/addons/point_of_sale/security/point_of_sale_security.xml
+++ b/addons/point_of_sale/security/point_of_sale_security.xml
@@ -52,6 +52,11 @@
         <field name="model_id" ref="model_pos_order" />
         <field name="domain_force">[('company_id', 'in', company_ids)]</field>
     </record>
+    <record id="rule_pos_order_line_multi_company" model="ir.rule">
+        <field name="name">Point Of Sale Order Line</field>
+        <field name="model_id" ref="model_pos_order_line" />
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
+    </record>
     <record id="rule_pos_session_multi_company" model="ir.rule">
         <field name="name">Point Of Sale Session</field>
         <field name="model_id" ref="model_pos_session" />


### PR DESCRIPTION
**Rational:** 

for the time being pos.order model has a classic ir.rule ([('company_id', 'in', company_ids)]). However pos.order.line doesn't have such rule. So if we create a new menu and action to display pos.order.line model, it will display all the order lines, regardless the current companies of the user.

**Note:** 
We apply exactly the same logic as for the model sale.order and sale.order.line.
See : https://github.com/odoo/odoo/blob/16.0/addons/sale/security/ir_rules.xml#L5-L15

