### PR TITLE
[FIX] product: fix product search issue in so

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -541,7 +541,11 @@ class ProductProduct(models.Model):
             positive_operators = ['=', 'ilike', '=ilike', 'like', '=like']
             product_ids = []
             if operator in positive_operators:
-                product_ids = list(self._search([('default_code', '=', name)] + domain, limit=limit, order=order))
+                product_ids = list(self._search(
+                    ['|', ('default_code', '=', name), ('name', '=', name)] + domain,
+                    limit=limit,
+                    order=order
+                ))
                 if not product_ids:
                     product_ids = list(self._search([('barcode', '=', name)] + domain, limit=limit, order=order))
             if not product_ids and operator not in expression.NEGATIVE_TERM_OPERATORS:


### PR DESCRIPTION
Version: saas-17.2
Before this fix, the `_name_search` method only supported searching by `default_code`.

Issue:
It seems to be an issue with product-wise searches in sales orders.

Fix:
Added `|` operator to the search domain for `name` in `_name_search`.

This improves the product search functionality and ensures better user experience when searching for products.

opw-4211232