### PR TITLE
[FIX] repair: prevent using same SN for product and part

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -236,6 +236,11 @@ class Repair(models.Model):
             self.partner_invoice_id = addresses['invoice']
             self.pricelist_id = self.partner_id.property_product_pricelist.id
 
+    @api.onchange('lot_id')
+    def onchange_lot_id(self):
+        if any(line.lot_id == self.lot_id and line.type == 'add' for line in self.operations):
+            raise UserError(_("The serial number of the product to be repaired cannot be the same as one of the part of the repair."))
+
     @api.depends('company_id')
     def _compute_location_id(self):
         for order in self:
@@ -816,6 +821,11 @@ class RepairLine(models.Model):
                 return {'warning': warning}
             else:
                 self.price_unit = price
+
+    @api.onchange('lot_id')
+    def onchange_lot_id(self):
+        if self.type == 'add' and self.lot_id == self.repair_id.lot_id:
+            raise UserError(_("The serial number of the product to be repaired cannot be the same as one of the part of the repair."))
 
 
 class RepairFee(models.Model):


### PR DESCRIPTION
Steps to reproduce the bug:

- Create a storable product “P1”:
    - Tracked by serial number (SN)
    - Update the quantity with SN1

- Create a repair order:
    - Product to repair: P1 with SN1
    - Add product “P1” with SN1 as a part of the repair

Problem:
No error is triggered. It should not be allowed to repair a product using the same product with the same SN. This can cause issues, such as an infinite loop, when trying to access the traceability of SN1.

This approach can be used to remove the product under this SN and replace it with another SN.


opw-4157445