### PR TITLE
[IMP] portal, website: include response template name as body class

### DIFF
--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="frontend_layout" name="Main Frontend Layout" inherit_id="web.frontend_layout">
+        <xpath expr="//body" position="before">
+            <t t-set="classname_from_template" t-value="(' o_' + response_template.replace('.', '_')) if isinstance(response_template, str) else 'o_id_' + str(response_template) if response_template else ''"/>
+            <t t-set="body_classname" t-valuef="{{body_classname}}{{classname_from_template}}"/>
+        </xpath>
         <xpath expr="//div[@id='wrapwrap']" position="attributes">
             <attribute name="t-attf-class" add="#{request.env['res.lang']._get_data(code=request.env.lang).direction == 'rtl' and 'o_rtl' or ''}" separator=" "/>
             <attribute name="t-attf-class" add="#{'o_portal' if is_portal else ''}" separator=" "/>

--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -182,24 +182,15 @@ class WebsiteMultiMixin(models.AbstractModel):
         return can_access
 
 
-class WebsitePublishedMixin(models.AbstractModel):
-    _name = 'website.published.mixin'
+class WebsiteLocatedMixin(models.AbstractModel):
+    _name = 'website.located.mixin'
 
-    _description = 'Website Published Mixin'
+    _description = "Website Located Mixin"
 
-    website_published = fields.Boolean('Visible on current website', related='is_published', readonly=False)
-    is_published = fields.Boolean('Is Published', copy=False, default=lambda self: self._default_is_published(), index=True)
-    publish_on = fields.Datetime(
-        "Auto publish on",
-        copy=False,
-        help="Automatically publish the page on the chosen date and time.",
-    )
-    published_date = fields.Datetime("Published date", copy=False)
-    can_publish = fields.Boolean('Can Publish', compute='_compute_can_publish')
-    website_url = fields.Char('Website URL', compute='_compute_website_url', help='The full relative URL to access the document through the website.')
+    website_url = fields.Char("Website URL", compute='_compute_website_url', help="The full relative URL to access the document through the website.")
     # The compute dependency (for get_base_url) must be added and get_base_url must be overridden if needed
-    website_absolute_url = fields.Char('Website Absolute URL', compute='_compute_website_absolute_url',
-                                       help='The full absolute URL to access the document through the website.')
+    website_absolute_url = fields.Char("Website Absolute URL", compute='_compute_website_absolute_url',
+                                       help="The full absolute URL to access the document through the website.")
 
     @api.depends_context('lang')
     def _compute_website_url(self):
@@ -212,6 +203,22 @@ class WebsitePublishedMixin(models.AbstractModel):
         for record in self:
             if record.website_url != '#':
                 record.website_absolute_url = url_join(record.get_base_url(), record.website_url)
+
+
+class WebsitePublishedMixin(models.AbstractModel):
+    _name = 'website.published.mixin'
+    _inherit = ['website.located.mixin']
+    _description = 'Website Published Mixin'
+
+    website_published = fields.Boolean('Visible on current website', related='is_published', readonly=False)
+    is_published = fields.Boolean('Is Published', copy=False, default=lambda self: self._default_is_published(), index=True)
+    publish_on = fields.Datetime(
+        "Auto publish on",
+        copy=False,
+        help="Automatically publish the page on the chosen date and time.",
+    )
+    published_date = fields.Datetime("Published date", copy=False)
+    can_publish = fields.Boolean('Can Publish', compute='_compute_can_publish')
 
     def _default_is_published(self):
         return False

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -188,6 +188,15 @@
         </t>
     </xpath>
 
+    <xpath expr="//t[@t-set='body_classname']" position="after">
+        <t t-set="default_lang_code" t-value="website.env['res.lang']._get_data(id=website._get_cached('default_lang_id')).code"/>
+        <t t-set="mainobject_url" t-value="main_object.with_context(lang=default_lang_code).website_url if main_object and 'website_url' in main_object else ''"/>
+        <t t-set="mainobject_url" t-value="mainobject_url.split('?')[0].split('#')[0]"/>
+        <t t-set="mainobject_url" t-value="'_home' if mainobject_url == '/' else mainobject_url"/>
+        <t t-set="classname_from_mainobject" t-value="' o_website_url' + mainobject_url.replace('/', '_').replace('-', '_') if mainobject_url else ''"/>
+        <t t-set="body_classname" t-valuef="{{body_classname}}{{classname_from_mainobject}}"/>
+    </xpath>
+
     <xpath expr="//header" position="attributes">
         <attribute name="data-name">Header</attribute>
         <attribute name="t-att-data-extra-items-toggle-aria-label">extra_items_toggle_aria_label</attribute>

--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -18,6 +18,7 @@ class BlogBlog(models.Model):
         'mail.thread',
         'website.seo.metadata',
         'website.multi.mixin',
+        'website.located.mixin',
         'website.cover_properties.mixin',
         'website.searchable.mixin',
     ]
