### PR TITLE
[FIX] l10n_br_sales: correctly override a t-call

### DIFF
--- a/addons/l10n_br_sales/report/sale_order_templates.xml
+++ b/addons/l10n_br_sales/report/sale_order_templates.xml
@@ -20,7 +20,10 @@
             <attribute name="t-field">line.price_total</attribute>
         </span>
         <xpath expr="//t[@t-call='sale.document_tax_totals']" position="replace">
-            <t t-call="l10n_br_sales.document_tax_totals_brazil"/>
+            <t t-call="l10n_br_sales.document_tax_totals_brazil">
+                <t t-set="tax_totals" t-value="doc.tax_totals"/>
+                <t t-set="currency" t-value="doc.currency_id"/>
+            </t>
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
Currently, you can't print quotations with a Brazilian company.

### Steps to reproduce

* install `l10n_br_sales`
* switch to a Brazilian company
* attempt to print a quotation

You should be met with the following traceback:
```
TypeError: 'NoneType' object is not subscriptable
Template: l10n_br_sales.document_tax_totals_brazil
Path: /t/tr[1]
Node: <tr t-if="\'cash_rounding_base_amount_currency\' in tax_totals"/>
```

### Cause

The `l10n_br_sales.document_tax_totals_brazil` currently overrides `sale.document_tax_totals` using the following code:

```xml
<xpath expr="//t[@t-call='sale.document_tax_totals']" position="replace">
    <t t-call="l10n_br_sales.document_tax_totals_brazil"/>
</xpath>
```

However, there was a recent update (d0e7be7832672d476f1b289af52d3a425990d719) to the `sale.document_tax_totals` call, as shown below:

```diff
-    <t t-set="tax_totals" t-value="doc.tax_totals"/>
-    <t t-call="sale.document_tax_totals"/>
+    <t t-call="sale.document_tax_totals">
+        <t t-set="tax_totals" t-value="doc.tax_totals"/>
+        <t t-set="currency" t-value="doc.currency_id"/>
+    </t>
```

With this change, the override in `l10n_br_sales.document_tax_totals_brazil` will no longer have access to the `tax_totals` and `currency` values because they are now passed inside the `t-call` block of `sale.document_tax_totals`.

opw-4239563