### PR TITLE
[FIX] website_crm_partner_assign: write missing crm.lead

### DIFF
--- a/addons/website_crm_partner_assign/models/crm_lead.py
+++ b/addons/website_crm_partner_assign/models/crm_lead.py
@@ -317,3 +317,15 @@ class CrmLead(models.Model):
                     'url': '/my/opportunity/%s' % record.id,
                 }
         return super(CrmLead, self)._get_access_action(access_uid=access_uid, force_website=force_website)
+
+    def write(self, vals):
+        if self.user_has_groups('base.group_portal'):
+            for fname, value in vals.items():
+                field = self._fields.get(fname)
+                if isinstance(field, fields.Many2one):
+                    model = getattr(self, fname)
+                    record = model.browse(value)
+                    record.check_access_rights('read')
+                    record.check_access_rule('read')
+        return super().write(vals)
+


### PR DESCRIPTION
When a partner is writing on a a missing crm.lead the xmlrpc call is accepted but should return an error.

opw-4247178

