### PR TITLE
[PERF] mail: speedup GC when deleting `ir.attachment`

### DIFF
--- a/addons/mail/models/mail_thread_main_attachment.py
+++ b/addons/mail/models/mail_thread_main_attachment.py
@@ -11,7 +11,7 @@ class MailMainAttachmentMixin(models.AbstractModel):
     _inherit = 'mail.thread'
     _description = 'Mail Main Attachment management'
 
-    message_main_attachment_id = fields.Many2one(string="Main Attachment", comodel_name='ir.attachment', copy=False)
+    message_main_attachment_id = fields.Many2one(string="Main Attachment", comodel_name='ir.attachment', copy=False, index='btree_not_null')
 
     def _message_post_after_hook(self, message, msg_values):
         """ Set main attachment field if necessary """


### PR DESCRIPTION
A frequent issue is the GC cron times-out when deleting attachments, due to a lack of index on the Fkey
`message_main_attachment_id`, forcing Postgres to do a `Seq.Scan` on potentially really large tables to check if it needs to set the Fkey to `NULL`. Therefor we add the missing index.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
