### PR TITLE
[FIX] project_todo: take whole page height for the todo form view

### DIFF
--- a/addons/project_todo/static/src/views/todo_form/todo_form_controller.js
+++ b/addons/project_todo/static/src/views/todo_form/todo_form_controller.js
@@ -2,17 +2,14 @@ import { onWillStart } from "@odoo/owl";
 
 import { _t } from "@web/core/l10n/translation";
 import { user } from "@web/core/user";
-import { FormController } from "@web/views/form/form_controller";
+import { FormControllerWithHTMLExpander } from "@resource/views/form_with_html_expander/form_controller_with_html_expander";
 
 /**
  *  The FormController is overridden to be able to manage the edition of the name of a to-do directly
  *  in the breadcrumb as well as the mark as done button next to it.
  */
 
-export class TodoFormController extends FormController {
-    static components = {
-        ...FormController.components,
-    };
+export class TodoFormController extends FormControllerWithHTMLExpander {
     setup() {
         super.setup();
         onWillStart(async () => {

--- a/addons/project_todo/static/src/views/todo_form/todo_form_renderer.js
+++ b/addons/project_todo/static/src/views/todo_form/todo_form_renderer.js
@@ -1,0 +1,18 @@
+import { FormRendererWithHtmlExpander } from "@resource/views/form_with_html_expander/form_renderer_with_html_expander";
+import { useBus } from "@web/core/utils/hooks";
+
+export class TodoFormRenderer extends FormRendererWithHtmlExpander {
+    setup() {
+        super.setup();
+        useBus(this.env.bus, "TODO:TOGGLE_CHATTER", this.toggleChatter);
+        this.sizeToExpandHTMLField = 1;
+    }
+
+    toggleChatter(ev) {
+        this.sizeToExpandHTMLField = ev.detail.displayChatter ? 6 : 1;
+    }
+
+    _canExpandHTMLField(size) {
+        return size >= this.sizeToExpandHTMLField;
+    }
+}

--- a/addons/project_todo/static/src/views/todo_form/todo_form_view.js
+++ b/addons/project_todo/static/src/views/todo_form/todo_form_view.js
@@ -1,14 +1,14 @@
-/** @odoo-module **/
-
 import { registry } from "@web/core/registry";
 import { formView } from "@web/views/form/form_view";
 import { TodoFormController } from "./todo_form_controller";
 import { TodoFormControlPanel } from "./todo_form_control_panel";
+import { TodoFormRenderer } from "./todo_form_renderer";
 
 export const todoFormView = {
     ...formView,
     Controller: TodoFormController,
     ControlPanel: TodoFormControlPanel,
+    Renderer: TodoFormRenderer,
 };
 
 registry.category("views").add("todo_form", todoFormView);

--- a/addons/resource/static/src/views/form_with_html_expander/form_controller_with_html_expander.js
+++ b/addons/resource/static/src/views/form_with_html_expander/form_controller_with_html_expander.js
@@ -16,7 +16,24 @@ export class FormControllerWithHTMLExpander extends FormController {
         };
     }
 
+    get modelParams() {
+        const modelParams = super.modelParams;
+        const onRootLoaded = modelParams.hooks.onRootLoaded;
+        modelParams.hooks.onRootLoaded = async () => {
+            if (onRootLoaded) {
+                onRootLoaded();
+            }
+            this.htmlExpanderState.reload = true;
+        };
+        return modelParams;
+    }
+
     notifyHTMLFieldExpanded() {
         this.htmlExpanderState.reload = false;
+    }
+
+    async onRecordSaved(record, changes) {
+        super.onRecordSaved(record, changes);
+        this.htmlExpanderState.reload = true;
     }
 }

--- a/addons/resource/static/src/views/form_with_html_expander/form_renderer_with_html_expander.js
+++ b/addons/resource/static/src/views/form_with_html_expander/form_renderer_with_html_expander.js
@@ -46,12 +46,7 @@ export class FormRendererWithHtmlExpander extends FormRenderer {
                 }
                 this.props.notifyHtmlExpander();
             },
-            () => [
-                ref.el,
-                this.uiService.size,
-                this.props.reloadHtmlFieldHeight,
-                this.props.record.resId,
-            ]
+            () => [ref.el, this.uiService.size, this.props.reloadHtmlFieldHeight]
         );
     }
 

--- a/addons/resource/static/src/views/form_with_html_expander/form_renderer_with_html_expander.js
+++ b/addons/resource/static/src/views/form_with_html_expander/form_renderer_with_html_expander.js
@@ -23,7 +23,7 @@ export class FormRendererWithHtmlExpander extends FormRenderer {
         const ref = useRef("compiled_view_root");
         useEffect(
             (el, size) => {
-                if (el && size === 6) {
+                if (el && this._canExpandHTMLField(size)) {
                     const descriptionField = el.querySelector(this.htmlFieldQuerySelector);
                     if (descriptionField) {
                         const containerEL = descriptionField.closest(
@@ -56,5 +56,9 @@ export class FormRendererWithHtmlExpander extends FormRenderer {
 
     get getHTMLFieldContainerQuerySelector() {
         return ".o_form_sheet";
+    }
+
+    _canExpandHTMLField(size) {
+        return size === 6;
     }
 }


### PR DESCRIPTION
Before this commit, the height of the form view does not really take the whole space available in the screen as it is the case in the form view of task.

This commit makes sure the height of the form view in To-Do app takes the whole screen height as task form view.