### PR TITLE
[FIX] maintenance: display lots

### DIFF
--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -373,7 +373,7 @@
                         <button type="object"
                             name="action_open_matched_serial"
                             icon="fa-bars" class="oe_stat_button"
-                            invisible="not match_serial">
+                            invisible="not match_serial"> <!-- The button must stay invisible without stock module -->
                             <field string="Serial Number" name="serial_no" widget="statinfo"/>
                         </button>
                         <button name="%(hr_equipment_request_action_from_equipment)d"


### PR DESCRIPTION
Commit [1] is using models and data from `stock` module but
`maintenance` does not depend on this one. A bridge would not be a
solution on stable, since existing DBs that have both `stock` and
`maintenance` would just lose the feature (the bridge would not be
auto-installed)

[1] https://github.com/odoo-dev/odoo/commit/1f2a5806b832529bd2ec53a878991e04800079bf

sentry-5964505411