### PR TITLE
[FIX] web: correct positioning of field translation in quotation template

### DIFF
--- a/addons/mail/static/src/views/web/fields/emojis_char_field/emojis_char_field.xml
+++ b/addons/mail/static/src/views/web/fields/emojis_char_field/emojis_char_field.xml
@@ -5,7 +5,7 @@
         <xpath expr="//span[1]" position="attributes">
             <attribute name="t-ref">targetReadonlyElement</attribute>
         </xpath>
-        <xpath expr="//*[hasclass('o_field_char_buttons')]/button" position="before">
+        <xpath expr="//div[hasclass('o_field_char_buttons')]" position="before">
             <t t-call="mail.EmojisFieldButton">
                 <t t-set="positionCenter" t-value="true"/>
             </t>

--- a/addons/project/static/tests/legacy/project_subtask_kanban_list_form_tests.js
+++ b/addons/project/static/tests/legacy/project_subtask_kanban_list_form_tests.js
@@ -175,7 +175,7 @@ QUnit.module('Subtask Kanban List tests', {
         await click(target.querySelector(".o_field_x2many_list_row_add a"));
         await clickDropdown(target, 'project_id');
         await clickOpenedDropdownItem(target, 'project_id', 'Project One');
-        await editInput(target, ".o_data_row > td[name='name'] > div > input", "aaa");
+        await editInput(target, ".o_data_row > td[name='name'] > div > div > input", "aaa");
         await click(target, ".o_form_button_save");
         assert.equal(target.querySelector('.o_field_project').textContent.trim(), 'Project One')
     });
@@ -188,7 +188,7 @@ QUnit.module('Subtask Kanban List tests', {
 
         assert.strictEqual(
             document.activeElement,
-            target.querySelector(".o_data_row > td[name='name'] > div > input"),
+            target.querySelector(".o_data_row > td[name='name'] > div > div > input"),
             "Upon clicking on 'Add a line', the new subtask's name should be focused."
         );
     });

--- a/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
+++ b/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
@@ -58,7 +58,7 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
     content: 'Click on Create button to create a task into your project.',
     run: "click",
 }, {
-    trigger: 'div[name="display_name"] > input',
+    trigger: 'div[name="display_name"] > div > input',
     content: 'Select the name of the task (e.g. Onboarding)',
     run: "edit Onboarding",
 }, {

--- a/addons/web/static/src/views/fields/char/char_field.xml
+++ b/addons/web/static/src/views/fields/char/char_field.xml
@@ -6,32 +6,35 @@
             <span t-esc="formattedValue" />
         </t>
         <t t-else="">
-            <input
-                class="o_input"
-                t-att-class="{
-                    'o_field_translate': isTranslatable,
-                    'o_field_placeholder': hasDynamicPlaceholder
-                }"
-                t-att-id="props.id"
-                t-att-type="props.isPassword ? 'password' : 'text'"
-                t-att-autocomplete="props.autocomplete or (props.isPassword ? 'new-password' : 'off')"
-                t-att-maxlength="maxLength > 0 and maxLength"
-                t-att-placeholder="placeholder"
-                t-on-blur="onBlur"
-                t-ref="input"
-            />
-            <div class="o_field_char_buttons position-absolute d-inline">
-                <t t-if="isTranslatable">
-                    <TranslationButton
-                        fieldName="props.name"
-                        record="props.record"
-                    />
-                </t>
-                <button t-if="hasDynamicPlaceholder"
-                    class="btn m-0 py-0 px-2 fa fa-magic"
-                    title="Insert Field"
-                    t-on-click="onDynamicPlaceholderOpen"
+            <div class="d-flex align-items-center w-100">
+                <input
+                    class="o_input flex-grow-1"
+                    t-att-class="{
+                        'o_field_translate': isTranslatable,
+                        'o_field_placeholder': hasDynamicPlaceholder
+                    }"
+                    t-att-id="props.id"
+                    t-att-type="props.isPassword ? 'password' : 'text'"
+                    t-att-autocomplete="props.autocomplete or (props.isPassword ? 'new-password' : 'off')"
+                    t-att-maxlength="maxLength > 0 and maxLength"
+                    t-att-placeholder="placeholder"
+                    t-on-blur="onBlur"
+                    t-ref="input"
                 />
+                <div class="o_field_char_buttons d-flex align-items-center ms-2">
+                    <t t-if="isTranslatable">
+                        <TranslationButton
+                            fieldName="props.name"
+                            record="props.record"
+                        />
+                    </t>
+                    <t t-if="hasDynamicPlaceholder">
+                        <button class="btn m-0 py-0 px-2 fa fa-magic"
+                            title="Insert Field"
+                            t-on-click="onDynamicPlaceholderOpen"
+                        />
+                    </t>
+                </div>
             </div>
         </t>
     </t>

--- a/addons/web/static/src/views/fields/text/text_field.xml
+++ b/addons/web/static/src/views/fields/text/text_field.xml
@@ -6,7 +6,7 @@
             <span t-esc="props.record.data[props.name] or ''" />
         </t>
         <t t-else="">
-            <div t-ref="div">
+            <div class="d-flex align-items-baseline" t-ref="div">
                 <textarea
                     class="o_input"
                     t-att-class="{'o_field_translate': isTranslatable}"


### PR DESCRIPTION
**Version**: 18.0

**Steps to Reproduce**:
1. Navigate to the Subscription module.
2. Open the quotation template form view.
3. Click on the description field in the lines.
   
**Issue 1**: 
The position of the translation field in the description lines appears misaligned.

**Solution 1**: 
Align the flex items along the baseline of the text to ensure proper alignment of the translation field.

---

**Steps to Reproduce**:
1. Install the Sign, Project, and Web Editor modules.
2. Enable multi-language support.

**Issue 2**: 
The translation button in multi-language support is misaligned due to improper absolute positioning within a `div` tag.

**Cause**:
The button is positioned using `absolute`, which disrupts alignment.

**Solution 2**: 
Remove the `absolute` positioning to fix the alignment issue and ensure proper placement of the translation button.
