### PR TITLE
[FIX] mrp: prevent error when clicking on Done button in WorkOrder

### DIFF
--- a/addons/mrp/static/src/components/wo_list_view_dropdown/wo_list_view_dropdown.xml
+++ b/addons/mrp/static/src/components/wo_list_view_dropdown/wo_list_view_dropdown.xml
@@ -3,7 +3,7 @@
 
     <t t-name="mrp.MOViewListDropdown" style="btn">
         <Dropdown>
-            <button class="btn btn-link d-flex p-0">
+            <button t-attf-class="btn btn-link d-flex p-0 {{!this.props.record.resId ? 'invisible': ''}}">
                 <div class="d-flex align-items-center">
                     <span t-attf-class="o_status {{statusColor}}"/>
                 </div>


### PR DESCRIPTION
When the customer creates the workorder for MO and clicks on the Done button
without saving the record, a traceback will appear.

Steps to reproduce the error:
- Create one MO > Work Orders > Add a line > Click on Dropdown > Click on Done

Traceback:
```
IndexError: tuple index out of range
  File "odoo/http.py", line 2364, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1891, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1954, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 137, in retrying
    result = func()
  File "odoo/http.py", line 1921, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2168, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 330, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 728, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 35, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 517, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "home/odoo/src/enterprise/18.0/mrp_workorder/models/mrp_workorder.py", line 876, in action_mark_as_done
    self.button_finish()
  File "home/odoo/src/enterprise/18.0/mrp_workorder/models/mrp_workorder.py", line 303, in button_finish
    return super().button_finish()
  File "addons/mrp/models/mrp_workorder.py", line 661, in button_finish
    workorder.with_context(bypass_duration_calculation=True).write(vals)
  File "home/odoo/src/enterprise/18.0/mrp_workorder/models/mrp_workorder.py", line 114, in write
    res = super().write(values)
  File "addons/mrp/models/mrp_workorder.py", line 475, in write
    if workorder == workorder.production_id.workorder_ids[0] and 'date_start' in values:
  File "odoo/models.py", line 7004, in __getitem__
    return self.browse((self._ids[key],))
```

https://github.com/odoo/odoo/blob/a082495359a2e6a2bf25cc3744eb80fd6899f5d1/addons/mrp/models/mrp_workorder.py#L462 Here, when customer clicks on the Done button without saving the record,
``workorder_ids`` will be empty, so it will lead to the above traceback.

https://github.com/odoo/odoo/blob/a082495359a2e6a2bf25cc3744eb80fd6899f5d1/addons/mrp/static/src/components/wo_list_view_dropdown/wo_list_view_dropdown.js#L52-L61
Here, ``ids`` is ``false`` because the record is not saved yet,
It will call the ``action_mark_as_done`` method with ``false`` ids,
eventually, it will generate the above traceback.

sentry-5973943945

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
