### PR TITLE
[PERF] point_of_sale: speed up adding products to cart

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -319,18 +319,19 @@ export class ProductScreen extends Component {
             list = this.products;
         }
 
-        if (!list) {
+        if (!list || list.length === 0) {
             return [];
         }
 
+        const excludedProductIds = [
+            this.pos.config.tip_product_id?.id,
+            ...this.pos.hiddenProductIds,
+            ...this.pos.session._pos_special_products_ids,
+        ];
+
         list = list
             .filter(
-                (product) =>
-                    ![
-                        this.pos.config.tip_product_id?.id,
-                        ...this.pos.hiddenProductIds,
-                        ...this.pos.session._pos_special_products_ids,
-                    ].includes(product.id) && product.available_in_pos
+                (product) => !excludedProductIds.includes(product.id) && product.available_in_pos
             )
             .slice(0, 100);
 
@@ -371,9 +372,9 @@ export class ProductScreen extends Component {
     }
 
     getProductsByCategory(category) {
-        const allCategories = category.getAllChildren();
-        return this.products.filter((p) =>
-            p.pos_categ_ids.some((categId) => allCategories.includes(categId))
+        const allCategoryIds = category.getAllChildren().map((cat) => cat.id);
+        return allCategoryIds.flatMap(
+            (catId) => this.pos.models["product.product"].getBy("pos_categ_ids", catId) || []
         );
     }
 


### PR DESCRIPTION
Before this commit, adding a product to the cart with 20,000 products was slow due to the time taken to render the screen and execute the productsToDisplay function. This commit optimizes the productsToDisplay function, making it 10 times faster with large product counts.

opw-4247716

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
