### PR TITLE
[FIX] point_of_sale: Formatting error in error message

### DIFF
--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -94,7 +94,7 @@ class ProductProduct(models.Model):
         if self.env['pos.session'].sudo().search_count([('state', '!=', 'closed')]):
             if self.with_context(product_ctx).search_count([('id', 'in', self.ids), ('product_tmpl_id.available_in_pos', '=', True)]):
                 raise UserError(_("To delete a product, make sure all point of sale sessions are closed.\n\n"
-                    "Deleting a product available in a session would be like attempting to snatch a"
+                    "Deleting a product available in a session would be like attempting to snatch a "
                     "hamburger from a customer’s hand mid-bite; chaos will ensue as ketchup and mayo go flying everywhere!"))
 
     def get_product_info_pos(self, price, quantity, pos_config_id):

--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -29,7 +29,7 @@ class ProductTemplate(models.Model):
         if self.with_context(product_ctx).search_count([('id', 'in', self.ids), ('available_in_pos', '=', True)]):
             if self.env['pos.session'].sudo().search_count([('state', '!=', 'closed')]):
                 raise UserError(_("To delete a product, make sure all point of sale sessions are closed.\n\n"
-                    "Deleting a product available in a session would be like attempting to snatch a"
+                    "Deleting a product available in a session would be like attempting to snatch a "
                     "hamburger from a customer’s hand mid-bite; chaos will ensue as ketchup and mayo go flying everywhere!"))
 
     @api.onchange('sale_ok')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
1. Start a POS session
2. Go back to the backend
3. Try to delete a product that is used in the POS
4. Error with no space between two words

Current behavior before PR:
The current error message has a format issue with no space after 'a' 

Desired behavior after PR is merged:
Correct formatting


opw-4247374
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