@@ -35,6 +36,12 @@ class BlogBlog(models.Model):
     content = fields.Html('Content', translate=html_translate, sanitize=False)
     blog_post_ids = fields.One2many('blog.post', 'blog_id', 'Blog Posts')
     blog_post_count = fields.Integer("Posts", compute='_compute_blog_post_count')
+
+    def _compute_website_url(self):
+        super()._compute_website_url()
+        for record in self:
+            if record.id:
+                record.website_url = '/blog/%s' % self.env['ir.http']._slug(record)
 
     @api.depends('blog_post_ids')
     def _compute_blog_post_count(self):

--- a/addons/website_forum/models/forum_post.py
+++ b/addons/website_forum/models/forum_post.py
@@ -20,6 +20,7 @@ class ForumPost(models.Model):
     _inherit = [
         'mail.thread',
         'website.seo.metadata',
+        'website.located.mixin',
         'website.searchable.mixin',
     ]
     _order = "is_correct DESC, vote_count DESC, last_activity_date DESC"
@@ -42,7 +43,6 @@ class ForumPost(models.Model):
     views = fields.Integer('Views', default=0, readonly=True, copy=False)
     active = fields.Boolean('Active', default=True)
     website_message_ids = fields.One2many(domain=lambda self: [('model', '=', self._name), ('message_type', 'in', ['email', 'comment', 'email_outgoing'])])
-    website_url = fields.Char('Website URL', compute='_compute_website_url')
     website_id = fields.Many2one(related='forum_id.website_id', readonly=True)
 
     # history

--- a/addons/website_forum/models/forum_tag.py
+++ b/addons/website_forum/models/forum_tag.py
@@ -11,6 +11,7 @@ class ForumTag(models.Model):
     _inherit = [
         'mail.thread',
         'website.searchable.mixin',
+        'website.located.mixin',
         'website.seo.metadata',
     ]
 
@@ -21,7 +22,6 @@ class ForumTag(models.Model):
         'forum.post', 'forum_tag_rel', 'forum_tag_id', 'forum_post_id',
         string='Posts', domain=[('state', '=', 'active')])
     posts_count = fields.Integer('Number of Posts', compute='_compute_posts_count', store=True)
-    website_url = fields.Char("Link to questions with the tag", compute='_compute_website_url')
     _name_uniq = models.Constraint(
         'unique (name, forum_id)',
         'Tag name already exists!',

--- a/addons/website_forum/tests/test_performance.py
+++ b/addons/website_forum/tests/test_performance.py
@@ -32,7 +32,7 @@ class TestForumPerformance(UtilPerf):
         })
 
     def test_perf_sql_forum_standard_data(self):
-        number_of_queries = self._get_url_hot_query(self.forum._compute_website_url())
+        number_of_queries = self._get_url_hot_query(self.forum.website_url)
         self.assertLessEqual(number_of_queries, 28)
         number_of_queries = self._get_url_hot_query(self.post.website_url)
         self.assertLessEqual(number_of_queries, 25)
@@ -79,5 +79,5 @@ class TestForumPerformance(UtilPerf):
             } for i in range(100)
         ])
         self.env.flush_all()
-        number_of_queries = self._get_url_hot_query(self.forum._compute_website_url())
+        number_of_queries = self._get_url_hot_query(self.forum.website_url)
         self.assertLessEqual(number_of_queries, 29)

--- a/addons/website_sale/models/product_public_category.py
+++ b/addons/website_sale/models/product_public_category.py
@@ -4,12 +4,15 @@ from odoo import api, fields, models
 from odoo.fields import Domain
 from odoo.tools.translate import html_translate
 
+from odoo.addons.website_sale.const import SHOP_PATH
+
 
 class ProductPublicCategory(models.Model):
     _name = 'product.public.category'
     _inherit = [
         'website.seo.metadata',
         'website.multi.mixin',
+        'website.located.mixin',
         'website.searchable.mixin',
         'image.mixin',
     ]
@@ -106,6 +109,12 @@ class ProductPublicCategory(models.Model):
             category.display_name = " / ".join(category.parents_and_self.mapped(
                 lambda cat: cat.name or self.env._("New")
             ))
+
+    def _compute_website_url(self):
+        super()._compute_website_url()
+        for category in self:
+            if category.id:
+                category.website_url = f'{SHOP_PATH}/category/%s' % self.env['ir.http']._slug(category)
 
     @api.depends('product_tmpl_ids.is_published', 'child_id.has_published_products')
     def _compute_has_published_products(self):


### PR DESCRIPTION
Designers need to apply CSS styles on specific pages. Unfortunately
detecting a specific page through CSS rules can be challenging.

This commit adds as a class on the `body`:
- `o_<response_template>` element for all frontend pages obtained from
named templates
- `o_id_<view_id>` for static pages
- `o_url_<main object's website_url>` if there is a `main_object`

For named templates:
- `o_portal_*` is also available as `o_p*`
- `o_website_*` is also available as `o_w*`

task-4058435
