### PR TITLE
[IMP] Employee: Birthdays

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import base64
+
 from pytz import timezone, UTC
 from datetime import datetime, time
 from random import choice
@@ -84,7 +85,9 @@ class HrEmployee(models.Model):
     children = fields.Integer(string='Number of Dependent Children', groups="hr.group_hr_user", tracking=True)
     place_of_birth = fields.Char('Place of Birth', groups="hr.group_hr_user", tracking=True)
     country_of_birth = fields.Many2one('res.country', string="Country of Birth", groups="hr.group_hr_user", tracking=True)
-    birthday = fields.Date('Date of Birth', groups="hr.group_hr_user", tracking=True)
+    birthday = fields.Date('Birthday', groups="hr.group_hr_user", tracking=True)
+    birthday_public_display = fields.Boolean('Show to all employees', groups="hr.group_hr_user", default=False)
+    birthday_public_display_string = fields.Char("Public Date of Birth", compute="_compute_birthday_public_display_string", default="hidden")
     ssnid = fields.Char('SSN No', help='Social Security Number', groups="hr.group_hr_user", tracking=True)
     sinid = fields.Char('SIN No', help='Social Insurance Number', groups="hr.group_hr_user", tracking=True)
     identification_id = fields.Char(string='Identification No', groups="hr.group_hr_user", tracking=True)
@@ -242,6 +245,14 @@ class HrEmployee(models.Model):
                 avatar = employee.user_id.sudo()[avatar_field]
             employee[avatar_field] = avatar
         super(HrEmployee, employee_wo_user_and_image)._compute_avatar(avatar_field, image_field)
+
+    @api.depends('birthday_public_display')
+    def _compute_birthday_public_display_string(self):
+        for employee in self:
+            if employee.birthday and employee.birthday_public_display:
+                employee.birthday_public_display_string = datetime.strftime(employee.birthday, "%d %B")
+            else:
+                employee.birthday_public_display_string = "hidden"
 
     @api.depends('name', 'permit_no')
     def _compute_work_permit_name(self):

--- a/addons/hr/models/hr_employee_public.py
+++ b/addons/hr/models/hr_employee_public.py
@@ -50,6 +50,7 @@ class HrEmployeePublic(models.Model):
     parent_id = fields.Many2one('hr.employee.public', 'Manager', readonly=True)
     coach_id = fields.Many2one('hr.employee.public', 'Coach', readonly=True)
     user_partner_id = fields.Many2one(related='user_id.partner_id', related_sudo=False, string="User's partner")
+    birthday_public_display_string = fields.Char("Public Date of Birth", related='employee_id.birthday_public_display_string')
 
     @api.depends_context('uid')
     @api.depends('parent_id')

