### PR TITLE
[IMP] project: add 'View Tasks' option in project calendar popover

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -9,11 +9,13 @@ from odoo.addons.mail.tools.discuss import Store
 from odoo.addons.rating.models import rating_data
 from odoo.exceptions import UserError
 from odoo.osv.expression import AND
-from odoo.tools import get_lang, SQL
+from odoo.tools import get_lang, SQL, LazyTranslate
 from odoo.tools.misc import unquote
 from odoo.tools.translate import _
 from .project_update import STATUS_COLOR
 from .project_task import CLOSED_STATES
+
+_lt = LazyTranslate(__name__)
 
 
 class ProjectProject(models.Model):
@@ -108,7 +110,7 @@ class ProjectProject(models.Model):
     task_ids = fields.One2many('project.task', 'project_id', string='Tasks', export_string_translation=False,
                                domain=lambda self: [('is_closed', '=', False)])
     color = fields.Integer(string='Color Index', export_string_translation=False)
-    user_id = fields.Many2one('res.users', string='Project Manager', default=lambda self: self.env.user, tracking=True)
+    user_id = fields.Many2one('res.users', string='Project Manager', default=lambda self: self.env.user, tracking=True, falsy_value_label=_lt("👤 Unassigned"))
     alias_id = fields.Many2one(help="Internal email associated with this project. Incoming emails are automatically synchronized "
                                     "with Tasks (or optionally Issues if the Issue Tracker module is installed).")
     privacy_visibility = fields.Selection([

--- a/addons/project/static/src/views/project_project_calendar/common/project_common_calendar_popover.js
+++ b/addons/project/static/src/views/project_project_calendar/common/project_common_calendar_popover.js
@@ -1,0 +1,23 @@
+import { useService } from "@web/core/utils/hooks";
+import { CalendarCommonPopover } from "@web/views/calendar/calendar_common/calendar_common_popover";
+
+export class ProjectCalendarCommonPopover extends CalendarCommonPopover {
+    static subTemplates = {
+        ...CalendarCommonPopover.subTemplates,
+        footer: "project.ProjectCalendarCommonPopover.footer",
+    };
+
+    setup() {
+        super.setup();
+        this.actionService = useService("action");
+    }
+
+    onClickViewTasks() {
+        this.actionService.doActionButton({
+            type: "object",
+            resId: this.props.record.id,
+            name: "action_view_tasks",
+            resModel: "project.project",
+        });
+    }
+}

--- a/addons/project/static/src/views/project_project_calendar/common/project_common_calendar_popover.xml
+++ b/addons/project/static/src/views/project_project_calendar/common/project_common_calendar_popover.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <t t-name="project.ProjectCalendarCommonPopover.footer" t-inherit="web.CalendarCommonPopover.footer" t-inherit-mode="primary">
+        <xpath expr="//t[@t-if='isEventEditable']" position="after">
+            <a href="#" class="btn btn-secondary" t-on-click="onClickViewTasks">View Tasks</a>
+        </xpath>
+    </t>
+</templates>

--- a/addons/project/static/src/views/project_project_calendar/common/project_common_calendar_renderer.js
+++ b/addons/project/static/src/views/project_project_calendar/common/project_common_calendar_renderer.js
@@ -1,0 +1,9 @@
+import { CalendarCommonRenderer } from "@web/views/calendar/calendar_common/calendar_common_renderer";
+import { ProjectCalendarCommonPopover } from "./project_common_calendar_popover";
+
+export class ProjectCalendarCommonRenderer extends CalendarCommonRenderer {
+    static components = {
+        ...CalendarCommonRenderer.components,
+        Popover: ProjectCalendarCommonPopover,
+    };
+}

--- a/addons/project/static/src/views/project_project_calendar/project_project_calendar_renderer.js
+++ b/addons/project/static/src/views/project_project_calendar/project_project_calendar_renderer.js
@@ -1,0 +1,11 @@
+import { CalendarRenderer } from "@web/views/calendar/calendar_renderer";
+import { ProjectCalendarCommonRenderer } from "./common/project_common_calendar_renderer";
+
+export class ProjectCalendarRenderer extends CalendarRenderer {
+    static components = {
+        ...CalendarRenderer.components,
+        day: ProjectCalendarCommonRenderer,
+        week: ProjectCalendarCommonRenderer,
+        month: ProjectCalendarCommonRenderer,
+    };
+}

--- a/addons/project/static/src/views/project_project_calendar/project_project_calendar_view.js
+++ b/addons/project/static/src/views/project_project_calendar/project_project_calendar_view.js
@@ -1,12 +1,14 @@
 import { registry } from "@web/core/registry";
 import { calendarView } from "@web/views/calendar/calendar_view";
 import { ProjectProjectCalendarController } from "./project_project_calendar_controller";
+import { ProjectCalendarRenderer } from "./project_project_calendar_renderer";
 
 const viewRegistry = registry.category("views");
 
 const projectProjectCalendarView = {
     ...calendarView,
     Controller: ProjectProjectCalendarController,
+    Renderer: ProjectCalendarRenderer,
 };
 
 viewRegistry.add("project_project_calendar", projectProjectCalendarView);

--- a/addons/project/static/tests/project_models.js
+++ b/addons/project/static/tests/project_models.js
@@ -8,11 +8,25 @@ export class ProjectProject extends models.Model {
     is_favorite = fields.Boolean();
     active = fields.Boolean({ default: true });
     stage_id = fields.Many2one({ relation: "project.project.stage" });
+    date = fields.Date({ string: "Expiration Date" });
+    date_start = fields.Date();
+    user_id = fields.Many2one({ relation: "res.users", falsy_value_label: "👤 Unassigned" });
 
     _records = [
-        { id: 1, name: "Project 1", stage_id: 1 },
+        {
+            id: 1,
+            name: "Project 1",
+            stage_id: 1,
+            date: "2024-01-09 07:00:00",
+            date_start: "2024-01-03 12:00:00",
+        },
         { id: 2, name: "Project 2", stage_id: 2 },
     ];
+
+    _views = {
+        list: '<list><field name="name"/></list>',
+        form: '<form><field name="name"/></form>',
+    };
 
     check_access_rights() {
         return Promise.resolve(true);
@@ -28,6 +42,11 @@ export class ProjectProjectStage extends models.Model {
         { id: 1, name: "Stage 1" },
         { id: 2, name: "Stage 2" },
     ];
+
+    _views = {
+        list: '<list><field name="name"/></list>',
+        form: '<form><field name="name"/></form>',
+    };
 }
 
 export class ProjectTask extends models.Model {

--- a/addons/project/static/tests/project_project_calendar.test.js
+++ b/addons/project/static/tests/project_project_calendar.test.js
@@ -1,0 +1,48 @@
+import { expect, test, describe } from "@odoo/hoot";
+import { mockDate, runAllTimers } from "@odoo/hoot-mock";
+import { click, queryAllTexts } from "@odoo/hoot-dom";
+
+import { mountView, onRpc } from "@web/../tests/web_test_helpers";
+
+import { defineProjectModels } from "./project_models";
+
+describe.current.tags("desktop");
+defineProjectModels();
+
+test("check 'Edit' and 'View Tasks' buttons are in Project Calendar Popover", async () => {
+    mockDate("2024-01-03 12:00:00", 0);
+    onRpc(({ method, model, args }) => {
+        if (method === "get_formview_id") {
+            expect(model).toBe("project.project");
+            expect(args[0]).toEqual([1]);
+            expect.step("Edit");
+            return false;
+        } else if (model === "project.project" && method === "action_view_tasks") {
+            expect.step("view tasks");
+            return false;
+        } else if (method === "has_access") {
+            return true;
+        }
+    });
+
+    await mountView({
+        resModel: "project.project",
+        type: "calendar",
+        arch: `
+            <calendar date_start="date_start" mode="week" js_class="project_project_calendar">
+                <field name="name"/>
+            </calendar>
+        `,
+    });
+
+    expect(".fc-event-main").toHaveCount(1);
+    await click(".fc-event-main");
+    await runAllTimers();
+    expect(".o_popover").toHaveCount(1);
+    expect(".o_popover .card-footer .btn").toHaveCount(3);
+    expect(queryAllTexts(".o_popover .card-footer .btn")).toEqual(["Edit", "View Tasks", "Delete"]);
+
+    await click(".o_popover .card-footer a:contains(View Tasks)");
+    await click(".o_popover .card-footer a:contains(Edit)");
+    expect.verifySteps(["view tasks", "Edit"]);
+});


### PR DESCRIPTION
- Add a `View Tasks` secondary button to the project calendar popover to open associated tasks.

task-4244705

ENT PR: https://github.com/odoo/enterprise/pull/71840
