### PR TITLE
[FIX] hr_payroll: fix paperformat in document layout

### DIFF
--- a/addons/web/views/base_document_layout_views.xml
+++ b/addons/web/views/base_document_layout_views.xml
@@ -32,7 +32,7 @@
                             <field name="company_details" string="Address" options="{'resizable': false}"/>
                             <field name="report_header" string="Tagline" placeholder="e.g. Global Business Solutions" options="{'resizable': false}"/>
                             <field name="report_footer" placeholder="Write your phone, email, bank account, tax ID, ..." string="Footer" options="{'resizable': false}"/>
-                            <field name="paperformat_id" widget="selection" required="1" domain="[('report_ids', '=', False)]"/>
+                            <field name="paperformat_id" widget="selection" required="1"/>
                         </group>
                         <div class="o_preview">
                             <field name="preview" widget="iframe_wrapper" class="preview_document_layout d-flex justify-content-center mb-0"/>


### PR DESCRIPTION
In the document layout configurator, the paper format A4 would not be there if the module l10n_be_hr_payroll is installed.

This is because in Belgium, some reports need A4 but in the configurator, we only get paperformat not linked to any report.

The solution is to remove the domain for this field in the configurator.

Since there will be more paper formats, I renamed the newly created formats in the Belgian payroll to differentiate them.