### PR TITLE
[FIX] stock_{account,dropshipping}: consider interco in dropships

### DIFF
--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -138,7 +138,8 @@ class StockMove(models.Model):
         :rtype: bool
         """
         self.ensure_one()
-        return self.location_id.usage == 'supplier' and self.location_dest_id.usage == 'customer'
+        return (self.location_id.usage == 'supplier' or (self.location_id.usage == 'transit' and not self.location_id.company_id)) \
+           and (self.location_dest_id.usage == 'customer' or (self.location_dest_id.usage == 'transit' and not self.location_dest_id.company_id))
 
     def _is_dropshipped_returned(self):
         """Check if the move should be considered as a returned dropshipping move so that the cost
@@ -148,7 +149,8 @@ class StockMove(models.Model):
         :rtype: bool
         """
         self.ensure_one()
-        return self.location_id.usage == 'customer' and self.location_dest_id.usage == 'supplier'
+        return (self.location_id.usage == 'customer' or (self.location_id.usage == 'transit' and not self.location_id.company_id)) \
+           and (self.location_dest_id.usage == 'supplier' or (self.location_dest_id.usage == 'transit' and not self.location_dest_id.company_id))
 
     def _prepare_common_svl_vals(self):
         """When a `stock.valuation.layer` is created from a `stock.move`, we can prepare a dict of

--- a/addons/stock_dropshipping/models/stock.py
+++ b/addons/stock_dropshipping/models/stock.py
@@ -37,10 +37,12 @@ class StockPicking(models.Model):
 
     is_dropship = fields.Boolean("Is a Dropship", compute='_compute_is_dropship')
 
-    @api.depends('location_dest_id.usage', 'location_id.usage')
+    @api.depends('location_dest_id.usage', 'location_dest_id.company_id', 'location_id.usage', 'location_id.company_id')
     def _compute_is_dropship(self):
         for picking in self:
-            picking.is_dropship = picking.location_dest_id.usage == 'customer' and picking.location_id.usage == 'supplier'
+            source, dest = picking.location_id, picking.location_dest_id
+            picking.is_dropship = (source.usage == 'supplier' or (source.usage == 'transit' and not source.company_id)) \
+                              and (dest.usage == 'customer' or (dest.usage == 'transit' and not dest.company_id))
 
     def _is_to_external_location(self):
         self.ensure_one()


### PR DESCRIPTION
Consider the Inter-Company transit location (which is a 'transit' location with no company set) as either a 'customer' or 'supplier' location for dropship purposes.

Both 'supplier' and 'customer' need to be considered as the dropship could be either from Vendor -> Other Company or Other Company -> Customer.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
