### PR TITLE
[FIX] hw_posbox_homepage rewrite fixes

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -19,6 +19,7 @@ import requests
 import secrets
 import socket
 import subprocess
+from urllib.parse import parse_qs
 import urllib3
 from threading import Thread, Lock
 import time
@@ -636,3 +637,38 @@ def migrate_old_config_files_to_new_config_file():
         unlink_file('odoo-remote-server.conf')
         unlink_file('token')
         unlink_file('odoo-subject.conf')
+
+
+def url_is_valid(url):
+    """
+    Checks whether the provided url is a valid one or not
+    :param url: the URL to check
+    :return: boolean indicating if the URL is valid.
+    """
+    try:
+        result = urllib3.util.parse_url(url.strip())
+        return all([result.scheme in ["http", "https"], result.netloc, result.host != 'localhost'])
+    except urllib3.exceptions.LocationParseError:
+        return False
+
+
+def parse_url(url):
+    """
+    Parses URL params and returns them as a dictionary starting by the url.
+
+    Does not allow multiple params with the same name (e.g. <url>?a=1&a=2 will return the same as <url>?a=1)
+    :param url: the URL to parse
+    :return: the dictionary containing the URL and params
+    """
+    if not url_is_valid(url):
+        raise ValueError("Invalid URL provided.")
+
+    url = urllib3.util.parse_url(url.strip())
+    search_params = {
+        key: value[0]
+        for key, value in parse_qs(url.query, keep_blank_values=True).items()
+    }
+    return {
+        "url": f"{url.scheme}://{url.netloc}",
+        **search_params,
+    }

--- a/addons/hw_posbox_homepage/controllers/homepage.py
+++ b/addons/hw_posbox_homepage/controllers/homepage.py
@@ -308,13 +308,22 @@ class IotBoxOwlHomePage(Home):
     @http.route('/hw_posbox_homepage/connect_to_server', auth="none", type="json", methods=['POST'], cors='*')
     def connect_to_odoo_server(self, token=False, iotname=False):
         if token:
-            credential = token.split('|')
-            url = credential[0]
-            token = credential[1]
-            db_uuid = credential[2]
-            enterprise_code = credential[3]
             try:
-                helpers.save_conf_server(url, token, db_uuid, enterprise_code)
+                if len(token.split('|')) == 4:
+                    # Old style token with pipe separators (pre v18 DB)
+                    url, token, db_uuid, enterprise_code = token.split('|')
+                    configuration = helpers.parse_url(url)
+                    helpers.save_conf_server(configuration["url"], token, db_uuid, enterprise_code)
+                else:
+                    # New token using query params (v18+ DB)
+                    configuration = helpers.parse_url(token)
+                    helpers.save_conf_server(**configuration)
+            except ValueError:
+                _logger.warning("Wrong server token: %s", token)
+                return {
+                    'status': 'failure',
+                    'message': 'Invalid URL provided.',
+                }
             except (subprocess.CalledProcessError, OSError, Exception):
                 return {
                     'status': 'failure',

--- a/addons/hw_posbox_homepage/controllers/homepage.py
+++ b/addons/hw_posbox_homepage/controllers/homepage.py
@@ -316,7 +316,10 @@ class IotBoxOwlHomePage(Home):
             try:
                 helpers.save_conf_server(url, token, db_uuid, enterprise_code)
             except (subprocess.CalledProcessError, OSError, Exception):
-                return 'Failed to write server configuration files on IoT. Please try again.'
+                return {
+                    'status': 'failure',
+                    'message': 'Failed to write server configuration files on IoT. Please try again.',
+                }
 
         if iotname and platform.system() == 'Linux' and iotname != helpers.get_hostname():
             subprocess.run([file_path(

--- a/addons/hw_posbox_homepage/static/src/app/Homepage.js
+++ b/addons/hw_posbox_homepage/static/src/app/Homepage.js
@@ -86,7 +86,7 @@ export class Homepage extends Component {
     </LoadingFullScreen>
 
     <div t-if="!this.state.loading" class="w-100 d-flex flex-column align-items-center justify-content-center" style="background-color: #F1F1F1; height: 100vh">
-        <div class="bg-white p-4 rounded overflow-auto position-relative" style="min-width: 600px;">
+        <div class="bg-white p-4 rounded overflow-auto position-relative" style="width: 100%; max-width: 600px;">
             <div class="position-absolute end-0 top-0 mt-3 me-4 d-flex gap-1">
                 <IconButton onClick.bind="toggleAdvanced" icon="this.store.advanced ? 'fa-cog' : 'fa-cogs'" />
                 <IconButton onClick.bind="restartOdooService" icon="'fa-power-off'" />

--- a/addons/hw_posbox_homepage/static/src/app/components/dialog/ServerDialog.js
+++ b/addons/hw_posbox_homepage/static/src/app/components/dialog/ServerDialog.js
@@ -12,7 +12,7 @@ export class ServerDialog extends Component {
 
     setup() {
         this.store = toRaw(useStore());
-        this.state = useState({ waitRestart: false });
+        this.state = useState({ waitRestart: false, loading: false, error: null });
         this.form = useState({
             token: "",
             iotname: this.store.base.hostname,
@@ -20,6 +20,8 @@ export class ServerDialog extends Component {
     }
 
     async connectToServer() {
+        this.state.loading = true;
+        this.state.error = null;
         try {
             const data = await this.store.rpc({
                 url: "/hw_posbox_homepage/connect_to_server",
@@ -29,10 +31,13 @@ export class ServerDialog extends Component {
 
             if (data.status === "success") {
                 this.state.waitRestart = true;
+            } else {
+                this.state.error = data.message;
             }
         } catch {
             console.warn("Error while fetching data");
         }
+        this.state.loading = false;
     }
 
     async clearConfiguration() {
@@ -77,8 +82,9 @@ export class ServerDialog extends Component {
                         <small t-if="!this.form.token" class="text-danger">Please enter a server token</small>
                     </div>
                     <div class="d-flex justify-content-end gap-2">
-                        <button type="submit" class="btn btn-warning btn-sm" t-on-click="connectToServer">Connect</button>
+                        <button type="submit" class="btn btn-warning btn-sm" t-att-disabled="this.state.loading" t-on-click="connectToServer">Connect</button>
                     </div>
+                    <small t-if="this.state.error" class="text-danger" t-esc="this.state.error"/>
                 </div>
             </t>
             <t t-set-slot="footer">

--- a/addons/hw_posbox_homepage/views/index.html
+++ b/addons/hw_posbox_homepage/views/index.html
@@ -3,6 +3,7 @@
     <head>
         <meta http-equiv="cache-control" content="no-cache" />
         <meta http-equiv="pragma" content="no-cache" />
+        <meta name="viewport" content="width=device-width,initial-scale=1">
 
         <title>Odoo's IoT Box</title>
 


### PR DESCRIPTION
This PR contains three small commits:

[FIX] hw_posbox_homepage: make homepage responsive

The new OWL IoT homepage is currently not responsive
on mobile due to a missing HTML meta tag. This PR
adds that tag as well as tweaking the width to not be
cutoff on small screens.


[FIX] hw_posbox_homepage: show error messages

The IoT box returns error messages when connecting
to a server fails. The new OWL homepage currently
does not show these or any other sign of failure,
instead just seeming unresponsive.

This PR now shows the error messages again, as well
as disabling the 'Connect' button while loading.


[FIX] hw_posbox_homepage: allow new IoT connection tokens

This change backports the URL helpers from 18.0, and modifies
the homepage controller to allow the new type of IoT token.
The result of this is that IoT boxes on v17 can connect to v18
databases via the token.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
