### PR TITLE
[FIX] sale, sale_project: correct SOL domain

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import defaultdict
@@ -1293,4 +1292,11 @@ class SaleOrderLine(models.Model):
         return self.move_ids
 
     def _sellable_lines_domain(self):
-        return [('is_downpayment', '=', False)]
+        discount_products_ids = self.env.companies.sale_discount_product_id.ids
+        domain = [('is_downpayment', '=', False)]
+        if discount_products_ids:
+            domain = expression.AND([
+                domain,
+                [('product_id', 'not in', discount_products_ids)],
+            ])
+        return domain

--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -819,7 +819,7 @@ class ProjectTask(models.Model):
         domain = expression.AND([
             self.env['sale.order.line']._sellable_lines_domain(),
             [
-                '|', ('order_partner_id.commercial_partner_id', 'parent_of', unquote('partner_id if partner_id else []')),
+                '|', ('order_partner_id.commercial_partner_id.id', 'parent_of', unquote('partner_id if partner_id else []')),
                     ('order_partner_id', '=?', unquote('partner_id')),
                 ('is_service', '=', True), ('is_expense', '=', False), ('state', '=', 'sale'),
             ],


### PR DESCRIPTION
- sale_project: fix domain as it is not possible to select a SOL
on a task in the case where the SOL's contact belongs to the same
company than the contact set as the task's customer.
The `.id` was removed by https://github.com/odoo/odoo/commit/e095ef5153fb1a8364a4f53896a522fefa35ecd9
and is actually necessary if we want to have SOLs where the
`order_partner_id` is the parent of the `partner_id` or shares
the same parent than `parent_id`.

- sale: remove SOLs of discount products from the SOLs considered
as sellable. The discount products are "fake" products used to
manage discounts.

opw-4212956