### PR TITLE
[FIX] account: Merge translations when merging accounts

### DIFF
--- a/addons/account/tests/test_account_merge_wizard.py
+++ b/addons/account/tests/test_account_merge_wizard.py
@@ -88,6 +88,13 @@ class TestAccountMergeWizard(TestAccountMergeCommon):
             for account in self.accounts
         }
 
+        # Also set up different names for the accounts in various languages
+        self.env['res.lang']._activate_lang('fr_FR')
+        self.env['res.lang']._activate_lang('nl_NL')
+        self.accounts[0].with_context({'lang': 'fr_FR'}).name = "Mon premier compte"
+        self.accounts[2].with_context({'lang': 'fr_FR'}).name = "Mon troisième compte"
+        self.accounts[2].with_context({'lang': 'nl_NL'}).name = "Mijn derde conto"
+
         # 2. Check that the merge wizard groups accounts 1 and 3 together, and accounts 2 and 4 together.
         wizard = self._create_account_merge_wizard(self.accounts)
         expected_wizard_line_vals = [
@@ -174,6 +181,10 @@ class TestAccountMergeWizard(TestAccountMergeCommon):
         self.assertEqual(self.env['account.chart.template'].ref('test_account_2'), self.accounts[1])
         self.assertEqual(self.env['account.chart.template'].with_company(self.company_2).ref('test_account_3'), self.accounts[0])
         self.assertEqual(self.env['account.chart.template'].with_company(self.company_2).ref('test_account_4'), self.accounts[1])
+
+        # 8. Check that the name translations are merged correctly
+        self.assertRecordValues(self.accounts[0].with_context({'lang': 'fr_FR'}), [{'name': "Mon premier compte"}])
+        self.assertRecordValues(self.accounts[0].with_context({'lang': 'nl_NL'}), [{'name': "Mijn derde conto"}])
 
     def test_cannot_merge_same_company(self):
         """ Check that you cannot merge two accounts belonging to the same company. """


### PR DESCRIPTION
At the moment, when we merge accounts, we don't merge the account name's translations.

This is a bit annoying since one account might have been called 'Account Receivable' in English, and another one might have been called 'Clientes' in Spanish. At the moment, the translations of the other accounts are lost.

This commit makes us merge the translations when merging the accounts.

taskid: 4210775