### PR TITLE
[REF] discuss: rename `rtcSession` fields to match python model

### DIFF
--- a/addons/mail/models/discuss/discuss_channel_rtc_session.py
+++ b/addons/mail/models/discuss/discuss_channel_rtc_session.py
@@ -136,21 +136,15 @@ class DiscussChannelRtcSession(models.Model):
             target._bus_send("discuss.channel.rtc.session/peer_notification", payload)
 
     def _to_store(self, store: Store, extra=False):
+        fields = []
+        if extra:
+            fields += ["is_camera_on", "is_deaf", "is_muted", "is_screen_sharing_on"]
         for rtc_session in self:
-            data = rtc_session._read_format([], load=False)[0]
-            data["channelMember"] = Store.one(
+            data = rtc_session._read_format(fields, load=False)[0]
+            data["channel_member_id"] = Store.one(
                 rtc_session.channel_member_id,
                 fields={"channel": [], "persona": ["name", "im_status"]},
             )
-            if extra:
-                data.update(
-                    {
-                        "isCameraOn": rtc_session.is_camera_on,
-                        "isDeaf": rtc_session.is_deaf,
-                        "isSelfMuted": rtc_session.is_muted,
-                        "isScreenSharingOn": rtc_session.is_screen_sharing_on,
-                    }
-                )
             store.add(rtc_session, data)
 
     @api.model

--- a/addons/mail/static/src/discuss/call/common/call.js
+++ b/addons/mail/static/src/discuss/call/common/call.js
@@ -89,7 +89,7 @@ export class Call extends Component {
         const filterVideos = this.store.settings.showOnlyVideo && this.props.thread.videoCount > 0;
         for (const session of this.props.thread.rtcSessions) {
             const target = session.raisingHand ? raisingHandCards : sessionCards;
-            const cameraStream = session.isCameraOn
+            const cameraStream = session.is_camera_on
                 ? session.videoStreams.get("camera")
                 : undefined;
             if (!filterVideos || cameraStream) {
@@ -100,7 +100,7 @@ export class Call extends Component {
                     videoStream: cameraStream,
                 });
             }
-            const screenStream = session.isScreenSharingOn
+            const screenStream = session.is_screen_sharing_on
                 ? session.videoStreams.get("screen")
                 : undefined;
             if (screenStream) {
@@ -125,8 +125,8 @@ export class Call extends Component {
         });
         sessionCards.sort((c1, c2) => {
             return (
-                c1.session.channelMember?.persona?.name?.localeCompare(
-                    c2.session.channelMember?.persona?.name
+                c1.session.channel_member_id?.persona?.name?.localeCompare(
+                    c2.session.channel_member_id?.persona?.name
                 ) ?? 1
             );
         });
@@ -144,7 +144,7 @@ export class Call extends Component {
             return this.visibleCards;
         }
         const type = activeSession.mainVideoStreamType;
-        if (type === "screen" || activeSession.isScreenSharingOn) {
+        if (type === "screen" || activeSession.is_screen_sharing_on) {
             this.setInset(activeSession, type === "camera" ? "screen" : "camera");
         }
         return [

--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -15,10 +15,10 @@ callActionsRegistry
         activeClass: "text-danger",
         select: (component) => {
             if (component.rtc.selfSession.isMute) {
-                if (component.rtc.selfSession.isSelfMuted) {
+                if (component.rtc.selfSession.is_muted) {
                     component.rtc.unmute();
                 }
-                if (component.rtc.selfSession.isDeaf) {
+                if (component.rtc.selfSession.is_deaf) {
                     component.rtc.undeafen();
                 }
             } else {
@@ -29,20 +29,20 @@ callActionsRegistry
     })
     .add("deafen", {
         condition: (component) => component.rtc,
-        name: (component) => (component.rtc.selfSession.isDeaf ? _t("Undeafen") : _t("Deafen")),
-        isActive: (component) => component.rtc.selfSession?.isDeaf,
+        name: (component) => (component.rtc.selfSession.is_deaf ? _t("Undeafen") : _t("Deafen")),
+        isActive: (component) => component.rtc.selfSession?.is_deaf,
         inactiveIcon: "fa-headphones",
         icon: "fa-deaf",
         activeClass: "text-danger",
         select: (component) =>
-            component.rtc.selfSession.isDeaf ? component.rtc.undeafen() : component.rtc.deafen(),
+            component.rtc.selfSession.is_deaf ? component.rtc.undeafen() : component.rtc.deafen(),
         sequence: 20,
     })
     .add("camera-on", {
         condition: (component) => component.rtc,
         name: (component) =>
-            component.rtc.selfSession.isCameraOn ? _t("Stop camera") : _t("Turn camera on"),
-        isActive: (component) => component.rtc.selfSession?.isCameraOn,
+            component.rtc.selfSession.is_camera_on ? _t("Stop camera") : _t("Turn camera on"),
+        isActive: (component) => component.rtc.selfSession?.is_camera_on,
         icon: "fa-video-camera",
         activeClass: "text-success",
         select: (component) => component.rtc.toggleVideo("camera"),
@@ -60,10 +60,10 @@ callActionsRegistry
     .add("share-screen", {
         condition: (component) => component.rtc && !isMobileOS(),
         name: (component) =>
-            component.rtc.selfSession.isScreenSharingOn
+            component.rtc.selfSession.is_screen_sharing_on
                 ? _t("Stop Sharing Screen")
                 : _t("Share Screen"),
-        isActive: (component) => component.rtc.selfSession?.isScreenSharingOn,
+        isActive: (component) => component.rtc.selfSession?.is_screen_sharing_on,
         icon: "fa-desktop",
         select: (component) => component.rtc.toggleVideo("screen"),
         sequence: 50,

--- a/addons/mail/static/src/discuss/call/common/call_context_menu.xml
+++ b/addons/mail/static/src/discuss/call/common/call_context_menu.xml
@@ -41,13 +41,13 @@
                     <div><span class="fw-bolder">codec: </span><t t-out="state.producerStats.audio.codec"/></div>
                     <div><span class="fw-bolder">clock rate: </span><t t-out="state.producerStats.audio.clockRate"/></div>
                 </t>
-                <t t-if="state.producerStats.camera and props.rtcSession.isCameraOn">
+                <t t-if="state.producerStats.camera and props.rtcSession.is_camera_on">
                     <hr class="w-100 border-top"/>
                     <div><span class="fw-bolder">camera</span></div>
                     <div><span class="fw-bolder">codec: </span><t t-out="state.producerStats.camera.codec"/></div>
                     <div><span class="fw-bolder">clock rate: </span><t t-out="state.producerStats.camera.clockRate"/></div>
                 </t>
-                <t t-if="state.producerStats.screen and props.rtcSession.isScreenSharingOn">
+                <t t-if="state.producerStats.screen and props.rtcSession.is_screen_sharing_on">
                     <hr class="w-100 border-top"/>
                     <div><span class="fw-bolder">screen</span></div>
                     <div><span class="fw-bolder">codec: </span><t t-out="state.producerStats.screen.codec"/></div>

--- a/addons/mail/static/src/discuss/call/common/call_invitation.xml
+++ b/addons/mail/static/src/discuss/call/common/call_invitation.xml
@@ -5,10 +5,10 @@
         <div class="o-discuss-CallInvitation d-flex flex-column m-2 p-5 border border-dark rounded-1 text-bg-900" t-attf-class="{{ className }}" t-ref="root">
             <div t-if="props.thread.rtcInvitingSession" class="o-discuss-CallInvitation-correspondent d-flex flex-column justify-content-around align-items-center text-nowrap">
                 <img class="mb-2 rounded-circle cursor-pointer o_object_fit_cover"
-                    t-att-src="props.thread.rtcInvitingSession.channelMember.persona.avatarUrl"
+                    t-att-src="props.thread.rtcInvitingSession.channel_member_id.persona.avatarUrl"
                     t-on-click="onClickAvatar"
                     alt="Avatar"/>
-                <span class="w-100 fw-bolder text-truncate text-center overflow-hidden" t-esc="props.thread.rtcInvitingSession.channelMember.persona.name"/>
+                <span class="w-100 fw-bolder text-truncate text-center overflow-hidden" t-esc="props.thread.rtcInvitingSession.channel_member_id.persona.name"/>
                 <span class="fst-italic opacity-75">Incoming Call...</span>
             </div>
             <div class="d-flex justify-content-around align-items-center w-100 mt-4">

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.js
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.js
@@ -68,7 +68,7 @@ export class CallParticipantCard extends Component {
     }
 
     get channelMember() {
-        return this.rtcSession ? this.rtcSession.channelMember : this.props.cardData.member;
+        return this.rtcSession ? this.rtcSession.channel_member_id : this.props.cardData.member;
     }
 
     get isOfActiveCall() {
@@ -83,7 +83,7 @@ export class CallParticipantCard extends Component {
 
     get showServerState() {
         return Boolean(
-            this.rtcSession.channelMember?.persona.eq(this.store.self) &&
+            this.rtcSession.channel_member_id?.persona.eq(this.store.self) &&
                 this.rtc.state.serverState &&
                 this.rtc.state.serverState !== "connected"
         );

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.xml
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.xml
@@ -30,7 +30,7 @@
                 <!-- overlay -->
                 <span class="o-discuss-CallParticipantCard-overlay o-discuss-CallParticipantCard-overlayBottom z-1 position-absolute bottom-0 start-0 d-flex overflow-hidden">
                     <span t-if="!props.minimized and !props.inset" class="p-1 rounded-1 text-truncate" t-esc="name"/>
-                    <small t-if="rtcSession.isScreenSharingOn and props.minimized and !isOfActiveCall" class="user-select-none o-minimized rounded-pill text-bg-danger d-flex align-items-center fw-bolder" title="live" aria-label="live">
+                    <small t-if="rtcSession.is_screen_sharing_on and props.minimized and !isOfActiveCall" class="user-select-none o-minimized rounded-pill text-bg-danger d-flex align-items-center fw-bolder" title="live" aria-label="live">
                         LIVE
                     </small>
                 </span>
@@ -38,10 +38,10 @@
                     <span t-if="hasRaisingHand" class="d-flex flex-column justify-content-center me-1 rounded-circle bg-500" t-att-class="{'o-minimized p-1': props.minimized, 'p-2': !props.minimized }" title="raising hand" aria-label="raising hand">
                         <i class="fa fa-hand-paper-o"/>
                     </span>
-                    <span t-if="rtcSession.isSelfMuted and !rtcSession.isDeaf" class="d-flex flex-column justify-content-center me-1 rounded-circle o-discuss-CallParticipantCard-iconBlackBg" t-att-class="{'o-minimized p-1': props.minimized, 'p-2': !props.minimized }" title="muted" aria-label="muted">
+                    <span t-if="rtcSession.is_muted and !rtcSession.is_deaf" class="d-flex flex-column justify-content-center me-1 rounded-circle o-discuss-CallParticipantCard-iconBlackBg" t-att-class="{'o-minimized p-1': props.minimized, 'p-2': !props.minimized }" title="muted" aria-label="muted">
                         <i class="fa fa-microphone-slash"/>
                     </span>
-                    <span t-if="rtcSession.isDeaf" class="d-flex flex-column justify-content-center me-1 rounded-circle o-discuss-CallParticipantCard-iconBlackBg" t-att-class="{'o-minimized p-1': props.minimized, 'p-2': !props.minimized }" title="deaf" aria-label="deaf">
+                    <span t-if="rtcSession.is_deaf" class="d-flex flex-column justify-content-center me-1 rounded-circle o-discuss-CallParticipantCard-iconBlackBg" t-att-class="{'o-minimized p-1': props.minimized, 'p-2': !props.minimized }" title="deaf" aria-label="deaf">
                         <i class="fa fa-deaf"/>
                     </span>
                     <span t-if="hasMediaError" class="o-discuss-CallParticipantCard-overlay-replayButton d-flex flex-column justify-content-center me-1 p-2 rounded-circle" title="media player Error" t-on-click.stop="onClickReplay">
@@ -54,7 +54,7 @@
                     <span t-if="showServerState" class="d-flex flex-column justify-content-center me-1 p-2 rounded-circle o-discuss-CallParticipantCard-iconBlackBg" t-att-title="rtc.state.serverState">
                         <i class="fa fa-exclamation-triangle text-warning"/>
                     </span>
-                    <span t-if="rtcSession.isScreenSharingOn and !props.minimized and !isOfActiveCall" class="user-select-none rounded-pill text-bg-danger d-flex align-items-center me-1 fw-bolder" title="live" aria-label="live">
+                    <span t-if="rtcSession.is_screen_sharing_on and !props.minimized and !isOfActiveCall" class="user-select-none rounded-pill text-bg-danger d-flex align-items-center me-1 fw-bolder" title="live" aria-label="live">
                         LIVE
                     </span>
                 </div>

--- a/addons/mail/static/src/discuss/call/common/rtc_session_model.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_session_model.js
@@ -25,23 +25,22 @@ export class RtcSession extends Record {
     }
 
     // Server data
-    /** @type {boolean} */
-    channelMember = Record.one("discuss.channel.member", { inverse: "rtcSession" });
+    channel_member_id = Record.one("discuss.channel.member", { inverse: "rtcSession" });
     persona = Record.one("Persona", {
         compute() {
-            return this.channelMember?.persona;
+            return this.channel_member_id?.persona;
         },
     });
     /** @type {boolean} */
-    isCameraOn;
+    is_camera_on;
     /** @type {boolean} */
-    isScreenSharingOn;
+    is_screen_sharing_on;
     /** @type {number} */
     id;
     /** @type {boolean} */
-    isDeaf;
+    is_deaf;
     /** @type {boolean} */
-    isSelfMuted;
+    is_muted;
     // Client data
     /** @type {HTMLAudioElement} */
     audioElement;
@@ -68,15 +67,15 @@ export class RtcSession extends Record {
     isVideoStreaming = Record.attr(false, {
         /** @this {import("models").RtcSession} */
         compute() {
-            return this.isScreenSharingOn || this.isCameraOn;
+            return this.is_screen_sharing_on || this.is_camera_on;
         },
     });
     shortStatus = Record.attr(undefined, {
         compute() {
-            if (this.isScreenSharingOn) {
+            if (this.is_screen_sharing_on) {
                 return "live";
             }
-            if (this.isDeaf) {
+            if (this.is_deaf) {
                 return "deafen";
             }
             if (this.isMute) {
@@ -108,11 +107,11 @@ export class RtcSession extends Record {
     logStep;
 
     get channel() {
-        return this.channelMember?.thread;
+        return this.channel_member_id?.thread;
     }
 
     get isMute() {
-        return this.isSelfMuted || this.isDeaf;
+        return this.is_muted || this.is_deaf;
     }
 
     get mainVideoStream() {
@@ -123,15 +122,17 @@ export class RtcSession extends Record {
         if (!this.mainVideoStreamType) {
             return false;
         }
-        return this.mainVideoStreamType === "camera" ? this.isCameraOn : this.isScreenSharingOn;
+        return this.mainVideoStreamType === "camera"
+            ? this.is_camera_on
+            : this.is_screen_sharing_on;
     }
 
     get hasVideo() {
-        return this.isScreenSharingOn || this.isCameraOn;
+        return this.is_screen_sharing_on || this.is_camera_on;
     }
 
     getStream(type) {
-        const isActive = type === "camera" ? this.isCameraOn : this.isScreenSharingOn;
+        const isActive = type === "camera" ? this.is_camera_on : this.is_screen_sharing_on;
         return isActive && this.videoStreams.get(type);
     }
 
@@ -140,22 +141,22 @@ export class RtcSession extends Record {
      */
     get info() {
         return {
-            isSelfMuted: this.isSelfMuted,
+            isSelfMuted: this.is_muted,
             isRaisingHand: Boolean(this.raisingHand),
-            isDeaf: this.isDeaf,
+            isDeaf: this.is_deaf,
             isTalking: this.isTalking,
-            isCameraOn: this.isCameraOn,
-            isScreenSharingOn: this.isScreenSharingOn,
+            isCameraOn: this.is_camera_on,
+            isScreenSharingOn: this.is_screen_sharing_on,
         };
     }
 
     get partnerId() {
-        const persona = this.channelMember?.persona;
+        const persona = this.channel_member_id?.persona;
         return persona.type === "partner" ? persona.id : undefined;
     }
 
     get guestId() {
-        const persona = this.channelMember?.persona;
+        const persona = this.channel_member_id?.persona;
         return persona.type === "guest" ? persona.id : undefined;
     }
 
@@ -163,7 +164,7 @@ export class RtcSession extends Record {
      * @returns {string}
      */
     get name() {
-        return this.channelMember?.persona.name;
+        return this.channel_member_id?.persona.name;
     }
 
     /**
@@ -198,9 +199,9 @@ export class RtcSession extends Record {
      */
     updateStreamState(type, state) {
         if (type === "camera") {
-            this.isCameraOn = state;
+            this.is_camera_on = state;
         } else if (type === "screen") {
-            this.isScreenSharingOn = state;
+            this.is_screen_sharing_on = state;
         }
     }
 }

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.js
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.js
@@ -76,8 +76,8 @@ export class DiscussSidebarCallParticipants extends Component {
         const sessions = [...this.props.thread.rtcSessions];
         return sessions.sort((s1, s2) => {
             return (
-                s1.channelMember?.persona?.nameOrDisplayName?.localeCompare(
-                    s2.channelMember?.persona?.nameOrDisplayName
+                s1.channel_member_id?.persona?.nameOrDisplayName?.localeCompare(
+                    s2.channel_member_id?.persona?.nameOrDisplayName
                 ) ?? 1
             );
         });

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
@@ -22,7 +22,7 @@
                 direction="compact ? 'v' : 'h'"
                 avatarClass="(p) => this.avatarClass(p)"
                 max="compact ? 1 : 4"
-                personas="sessions.map((s) => s.channelMember.persona)"
+                personas="sessions.map((s) => s.channel_member_id.persona)"
             />
             <t t-else="" t-call="mail.DiscussSidebarCallParticipants.list"/>
         </div>
@@ -35,8 +35,8 @@
                 <img t-att-src="persona?.avatarUrl" class="rounded-circle" t-att-title="persona?.name" t-att-class="{'o-mail-DiscussSidebarCallParticipants-avatar o-isTalking': session.isActuallyTalking}" style="width:24px;height:24px"/>
                 <span class="mx-1 text-truncate fw-bolder smaller" t-esc="persona?.name"/>
                 <span t-if="session.isMute" class="px-1 fa" t-att-class="callActionsRegistry.get('mute').icon"/>
-                <span t-if="session.isDeaf" class="px-1 fa position-relative" t-att-class="callActionsRegistry.get('deafen').icon" style="top: -2px;"/>
-                <span t-if="session.isScreenSharingOn" class="badge bg-danger o-text-white" style="font-size: 0.6rem;">LIVE</span>
+                <span t-if="session.is_deaf" class="px-1 fa position-relative" t-att-class="callActionsRegistry.get('deafen').icon" style="top: -2px;"/>
+                <span t-if="session.is_screen_sharing_on" class="badge bg-danger o-text-white" style="font-size: 0.6rem;">LIVE</span>
             </div>
         </div>
     </t>

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -43,8 +43,8 @@
             <span t-ref="displayName" class="ms-2 text-truncate" t-esc="member.name"/>
             <span class="ms-auto">
                 <span t-if="member.in(props.thread.invitedMembers)" class="p-1 fa fa-user-plus"/>
-                <span t-if="member.rtcSession?.isSelfMuted and !member.rtcSession?.isDeaf" class="p-1 fa fa-microphone-slash"/>
-                <span t-elif="member.rtcSession?.isDeaf" class="p-1 fa fa-deaf"/>
+                <span t-if="member.rtcSession?.is_muted and !member.rtcSession?.is_deaf" class="p-1 fa fa-microphone-slash"/>
+                <span t-elif="member.rtcSession?.is_deaf" class="p-1 fa fa-deaf"/>
                 <span t-if="member.rtcSession?.raisingHand" class="p-1 fa fa-hand-paper-o"/>
             </span>
 

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -181,7 +181,7 @@ test("should display invitations", async () => {
         partner,
         "mail.record/insert",
         new mailDataHelpers.Store(pyEnv["discuss.channel.rtc.session"].browse(sessionId), {
-            channelMember: { id: memberId },
+            channel_member_id: { id: memberId },
         })
             .add(pyEnv["discuss.channel.member"].browse(memberId), {
                 persona: { id: partnerId, type: "partner" },

--- a/addons/mail/static/tests/legacy/helpers/mock_server/models/discuss_channel_rtc_session.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/models/discuss_channel_rtc_session.js
@@ -46,16 +46,16 @@ patch(MockServer.prototype, {
         const [rtcSession] = this.getRecords("discuss.channel.rtc.session", [["id", "=", id]]);
         const vals = {
             id: rtcSession.id,
-            channelMember: this._mockDiscussChannelMember_DiscussChannelMemberFormat([
+            channel_member_id: this._mockDiscussChannelMember_DiscussChannelMemberFormat([
                 rtcSession.channel_member_id,
             ])[0],
         };
         if (extra) {
             Object.assign(vals, {
-                isCameraOn: rtcSession.is_camera_on,
-                isDeaf: rtcSession.is_deaf,
-                isSelfMuted: rtcSession.is_self_muted,
-                isScreenSharingOn: rtcSession.is_screen_sharing_on,
+                is_camera_on: rtcSession.is_camera_on,
+                is_deaf: rtcSession.is_deaf,
+                is_muted: rtcSession.is_muted,
+                is_screen_sharing_on: rtcSession.is_screen_sharing_on,
             });
         }
         return vals;
@@ -94,7 +94,7 @@ patch(MockServer.prototype, {
         this.pyEnv["discuss.channel.rtc.session"].write([id], values);
         const sessionData = this._mockDiscussChannelRtcSession_DiscussChannelRtcSessionFormat(id);
         const [channel] = this.pyEnv["discuss.channel"].search_read([
-            ["id", "=", sessionData.channelMember.thread.id],
+            ["id", "=", sessionData.channel_member_id.thread.id],
         ]);
         this.pyEnv["bus.bus"]._sendone(
             channel,

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel_rtc_session.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel_rtc_session.js
@@ -55,17 +55,17 @@ export class DiscussChannelRtcSession extends models.ServerModel {
         const DiscussChannelMember = this.env["discuss.channel.member"];
 
         for (const rtcSession of this.browse(ids)) {
-            const [data] = this.read(rtcSession.id, [], makeKwArgs({ load: false }));
-            data.channelMember = mailDataHelpers.Store.one(
+            const [data] = this._read_format(rtcSession.id, [], makeKwArgs({ load: false }));
+            data.channel_member_id = mailDataHelpers.Store.one(
                 DiscussChannelMember.browse(rtcSession.channel_member_id),
                 makeKwArgs({ fields: { channel: [], persona: ["name", "im_status"] } })
             );
             if (extra) {
                 Object.assign(data, {
-                    isCameraOn: rtcSession.is_camera_on,
-                    isDeaf: rtcSession.is_deaf,
-                    isSelfMuted: rtcSession.is_self_muted,
-                    isScreenSharingOn: rtcSession.is_screen_sharing_on,
+                    is_camera_on: rtcSession.is_camera_on,
+                    is_deaf: rtcSession.is_deaf,
+                    is_muted: rtcSession.is_muted,
+                    is_screen_sharing_on: rtcSession.is_screen_sharing_on,
                 });
             }
             store.add(this.browse(rtcSession.id), data);

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -68,7 +68,7 @@ class TestChannelRTC(MailCommon):
                         ],
                         "discuss.channel.rtc.session": [
                             {
-                                "channelMember": channel_member.id,
+                                "channel_member_id": channel_member.id,
                                 "id": channel_member.rtc_session_ids.id + 1,
                             },
                         ],
@@ -110,7 +110,7 @@ class TestChannelRTC(MailCommon):
                 ],
                 "discuss.channel.rtc.session": [
                     {
-                        "channelMember": channel_member.id,
+                        "channel_member_id": channel_member.id,
                         "id": channel_member.rtc_session_ids.id,
                     },
                 ],
@@ -180,7 +180,7 @@ class TestChannelRTC(MailCommon):
                         ],
                         "discuss.channel.rtc.session": [
                             {
-                                "channelMember": channel_member.id,
+                                "channel_member_id": channel_member.id,
                                 "id": last_rtc_session_id + 1,
                             },
                         ],
@@ -286,7 +286,7 @@ class TestChannelRTC(MailCommon):
                         ],
                         "discuss.channel.rtc.session": [
                             {
-                                "channelMember": channel_member.id,
+                                "channel_member_id": channel_member.id,
                                 "id": last_rtc_session_id + 1,
                             },
                         ],
@@ -320,7 +320,7 @@ class TestChannelRTC(MailCommon):
                         ],
                         "discuss.channel.rtc.session": [
                             {
-                                "channelMember": channel_member.id,
+                                "channel_member_id": channel_member.id,
                                 "id": last_rtc_session_id + 1,
                             },
                         ],
@@ -476,7 +476,7 @@ class TestChannelRTC(MailCommon):
                         ],
                         "discuss.channel.rtc.session": [
                             {
-                                "channelMember": channel_member_test_user.id,
+                                "channel_member_id": channel_member_test_user.id,
                                 "id": channel_member.rtc_session_ids.id + 1,
                             },
                         ],
@@ -566,7 +566,7 @@ class TestChannelRTC(MailCommon):
                         ],
                         "discuss.channel.rtc.session": [
                             {
-                                "channelMember": channel_member_test_guest.id,
+                                "channel_member_id": channel_member_test_guest.id,
                                 "id": channel_member.rtc_session_ids.id + 2,
                             },
                         ],
@@ -876,7 +876,7 @@ class TestChannelRTC(MailCommon):
                         ],
                         "discuss.channel.rtc.session": [
                             {
-                                "channelMember": channel_member.id,
+                                "channel_member_id": channel_member.id,
                                 "id": channel_member.rtc_session_ids.id,
                             },
                         ],
@@ -910,7 +910,7 @@ class TestChannelRTC(MailCommon):
                         ],
                         "discuss.channel.rtc.session": [
                             {
-                                "channelMember": channel_member.id,
+                                "channel_member_id": channel_member.id,
                                 "id": channel_member.rtc_session_ids.id,
                             },
                         ],

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -1683,12 +1683,12 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         if channel == self.channel_channel_group_1 and user == self.users[2]:
             return {
                 # sudo: discuss.channel.rtc.session - reading a session in a test file
-                "channelMember": member_2.id,
+                "channel_member_id": member_2.id,
                 "id": member_2.sudo().rtc_session_ids.id,
-                "isCameraOn": False,
-                "isDeaf": False,
-                "isScreenSharingOn": False,
-                "isSelfMuted": False,
+                "is_camera_on": False,
+                "is_deaf": False,
+                "is_screen_sharing_on": False,
+                "is_muted": False,
             }
         return {}
 

--- a/addons/web/static/tests/_framework/mock_server/mock_model.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_model.js
@@ -1783,6 +1783,15 @@ export class Model extends Array {
         ({ ids: idOrIds, fields = [], load = "_classic_read" } = kwargs);
 
         const fieldNames = fields.length ? unique(["id", ...fields]) : Object.keys(this._fields);
+        return this._read_format(idOrIds, fieldNames, load);
+    }
+
+    _read_format(idOrIds, fnames, load) {
+        const kwargs = getKwArgs(arguments, "ids", "fnames", "load");
+        ({ ids: idOrIds, fnames = [], load = "_classic_read" } = kwargs);
+
+        fnames = unique(["id", ...fnames]);
+
         /** @type {ModelRecord[]} */
         const records = [];
 
@@ -1793,7 +1802,7 @@ export class Model extends Array {
         for (const record of this) {
             modelMap[this._name][record.id] = record;
         }
-        for (const fieldName of fieldNames) {
+        for (const fieldName of fnames) {
             const field = this._fields[fieldName];
             if (!field) {
                 continue; // the field doesn't exist on the model, so skip it
@@ -1828,7 +1837,7 @@ export class Model extends Array {
                 continue;
             }
             const result = { id: record.id };
-            for (const fieldName of fieldNames) {
+            for (const fieldName of fnames) {
                 const field = this._fields[fieldName];
                 if (!field) {
                     continue; // the field doesn't exist on the model, so skip it


### PR DESCRIPTION
The fields shared between `discuss.channel.rtc.session` and  the Record `RtcSession` are now always in snake_case.


