### PR TITLE
[FIX] mail: allow saving template in mass mode

### DIFF
--- a/addons/mail/static/src/core/web/mail_composer_template_selector.js
+++ b/addons/mail/static/src/core/web/mail_composer_template_selector.js
@@ -87,7 +87,9 @@ export class MailComposerTemplateSelector extends Component {
     }
 
     async onSaveTemplate() {
-        await this.props.record.save();
+        if (!(await this.props.record.save())) {
+            return;
+        }
         await this.action.doActionButton({
             type: "object",
             name: "open_template_creation_wizard",


### PR DESCRIPTION
In the new composer design [1] saving a template is done by first saving the composer, then opening the "template creation" view on the same composer.

The second step thus requires the composer to be properly saved first.

This is easily checked as `Record.save` returns false on failure. In that case we do nothing and let the framework point out why the record could not be saved.

[1]: 6c4526ec3b9509e0a6b99503d8d888417b2695e0

task-4246399
