### PR TITLE
[FIX] hr_expense: Singleton error when updating expenses in bulk

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1160,7 +1160,7 @@ class HrExpenseSheet(models.Model):
     def write(self, vals):
         if 'state' in vals:
             # Avoid user with write access on expense sheet in draft state to bypass the validation process
-            if not self.user_has_groups('hr_expense.group_hr_expense_manager') and self.state == 'draft' and vals['state'] != 'submit':
+            if vals['state'] != 'submit' and not self.user_has_groups('hr_expense.group_hr_expense_manager') and any(e.state == 'draft' for e in self):
                 raise UserError(_("You don't have the rights to bypass the validation process of this expense report."))
             elif vals['state'] == 'approve':
                 self._check_can_approve()


### PR DESCRIPTION
Before this commit, writing a bulk of expenses by a user who does not belong to the "hr_expense.group_hr_expense_manager" access group led to a Singleton traceback.

**Steps to reproduce the error:**
1. Create two expense reports for the same employee,
2. Approve and create journal entries for these expense reports. Go to Accounting > Vendors > Bills and search for both, 
3. journal entries created in step 2,
4. Select both of them in the list view and click on "Register Payment",
5. In the payment registration popup, check the "Group Payments" checkbox and click "Create Payment".

**Fix:**
We now loop over self to check the state of each expense before writing.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
