### PR TITLE
[FIX] calendar: remove `CP buttons` extra spacing

### DIFF
--- a/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.xml
+++ b/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.xml
@@ -3,7 +3,7 @@
     <t t-name="calendar.AttendeeCalendarController" t-inherit="web.CalendarController" t-inherit-mode="primary">
         <xpath expr="//Layout" position="inside">
             <t t-set-slot="control-panel-create-button">
-                <button class="btn btn-primary o-calendar-button-new me-1" t-on-click="onClickAddButton">New</button>
+                <button class="btn btn-primary o-calendar-button-new" t-on-click="onClickAddButton">New</button>
             </t>
         </xpath>
         <!-- Add header div to be filled with synchronization buttons in synchronization modules. -->


### PR DESCRIPTION
This PR removes an extra spacing added on top of the gap rule already defined at the control panel level. As this extra spacing was leading to a weird and inconsistent visual result, we simply remove it.

- requires https://github.com/odoo/enterprise/pull/71622

| Master | This PR |
|--------|--------|
| <img width="350" alt="image" src="https://github.com/user-attachments/assets/3cf00d66-13c1-413b-a4b0-c29ab0f62453"> | <img width="326" alt="image" src="https://github.com/user-attachments/assets/0c560add-ca11-4881-b255-0f200c00ea69"> | 

task-3833933

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
