### PR TITLE
[FIX] website_slides: restrict 'edit' or 'delete' made by other users

### DIFF
--- a/addons/portal_rating/static/src/js/portal_chatter.js
+++ b/addons/portal_rating/static/src/js/portal_chatter.js
@@ -100,6 +100,19 @@ PortalChatter.include({
         }
     },
 
+        /**
+    * Retrieves rating and publisher status for a message.
+    *
+    * @param {number} messageIndex - Index of the message to retrieve values for.
+    * @returns {Object} Object containing rating and user publisher status.
+    */
+    getCommentsData: function (messageIndex) {
+        return {
+            rating: this.messages[messageIndex].rating,
+            is_publisher: this.options.is_user_publisher,
+        }
+    },
+
     //--------------------------------------------------------------------------
     // Private
     //--------------------------------------------------------------------------
@@ -342,10 +355,7 @@ PortalChatter.include({
             if (self.messages[messageIndex].rating.publisher_comment !== '') {
                 // Remove the button comment if exist and render the comment
                 self._getCommentButton($source).addClass('d-none');
-                self._getCommentContainer($source).html($(qweb.render("portal_rating.chatter_rating_publisher_comment", { 
-                    rating: self.messages[messageIndex].rating,
-                    is_publisher: self.options.is_user_publisher
-                })));
+                self._getCommentContainer($source).html($(qweb.render("portal_rating.chatter_rating_publisher_comment",  self.getCommentsData(messageIndex))));
             } else {
                 // Empty string or false considers as no comment
                 self._getCommentButton($source).removeClass("d-none");
@@ -364,11 +374,7 @@ PortalChatter.include({
 
         var comment = this.messages[messageIndex].rating.publisher_comment;
         if (comment) {
-            var data = {
-                rating: this.messages[messageIndex].rating,
-                is_publisher: this.options.is_user_publisher
-            };
-            this._getCommentContainer($source).html($(qweb.render("portal_rating.chatter_rating_publisher_comment", data)));
+            this._getCommentContainer($source).html($(qweb.render("portal_rating.chatter_rating_publisher_comment", this.getCommentsData(messageIndex))));
         } else {
             this._getCommentContainer($source).empty();
         }

--- a/addons/website_slides/__manifest__.py
+++ b/addons/website_slides/__manifest__.py
@@ -114,6 +114,7 @@ Featuring
             'website_slides/static/src/xml/slide_course_join.xml',
             'website_slides/static/src/xml/slide_quiz_create.xml',
             'website_slides/static/src/xml/slide_quiz.xml',
+            'website_slides/static/src/xml/portal_chatter.xml',
         ],
         'website.assets_editor': [
             'website_slides/static/src/js/systray_items/*.js',

--- a/addons/website_slides/controllers/mail.py
+++ b/addons/website_slides/controllers/mail.py
@@ -99,3 +99,9 @@ class SlidesPortalChatter(PortalChatter):
             'default_attachment_ids': message.attachment_ids.sudo().read(['id', 'name', 'mimetype', 'file_size', 'access_token']),
             'force_submit_url': '/slides/mail/update_comment',
         }
+
+    @http.route()
+    def portal_chatter_init(self, res_model, res_id, domain=False, limit=False, **kwargs):
+        result = super().portal_chatter_init(res_model, res_id, domain=domain, limit=limit, **kwargs)
+        result["options"].update({"is_user_manager": request.env.user.has_group('website_slides.group_website_slides_manager')})
+        return result

--- a/addons/website_slides/static/src/js/portal_chatter.js
+++ b/addons/website_slides/static/src/js/portal_chatter.js
@@ -21,4 +21,15 @@ PortalChatter.include({
             $('#review-tab').text(_.str.sprintf(_t('Reviews (%d)'), data.rating_count));
         }
     },
+        /**
+     * Update values to restrict editing and deleting comments.
+     *
+     * @param {number} messageIndex
+     * @override
+     */
+    getCommentsData: function (messageIndex) {
+        let vals = this._super(...arguments);
+        Object.assign(vals, { is_user_manager: this.options.is_user_manager, partner_id: this.options.partner_id});
+        return vals;
+    },
 });

--- a/addons/website_slides/static/src/xml/portal_chatter.xml
+++ b/addons/website_slides/static/src/xml/portal_chatter.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-extend="portal.chatter_messages">
+        <t t-jquery=".o_portal_chatter_attachments" t-operation="after">
+            <t t-set="is_user_manager" t-value="widget.options['is_user_manager']"/>
+            <t t-set="partner_id" t-value="widget.options['partner_id']"/>
+        </t>
+    </t>
+
+    <t t-extend="portal_rating.chatter_rating_publisher_comment">
+        <t t-jquery=".dropdown" t-operation="attributes">
+            <attribute name="t-if">is_publisher and (is_user_manager or rating.publisher_id == partner_id)</attribute>
+        </t>
+        <t t-jquery="button.o_wrating_js_publisher_comment_edit" t-operation="attributes">
+            <attribute name="t-if">rating.publisher_id == partner_id</attribute>
+        </t>
+    </t>
+
+</templates>


### PR DESCRIPTION
Steps to reproduce:
1. Login with admin, then post a comment on one of the courses.
2. Log out with admin.
3. Login with a demo, go to that particular comment and try to edit or delete the comments.

The user can 'edit' or 'delete' the comment posted on the reviews of the course by admin.

Technical Reason:
There is a condition that always returns 'true', which shows the 'edit' and 'delete' menus. This condition is 'is_publisher', which is set by checking if request.env.user.has_group('website.group_website_publisher').

After this Commit:
the users would not be allowed to 'edit' or 'delete' the comments made by other users, Only the Manager group has that accessibility or if the comment is there which is made by the logged-in user.

Task-3834294