### PR TITLE
[FIX] web_editor: fix preview of custom newsletter popup

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -9447,7 +9447,7 @@ registry.SnippetSave = SnippetOptionWidget.extend({
                     this.trigger_up('context_get', {
                         callback: ctx => context = ctx,
                     });
-                    if (this.$target[0].matches("[data-snippet=s_popup]")) {
+                    if (this.$target[0].matches(".s_popup")) {
                         // Do not "cleanForSave" the popup before copying the
                         // HTML, otherwise the popup will be saved invisible and
                         // therefore not visible in the "add snippet" dialog.


### PR DESCRIPTION
Steps to Reproduce : 

1. Go to Website --> Drop a newsletter popup snippet
2. Saved the snippet for later use
3. Drag and drop the Custom Category snippet -> In that you will find no preview of the Newsletter pop-up.

Prior to this fix, to prevent pop-up snippets (like the newsletter) from becoming invisible, we saved the element before invoking cleanForSave. However, this approach specifically targeted the standard pop-up (not newsletter popup) snippet only.

With this commit, we adapt the condition to target the newsletter and other pop-up snippets, ensuring proper visibility across all popup types during snippet previews.

task-4251878
