### PR TITLE
[FIX] account_edi: ensure one on button_process_edi_web_services

### DIFF
--- a/addons/account_edi/models/account_move.py
+++ b/addons/account_edi/models/account_move.py
@@ -426,6 +426,7 @@ class AccountMove(models.Model):
     ####################################################
 
     def button_process_edi_web_services(self):
+        self.ensure_one()
         self.action_process_edi_web_services(with_commit=False)
 
     def action_process_edi_web_services(self, with_commit=True):


### PR DESCRIPTION
This fix aims to prevent the button_process_edi_web_services function from being executed with multiple records simultaneously. The reason is that calling action_process_edi_web_services with with_commit=False can cause issues if Odoo crashes in the middle of execution (e.g., the document is sent but not updated in Odoo, so when the server restarts, the document is sent again).

Although I don't believe anything in Odoo calls this function with multiple records. But we encountered a case where a client had a server action that invoked this function with multiple records at the same tim, and it caused a duplicate document sent.

opw-4195392