### PR TITLE
[FIX] point_of_sale: fix order deletion without sync

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -929,6 +929,11 @@ export class PosStore extends Reactive {
             }
         }
 
+        if (typeof order.id === "string" && order.finalized) {
+            this.addPendingOrder([order.id]);
+            return;
+        }
+
         return this.data.localDeleteCascade(order, removeFromServer);
     }
 


### PR DESCRIPTION
Before this commit it was possible to delete a paid order that wasn't yet synced to the backend. This commit adds a check to prevent this behavior.

taskId: 4250522
