### PR TITLE
[IMP] base: place for international wire info on res.partner.bank

### DIFF
--- a/odoo/addons/base/models/res_bank.py
+++ b/odoo/addons/base/models/res_bank.py
@@ -85,6 +85,7 @@ class ResPartnerBank(models.Model):
     currency_id = fields.Many2one('res.currency', string='Currency')
     company_id = fields.Many2one('res.company', 'Company', related='partner_id.company_id', store=True, readonly=True)
     country_code = fields.Char(related='partner_id.country_code', string="Country Code")
+    note = fields.Text('Notes')
 
     _unique_number = models.Constraint(
         'unique(sanitized_acc_number, partner_id)',

--- a/odoo/addons/base/views/res_bank_views.xml
+++ b/odoo/addons/base/views/res_bank_views.xml
@@ -93,6 +93,9 @@
                             <field name="allow_out_payment" widget="boolean_toggle"/>
                         </group>
                     </group>
+                    <group name="note" string="Notes">
+                        <field name="note" colspan="2" nolabel="1" placeholder="Internal notes..."/>
+                    </group>
                 </sheet>
                 </form>
             </field>


### PR DESCRIPTION
It's common to have to provide some additional info when doing international wires. Examples are e.g. a Canadian transit number, or miscellaneous info like "further credit to John Doe" in a note field.

This provides a safe place for accountants to store it and also benefits from the allow_out_payment mechanism.

task-4252963
