### PR TITLE
[FIX] website_sale: prevent payment when no pickup point selected

### DIFF
--- a/addons/website_sale/static/src/js/payment_button.js
+++ b/addons/website_sale/static/src/js/payment_button.js
@@ -44,14 +44,8 @@ paymentButton.include({
             const address = carriersContainer.querySelector(
                 '.o_order_location_address'
             ).innerText;
-            const isPickUp = carriersContainer.lastChild.previousSibling.children;
-            if (
-                isPickUp.length > 1 && (address === '' || isPickUp[0].classList.contains('d-none'))
-            ) { // A pickup point is required but not selected
-                return false;
-            }
+            return address !== '';  // A pickup point is required but not selected.
         }
-
         return true;
     },
 


### PR DESCRIPTION
Before this commit, when users added a description to a pickup shipping method, the algorithm to prevent the payment button from being enabled when no pickup location was selected failed.

Now, the payment button will be disabled when no pickup is selected even if the shipping method has a description.

opw-4040317
