### PR TITLE
[FIX] stock: report availability from sublocations

### DIFF
--- a/addons/stock/tests/test_report.py
+++ b/addons/stock/tests/test_report.py
@@ -1389,6 +1389,18 @@ class TestReports(TestReportsCommon):
                 'forecast_availability': 3.0,
             }
         ])
+        _, _, lines = self.get_report_forecast(product_template_ids=self.product.product_tmpl_id.ids)
+        self.assertEqual(len(lines), 2)
+        picking_line = next(filter(lambda line: line.get('document_out'), lines))
+        self.assertEqual(
+            (picking_line['quantity'], picking_line['replenishment_filled'], picking_line['document_out']['id']),
+            (3.0, True, delivery.id)
+        )
+        stock_line = next(filter(lambda line: not line.get('document_out'), lines))
+        self.assertEqual(
+            (stock_line['quantity'], stock_line['replenishment_filled']),
+            (7.0, True)
+        )
 
     def test_report_forecast_14_ongoing_multi_step_delivery(self):
         """ Check that an ongoing multi-step delivery is properly picked up by the forecast report.


### PR DESCRIPTION
### Steps to reproduce:

- Enable multisteps route in the settings
- Create a storable product P and put 10 units in WH/Stock/Shelf
- Create and confirm an SO for 1 unit of P
- Go to the associated delivery and change the Source Location to WH/Stock/Shelf
- Back to the SO, click on the chart icon > view forecast
- Unreserve the 1 unit currently used by your picking

### Issue:

While you have 10 units in WH/Stock/Shelf perfectly suitable to fulfill the demand of the picking, instead of displaying a line allowing you to reserve the 1 unit, you have a line telling you that the qty is "not available" -1 unit associated with the SO.

### Cause of the issue:

Currently, in the `_get_report_lines` used to compute the forecast datas the `currents` dict used to compute both the reserved and the on hand quantity only updates the quantity of the warehouse if the location belongs to the warehouse:
https://github.com/odoo/odoo/blob/7e8afedda2cdc5ec64c1f022c116d56ec90c907a/addons/stock/report/stock_forecasted.py#L330-L336 As such, 0 units are considered to be available in these locations and nothing can be taken from stock for these moves:
https://github.com/odoo/odoo/blob/7e8afedda2cdc5ec64c1f022c116d56ec90c907a/addons/stock/report/stock_forecasted.py#L243-L249

opw-4220367
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
