### PR TITLE
[FIX] analytic: prevent incorrect xpath in studio Analytic Line

### DIFF
--- a/addons/analytic/models/analytic_line.py
+++ b/addons/analytic/models/analytic_line.py
@@ -107,7 +107,7 @@ class AccountAnalyticLine(models.Model):
 
     def _get_view(self, view_id=None, view_type='form', **options):
         arch, view = super()._get_view(view_id, view_type, **options)
-        if self.env['account.analytic.plan'].check_access_rights('read', raise_exception=False):
+        if not self._context.get("studio") and self.env['account.analytic.plan'].check_access_rights('read', raise_exception=False):
             project_plan, other_plans = self.env['account.analytic.plan']._get_all_plans()
 
             # Find main account nodes
@@ -131,7 +131,7 @@ class AccountAnalyticLine(models.Model):
     @api.model
     def fields_get(self, allfields=None, attributes=None):
         fields = super().fields_get(allfields, attributes)
-        if self.env['account.analytic.plan'].check_access_rights('read', raise_exception=False):
+        if not self._context.get("studio") and self.env['account.analytic.plan'].check_access_rights('read', raise_exception=False):
             project_plan, other_plans = self.env['account.analytic.plan']._get_all_plans()
             for plan in project_plan + other_plans:
                 fname = plan._column_name()


### PR DESCRIPTION
Steps to reproduce
==================

- Install web_studio,account_accountant
- Enable Analytic accounts in Accounting
- Navigate to Accounting > Analytic items
- Open studio
- Toggle show invisible
- Edit the label of the last column

=> Xpath `/tree/field[17]` has no match

Cause of the issue
==================

- x_plan_* fields are dynamically added in get_views
- Studio receives those fields and expect them to be part of the original arch. It assigns xpaths to them
- When making an edit, studio create an inheriting view that is applied before the x_plan fields are added. => Xpaths do not match

Solution
========

When in studio, don't add x_plan_* fields

opw-4210657