### PR TITLE
[FIX] hr_expense: add total amount label in specific case in expense form view

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -199,7 +199,8 @@
                             </div>
 
                             <!-- CASE: converter when currency is different than the company one -->
-                            <label for="total_amount" string="" invisible="not is_multiple_currency and not product_has_cost"/>
+                            <label name="total_amount_product_cost_label" for="total_amount" string="Total" invisible="is_multiple_currency or not product_has_cost"/>
+                            <label name="total_amount_multicurrency_label" for="total_amount" string="" invisible="not is_multiple_currency"/>
                             <div class="o_row" invisible="not is_multiple_currency and not product_has_cost">
                                 <field name="total_amount" widget='monetary' options="{'currency_field': 'company_currency_id'}"
                                        force_save="1" readonly="not is_editable or product_has_cost" class="oe_inline"/>


### PR DESCRIPTION
Updated the label for `total_amount` to display `Total` when the expense is not in multiple currencies and the product has a cost, and to show an empty label in the other previously considered cases. This change ensures that the label is displayed correctly without repetitions or omissions in the relevant scenarios.

Current behavior before PR:
<img width="438" alt="Screenshot 2024-10-10 at 11 05 52 PM" src="https://github.com/user-attachments/assets/af93e767-bc0f-487b-bb35-49ad4602f0ba">

Desired behavior after PR is merged:
<img width="450" alt="Screenshot 2024-10-10 at 11 04 51 PM" src="https://github.com/user-attachments/assets/40f531a8-0d79-4eb6-a3d6-cd80abcb145c">

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
