### PR TITLE
[FIX] website: fix JS example in HTML/CSS Editor

### DIFF
--- a/addons/website/static/src/js/user_custom_javascript.js
+++ b/addons/website/static/src/js/user_custom_javascript.js
@@ -14,6 +14,7 @@ publicWidget.registry.HelloWorldPopup = publicWidget.Widget.extend({
     selector: '#wrapwrap',
 
     init() {
+        this._super(...arguments);
         this.dialog = this.bindService("dialog");
     },
     start() {


### PR DESCRIPTION
Steps to reproduce:
- In website, open the HTML/CSS Editor (Site > HTML/CSS Editor).
- In the dropdown, select JS.
- Uncomment the given example (about the "Hello World" dialog) and save.
- Try to go in edit mode.
=> Traceback

This happens since commit [1], which replaced the dialogs by OWL Dialog ones. Indeed, the call to `super` in the `init` function was forgotten, making the widget not being initialized correctly, and therefore not destroyed correctly either when going in edit mode.

This commit adds this missing call.

[1]: https://github.com/odoo/odoo/commit/57ed8bc0bf9d1ae2b7542d677a4d7e8fd1899ea2

opw-4243615
