### PR TITLE
[FIX] mrp: avoid traceback when leave_id on workorders is not set

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1400,7 +1400,7 @@ class MrpProduction(models.Model):
         for workorder in final_workorders:
             workorder._plan_workorder(replan)
 
-        workorders = self.workorder_ids.filtered(lambda w: w.state not in ['done', 'cancel'])
+        workorders = self.workorder_ids.filtered(lambda w: w.state not in ['done', 'cancel'] and w.leave_id)
         if not workorders:
             return
 


### PR DESCRIPTION
File "/opt/odoo/16.0/addons/mrp/models/mrp_production.py", line 1408, in _plan_workorders

'date_planned_start': min([workorder.leave_id.date_from for workorder in workorders]),

TypeError: '<' not supported between instances of 'datetime.datetime' and 'bool'





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
