### PR TITLE
[FIX] html_editor: update displayName for font params after undo

### DIFF
--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -12,11 +12,13 @@ import {
     convertNumericToUnit,
     getCSSVariableValue,
     getHtmlStyle,
+    getFontSizeDisplayValue,
 } from "@html_editor/utils/formatting";
 import { DIRECTIONS } from "@html_editor/utils/position";
 import { _t } from "@web/core/l10n/translation";
 import { FontSelector } from "./font_selector";
 import { withSequence } from "@html_editor/utils/resource";
+import { reactive } from "@odoo/owl";
 
 export const fontItems = [
     {
@@ -159,11 +161,13 @@ export class FontPlugin extends Plugin {
                 Component: FontSelector,
                 props: {
                     getItems: () => fontItems,
+                    getDisplay: () => this.font,
                     onSelected: (item) => {
                         this.dependencies.dom.setTag({
                             tagName: item.tagName,
                             extraClass: item.extraClass,
                         });
+                        this.updateFontParams();
                     },
                 },
             },
@@ -174,13 +178,14 @@ export class FontPlugin extends Plugin {
                 Component: FontSelector,
                 props: {
                     getItems: () => this.fontSizeItems,
-                    onSelected: (item) =>
+                    getDisplay: () => this.fontSize,
+                    onSelected: (item) => {
                         this.dependencies.format.formatSelection("setFontSizeClassName", {
                             formatProps: { className: item.className },
                             applyStyle: true,
-                        }),
-                    isFontSize: true,
-                    document: this.document,
+                        });
+                        this.updateFontParams();
+                    },
                 },
             },
         ],
