### PR TITLE
[FIX] point_of_sale: show line price without discount on receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.xml
@@ -21,7 +21,7 @@
                     </t>
                 </li>
                 <li t-if="line.price !== 0 and line.discount and line.discount !== '0'">
-                    With a <em><t t-esc="line.discount" />% </em> discount
+                    <t t-esc="line.price_without_discount"/> With a <em><t t-esc="line.discount" />% </em> discount
                 </li>
                 <t t-slot="default" />
                 <li t-if="line.customerNote" class="customer-note w-100 p-2 my-1 rounded text-break text-bg-warning text-warning bg-opacity-25">

--- a/addons/point_of_sale/static/tests/tours/ReceiptScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/ReceiptScreen.tour.js
@@ -77,6 +77,20 @@ registry.category("web_tour.tours").add("ReceiptScreenTour", {
             PaymentScreen.clickValidate(),
             Order.hasLine({ customerNote: "Test customer note" }),
             ReceiptScreen.clickNextOrder(),
+
+            // Test discount and original price
+            ProductScreen.addOrderline("Desk Pad", "2", "10"),
+            ProductScreen.pressNumpad("% Disc"),
+            ProductScreen.modeIsActive("% Disc"),
+            ProductScreen.pressNumpad("5", "."),
+            ProductScreen.selectedOrderlineHas("Desk Pad", "2", "19"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.receiptIsThere(),
+            Order.hasLine({ productName: "Desk Pad", priceNoDiscount: "10" }),
+            ReceiptScreen.totalAmountContains("19.00"),
+            ReceiptScreen.clickNextOrder(),
         ].flat(),
 });
 

--- a/addons/point_of_sale/static/tests/tours/helpers/generic_components/OrderWidgetMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/generic_components/OrderWidgetMethods.js
@@ -31,7 +31,8 @@ export function hasLine({
     comboParent,
     discount,
     oldPrice,
-    atts
+    priceNoDiscount,
+    atts,
 } = {}) {
     let trigger = `.order-container .orderline${withClass}`;
     if (withoutClass) {
@@ -61,8 +62,13 @@ export function hasLine({
     if (oldPrice) {
         trigger += `:has(.info-list .price-per-unit s:contains("${oldPrice}"))`;
     }
-    if(atts) {
-        trigger += Object.entries(atts).map(([key, value]) =>  `:has(.info-list div:contains("${key}: ${value}"))`).join();
+    if (priceNoDiscount) {
+        trigger += `:has(.info-list:contains("${priceNoDiscount}"))`;
+    }
+    if (atts) {
+        trigger += Object.entries(atts)
+            .map(([key, value]) => `:has(.info-list div:contains("${key}: ${value}"))`)
+            .join();
     }
     const args = JSON.stringify(arguments[0]);
     return [


### PR DESCRIPTION
Currently, when a discount is applied on a specific pos order line, the receipt does not reflect the original price of the article.

Steps to reproduce:
-------------------
* Open shop session
* Add any product to the order
* Apply a discount on that order line
* Validate and pay order
> Observation: The original price of the order is not reflected

Why the fix:
------------
We now show the original price, without the discount, on the receipt.

opw-4179118


Before:
---------
![image](https://github.com/user-attachments/assets/52af13bc-5557-4ca2-93d2-ac5c035d51e1)

After:
-------
![image](https://github.com/user-attachments/assets/302be07b-cf11-4a4a-be2b-a4f1755e84de)
