### PR TITLE
[FIX] web: ARIA attributes of field widgets not ported correctly to OWL

### DIFF
--- a/addons/web/static/src/views/fields/priority/priority_field.xml
+++ b/addons/web/static/src/views/fields/priority/priority_field.xml
@@ -10,9 +10,9 @@
                             class="o_priority_star fa"
                             role="radio"
                             t-att-class="value_index lte index ? 'fa-star' : 'fa-star-o'"
-                            t-att-tabindex="value_index === state.index ? 0 : -1"
+                            tabindex="0"
                             t-att-data-tooltip="getTooltip(value[1])"
-                            t-att-aria-checked="value_index lte index"
+                            t-att-aria-checked="value_index === index ? 'true' : 'false'"
                             t-att-aria-label="value[1]"
                         />
                     </t>
@@ -22,9 +22,9 @@
                             class="o_priority_star fa"
                             role="radio"
                             t-att-class="value_index lte index ? 'fa-star' : 'fa-star-o'"
-                            t-att-tabindex="value_index === state.index ? 0 : -1"
+                            tabindex="0"
                             t-att-data-tooltip="getTooltip(value[1])"
-                            t-att-aria-checked="value_index lte index"
+                            t-att-aria-checked="value_index === index ? 'true' : 'false'"
                             t-att-aria-label="value[1]"
                             t-on-click.prevent.stop="() => this.onStarClicked(value[0])"
                             t-on-mouseenter="() => state.index = value_index"

--- a/addons/web/static/src/views/fields/statusbar/statusbar_field.xml
+++ b/addons/web/static/src/views/fields/statusbar/statusbar_field.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.StatusBarField" owl="1">
-        <div class="o_statusbar_status">
+        <div role="radiogroup" class="o_statusbar_status" aria-label="Statusbar">
             <t t-set="items" t-value="computeItems()" />
 
             <t t-if="items.folded.length">
@@ -28,7 +28,6 @@
                         class="btn o_arrow_button_current o_arrow_button disabled text-uppercase"
                         disabled="disabled"
                         role="radio"
-                        aria-label="Current state"
                         aria-checked="true"
                         aria-current="step"
                         t-att-disabled="isDisabled"
@@ -42,7 +41,6 @@
                         class="btn o_arrow_button disabled text-uppercase"
                         disabled="disabled"
                         role="radio"
-                        aria-label="Not active state"
                         aria-checked="false"
                         t-att-disabled="isDisabled"
                         t-att-data-value="item.id"
@@ -54,7 +52,6 @@
                         type="button"
                         class="btn o_arrow_button text-uppercase"
                         role="radio"
-                        aria-label="Not active state, click to change it"
                         aria-checked="false"
                         t-att-data-value="item.id"
                         t-esc="item.name"

--- a/addons/web/static/tests/views/fields/statusbar_field_tests.js
+++ b/addons/web/static/tests/views/fields/statusbar_field_tests.js
@@ -463,7 +463,7 @@ QUnit.module("Fields", (hooks) => {
         });
 
         assert.strictEqual(
-            target.querySelector("[aria-label='Current state']").textContent,
+            target.querySelector("[aria-checked='true']").textContent,
             "aaa",
             "default status is 'aaa'"
         );
@@ -478,7 +478,7 @@ QUnit.module("Fields", (hooks) => {
         await click(target, ".o_statusbar_status .dropdown-toggle");
         await click(target, ".o-dropdown .dropdown-item");
         assert.strictEqual(
-            target.querySelector("[aria-label='Current state']").textContent,
+            target.querySelector("[aria-checked='true']").textContent,
             "second record",
             "status has changed to the selected dropdown item"
         );


### PR DESCRIPTION
When field widgets were ported to OWL in 48ef812a, a few ARIA attributes
were not adapted correctly. For instance, in the statusbar widget, the
title was ported as an `aria-label` attribute ("Current state" and "Not
active state"), which overrides the actual status name.

This commit fixes the above issue by removing the incorrect `aria-label`
attributes and fixing logic for other ones like `aria-checked`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
