### PR TITLE
[FIX] stock_account: remove CoGS analytic_distribution

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -160,7 +160,6 @@ class AccountMove(models.Model):
                     'price_unit': -price_unit,
                     'amount_currency': amount_currency,
                     'account_id': credit_expense_account.id,
-                    'analytic_distribution': line.analytic_distribution,
                     'display_type': 'cogs',
                     'tax_ids': [],
                 })


### PR DESCRIPTION
Steps to reproduce:
 - Enable Analytic Accounting and Anglo-Saxon Accounting in the settings
 - Create a storable product
    - Set inventory valuation to Automated on the product's category
    - Add a cost to the product
 - Create an invoice with the product and add an analytic distribution
 - When the invoice is confirmed, the distribution is also applied to the CoGS line.

For example, in an invoice where the product’s sale price equals its cost, the account plan will show a balance of 0 (debit = credit).

After this fix, the account plan will show a balance of 10.

Task 2008567 led to the commit https://github.com/odoo/odoo/commit/3590efa47849be09e694e7755ec640f41cb14313, which removed the analytic distribution from the stock interim account. However, the expense line was not modified accordingly.

opw-4177695