### PR TITLE
[FIX] website_sale: update window after selecting variant in carousel

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -83,11 +83,9 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, cartHandlerM
 
         this._startZoom();
 
-        window.addEventListener('popstate', (ev) => {
-            if (ev.state?.newURL) {
-                this._applyHash();
-                this.triggerVariantChange(this.$el);
-            }
+        window.addEventListener("hashchange", (ev) => {
+            this._applyHash();
+            this.triggerVariantChange(this.$el);
         });
 
         // This allows conditional styling for the filmstrip


### PR DESCRIPTION
Versions
--------
- saas-17.2+

Steps
-----
1. Go to eCommerce;
2. go to a product page with variants;
3. open editor;
4. drag & drop a "Products" block from Dynamic Content;
5. click on the newly added block;
6. set filter to "Recently Viewed Products";
7. save;
8. change an attribute of the current product;
9. use the added carousel to go back to the previous variant.

Issue
-----
Nothing happens.

Cause
-----
Commit 016a72bae9c3 changed the event listener on website_sale from `hashchange` to `popevent` with a check on the event's `state?.newURL` attribute. Issue is that this will always be `undefined`, as there's no logic in place to push or replace states[^1] when viewing products.

Solution
--------
Revert the change, and have the listener trigger on `hashchange` events[^2] again.

> [!Note]
> In the future we could consider moving away from using the URL hash property[^3] for storing product attribute ids to a more conventional practice, as was intended by the commit that made this change.

opw-4150284

[^1]: https://developer.mozilla.org/en-US/docs/Web/API/PopStateEvent/state
[^2]: https://developer.mozilla.org/en-US/docs/Web/API/Window/hashchange_event
[^3]: https://developer.mozilla.org/en-US/docs/Web/API/URL/hash