### PR TITLE
[FIX] point_of_sale: enable import of orders with missing relations

### DIFF
--- a/addons/point_of_sale/static/src/app/debug/debug_widget.js
+++ b/addons/point_of_sale/static/src/app/debug/debug_widget.js
@@ -162,6 +162,10 @@ export class DebugWidget extends Component {
                         continue;
                     }
 
+                    if (!order[rel.name] && (rel.local || rel.related || rel.compute)) {
+                        order[rel.name] = [];
+                    }
+
                     const existingRecords = model.getAllBy("id");
                     const records = order[rel.name]
                         .filter((rel) => !existingRecords[rel[2]])


### PR DESCRIPTION
Before this commit, importing an exported order through the PoS UI failed due to missing relations in the imported order data.

opw-4237952

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
