### PR TITLE
[FIX] payment_authorize: allow voiding confirmed transactions

### DIFF
--- a/addons/payment_authorize/models/payment_transaction.py
+++ b/addons/payment_authorize/models/payment_transaction.py
@@ -119,7 +119,7 @@ class PaymentTransaction(models.Model):
             self.env.ref('payment.cron_post_process_payment_tx')._trigger()
         elif any(tx_status in TRANSACTION_STATUS_MAPPING[k] for k in ('authorized', 'captured')):
             if tx_status in TRANSACTION_STATUS_MAPPING['authorized']:
-                # The payment has not been settle on Authorize.net yet. It must be voided rather
+                # The payment has not been settled on Authorize.net yet. It must be voided rather
                 # than refunded. Since the funds have not moved yet, we don't create a refund tx.
                 res_content = authorize_api.void(self.provider_reference)
                 tx_to_process = self
@@ -239,7 +239,7 @@ class PaymentTransaction(models.Model):
                 if self.operation == 'validation':  # Validation txs are authorized and then voided
                     self._set_done()  # If the refund went through, the validation tx is confirmed
                 else:
-                    self._set_canceled()
+                    self._set_canceled(extra_allowed_states=('done',))
             elif status_type == 'refund' and self.operation == 'refund':
                 self._set_done()
                 # Immediately post-process the transaction as the post-processing will not be

--- a/addons/payment_authorize/tests/test_authorize.py
+++ b/addons/payment_authorize/tests/test_authorize.py
@@ -46,3 +46,14 @@ class AuthorizeTest(AuthorizeCommon):
         self.assertEqual(self.authorize.available_currency_ids[0], self.currency_usd)
         self.assertEqual(self.authorize._get_validation_amount(), 0.01)
         self.assertEqual(self.authorize._get_validation_currency(), self.currency_usd)
+
+    def test_voiding_confirmed_tx_cancels_it(self):
+        """ Test that voiding a transaction cancels it even if it's already confirmed. """
+        source_tx = self._create_transaction('direct', state='done')
+        source_tx._handle_notification_data('authorize', {
+            'response': {
+                'x_response_code': '1',
+                'x_type': 'void',
+            },
+        })
+        self.assertEqual(source_tx.state, 'cancel')

--- a/addons/payment_authorize/tests/test_refund_flows.py
+++ b/addons/payment_authorize/tests/test_refund_flows.py
@@ -41,7 +41,7 @@ class TestRefundFlows(AuthorizeCommon):
     @mute_logger('odoo.addons.payment_authorize.models.payment_transaction')
     def test_refunding_authorized_tx_voids_it(self):
         """ Test that refunding a transaction that is still authorized on Authorize.net side voids
-        it instead. """
+        it on Authorize.net instead of refunding it. """
         source_tx = self._create_transaction('direct', state='done')
         with patch(
             'odoo.addons.payment_authorize.models.authorize_request.AuthorizeAPI'


### PR DESCRIPTION
Upon attempting to refund an Authorize.net transaction, its state on the provider side is fetched to decide on the refund strategy. If the payment is not yet settled, the refund is achieved by sending a void request rather than a refund request.

This flow was not fully working because the payment engine refused to move the transaction state from `done` to `cancel`. This forced users to hit the "Refund" button once to send the void request and a second time to cancel the transaction, as the second attempt was working thanks to the change of transaction state on the provider side.

This commit allows Authorize.net transactions to move from the `done` state to the `cancel` state. It is not necessary to ensure we are in the context of a refund because we always check that a transaction is in the `authorized` state before attempting to void it.

opw-4201355