### PR TITLE
[FIX] hr_recruitement{_skills}: No error on create employee from cdt

### DIFF
--- a/addons/hr_recruitment/models/hr_candidate.py
+++ b/addons/hr_recruitment/models/hr_candidate.py
@@ -311,16 +311,6 @@ class HrCandidate(models.Model):
         }
         return res
 
-    def write(self, vals):
-        res = super().write(vals)
-        if vals.get('employee_id'):
-            self._update_employee_from_candidate()
-        return res
-
-    def _update_employee_from_candidate(self):
-        # This method is to be overriden
-        return
-
     @api.ondelete(at_uninstall=False)
     def _unlink_except_linked_employee(self):
         if self.employee_id:

--- a/addons/hr_recruitment_skills/models/hr_candidate.py
+++ b/addons/hr_recruitment_skills/models/hr_candidate.py
@@ -34,20 +34,6 @@ class HrCandidate(models.Model):
         for candidate in self:
             candidate.skill_ids = candidate.candidate_skill_ids.skill_id
 
-    def _update_employee_from_candidate(self):
-        vals_list = []
-        for candidate in self:
-            existing_skills = candidate.employee_id.employee_skill_ids.skill_id
-            skills_to_create = candidate.candidate_skill_ids.skill_id - existing_skills
-            vals_list.extend([{
-                'employee_id': candidate.employee_id.id,
-                'skill_id': skill.id,
-                'skill_level_id': candidate.candidate_skill_ids.filtered(lambda s: s.skill_id == skill).skill_level_id.id,
-                'skill_type_id': skill.skill_type_id.id,
-            } for skill in skills_to_create])
-        self.env['hr.employee.skill'].create(vals_list)
-        return super()._update_employee_from_candidate()
-
     def _get_employee_create_vals(self):
         vals = super()._get_employee_create_vals()
         vals['employee_skill_ids'] = [(0, 0, {


### PR DESCRIPTION
Steps
---
* Create a candidate
* Give them a skill
* *Create Employee*
* => Traceback -> "Two levels for the same skill is not allowed"

Cause
---
* on `hr.employee.skill` we have a unique constraint on the skill
  employee pair
* but when creating an employee we would attepmt to create the skills
  twice, once through regualr create and once from the override of
  `_update_employee_from_candidate` call in the write

Fix
---
Remove the `_update_employee_from_candidate` method, which seems
unnecessary.

task-4207776