### PR TITLE
[FIX] mrp,product,web: fix badge default background color

### DIFF
--- a/addons/mrp/static/src/components/mo_overview_line/mo_overview_colors.js
+++ b/addons/mrp/static/src/components/mo_overview_line/mo_overview_colors.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 const PRODUCTION_DECORATORS = {
-    draft: "muted",
+    draft: "secondary",
     confirmed: "info",
     progress: "warning",
     done: "success",
@@ -15,11 +15,11 @@ const PURCHASE_DECORATORS = {
     ['to approve']: "info",
     purchase: "info",
     done: "info",
-    cancel: "muted",
+    cancel: "secondary",
 };
 
 const PICKING_DECORATORS = {
-    draft: "muted",
+    draft: "secondary",
     waiting: "warning",
     confirmed: "warning",
     assigned: "info",
@@ -33,7 +33,7 @@ const OPERATION_DECORATORS = {
     ready: "info",
     progress: "warning",
     done: "success",
-    cancel: "muted",
+    cancel: "secondary",
 };
 
 const PRODUCT_DECORATORS = {

--- a/addons/product/static/src/js/pricelist_report/product_pricelist_report.xml
+++ b/addons/product/static/src/js/pricelist_report/product_pricelist_report.xml
@@ -59,7 +59,7 @@
                             <div class="d-flex align-items-center w-50">
                                 <span class="o_badges_list d-flex">
                                     <t t-foreach="quantities" t-as="qty" t-key="qty">
-                                        <span class="o_field_badge o_remove_qty badge rounded-pill me-2 py-1 border " t-att-value="qty">
+                                        <span class="text-bg-300 o_remove_qty badge rounded-pill me-2 py-1 border " t-att-value="qty">
                                             <t class="me-2" t-esc="qty"/>
                                             <i class="oi oi-close ms-1 opacity-50 opacity-100-hover text-900 cursor-pointer"
                                             title="Remove quantity"

--- a/addons/web/static/src/views/fields/badge/badge_field.js
+++ b/addons/web/static/src/views/fields/badge/badge_field.js
@@ -27,10 +27,14 @@ export class BadgeField extends Component {
         const evalContext = this.props.record.evalContextWithVirtualIds;
         for (const decorationName in this.props.decorations) {
             if (evaluateBooleanExpr(this.props.decorations[decorationName], evalContext)) {
+                // fallback case for text-bg-muted
+                if (decorationName === "muted") {
+                    return "text-bg-300";
+                }
                 return `text-bg-${decorationName}`;
             }
         }
-        return "";
+        return "text-bg-300";
     }
 }
 

--- a/addons/web/static/src/webclient/webclient.scss
+++ b/addons/web/static/src/webclient/webclient.scss
@@ -59,7 +59,6 @@ kbd {
   border: 0;
   font-size: 0.85em;
   user-select: none;
-  background-color: $o-gray-300;
   font-weight: 500;
   @include o-text-overflow;
   transition: none; // remove transition to prevent badges from flickering at reload


### PR DESCRIPTION
Before this commit:
- Previously, the badge displayed a default background color of grey.

After this commit:
- The badge should not display a default background color.
- The `text-bg-muted` class, which is not supported in Bootstrap 5, has been 
  replaced with `text-bg-secondary`.

task-4247109

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
