### PR TITLE
[FIX] web: remove red dot from search panel on small screen

### DIFF
--- a/addons/web/static/src/search/search_panel/search_panel.xml
+++ b/addons/web/static/src/search/search_panel/search_panel.xml
@@ -157,7 +157,6 @@
             </div>
             <Dropdown t-foreach="sections" t-as="section" t-key="section.id" menuClass="'my-2 mx-1'" onOpened.bind="updateGroupHeadersChecked">
                 <span class="btn btn-secondary my-2 mx-1 o-dropdown-caret">
-                    <i t-if="hasSelection(section.id)" class="position-absolute fa fa-circle" style="color: red; top: -5px; right: -5px"/>
                     <i t-attf-class="fa {{ section.icon }} o_search_panel_section_icon {{!section.color &amp;&amp; section.type == 'filter' ? 'text-warning' : !section.color ? 'text-primary': ''}} me-2"
                         t-att-style="section.color and ('color: ' + section.color)"
                     />

--- a/addons/web/static/tests/legacy/mobile/search/search_panel_tests.js
+++ b/addons/web/static/tests/legacy/mobile/search/search_panel_tests.js
@@ -80,10 +80,8 @@ QUnit.module("Search", (hooks) => {
         assert.strictEqual(target.querySelector(".o_search_panel_field").innerText, "All\nGold\nSilver");
         await click(target, ".o_search_panel_category_value:nth-of-type(2) header");
         assert.strictEqual(target.querySelector(".o_search_panel .o-dropdown").innerText, "Gold");
-        assert.containsOnce(target, ".o_search_panel .o-dropdown .fa-circle");
         assert.containsOnce(target, ".o_search_panel a");
         await click(target, ".o_search_panel a");
         assert.strictEqual(target.querySelector(".o_search_panel .o-dropdown").innerText, "Tags");
-        assert.containsNone(target, ".o_search_panel .o-dropdown .fa-circle");
     });
 });


### PR DESCRIPTION
On mobile, whwen a domain is selected in the SearchPanel, there is a red dot that indicates there is a domain applied.

This red dot is useless because we actually see that the domain is selected.

This commit removes it.

task-4246980


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
