### PR TITLE
[FIX] project: fix wrong usage of _t in burndown chart.

### DIFF
--- a/addons/project/static/src/views/burndown_chart/burndown_chart_search_model.js
+++ b/addons/project/static/src/views/burndown_chart/burndown_chart_search_model.js
@@ -95,14 +95,13 @@ export class BurndownChartSearchModel extends SearchModel {
     }
 
     /**
-     * Adds a notification relative to the group by constraint of the Burndown Chart.
-     * @param fieldName The field name(s) the notification has to be related to.
+     * Adds a notification related to the group by constraint of the Burndown Chart.
+     * @param body The message to display in the notification.
      * @private
      */
     _addGroupByNotification(body) {
-        const notif = _t(body);
         this.notificationService.add(
-            `${notif}`,
+            body,
             { type: "danger" }
         );
     }


### PR DESCRIPTION
This PR removes a call to _t with a dynamic argument.