### PR TITLE
[FIX] point_of_sale: check the type of order id when closing register

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -338,7 +338,10 @@ export class PosStore extends Reactive {
         const ids = new Set();
         for (const order of orders) {
             if (order && (await this._onBeforeDeleteOrder(order))) {
-                if (Object.keys(order.last_order_preparation_change).length > 0) {
+                if (
+                    typeof order.id === "number" &&
+                    Object.keys(order.last_order_preparation_change).length > 0
+                ) {
                     await this.sendOrderInPreparation(order, true);
                 }
 


### PR DESCRIPTION
Steps to reproduce:
---
- Install the ``pos_restaurant`` module
- Open Register of Restaurant > Select any table
- Add two tables from the (+) sign
- Complete the order in the first table and In the second table just order the food(Don't make payment)
- Now Close the register and cancel the orders

Traceback:
---
``Expected singleton: pos.order('p', 'o', 's', '.', 'o', 'r', 'd', 'e', 'r', '_', '3')``

Previous Behaviour:
---
When we closed the register and canceled an order, it included orders with a status of 'Ongoing.' These ongoing orders have an ``order ID like "pos.order_3"`` which is causing an error.

After Commit:
---
We will now only pass the order whose id will be in number when closing the register. Due to this, we will only have the order whose id is in number.

sentry-5703437687

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
