### PR TITLE
[FIX] product,sale_pdf_quote_builder: prevent uploading non-supported files

### DIFF
--- a/addons/product/i18n/product.pot
+++ b/addons/product/i18n/product.pot
@@ -2242,6 +2242,12 @@ msgid ""
 msgstr ""
 
 #. module: product
+#. odoo-javascript
+#: code:addons/product/static/src/js/product_document_kanban/upload_button/upload_button.js:0
+msgid "Oops! '%(fileName)s' didn’t upload since its format isn’t allowed."
+msgstr ""
+
+#. module: product
 #: model:ir.model.fields,field_description:product.field_product_document__original_id
 msgid "Original (unoptimized, unresized) attachment"
 msgstr ""

--- a/addons/product/static/src/js/product_document_kanban/product_document_kanban_controller.xml
+++ b/addons/product/static/src/js/product_document_kanban/product_document_kanban_controller.xml
@@ -8,6 +8,7 @@
         <xpath expr="//div[hasclass('o_cp_buttons')]" position="inside">
             <UploadButton
                 formData="formData"
+                allowedMIMETypes="allowedMIMETypes"
                 load.bind="() => this.model.root.load()"
                 uploadRoute="uploadRoute"
             />

--- a/addons/product/static/src/js/product_document_kanban/upload_button/upload_button.js
+++ b/addons/product/static/src/js/product_document_kanban/upload_button/upload_button.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import { _t } from "@web/core/l10n/translation";
 import { Component, useRef } from "@odoo/owl";
 import { useBus, useService } from "@web/core/utils/hooks";
 
@@ -7,6 +8,8 @@ export class UploadButton extends Component {
     static template = "product.UploadButton";
     static props = {
         formData: { type: Object, optional: true},
+        // See https://www.iana.org/assignments/media-types/media-types.xhtml
+        allowedMIMETypes: { type: String, optional: true},
         load: Function,
         uploadRoute: String,
     }
@@ -17,6 +20,7 @@ export class UploadButton extends Component {
     setup() {
         this.uploadFileInputRef = useRef("uploadFileInput");
         this.fileUploadService = useService("file_upload");
+        this.notification = useService('notification');
         useBus(
             this.fileUploadService.bus,
             "FILE_UPLOAD_LOADED",
@@ -27,18 +31,42 @@ export class UploadButton extends Component {
     }
 
     async onFileInputChange(ev) {
-        if (!ev.target.files.length) {
+        const files = [...ev.target.files].filter(file => this.validFileType(file));
+        if (!files.length) {
             return;
         }
         await this.fileUploadService.upload(
             this.props.uploadRoute,
-            ev.target.files,
+            files,
             {
                 buildFormData: (formData) => this.buildFormData(formData)
             },
         );
         // Reset the file input's value so that the same file may be uploaded twice.
         ev.target.value = "";
+    }
+
+    /**
+     * The `allowedMIMETypes` prop can restrict the file types users are guided to select. However,
+     * the `accept` attribute doesn't enforce strict validation; it only suggests file types for
+     * browsers.
+     *
+     * @param {File} file
+     * @returns Whether the upload file's type is in the whitelist (`allowedMIMETypes`).
+     */
+    validFileType(file) {
+        if (this.props.allowedMIMETypes && !this.props.allowedMIMETypes.includes(file.type)) {
+            this.notification.add(
+                _t(`Oops! '%(fileName)s' didn’t upload since its format isn’t allowed.`, {
+                    fileName: file.name,
+                }),
+                {
+                    type: "danger",
+                }
+            );
+            return false;
+        }
+        return true;
     }
 
     buildFormData(formData) {

--- a/addons/product/static/src/js/product_document_kanban/upload_button/upload_button.xml
+++ b/addons/product/static/src/js/product_document_kanban/upload_button/upload_button.xml
@@ -5,7 +5,7 @@
             type="file"
             multiple="true"
             t-ref="uploadFileInput"
-            accept="application/pdf"
+            t-att-accept="props.allowedMIMETypes"
             class="o_input_file o_hidden"
             t-on-change.stop="onFileInputChange"
         />

--- a/addons/sale_pdf_quote_builder/static/src/js/quotation_document_kanban/quotation_document_kanban_controller.js
+++ b/addons/sale_pdf_quote_builder/static/src/js/quotation_document_kanban/quotation_document_kanban_controller.js
@@ -9,5 +9,6 @@ export class QuotationDocumentKanbanController extends KanbanController {
     setup() {
         super.setup();
         this.uploadRoute = '/sale_pdf_quote_builder/quotation_document/upload';
+        this.allowedMIMETypes='application/pdf';
     }
 }

--- a/addons/sale_pdf_quote_builder/static/src/js/quotation_document_kanban/quotation_document_kanban_widget.js
+++ b/addons/sale_pdf_quote_builder/static/src/js/quotation_document_kanban/quotation_document_kanban_widget.js
@@ -21,6 +21,7 @@ export class QuotationDocumentX2ManyField extends X2ManyField {
         this.formData = {
             'sale_order_template_id': this.props.record.resId,
         };
+        this.allowedMIMETypes='application/pdf';
     }
 }
 

--- a/addons/sale_pdf_quote_builder/static/src/js/quotation_document_kanban/quotation_document_kanban_widget.xml
+++ b/addons/sale_pdf_quote_builder/static/src/js/quotation_document_kanban/quotation_document_kanban_widget.xml
@@ -8,6 +8,7 @@
         <xpath expr="//div[hasclass('o_cp_buttons')]" position="inside">
             <UploadButton
                 formData="formData"
+                allowedMIMETypes="allowedMIMETypes"
                 load.bind="() => this.props.record.load()"
                 uploadRoute="uploadRoute"
             />


### PR DESCRIPTION
Currently, an exception was generated when the user uploaded a non-pdf
file in Quate Builder of quotation templates.

error: `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0:
invalid start byte`

This commit will fix the above issue by preventing uploading non-supported
files that were uploaded by users.

sentry-5962839786