### PR TITLE
[FIX] website_sale: update product href on search query change

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -408,10 +408,10 @@
         </t>
     </template>
 
-    <!-- Add the fiscal position in the t-cache key after all overrides -->
+    <!-- Add the fiscal position & keep() in the t-cache key after all overrides -->
     <template id="products_fiscal_position" inherit_id="website_sale.products" priority="99">
         <xpath expr="//div[starts-with(@t-cache, 'pricelist,products')]" position="attributes">
-            <attribute name="t-cache" add="fiscal_position_id" separator=","/>
+            <attribute name="t-cache" add="fiscal_position_id,keep()" separator=","/>
         </xpath>
     </template>
 


### PR DESCRIPTION
Versions
--------
- 16.0

Steps
-----
### Example 1:
1. Ensure database isn't running with developer mode enabled;
2. go to product overview on website;
3. enter edit mode;
4. click on product image;
5. enable datepicker;
6. save & close editor;
7. pick dates in datepicker;
8. pick new dates;
9. click on product.

### Example 2:
1. Change max price from $4000 to $3000;
2. click on product;
3. go back to shop search results via breadcrumb.

Issue
-----
### Example 1:
The product's URL wasn't updated for the new dates, so the product page is still showing the previous ones.

### Example 2:
The max price search parameter was reset to $4000.

Cause
-----
The `t-cache` directive used in eCommerce templates prevents Product nodes from updating after a search parameter change, e.g. datepicker or max price, unless the product ids displayed also change. This is because changes in the search query parameters aren't being taken into account by the cache key, even though they ought to be included in the product links.

Solution
--------
Because `t-cache` was causing several issues in eCommerce, commit odoo/odoo@540872d removed it for 17.0+, but it's still present in 16.0.

Instead we can resolve this by adding `keep()` to the `t-cache` key. This function is used to create `href` values for products based on the current URL, i.e. if a different `href` would be generated, the template engine should now re-render the products with updated links as expected.

This is done in the `product_fiscal_position` template, which adds `fiscal_position_id` to the cache key with late priority, in order to minimize potential conflicts with custom templates.

opw-4167464