### PR TITLE
[FIX] website: fix scroll top button without copyright

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1463,6 +1463,12 @@ span.list-inline-item.o_add_language:last-child {
     #o_footer_scrolltop_wrapper {
         position: relative;
         z-index: 1;
+
+        &:last-child {
+            height: 3rem !important;
+            margin-top: -3rem;
+            margin-bottom: 1rem;
+        }
     }
     #o_footer_scrolltop {
         $-footer-color: o-color('footer-custom') or o-color('footer') or rgba(0, 0, 0, 0);


### PR DESCRIPTION
Steps to reproduce the bug:

- In website dit mode.
- Click on the footer.
- Enable the "Scroll Top Button" option for the footer.
- Disable the "Copyright" option for the footer.
- Bug: There is a white space below the footer.

task-4208475