### PR TITLE
[FIX] crm: prevent crash with many2many tasks

### DIFF
--- a/addons/crm/static/src/views/crm_form/crm_form.js
+++ b/addons/crm/static/src/views/crm_form/crm_form.js
@@ -6,7 +6,7 @@ import { formView } from "@web/views/form/form_view";
 
 class CrmFormRecord extends formView.Model.Record {
      /**
-     * Main method used when saving the record hitting the "Save" button.
+     * override of record _save mechanism intended to affect the main form record
      * We check if the stage_id field was altered and if we need to display a rainbowman
      * message.
      *
@@ -23,6 +23,9 @@ class CrmFormRecord extends formView.Model.Record {
      * @override
      */
     async _save() {
+        if (this.resModel !== "crm.lead") {
+            return super._save(...arguments);
+        }
         let changeStage = false;
         const needsSynchronizationEmail =
             this._changes.partner_email_update === undefined


### PR DESCRIPTION
Steps to reproduce
==================

- Go to CRM
- Open a lead
- Open studio
- Add a new notebook page
- Add a many2many field
- Select the task model
- Save and exit studio
- Switch to the new notebook page
- Add a new task

=> Record does not exist or has been deleted.

Cause of the issue
==================

The CrmFormRecord is also used for the Many2Many popup. project.task also has a stage_id field, checkRainbowmanMessage is then called, but with the id of the task

https://github.com/odoo/odoo/blob/54d6a19444bfa4f01d03117e4542a5244f274429/addons/crm/static/src/views/crm_form/crm_form.js#L44-L51

Solution
========

It makes no sense to do this if we are not acting on a crm.lead record => We check the resModel before proceeding

opw-4101752