### PR TITLE
[FIX] website_sale: display base unit price for product variants

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1077,7 +1077,7 @@
                                 <div class="js_product js_main_product mb-3">
                                     <div>
                                         <t t-call="website_sale.product_price"/>
-                                        <small t-if="combination_info['base_unit_price']"
+                                        <small t-if="'base_unit_price' in combination_info"
                                                class="ms-1 text-muted o_base_unit_price_wrapper d-none" groups="website_sale.group_show_uom_price">
                                             <t t-call='website_sale.base_unit_price'/>
                                         </small>


### PR DESCRIPTION
**Steps:**
- Create a product with two variants (e.g., Steel & White and Aluminum & White).
- Enable 'Product Reference Price' in the settings.
- Set the base_unit_price of the 'Steel & White' variant to 0.
- Go to the product page on the website and observe that the base unit price disappears for all variants, even though it should be displayed for the other variants.

**Issue:**
- The base_unit_price for product variants was not being displayed when the base_unit_price of one variant was set to 0. This caused the price to disappear for all variants in the template, even when other variants had valid base_unit_price values.

**Cause:**
The condition in the template was relying on a falsy check, which incorrectly evaluated 0 as a falsy value and prevented the display of base_unit_price for all variants, including those with valid prices.

**Fix:**
The condition in the template was updated to check for the existence of base_unit_price explicitly using if condition effectively. This ensures that even when base_unit_price is 0, it will still be displayed, while preventing the field from disappearing for other variants.

Affected Version: 17.0~master
opw-4061530