### PR TITLE
[FIX] google_calendar: sync issue when is a private address

### DIFF
--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -267,9 +267,9 @@ class Meeting(models.Model):
 
         attendees = self.attendee_ids
         attendee_values = [{
-            'email': attendee.partner_id.email_normalized,
+            'email': attendee.partner_id.sudo().email_normalized,
             'responseStatus': attendee.state or 'needsAction',
-        } for attendee in attendees if attendee.partner_id.email_normalized]
+        } for attendee in attendees if attendee.partner_id.sudo().email_normalized]
         # We sort the attendees to avoid undeterministic test fails. It's not mandatory for Google.
         attendee_values.sort(key=lambda k: k['email'])
         values = {


### PR DESCRIPTION
When an event is created with a private address attendee and an internal user attendee who has minimal contacts permissions, the internal user with minimal contacts permissions would encounter an access error when trying to sync with Google.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
