### PR TITLE
[FIX] sale: take total_amount_currency instead of amount_total from tax_totals

### DIFF
--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -185,17 +185,13 @@ class AccountMove(models.Model):
             exclude_amount += order_amount_company
         return exclude_amount
 
+    # todo need to remove both the field and compute method in master as this field is neither used in python nor in XML
     @api.depends('line_ids.sale_line_ids.order_id', 'currency_id', 'tax_totals', 'date')
     def _compute_partner_credit(self):
         super()._compute_partner_credit()
         for move in self.filtered(lambda m: m.is_invoice(include_receipts=True)):
             sale_orders = move.line_ids.sale_line_ids.order_id
-            amount_total_currency = move.currency_id._convert(
-                move.tax_totals['amount_total'],
-                move.company_currency_id,
-                move.company_id,
-                move.date
-            )
+            amount_total_currency = move.tax_totals['total_amount_currency']
             amount_to_invoice_currency = sum(
                 sale_order.currency_id._convert(
                     sale_order.amount_to_invoice,


### PR DESCRIPTION
Currently, a traceback occurs when the user tries to add the `partner_credit`
 field to the form view of the `account.move` through the studio.

Error:- 
```
KeyError: 'amount_total'
```

This error is occurring because the `amount_total` was removed from the
`tax_taotals` from the commit [1].

A major refactor was done to compute the tax_totals from [1]

[1]
https://github.com/odoo/odoo/commit/d0e7be7832672d476f1b289af52d3a425990d719

We can resolve this issue by taking the `total_amount_currency` from tax_totals

Note:- 
However, the actual problem was the field and the compute method itself.

Initially the field `partner_credit` was used for building the warning 
from [2]

[2]
https://github.com/odoo/odoo/commit/7bd93cc64b582cdd559a6b6f855c1950a992df68#diff-1e3bd6be3bfb83a37ec9fb800ce8b1c95afe0be90ff792874ae7299c320a2f6eR1383

But later it was removed from the commit [3]

[3]
https://github.com/odoo/odoo/pull/126575/commits/32954ca0ae54752073c7b5ae46793d1f2e34f0d1#diff-1e3bd6be3bfb83a37ec9fb800ce8b1c95afe0be90ff792874ae7299c320a2f6eL1416

So the field `partner_credit` was neither used in the Python side nor used in the 
XML side also. which is completely dead code and has never been executed.

We should remove both the field and compute method in the master

sentry-5987829118

