### PR TITLE
[FIX] spreadsheet_dashboard_stock_account: make the metrics' names translatable

### DIFF
--- a/addons/spreadsheet_dashboard_stock_account/data/files/warehouse_metrics_dashboard.json
+++ b/addons/spreadsheet_dashboard_stock_account/data/files/warehouse_metrics_dashboard.json
@@ -82,18 +82,18 @@
             "merges": [],
             "cells": {
                 "A7": {
-                    "content": "=_t(\"Available and reserved stock qty (top locations)\")"
+                    "content": "Available and reserved stock qty (top locations)"
                 },
                 "A23": {
-                    "content": "=_t(\"Available and reserved stock qty (top propducts)\")"
+                    "content": "Available and reserved stock qty (top products)"
                 },
                 "A41": {
-                    "content": "=_t(\"Ageing stock qty by category and creation date\")"
+                    "content": "Ageing stock qty by category and creation date"
                 },
                 "A58": {
                     "content": "=_t(\"Top 10 products with negative stock\")"
                 },
-                "A59": { "content": "Products" },
+                "A59": { "content": "=_t(\"Products\")" },
                 "A60": { "content": "=PIVOT.HEADER(22,\"#product_id\",1)" },
                 "A61": { "content": "=PIVOT.HEADER(22,\"#product_id\",2)" },
                 "A62": { "content": "=PIVOT.HEADER(22,\"#product_id\",3)" },
@@ -138,13 +138,13 @@
                     "content": "=PIVOT.VALUE(22,\"quantity\",\"#product_id\",10)"
                 },
                 "E7": {
-                    "content": "=_t(\"Available and reserved stock value (top locations)\")"
+                    "content": "Available and reserved stock value (top locations)"
                 },
                 "E23": {
-                    "content": "=_t(\"Available and reserved stock value (top propducts)\")"
+                    "content": "Available and reserved stock value (top products)"
                 },
                 "E41": {
-                    "content": "=_t(\"Ageing stock value by product and creation date\")"
+                    "content": "Ageing stock value by product and creation date"
                 }
             },
             "styles": {

--- a/addons/spreadsheet_dashboard_stock_account/data/files/warehouse_metrics_dashboard.json
+++ b/addons/spreadsheet_dashboard_stock_account/data/files/warehouse_metrics_dashboard.json
@@ -82,13 +82,13 @@
             "merges": [],
             "cells": {
                 "A7": {
-                    "content": "Available and reserved stock qty (top locations)"
+                    "content": "=_t(\"Available and reserved stock qty (top locations)\")"
                 },
                 "A23": {
-                    "content": "Available and reserved stock qty (top products)"
+                    "content": "=_t(\"Available and reserved stock qty (top propducts)\")"
                 },
                 "A41": {
-                    "content": "Ageing stock qty by category and creation date"
+                    "content": "=_t(\"Ageing stock qty by category and creation date\")"
                 },
                 "A58": {
                     "content": "=_t(\"Top 10 products with negative stock\")"
@@ -138,13 +138,13 @@
                     "content": "=PIVOT.VALUE(22,\"quantity\",\"#product_id\",10)"
                 },
                 "E7": {
-                    "content": "Available and reserved stock value (top locations)"
+                    "content": "=_t(\"Available and reserved stock value (top locations)\")"
                 },
                 "E23": {
-                    "content": "Available and reserved stock value (top products)"
+                    "content": "=_t(\"Available and reserved stock value (top propducts)\")"
                 },
                 "E41": {
-                    "content": "Ageing stock value by product and creation date"
+                    "content": "=_t(\"Ageing stock value by product and creation date\")"
                 }
             },
             "styles": {

--- a/addons/spreadsheet_dashboard_stock_account/data/files/warehouse_metrics_dashboard.json
+++ b/addons/spreadsheet_dashboard_stock_account/data/files/warehouse_metrics_dashboard.json
@@ -93,7 +93,7 @@
                 "A58": {
                     "content": "=_t(\"Top 10 products with negative stock\")"
                 },
-                "A59": { "content": "Products" },
+                "A59": { "content": "=_t(\"Products\")" },
                 "A60": { "content": "=PIVOT.HEADER(22,\"#product_id\",1)" },
                 "A61": { "content": "=PIVOT.HEADER(22,\"#product_id\",2)" },
                 "A62": { "content": "=PIVOT.HEADER(22,\"#product_id\",3)" },

--- a/addons/spreadsheet_dashboard_stock_account/data/files/warehouse_metrics_dashboard.json
+++ b/addons/spreadsheet_dashboard_stock_account/data/files/warehouse_metrics_dashboard.json
@@ -82,18 +82,18 @@
             "merges": [],
             "cells": {
                 "A7": {
-                    "content": "Available and reserved stock qty (top locations)"
+                    "content": "=_t(\"Available and reserved stock qty (top locations)\")"
                 },
                 "A23": {
-                    "content": "Available and reserved stock qty (top products)"
+                    "content": "=_t(\"Available and reserved stock qty (top propducts)\")"
                 },
                 "A41": {
-                    "content": "Ageing stock qty by category and creation date"
+                    "content": "=_t(\"Ageing stock qty by category and creation date\")"
                 },
                 "A58": {
                     "content": "=_t(\"Top 10 products with negative stock\")"
                 },
-                "A59": { "content": "=_t(\"Products\")" },
+                "A59": { "content": "Products" },
                 "A60": { "content": "=PIVOT.HEADER(22,\"#product_id\",1)" },
                 "A61": { "content": "=PIVOT.HEADER(22,\"#product_id\",2)" },
                 "A62": { "content": "=PIVOT.HEADER(22,\"#product_id\",3)" },
@@ -138,13 +138,13 @@
                     "content": "=PIVOT.VALUE(22,\"quantity\",\"#product_id\",10)"
                 },
                 "E7": {
-                    "content": "Available and reserved stock value (top locations)"
+                    "content": "=_t(\"Available and reserved stock value (top locations)\")"
                 },
                 "E23": {
-                    "content": "Available and reserved stock value (top products)"
+                    "content": "=_t(\"Available and reserved stock value (top propducts)\")"
                 },
                 "E41": {
-                    "content": "Ageing stock value by product and creation date"
+                    "content": "=_t(\"Ageing stock value by product and creation date\")"
                 }
             },
             "styles": {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Some dashboard metrics' names are not translatable. 

Current behavior before PR:

Desired behavior after PR is merged:
Make them translatable




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
