### PR TITLE
[IMP] event: editable event and ticket type after registration

### DIFF
--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -31,9 +31,9 @@ class EventRegistration(models.Model):
 
     # event
     event_id = fields.Many2one(
-        'event.event', string='Event', required=True)
+        'event.event', string='Event', required=True, tracking=True)
     event_ticket_id = fields.Many2one(
-        'event.event.ticket', string='Ticket Type', ondelete='restrict')
+        'event.event.ticket', string='Ticket Type', ondelete='restrict', tracking=True)
     active = fields.Boolean(default=True)
     barcode = fields.Char(string='Barcode', default=lambda self: self._get_random_barcode(), readonly=True, copy=False)
     # utm informations

--- a/addons/event/views/event_registration_views.xml
+++ b/addons/event/views/event_registration_views.xml
@@ -17,8 +17,8 @@
                 <field name="email" optional="show"/>
                 <field name="phone" optional="show"/>
                 <field name="company_name" optional="hide"/>
-                <field name="event_id" column_invisible="context.get('default_event_id')" readonly="state != 'draft'"/>
-                <field name="event_ticket_id" domain="[('event_id', '=', event_id)]" readonly="state != 'draft'"/>
+                <field name="event_id" column_invisible="context.get('default_event_id')"/>
+                <field name="event_ticket_id" domain="[('event_id', '=', event_id)]"/>
                 <field name="activity_ids" widget="list_activity"/>
                 <field name="state" decoration-info="state in ('draft', 'open')"
                        decoration-success="state == 'done'"
@@ -66,10 +66,10 @@
                             <field name="company_name" placeholder='e.g. "Azure Interior"'/>
                         </group>
                         <group string="Event Information" name="event">
-                            <field class="text-break" name="event_id" readonly="event_id and state != 'draft' and id"
+                            <field class="text-break" name="event_id"
                                    context="{'name_with_seats_availability': True}" options="{'no_create': True}"/>
                             <field name="barcode" groups="base.group_no_one"/>
-                            <field name="event_ticket_id" invisible="not event_id" readonly="event_ticket_id and state != 'draft' and id"
+                            <field name="event_ticket_id" invisible="not event_id"
                                    context="{'name_with_seats_availability': True}" options="{'no_open': True, 'no_create': True}"
                                    domain="[('event_id', '=', event_id)]"/>
                             <field name="partner_id"/>


### PR DESCRIPTION
#### Purpose:
Enhance the flexibility for event organizers by:
- Allowing users to change the event after registration.
- Allowing users to change the ticket type after registration.

#### After this PR:
Removed the `readonly` attribute from the `event_id` and `event_ticket_id` fields.
Added tracking to allow users to track changes made to these fields.

Task-4243953
