### PR TITLE
[FIX] core: content tab discovery in headful mode

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -916,11 +916,12 @@ class ChromeBrowser:
             os._exit(0)
 
     def stop(self):
-        if self.chrome_pid is not None:
+        if self.ws is not None:
             self._logger.info("Closing chrome headless with pid %s", self.chrome_pid)
             self._websocket_send('Browser.close')
             self._logger.info("Closing websocket connection")
             self.ws.close()
+        if self.chrome_pid is not None:
             self._logger.info("Terminating chrome headless with pid %s", self.chrome_pid)
             os.kill(self.chrome_pid, signal.SIGTERM)
         if self.user_data_dir and os.path.isdir(self.user_data_dir) and self.user_data_dir != '/':
@@ -1038,12 +1039,24 @@ class ChromeBrowser:
     def _find_websocket(self):
         version = self._json_command('version')
         self._logger.info('Browser version: %s', version['Browser'])
-        infos = self._json_command('', get_key=0)  # Infos about the first tab
-        self.ws_url = infos['webSocketDebuggerUrl']
-        self.dev_tools_frontend_url = infos.get('devtoolsFrontendUrl')
+
+        start = time.time()
+        while (time.time() - start) < 5.0:
+            self.ws_url, self.dev_tools_frontend_url = next((
+                (target['webSocketDebuggerUrl'], target['devtoolsFrontendUrl'])
+                for target in self._json_command('')
+                if target['type'] == 'page'
+                if target['url'] == 'about:blank'
+            ), None)
+            if self.ws_url:
+                break
+            time.sleep(0.1)
+        else:
+            self.stop()
+            raise unittest.SkipTest("Error during Chrome connection: never found 'page' target")
         self._logger.info('Chrome headless temporary user profile dir: %s', self.user_data_dir)
 
-    def _json_command(self, command, timeout=3, get_key=None):
+    def _json_command(self, command, timeout=3):
         """Queries browser state using JSON
 
         Available commands:
@@ -1079,11 +1092,7 @@ class ChromeBrowser:
             try:
                 r = requests.get(url, timeout=3)
                 if r.ok:
-                    res = r.json()
-                    if get_key is None:
-                        return res
-                    else:
-                        return res[get_key]
+                    return r.json()
             except requests.ConnectionError as e:
                 failure_info = str(e)
                 message = 'Connection Error while trying to connect to Chrome debugger'
@@ -1091,8 +1100,7 @@ class ChromeBrowser:
                 failure_info = str(e)
                 message = 'Connection Timeout while trying to connect to Chrome debugger'
                 break
-            except (KeyError, IndexError):
-                message = 'Key "%s" not found in json result "%s" after connecting to Chrome debugger' % (get_key, res)
+
             time.sleep(delay)
             timeout -= delay
             delay = delay * 1.5


### PR DESCRIPTION
This commit is a backport of commit odoo/odoo@2b30be424f8c485e57b2ce456288589ffc1a96b6

For reference:

    It's not clear when and how this happened but apparently "headful"
    chrome has a built-in background_page for hangouts which appears
    before the `about:blank` page in the list of targets, and possibly
    appears before the `about:blank` page has opened at all.

    odoo/odoo#111422 was tested with chromium which apparently doesn't
    have this feature either (or does it?), which probably contributes to
    having no idea when it appears.

    This feature also doesn't respond to `--disable-extensions`, despite
    its url marking it as one:

        chrome-extension://nkeimhogjdpnpccoofpliimaahmaaome/background.html

    The result was that the tour runner would hook onto the hangouts
    target and try to load pages, which it would reject with
    `net::ERR_ABORTED`, hence the tours just getting stuck.

    Fix by improving the heuristic to find a content page: look for a
    target of type `page`, and with the url `about:blank`, rather than
    just take whichever tab target is listed first. Requires modifying
    `stop` as it can now be called after we've started the browser, but
    before we've created the websocket connection.

    Also move `--no-first-run` from the headless to the default switches
    to avoid Chrome's migration & default browser popup, apparently it
    doesn't cause Chromium grief anymore (???). If this turns out to be a
    concern, add a condition on the `executable` or something.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
