### PR TITLE
[FIX] stock_account: get singletone value within loop

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -186,7 +186,7 @@ class MrpBom(models.Model):
             if sum(bom.byproduct_ids.mapped('cost_share')) > 100:
                 raise ValidationError(_("The total cost share for a BoM's by-products cannot exceed 100."))
 
-    @api.onchange('bom_line_ids', 'product_qty')
+    @api.onchange('bom_line_ids', 'product_qty', 'product_id', 'product_tmpl_id')
     def onchange_bom_structure(self):
         if self.type == 'phantom' and self._origin and self.env['stock.move'].search([('bom_line_id', 'in', self._origin.bom_line_ids.ids)], limit=1):
             return {

--- a/addons/stock_account/models/stock_valuation_layer.py
+++ b/addons/stock_account/models/stock_valuation_layer.py
@@ -118,10 +118,10 @@ class StockValuationLayer(models.Model):
         if not self:
             return 0, 0
 
-        rounding = self.product_id.uom_id.rounding
         qty_to_take_on_candidates = qty_to_value
         tmp_value = 0  # to accumulate the value taken on the candidates
         for candidate in self:
+            rounding = candidate.product_id.uom_id.rounding
             if float_is_zero(candidate.quantity, precision_rounding=rounding):
                 continue
             candidate_quantity = abs(candidate.quantity)
@@ -154,13 +154,15 @@ class StockValuationLayer(models.Model):
         if not self:
             return 0, 0
 
-        rounding = self.product_id.uom_id.rounding
+        min_rounding = 1.0
         qty_total = -qty_valued
         value_total = -valued
         new_valued_qty = 0
         new_valuation = 0
 
         for svl in self:
+            rounding = svl.product_id.uom_id.rounding
+            min_rounding = min(min_rounding, rounding)
             if float_is_zero(svl.quantity, precision_rounding=rounding):
                 continue
             relevant_qty = abs(svl.quantity)
@@ -172,7 +174,7 @@ class StockValuationLayer(models.Model):
             qty_total += relevant_qty
             value_total += relevant_qty * ((svl.value + sum(svl.stock_valuation_layer_ids.mapped('value'))) / svl.quantity)
 
-        if float_compare(qty_total, 0, precision_rounding=rounding) > 0:
+        if float_compare(qty_total, 0, precision_rounding=min_rounding) > 0:
             unit_cost = value_total / qty_total
             new_valued_qty = min(qty_total, qty_to_value)
             new_valuation = unit_cost * new_valued_qty


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

I'm not sure how to reproduce right now. Clue: these modules are installed:
- sale_stock_margin
- stock_account

Other clue: user is going to an mrp.production order and clicking on "Set as done".

Some unknown combination of facts under this situation make multiple `sale.order.line` have to recompute their `purchase_price`. It happens that some product involved is measured in Units, while some other is measured in Kg.

At the end of the rabbit hole, the code ends up here, where there's a pretty obvious bug: a singleton value being extracted from a multi-record variable.

So, yes, this is probably the worse fix description ever. 😅 However, the bug is so obvious that I'm not sure I really need something more elaborate in this case. So, here's the fix! 🎁

@moduon MT-7556


Current behavior before PR:

<details>

```
Traceback (most recent call last):
  File "/opt/odoo/auto/addons/etl/controllers/﻿[﻿dataset.py﻿](https://dataset.py/)﻿", line 15, in _call_kw

    raise ValueError

ValueError



During handling of the above exception, another exception occurred:



Traceback (most recent call last):

  File "/opt/odoo/custom/src/odoo/odoo/﻿[﻿models.py﻿](https://models.py/)﻿", line 5182, in ensure_one

    _id, = self._ids

ValueError: too many values to unpack (expected 1)



During handling of the above exception, another exception occurred:



Traceback (most recent call last):

  File "/opt/odoo/custom/src/odoo/odoo/﻿[﻿http.py﻿](https://http.py/)﻿", line 1651, in _serve_db

    return service_model.retrying(self._serve_ir_http, self.env)

  File "/opt/odoo/custom/src/odoo/odoo/service/﻿[﻿model.py﻿](https://model.py/)﻿", line 133, in retrying

    result = func()

  File "/opt/odoo/custom/src/odoo/odoo/﻿[﻿http.py﻿](https://http.py/)﻿", line 1678, in _serve_ir_http

    response = self.dispatcher.dispatch(rule.endpoint, args)

  File "/opt/odoo/custom/src/odoo/odoo/﻿[﻿http.py﻿](https://http.py/)﻿", line 1882, in dispatch

    result = self.request.registry['ir.http']._dispatch(endpoint)

  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/﻿[﻿ir_http.py﻿](https://ir_http.py/)﻿", line 154, in _dispatch

    result = endpoint(**request.params)

  File "/opt/odoo/custom/src/odoo/odoo/﻿[﻿http.py﻿](https://http.py/)﻿", line 734, in route_wrapper

    result = endpoint(self, *args, **params_ok)

  File "/opt/odoo/auto/addons/web/controllers/﻿[﻿dataset.py﻿](https://dataset.py/)﻿", line 46, in call_button

    action = self._call_kw(model, method, args, kwargs)

  File "/opt/odoo/auto/addons/etl/controllers/﻿[﻿dataset.py﻿](https://dataset.py/)﻿", line 19, in _call_kw

    return super()._call_kw(model, method, args, kwargs)

  File "/opt/odoo/auto/addons/web/controllers/﻿[﻿dataset.py﻿](https://dataset.py/)﻿", line 33, in _call_kw

    return call_kw(request.env[model], method, args, kwargs)

  File "/opt/odoo/custom/src/odoo/odoo/﻿[﻿api.py﻿](https://api.py/)﻿", line 469, in call_kw

    model.env.flush_all()

  File "/opt/odoo/custom/src/odoo/odoo/﻿[﻿api.py﻿](https://api.py/)﻿", line 745, in flush_all

    self._recompute_all()

  File "/opt/odoo/custom/src/odoo/odoo/﻿[﻿api.py﻿](https://api.py/)﻿", line 741, in _recompute_all

    self[field.model_name]._recompute_field(field)

  File "/opt/odoo/custom/src/odoo/odoo/﻿[﻿models.py﻿](https://models.py/)﻿", line 6282, in _recompute_field

    field.recompute(records)

  File "/opt/odoo/custom/src/odoo/odoo/﻿[﻿fields.py﻿](https://fields.py/)﻿", line 1370, in recompute

    apply_except_missing(self.compute_value, recs)

  File "/opt/odoo/custom/src/odoo/odoo/﻿[﻿fields.py﻿](https://fields.py/)﻿", line 1343, in apply_except_missing

    func(records)

  File "/opt/odoo/custom/src/odoo/odoo/﻿[﻿fields.py﻿](https://fields.py/)﻿", line 1392, in compute_value

    records._compute_field_value(self)

  File "/opt/odoo/custom/src/odoo/odoo/﻿[﻿models.py﻿](https://models.py/)﻿", line 4240, in _compute_field_value

    fields.determine(field.compute, self)

  File "/opt/odoo/custom/src/odoo/odoo/﻿[﻿fields.py﻿](https://fields.py/)﻿", line 98, in determine

    return needle(*args)

  File "/opt/odoo/auto/addons/sale_stock_margin/models/﻿[﻿sale_order_line.py﻿](https://sale_order_line.py/)﻿", line 18, in _compute_purchase_price

    purch_price = product._compute_average_price(0, line.product_uom_qty, line.move_ids)

  File "/opt/odoo/auto/addons/mrp_account/models/﻿[﻿product.py﻿](https://product.py/)﻿", line 54, in _compute_average_price

    return super()._compute_average_price(qty_invoiced, qty_to_invoice, stock_moves, is_returned=is_returned)

  File "/opt/odoo/auto/addons/stock_account/models/﻿[﻿product.py﻿](https://product.py/)﻿", line 788, in _compute_average_price

    qty_valued, valuation = candidates._consume_specific_qty(qty_invoiced, qty_to_invoice)

  File "/opt/odoo/auto/addons/stock_account/models/﻿[﻿stock_valuation_layer.py﻿](https://stock_valuation_layer.py/)﻿", line 113, in _consume_specific_qty

    rounding = self.product_id.uom_id.rounding

  File "/opt/odoo/custom/src/odoo/odoo/﻿[﻿fields.py﻿](https://fields.py/)﻿", line 1154, in __get__

    record.ensure_one()

  File "/opt/odoo/custom/src/odoo/odoo/﻿[﻿models.py﻿](https://models.py/)﻿", line 5185, in ensure_one

    raise ValueError("Expected singleton: %s" % self)

ValueError: Expected singleton: uom.uom(1, 12)
```

</details>

Desired behavior after PR is merged: Fixed!




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
