### PR TITLE
[FIX] hr_holidays : Use employee resource for computation of allocation

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -196,7 +196,8 @@ class HolidaysAllocation(models.Model):
     @api.depends('number_of_days')
     def _compute_number_of_hours_display(self):
         for allocation in self:
-            allocation.number_of_hours_display = allocation.number_of_days * HOURS_PER_DAY
+            hours_per_day = allocation.employee_id.sudo().resource_id.calendar_id.hours_per_day or HOURS_PER_DAY
+            allocation.number_of_hours_display = allocation.number_of_days * hours_per_day
 
     @api.depends('number_of_hours_display', 'number_of_days_display')
     def _compute_duration_display(self):


### PR DESCRIPTION
### Steps to reproduce:
	- Create a new working schedule that is not 8 hours a day
	- Assign this working schedule to one of the employees
	- Create a Time off type and set the unit as 'Hours'
	- Create an allocation for the created type and the employee with the new working schedule
	- Set the Allocation for 80 hours and save
	- Notice the 80 has been changed

### Current behavior before PR:
This is happening because in this commit https://github.com/odoo-dev/odoo/commit/1d8898bae93da9ccc1687971a19b238f279032eb we changed the computation of the allocation to use HOURS_PER_DAY which is a static variable set to 8 -default working hours per day- so if the employee has different working hours a day it will be calculated wrongly.

### Desired behavior after PR is merged:
We are now using the working hours for the resource of the employee and we only fallback on HOURS_PER_DAY if there isn't a resource for the employee.

opw-4224592