### PR TITLE
[FIX] hr_attendance: use same timezone for attendance and overtime

### DIFF
--- a/addons/hr_contract/models/hr_employee.py
+++ b/addons/hr_contract/models/hr_employee.py
@@ -133,6 +133,20 @@ class Employee(models.Model):
         return contracts[0].resource_calendar_id.sudo(False)
 
     @api.model
+    def _get_timezones_query(self):
+        super_query = super()._get_timezones_query()
+        return f'''(
+            WITH super AS {super_query}
+          SELECT super.employee_id,
+                 coalesce(contract_calendar.tz, super.timezone) as timezone
+            FROM super
+       LEFT JOIN hr_contract contract
+              ON contract.employee_id = super.employee_id
+       LEFT JOIN resource_calendar contract_calendar
+              ON contract.resource_calendar_id = contract_calendar.id
+        )'''
+
+    @api.model
     def _get_all_contracts(self, date_from, date_to, states=['open']):
         """
         Returns the contracts of all employees between date_from and date_to


### PR DESCRIPTION
Steps
---
* install hr_contract, hr_attendance
* On some employee with a running contract (Anita Oliver) set the schedule's timezone to America/New_York (Assuming we're in Europe/Brussels, otherwise adjust)
* create an attendance for today: 4:15 (or any time local time before 0:00 New York) -> 21:00
* The overtime stays 0 (unless there is an overtime for the previous day, in which case the hours are taken from it and aren't affected by the attendance times)

Cause
---
* when we compute the date for an attendance from the `check_in`, we preferentially use the employee timezone - when defined - as per `_get_tz` rules (https://github.com/odoo/odoo/blob/b9439513e3e99abc5d748ae30e79e367209b18a5/addons/hr_attendance/models/hr_attendance.py#L222)
* but in the sql query where we try to match attendances with overtimes we only look at the calendar timezone (https://github.com/odoo/odoo/blob/b9439513e3e99abc5d748ae30e79e367209b18a5/addons/hr_attendance/models/hr_attendance.py#L79-L83)

Fix
---
Make the sql query match `_get_tz` logic

task-3937428