### PR TITLE
[IMP] web: improve many2many_binary widget

### DIFF
--- a/addons/web/static/src/views/fields/many2many_binary/many2many_binary_field.js
+++ b/addons/web/static/src/views/fields/many2many_binary/many2many_binary_field.js
@@ -45,6 +45,10 @@ export class Many2ManyBinaryField extends Component {
         return file.name.replace(/^.*\./, "");
     }
 
+    isImage(file) {
+        return file.mimetype.startsWith("image/");
+    }
+
     async onFileUploaded(files) {
         for (const file of files) {
             if (file.error) {

--- a/addons/web/static/src/views/fields/many2many_binary/many2many_binary_field.scss
+++ b/addons/web/static/src/views/fields/many2many_binary/many2many_binary_field.scss
@@ -22,7 +22,7 @@ $o-attachment-margin: 5px;
         }
     }
 
-    .o_image {
+    .o_preview_image {
         width: $o-attachment-image-size;
         height: $o-attachment-image-size;
         image-orientation: from-image; // Only supported in Firefox

--- a/addons/web/static/src/views/fields/many2many_binary/many2many_binary_field.xml
+++ b/addons/web/static/src/views/fields/many2many_binary/many2many_binary_field.xml
@@ -33,7 +33,9 @@
             <t t-set="url" t-value="getUrl(file.id)"/>
             <div class="o_image_box float-start" t-att-data-tooltip="'Download ' + file.name">
                 <a t-att-href="url" aria-label="Download" download="">
-                    <span class="o_image o_hover" t-att-data-mimetype="file.mimetype" t-att-data-ext="ext" role="img"/>
+                    <img t-if="isImage(file)" class="o_preview_image o_hover object-fit-cover rounded align-baseline"
+                        t-attf-src="/web/image/{{ file.id }}" onerror="this.src = '/web/static/img/mimetypes/image.svg'"/>
+                    <span t-else="" class="o_image o_preview_image o_hover" t-att-data-mimetype="file.mimetype" t-att-data-ext="ext" role="img"/>
                 </a>
             </div>
 


### PR DESCRIPTION
Easing the attachments management by showing the attachment preview
instead of the mimetype icon when the attachment is an image.

Task-4243326

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
