### PR TITLE
[FIX] html_editor: consistent working of toolbar dropdown

### DIFF
--- a/addons/html_editor/static/src/main/chatgpt/language_selector.xml
+++ b/addons/html_editor/static/src/main/chatgpt/language_selector.xml
@@ -13,8 +13,8 @@
             </button>
             <t t-set-slot="content">
                 <t t-foreach="state.languages" t-as="language" t-key="language[0]">
-                    <DropdownItem onSelected="() => this.onSelected(language[1])">
-                        <div class="user-select-none lang" t-esc="language[1]"/>
+                    <DropdownItem class="'user-select-none'" onSelected="() => this.onSelected(language[1])">
+                        <div class="lang" t-esc="language[1]"/>
                     </DropdownItem>
                 </t>
             </t>

--- a/addons/html_editor/static/src/main/font/font_selector.xml
+++ b/addons/html_editor/static/src/main/font/font_selector.xml
@@ -6,8 +6,8 @@
             </button>
             <t t-set-slot="content">
                 <t t-foreach="items" t-as="item" t-key="item_index">
-                    <DropdownItem onSelected="() => this.onSelected(item)">
-                        <div class="user-select-none" t-esc="item.name"/>
+                    <DropdownItem class="'user-select-none'" onSelected="() => this.onSelected(item)">
+                        <t t-esc="item.name"/>
                     </DropdownItem>
                 </t>
             </t>

--- a/addons/html_editor/static/src/main/media/image_padding.xml
+++ b/addons/html_editor/static/src/main/media/image_padding.xml
@@ -4,8 +4,8 @@
             <button t-att-title="props.title" class="btn btn-light fa fa-plus-square-o"> </button>
             <t t-set-slot="content">
                 <t t-foreach="this.paddings" t-as="padding" t-key="padding">
-                    <DropdownItem onSelected="() => this.onSelected(padding)">
-                        <div class="user-select-none" t-esc="padding"/>
+                    <DropdownItem class="'user-select-none'" onSelected="() => this.onSelected(padding)">
+                        <t t-esc="padding"/>
                     </DropdownItem>
                 </t>
             </t>

--- a/addons/html_editor/static/src/utils/formatting.js
+++ b/addons/html_editor/static/src/utils/formatting.js
@@ -19,6 +19,7 @@ export const FONT_SIZE_CLASSES = [
     "h6-fs",
     "base-fs",
     "small",
+    "o_small-fs",
 ];
 
 export const TEXT_STYLE_CLASSES = ["display-1", "display-2", "display-3", "display-4", "lead"];

--- a/addons/html_editor/static/tests/image.test.js
+++ b/addons/html_editor/static/tests/image.test.js
@@ -205,34 +205,34 @@ test("Can change the padding of an image", async () => {
 
     await click(".o-we-toolbar div[name='image_padding'] button");
     await animationFrame();
-    await click(".o_popover div:contains('Small')");
+    await click(".o_popover span:contains('Small')");
     await animationFrame();
     expect("img").toHaveClass("p-1");
 
     await click(".o-we-toolbar div[name='image_padding'] button");
     await animationFrame();
-    await click(".o_popover div:contains('Medium')");
+    await click(".o_popover span:contains('Medium')");
     await animationFrame();
     expect("img").not.toHaveClass("p-1");
     expect("img").toHaveClass("p-2");
 
     await click(".o-we-toolbar div[name='image_padding'] button");
     await animationFrame();
-    await click(".o_popover div:contains('Large')");
+    await click(".o_popover span:contains('Large')");
     await animationFrame();
     expect("img").not.toHaveClass("p-2");
     expect("img").toHaveClass("p-3");
 
     await click(".o-we-toolbar div[name='image_padding'] button");
     await animationFrame();
-    await click(".o_popover div:contains('XL')");
+    await click(".o_popover span:contains('XL')");
     await animationFrame();
     expect("img").not.toHaveClass("p-3");
     expect("img").toHaveClass("p-5");
 
     await click(".o-we-toolbar div[name='image_padding'] button");
     await animationFrame();
-    await click(".o_popover div:contains('None')");
+    await click(".o_popover span:contains('None')");
     await animationFrame();
     expect("img").not.toHaveClass("p-5");
 });
@@ -246,7 +246,7 @@ test("Can undo the image padding", async () => {
 
     await click(".o-we-toolbar div[name='image_padding'] button");
     await animationFrame();
-    await click(".o_popover div:contains('Small')");
+    await click(".o_popover span:contains('Small')");
     await animationFrame();
     expect("img").toHaveClass("p-1");
 

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -268,6 +268,11 @@ test("toolbar works: can select font size", async () => {
     await contains(`.o_font_selector_menu .dropdown-item:contains('${h1Size}')`).click();
     expect(getContent(el)).toBe(`<p><span class="h1-fs">[test]</span></p>`);
     expect(".o-we-toolbar [name='font-size']").toHaveText(h1Size);
+    await contains(".o-we-toolbar [name='font-size'] .dropdown-toggle").click();
+    const oSmallSize = getFontSizeFromVar("small-font-size").toString();
+    await contains(`.o_font_selector_menu .dropdown-item:contains('${oSmallSize}')`).click();
+    expect(getContent(el)).toBe(`<p><span class="o_small-fs">[test]</span></p>`);
+    expect(".o-we-toolbar [name='font-size']").toHaveText(oSmallSize);
 });
 
 test.tags("desktop")("toolbar should not open on keypress tab inside table", async () => {


### PR DESCRIPTION
Description of the issue this PR addresses:

Current behavior before PR:

Clicking near the edge of a toolbar dropdown item would not work. This occurred because the `user-select-none` class was applied to the child element rather than the dropdown item itself, causing `onSelectionChange` to be triggered, followed by `updateToolbarVisibility` closing the toolbar.

Desired behavior after PR is merged:

The `user-select-none` class is now applied directly to the dropdown item, preventing `updateToolbarVisibility` from closing the toolbar when clicking near the edges of dropdown items.

task-4241028

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
