### PR TITLE
[FIX] point_of_sale: Add space to error message

### DIFF
--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -29,7 +29,7 @@ class ProductTemplate(models.Model):
         if self.with_context(product_ctx).search_count([('id', 'in', self.ids), ('available_in_pos', '=', True)]):
             if self.env['pos.session'].sudo().search_count([('state', '!=', 'closed')]):
                 raise UserError(_("To delete a product, make sure all point of sale sessions are closed.\n\n"
-                    "Deleting a product available in a session would be like attempting to snatch a"
+                    "Deleting a product available in a session would be like attempting to snatch a "
                     "hamburger from a customer’s hand mid-bite; chaos will ensue as ketchup and mayo go flying everywhere!"))
 
     @api.onchange('sale_ok')
@@ -94,7 +94,7 @@ class ProductProduct(models.Model):
         if self.env['pos.session'].sudo().search_count([('state', '!=', 'closed')]):
             if self.with_context(product_ctx).search_count([('id', 'in', self.ids), ('product_tmpl_id.available_in_pos', '=', True)]):
                 raise UserError(_("To delete a product, make sure all point of sale sessions are closed.\n\n"
-                    "Deleting a product available in a session would be like attempting to snatch a"
+                    "Deleting a product available in a session would be like attempting to snatch a "
                     "hamburger from a customer’s hand mid-bite; chaos will ensue as ketchup and mayo go flying everywhere!"))
 
     def get_product_info_pos(self, price, quantity, pos_config_id):


### PR DESCRIPTION
There is a missing space in this error message causing a display issue when it is triggered. The space has simply been added back.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
