### PR TITLE
[IMP] sale_loyalty: show gift card from SO

### DIFF
--- a/addons/sale_loyalty/views/sale_order_views.xml
+++ b/addons/sale_loyalty/views/sale_order_views.xml
@@ -7,6 +7,17 @@
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="priority">10</field>
         <field name="arch" type="xml">
+            <div name="button_box" position="inside">
+                <button
+                    name="action_view_gift_cards"
+                    class="oe_stat_button"
+                    type="object"
+                    icon="fa-gift"
+                    invisible="gift_card_count == 0"
+                >
+                    <field string="Gift Cards" name="gift_card_count" widget="statinfo"/>
+                </button>
+            </div>
             <button name="action_open_discount_wizard" position="before">
                 <button name="%(sale_loyalty.sale_loyalty_coupon_wizard_action)d"
                         type="action"


### PR DESCRIPTION
Before this commit:
When a gift card was sold from the sales app (backend), there was no easy way to find the generated gift card. The user had to manually locate it in the list of gift cards, verify if it was for that particular sale order, and then send it to the customer.

After this commit:
A smart button has been added to the sale order form view. This button shows the number of gift cards linked to that particular sale order, and clicking on it opens the list view of gift cards linked to that specific sale order. This improvement makes it easy for the user to find the related gift card directly from the sale order itself.

task-4237701