### PR TITLE
[FIX] event_sale: stop displaying erroneous discount in foreign currency

### DIFF
--- a/addons/event_booth_sale/models/event_booth_category.py
+++ b/addons/event_booth_sale/models/event_booth_category.py
@@ -54,7 +54,8 @@ class EventBoothCategory(models.Model):
                 product.lst_price,
                 pricelist.currency_id,
                 self.env.company,
-                fields.Datetime.now()
+                fields.Datetime.now(),
+                round=False,
             )
             discount = (lst_price - product._get_contextual_price()) / lst_price if lst_price else 0.0
             category.price_reduce = (1.0 - discount) * category.price

--- a/addons/event_sale/models/event_ticket.py
+++ b/addons/event_sale/models/event_ticket.py
@@ -58,7 +58,8 @@ class EventTemplateTicket(models.Model):
                 product.lst_price,
                 pricelist.currency_id,
                 self.env.company,
-                fields.Datetime.now()
+                fields.Datetime.now(),
+                round=False,
             )
             discount = (lst_price - product._get_contextual_price()) / lst_price if lst_price else 0.0
             ticket.price_reduce = (1.0 - discount) * ticket.price

--- a/addons/test_event_full/tests/__init__.py
+++ b/addons/test_event_full/tests/__init__.py
@@ -8,3 +8,4 @@ from . import test_event_mail
 from . import test_event_security
 from . import test_performance
 from . import test_wevent_register
+from . import test_event_discount

--- a/addons/test_event_full/tests/test_event_discount.py
+++ b/addons/test_event_full/tests/test_event_discount.py
@@ -1,0 +1,78 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import time
+
+from odoo.tests import tagged
+from odoo.fields import Command
+
+from odoo.addons.test_event_full.tests.common import TestEventFullCommon
+
+
+@tagged('post_install', '-at_install')
+class TestEventTicketPriceRounding(TestEventFullCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.ticket_product.write({
+            'lst_price': 1.0
+        })
+
+        cls.currency_jpy = cls.env['res.currency'].create({
+            'name': 'JPX',
+            'symbol': '¥',
+            'rounding': 1.0,
+            'rate_ids': [Command.create({'rate': 133.6200, 'name': time.strftime('%Y-%m-%d')})],
+        })
+
+        cls.currency_cad = cls.env['res.currency'].create({
+            'name': 'CXD',
+            'symbol': '$',
+            'rounding': 0.01,
+            'rate_ids': [Command.create({'rate': 1.338800, 'name': time.strftime('%Y-%m-%d')})],
+        })
+
+        cls.pricelist_usd = cls.env['product.pricelist'].create({
+            'name': 'Pricelist USD',
+            'currency_id': cls.env.ref('base.USD').id,
+        })
+
+        cls.pricelist_jpy = cls.env['product.pricelist'].create({
+            'name': 'Pricelist JPY',
+            'currency_id': cls.currency_jpy.id,
+        })
+
+        cls.pricelist_cad = cls.env['product.pricelist'].create({
+            'name': 'Pricelist CAD',
+            'currency_id': cls.currency_cad.id,
+        })
+
+        cls.event_type = cls.env['event.type'].create({
+            'name': 'Test Event Type',
+            'auto_confirm': True,
+            'event_type_ticket_ids': [
+                (0, 0, {
+                    'name': 'Test Event Ticket',
+                    'product_id': cls.ticket_product.id,
+                    'price': 30.0,
+                })
+            ],
+        })
+
+        cls.event_ticket = cls.event_type.event_type_ticket_ids[0]
+
+    def test_no_discount_usd(self):
+        ticket = self.event_ticket.with_context(pricelist=self.pricelist_usd.id)
+        ticket._compute_price_reduce()
+        self.assertAlmostEqual(ticket.price_reduce, 30.0, places=6, msg="No discount should be applied for the USD pricelist.")
+
+    def test_no_discount_jpy(self):
+        ticket = self.event_ticket.with_context(pricelist=self.pricelist_jpy.id)
+        ticket._compute_price_reduce()
+        self.assertAlmostEqual(ticket.price_reduce, 30.0, places=6, msg="No discount should be applied for the JPY pricelist.")
+
+    def test_no_discount_cad(self):
+        ticket = self.event_ticket.with_context(pricelist=self.pricelist_cad.id)
+        ticket._compute_price_reduce()
+        self.assertAlmostEqual(ticket.price_reduce, 30.0, places=6, msg="No discount should be applied for the CAD pricelist.")


### PR DESCRIPTION
[FIX] event_sale: stop displaying erroneous discount in foreign currency

When purchasing event tickets in foreign currencies such as JPY or CAD,
Odoo was incorrectly applying small discounts to products even when no
discount was intended. This behavior affected the Event Sales module,
where the wrong price was shown on the event registration and product
page.

For Odoo 17.4+, this issue displayed as a strikethrough on the correct
price next to a mistakenly discounted price. For versions prior to 17.4,
only the incorrect discounted price was displayed without a strikethrough.
This bug only occurred when the Event Registration product price was set
to a value different from the price defined in the Event record. While this
bug is present in 16.0 onwards, the logic causing the issue has been
refactored since 17.0, so this separate fix is required for all versions
prior to 17.0.

Steps to reproduce the issue:

1.   Create Pricelists for additional currencies (CAD, JPY) with empty rules
and enable the “Selectable” checkbox for Ecommerce.
2.   Set currency rates to 133.6200 for JPY and 1.338800 for CAD to
replicate the conditions when the bug was found.
3.   Create an Event.
4.   Create an Event Registration Ticket, ensuring the linked Event
Registration product price is $1.00 and the price in the event view is
set to $30.00.
5.   Visit the Event page on the website and attempt to purchase a ticket.
Switch between currencies (JPY, CAD) on the Shop page to observe the
issue.
6.   Using JPY at the conversion rate of 133.6200, the expected converted
price for a $30.00 ticket should be ¥4009, but Odoo calculates the
price as discounted to ¥3997.
7.   With CAD at 1.338800, the correct converted price should be $40.16
CAD, but the price is instead calculated as $40.12 CAD.

Cause of the issue:
The method _compute_price_reduce in event_ticket.py and event_booth_category.py
was comparing a rounded lst_price to an unrounded contextual price, leading to
a tiny discrepancy being mistaken as a discount. The bug occurred because the
rounding of the lst_price did not match the rounding of the contextual price.

Solution:
The fix ensures neither operands are rounded before comparison. Now, the
_compute_price_reduce method does not round lst_price, so that the
value is consistent with the result of _get_contextual_price.

opw-4213704