### PR TITLE
[FIX] marketing_automation: fix email template height

### DIFF
--- a/addons/mass_mailing/static/src/scss/mass_mailing.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.scss
@@ -200,3 +200,7 @@ body.editor_has_snippets .o_field_mass_mailing_html div.d-flex:has(iframe) {
         min-height: 55vh;
     }
 }
+
+.o_dialog .o_content:has(.o_field_mass_mailing_html) {
+    overflow: unset;
+}


### PR DESCRIPTION
How to reproduce
-----------------
1. Inside the marketing automation module, enter any campaign.
2. Click on the title of any of the hierarchy card.
3. From the dialog box, type a new name and then select `Create and edit`.
4. In the `Create Marketing Template` dialog box opened, select the `Event Promo` template.
5. Scroll on the outer scroll bar of the dialog box and you will notice the snippets' box height does not extend to the bottom.

Issue
-----
- The height of the main marketing template is not set, hence an extra scroll bar appears on the dialog box.

![image](https://github.com/user-attachments/assets/41482587-76d8-4b1c-b30e-d00a5d617b4e)


Fix
---
- We modify the condition to not set the height attribute when in Dialog box.

Task-4137980