### PR TITLE
[IMP] account_peppol: hide edi demo mode selection view

### DIFF
--- a/addons/account_peppol/views/res_config_settings_views.xml
+++ b/addons/account_peppol/views/res_config_settings_views.xml
@@ -134,13 +134,8 @@
                                            nolabel="1"/>
                                 </div>
                                 <div class="mt-4" invisible="account_peppol_proxy_state != 'not_registered'">
-                                <field name="account_peppol_mode_constraint" invisible="1"/>
-                                <field name="account_peppol_edi_mode"
-                                       widget="account_peppol_radio_field"
-                                       class="o_field_radio"
-                                       readonly_items="account_peppol_mode_constraint != 'prod' and ['prod'] or []"
-                                       hidden_items="account_peppol_mode_constraint != 'test' and ['test'] or []"
-                                       options="{'horizontal': true }"/>
+                                    <field name="account_peppol_mode_constraint" invisible="1"/>
+                                    <field name="account_peppol_edi_mode" invisible="1"/>
                                     <div class="mb-3" invisible="not account_peppol_edi_mode == 'prod'">
                                         By clicking the button below I accept that Odoo may process my e-invoices.
                                     </div>


### PR DESCRIPTION
The demo mode option in the Peppol connection wizard is primarily used by internal teams (BA, support, sales) for demonstrations or testing. It is more appropriate to manage this mode through a system parameter instead of exposing it to all users in the wizard interface. 

This commit mirrors the change from (commit 6d222885f41f5136c690dcd56953f1a9775204ae pr odoo/odoo#182893), but without removing the related fields, making it suitable for stable versions.

task-4215904