### PR TITLE
[FIX] stock_delivery: check active carrier_id

### DIFF
--- a/addons/stock_delivery/models/stock_picking.py
+++ b/addons/stock_delivery/models/stock_picking.py
@@ -31,7 +31,7 @@ class StockPicking(models.Model):
     @api.depends('carrier_id', 'carrier_tracking_ref')
     def _compute_carrier_tracking_url(self):
         for picking in self:
-            picking.carrier_tracking_url = picking.carrier_id.get_tracking_link(picking) if picking.carrier_id and picking.carrier_tracking_ref else False
+            picking.carrier_tracking_url = picking.carrier_id.get_tracking_link(picking) if picking.carrier_id and picking.carrier_id.active and picking.carrier_tracking_ref else False
 
     @api.depends('carrier_id', 'move_ids_without_package')
     def _compute_return_picking(self):


### PR DESCRIPTION
We should only try to fetch tracking_url for the delivery carriers which are active. We get errors when running database in test as this leads database trying to fetch url from external and neutralize of database not working as expected.


Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
