### PR TITLE
[FIX] web: compute containing block layout in position hook

### DIFF
--- a/addons/web/static/src/core/position_hook.js
+++ b/addons/web/static/src/core/position_hook.js
@@ -188,8 +188,8 @@ function getBestPosition(reference, popper, { container, margin, position }) {
             // viewport). It can be done like that because the style top and
             // left were reset to 0px in `reposition`
             // https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block
-            top: positioning.top - popBox.top,
-            left: positioning.left - popBox.left,
+            top: Math.max(positioning.top - popBox.top, 0),
+            left: Math.max(positioning.left - popBox.left, 0),
             direction: DIRECTIONS[d],
             variant: VARIANTS[v],
         };


### PR DESCRIPTION
How to reproduce:
- go to Project menu
- in the control panel click on "Group By" > click on "Status"
- click on button Manage (3 vertical dots) on project record

Current behavior:
- the dropdown is not correctly positioned, because positioning.left has negative value

![Screenshot from 2024-10-14 12-06-34](https://github.com/user-attachments/assets/10ae813b-810e-43d0-ad47-e927868682c1)


Expected behavior:
- the dropdown should be positioned around the button
![Screenshot from 2024-10-14 12-06-51](https://github.com/user-attachments/assets/3d34ec98-ce8b-46dc-a5ae-a6c37182dc25)


Fix:
if `top` and `left` are negative, return 0





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
