### PR TITLE
[FIX] stock: reconcile outgoing moves in forecast

### DIFF
--- a/addons/sale_stock/tests/test_sale_stock_report.py
+++ b/addons/sale_stock/tests/test_sale_stock_report.py
@@ -4,6 +4,7 @@
 from datetime import datetime, timedelta
 from odoo.tools import html2plaintext
 
+from odoo import Command
 from odoo.tests.common import Form, tagged
 from odoo.addons.stock.tests.test_report import TestReportsCommon
 from odoo.addons.sale.tests.common import TestSaleCommon
@@ -84,6 +85,54 @@ class TestSaleStockReports(TestReportsCommon):
                     self.assertTrue(line['is_matched'], "The corresponding SO line should be matched in the forecast report.")
                 else:
                     self.assertFalse(line['is_matched'], "A line of the forecast report not linked to the SO shoud not be matched.")
+
+    def test_report_forecast_3_unreserve_2_step_delivery(self):
+        """
+        Check that the forecast correctly reconciles the outgoing moves
+        that are part of a chain with stock availability when unreserved.
+        """
+        warehouse = self.env.ref("stock.warehouse0")
+        warehouse.delivery_steps = 'pick_ship'
+        product = self.product
+        # Put 5 units in stock
+        self.env['stock.quant']._update_available_quantity(product, warehouse.lot_stock_id, 5)
+        # Create and confirm an SO for 3 units
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [
+                Command.create({
+                    'name': product.name,
+                    'product_id': product.id,
+                    'product_uom_qty': 3,
+                }),
+            ],
+        })
+        so.action_confirm()
+        _, _, lines = self.get_report_forecast(product_template_ids=product.product_tmpl_id.ids)
+        outgoing_line = next(filter(lambda line: line.get('document_out'), lines))
+        self.assertEqual(
+            (outgoing_line['document_out'], outgoing_line['quantity'], outgoing_line['replenishment_filled'], outgoing_line['reservation']),
+            (so, 3.0, True, True)
+        )
+        stock_line = next(filter(lambda line: not line.get('document_out'), lines))
+        self.assertEqual(
+            (stock_line['quantity'], stock_line['replenishment_filled'], stock_line['reservation']),
+            (2.0, True, False)
+        )
+        # unrerseve the PICK delivery
+        pick_delivery = so.picking_ids.filtered(lambda p: p.picking_type_id == warehouse.pick_type_id)
+        pick_delivery.do_unreserve()
+        _, _, lines = self.get_report_forecast(product_template_ids=product.product_tmpl_id.ids)
+        outgoing_line = next(filter(lambda line: line.get('document_out'), lines))
+        self.assertEqual(
+            (outgoing_line['document_out'], outgoing_line['quantity'], outgoing_line['replenishment_filled'], outgoing_line['reservation']),
+            (so, 3.0, True, False)
+        )
+        stock_line = next(filter(lambda line: not line.get('document_out'), lines))
+        self.assertEqual(
+            (stock_line['quantity'], stock_line['replenishment_filled'], stock_line['reservation']),
+            (2.0, True, False)
+        )
 
 
 @tagged('post_install', '-at_install')

--- a/addons/stock/report/stock_forecasted.py
+++ b/addons/stock/report/stock_forecasted.py
@@ -280,7 +280,7 @@ class ReplenishmentReport(models.AbstractModel):
                 if float_is_zero(demand, precision_rounding=product_rounding):
                     continue
                 current = currents[product.id]
-                taken_from_stock = min(demand, current) if out.procure_method != 'make_to_order' else 0
+                taken_from_stock = min(demand, current) if (out.procure_method != 'make_to_order' or any(not m.move_orig_ids and m.location_id.id in wh_location_ids for m in self.env['stock.move'].browse(out._rollup_move_origs()))) else 0
                 if not float_is_zero(taken_from_stock, precision_rounding=product_rounding):
                     currents[product.id] -= taken_from_stock
                     demand -= taken_from_stock


### PR DESCRIPTION
### Steps to reproduce:

- Enable "Multi-steps Routes" in the settings
- Inventory > COnfiguration > Warehouse Management > Warehouses
- Change your warehouse settings to Deliver in 2 steps
- Create a Storable product P with 10 units in stock
- Create and confirm an SO for 1 unit of P
> A pick and a ship deliveries were created.
- Unreserve the PICK deliveries
- Go to the forecast of your product avaialbility
#### > the SO is unreconcilled and the product is treated as unavailable

### Cause of the issue:

Since you unreserved the PICK delivery, the demand of the outgoing move is not null in the forecast lines computations:
https://github.com/odoo/odoo/blob/91316ec8d55dbc5e1cd712568f614c62539bd807/addons/stock/report/stock_forecasted.py#L278 In addition, since you deliver in 2 steps the outgoing moves are part of a move chain. To generate this chain, the moves were created with an `make_to_order` `procure_method` and as such, the quantity considered to reconcile this move from stock is set to be at 0 here: https://github.com/odoo/odoo/blob/91316ec8d55dbc5e1cd712568f614c62539bd807/addons/stock/report/stock_forecasted.py#L283-L287 Furthermore, since there is no incoming moves made to reconcile this outgoing move (whcih happen for real "MTO" moves and not these flagged as MTO because they were part of a chain) the line will be created here and flagged as not repleinshed nor available:
https://github.com/odoo/odoo/blob/91316ec8d55dbc5e1cd712568f614c62539bd807/addons/stock/report/stock_forecasted.py#L295-L299 The forecast error

### Note:

The issue is not reproducible in 16.0 since the forecast datas computed by the `_get_report_lines` was drastically prior to the 17.0 version.

opw-4164403
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
