### PR TITLE
[FIX] website: passing correct parent_id

### DIFF
--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -122,13 +122,16 @@ class Menu(models.Model):
                 continue
             else:
                 # create for every site
-                w_vals = [dict(vals, **{
-                    'website_id': website.id,
-                    'parent_id': website.menu_id.id,
-                }) for website in self.env['website'].search([])]
+                default_menu = self.env.ref('website.main_menu', raise_if_not_found=False)
+                w_vals = [
+                    dict(vals, **{
+                        'website_id': website.id,
+                        **({'parent_id': website.menu_id.id} if 'website_id' in vals or vals.get('parent_id') == default_menu.id else {}),
+                    })
+                    for website in self.env['website'].search([])
+                ]
                 new_menu = super().create(w_vals)[-1:]  # take the last one
                 # if creating a default menu, we should also save it as such
-                default_menu = self.env.ref('website.main_menu', raise_if_not_found=False)
                 if default_menu and vals.get('parent_id') == default_menu.id:
                     new_menu = super().create(vals)
                 menus |= new_menu


### PR DESCRIPTION
**Step to reproduce:**

- Have a database with only website module installed --> Turn On the developer mode.
- Go to Configuration ---> Menus
- Create a Menu ( here shra-main) and a child menu ( here shra-child) in that .
- Upon saving the following behavior is observed : that the child menu is converted to the main menu .

**Issue:**

Before this commit, when we create child menu for single website then it takes `website.menu_id.id` as `parent_id`. Which is wrong because it gives the `parent_id` of websites top menu.

**Solution:**

With this commit, we have passed correct `parent_id` from `vals` to solve this issue.

task-4231974
