### PR TITLE
[FIX] web_editor: remove .o_default_snippet_text on partial text edits

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -3053,7 +3053,7 @@ const Wysiwyg = Widget.extend({
         // command is being applied. Note that this needs to be done *before*
         // the command and not after because some commands (e.g. font-size)
         // rely on some elements not to have the class to fully work.
-        for (const node of OdooEditorLib.getSelectedNodes(this.$editable[0])) {
+        for (const node of OdooEditorLib.getTraversedNodes(this.$editable[0])) {
             const el = node.nodeType === Node.TEXT_NODE ? node.parentElement : node;
             const defaultTextEl = el.closest('.o_default_snippet_text');
             if (defaultTextEl) {


### PR DESCRIPTION
Issue: The `.o_default_snippet_text` class was not being removed when applying formatting (e.g., bold, italic, font-size) to a portion of the default text in an editable snippet.

Steps to reproduce:

1. Insert a snippet with default placeholder text containing the `.o_default_snippet_text` class. E.g. A Banner.
2. Select part of the placeholder text (not the entire text). E.g. "Easily" in the "Banner" snippet
3. Apply a formatting command (bold, italic, font-size change).
4. The formatting is applied, but the `.o_default_snippet_text` class remains on the element.
5. Save and re-edit
6. Click on the title -> The text is entirely selected because it's still treated as a default text.

This commit ensures the correct behaviour of this feature.

task-4147162