@@ -224,6 +229,9 @@ export class FontPlugin extends Plugin {
 
         /** Handlers */
         input_handlers: this.onInput.bind(this),
+        selectionchange_handlers: this.updateFontParams.bind(this),
+        post_undo_handlers: this.updateFontParams.bind(this),
+        post_redo_handlers: this.updateFontParams.bind(this),
 
         /** Overrides */
         split_element_block_overrides: [
@@ -234,6 +242,44 @@ export class FontPlugin extends Plugin {
         delete_backward_overrides: withSequence(20, this.handleDeleteBackward.bind(this)),
         delete_backward_word_overrides: this.handleDeleteBackward.bind(this),
     };
+
+    setup() {
+        this.fontSize = reactive({ displayName: "" });
+        this.font = reactive({ displayName: "" });
+    }
+
+    get fontName() {
+        const sel = this.dependencies.selection.getSelectionData().deepEditableSelection;
+        // if (!sel) {
+        //     return "Normal";
+        // }
+        const anchorNode = sel.anchorNode;
+        const block = closestBlock(anchorNode);
+        const tagName = block.tagName.toLowerCase();
+
+        const matchingItems = fontItems.filter((item) => {
+            return item.tagName === tagName;
+        });
+
+        const matchingItemsWitoutExtraClass = matchingItems.filter((item) => !item.extraClass);
+
+        if (!matchingItems.length) {
+            return "Normal";
+        }
+
+        return (
+            matchingItems.find((item) => block.classList.contains(item.extraClass)) ||
+            (matchingItemsWitoutExtraClass.length && matchingItemsWitoutExtraClass[0])
+        ).name;
+    }
+
+    get fontSizeName() {
+        const sel = this.dependencies.selection.getSelectionData().deepEditableSelection;
+        if (!sel) {
+            return fontSizeItems[0].name;
+        }
+        return Math.round(getFontSizeDisplayValue(sel, this.document));
+    }
 
     get fontSizeItems() {
         const style = getHtmlStyle(this.document);
@@ -414,5 +460,9 @@ export class FontPlugin extends Plugin {
             fillEmpty(blockEl);
             this.dependencies.dom.setTag({ tagName: headingToBe });
         }
+    }
+    updateFontParams() {
+        this.font.displayName = this.fontName;
+        this.fontSize.displayName = this.fontSizeName;
     }
 }

--- a/addons/html_editor/static/src/main/font/font_selector.js
+++ b/addons/html_editor/static/src/main/font/font_selector.js
@@ -1,5 +1,3 @@
-import { closestBlock } from "@html_editor/utils/blocks";
-import { getFontSizeDisplayValue } from "@html_editor/utils/formatting";
 import { Component, useState } from "@odoo/owl";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
@@ -8,9 +6,8 @@ import { toolbarButtonProps } from "@html_editor/main/toolbar/toolbar";
 export class FontSelector extends Component {
     static template = "html_editor.FontSelector";
     static props = {
-        document: { optional: true },
         getItems: Function,
-        isFontSize: { type: Boolean, optional: true },
+        getDisplay: Function,
         onSelected: Function,
         ...toolbarButtonProps,
     };
@@ -18,50 +15,10 @@ export class FontSelector extends Component {
 
     setup() {
         this.items = this.props.getItems();
-        this.state = useState({
-            displayName: this.getDisplay(),
-        });
-    }
-
-    getDisplay() {
-        return this.props.isFontSize ? this.fontSizeName : this.fontName;
-    }
-
-    get fontName() {
-        const sel = this.props.getSelection().deepEditableSelection;
-        // if (!sel) {
-        //     return "Normal";
-        // }
-        const anchorNode = sel.anchorNode;
-        const block = closestBlock(anchorNode);
-        const tagName = block.tagName.toLowerCase();
-
-        const matchingItems = this.items.filter((item) => {
-            return item.tagName === tagName;
-        });
-
-        const matchingItemsWitoutExtraClass = matchingItems.filter((item) => !item.extraClass);
-
-        if (!matchingItems.length) {
-            return "Normal";
-        }
-
-        return (
-            matchingItems.find((item) => block.classList.contains(item.extraClass)) ||
-            (matchingItemsWitoutExtraClass.length && matchingItemsWitoutExtraClass[0])
-        ).name;
-    }
-
-    get fontSizeName() {
-        const sel = this.props.getSelection().deepEditableSelection;
-        if (!sel) {
-            return this.items[0].name;
-        }
-        return Math.round(getFontSizeDisplayValue(sel, this.props.document));
+        this.state = useState(this.props.getDisplay());
     }
 
     onSelected(item) {
         this.props.onSelected(item);
-        this.state.displayName = this.getDisplay();
     }
 }

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -219,6 +219,7 @@ test("toolbar works: show the right font name", async () => {
     await waitFor(".o-we-toolbar");
     for (const item of fontItems) {
         await contains(".o-we-toolbar [name='font'] .dropdown-toggle").click();
+        await animationFrame();
         const name = item.name.toString();
         let selector = `.o_font_selector_menu .dropdown-item:contains('${name}')`;
         for (const tempItem of fontItems) {
@@ -232,8 +233,28 @@ test("toolbar works: show the right font name", async () => {
             }
         }
         await contains(selector).click();
+        await animationFrame();
         expect(".o-we-toolbar [name='font']").toHaveText(name);
     }
+});
+
+test("toolbar works: show the right font name after undo", async () => {
+    const { el } = await setupEditor("<p>[test]</p>");
+    await waitFor(".o-we-toolbar");
+    expect(".o-we-toolbar [name='font']").toHaveText("Normal");
+
+    await contains(".o-we-toolbar [name='font'] .dropdown-toggle").click();
+    await contains(".o_font_selector_menu .dropdown-item:contains('Header 2')").click();
+    expect(getContent(el)).toBe("<h2>[test]</h2>");
+    expect(".o-we-toolbar [name='font']").toHaveText("Header 2");
+    await press(["ctrl", "z"]);
+    await animationFrame();
+    expect(getContent(el)).toBe("<p>[test]</p>");
+    expect(".o-we-toolbar [name='font']").toHaveText("Normal");
+    await press(["ctrl", "y"]);
+    await animationFrame();
+    expect(getContent(el)).toBe("<h2>[test]</h2>");
+    expect(".o-we-toolbar [name='font']").toHaveText("Header 2");
 });
 
 test("toolbar works: can select font size", async () => {


### PR DESCRIPTION
Steps to reproduce the issue:
=============================
- Create a new todo
- Add some content
- Select it and choose a font
- Press `ctrl+z`
- The display name doesn't get updated

Origin of the issue:
====================
We don't update the state of the font_selector after redo/undo.

Solution:
=========
We need to lift the state from font_selector to the font_plugin so we can detect commands and events and upate the displayName accordingly

task-4243952