### PR TITLE
[FIX] purchase_mrp: remove rounding in kit price calculation

### DIFF
--- a/addons/purchase_mrp/models/stock_move.py
+++ b/addons/purchase_mrp/models/stock_move.py
@@ -26,7 +26,6 @@ class StockMove(models.Model):
         if line.currency_id != self.company_id.currency_id:
             kit_price_unit = line.currency_id._convert(kit_price_unit, self.company_id.currency_id, self.company_id, fields.Date.context_today(self), round=False)
         cost_share = self.bom_line_id._get_cost_share()
-        price_unit_prec = self.env['decimal.precision'].precision_get('Product Price')
         uom_factor = 1.0
         kit_product = bom.product_id or bom.product_tmpl_id
 
@@ -36,7 +35,7 @@ class StockMove(models.Model):
         # Convert uom from bom_line_uom to product_uom for bom_line
         uom_factor = bom_line.product_id.uom_id._compute_quantity(uom_factor, bom_line.product_uom_id)
 
-        return float_round(kit_price_unit * cost_share * uom_factor * bom.product_qty / bom_line.product_qty, precision_digits=price_unit_prec)
+        return (kit_price_unit * cost_share * uom_factor * bom.product_qty / bom_line.product_qty)
 
     def _get_valuation_price_and_qty(self, related_aml, to_curr):
         valuation_price_unit_total, valuation_total_qty = super()._get_valuation_price_and_qty(related_aml, to_curr)

--- a/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
+++ b/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
@@ -1043,3 +1043,51 @@ class TestPurchaseMrpFlow(AccountTestInvoicingCommon):
             })],
         })
         self.assertTrue(bom)
+
+    def test_kit_price_without_rounding(self):
+        warehouse = self.warehouse
+        buy_route = warehouse.buy_pull_id.route_id
+        manufacture_route = warehouse.manufacture_pull_id.route_id
+
+        avco_category = self.env['product.category'].create({
+            'name': 'AVCO',
+            'property_cost_method': 'average',
+            'property_valuation': 'real_time'
+        })
+
+        prod, compo = self.env['product.product'].create([{
+        'name': name,
+        'type': 'product',
+        'categ_id': avco_category.id,
+        'route_ids': [(4, route_id)],
+        } for name, route_id in [('product a', manufacture_route.id), ('component a', buy_route.id)]])
+
+        self.env['mrp.bom'].create({
+            'product_tmpl_id': prod.product_tmpl_id.id,
+            'type': 'phantom',
+            'bom_line_ids': [(0, 0, {
+                'product_id': compo.id,
+                'product_qty': 12,
+            })]
+        })
+
+        po_form = Form(self.env['purchase.order'])
+        partner = self.env['res.partner'].create({'name': 'Testy'})
+        po_form.partner_id = partner
+        with po_form.order_line.new() as pol_form:
+            pol_form.product_id = prod
+            pol_form.product_qty = 1
+            pol_form.price_unit = 100
+            pol_form.taxes_id.clear()
+        po = po_form.save()
+        po.button_confirm()
+        receipt = po.picking_ids
+        receipt.move_line_ids[0].qty_done = 12
+        receipt.button_validate()
+        move = receipt.move_ids[0]
+        # the price unit for 1 unit of the kit is 100
+        # calculating the unit cost per component: 100 / 12 = 8.33333333333
+        # total cost for 12 components: 8.33 * 12 = 99.96
+        # however, due to rounding differences, the expected value is 100
+        svl_val = self.env['stock.valuation.layer'].search([('stock_move_id', '=', move.id)]).value
+        self.assertEqual(svl_val, 100)


### PR DESCRIPTION
Fixes a rounding issue where the cost of kit components is rounded too early in the stock valuation process, leading to discrepancies in the final stock valuation layer values. The kit's total cost was being calculated with an early rounding step, which caused a small mismatch between the expected and actual values. This fix ensures that the correct unit cost is used in the stock valuation layer without affecting the product's standard price.

Example:
1.) Create Product A:
Storable Product Type
Route = Manufacturing
Category = AVCO or FIFO

2.) Create Product B: 
Storable Product Type
Routes = Buy
Category = AVCO or FIFO

3.) Make a BOM
Product A
Quantity = 1
Kit
Components: 12 units of Product B

4.) Create a Purchase Order:
Buy 1 unit of Product A at $100
5.) Confirm PO -> this will generate a receipt
6.) Validate receipt
7.) Note the valuation is 12 units @ a value of 99.96 where it should be 100

Current behavior before PR:
svl.value = 99.96
Desired behavior after PR is merged:
svl.value = 100

opw-4208554

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
