### PR TITLE
[FIX] account: ignore non-product lines on sale/purchase orders when …

### DIFF
--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -155,9 +155,10 @@ class AccruedExpenseRevenue(models.TransientModel):
         fnames = []
         total_balance = 0.0
         for order in orders:
-            if len(orders) == 1 and self.amount and order.order_line:
+            product_lines = order.order_line.filtered(lambda x: x.product_id)
+            if len(orders) == 1 and product_lines and self.amount and order.order_line:
                 total_balance = self.amount
-                order_line = order.order_line[0]
+                order_line = product_lines[0]
                 account = self._get_computed_account(order, order_line.product_id, is_purchase)
                 distribution = order_line.analytic_distribution if order_line.analytic_distribution else {}
                 if not is_purchase and order.analytic_account_id:


### PR DESCRIPTION
…creating accrued revenue entries

Problem:
When using the generate accrued revenue entries action on a sale/purchase order where the first order line is a section or note leads to an invalid account move being created. The move contains a line with not account set.

Purpose of this PR:
To make sure only product lines are taken into account when generating these entries

How to reproduce:
1) Create and confirm a sale order where the first order line is a section or note and the next contains a product 
2) Run the Accrued Revenue Entry contextual action 
3) Fill the Accrual Account and Amount fields with arbitrary data and hit Create Entry 
4) Error appears, a move line is generated with no account

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
