### PR TITLE
[FIX] point_of_sale: tb when try to print bill from actions

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1437,7 +1437,9 @@ export class PosStore extends Reactive {
             { webPrintFallback: true }
         );
         const nbrPrint = order.nb_print;
-        await this.data.write("pos.order", [order.id], { nb_print: nbrPrint + 1 });
+        if (typeof order.id !== "string") {
+            await this.data.write("pos.order", [order.id], { nb_print: nbrPrint + 1 });
+        }
         return true;
     }
     getOrderChanges(skipped = false, order = this.get_order()) {


### PR DESCRIPTION
Steps to reproduce :
--------------------------
- Install the pos_restaurant module.
- Open session and add something to order.
- Don't order them and try to print the bill.

Issue :
--------
- There will be a traceback as it was trying to update order at backend.

Cause :
---------
- The order is still draft and have string_id so we can't update it.

Fix :
------
- Only update if order is created at backend and have integer id.
