### PR TITLE
[FIX] pos_loyalty: exclude loyalty cards from archived programs

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/components/partner_list_screen/partner_list_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/partner_list_screen/partner_list_screen.js
@@ -14,6 +14,7 @@ patch(PartnerList.prototype, {
         const res = await super.searchPartner();
         const coupons = await this.pos.fetchCoupons([
             ["partner_id", "in", res.map((partner) => partner.id)],
+            ["program_id.active", "=", true],
         ]);
         this.pos.computePartnerCouponIds(coupons);
         return res;


### PR DESCRIPTION
Before this commit, loading a partner could inadvertently fetch a loyalty card associated with an archived loyalty program, preventing order validation. This commit ensures loyalty cards from archived programs are not loaded, thus preventing validation issues.

opw-4246931

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
