### PR TITLE
[FIX] web: fix dynamic placeholder button

### DIFF
--- a/addons/web/static/src/views/fields/char/char_field.scss
+++ b/addons/web/static/src/views/fields/char/char_field.scss
@@ -9,7 +9,6 @@
 .o_field_char_buttons {
     right: 0;
     margin-left: -35px;
-    margin-right: 20px;
 
     .o_field_translate {
         margin-left: 0 !important;

--- a/addons/web/static/src/views/fields/char/char_field.xml
+++ b/addons/web/static/src/views/fields/char/char_field.xml
@@ -20,18 +20,20 @@
                 t-on-blur="onBlur"
                 t-ref="input"
             />
-            <div class="o_field_char_buttons position-absolute d-inline">
-                <t t-if="isTranslatable">
-                    <TranslationButton
-                        fieldName="props.name"
-                        record="props.record"
+            <div class="position-relative d-inline">
+                <div class="o_field_char_buttons position-absolute d-inline-flex">
+                    <t t-if="isTranslatable">
+                        <TranslationButton
+                            fieldName="props.name"
+                            record="props.record"
+                        />
+                    </t>
+                    <button t-if="hasDynamicPlaceholder"
+                        class="btn m-0 py-0 px-2 fa fa-magic"
+                        title="Insert Field"
+                        t-on-click="onDynamicPlaceholderOpen"
                     />
-                </t>
-                <button t-if="hasDynamicPlaceholder"
-                    class="btn m-0 py-0 px-2 fa fa-magic"
-                    title="Insert Field"
-                    t-on-click="onDynamicPlaceholderOpen"
-                />
+                </div>
             </div>
         </t>
     </t>

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -646,8 +646,8 @@
     }
 
     div {
-        div:focus-within > div.o_field_char_buttons > span.o_field_translate,
-        div:hover > div.o_field_char_buttons > span.o_field_translate {
+        div:focus-within > div > div.o_field_char_buttons > span.o_field_translate,
+        div:hover > div > div.o_field_char_buttons > span.o_field_translate {
             visibility: visible !important;
         }
     }


### PR DESCRIPTION
Steps to reproduce
===============
1. Go to Email Marketing and open any mailing.
2.  Go to Settings of the mailing inside notebook. -> The dynamic placeholder button and emoji icon is next to the medium but it should be after preview field.

Issue
===============
We are using position absolute for the container of the button but as the
nearest positioned ancestor is the sheet itself it is placed to the right of
the sheet.

After this commit
===============
The buttons for the preview field will be next to the preview field.

Task-4244780