### PR TITLE
[FIX] website_sale_delivery: update carrier_id of SO on shop/payment

### DIFF
--- a/addons/website_sale_delivery/controllers/main.py
+++ b/addons/website_sale_delivery/controllers/main.py
@@ -14,15 +14,15 @@ class WebsiteSaleDelivery(WebsiteSale):
     @http.route()
     def shop_payment(self, **post):
         order = request.website.sale_get_order()
-        if order and not order.only_services and (request.httprequest.method == 'POST' or not order.carrier_id):
+        if order and not order.only_services:
             # Update order's carrier_id (will be the one of the partner if not defined)
             # If a carrier_id is (re)defined, redirect to "/shop/payment" (GET method to avoid infinite loop)
             carrier_id = post.get('carrier_id')
-            keep_carrier = post.get('keep_carrier', False)
-            if keep_carrier:
-                keep_carrier = bool(int(keep_carrier))
+            keep_carrier = False
             if carrier_id:
                 carrier_id = int(carrier_id)
+            elif order.carrier_id:  # If a carrier is selected.
+                keep_carrier = True  # Check availability of selected carrier and recompute rate.
             order._check_carrier_quotation(force_carrier_id=carrier_id, keep_carrier=keep_carrier)
             if carrier_id:
                 return request.redirect("/shop/payment")

--- a/addons/website_sale_delivery/tests/__init__.py
+++ b/addons/website_sale_delivery/tests/__init__.py
@@ -4,3 +4,4 @@
 from . import test_express_checkout_flows
 from . import test_ui
 from . import test_controller
+from . import test_website_sale_controller

--- a/addons/website_sale_delivery/tests/test_website_sale_controller.py
+++ b/addons/website_sale_delivery/tests/test_website_sale_controller.py
@@ -1,0 +1,70 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.fields import Command
+from odoo.tests import tagged
+
+from odoo.addons.website_sale.tests.test_sale_process import TestWebsiteSaleCheckoutAddress
+from odoo.addons.website_sale_delivery.controllers.main import WebsiteSaleDelivery
+from odoo.addons.website.tools import MockRequest
+
+
+@tagged('post_install', '-at_install')
+class TestWebsiteSaleController(TestWebsiteSaleCheckoutAddress):
+    def setUp(self):
+        super().setUp()
+
+    def test_carrier_update_on_shop_payment(self):
+        """ Test that a correct carrier is set on SO on shop/payment when partner_shipping_id is
+        changed. """
+
+        # Unpublish all carriers.
+        self.env['delivery.carrier'].search([]).website_published = False
+
+        country_be = self.env.ref('base.be')
+        country_fr = self.env.ref('base.fr')
+
+        # Create a delivery product.
+        self.product_delivery_poste = self.env['product.product'].create({
+            'name': 'The Poste',
+            'type': 'service',
+            'categ_id': self.env.ref('delivery.product_category_deliveries').id,
+            'sale_ok': False,
+            'purchase_ok': False,
+        })
+
+        # Create a carrier which ships only to Belgium.
+        carrier_be = self.env['delivery.carrier'].create([{
+            'name': 'Fixed BE',
+            'product_id': self.product_delivery_poste.id,
+            'country_ids': [Command.set([country_be.id])],
+            'website_published': True,
+        }])
+
+        # Create a carrier which ships only to France.
+        carrier_fr = self.env['delivery.carrier'].create([{
+            'name': 'Fixed FR',
+            'product_id': self.product_delivery_poste.id,
+            'country_ids': [Command.set([country_fr.id])],
+            'website_published': True,
+        }])
+
+        # Create partner_shipping_id with BE country.
+        p = self.env.user.partner_id
+        so = self._create_so(p.id)
+        so.partner_shipping_id = self.env['res.partner'].create({
+            'name': 'a res.partner address',
+            'email': 'email@email.email',
+            'street': 'ooo',
+            'city': 'ooo',
+            'zip': '1200',
+            'country_id': country_be.id,
+            'parent_id': p.id,
+            'type': 'delivery',
+        })
+        so.set_delivery_line(carrier_be, carrier_be.fixed_price)
+        with MockRequest(self.env, website=self.website, sale_order_id=so.id):
+            # Change the country of the partner_shipping_id.
+            so.partner_shipping_id.country_id = country_fr
+            WebsiteSaleDelivery().shop_payment()
+            # Check that a carrier is updated.
+            self.assertEqual(so.carrier_id, carrier_fr)


### PR DESCRIPTION
Steps to reproduce:
1) Configure 2 carriers with different price and different available countries.
2) Go to /shop and add deliverable product to the cart and checkout
3) Observe that the carrier is chosen for you.
4) Go to /checkout and edit a shipping address changing its country to the available country of the other carrier.
5) Go back to /payment and observe that the carrier is not updated accordingly

Problem: When partner_shipping_id is changed or edited carrier_id is not updated accordingly.

Solution: Check that the carrier set on SO is available and recalculate its rate on shop/payment load.

opw-4202126

