### PR TITLE
[FIX] mass_mailing: display cover snippet in training theme template

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -285,6 +285,10 @@ export class MassMailingHtmlField extends HtmlField {
             this._themeParams = Array.from(displayableThemes).map((theme) => {
                 const $theme = $(theme);
                 const name = $theme.data("name");
+                // TODO remove in master and apply the update in xml directly
+                if (name === "training") {
+                    $theme.get(0).querySelector("div.oe_img_bg").classList.add("col-lg-12");
+                }
                 const classname = "o_" + name + "_theme";
                 this._themeClassNames += " " + classname;
                 const imagesInfo = Object.assign({


### PR DESCRIPTION
Issue:
=====
The cover template of the training theme template doesn't show in the sent email.

Steps to reproduce the issue:
=============================
- Create a new mailing with training template
- Send a test email
- Cover snippet missing

Origin of the issue:
====================
While converting the template from bootstrap to table we expect to have `container` -> `row` -> `col` classes but the template was missing the `col` class

opw-3944347