### PR TITLE
[FIX] website_event_sale: website_event_sale_last_ticket tour

### DIFF
--- a/addons/website_event_sale/static/tests/tours/website_event_sale_last_ticket.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale_last_ticket.js
@@ -1,41 +1,46 @@
 /** @odoo-module **/
 
 import { registry } from "@web/core/registry";
-import * as wsTourUtils from '@website_sale/js/tours/tour_utils';
+import * as wsTourUtils from "@website_sale/js/tours/tour_utils";
 
-registry.category("web_tour.tours").add('event_buy_last_ticket', {
+registry.category("web_tour.tours").add("event_buy_last_ticket", {
     test: true,
-    url: '/event',
-    steps: () => [{
+    url: "/event",
+    checkDelay: 100,
+    steps: () => [
+    {
         content: "Open the Last ticket test event page",
         trigger: '.o_wevent_events_list a:contains("Last ticket test")',
         run: "click",
     },
     {
-        content: "Open Registration Page",
-        trigger: '.btn-primary:contains("Register")',
+        content: "Open Registration Modal",
+        trigger: ".btn-primary:contains(Register)",
         run: "click",
     },
     {
-        content: "Open the register modal",
-        trigger: 'button:contains("Register")',
-        run: "click",
+        content: "Check the modal Tickets is opened",
+        trigger: "body:has(.modal:contains(Tickets))",
     },
     {
         trigger: '#wrap:not(:has(a[href*="/event"]:contains("Last ticket test")))',
     },
     {
         content: "Select 2 units of `VIP` ticket type",
-        trigger: 'select:eq(0)',
+        trigger: ".modal select:eq(0)",
         run: "select 2",
     },
     {
-        trigger: "select:eq(0):has(option:contains(2):selected)",
+        trigger: ".modal select:eq(0):has(option:contains(2):selected)",
     },
     {
-        content: "Click on `Order Now` button",
-        trigger: '.a-submit:contains("Register")',
+        content: "Click on `Register` button",
+        trigger: ".modal .modal-footer button.btn-primary.a-submit:contains(Register)",
         run: "click",
+    },
+    {
+        content: "Check the modal Attendees is opened",
+        trigger: ".modal:contains(Attendees):contains(Ticket #1):contains(Ticket #2)",
     },
     {
         content: "Fill attendees details",
@@ -50,11 +55,8 @@ registry.category("web_tour.tours").add('event_buy_last_ticket', {
         },
     },
     {
-        trigger: "input[name*='1-name'], input[name*='2-name']",
-    },
-    {
         content: "Validate attendees details",
-        trigger: "button[type=submit]:contains(Go to Payment)",
+        trigger: ".modal:contains(Attendees) button[type=submit]:contains(Go to Payment)",
         run: "click",
     },
     ...wsTourUtils.fillAdressForm({
@@ -66,4 +68,5 @@ registry.category("web_tour.tours").add('event_buy_last_ticket', {
         zip: "123",
     }),
     ...wsTourUtils.payWithTransfer(true),
-]});
+    ],
+});


### PR DESCRIPTION
Decrease checkDelay to 100ms instead of 750ms by default. Add intermediate steps to ensure elements are in DOM before to continue the tour.
Modify steps that are not logicals.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
