### PR TITLE
[FIX] base: avoid duplicate emails when extracting rfc2822 addresses

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -428,13 +428,10 @@ class MailMail(models.Model):
         for partner in self.recipient_ids:
             # check partner email content
             emails_normalized = tools.email_normalize_all(partner.email)
-            if emails_normalized:
-                email_to = [
-                    tools.formataddr((partner.name or "", email or "False"))
-                    for email in emails_normalized
-                ]
-            else:
-                email_to = [tools.formataddr((partner.name or "", partner.email or "False"))]
+            email_to = [
+                tools.formataddr_sanitized_name((partner.name or "", email or "False"))
+                for email in emails_normalized or [partner.email]
+            ]
             email_list.append({
                 'email_cc': [],
                 'email_to': email_to,

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -505,9 +505,12 @@ class MailMail(models.Model):
         # First group the <mail.mail> per mail_server_id, per alias_domain (if no server) and per email_from
         group_per_email_from = defaultdict(list)
         for values in mail_values:
+            # protect against ill-formatted email_from when formataddr was used on an already formatted email
+            emails_from = tools.email_split_and_format(values['email_from'])
+            email_from = emails_from[0] if emails_from else values['email_from']
             mail_server_id = values['mail_server_id'][0] if values['mail_server_id'] else False
             alias_domain_id = values['record_alias_domain_id'][0] if values['record_alias_domain_id'] else False
-            key = (mail_server_id, alias_domain_id, values['email_from'])
+            key = (mail_server_id, alias_domain_id, email_from)
             group_per_email_from[key].append(values['id'])
 
         # Then find the mail server for each email_from and group the <mail.mail>

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -22,7 +22,7 @@ from odoo.addons.mail.models.mail_message import Message
 from odoo.addons.mail.models.mail_notification import MailNotification
 from odoo.addons.mail.models.res_users import Users
 from odoo.tests import common, new_test_user
-from odoo.tools import email_normalize, formataddr, mute_logger, pycompat
+from odoo.tools import email_normalize, formataddr, mute_logger, prepare_name_for_email, pycompat
 from odoo.tools.translate import code_translations
 
 mail_new_test_user = partial(new_test_user, context={'mail_create_nolog': True,
@@ -675,7 +675,10 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
             email_to_list = []
             for email_to in recipients:
                 if isinstance(email_to, self.env['res.partner'].__class__):
-                    email_to_list.append(formataddr((email_to.name, email_normalize(email_to.email, strict=False) or email_to.email)))
+                    email_to_list.append(formataddr((
+                        prepare_name_for_email(email_to.name),
+                        email_normalize(email_to.email, strict=False) or email_to.email))
+                    )
                 else:
                     email_to_list.append(email_to)
         expected['email_to'] = email_to_list

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -1978,8 +1978,10 @@ class TestComposerResultsComment(TestMailComposer, CronMixinCase):
                      self.mock_mail_app():
                     composer._action_send_mail()
 
+                # found new partner, whose name = email
                 new_partner = self.env['res.partner'].search([('email_normalized', '=', 'test.to.1@test.example.com')])
                 self.assertEqual(len(new_partner), 1)
+                self.assertEqual(new_partner.name, 'test.to.1@test.example.com')
                 # check output, company-specific values mainly for this test
                 for record, exp_company, exp_alias_domain in zip(
                     test_records, expected_companies, expected_alias_domains
@@ -2009,11 +2011,10 @@ class TestComposerResultsComment(TestMailComposer, CronMixinCase):
                                 'subject': f'TemplateSubject {record.name}',
                             },
                         )
-                        # to check behavior of extract_rfc2822_addresses
-                        if recipient == new_partner:
-                            smtp_to_list = ['test.to.1@test.example.com', 'test.to.1@test.example.com']
-                        else:
-                            smtp_to_list = [recipient.email_normalized]
+                        # thanks to extract_rfc2822_addresses_unique only a single email
+                        # is sent to 'test.to.1' even if its formatted email contains
+                        # 2 emails (see odoo/odoo#183334)
+                        smtp_to_list = [recipient.email_normalized]
                         if exp_alias_domain == self.mail_alias_domain:
                             self.assertSMTPEmailsSent(
                                 smtp_from=f'{self.default_from}@{self.alias_domain}',
@@ -2196,23 +2197,12 @@ class TestComposerResultsComment(TestMailComposer, CronMixinCase):
             elif recipient == new_partners[1]:
                 self.assertEqual(recipient, partner_multi_tofind)
                 smtp_to_list = ['find.me.multi.1@test.example.com', 'find.me.multi.2@test.example.com']
-            # FIXME: name being an email, extract_rfc2822 finds 2 emails
             elif recipient == new_partners[3]:
-                smtp_to_list = ['find.me.multi.2@test.example.com', 'find.me.multi.2@test.example.com']
+                smtp_to_list = ['find.me.multi.2@test.example.com']
             # bike@home: name is recognized as email
             elif recipient == new_partners[2]:
                 self.assertEqual(recipient, partner_at_tofind)
                 smtp_to_list = ['NotBike@Home', 'find.me.at@test.example.com']
-            # name being an email = 2 sent emails due to extract_rfc2822
-            elif recipient.name in [
-                'test.to.1@example.com',
-                'test.to.2@example.com',
-                'test.cc.1@example.com',
-                'test.cc.2@example.com',
-                'test.cc.2.2@example.com',
-                'test.cc.3@example.com',
-            ]:
-                smtp_to_list = [recipient.name, recipient.email_normalized]
             else:
                 smtp_to_list = [recipient.email_normalized]
             self.assertSMTPEmailsSent(
@@ -2891,8 +2881,10 @@ class TestComposerResultsMass(TestMailComposer):
                      self.mock_mail_app():
                     composer._action_send_mail()
 
+                # found new partner, whose name = email
                 new_partner = self.env['res.partner'].search([('email_normalized', '=', 'test.to.1@test.example.com')])
                 self.assertEqual(len(new_partner), 1)
+                self.assertEqual(new_partner.name, 'test.to.1@test.example.com')
                 # check output, company-specific values mainly for this test
                 for record, exp_company, exp_alias_domain in zip(
                     test_records, expected_companies, expected_alias_domains
@@ -2924,11 +2916,10 @@ class TestComposerResultsMass(TestMailComposer):
                         },
                     )
                     for recipient in recipients:
-                        # to check behavior of extract_rfc2822_addresses
-                        if recipient == new_partner:
-                            smtp_to_list = ['test.to.1@test.example.com', 'test.to.1@test.example.com']
-                        else:
-                            smtp_to_list = [recipient.email_normalized]
+                        # thanks to extract_rfc2822_addresses_unique only a single email
+                        # is sent to 'test.to.1' even if its formatted email contains
+                        # 2 emails (see odoo/odoo#183334)
+                        smtp_to_list = [recipient.email_normalized]
                         if exp_alias_domain == self.mail_alias_domain:
                             self.assertSMTPEmailsSent(
                                 smtp_from=f'{self.default_from}@{self.alias_domain}',
@@ -3242,23 +3233,12 @@ class TestComposerResultsMass(TestMailComposer):
                 elif recipient == new_partners[1]:
                     self.assertEqual(recipient, partner_multi_tofind)
                     smtp_to_list = ['find.me.multi.1@test.example.com', 'find.me.multi.2@test.example.com']
-                # name being an email = 2 sent emails due to extract_rfc2822
                 elif recipient == new_partners[3]:
-                    smtp_to_list = ['find.me.multi.2@test.example.com', 'find.me.multi.2@test.example.com']
+                    smtp_to_list = ['find.me.multi.2@test.example.com']
                 # bike@home: name is recognized as email
                 elif recipient == new_partners[2]:
                     self.assertEqual(recipient, partner_at_tofind)
                     smtp_to_list = ['NotBike@Home', 'find.me.at@test.example.com']
-                # name being an email = 2 sent emails due to extract_rfc2822
-                elif recipient.name in [
-                    'test.to.1@example.com',
-                    'test.to.2@example.com',
-                    'test.cc.1@example.com',
-                    'test.cc.2@example.com',
-                    'test.cc.2.2@example.com',
-                    'test.cc.3@example.com',
-                ]:
-                    smtp_to_list = [recipient.name, recipient.email_normalized]
                 else:
                     smtp_to_list = [recipient.email_normalized]
                 self.assertSMTPEmailsSent(

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -2219,10 +2219,10 @@ class TestComposerResultsComment(TestMailComposer, CronMixinCase):
                 smtp_from=f'{self.alias_bounce}@{self.alias_domain}',
                 smtp_to_list=smtp_to_list,
                 mail_server=self.mail_server_domain,
-                # FIXME: email_from of smtp still multi-email with a weird format
+                # msg_from takes only first found normalized email to make a valid email_from
                 message_from=formataddr(
                     (self.user_employee.name,
-                    'email.from.1@test.mycompany.com>,email.from.2@test.mycompany.com',
+                    'email.from.1@test.mycompany.com',
                 )),
                 # similar envelope, assertSMTPEmailsSent cannot distinguish
                 # records (would have to dive into content, too complicated)
@@ -3265,10 +3265,10 @@ class TestComposerResultsMass(TestMailComposer):
                     smtp_from=f'{self.alias_bounce}@{self.alias_domain}',
                     smtp_to_list=smtp_to_list,
                     mail_server=self.mail_server_domain,
-                    # FIXME: email_from of smtp still multi-email with a weird format
+                    # msg_from takes only first found normalized email to make a valid email_from
                     message_from=formataddr(
                         (self.user_employee.name,
-                        'email.from.1@test.mycompany.com>,email.from.2@test.mycompany.com',
+                        'email.from.1@test.mycompany.com',
                     )),
                     # similar envelope, assertSMTPEmailsSent cannot distinguish
                     # records (would have to dive into content, too complicated)

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -2111,15 +2111,15 @@ class TestComposerResultsComment(TestMailComposer, CronMixinCase):
         )
         self.assertEqual(
             sorted(new_partners.mapped('email_formatted')),
-            sorted(['"NotBike@Home" <find.me.at@test.example.com>',
+            sorted(['"NotBike @ Home" <find.me.at@test.example.com>',
                     '"FindMe Format" <find.me.format@test.example.com>',
                     '"FindMe Multi" <find.me.multi.1@test.example.com,find.me.multi.2@test.example.com>',
-                    '"find.me.multi.2@test.example.com" <find.me.multi.2@test.example.com>',
-                    '"test.cc.1@example.com" <test.cc.1@example.com>',
-                    '"test.cc.2@example.com" <test.cc.2@example.com>',
-                    '"test.cc.2.2@example.com" <test.cc.2.2@example.com>',
-                    '"test.to.1@example.com" <test.to.1@example.com>',
-                    '"test.to.2@example.com" <test.to.2@example.com>']),
+                    '"find.me.multi.2 @ test.example.com" <find.me.multi.2@test.example.com>',
+                    '"test.cc.1 @ example.com" <test.cc.1@example.com>',
+                    '"test.cc.2 @ example.com" <test.cc.2@example.com>',
+                    '"test.cc.2.2 @ example.com" <test.cc.2.2@example.com>',
+                    '"test.to.1 @ example.com" <test.to.1@example.com>',
+                    '"test.to.2 @ example.com" <test.to.2@example.com>']),
         )
         self.assertEqual(
             sorted(new_partners.mapped('name')),
@@ -2199,10 +2199,10 @@ class TestComposerResultsComment(TestMailComposer, CronMixinCase):
                 smtp_to_list = ['find.me.multi.1@test.example.com', 'find.me.multi.2@test.example.com']
             elif recipient == new_partners[3]:
                 smtp_to_list = ['find.me.multi.2@test.example.com']
-            # bike@home: name is recognized as email
+            # bike@home: name is not recognized as email anymore
             elif recipient == new_partners[2]:
                 self.assertEqual(recipient, partner_at_tofind)
-                smtp_to_list = ['NotBike@Home', 'find.me.at@test.example.com']
+                smtp_to_list = ['find.me.at@test.example.com']
             else:
                 smtp_to_list = [recipient.email_normalized]
             self.assertSMTPEmailsSent(
@@ -3151,15 +3151,15 @@ class TestComposerResultsMass(TestMailComposer):
         )
         self.assertEqual(
             sorted(new_partners.mapped('email_formatted')),
-            sorted(['"NotBike@Home" <find.me.at@test.example.com>',
+            sorted(['"NotBike @ Home" <find.me.at@test.example.com>',
                     '"FindMe Format" <find.me.format@test.example.com>',
                     '"FindMe Multi" <find.me.multi.1@test.example.com,find.me.multi.2@test.example.com>',
-                    '"find.me.multi.2@test.example.com" <find.me.multi.2@test.example.com>',
-                    '"test.cc.1@example.com" <test.cc.1@example.com>',
-                    '"test.cc.2@example.com" <test.cc.2@example.com>',
-                    '"test.cc.2.2@example.com" <test.cc.2.2@example.com>',
-                    '"test.to.1@example.com" <test.to.1@example.com>',
-                    '"test.to.2@example.com" <test.to.2@example.com>']),
+                    '"find.me.multi.2 @ test.example.com" <find.me.multi.2@test.example.com>',
+                    '"test.cc.1 @ example.com" <test.cc.1@example.com>',
+                    '"test.cc.2 @ example.com" <test.cc.2@example.com>',
+                    '"test.cc.2.2 @ example.com" <test.cc.2.2@example.com>',
+                    '"test.to.1 @ example.com" <test.to.1@example.com>',
+                    '"test.to.2 @ example.com" <test.to.2@example.com>']),
         )
         self.assertEqual(
             sorted(new_partners.mapped('name')),
@@ -3235,10 +3235,10 @@ class TestComposerResultsMass(TestMailComposer):
                     smtp_to_list = ['find.me.multi.1@test.example.com', 'find.me.multi.2@test.example.com']
                 elif recipient == new_partners[3]:
                     smtp_to_list = ['find.me.multi.2@test.example.com']
-                # bike@home: name is recognized as email
+                # bike@home: name is not recognized as email anymore
                 elif recipient == new_partners[2]:
                     self.assertEqual(recipient, partner_at_tofind)
-                    smtp_to_list = ['NotBike@Home', 'find.me.at@test.example.com']
+                    smtp_to_list = ['find.me.at@test.example.com']
                 else:
                     smtp_to_list = [recipient.email_normalized]
                 self.assertSMTPEmailsSent(

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -540,15 +540,13 @@ class Partner(models.Model):
             if emails_normalized:
                 # note: multi-email input leads to invalid email like "Name" <email1, email2>
                 # but this is current behavior in Odoo 14+ and some servers allow it
-                partner.email_formatted = tools.formataddr((
-                    partner.name or u"False",
-                    ','.join(emails_normalized)
-                ))
+                partner.email_formatted = tools.formataddr_sanitized_name(
+                    (partner.name or u"False", ','.join(emails_normalized))
+                )
             elif partner.email:
-                partner.email_formatted = tools.formataddr((
-                    partner.name or u"False",
-                    partner.email
-                ))
+                partner.email_formatted = tools.formataddr_sanitized_name(
+                    (partner.name or u"False", partner.email)
+                )
 
     @api.depends('is_company')
     def _compute_company_type(self):

--- a/odoo/addons/base/tests/common.py
+++ b/odoo/addons/base/tests/common.py
@@ -325,6 +325,7 @@ class MockSmtplibCase:
                     'smtp_from': smtp_from,
                     'smtp_to_list': smtp_to_list,
                     'message': message.as_string(),
+                    'msg_from': message['From'],
                     'from_filter': self.from_filter,
                 })
 
@@ -333,6 +334,7 @@ class MockSmtplibCase:
                     'smtp_from': smtp_from,
                     'smtp_to_list': smtp_to_list,
                     'message': message_str,
+                    'msg_from': None,  # to fix if necessary
                     'from_filter': self.from_filter,
                 })
 

--- a/odoo/addons/base/tests/test_mail.py
+++ b/odoo/addons/base/tests/test_mail.py
@@ -5,7 +5,7 @@ from markupsafe import Markup
 
 import re
 
-from odoo.addons.base.models.ir_mail_server import extract_rfc2822_addresses
+from odoo.addons.base.models.ir_mail_server import extract_rfc2822_addresses, extract_rfc2822_addresses_unique
 from odoo.addons.base.models.ir_qweb_fields import nl2br_enclose
 from odoo.tests import tagged
 from odoo.tests.common import BaseCase
@@ -803,17 +803,42 @@ class TestEmailTools(BaseCase):
             ('admin@example.com', ['admin@example.com']),
             ('"Admin" <admin@example.com>, Demo <malformed email>', ['admin@example.com']),
             ('admin@éxample.com', ['admin@xn--xample-9ua.com']),
-            # formatted input containing email
-            ('"admin@éxample.com" <admin@éxample.com>', ['admin@xn--xample-9ua.com', 'admin@xn--xample-9ua.com']),
-            ('"Robert Le Grand" <robert@notgmail.com>', ['robert@notgmail.com']),
-            ('"robert@notgmail.com" <robert@notgmail.com>', ['robert@notgmail.com', 'robert@notgmail.com']),
+            # "@' in names
+            ('"Bike @ Home" <bike@example.com>', ['bike@example.com']),
+            ('"Bike@Home" <bike@example.com>', ['Bike@Home', 'bike@example.com']),
             # accents
             ('DéBoulonneur@examplé.com', ['DéBoulonneur@xn--exampl-gva.com']),
         ]
-
         for source, expected in cases:
             with self.subTest(source=source):
                 self.assertEqual(extract_rfc2822_addresses(source), expected)
+                self.assertEqual(extract_rfc2822_addresses_unique(source), expected)
+
+        # 15.0+: specific cases for input recognized as holding 2 times same email
+        dupe_cases = [
+            # formatted input containing email
+            (
+                '"admin@éxample.com" <admin@éxample.com>',
+                ['admin@xn--xample-9ua.com', 'admin@xn--xample-9ua.com'],
+                ['admin@xn--xample-9ua.com'],
+            ), (
+                '"Robert Le Grand" <robert@notgmail.com>', ['robert@notgmail.com'], ['robert@notgmail.com'],
+            ), (
+                '"robert@notgmail.com" <robert@notgmail.com>',
+                ['robert@notgmail.com', 'robert@notgmail.com'],
+                ['robert@notgmail.com'],
+            ),
+            # complex case, just in case
+            (
+                '"Not an Email" <robert@notgmail.com>, "robert@notgmail.com" <robert@notgmail.com>',
+                ['robert@notgmail.com', 'robert@notgmail.com', 'robert@notgmail.com'],
+                ['robert@notgmail.com'],
+            ),
+        ]
+        for source, expected, expected_unique in dupe_cases:
+            with self.subTest(source=source):
+                self.assertEqual(extract_rfc2822_addresses(source), expected)
+                self.assertEqual(extract_rfc2822_addresses_unique(source), expected_unique)
 
     def test_single_email_re(self):
         """ Test 'single_email_re', matching text input containing only one email """

--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -128,15 +128,15 @@ class TestPartner(TransactionCaseWithUserDemo):
             ),
             # check with '@' in name
             (
-                'Bike@Home', '"Bike@Home" <vlad.the.impaler@example.com>',
-                ['Bike@Home', 'vlad.the.impaler@example.com']
+                'Bike@Home', '"Bike @ Home" <vlad.the.impaler@example.com>',
+                ['vlad.the.impaler@example.com']
             ), (
-                'Bike @ Home@Home', '"Bike @ Home@Home" <vlad.the.impaler@example.com>',
-                ['Home@Home', 'vlad.the.impaler@example.com']
+                'Bike @ Home@Home', '"Bike @ Home @ Home" <vlad.the.impaler@example.com>',
+                ['vlad.the.impaler@example.com']
             ), (
                 'Balázs <email.in.name@example.com>',
-                '"Balázs <email.in.name@example.com>" <vlad.the.impaler@example.com>',
-                ['email.in.name@example.com', 'vlad.the.impaler@example.com']
+                '"Balázs <email.in.name @ example.com>" <vlad.the.impaler@example.com>',
+                ['vlad.the.impaler@example.com']
             ),
         ]:
             with self.subTest(source=source):

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -706,6 +706,7 @@ def email_escape_char(email_address):
 def decode_message_header(message, header, separator=' '):
     return separator.join(h for h in message.get_all(header, []) if h)
 
+
 def formataddr(pair, charset='utf-8'):
     """Pretty format a 2-tuple of the form (realname, email_address).
 
@@ -748,6 +749,20 @@ def formataddr(pair, charset='utf-8'):
             name = email_addr_escapes_re.sub(r'\\\g<0>', name)
             return f'"{name}" <{local}@{domain}>'
     return f"{local}@{domain}"
+
+
+def formataddr_sanitized_name(pair, charset='utf-8'):
+    """Same as formataddr but sanitizing the name to not contain something
+    that looks like an email.
+
+    >>> formataddr(('John Doe', 'johndoe@example.com'))
+    '"John Doe" <johndoe@example.com>'
+
+    >>> formataddr(('', 'johndoe@example.com'))
+    'johndoe@example.com'
+    """
+    name, address = pair
+    return formataddr((prepare_name_for_email(name), address), charset=charset)
 
 
 def encapsulate_email(old_email, new_email):
@@ -803,3 +818,12 @@ def parse_contact_from_email(text):
         name, email_normalized = text, ''
 
     return name, email_normalized
+
+
+def prepare_name_for_email(text):
+    if text:
+        return re.sub(
+            '([^ ]+@[^ ]+)',
+            lambda p: p.group(0).replace('@', ' @ '),
+            text)
+    return ""


### PR DESCRIPTION
Followup of odoo/odoo@795091c69d2bc40e3bd2b5ae29451ea3af07d908

Followup of odoo/odoo#74474 which improved support of multiemails and formatted emails in various email input. This notably lead to better formatted email computation on partner model that can generate emails like '"email@example.com" <email@example.com>' when email is used both as name and email. When sending emails to this partner only a single email should be sent and counted.

Task-
