### PR TITLE
[FIX] web: can't update apps from odoo apps store

### DIFF
--- a/addons/web/static/src/legacy/js/apps.js
+++ b/addons/web/static/src/legacy/js/apps.js
@@ -91,7 +91,13 @@ var Apps = AbstractAction.extend({
                 });
             },
             'Model': function(m) {
-                return self._rpc({model: m.model, method: m.args[0], args: m.args[1]})
+                let kwargs = {};
+                if (typeof(m.args[1][1]) === 'object' && !Array.isArray(m.args[1][1]) && m.args[1][1] !== null){
+                    // when method is search_read the second args cound be an array
+                    // but when method is button_immediate_upgrade the second args is {}
+                    kwargs = m.args[1][1];
+                }
+                return self._rpc({model: m.model, method: m.args[0], args: [m.args[1][0]], kwargs: kwargs})
                     .then(function(r) {
                         var w = self.$ifr[0].contentWindow;
                         w.postMessage({id: m.id, result: r}, client.origin);


### PR DESCRIPTION
* STEP TO REPRODUCE: we have 2 addons, one is odoo and other is OCA/web for example. A module has lower version so user decide to go to Apps -> hit button 'Updates' -> Odoo Apps Store return to user which app need to update with a 'update' button -> User hit button 'update' -> Error
* Reason: see method 'loempia.embed.local_module_exec' in Odoo Apps Store, it try to pass into args empty context {} so when calling button_immediate_upgrade, it will say we pass too much arguments when we only need one is the id of local module which already has

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