--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -36,6 +36,7 @@ HR_WRITABLE_FIELDS = [
     'address_id',
     'barcode',
     'birthday',
+    'birthday_public_display',
     'category_ids',
     'children',
     'coach_id',
@@ -123,6 +124,7 @@ class ResUsers(models.Model):
     passport_id = fields.Char(related='employee_id.passport_id', readonly=False, related_sudo=False)
     gender = fields.Selection(related='employee_id.gender', readonly=False, related_sudo=False)
     birthday = fields.Date(related='employee_id.birthday', readonly=False, related_sudo=False)
+    birthday_public_display = fields.Boolean(related='employee_id.birthday_public_display', readonly=False, related_sudo=False)
     place_of_birth = fields.Char(related='employee_id.place_of_birth', readonly=False, related_sudo=False)
     country_of_birth = fields.Many2one(related='employee_id.country_of_birth', readonly=False, related_sudo=False)
     marital = fields.Selection(related='employee_id.marital', readonly=False, related_sudo=False)

--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -150,10 +150,14 @@
                                     <i class="fa fa-fw me-2 fa-envelope text-primary" title="Email"/>
                                     <field name="work_email"/>
                                 </div>
+                                <div t-if="record.work_phone.raw_value">
+                                    <i class="fa fa-fw me-2 fa-phone text-primary" title="Phone"/>
+                                    <field name="work_phone"/>
+                                </div>
                                 <div class="d-flex">
-                                    <div t-if="record.work_phone.raw_value">
-                                        <i class="fa fa-fw me-2 fa-phone text-primary" title="Phone"/>
-                                        <field name="work_phone"/>
+                                    <div invisible="birthday_public_display_string == 'hidden'">
+                                        <i class="fa fa-fw me-2 fa-birthday-cake text-primary" title="Birthday"/>
+                                        <field name="birthday_public_display_string"/>
                                     </div>
                                     <field name="user_id" widget="many2one_avatar_user" readonly="1" class="ms-auto"/>
                                 </div>

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -38,6 +38,7 @@
                         <filter name="group_manager" string="Manager" domain="[]" context="{'group_by': 'parent_id'}"/>
                         <filter name="group_department" string="Department" domain="[]" context="{'group_by': 'department_id'}"/>
                         <filter name="group_job" string="Job Position" domain="[]" context="{'group_by': 'job_id'}"/>
+                        <filter name="group_birthday" domain="[]" context="{'group_by': 'birthday'}"/>
                         <filter name="group_start" string="Start Date" domain="[]" context="{'group_by': 'create_date'}"/>
                         <filter name="group_category_ids" string="Tags" domain="[]" context="{'group_by': 'category_ids'}"/>
                     </group>
@@ -160,7 +161,14 @@
                                         <field name="ssnid"/>
                                         <field name="passport_id"/>
                                         <field name="gender"/>
-                                        <field name="birthday"/>
+                                        <label for="birthday"/>
+                                        <div class="o_row" name="div_km_home_work">
+                                            <field name="birthday" class="o_hr_narrow_field"/>
+                                            <span invisible="not birthday" >
+                                                <label for="birthday_public_display" class="fw-bold text-900 form-check-label ms-3"/>
+                                                <field name="birthday_public_display" class="ms-3"/>
+                                            </span>
+                                        </div>
                                         <field name="place_of_birth"/>
                                         <field name="country_of_birth"/>
                                     </group>
@@ -275,6 +283,7 @@
                     <field name="parent_id" widget="many2one_avatar_user" optional="show"/>
                     <field name="address_id" column_invisible="True"/>
                     <field name="company_id" column_invisible="True"/>
+                    <field name="birthday" optional="hide"/>
                     <field name="work_location_id" optional="hide"/>
                     <field name="coach_id" widget="many2one_avatar_user" optional="hide"/>
                     <field name="active" column_invisible="True"/>
@@ -326,6 +335,10 @@
                                 <div t-if="record.work_phone.raw_value">
                                     <i class="fa fa-fw me-2 fa-phone text-primary" title="Phone"/>
                                     <field name="work_phone" />
+                                </div>
+                                <div invisible="birthday_public_display_string == 'hidden'">
+                                    <i class="fa fa-fw me-2 fa-birthday-cake text-primary" title="Birthday"/>
+                                    <field name="birthday_public_display_string"/>
                                 </div>
                                 <field name="employee_properties" widget="properties"/>
                                 <field class="hr_tags" name="category_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>

--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -158,7 +158,14 @@
                                 <field name="ssnid" readonly="not can_edit"/>
                                 <field name="passport_id" readonly="not can_edit"/>
                                 <field name="gender" readonly="not can_edit"/>
-                                <field name="birthday" readonly="not can_edit"/>
+                                <label for="birthday"/>
+                                        <div class="oe_inline">
+                                            <field name="birthday" class="o_hr_narrow_field" readonly="not can_edit"/>
+                                            <span invisible="not birthday" groups="hr.group_hr_user">
+                                                <label for="birthday_public_display" class="fw-bold text-900 form-check-label ms-3"/>
+                                                <field name="birthday_public_display" class="ms-3" readonly="not can_edit"/>
+                                            </span>
+                                        </div>
                                 <field name="place_of_birth" readonly="not can_edit"/>
                                 <field name="country_of_birth" readonly="not can_edit"/>
                             </group>


### PR DESCRIPTION
Problem
----------
There is no dedicated section for Employee birthdays, which is a valuable feature in any HR software.

Objective
----------
- Add only the day and month of the employee's birth date to the employee's kanban view card.
- The full date of birth is still a private field. (Thanks to this, the age is still not accessible)
- To display our day and month of birth publicly to other employees, there is an option in the user profile form view, next to the birthdate field.
- For employees (and not users), a user with HR access rights can edit these fields for all employees according to employees' wishes.
- Add a Group by Birthdate option to the search bar for users with HR access rights.

Solution
----------
Add a checkbox in the user form view and the private employee form view (only visible if a birth date exists) A new char field is compute to display only "day month" On employee kanban private view, the special char field is accessible to display it For the public view, a link is made only to this field, thanks to this special field the full birthdate is not accessible.

task-4144174

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
