### PR TITLE
[FIX] hr_holidays_attendance: remove unnecessary view

### DIFF
--- a/addons/hr_holidays_attendance/views/hr_leave_views.xml
+++ b/addons/hr_holidays_attendance/views/hr_leave_views.xml
@@ -11,16 +11,4 @@
             </field>
         </field>
     </record>
-
-    <record id="hr_leave_view_form_overtime" model="ir.ui.view">
-        <field name="model">hr.leave</field>
-        <field name="inherit_id" ref="hr_holidays.hr_leave_view_form" />
-        <field name="arch" type="xml">
-            <field name='duration_display' position="after">
-                <div invisible="not employee_id or not overtime_deductible or employee_overtime &lt;= 0">
-                    <field name="employee_overtime" nolabel="1" widget="float_time" class="text-success" style="max-width: 6rem;" /> Extra Hours Available
-                </div>
-            </field>
-        </field>
-    </record>
 </odoo>


### PR DESCRIPTION
Steps to reproduce:

1. enable "extra hours" and add extra hours to an employee
2. as an admin go to management > time off
3. make a new time off and choose "extra hours" as the time off type
4. The duration of extra hours is duplicated

The issue happens because the form view inherits two identical views. This commit removes the unnecessary view.

task-4102491


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
