### PR TITLE
[FIX] html_editor, web_editor: adapt selectors to match both /shape/

### DIFF
--- a/addons/html_editor/static/src/main/media/image_crop.js
+++ b/addons/html_editor/static/src/main/media/image_crop.js
@@ -92,7 +92,7 @@ export class ImageCrop extends Component {
         this.mimetype = this.props.mimetype || mimetype;
 
         await loadImageInfo(this.media);
-        const isIllustration = /^\/html_editor\/shape\/illustration\//.test(
+        const isIllustration = /^\/(?:html|web)_editor\/shape\/illustration\//.test(
             this.media.dataset.originalSrc
         );
         this.uncroppable = false;

--- a/addons/html_editor/static/src/main/media/media_dialog/file_documents_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/file_documents_selector.js
@@ -31,7 +31,9 @@ export class FileDocumentsSelector extends DocumentSelector {
             "!",
             ["url", "=like", "/%/static/%"],
             "!",
-            ["url", "=ilike", "/html_editor/shape/%"]
+            "|",
+            ["url", "=ilike", "/html_editor/shape/%"],
+            ["url", "=ilike", "/web_editor/shape/%"],
         );
         domain.push("!", ["name", "=like", "%.crop"]);
         return domain;

--- a/addons/html_editor/static/src/main/media/media_dialog/image_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/image_selector.js
@@ -132,7 +132,9 @@ export class ImageSelector extends FileSelector {
         const domain = super.attachmentsDomain;
         domain.push(["mimetype", "in", IMAGE_MIMETYPES]);
         if (!this.props.useMediaLibrary) {
-            domain.push("|", ["url", "=", false], "!", ["url", "=ilike", "/html_editor/shape/%"]);
+            domain.push("|", ["url", "=", false],
+                "!", "|", ["url", "=ilike", "/html_editor/shape/%"], ["url", "=ilike", "/web_editor/shape/%"],
+            );
         }
         domain.push("!", ["name", "=like", "%.crop"]);
         domain.push("|", ["type", "=", "binary"], "!", ["url", "=like", "/%/static/%"]);
@@ -204,7 +206,10 @@ export class ImageSelector extends FileSelector {
             if (attachment.image_src.startsWith("/")) {
                 const newURL = new URL(attachment.image_src, window.location.origin);
                 // Set the main colors of dynamic SVGs to o-color-1~5
-                if (attachment.image_src.startsWith("/html_editor/shape/")) {
+                if (
+                    attachment.image_src.startsWith("/html_editor/shape/") ||
+                    attachment.image_src.startsWith("/web_editor/shape/")
+                ) {
                     newURL.searchParams.forEach((value, key) => {
                         const match = key.match(/^c([1-5])$/);
                         if (match) {
@@ -329,7 +334,10 @@ export class ImageSelector extends FileSelector {
             .concat(savedMedia)
             .map((attachment) => {
                 // Color-customize dynamic SVGs with the theme colors
-                if (attachment.image_src && attachment.image_src.startsWith("/html_editor/shape/")) {
+                if (attachment.image_src && (
+                    attachment.image_src.startsWith("/html_editor/shape/") ||
+                    attachment.image_src.startsWith("/web_editor/shape/")
+                )) {
                     const colorCustomizedURL = new URL(
                         attachment.image_src,
                         window.location.origin

--- a/addons/web_editor/static/src/components/media_dialog/image_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/image_selector.js
@@ -124,7 +124,9 @@ export class ImageSelector extends FileSelector {
         const domain = super.attachmentsDomain;
         domain.push(['mimetype', 'in', IMAGE_MIMETYPES]);
         if (!this.props.useMediaLibrary) {
-            domain.push('|', ['url', '=', false], '!', ['url', '=ilike', '/web_editor/shape/%']);
+            domain.push("|", ["url", "=", false],
+                "!", "|", ["url", "=ilike", "/html_editor/shape/%"], ["url", "=ilike", "/web_editor/shape/%"],
+            );
         }
         domain.push('!', ['name', '=like', '%.crop']);
         domain.push('|', ['type', '=', 'binary'], '!', ['url', '=like', '/%/static/%']);
@@ -216,7 +218,9 @@ export class ImageSelector extends FileSelector {
             if (attachment.image_src.startsWith('/')) {
                 const newURL = new URL(attachment.image_src, window.location.origin);
                 // Set the main colors of dynamic SVGs to o-color-1~5
-                if (attachment.image_src.startsWith('/web_editor/shape/')) {
+                if (attachment.image_src.startsWith('/html_editor/shape/') ||
+                    attachment.image_src.startsWith('/web_editor/shape/')
+                ) {
                     newURL.searchParams.forEach((value, key) => {
                         const match = key.match(/^c([1-5])$/);
                         if (match) {
@@ -328,7 +332,10 @@ export class ImageSelector extends FileSelector {
         }
         const selected = selectedMedia.filter(media => media.mediaType === 'attachment').concat(savedMedia).map(attachment => {
             // Color-customize dynamic SVGs with the theme colors
-            if (attachment.image_src && attachment.image_src.startsWith('/web_editor/shape/')) {
+            if (attachment.image_src && (
+                attachment.image_src.startsWith('/html_editor/shape/') ||
+                attachment.image_src.startsWith('/web_editor/shape/')
+            )) {
                 const colorCustomizedURL = new URL(attachment.image_src, window.location.origin);
                 colorCustomizedURL.searchParams.forEach((value, key) => {
                     const match = key.match(/^c([1-5])$/);

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -3637,7 +3637,7 @@ class SnippetsMenu extends Component {
                 $toInsert = $baseBody.clone();
                 isSnippetGroup = $toInsert[0].matches(".s_snippet_group");
                 // Color-customize dynamic SVGs in dropped snippets with current theme colors.
-                [...$toInsert.find('img[src^="/web_editor/shape/"]')].forEach(dynamicSvg => {
+                [...$toInsert.find('img[src^="/html_editor/shape/"], img[src^="/web_editor/shape/"]')].forEach(dynamicSvg => {
                     const colorCustomizedURL = new URL(dynamicSvg.getAttribute('src'), window.location.origin);
                     colorCustomizedURL.searchParams.forEach((value, key) => {
                         const match = key.match(/^c([1-5])$/);

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -8277,7 +8277,10 @@ registry.BackgroundImage = SnippetOptionWidget.extend({
             return src.searchParams.has(params.colorName);
         } else if (widgetName === 'main_color_opt') {
             const src = new URL(getBgImageURL(this.$target[0]), window.location.origin);
-            return src.origin === window.location.origin && src.pathname.startsWith('/web_editor/shape/');
+            return src.origin === window.location.origin && (
+                src.pathname.startsWith('/html_editor/shape/') ||
+                src.pathname.startsWith('/web_editor/shape/')
+            );
         }
         return this._super(...arguments);
     },
@@ -9580,7 +9583,7 @@ registry.DynamicSvg = SnippetOptionWidget.extend({
      * @override
      */
     _computeVisibility(methodName, params) {
-        return this.$target.is("img[src^='/web_editor/shape/']");
+        return this.$target.is("img[src^='/html_editor/shape/'], img[src^='/web_editor/shape/']");
     },
 
     //--------------------------------------------------------------------------

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop.js
@@ -150,7 +150,7 @@ export class ImageCrop extends Component {
         this.mimetype = this.props.mimetype || mimetype;
 
         await loadImageInfo(this.media);
-        const isIllustration = /^\/web_editor\/shape\/illustration\//.test(this.media.dataset.originalSrc);
+        const isIllustration = /^\/(?:html|web)_editor\/shape\/illustration\//.test(this.media.dataset.originalSrc);
         this.uncroppable = false;
         if (this.media.dataset.originalSrc && !isIllustration) {
             this.originalSrc = this.media.dataset.originalSrc;

--- a/addons/website/static/tests/tours/media_dialog.js
+++ b/addons/website/static/tests/tours/media_dialog.js
@@ -41,37 +41,31 @@ registerWebsitePreviewTour("website_media_dialog_external_library", {
     }),
     {
         content: "Open the media dialog from the snippet",
-        trigger: "iframe .s_text_image img",
+        trigger: ":iframe .s_text_image img",
         run: "dblclick",
     }, {
         content: "Dummy search to call the media library",
         trigger: ".o_select_media_dialog .o_we_search",
-        run: "text a",
+        run: "edit a",
     }, {
         content: "Choose the media library to only show its media",
         trigger: ".o_select_media_dialog .o_we_search_select",
-        // This is a standard <select>: we can't simulate a click on the option
-        // directly.
-        async run(actions) {
-            await actions.click();
-            await actions.text("Illustrations");
-            this.$anchor.trigger($.Event("keydown", {key: 'Enter', keyCode: 13}));
-        },
+        run: "select Illustrations",
     }, {
         content: "Double click on the first image",
         trigger: ".o_select_media_dialog img.o_we_attachment_highlight",
-        run: "dblclick",
+        run: "click",
     }, {
         content: "Reopen the media dialog",
-        trigger: "iframe .s_text_image img",
+        trigger: ":iframe .s_text_image img",
         run: "dblclick",
     }, {
         content: "Check that the image was created only once",
-        trigger: ".o_select_media_dialog .o_we_existing_attachments",
+        trigger: ".o_select_media_dialog .o_we_existing_attachments .o_existing_attachment_cell img[src^='/html_editor/shape/illustration/']",
         run() {
-            const selector = ".o_existing_attachment_cell img[src^='/web_editor/shape/illustration/']";
-            const imgName = this.anchor.querySelector(selector).title;
-            const uploadedImgs = this.anchor.querySelectorAll(`${selector}[title='${imgName}']`);
+            const listEl = this.anchor.closest(".o_select_media_dialog .o_we_existing_attachments");
+            const selector = ".o_existing_attachment_cell img[src^='/html_editor/shape/illustration/']";
+            const uploadedImgs = listEl.querySelectorAll(`${selector}[title='${this.anchor.title}']`);
             if (uploadedImgs.length !== 1) {
                 throw new Error(`${uploadedImgs.length} attachment(s) were found. Exactly 1 should have been created.`);
             }


### PR DESCRIPTION
In [1] shapes and illustrations were moved to `html_editor`. While some features have been adapted to the new path, others did not. No upgrade script was created to convert existing `/web_editor/shape/` paths to new `/html_editor/shape/` paths. Instead, the old route was kept available.
However, some conditions, selectors and domains that recognized those paths have not been adapted to detect both kinds of paths.

This commit adapts those conditions, selectors and domains so that both kinds of paths are identified as being shapes or illustrations.

Steps to reproduce:
- Add an SVG illustration in a website page
- Select it

=> The "Dynamic Colors" options were not displayed

[1]: https://github.com/odoo/odoo/commit/44129d85bdc993e37384536519a03d7c29ac7e83

task-4052712
