### PR TITLE
[FIX] maintenance: allow to update multiple maintenance.request

### DIFF
--- a/addons/maintenance/tests/test_maintenance.py
+++ b/addons/maintenance/tests/test_maintenance.py
@@ -97,3 +97,25 @@ class TestEquipment(TransactionCase):
         maintenance_request.with_context(default_stage_id=maintenance_stages[1].id).stage_id = done_maintenance_stage
         new_maintenance = self.env['maintenance.request'].search([('name', '=', 'Test forever maintenance'), ('stage_id', '=', maintenance_stages[0].id)])
         self.assertTrue(new_maintenance)
+
+    def test_update_multiple_maintenance_request_record(self):
+        """
+        Test that multiple records of the model 'maintenance.request' can be written simultaneously.
+        """
+        maintenance_requests = self.env['maintenance.request'].create([
+            {
+                'name': 'm_1',
+                'maintenance_type': 'preventive',
+                'kanban_state': 'normal',
+            },
+            {
+                'name': 'm_2',
+                'maintenance_type': 'preventive',
+                'kanban_state': 'normal',
+            },
+        ])
+        maintenance_requests.write({'kanban_state': 'blocked', 'stage_id': self.ref('maintenance.stage_0')})
+        self.assertRecordValues(maintenance_requests, [
+            {'kanban_state': 'blocked', 'stage_id': self.ref('maintenance.stage_0')},
+            {'kanban_state': 'blocked', 'stage_id': self.ref('maintenance.stage_0')},
+        ])


### PR DESCRIPTION
The issue: When trying to update the stage field of multiple maintenance request there was an error.

How to reproduce the issue:
-Navigate to the Maintenance app
-Click the Maintenance menu item and select Maintenance Requests from the drop-down menu -Click the List view
-Select more than one request
-Click the Stage field on the list view and select a different stage -Confirm the stage move
-> Traceback

Explanation: In the write method of the maintenance.request model, the fields maintenance_type and recurring_maintenance were directly accessed on a recordset instead of a single record. This caused an error in the __get__ method of field.py because it expects a single record.

opw-4213560

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
