### PR TITLE
[IMP] project_todo: hide some actions in cog menu for todo

### DIFF
--- a/addons/project_todo/models/project_task.py
+++ b/addons/project_todo/models/project_task.py
@@ -49,10 +49,9 @@ class ProjectTask(models.Model):
         self.ensure_one()
         self.company_id = self.project_id.company_id
         return {
-            'view_mode': 'form',
-            'res_model': 'project.task',
-            'res_id': self.id,
-            'type': 'ir.actions.act_window',
+            'type': 'ir.actions.act_url',
+            'target': 'self',
+            'url': f'/odoo/project/{self.project_id.id}/tasks/{self.id}',
         }
 
     @api.model

--- a/addons/project_todo/static/src/views/todo_form/todo_form_cog_menu.js
+++ b/addons/project_todo/static/src/views/todo_form/todo_form_cog_menu.js
@@ -1,0 +1,8 @@
+import { FormCogMenu } from "@web/views/form/form_cog_menu/form_cog_menu";
+
+export class TodoFormCogMenu extends FormCogMenu {
+    async _registryItems() {
+        // we don't want action added by other apps since the todo form view is more personal task
+        return [];
+    }
+}

--- a/addons/project_todo/static/src/views/todo_form/todo_form_controller.js
+++ b/addons/project_todo/static/src/views/todo_form/todo_form_controller.js
@@ -3,6 +3,7 @@ import { onWillStart } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { user } from "@web/core/user";
 import { FormControllerWithHTMLExpander } from "@resource/views/form_with_html_expander/form_controller_with_html_expander";
+import { TodoFormCogMenu } from "./todo_form_cog_menu";
 
 /**
  *  The FormController is overridden to be able to manage the edition of the name of a to-do directly
@@ -10,6 +11,11 @@ import { FormControllerWithHTMLExpander } from "@resource/views/form_with_html_e
  */
 
 export class TodoFormController extends FormControllerWithHTMLExpander {
+    static components = {
+        ...FormControllerWithHTMLExpander.components,
+        CogMenu: TodoFormCogMenu,
+    };
+
     setup() {
         super.setup();
         onWillStart(async () => {

--- a/addons/project_todo/static/tests/tours/project_todo_main_functions.js
+++ b/addons/project_todo/static/tests/tours/project_todo_main_functions.js
@@ -164,8 +164,8 @@ registry.category("web_tour.tours").add('project_todo_main_functions', {
     content: 'Convert the todo to a task',
     run: "click",
 }, {
-    trigger: ".breadcrumb-item:nth-child(1)",
-    content: markup("Let's go back to the <b>kanban view</b> to have an overview of your next tasks."),
+    trigger: ".o_project_task_form_view .breadcrumb-item:last-child",
+    content: markup("Let's go back to the <b>kanban view</b> to have an overview of tasks linked to project chosen."),
     run: "click",
 }, {
     trigger: ".o_kanban_view",


### PR DESCRIPTION
## [IMP] project_todo: hide some actions in cog menu for todo

Before this commit, the `Request Signature` action is added in the Todo
form view but that action is not really useful for the To-dos.

This commit removes the actions added in the "cog_menu" registry since
those actions in the cog menu are not useful for To-Dos.

## [IMP] project_todo: redirect user in project when todo converted in task

Before this commit, when the user converts one of his to-dos in task, he
will go back to the form view of todo and so all actions we could have
in the cog menu for a task is not available.

This commit redirects the user to the form view of task inside the
project he chooses when he converts his to-do. By doing that, he can use
the breadcrumb to go to the tasks of the project chosen.

task-4190723
