### PR TITLE
[FIX] website: restore proper body-bg meaning with boxed layouts

### DIFF
--- a/addons/website/static/src/scss/bootstrap_overridden.scss
+++ b/addons/website/static/src/scss/bootstrap_overridden.scss
@@ -64,7 +64,8 @@ $spacers: (
 // variable to compute some of their colors too). The background color behind
 // the box will be forced by an Odoo CSS rule instead of relying on Bootstrap
 // CSS rule (the <body> background color CSS rule) which uses `$body-bg`.
-// In future bootstrap version (> 5.1.3), this should probably be reviewed.
+// TODO lots of variables are still using $body-bg directly, they should use
+// var(--body-bg) instead, as the new bootstrap version intended.
 // grep: BOXED_BODY_BG_ODOO
 $body-bg: o-color('o-cc1-bg') !default;
 $body-color: o-color('o-cc1-text') or color-contrast($body-bg) !default;

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -18,15 +18,6 @@ $-seen-urls: ();
 }
 
 :root {
-    // The color behind the boxed layout is forced by Odoo. The box background
-    // color uses the `$body-bg` variable.
-    // grep: BOXED_BODY_BG_ODOO
-    @if o-website-value('layout') != 'full' {
-        $-boxed-layout-body-bg: o-color('body');
-        --#{$variable-prefix}body-bg-rgb: #{to-rgb($-boxed-layout-body-bg)};
-        --#{$variable-prefix}body-bg: #{$-boxed-layout-body-bg};
-    }
-
     // Border color
     // Let borders color adapt according to body and CCs. Also, set a fallback
     // value for browsers that don't support the color-mix function (used by
@@ -189,6 +180,15 @@ $-seen-urls: ();
         background-repeat: no-repeat;
     }
 };
+
+body {
+    // The color behind the boxed layout is forced by Odoo. The box background
+    // color uses the `$body-bg` variable.
+    // grep: BOXED_BODY_BG_ODOO
+    @if o-website-value('layout') != 'full' {
+        background-color: o-color('body');
+    }
+}
 
 #wrapwrap {
     @if o-website-value('body-image') {


### PR DESCRIPTION
Since [1], when using a website boxed layout, the Bootstrap $body-bg variable was used as the color of the *box* instead of the body itself. Indeed, it made sense as default Bootstrap components started to use that $body-bg value themselves, supposing those components would be placed in the body by default, and not a colored main box.

The color of the body itself was then forced to the user-chosen Odoo color, by setting the --body-bg CSS variable Bootstrap sets up and which at the time, was only used for that.

However, since [2], the new Bootstrap version started to use that CSS variable instead of the $body-bg SCSS variable to style components. Therefore, in boxed layout, this was broken: the components used the "color behind the box" instead of the "color of the box".

Commit [3] solved a specific consequence of this issue: the tables, in boxed layouts, would use the "color behind the box" (for instance, on the shop page) breaking the design. It fixed the issue by restoring the table transparent background color as wanted (not only in those boxed layouts). But other components that use var(--body-bg) would still be broken... (un)fortunately, it seems to not be the case as we force those variables ourselves to $body-bg instead of var(--body-bg) (which will be changed in master to follow Bootstrap conventions).

[1]: https://github.com/odoo/odoo/commit/977868f5e0f50937499c89efacadf1d30ed19b5d
[2]: https://github.com/odoo/odoo/commit/058212e12b5079eba870bde9775fe98f27928935
[3]: https://github.com/odoo/odoo/commit/17592b131001647cc4c8028db8c1dacb05797c0b

Related to opw-4203976
