### PR TITLE
[PERF] point_of_sale: optimize product addition to order

### DIFF
--- a/addons/point_of_sale/static/src/app/models/data_service_options.js
+++ b/addons/point_of_sale/static/src/app/models/data_service_options.js
@@ -28,15 +28,6 @@ export class DataServiceOptions {
                     typeof record.pos_order_line_id.order_id.id === "number",
             },
             {
-                name: "product.product",
-                key: "id",
-                condition: (record) => {
-                    return record["<-pos.order.line.product_id"].find(
-                        (l) => !(l.order_id?.finalized && typeof l.order_id.id === "number")
-                    );
-                },
-            },
-            {
                 name: "product.attribute.custom.value",
                 key: "id",
                 condition: (record) => {

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -15,6 +15,10 @@ export class PosOrderline extends Base {
 
     setup(vals) {
         super.setup(vals);
+        if (!this.product_id) {
+            this.delete();
+            return;
+        }
         this.uuid = vals.uuid ? vals.uuid : uuidv4();
         this.skip_change = vals.skip_change || false;
         this.set_full_product_name();


### PR DESCRIPTION
Before this commit, loading 20,000 products into the PoS and adding a product to an order was slow due to multiple writes to the IndexedDb. This commit optimizes the process by not saving ongoing order's products in the IndexedDb, as they can be loaded as needed. Missing products are loaded when loading the orderlines.

opw-4200540

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
