### PR TITLE
[IMP] pos_restaurant: order lines should stick to their initial table

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_restaurant/static/src/overrides/components/payment_screen/payment_screen.js
@@ -24,6 +24,23 @@ patch(PaymentScreen.prototype, {
                 this.pos.data.write("restaurant.table", [table.id], { parent_id: null });
             }
         }
+        // Delete orders from the original table if it has been merged with another table
+        const orderToDelete = [];
+        let table = this.currentOrder?.table_id?.uiState?.childTable;
+
+        while (table) {
+            const orders = table
+                .map((tableId) =>
+                    this.pos.models["pos.order"].find(
+                        (o) => o.table_id.id === tableId && !o.finalized
+                    )
+                )
+                .filter((order) => order);
+            orderToDelete.push(...orders);
+            table = table?.uiState?.childTable;
+        }
+        await this.pos.deleteOrders(orderToDelete);
+
         return await super.afterOrderValidation(...arguments);
     },
 });


### PR DESCRIPTION
Before this commit:
===================
When merging tables, the order from the original table was transferred to the destination table, and the original table's order was deleted. As a result, when tables were unmerged, the original table's order could not be restored.

After this commit:
==================
When tables are merged and later unmerged, the original table's orders are successfully restored. This ensures that each table retains its initial order even after being merged and unmerged.

Task- 4224207

