### PR TITLE
[FIX] mrp: fix inconsistency of product's on hand quantity

### DIFF
--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -299,11 +299,11 @@ class ProductProduct(models.Model):
                 ratios_free_qty.append(component_res["free_qty"] / qty_per_kit)
             if bom_sub_lines and ratios_virtual_available:  # Guard against all cnsumable bom: at least one ratio should be present.
                 res[product.id] = {
-                    'virtual_available': min(ratios_virtual_available) * bom_kits[product].product_qty // 1,
-                    'qty_available': min(ratios_qty_available) * bom_kits[product].product_qty // 1,
-                    'incoming_qty': min(ratios_incoming_qty) * bom_kits[product].product_qty // 1,
-                    'outgoing_qty': min(ratios_outgoing_qty) * bom_kits[product].product_qty // 1,
-                    'free_qty': min(ratios_free_qty) * bom_kits[product].product_qty // 1,
+                    'virtual_available': float_round(min(ratios_virtual_available) * bom_kits[product].product_qty, precision_rounding=rounding) // 1,
+                    'qty_available': float_round(min(ratios_qty_available) * bom_kits[product].product_qty, precision_rounding=rounding) // 1,
+                    'incoming_qty': float_round(min(ratios_incoming_qty) * bom_kits[product].product_qty, precision_rounding=rounding) // 1,
+                    'outgoing_qty': float_round(min(ratios_outgoing_qty) * bom_kits[product].product_qty, precision_rounding=rounding) // 1,
+                    'free_qty': float_round(min(ratios_free_qty) * bom_kits[product].product_qty, precision_rounding=rounding) // 1,
                 }
             else:
                 res[product.id] = {

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -1322,15 +1322,21 @@ class TestBoM(TestMrpCommon):
 
     def test_bom_kit_with_sub_kit(self):
         p1, p2, p3, p4 = self.make_prods(4)
+        prod1, prod2 = self.make_prods(2)
         self.make_bom(p1, p2, p3)
         self.make_bom(p2, p3, p4)
+        bom = self.make_bom(prod1, prod2)
+        bom.product_qty = 100
 
         loc = self.env.ref("stock.stock_location_stock")
         self.env["stock.quant"]._update_available_quantity(p3, loc, 10)
         self.env["stock.quant"]._update_available_quantity(p4, loc, 10)
+        self.env["stock.quant"]._update_available_quantity(prod2, loc, 5.57)
+        self.env["stock.quant"]._update_available_quantity(prod2, loc, -5)
         self.assertEqual(p1.qty_available, 5.0)
         self.assertEqual(p2.qty_available, 10.0)
         self.assertEqual(p3.qty_available, 10.0)
+        self.assertEqual(prod1.qty_available, 57.0)
 
     def test_operation_blocked_by_another_operation(self):
         """ Test that an operation is not blocked by another operation if the variant is different


### PR DESCRIPTION
After this commit 784f1511 , The `float_round()` functionality is changed. 
Before this commit, If the `qty_available` is 0.57:
```
In [2]: float_round(0.57,2)
Out[2]: 0.5700000000000001

After this commit:
In [2]: float_round(0.57,2)
Out[2]: 0.57
```

Now, while executing this line of code
https://github.com/odoo/odoo/blob/baea953d248471e8aef60e02c1216f77941f1951/addons/mrp/models/product.py#L244
```
Before:
In [3]: 0.5700000000000001*100//1
Out[3]: 57.0

After:
In [3]: 0.57*100//1
Out[3]: 56.0
```

These differences leads to blocking the upgrade process.
```
Traceback (most recent call last):
File "/tmp/tmpft9eq3rf/migrations/testing.py", line 212, in test_check
self.check(value)
File "/tmp/tmpft9eq3rf/migrations/stock/tests/test_on_hand_quantity.py", line 90, in check
self.assertEqual(before_results, self.convert_check(after_results), self.message)
AssertionError: Lists differ: [[12,[7979 chars]6, '57'], [20249, '17.06'], [20250, '1705'], [[12354 chars]'1']] != [[12,[7979 chars]6, '56'], [20249, '17.06'], [20250, '1705'], [[12354 chars]'1']]

First differing element 529:
[20246, '57']
[20246, '56']
```

upg-2096343
opw-4224012

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
