### PR TITLE
[IMP] mrp_account: add smart button for WIP journal entry to MO view

### DIFF
--- a/addons/mrp_account/models/account_move.py
+++ b/addons/mrp_account/models/account_move.py
@@ -10,7 +10,7 @@ class AccountMove(models.Model):
     _inherit = 'account.move'
 
     wip_production_ids = fields.Many2many(
-        'mrp.production', string="Relevant WIP MOs",
+        'mrp.production', 'wip_move_production_rel', 'move_id', 'production_id', string="Relevant WIP MOs",
         help="The MOs that this WIP entry was based on. Expected to be set at time of WIP entry creation.")
     wip_production_count = fields.Integer("Manufacturing Orders Count", compute='_compute_wip_production_count')
 

--- a/addons/mrp_account/views/mrp_production_views.xml
+++ b/addons/mrp_account/views/mrp_production_views.xml
@@ -18,6 +18,13 @@
                         </div>
                     </button>
                 </t>
+                <button name="action_view_move_wip" type="object" class="oe_stat_button" icon="fa-book"
+                        groups="account.group_account_user" invisible="wip_move_count == 0">
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_value"><field name="wip_move_count"/></span>
+                        <span class="o_stat_text">WIP</span>
+                    </div>
+                </button>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Adds a smart button to manufacturing order views to view the corresponding WIP journal entries, mirroring the function of the smart button in journal entries.

Task ID: [4286477](https://www.odoo.com/odoo/966/tasks/4286477)