### PR TITLE
[FIX] sale_timesheet: allow linking timesheets with parent company SO

### DIFF
--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -133,13 +133,13 @@
                         column_invisible="not parent.allow_billable"
                         readonly="readonly_timesheet"
                         context="{'with_remaining_hours': True, 'with_price_unit': True}" options="{'no_create': True, 'no_open': True}"
-                        domain="[('is_service', '=', True), ('order_partner_id', 'child_of', parent.partner_id), ('is_expense', '=', False), ('state', '=', 'sale')]"
+                        domain="[('is_service', '=', True), ('order_partner_id.commercial_partner_id.id', 'parent_of', parent.partner_id), ('is_expense', '=', False), ('state', '=', 'sale')]"
                         optional="hide"/>
                     <field name="so_line" widget="so_line_field" groups="sales_team.group_sale_salesman"
                         column_invisible="not parent.allow_billable"
                         readonly="readonly_timesheet"
                         context="{'with_remaining_hours': True, 'with_price_unit': True}" options="{'no_create': True, 'no_open': True}"
-                        domain="[('is_service', '=', True), ('order_partner_id', 'child_of', parent.partner_id), ('is_expense', '=', False), ('state', '=', 'sale')]"
+                        domain="[('is_service', '=', True), ('order_partner_id.commercial_partner_id.id', 'parent_of', parent.partner_id), ('is_expense', '=', False), ('state', '=', 'sale')]"
                         optional="hide"/>
                 </xpath>
                 <xpath expr="//field[@name='remaining_hours']" position="after">


### PR DESCRIPTION
Steps to reproduce:
- Sell any service product to a company with a child contact
- Create a billable project with timesheets
- Create a new task inside the project with the child contact as customer
- Timesheets tab > Add a timesheet > Remove the Sales Order Item
- Try to fill in the Sales Order Item

Only SOs with the child contact show up as option when the expected behavior would be to have those of the parent company as well. This happened because the commercial_partner_id field was removed from project.task in 17.0.

This fix only shows the SOs where the partner is the same as that of the task's partner or it's parent company when we previously wuld have had access to 'siblings' under the same cmpany. Restoring it fully would require bringing back the commeercial_partner_id field on task.

opw-4214601

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
