### PR TITLE
[IMP] discuss: improve rtc logging

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_context_menu.xml
+++ b/addons/mail/static/src/discuss/call/common/call_context_menu.xml
@@ -19,7 +19,7 @@
                 <div><span class="fw-bolder">ICE gathering: </span><t t-out="state.peerStats.iceGatheringState"/></div>
                 <div><span class="fw-bolder">Packets sent: </span><t t-out="state.peerStats.packetsSent"/></div>
                 <div><span class="fw-bolder">Packets received: </span><t t-out="state.peerStats.packetsReceived"/></div>
-                <div><span class="fw-bolder">Log step: </span><t t-out="state.peerStats.logStep"/></div>
+                <div><span class="fw-bolder">Log step: </span><t t-out="props.rtcSession.logStep"/></div>
             </t>
             <t t-elif="env.debug and isSelf and rtc.state.connectionType === rtcConnectionTypes.SERVER">
                 <div><span class="fw-bolder">Connection type: </span><t t-out="rtc.state.connectionType"/></div>

--- a/addons/mail/static/src/discuss/call/common/discuss_p2p_service.js
+++ b/addons/mail/static/src/discuss/call/common/discuss_p2p_service.js
@@ -8,7 +8,10 @@ export const discussP2P = {
      * @param {import("services").ServiceFactories} services
      */
     start(env, services) {
-        const p2p = new PeerToPeer({ notificationRoute: "/mail/rtc/session/notify_call_members" });
+        const p2p = new PeerToPeer({
+            logLevel: env.debug ? "info" : undefined,
+            notificationRoute: "/mail/rtc/session/notify_call_members",
+        });
         services["bus_service"].subscribe(
             "discuss.channel.rtc.session/peer_notification",
             ({ sender, notifications }) => {

--- a/addons/mail/static/src/discuss/call/common/rtc_session_model.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_session_model.js
@@ -96,14 +96,6 @@ export class RtcSession extends Record {
     mainVideoStreamType;
     // RTC stats
     connectionState;
-    localCandidateType;
-    remoteCandidateType;
-    dataChannelState;
-    packetsReceived;
-    packetsSent;
-    dtlsState;
-    iceState;
-    iceGatheringState;
     logStep;
 
     get channel() {


### PR DESCRIPTION
With this commit, the peer to peer service will use the logs from
the peer-to-peer service and `console.debug()` all its logs when the
log setting is enabled.