### PR TITLE
17.0 pypdf trixie compat moc

### DIFF
--- a/addons/account/models/ir_actions_report.py
+++ b/addons/account/models/ir_actions_report.py
@@ -1,14 +1,11 @@
 # -*- coding: utf-8 -*-
 from collections import OrderedDict
 from zlib import error as zlib_error
-try:
-    from PyPDF2.errors import PdfStreamError, PdfReadError
-except ImportError:
-    from PyPDF2.utils import PdfStreamError, PdfReadError
 
 from odoo import api, models, _
 from odoo.exceptions import UserError
 from odoo.tools import pdf
+from odoo.tools.pdf import PdfReadError, PdfStreamError
 
 
 class IrActionsReport(models.Model):

--- a/addons/account/models/ir_attachment.py
+++ b/addons/account/models/ir_attachment.py
@@ -1,13 +1,9 @@
 # -*- coding: utf-8 -*-
 from odoo import api, models
-from odoo.tools.pdf import OdooPdfFileReader
+from odoo.tools.pdf import OdooPdfFileReader, PdfReadError
 
 from lxml import etree
 from struct import error as StructError
-try:
-    from PyPDF2.errors import PdfReadError
-except ImportError:
-    from PyPDF2.utils import PdfReadError
 import io
 import logging
 import zipfile

--- a/addons/account/tests/test_ir_actions_report.py
+++ b/addons/account/tests/test_ir_actions_report.py
@@ -7,8 +7,8 @@ from odoo.exceptions import RedirectWarning
 from odoo.tools import pdf
 from odoo.tests import tagged
 from odoo.tools import file_open
+from odoo.tools.pdf import PdfFileReader, PdfFileWriter
 
-from PyPDF2 import PdfFileReader, PdfFileWriter
 
 @tagged('post_install', '-at_install')
 class TestIrActionsReport(AccountTestInvoicingCommon):

--- a/addons/account/tests/test_ir_actions_report.py
+++ b/addons/account/tests/test_ir_actions_report.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import base64
 import io
+import re
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.exceptions import RedirectWarning
@@ -56,17 +57,20 @@ class TestIrActionsReport(AccountTestInvoicingCommon):
             for page_num in range(pdf_reader.getNumPages()):
                 pdf_writer.addPage(pdf_reader.getPage(page_num))
             # Encrypt the PDF
-            pdf_writer.encrypt('', use_128bit=True)
+            pdf_writer.encrypt('')
             # Get the binary
             output_buffer = io.BytesIO()
             pdf_writer.write(output_buffer)
             encrypted_file = output_buffer.getvalue()
 
