### PR TITLE
[FIX] {pos_,}sale: fix price unit in report

### DIFF
--- a/addons/pos_sale/report/sale_report.py
+++ b/addons/pos_sale/report/sale_report.py
@@ -34,7 +34,7 @@ class SaleReport(models.Model):
             SUM(l.qty - l.qty_delivered) AS qty_to_deliver,
             CASE WHEN pos.state = 'invoiced' THEN SUM(l.qty) ELSE 0 END AS qty_invoiced,
             CASE WHEN pos.state != 'invoiced' THEN SUM(l.qty) ELSE 0 END AS qty_to_invoice,
-            SUM(l.price_unit)
+            AVG(l.price_unit)
                 / MIN({self._case_value_or_one('pos.currency_rate')})
                 * {self._case_value_or_one('currency_table.rate')}
             AS price_unit,

--- a/addons/sale/report/sale_report.py
+++ b/addons/sale/report/sale_report.py
@@ -108,7 +108,7 @@ class SaleReport(models.Model):
             CASE WHEN l.product_id IS NOT NULL THEN SUM((l.product_uom_qty - l.qty_delivered) / u.factor * u2.factor) ELSE 0 END AS qty_to_deliver,
             CASE WHEN l.product_id IS NOT NULL THEN SUM(l.qty_invoiced / u.factor * u2.factor) ELSE 0 END AS qty_invoiced,
             CASE WHEN l.product_id IS NOT NULL THEN SUM(l.qty_to_invoice / u.factor * u2.factor) ELSE 0 END AS qty_to_invoice,
-            CASE WHEN l.product_id IS NOT NULL THEN SUM(l.price_unit
+            CASE WHEN l.product_id IS NOT NULL THEN AVG(l.price_unit
                 / {self._case_value_or_one('s.currency_rate')}
                 * {self._case_value_or_one('currency_table.rate')}
                 ) ELSE 0


### PR DESCRIPTION
Steps:
- Install sales app.
- Create an order with 2 lines containing same products.
- Go to Reporting list view.

Issue:
- Price unit should not display sum of all price unit it should be avg.
e.g.
A line with 10 quantity and 100 amount and other with same product 10 quantity with 200 amount price unit should be avg of both lines 150 not 300 sum of both lines.

Cause:
- Wrong method used in PR: https://github.com/odoo/odoo/pull/162554

Fix:
- Use AVG method instead of SUM.

opw-4188030
