### PR TITLE
[IMP] website_project: make task received webpage similar to ticket webpage

### DIFF
--- a/addons/website_project/views/project_portal_project_task_template.xml
+++ b/addons/website_project/views/project_portal_project_task_template.xml
@@ -4,31 +4,23 @@
         <t t-call="website.layout">
             <div class="oe_structure oe_empty h-100">
                 <div class="container d-flex flex-column justify-content-center h-100">
-                    <div class="row justify-content-center mb16">
+                    <div class="d-flex flex-column align-items-center mb16 p-4 text-center">
                         <t t-if="request.session.get('form_builder_model_model', '') == 'project.task'">
                             <t t-set="task" t-value="request.website._website_form_last_record()"/>
                         </t>
-                        <h1 class="text-center">
-                            <i class="fa fa-check-circle fa-1x text-success me-2" role="img" aria-label="Success" title="Success"/>
-                                <t t-if="task">
-                                    <span>
-                                    Your Task Number is
-                                        <a t-if="request.session.uid and task.sudo().project_id.id and task.project_privacy_visibility != 'followers'"
-                                            t-attf-href="/my/task/#{task.id}">
-                                            #<span t-field="task.id"/>
-                                        </a>
-                                        <t t-else="">#<span t-field="task.id"/></t>.
-                                    </span>
-                                </t>
-                        </h1>
-                        <h2 class="text-center">Thank you for contacting us, our team will get right on it!</h2>
-                        <div class="text-center">
-                            <a class="btn btn-primary" t-attf-href="/my/task/#{task.id}"
-                                t-if="task and task.id and request.session.uid and task.project_id.id and task.project_privacy_visibility != 'followers'">
-                                View Task
+                        <i class="fa fa-paper-plane fa-2x mb-3 rounded-circle text-bg-success" role="presentation"/>
+                        <h1 class="fw-bolder">Thank you!</h1>
+                        <t t-if="task">
+                            <p class="lead mb-0">Your task has been sent.</p>
+                            <p class="lead">Our team will get right on it.</p>
+                            <a t-if="request.session.uid and task.sudo().project_id.id and task.project_privacy_visibility != 'followers'" class="my-3 border rounded px-4 py-3 bg-100 fs-5 fw-bold shadow-sm text-decoration-none" t-attf-href="/my/task/#{task.id}" t-att-title="'Ticket #' + str(task.id)">
+                                Task #<span t-field="task.id"/>
                             </a>
-                            <a class="btn btn-primary" href='/'>Go to the Homepage</a>
-                        </div>
+                            <span t-else="" class="my-3 border rounded px-4 py-3 fs-5 fw-bold shadow-sm">
+                                Task #<span t-field="task.id"/>
+                            </span>
+                        </t>
+                        <a href="/">Go to Homepage</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
[IMP] website_project: make task received webpage similar to ticket webpage

Before this commit:
'task received webpage' was missed in task 3790303.
only 'ticket received webpage' was improved

In this commit:
'task received webpage' was adapted accordingly.

task-4216270