### PR TITLE
[FIX] sale_project: top bar unavailable from tasks button in SO form view

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -141,7 +141,19 @@ class SaleOrder(models.Model):
         form_view_id = self.env.ref('project.view_task_form2').id
         kanban_view_id = self.env.ref('project.view_task_kanban_inherit_view_default_project').id
 
-        action = self.env["ir.actions.actions"]._for_xml_id("project.action_view_task")
+        project_ids = self.tasks_ids.project_id
+        if len(project_ids) > 1:
+            action = self.env['ir.actions.actions']._for_xml_id('project.action_view_task')
+            action['domain'] = AND([ast.literal_eval(action['domain']), [('id', 'in', self.tasks_ids.ids)]])
+            action['context'] = {}
+        else:
+            # Load top bar if all the tasks linked to the SO belong to the same project
+            action = self.env['ir.actions.actions'].with_context({'active_id': project_ids.id})._for_xml_id('project.act_project_project_2_project_task_all')
+            action['context'] = {
+                'active_id': project_ids.id,
+                'search_default_sale_order_id': self.id,
+            }
+
         if self.tasks_count > 1:  # cross project kanban task
             for idx, (view_id, view_type) in enumerate(action['views']):
                 if view_type == 'kanban':
@@ -157,14 +169,13 @@ class SaleOrder(models.Model):
         default_line = next((sol for sol in self.order_line if sol.product_id.type == 'service'), self.env['sale.order.line'])
         default_project_id = default_line.project_id.id or self.project_ids[:1].id or self.tasks_ids.project_id[:1].id
 
-        action['context'] = {
+        action['context'].update({
             'default_sale_order_id': self.id,
             'default_sale_line_id': default_line.id,
             'default_partner_id': self.partner_id.id,
             'default_project_id': default_project_id,
             'default_user_ids': [self.env.uid],
-        }
-        action['domain'] = AND([ast.literal_eval(action['domain']), [('id', 'in', self.tasks_ids.ids)]])
+        })
         return action
 
     def action_create_project(self):


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Install Project and Sales app
2. Create an SO which generates a project with tasks on confirmation
3. Confirm the SO
4. From the SO form view, click on the 'Tasks' stat button
5. The top bar is unavailable

Fix:
-------------------
In the action method, we check if all the tasks linked to the SO are in the same project. If so, we display the top bar by retrieving the right xml_id and passing the active_id of the project in the context. If not (more than one project), we fall back on the current behaviour.

task-4239673
version-18.0

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
