### PR TITLE
[FIX] point_of_sale: fix installing CoA when payment method exists

### DIFF
--- a/addons/point_of_sale/models/account_journal.py
+++ b/addons/point_of_sale/models/account_journal.py
@@ -4,6 +4,8 @@
 from odoo import fields, models, api, _
 from odoo.exceptions import ValidationError
 
+from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
+
 class AccountJournal(models.Model):
     _inherit = 'account.journal'
 
@@ -41,3 +43,10 @@ class AccountJournal(models.Model):
                 'company_id': self.env.company.id,
             })
         return journal
+
+    def unlink(self):
+        if self.env.context.get(MODULE_UNINSTALL_FLAG):
+            payment_methods = self.env['pos.payment.method'].search([('journal_id', 'in', self.ids)])
+            self.env['pos.payment'].search([('payment_method_id', 'in', payment_methods.ids)]).unlink()
+            payment_methods.unlink()
+        return super().unlink()


### PR DESCRIPTION
When trying to install a CoA on a company that already have pos payment methods the installing would fail because it's trying to delete a journal linked to the payment methods

Steps to reproduce:
-------------------
* Create a new company, do not install CoA
* Create a PoS payment method
* Install any CoA
> Observation: You get an error saying you cannot delete some records

Why the fix:
------------
When we are unlinking account_journal records with this context `{MODULE_UNINSTALL_FLAG: True}` we make sure to also delete the pos_payment_method and pos_payment linked to that journal. This is done here https://github.com/odoo/odoo/blob/854c3b27aa5476c208572f19e64f8f3364bfc381/addons/account/models/chart_template.py#L202

opw-4245944
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
