### PR TITLE
[IMP] l10n_us: allow encoding an intermediary bank

### DIFF
--- a/addons/l10n_us_account/__init__.py
+++ b/addons/l10n_us_account/__init__.py
@@ -2,4 +2,4 @@
 
 # The purpose of l10n_us_account is to automatically trigger the installation of l10n_us for the new US databases
 # Also, l10n_us_account should contains all the accounting-related dependencies of US localization package
-# Currently, It's empty module but it should be filled going forward!
+from . import models

--- a/addons/l10n_us_account/__manifest__.py
+++ b/addons/l10n_us_account/__manifest__.py
@@ -10,6 +10,9 @@
     'description': """
     """,
     'depends': ['l10n_us', 'account'],
+    'data': [
+        'views/res_bank_views.xml',
+    ],
     'installable': True,
     'auto_install': ['account'],
     'license': 'LGPL-3',

--- a/addons/l10n_us_account/models/__init__.py
+++ b/addons/l10n_us_account/models/__init__.py
@@ -1,0 +1,2 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import res_bank

--- a/addons/l10n_us_account/models/res_bank.py
+++ b/addons/l10n_us_account/models/res_bank.py
@@ -1,0 +1,19 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class ResBank(models.Model):
+    _inherit = "res.bank"
+
+    intermediary_bank_id = fields.Many2one(
+        comodel_name='res.bank',
+        domain="[('id', '!=', id)]",
+        help="An intermediary bank facilitates international wire transfers between your bank and the beneficiary's bank when they don’t have a direct relationship.",
+    )
+
+    @api.constrains("intermediary_bank_id")
+    def _constrains_intermediary_bank_id(self):
+        for bank in self:
+            if bank == bank.intermediary_bank_id:
+                raise ValidationError(_("A bank cannot be its own intermediary bank."))

--- a/addons/l10n_us_account/views/res_bank_views.xml
+++ b/addons/l10n_us_account/views/res_bank_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_bank_view_form" model="ir.ui.view">
+        <field name="name">res.bank.view.form.inherit.intermediary</field>
+        <field name="model">res.bank</field>
+        <field name="inherit_id" ref="base.view_res_bank_form"/>
+        <field name="arch" type="xml">
+            <field name="bic" position="after">
+                <field name="intermediary_bank_id"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
For international wire transfers it's common to have to specify an intermediary bank [1]. This is needed when the user's bank doesn't have a direct relationship with the recipient's bank.

We add a field for it so that it can be encoded in a structured way. This allows accountants to easily export this data, process it, and upload it to their bank's portal to generate the payments.

task-4252963

[1] https://stripe.com/resources/more/what-are-intermediary-banks-and-how-do-they-work
