### PR TITLE
[IMP] mail: restrict template rendering by default

### DIFF
--- a/addons/event/security/event_security.xml
+++ b/addons/event/security/event_security.xml
@@ -21,7 +21,7 @@
         <record id="group_event_manager" model="res.groups">
             <field name="name">Administrator</field>
             <field name="category_id" ref="base.module_category_marketing_events"/>
-            <field name="implied_ids" eval="[(4, ref('group_event_user')), (4, ref('mail.group_mail_template_editor'))]"/>
+            <field name="implied_ids" eval="[(4, ref('group_event_user'))]"/>
             <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
         </record>
     </data>

--- a/addons/hr_recruitment/security/hr_recruitment_security.xml
+++ b/addons/hr_recruitment/security/hr_recruitment_security.xml
@@ -35,7 +35,7 @@
     <record id="group_hr_recruitment_manager" model="res.groups">
         <field name="name">Administrator</field>
         <field name="category_id" ref="base.module_category_human_resources_recruitment"/>
-        <field name="implied_ids" eval="[(4, ref('group_hr_recruitment_user')), (4, ref('mail.group_mail_template_editor'))]"/>
+        <field name="implied_ids" eval="[(4, ref('group_hr_recruitment_user'))]"/>
         <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
     </record>
 

--- a/addons/mail/data/ir_config_parameter_data.xml
+++ b/addons/mail/data/ir_config_parameter_data.xml
@@ -5,5 +5,9 @@
             <field name="key">mail.activity.gc.delete_overdue_years</field>
             <field name="value">3</field>
         </record>
+        <record id="restrict_template_rendering" model="ir.config_parameter">
+            <field name="key">mail.restrict.template.rendering</field>
+            <field name="value">1</field>
+        </record>
     </data>
 </odoo>

--- a/addons/mail/data/mail_groups.xml
+++ b/addons/mail/data/mail_groups.xml
@@ -19,11 +19,6 @@
         <field name="implied_ids" eval="[(4, ref('mail.group_mail_template_editor')), (4, ref('mail.group_mail_canned_response_admin'))]"/>
     </record>
 
-    <!-- By default, allow all users to edit mail templates -->
-    <record id="base.group_user" model="res.groups">
-        <field name="implied_ids" eval="[(4, ref('mail.group_mail_template_editor'))]"/>
-    </record>
-
     <!-- Group used for the notification_type field of res.users -->
     <record id="group_mail_notification_type_inbox" model="res.groups">
         <field name="name">Receive notifications in Odoo</field>

--- a/addons/marketing_card/models/card_campaign.py
+++ b/addons/marketing_card/models/card_campaign.py
@@ -10,6 +10,7 @@ class CardCampaign(models.Model):
     _description = 'Marketing Card Campaign'
     _inherit = ['mail.activity.mixin', 'mail.render.mixin', 'mail.thread']
     _order = 'id DESC'
+    _unrestricted_rendering = True
 
     def _default_card_template_id(self):
         return self.env['card.template'].search([], limit=1)
@@ -114,6 +115,24 @@ class CardCampaign(models.Model):
             'content_section_path', 'content_sub_section1', 'content_sub_section1_dyn', 'content_sub_header_color',
             'content_sub_section1_path', 'content_sub_section2', 'content_sub_section2_dyn', 'content_sub_section2_path'
         ]
+
+    def _check_access_right_dynamic_template(self):
+        """ `_unrestricted_rendering` being True means we trust the value on model
+        when rendering. This means once created, rendering is done without restriction.
+        But this attribute triggers a check at create / write / translation update that
+        current user is an admin or has full edition rights (group_mail_template_editor).
+
+         However here a Marketing Card Manager must be able to edit the fields other
+         than the rendering fields. The qweb rendered field `body_html` cannot be
+         modified by users other than the `base.group_system` users, as
+        - it's a related field to `card.template.body`,
+        - store=False
+        - the model `card.template` can only be altered by `base.group_system`
+
+        Hence the security is delegated to the 'card.template' model, hence the
+        check done by `_check_access_right_dynamic_template` can be bypassed.
+        """
+        return
 
     @api.depends(lambda self: self._get_render_fields() + ['preview_record_ref'])
     def _compute_image_preview(self):

--- a/addons/mass_mailing/security/res_groups_data.xml
+++ b/addons/mass_mailing/security/res_groups_data.xml
@@ -13,9 +13,4 @@
         <field name="category_id" ref="base.module_category_hidden"/>
     </record>
 
-    <data noupdate="1">
-        <record id="group_mass_mailing_user" model="res.groups">
-            <field name="implied_ids" eval="[(4, ref('mail.group_mail_template_editor'))]"/>
-        </record>
-    </data>
 </odoo>

--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -15,7 +15,7 @@
     <record id="group_project_manager" model="res.groups">
         <field name="name">Administrator</field>
         <field name="category_id" ref="base.module_category_services_project"/>
-        <field name="implied_ids" eval="[(4, ref('group_project_user')), (4, ref('mail.group_mail_template_editor')), (4, ref('mail.group_mail_canned_response_admin'))]"/>
+        <field name="implied_ids" eval="[(4, ref('group_project_user')), (4, ref('mail.group_mail_canned_response_admin'))]"/>
         <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
     </record>
 

--- a/addons/sales_team/security/sales_team_security.xml
+++ b/addons/sales_team/security/sales_team_security.xml
@@ -24,7 +24,6 @@
             <field name="comment">the user will have an access to the sales configuration as well as statistic reports.</field>
             <field name="category_id" ref="base.module_category_sales_sales"/>
             <field name="implied_ids" eval="[(4, ref('group_sale_salesman_all_leads')),
-                         (4, ref('mail.group_mail_template_editor')),
                          (4, ref('mail.group_mail_canned_response_admin'))]"/>
             <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
         </record>


### PR DESCRIPTION
https://github.com/odoo/odoo/pull/164671
offers a way for non-template editors to use simple expressions.

Thanks to this, most of the expressions used in email templates, such as the partner name in an opportunity email template, can be used by regular users without the need to be an email template editor.

Thanks to this, the need to set, by default,
internal users as template editors is no longer a strong necessity.

This revision aims to set the "Restrict Template Rendering" setting by default.
Companies needing to set everyone as an email template editor can enable this back by un-checking its related box in the general settings.

task-4246174
