### PR TITLE
17.0 fix mrp bom write method

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -248,7 +248,7 @@ class MrpBom(models.Model):
         relevant_fields = ['bom_line_ids', 'byproduct_ids', 'product_tmpl_id', 'product_id', 'product_qty']
         if any(field_name in vals for field_name in relevant_fields):
             self._set_outdated_bom_in_productions()
-        if 'sequence' in vals and self and self[-1].id == self._prefetch_ids[-1]:
+        if 'sequence' in vals and self and self[-1].id == list(self._prefetch_ids)[-1]:
             self.browse(self._prefetch_ids)._check_bom_cycle()
         return res
 

--- a/doc/cla/individual/Kosaaaaa.md
+++ b/doc/cla/individual/Kosaaaaa.md
@@ -1,0 +1,12 @@
+Poland, 2024-10-10
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Oskar Kosobucki 43652764+kosaaaaa@users.noreply.github.com https://github.com/Kosaaaaa
+


### PR DESCRIPTION
Issue:

if 'sequence' in vals and self and self[-1].id == self._prefetch_ids[-1]: TypeError: 'PrefetchX2many' object is not subscriptable

Cause of the issue:
PrefetchX2many object does not have __getitem__ method, only __iter__




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
