### PR TITLE
[FIX] mail: avoid exception on closing composer

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -508,21 +508,21 @@ export class Composer extends Component {
         };
         const options = {
             onClose: (...args) => {
-                // args === [] : click on 'X'
+                // args === [] : click on 'X' or press escape
                 // args === { special: true } : click on 'discard'
-                const isDiscard = args.length === 0 || args[0]?.special;
+                const accidentalDiscard = args.length === 0;
+                const isDiscard = accidentalDiscard || args[0]?.special;
                 // otherwise message is posted (args === [undefined])
                 if (!isDiscard && this.props.composer.thread.model === "mail.box") {
                     this.notifySendFromMailbox();
                 }
-                if (
-                    args.length === 0 &&
-                    document
-                        .querySelector(".o_mail_composer_form_view .note-editable")
-                        .innerText.replace(/^\s*$/gm, "")
-                ) {
-                    this.saveContent();
-                    this.restoreContent();
+                if (accidentalDiscard) {
+                    const editor = document.querySelector(".o_mail_composer_form_view .note-editable");
+                    const editorIsEmpty = !editor || !editor.innerText.replace(/^\s*$/gm, "");
+                    if (!editorIsEmpty) {
+                        this.saveContent();
+                        this.restoreContent();
+                    }
                 } else {
                     this.clear();
                 }


### PR DESCRIPTION
- open a composer in full view
- click to save a template
- close the modal before saving/cancelling
- get a traceback

The issue is that `onClose` when passed to an action is called even if the dialog closed did not come from the original action.

This seems intended as documented by `_removeDialog`.

`onClose` needs to be able to handle the composer not being in the DOM at all.

task-4246399
