### PR TITLE
[FIX] stock: prevent wrong delivery address in delivery slip

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -739,7 +739,7 @@ class Picking(models.Model):
             if picking_id:
                 moves = self.env['stock.move'].search([('picking_id', '=', picking_id)])
                 for move in moves:
-                    move.write({'partner_id': picking.partner_id.id})
+                    move.partner_id = picking.partner_id.id
 
     @api.onchange('picking_type_id', 'partner_id')
     def _onchange_picking_type(self):


### PR DESCRIPTION
When creating a transfer, if a partner is selected and changed without saving, the delivery slip incorrectly displays the address of the initial partner.

**Steps to reproduce:**

1. Navigate to Inventory.
2. Go to Operations -> Transfers.
3. Create a new transfer.
4. Select a contact and a transfer type.
5. Add an item.
6. Change the contact.
7. Print the delivery slip; **all this should be done without clicking on save**.

The delivery slip will incorrectly display the address of the first selected contact.

opw-4237398

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
