### PR TITLE
[IMP] stock: always pass warehouses as a list in the context of forecast report

### DIFF
--- a/addons/purchase_mrp/report/mrp_report_mo_overview.py
+++ b/addons/purchase_mrp/report/mrp_report_mo_overview.py
@@ -12,8 +12,7 @@ class ReportMrpReport_Mo_Overview(models.AbstractModel):
         domain = [('state', 'in', ['draft', 'sent', 'to approve']), ('product_id', '=', product.id)]
         warehouse_id = self.env.context.get('warehouse_id', False)
         if warehouse_id:
-            warehouse_id = warehouse_id if isinstance(warehouse_id, list) else [warehouse_id]
-            domain += [('order_id.picking_type_id.warehouse_id', 'in', warehouse_id)]
+            domain += [('order_id.picking_type_id.warehouse_id', '=', warehouse_id)]
         po_lines = self.env['purchase.order.line'].search(domain, order='date_planned, id')
 
         for po_line in po_lines:

--- a/addons/purchase_stock/report/stock_forecasted.py
+++ b/addons/purchase_stock/report/stock_forecasted.py
@@ -13,8 +13,7 @@ class StockForecasted_Product_Product(models.AbstractModel):
         domain += self._product_purchase_domain(product_template_ids, product_ids)
         warehouse_id = self.env.context.get('warehouse_id', False)
         if warehouse_id:
-            warehouse_id = warehouse_id if isinstance(warehouse_id, list) else [warehouse_id]
-            domain += [('order_id.picking_type_id.warehouse_id', 'in', warehouse_id)]
+            domain += [('order_id.picking_type_id.warehouse_id', '=', warehouse_id)]
         po_lines = self.env['purchase.order.line'].search(domain)
         in_sum = sum(po_lines.mapped('product_uom_qty'))
         res['draft_purchase_qty'] = in_sum

--- a/addons/sale_stock/report/stock_forecasted.py
+++ b/addons/sale_stock/report/stock_forecasted.py
@@ -53,6 +53,5 @@ class StockForecasted_Product_Product(models.AbstractModel):
             domain += [('product_id', 'in', product_ids)]
         warehouse_id = self.env.context.get('warehouse_id', False)
         if warehouse_id:
-            warehouse_id = warehouse_id if isinstance(warehouse_id, list) else [warehouse_id]
-            domain += [('warehouse_id', 'in', warehouse_id)]
+            domain += [('warehouse_id', '=', warehouse_id)]
         return domain

--- a/addons/stock/report/stock_forecasted.py
+++ b/addons/stock/report/stock_forecasted.py
@@ -115,9 +115,9 @@ class StockForecasted_Product_Product(models.AbstractModel):
     def _get_report_data(self, product_template_ids=False, product_ids=False):
         assert product_template_ids or product_ids
         res = {}
-
-        if self.env.context.get('warehouse_id') and isinstance(self.env.context['warehouse_id'], int):
-            warehouse = self.env['stock.warehouse'].browse(self.env.context.get('warehouse_id'))
+        breakpoint()
+        if self.env.context.get('warehouse_id') and not isinstance(self.env.context['warehouse_id'], int):
+            warehouse = self.env['stock.warehouse'].browse(self.env.context.get('warehouse_id')[0])
         else:
             warehouse = self.env['stock.warehouse'].search([['active', '=', True]])[0]
 

--- a/addons/stock/static/src/stock_forecasted/forecasted_warehouse_filter.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_warehouse_filter.js
@@ -24,14 +24,9 @@ export class ForecastedWarehouseFilter extends Component {
     }
 
     get activeWarehouse() {
-        let warehouseIds = null;
-        if (Array.isArray(this.context.warehouse_id)) {
-            warehouseIds = this.context.warehouse_id;
-        } else {
-            warehouseIds = [this.context.warehouse_id];
-        }
-        return warehouseIds
-            ? this.warehouses.find((w) => warehouseIds.includes(w.id))
+        const warehouse_id = this.context.warehouse_id[0];
+        return warehouse_id
+            ? this.warehouses.find((w) => w.id === warehouse_id)
             : this.warehouses[0];
     }
 

--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.js
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.js
@@ -107,12 +107,9 @@ export class StockForecasted extends Component {
     }
 
     get graphDomain() {
-        const warehouseIds = Array.isArray(this.context.warehouse_id)
-            ? this.context.warehouse_id
-            : [this.context.warehouse_id];
         const domain = [
             ["state", "=", "forecast"],
-            ["warehouse_id", "in", warehouseIds],
+            ["warehouse_id", "=", this.context.warehouse_id],
         ];
         if (this.resModel === "product.template") {
             domain.push(["product_tmpl_id", "=", this.productId]);


### PR DESCRIPTION
In this PR
========================

1. For the forecast report, always pass warehouses as a list, regardless of whether it's one or more. This reduces unnecessary code and simplifies the logic.

     The main goal is to clean this PR: ﻿﻿https://github.com/odoo/odoo/pull/178909﻿﻿

TaskId: 4214109