### PR TITLE
[FIX] web: update fullcalendar from v6.1.10 to v6.1.11

### DIFF
--- a/addons/web/static/lib/fullcalendar/core/locales-all.global.js
+++ b/addons/web/static/lib/fullcalendar/core/locales-all.global.js
@@ -1,5 +1,5 @@
 /*!
-FullCalendar Core v6.1.10
+FullCalendar Core v6.1.11
 Docs & License: https://fullcalendar.io
 (c) 2023 Adam Shaw
 */

--- a/addons/web/static/lib/fullcalendar/interaction/index.global.js
+++ b/addons/web/static/lib/fullcalendar/interaction/index.global.js
@@ -1,5 +1,5 @@
 /*!
-FullCalendar Interaction Plugin v6.1.10
+FullCalendar Interaction Plugin v6.1.11
 Docs & License: https://fullcalendar.io/docs/editable
 (c) 2023 Adam Shaw
 */

--- a/addons/web/static/lib/fullcalendar/list/index.global.js
+++ b/addons/web/static/lib/fullcalendar/list/index.global.js
@@ -1,5 +1,5 @@
 /*!
-FullCalendar List View Plugin v6.1.10
+FullCalendar List View Plugin v6.1.11
 Docs & License: https://fullcalendar.io/docs/list-view
 (c) 2023 Adam Shaw
 */

--- a/addons/web/static/lib/fullcalendar/luxon3/index.global.js
+++ b/addons/web/static/lib/fullcalendar/luxon3/index.global.js
@@ -1,5 +1,5 @@
 /*!
-FullCalendar Luxon 3 Plugin v6.1.10
+FullCalendar Luxon 3 Plugin v6.1.11
 Docs & License: https://fullcalendar.io/docs/luxon
 (c) 2023 Adam Shaw
 */

--- a/addons/web/static/lib/fullcalendar/timegrid/index.global.js
+++ b/addons/web/static/lib/fullcalendar/timegrid/index.global.js
@@ -1,5 +1,5 @@
 /*!
-FullCalendar Time Grid Plugin v6.1.10
+FullCalendar Time Grid Plugin v6.1.11
 Docs & License: https://fullcalendar.io/docs/timegrid-view
 (c) 2023 Adam Shaw
 */


### PR DESCRIPTION
Steps to reproduce:
- Install Timesheet
- Delete all tasks
- Run server actions to create tasks with the following scripts https://gist.github.com/mattismegevand/5db26ee9d1e7756e7fe4600897244c1e
- Go to Project -> Tasks -> All tasks
- Switch to calendar view and go to june 2024

Issues:
A traceback appears, the cause is an infinite recursion caused by the computation of the intersection. Since two events are next to each other their intersection is null but fullcalendar try to compute it anyway which leads to the intersection span being null which causes a traceback.

I suspect that the fix is https://github.com/fullcalendar/fullcalendar/commit/362a37345a4b7cb65d16f345e8555f727f1c8450 However for good measure and to fix preemptively other bug from fullcalendar an update seems like the best decision.

opw-3997810