### PR TITLE
[FIX] html_editor: traceback when pressing back button after selection

### DIFF
--- a/addons/html_editor/static/src/core/overlay.js
+++ b/addons/html_editor/static/src/core/overlay.js
@@ -18,6 +18,7 @@ export class EditorOverlay extends Component {
         getContainer: Function,
         history: Object,
         close: Function,
+        isOverlayOpen: Function,
 
         // Props from createOverlay
         positionOptions: { type: Object, optional: true },
@@ -91,7 +92,7 @@ export class EditorOverlay extends Component {
     getSelectionTarget() {
         const doc = this.props.editable.ownerDocument;
         const selection = doc.getSelection();
-        if (!selection || !selection.rangeCount) {
+        if (!selection || !selection.rangeCount || !this.props.isOverlayOpen()) {
             return null;
         }
         const inEditable = this.props.editable.contains(selection.anchorNode);

--- a/addons/html_editor/static/src/core/overlay_plugin.js
+++ b/addons/html_editor/static/src/core/overlay_plugin.js
@@ -110,6 +110,7 @@ export class Overlay {
                     bus: this.bus,
                     getContainer: this.getContainer,
                     close: this.close.bind(this),
+                    isOverlayOpen: this.isOverlayOpen.bind(this),
                     history: {
                         enableObserver: this.plugin.dependencies.history.enableObserver,
                         disableObserver: this.plugin.dependencies.history.disableObserver,
@@ -127,6 +128,10 @@ export class Overlay {
         if (this._remove) {
             this._remove();
         }
+    }
+
+    isOverlayOpen() {
+        return this.isOpen;
     }
 
     updatePosition() {


### PR DESCRIPTION
Steps to Reproduce:

1. Navigate to the To-do section and create a new task.
2. Enter text.
3. Select the text and press the back button to return to the Dashboard.
4. A traceback occurs.

Description of the issue/feature this PR addresses:

Pressing back button to return Dashboard kept the toolbar open due to an active selection. This caused the editor to search for the selection target using `getSelectionTarget`, where `range.getBoundingClientRect()` returned zero. Before inserting an invisible character, the editor disabled observer and dispatched an event, but the editor was destroyed, resulting in a traceback.

Desired behavior after PR is merged:

Returning to the Dashboard on pressing back no longer triggers a traceback.

task-4240335