### PR TITLE
[IMP] web_editor: clean calls to _deduceUrl

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -555,7 +555,7 @@ export class Link extends Component {
             this.state.originalText = this.state.originalText ? this.state.originalText.replace(/[ \t\r\n]+/g, ' ') : '';
         }
 
-        this.state.url ||= this._deduceUrl(this.state.originalText, this.linkEl);
+        this.state.url ||= this._deduceUrl(this.state.originalText);
 
         if (this.linkEl) {
             this.initialNewWindow = this.initialNewWindow || this.linkEl.target === '_blank';
@@ -637,7 +637,7 @@ export class Link extends Component {
      */
     __onURLInput() {
         const inputValue = this.$el[0].querySelector('#o_link_dialog_url_input').value;
-        this.state.url = this._deduceUrl(inputValue, this.linkEl) || inputValue;
+        this.state.url = this._deduceUrl(inputValue) || inputValue;
         this._onURLInput(...arguments);
     }
     /**


### PR DESCRIPTION
Since [1] when `_deduceUrl` was introduced, its signature takes one parameter but all calls use a second parameter.
Fortunately, the parameter is always `this.linkEl` and this is also what is used inside the method.

This commit removes the second parameter from the call.

[1]: https://github.com/odoo/odoo/commit/6d4a3b3

task-4208243
