### PR TITLE
[FIX] website: apply grid padding option only on grid mode rows

### DIFF
--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -118,6 +118,10 @@ const wSnippetMenu = weSnippetEditor.SnippetsMenu.extend({
         `, _t("Position"), _t("Cover"), _t("Contain"))));
         // TODO remove me in master
         $html.find('[data-attribute-name="interval"]')[0].dataset.attributeName = "bsInterval";
+        // TODO adapt in 17.0: changing the `data-apply-to` attribute of the
+        // grid padding option so it is not applied on inner rows.
+        const $gridPaddingOptions = $html.find('[data-css-property="--grid-item-padding-y"], [data-css-property="--grid-item-padding-x"]');
+        $gridPaddingOptions.attr("data-apply-to", ".row.o_grid_mode");
     },
     /**
      * Depending of the demand, reconfigure they gmap key or configure it


### PR DESCRIPTION
Steps to reproduce:
- Drop the "Team" snippet and toggle it to grid mode.
- Change the grid items padding with the "Padding (Y, X)" option. => The `o_we_padding_highlight` class used to show the padding preview is also added on the inner row of the grid items.

This happens because the `data-apply-to` attribute of this option targets the `.row` elements in general, instead of only the grid mode one (so having the `o_grid_mode` class).

This commit fixes this issue by changing this attribute, by patching the template in JS as a stable fix.

Note that in above versions, the padding option changed so this fix will not be needed (but other grid options will need a similar fix).

task-4247543
