### PR TITLE
[IMP] l10n_br_website_sale: select cities with SelectMenu

### DIFF
--- a/addons/l10n_br_website_sale/static/src/js/address.js
+++ b/addons/l10n_br_website_sale/static/src/js/address.js
@@ -1,40 +1,88 @@
-import websiteSaleAddress from '@website_sale/js/address';
+/** @odoo-module **/
+
+import websiteSaleAddress from "@website_sale/js/address";
+import { Component, useState } from "@odoo/owl";
+import { SelectMenu } from "@web/core/select_menu/select_menu";
+import { attachComponent } from "@web_editor/js/core/owl_utils";
+
+class SelectMenuWrapper extends Component {
+    static template = "l10n_br_website_sale.SelectMenuWrapper";
+    static components = { SelectMenu };
+    static props = {
+        el: { optional: true, type: Object },
+    };
+
+    setup() {
+        this.state = useState({
+            choices: [],
+            value: this.props.el.value,
+        });
+        this.state.choices = [...this.props.el.querySelectorAll("option")].filter((x) => x.value);
+        this.props.el.classList.add("d-none");
+    }
+
+    onSelect(value) {
+        this.state.value = value;
+        this.props.el.value = value;
+        // Manually trigger the change event
+        const event = new Event("change", { bubbles: true });
+        this.props.el.dispatchEvent(event);
+    }
+}
 
 websiteSaleAddress.include({
-    events: Object.assign(
-        {},
-        websiteSaleAddress.prototype.events,
-        {
-            'input input[name="zip"]': '_onChangeZip',
-        }
-    ),
+    events: Object.assign({}, websiteSaleAddress.prototype.events, {
+        'input input[name="zip"]': "_onChangeZip",
+        "change .o_select_city": "_onChangeBrazilianCity",
+    }),
 
-    _selectState: function(id) {
-        this.addressForm.querySelector(`select[name="state_id"] > option[value="${id}"]`).selected = 'selected';
+    start: async function () {
+        this._super.apply(this, arguments);
+
+        if (this.countryCode === "BR") {
+            const selectEl = this.el.querySelector("select[name='city_id']");
+            this.selectMenuWrapper = await attachComponent(
+                this,
+                selectEl.parentElement,
+                SelectMenuWrapper,
+                {
+                    el: selectEl,
+                }
+            );
+            await this._changeCountry();
+        }
     },
 
-    _onChangeZip: function() {
-        if (this.countryCode !== 'BR') {
+    _selectState: function (id) {
+        this.addressForm.querySelector(`select[name="state_id"] > option[value="${id}"]`).selected =
+            "selected";
+    },
+
+    _onChangeZip: function () {
+        if (this.countryCode !== "BR") {
             return;
         }
 
-        const newZip = this.addressForm.zip.value.padEnd(5, '0');
+        const newZip = this.addressForm.zip.value.padEnd(5, "0");
 
-        for (let option of this.addressForm.querySelectorAll('select[name="city_id"]:not(.d-none) > option')) {
-            const ranges = option.getAttribute('zip-ranges');
+        for (const option of this.addressForm.querySelectorAll(".o_select_city option")) {
+            const ranges = option.getAttribute("zip-ranges");
             if (ranges) {
                 // Parse the l10n_br_zip_ranges field (e.g. "[01000-001 05999-999] [08000-000 08499-999]").
                 // Loop over each range that is enclosed in [] (e.g. "[01000-001 05999-999]" followed by "[08000-000 08499-999]").
-                for (let range of ranges.matchAll(/\[[^\[]+\]/g)) {
+                for (let range of ranges.matchAll(/\[[^[]+]/g)) {
                     // Remove square brackets (after this, range is e.g. "01000-001 05999-999")
-                    range = range[0].replace(/[\[\]]/g, '');
+                    range = range[0].replace(/[[\]]/g, "");
 
-                    let [start, end] = range.split(' ');
+                    const [start, end] = range.split(" ");
 
                     // Rely on lexicographical order to figure out if the new zip is in this range.
                     if (newZip >= start && newZip <= end) {
-                        option.selected = 'selected';
-                        this._selectState(option.getAttribute('state-id'));
+                        if (this.selectMenuWrapper) {
+                            this.selectMenuWrapper.component.onSelect(option.value);
+                        }
+                        option.selected = "selected";
+                        this._selectState(option.getAttribute("state-id"));
                         return;
                     }
                 }
@@ -42,42 +90,58 @@ websiteSaleAddress.include({
         }
     },
 
+    _onChangeBrazilianCity: function () {
+        if (this.countryCode !== "BR") {
+            return;
+        }
+
+        if (this.addressForm.city_id.value) {
+            this._selectState(
+                this.addressForm.city_id
+                    .querySelector(`option[value='${this.addressForm.city_id.value}']`)
+                    .getAttribute("state-id")
+            );
+        }
+    },
+
     _setVisibility(selector, should_show) {
-        this.addressForm.querySelectorAll(selector).forEach(el => {
+        this.addressForm.querySelectorAll(selector).forEach((el) => {
             if (should_show) {
-                el.classList.remove('d-none');
+                el.classList.remove("d-none");
             } else {
-                el.classList.add('d-none');
+                el.classList.add("d-none");
             }
 
             // Disable hidden inputs to avoid sending back e.g. an empty street when street_name and street_number is
             // filled. It causes street_name and street_number to be lost.
-            if (el.tagName === 'INPUT') {
+            if (el.tagName === "INPUT") {
                 el.disabled = !should_show;
             }
 
-            el.querySelectorAll('input').forEach(input => input.disabled = !should_show);
-        })
+            el.querySelectorAll("input").forEach((input) => (input.disabled = !should_show));
+        });
     },
 
     async _changeCountry(ev) {
         const res = await this._super(...arguments);
-        if (this.countryCode !== 'BR') {
+        if (this.countryCode !== "BR") {
             return res;
         }
 
         const countryOption = this.addressForm.country_id;
-        const selectedCountryCode = countryOption.value ? countryOption.selectedOptions[0].getAttribute('code') : '';
+        const selectedCountryCode = countryOption.value
+            ? countryOption.selectedOptions[0].getAttribute("code")
+            : "";
 
-        if (selectedCountryCode === 'BR') {
-            this._setVisibility('.o_standard_address', false); // hide
-            this._setVisibility('.o_extended_address', true); // show
+        if (selectedCountryCode === "BR") {
+            this._setVisibility(".o_standard_address", false); // hide
+            this._setVisibility(".o_extended_address", true); // show
             this._onChangeZip();
         } else {
-            this._setVisibility('.o_standard_address', true); // show
-            this._setVisibility('.o_extended_address', false); // hide
+            this._setVisibility(".o_standard_address", true); // show
+            this._setVisibility(".o_extended_address", false); // hide
         }
 
         return res;
-    }
+    },
 });

--- a/addons/l10n_br_website_sale/static/src/xml/select_menu_wrapper_template.xml
+++ b/addons/l10n_br_website_sale/static/src/xml/select_menu_wrapper_template.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+
+<t t-name="l10n_br_website_sale.SelectMenuWrapper">
+    <SelectMenu value="state.value" choices="state.choices" class="'o_extended_address'" onSelect.bind="onSelect"/>
+</t>
+
+</templates>

--- a/addons/l10n_br_website_sale/static/tests/tours/brazilian_address.js
+++ b/addons/l10n_br_website_sale/static/tests/tours/brazilian_address.js
@@ -1,70 +1,64 @@
 import { registry } from "@web/core/registry";
 import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
-function assertCityAndState(expectedCity, expectedState) {
+function assertState(expectedState) {
     // :checked doesn't seem to work in the trigger, so let's check manually.
-    let select_value = document.querySelector('select[name="city_id"]').value;
-    let option = document.querySelector(`select[name="city_id"] option[value="${select_value}"]`);
-    if (!option.innerText.includes(expectedCity)) {
-        throw new Error("The right city was not auto-selected.");
-    }
-
-    select_value = document.querySelector('select[name="state_id"]').value;
-    option = document.querySelector(`select[name="state_id"] option[value="${select_value}"]`);
+    const select_value = document.querySelector('select[name="state_id"]').value;
+    const option = document.querySelector(
+        `select[name="state_id"] option[value="${select_value}"]`
+    );
     if (!option.innerText.includes(expectedState)) {
         throw new Error("The right state was not auto-selected.");
     }
 }
 
 registry.category("web_tour.tours").add("test_brazilian_address", {
-    url: '/shop?search=Brazilian test product',
+    url: "/shop?search=Brazilian test product",
     steps: () => [
-        ...tourUtils.addToCart({productName: "Brazilian test product", search: false}),
-        tourUtils.goToCart({quantity: 1}),
+        ...tourUtils.addToCart({ productName: "Brazilian test product", search: false }),
+        tourUtils.goToCart({ quantity: 1 }),
         tourUtils.goToCheckout(),
         {
-            content: 'base_address_extended should not be shown',
+            content: "base_address_extended should not be shown",
             trigger: 'select[name="city_id"]:not(:visible)',
         },
         {
-            content: 'Set Brazil first',
+            content: "Set Brazil first",
             trigger: 'select[name="country_id"]',
-            run: 'selectByLabel Brazil',
+            run: "selectByLabel Brazil",
         },
         {
-            content: 'base_address_extended fields should be shown',
-            trigger: 'select[name="city_id"]',
+            content: "Click to select a city",
+            trigger: ".o_select_menu_toggler",
+            run: "click",
         },
         {
-            content: 'Input a zip second',
-            trigger: 'input[name="zip"]',
-            run: 'fill 12345',
+            content: "Select Abadia de Goiás",
+            trigger: ".o_select_menu_menu > span:first",
+            run: "click",
         },
         {
-            content: 'Check that Jacareí city and São Paulo state are automatically selected based on the previous zip',
-            trigger: 'select[name="city_id"]',
-            run: () => assertCityAndState('Jacareí', 'São Paulo'),
+            content: "Check that Abadia de Goiás is selected",
+            trigger: '.o_select_city:contains("Abadia de Goiás")',
         },
         {
-            content: 'Discard',
-            trigger: 'a[href^="/shop/cart"]',
-            run: 'click',
-        },
-        tourUtils.goToCheckout(),
-        {
-            content: 'Input a zip first',
-            trigger: 'input[name="zip"]',
-            run: 'fill 83490-000',
-        },
-        {
-            content: 'Set Brazil second',
+            content: "Check that Goiás state is automatically selected based on the city.",
             trigger: 'select[name="country_id"]',
-            run: 'selectByLabel Brazil',
+            run: () => assertState("Goiás"),
         },
         {
-            content: 'Check that Adrianópolis city and Paraná state are automatically selected based on the previous zip',
-            trigger: 'select[name="city_id"]',
-            run: () => assertCityAndState('Adrianópolis', 'Paraná'),
+            content: "Input a zip",
+            trigger: 'input[name="zip"]',
+            run: "fill 12345-000",
+        },
+        {
+            content: "Check that Jacareí is selected",
+            trigger: '.o_select_city:contains("Jacareí")',
+        },
+        {
+            content: "Check that São Paulo state is automatically selected based on the city.",
+            trigger: 'select[name="country_id"]',
+            run: () => assertState("São Paulo"),
         },
     ],
 });

--- a/addons/l10n_br_website_sale/views/templates.xml
+++ b/addons/l10n_br_website_sale/views/templates.xml
@@ -38,14 +38,17 @@
             <attribute name="class" separator=" " add="o_standard_address"/>
         </input>
         <input id="o_city" position="after">
-            <select t-if="res_company.account_fiscal_country_id.code == 'BR'" id="o_city_id" name="city_id" class="form-select o_extended_address">
-                <option value="">City...</option>
-                <t t-foreach="cities_sudo" t-as="c">
-                    <option t-att-value="c.id" t-att-selected="c.id == city_sudo.id" t-att-code="c.id" t-att-state-id="c.state_id.id" t-att-zip-ranges="c.l10n_br_zip_ranges">
-                        <t t-esc="c.name" />
-                    </option>
-                </t>
-            </select>
+            <div t-if="res_company.account_fiscal_country_id.code == 'BR'" class="o_select_city">
+                <!-- will be replaced with SelectMenuWrapper -->
+                <select id="o_city_id" name="city_id" class="form-select">
+                    <option value="">City...</option>
+                    <t t-foreach="cities_sudo" t-as="c">
+                        <option t-att-value="c.id" t-att-selected="c.id == city_sudo.id" t-att-code="c.id" t-att-state-id="c.state_id.id" t-att-zip-ranges="c.l10n_br_zip_ranges">
+                            <t t-esc="c.name" />
+                        </option>
+                    </t>
+                </select>
+            </div>
         </input>
         <!-- put base_address_extended fields separately to be more user-friendly -->
         <div id="div_street" position="attributes">

--- a/addons/web/tooling/_eslintignore
+++ b/addons/web/tooling/_eslintignore
@@ -223,6 +223,10 @@ addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet.js
 !stock_barcode_quality_mrp
 !stock_barcode_quality_mrp/**/*
 
+# Whitelist Brazilian eCommerce adaptations
+!addons/l10n_br_website_sale
+!addons/l10n_br_website_sale/**/*
+
 # Whitelist point_of_sale
 !addons/point_of_sale
 !addons/point_of_sale/**/*


### PR DESCRIPTION
Customers have to select a res.city in eCommerce for EDI. This was implemented previously [1]. An auto-completion mechanism was implemented to select city and state based on the zip, because there are many cities in the city `<select>` element.

This improves the selection further by making the cities searchable with the SelectMenu widget. It's especially useful for customers who may try to select the city before entering the zip.

[1] https://github.com/odoo/odoo/pull/177124

task-4198405