-        # we need to change the encryption value from 4 to 5 to simulate an encryption not used by PyPDF2
-        encrypt_start = encrypted_file.find(b'/Encrypt')
-        encrypt_end = encrypted_file.find(b'>>', encrypt_start)
-        encrypt_version = encrypted_file[encrypt_start : encrypt_end]
-        encrypted_file = encrypted_file.replace(encrypt_version, encrypt_version.replace(b'4', b'5'))
+        # corrupt encryption: point the /Encrypt xref as a non-encrypt
+        # (but valid otherwise pypdf skips it)
+        encrypted_file, n = re.subn(
+            b'/Encrypt (?P<index>\\d+) (?P<gen>\\d+) R',
+            b'/Encrypt 1 \\g<gen> R',
+            encrypted_file,
+        )
+        self.assertEqual(n, 1, "should have updated the /Encrypt entry")
 
         in_invoice_1 = self.env['account.move'].create({
             'move_type': 'in_invoice',
@@ -75,7 +79,7 @@ class TestIrActionsReport(AccountTestInvoicingCommon):
         })
 
         in_invoice_1.message_main_attachment_id = self.env['ir.attachment'].create({
-            'datas': base64.b64encode(encrypted_file),
+            'raw': encrypted_file,
             'name': attach_name,
             'mimetype': 'application/pdf',
             'res_model': 'account.move',
@@ -87,7 +91,7 @@ class TestIrActionsReport(AccountTestInvoicingCommon):
         in_invoice_2 = in_invoice_1.copy()
 
         in_invoice_2.message_main_attachment_id = self.env['ir.attachment'].create({
-            'datas': base64.b64encode(self.file),
+            'raw': self.file,
             'name': attach_name,
             'mimetype': 'application/pdf',
             'res_model': 'account.move',

--- a/addons/sale_pdf_quote_builder/models/ir_actions_report.py
+++ b/addons/sale_pdf_quote_builder/models/ir_actions_report.py
@@ -3,11 +3,9 @@
 import base64
 import io
 
-from PyPDF2 import PdfFileWriter, PdfFileReader
-from PyPDF2.generic import NameObject, createStringObject
-
 from odoo import models
 from odoo.tools import format_amount, format_date, format_datetime, pdf
+from odoo.tools.pdf import PdfFileWriter, PdfFileReader, NameObject, createStringObject
 
 
 class IrActionsReport(models.Model):

--- a/addons/snailmail/models/snailmail_letter.py
+++ b/addons/snailmail/models/snailmail_letter.py
@@ -4,7 +4,6 @@ import re
 import base64
 import io
 
-from PyPDF2 import PdfFileReader, PdfFileWriter
 from reportlab.platypus import Frame, Paragraph, KeepInFrame
 from reportlab.lib.units import mm
 from reportlab.lib.pagesizes import A4
@@ -14,6 +13,7 @@ from reportlab.pdfgen.canvas import Canvas
 from odoo import fields, models, api, _
 from odoo.addons.iap.tools import iap_tools
 from odoo.exceptions import AccessError, UserError
+from odoo.tools.pdf import PdfFileReader, PdfFileWriter
 from odoo.tools.safe_eval import safe_eval
 
 DEFAULT_ENDPOINT = 'https://iap-snailmail.odoo.com'

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -7,7 +7,6 @@ import io
 import logging
 import re
 import requests
-import PyPDF2
 
 from dateutil.relativedelta import relativedelta
 from markupsafe import Markup
@@ -18,6 +17,7 @@ from odoo.addons.http_routing.models.ir_http import slug, url_for
 from odoo.exceptions import RedirectWarning, UserError, AccessError
 from odoo.http import request
 from odoo.tools import html2plaintext, sql
+from odoo.tools.pdf import PdfFileReader
 
 _logger = logging.getLogger(__name__)
 
@@ -1336,7 +1336,7 @@ class Slide(models.Model):
 
         if data_bytes.startswith(b'%PDF-'):
             try:
-                pdf = PyPDF2.PdfFileReader(io.BytesIO(data_bytes), overwriteWarnings=False)
+                pdf = PdfFileReader(io.BytesIO(data_bytes), overwriteWarnings=False)
                 return (5 * len(pdf.pages)) / 60
             except Exception:
                 pass  # as this is a nice to have, fail silently

--- a/debian/py3dist-overrides
+++ b/debian/py3dist-overrides
@@ -1,0 +1,1 @@
+lxml python3-lxml-html-clean | python3-lxml

--- a/odoo/__init__.py
+++ b/odoo/__init__.py
@@ -68,26 +68,6 @@ import time
 if hasattr(time, 'tzset'):
     time.tzset()
 
-#----------------------------------------------------------
-# PyPDF2 hack
-# ensure that zlib does not throw error -5 when decompressing
-# because some pdf won't fit into allocated memory
-# https://docs.python.org/3/library/zlib.html#zlib.decompressobj
-# ----------------------------------------------------------
-import PyPDF2
-
-try:
-    import zlib
-
-    def _decompress(data):
-        zobj = zlib.decompressobj()
-        return zobj.decompress(data)
-
-    import PyPDF2.filters  # needed after PyPDF2 2.0.0 and before 2.11.0
-    PyPDF2.filters.decompress = _decompress
-except ImportError:
-    pass # no fix required
-
 # ---------------------------------------------------------
 # some charset are known by Python under a different name
 # ---------------------------------------------------------

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -8,6 +8,7 @@ from odoo.exceptions import UserError, AccessError, RedirectWarning
 from odoo.tools.safe_eval import safe_eval, time
 from odoo.tools.misc import find_in_path, ustr
 from odoo.tools import check_barcode_encoding, config, is_html_empty, parse_version, split_every
+from odoo.tools.pdf import PdfFileWriter, PdfFileReader, PdfReadError
 from odoo.http import request
 from odoo.osv.expression import NEGATIVE_TERM_OPERATORS, FALSE_DOMAIN
 
@@ -24,7 +25,6 @@ from lxml import etree
 from contextlib import closing
 from reportlab.graphics.barcode import createBarcodeDrawing
 from reportlab.pdfbase.pdfmetrics import getFont, TypeFace
-from PyPDF2 import PdfFileWriter, PdfFileReader
 from collections import OrderedDict
 from collections.abc import Iterable
 from PIL import Image, ImageFile
@@ -32,11 +32,6 @@ from itertools import islice
 
 # Allow truncated images
 ImageFile.LOAD_TRUNCATED_IMAGES = True
-
-try:
-    from PyPDF2.errors import PdfReadError
-except ImportError:
-    from PyPDF2.utils import PdfReadError
 
 _logger = logging.getLogger(__name__)
 

--- a/odoo/addons/base/tests/test_test_suite.py
+++ b/odoo/addons/base/tests/test_test_suite.py
@@ -134,6 +134,7 @@ class TestRunnerLoggingCommon(TransactionCase):
         message = re.sub(r'line \d+', 'line $line', message)
         message = re.sub(r'py:\d+', 'py:$line', message)
         message = re.sub(r'decorator-gen-\d+', 'decorator-gen-xxx', message)
+        message = re.sub(r'^\s*\^+\s*\n', '', message, flags=re.MULTILINE)
         message = message.replace(f'"{root_path}', '"/root_path/odoo')
         message = message.replace(f'"{python_path}', '"/usr/lib/python')
         message = message.replace('\\', '/')

--- a/odoo/tools/pdf/__init__.py
+++ b/odoo/tools/pdf/__init__.py
@@ -93,13 +93,24 @@ def _unwrapping_get(self, key, default=None):
 DictionaryObject.get = _unwrapping_get
 
 
-class BrandedFileWriter(PdfFileWriter):
-    def __init__(self):
-        super().__init__()
-        self.addMetadata({
-            '/Creator': "Odoo",
-            '/Producer': "Odoo",
-        })
+if hasattr(PdfWriter, 'write_stream'):
+    # >= 2.x has a utility `write` which can open a path, so `write_stream` could be called directly
+    class BrandedFileWriter(PdfWriter):
+        def write_stream(self, *args, **kwargs):
+            self.add_metadata({
+                '/Creator': "Odoo",
+                '/Producer': "Odoo",
+            })
+            super().write_stream(*args, **kwargs)
+else:
+    # 1.x has a monolithic write method
+    class BrandedFileWriter(PdfWriter):
+        def write(self, *args, **kwargs):
+            self.addMetadata({
+                '/Creator': "Odoo",
+                '/Producer': "Odoo",
+            })
+            super().write(*args, **kwargs)
 
 
 PdfFileWriter = BrandedFileWriter

--- a/odoo/tools/pdf/__init__.py
+++ b/odoo/tools/pdf/__init__.py
@@ -297,7 +297,7 @@ class OdooPdfFileWriter(PdfFileWriter):
         self._reader = None
         self.is_pdfa = False
 
-    def addAttachment(self, name, data, subtype=None):
+    def add_attachment(self, name, data, subtype=None):
         """
         Add an attachment to the pdf. Supports adding multiple attachment, while respecting PDF/A rules.
         :param name: The name of the attachement
@@ -350,6 +350,7 @@ class OdooPdfFileWriter(PdfFileWriter):
             self._root_object.update({
                 NameObject("/AF"): attachment_array
             })
+    addAttachment = add_attachment
 
     def embed_odoo_attachment(self, attachment, subtype=None):
         assert attachment, "embed_odoo_attachment cannot be called without attachment."

--- a/odoo/tools/pdf/__init__.py
+++ b/odoo/tools/pdf/__init__.py
@@ -278,10 +278,10 @@ class OdooPdfFileReader(PdfFileReader):
 
             if not file_path:
                 return []
-            for i in range(0, len(file_path), 2):
-                attachment = file_path[i+1].getObject()
+            for p in file_path[1::2]:
+                attachment = p.getObject()
                 yield (attachment["/F"], attachment["/EF"]["/F"].getObject().getData())
-        except Exception:
+        except Exception:  # noqa: BLE001
             # malformed pdf (i.e. invalid xref page)
             return []
 

--- a/odoo/tools/pdf/__init__.py
+++ b/odoo/tools/pdf/__init__.py
@@ -1,41 +1,21 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import importlib
 import io
 import re
-
+import sys
 from datetime import datetime
 from hashlib import md5
 from logging import getLogger
-from zlib import compress, decompress
+from zlib import compress, decompress, decompressobj
+
 from PIL import Image, PdfImagePlugin
 from reportlab.lib import colors
 from reportlab.lib.units import cm
 from reportlab.lib.utils import ImageReader
 from reportlab.pdfgen import canvas
+
 from odoo.tools.parse_version import parse_version
-
-try:
-    # class were renamed in PyPDF2 > 2.0
-    # https://pypdf2.readthedocs.io/en/latest/user/migration-1-to-2.html#classes
-    from PyPDF2 import PdfReader
-    import PyPDF2
-    # monkey patch to discard unused arguments as the old arguments were not discarded in the transitional class
-    # https://pypdf2.readthedocs.io/en/2.0.0/_modules/PyPDF2/_reader.html#PdfReader
-    class PdfFileReader(PdfReader):
-        def __init__(self, *args, **kwargs):
-            if "strict" not in kwargs and len(args) < 2:
-                kwargs["strict"] = True  # maintain the default
-            kwargs = {k:v for k, v in kwargs.items() if k in ('strict', 'stream')}
-            super().__init__(*args, **kwargs)
-
-    PyPDF2.PdfFileReader = PdfFileReader
-    from PyPDF2 import PdfFileWriter, PdfFileReader
-    PdfFileReader.getFields = PdfFileReader.get_fields
-    PdfFileWriter._addObject = PdfFileWriter._add_object
-except ImportError:
-    from PyPDF2 import PdfFileWriter, PdfFileReader
-
-from PyPDF2.generic import ArrayObject, BooleanObject, ByteStringObject, DecodedStreamObject, DictionaryObject, IndirectObject, NameObject, NumberObject, createStringObject
+from odoo.tools.misc import file_open
 
 try:
     import fontTools
@@ -43,7 +23,54 @@ try:
 except ImportError:
     TTFont = None
 
-from odoo.tools.misc import file_open
+
+# might be a good case for exception groups
+error = None
+# keep pypdf2 2.x first so noble uses that rather than pypdf 4.0
+for submod in ['._pypdf2_2', '._pypdf', '._pypdf2_1']:
+    try:
+        pypdf = importlib.import_module(submod, __spec__.name)
+        break
+    except ImportError as e:
+        if error is None:
+            error = e
+else:
+    raise ImportError("pypdf implementation not found") from error
+del error
+
+PdfReader, PdfWriter, filters, generic, errors, create_string_object =\
+    pypdf.PdfReader, pypdf.PdfWriter, pypdf.filters, pypdf.generic, pypdf.errors, pypdf.create_string_object
+# because they got re-exported
+ArrayObject, BooleanObject, ByteStringObject, DecodedStreamObject, DictionaryObject, IndirectObject, NameObject, NumberObject =\
+    generic.ArrayObject, generic.BooleanObject, generic.ByteStringObject, generic.DecodedStreamObject, generic.DictionaryObject, generic.IndirectObject, generic.NameObject, generic.NumberObject
+
+# compatibility aliases
+PdfReadError = errors.PdfReadError  # moved in 2.0
+PdfStreamError = errors.PdfStreamError  # moved in 2.0
+createStringObject = create_string_object  # deprecated in 2.0, removed in 5.0
+
+# ----------------------------------------------------------
+# PyPDF2 hack
+# ensure that zlib does not throw error -5 when decompressing
+# because some pdf won't fit into allocated memory
+# https://docs.python.org/3/library/zlib.html#zlib.decompressobj
+# ----------------------------------------------------------
+pypdf.filters.decompress = lambda data: decompressobj().decompress(data)
+
+
+# monkey patch to discard unused arguments as the old arguments were not discarded in the transitional class
+# https://pypdf2.readthedocs.io/en/2.0.0/_modules/PyPDF2/_reader.html#PdfReader
+class PdfFileReader(PdfReader):
+    def __init__(self, *args, **kwargs):
+        if "strict" not in kwargs and len(args) < 2:
+            kwargs["strict"] = True  # maintain the default
+        kwargs = {k: v for k, v in kwargs.items() if k in ('strict', 'stream')}
+        super().__init__(*args, **kwargs)
+
+
+if 'PyPDF2' in sys.modules:
+    pypdf.PdfFileReader = PdfFileReader
+    pypdf.PdfFileWriter = PdfWriter
 
 _logger = getLogger(__name__)
 DEFAULT_PDF_DATETIME_FORMAT = "D:%Y%m%d%H%M%S+00'00'"
@@ -53,6 +80,7 @@ REGEX_SUBTYPE_FORMATED = re.compile(r'^/\w+#2F[\w-]+$')
 
 # Disable linter warning: this import is needed to make sure a PDF stream can be saved in Image.
 PdfImagePlugin.__name__
+
 
 # make sure values are unwrapped by calling the specialized __getitem__
 def _unwrapping_get(self, key, default=None):
@@ -92,6 +120,7 @@ def merge_pdf(pdf_data):
     with io.BytesIO() as _buffer:
         writer.write(_buffer)
         return _buffer.getvalue()
+
 
 def fill_form_fields_pdf(writer, form_fields):
     ''' Fill in the form fields of a PDF
@@ -140,6 +169,7 @@ def fill_form_fields_pdf(writer, form_fields):
                 # Mark filled fields as readonly to avoid the blue overlay:
                 if annot.get('/T') == field:
                     annot.update({NameObject("/Ff"): NumberObject(1)})
+
 
 def rotate_pdf(pdf):
     ''' Rotate clockwise PDF (90°) into a new PDF.
@@ -231,13 +261,6 @@ def add_banner(pdf_stream, text=None, logo=False, thickness=2 * cm):
 
     return output
 
-
-# by default PdfFileReader will overwrite warnings.showwarning which is what
-# logging.captureWarnings does, meaning it essentially reverts captureWarnings
-# every time it's called which is undesirable
-old_init = PdfFileReader.__init__
-PdfFileReader.__init__ = lambda self, stream, strict=True, warndest=None, overwriteWarnings=True: \
-    old_init(self, stream=stream, strict=strict, warndest=None, overwriteWarnings=False)
 
 class OdooPdfFileReader(PdfFileReader):
     # OVERRIDE of PdfFileReader to add the management of multiple embedded files.

--- a/odoo/tools/pdf/_pypdf.py
+++ b/odoo/tools/pdf/_pypdf.py
@@ -1,0 +1,73 @@
+import pypdf
+from pypdf import errors, filters, generic, PdfReader as _Reader, PdfWriter as _Writer
+from pypdf.generic import create_string_object
+
+__all__ = [
+    "PdfReader",
+    "PdfWriter",
+    "create_string_object",
+    "errors",
+    "filters",
+    "generic",
+]
+
+
+pypdf.PageObject.mergePage = lambda self, page2: self.merge_page(page2)
+pypdf.PageObject.mediaBox = property(lambda self: self.mediabox)
+# use lambdas (rather than copying) to allow overrides of the base method
+generic.PdfObject.getObject = lambda self: self.get_object()
+generic.StreamObject.getData = lambda self: self.get_data()
+generic.StreamObject.setData = lambda self, data: self.set_data(data)
+generic.RectangleObject.getWidth = lambda self: self.width
+generic.RectangleObject.getHeight = lambda self: self.height
+
+
+class PdfReader(_Reader):
+    @property
+    def isEncrypted(self):
+        return self.is_encrypted
+
+    def getPage(self, pageNumber):
+        return self.pages[pageNumber]
+
+    def getNumPages(self):
+        return len(self.pages)
+
+    @property
+    def numPages(self):
+        return len(self.pages)
+
+    def getDocumentInfo(self):
+        return self.metadata
+
+
+class PdfWriter(_Writer):
+    def getPage(self, pageNumber):
+        return self.pages[pageNumber]
+
+    def getNumPages(self):
+        return len(self.pages)
+
+    def addPage(self, page):
+        return self.add_page(page)
+
+    def appendPagesFromReader(self, reader):
+        return self.append_pages_from_reader(reader)
+
+    def addBlankPage(self):
+        return self.add_blank_page()
+
+    def addAttachment(self, fname, data):
+        return self.add_attachment(fname, data)
+
+    def addMetadata(self, infos):
+        return self.add_metadata(infos)
+
+    def cloneReaderDocumentRoot(self, reader):
+        return self.clone_reader_document_root(reader)
+
+    def getFields(self, *args, **kwargs):
+        return self.get_fields(*args, **kwargs)
+
+    def _addObject(self, *args, **kwargs):
+        return self._add_object(*args, **kwargs)

--- a/odoo/tools/pdf/_pypdf2_1.py
+++ b/odoo/tools/pdf/_pypdf2_1.py
@@ -1,0 +1,27 @@
+from PyPDF2 import filters, generic, utils as errors, PdfFileReader, PdfFileWriter
+from PyPDF2.generic import createStringObject as create_string_object
+
+__all__ = [
+    "PdfReader",
+    "PdfWriter",
+    "create_string_object",
+    "errors",
+    "filters",
+    "generic",
+]
+
+
+# by default PdfFileReader will overwrite warnings.showwarning which is what
+# logging.captureWarnings does, meaning it essentially reverts captureWarnings
+# every time it's called which is undesirable
+class PdfReader(PdfFileReader):
+    def __init__(self, stream, strict=True, warndest=None, overwriteWarnings=True):
+        super().__init__(stream, strict=True, warndest=None, overwriteWarnings=False)
+
+
+class PdfWriter(PdfFileWriter):
+    def get_fields(self, *args, **kwargs):
+        return self.getFields(*args, **kwargs)
+
+    def _add_object(self, *args, **kwargs):
+        return self._addObject(*args, **kwargs)

--- a/odoo/tools/pdf/_pypdf2_2.py
+++ b/odoo/tools/pdf/_pypdf2_2.py
@@ -1,0 +1,19 @@
+from PyPDF2 import errors, filters, generic, PdfReader, PdfWriter as _Writer
+from PyPDF2.generic import create_string_object
+
+__all__ = [
+    "PdfReader",
+    "PdfWriter",
+    "create_string_object",
+    "errors",
+    "filters",
+    "generic",
+]
+
+
+class PdfWriter(_Writer):
+    def getFields(self, *args, **kwargs):
+        return self.get_fields(*args, **kwargs)
+
+    def _addObject(self, *args, **kwargs):
+        return self._add_object(*args, **kwargs)


### PR DESCRIPTION
As Debian wants to remove pypdf2 and keep only pypdf (4.3) in
trixie, so we need to be compatible otherwise Odoo could not be released in the next Debian.
