### PR TITLE
[FIX] l10n_sa_edi: adapt tax calculation to recent refactoring

### DIFF
--- a/addons/l10n_sa_edi/tests/test_edi_zatca.py
+++ b/addons/l10n_sa_edi/tests/test_edi_zatca.py
@@ -123,3 +123,21 @@ class TestEdiZatca(TestSaEdiCommon):
             current_tree = self.with_applied_xpath(current_tree, self.remove_ubl_extensions_xpath)
 
             self.assertXmlTreeEqual(current_tree, expected_tree)
+
+    def test_invoice_tax_amount_calculation(self):
+        taxes = self.env['account.tax'].create([
+            {
+                'l10n_sa_is_retention': True,
+                'name': "Retention 10%",
+                'amount': -10
+            },
+            {
+                'name': "15% sales",
+                'amount': 15
+            },
+        ])
+
+        invoice = self.init_invoice('out_invoice', amounts=[1000], taxes=taxes)
+        self.assertRecordValues(invoice.line_ids.filtered(lambda l: l.display_type == 'product'), [{
+            'l10n_gcc_invoice_tax_amount': 150
+        }])


### PR DESCRIPTION
### Steps to reproduce

* install `l10n_sa_edi`
* switch to a Saudi company
* create an invoice and attempt to print it

You should be met with a traceback:
```
odoo.addons.base.models.ir_qweb.QWebException: Error while render the template
KeyError: 'id'
Template: l10n_gcc_invoice.arabic_english_invoice
Path: /t/t/div/table/tbody/t[3]/tr/t[1]/td[2]/span
Node: <span class="text-nowrap" t-field="line.l10n_gcc_invoice_tax_amount"/>
```

### Cause

The calculation of `l10n_gcc_invoice_tax_amount` relies on code that was recently refactored, and therefore doesn't work anymore

opw-4243831