### PR TITLE
[FIX] mail: sync sub-thread with its parent

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1134,7 +1134,10 @@ class Channel(models.Model):
             message = self.env["mail.message"].search([("id", "=", from_message_id)])
         sub_channel = self.create(
             {
-                "channel_member_ids": [Command.create({"partner_id": self.env.user.partner_id.id})],
+                "channel_member_ids": [
+                    Command.create({"partner_id": partner.id})
+                    for partner in self.channel_member_ids.partner_id | self.env.user.partner_id
+                ],
                 "channel_type": "channel",
                 "from_message_id": message.id,
                 "name": name or (message.body.striptags()[:30] if message else _("New Thread")),

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -217,9 +217,13 @@ class ChannelMember(models.Model):
         sub_members = []
         for parent in self.channel_id.filtered(lambda c: c.sub_channel_ids):
             sub_members += parent.sub_channel_ids.channel_member_ids.filtered(
-                lambda m: m.partner_id in set(parent.channel_member_ids.partner_id)
-                if m.partner_id
-                else m.guest_id in set(parent.channel_member_ids.guest_id)
+                lambda m: (
+                    m.partner_id in self.partner_id
+                    and m.partner_id in set(parent.channel_member_ids.partner_id)
+                    if m.partner_id
+                    else m.guest_id in self.guest_id
+                         and m.guest_id in set(parent.channel_member_ids.guest_id)
+                )
             )
         for member in sub_members:
             member.channel_id._action_unfollow(partner=member.partner_id, guest=member.guest_id)


### PR DESCRIPTION
This commit fixes two bugs in the sub-thread behavior. Steps to reproduce:
- Create a thread with non admin user and add another member to the thread
- Create a sub-thread
- The other user is not automatically added to the sub-thread (bug)
- Add another member to the sub-thread
- Go to the parent thread and type `/leave` command
- You see the access error (bug)
