### PR TITLE
[FIX] web_editor: insert p inside empty div

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -4205,6 +4205,15 @@ export class OdooEditor extends EventTarget {
             // The _onSelectionChange handler is going to be triggered again.
             return;
         }
+        if (
+            selection.isCollapsed && anchorNode &&
+            anchorNode.nodeName === "DIV" && anchorNode.innerHTML.trim() === "" &&
+            this.isSelectionInEditable(selection)
+        ) {
+            this._fixSelectionInEmptyDiv(selection);
+            // The _onSelectionChange handler is going to be triggered again.
+            return;
+        }
         let appliedCustomSelection = false;
         if (selection.rangeCount && selection.getRangeAt(0)) {
             appliedCustomSelection = this._handleSelectionInTable();
@@ -4628,6 +4637,14 @@ export class OdooEditor extends EventTarget {
             // Remove selection as a fallback.
             selection.removeAllRanges();
         }
+    }
+
+    _fixSelectionInEmptyDiv(selection){
+        const p = this.document.createElement("p");
+        const br = this.document.createElement("br");
+        p.appendChild(br);
+        selection.anchorNode.appendChild(p);
+        setSelection(p, 0);
     }
 
     _onMouseup(ev) {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -7838,5 +7838,12 @@ X[]
                 });
             });
         });
+
+        it('should insert a p in empty div', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<div>[]</div>',
+                contentAfterEdit: '<div><p placeholder="Type &quot;/&quot; for commands" class="oe-hint oe-command-temporary-hint">[]<br></p></div>',
+            });
+        });
     });
 });


### PR DESCRIPTION
Issue:
======
sperator isn't inserted in the correct place.

Steps to reproduce the issue:
=============================
- Go to studio
- Create a new internal report
- Put the cursor in the div (second line)
- Add some content over some lines
- Insert seperator at the end of the lines
- It gets inserted at the start

Origin of the issue:
====================
Since we are writing inside the div directly, inserting the hr will look
for the closest block and insert it before it which is the div. Because,
new line inside a div is just a br and doesn't split the div.

Solution:
=========
Add a p element inside an empty div element when we put the selection
there.

task-4240730