### PR TITLE
[FIX] website_profile: prevent table /profile/users overflow

### DIFF
--- a/addons/website_profile/views/website_profile.xml
+++ b/addons/website_profile/views/website_profile.xml
@@ -531,24 +531,26 @@
                     <t t-call="website_profile.top3_user_card"></t>
                 </div>
             </div>
-            <table class="table table-sm" t-if='users'>
-                <t t-foreach="users" t-as="user">
-                    <tr t-attf-onclick="location.href='/profile/user/#{user['id']}';" t-attf-class="o_wprofile_pointer bg-white #{user['id'] == user_id.id and 'o_wprofile_border_focus'}">
-                        <t t-call="website_profile.all_user_card"/>
-                    </tr>
-                </t>
-                <t t-if="my_user">
-                    <!-- keep same table to avoid missaligment -->
-                    <tr>
-                        <td colspan="7"></td>
-                    </tr>
-                    <t t-set='user' t-value='my_user'/>
-                    <tr t-attf-onclick="location.href='/profile/user/#{user['id']}';" t-attf-class="o_wprofile_pointer bg-white o_wprofile_border_focus">
-                        <t t-call="website_profile.all_user_card">
-                        </t>
-                    </tr>
-                </t>
-            </table>
+            <div class="table-responsive" t-if="users">
+                <table class="table table-sm" t-if="users">
+                    <t t-foreach="users" t-as="user">
+                        <tr t-attf-onclick="location.href='/profile/user/#{user['id']}';" t-attf-class="o_wprofile_pointer bg-white #{user['id'] == user_id.id and 'o_wprofile_border_focus'}">
+                            <t t-call="website_profile.all_user_card"/>
+                        </tr>
+                    </t>
+                    <t t-if="my_user">
+                        <!-- keep same table to avoid missaligment -->
+                        <tr>
+                            <td colspan="7"></td>
+                        </tr>
+                        <t t-set='user' t-value='my_user'/>
+                        <tr t-attf-onclick="location.href='/profile/user/#{user['id']}';" t-attf-class="o_wprofile_pointer bg-white o_wprofile_border_focus">
+                            <t t-call="website_profile.all_user_card">
+                            </t>
+                        </tr>
+                    </t>
+                </table>
+            </div>
             <t t-if='search and not users'>
                 <div class='alert alert-warning'>No user found for <strong><t t-esc="search"/></strong>. Try another search.</div>
             </t>


### PR DESCRIPTION
The issue: In the mobile view of the website page /profile/users, the ranking table's content overflows the screen.

How to reproduce the issue:
-Install the website_profile and website_slides_survey modules. -Go to the /profile/users page in the website view. -Switch to mobile view.

Explanation:
Table overflowed on smaller screens due to missing responsive wrapper.

opw-4120453

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
