### PR TITLE
[FIX] test_website: remove :text pseudo-class

### DIFF
--- a/addons/test_website/static/tests/tours/website_page_properties.js
+++ b/addons/test_website/static/tests/tours/website_page_properties.js
@@ -88,7 +88,7 @@ function checkIsTemplate(isTemplate, pageTitle = undefined) {
             ? [
                   {
                       content: `Verify template ${pageTitle} exists`,
-                      trigger: `:visible .o_page_template .o_page_name:text(${pageTitle})`,
+                      trigger: `:visible .o_page_template .o_page_name:contains(${pageTitle})`,
                   },
               ]
             : [
@@ -262,7 +262,7 @@ function testWebsitePageProperties() {
     steps.check.push(
         {
             content: "Verify page title",
-            trigger: ":visible :iframe head title:text(/Cool Page/)",
+            trigger: ":visible :iframe head title:contains(/Cool Page/)",
         },
         ...assertPageCanonicalUrlIs("/cool-page"),
         stepUtils.goToUrl(getClientActionUrl("/new-page")),
@@ -317,7 +317,7 @@ function testWebsitePageProperties() {
     steps.checkTorndown.push(
         {
             content: "Verify page title",
-            trigger: ":visible :iframe head title:text(/New Page/)",
+            trigger: ":visible :iframe head title:contains(/New Page/)",
         },
         ...assertPageCanonicalUrlIs("/new-page"),
         stepUtils.goToUrl(getClientActionUrl("/new-page")),


### PR DESCRIPTION
This PR replaces the uses of ":text" by ":contains", following the recent changes that removed the ":text" pseudo-class.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
