### PR TITLE
[FIX] hr_recruitment: prevent error when refusing duplicate application

### DIFF
--- a/addons/hr_recruitment/wizard/applicant_refuse_reason.py
+++ b/addons/hr_recruitment/wizard/applicant_refuse_reason.py
@@ -72,8 +72,10 @@ class ApplicantGetRefuseReason(models.TransientModel):
 
         refused_applications = self.applicant_ids
         if self.duplicates_count and self.duplicates:
-            duplicate_domain = self.applicant_ids._get_similar_applicants_domain()
-            duplicate_domain = expression.AND([duplicate_domain, [('application_status', '!=', 'refused')]])
+            duplicate_domain = expression.AND([
+                [('candidate_id', 'any', self.applicant_ids.candidate_id._get_similar_candidates_domain())],
+                [('application_status', '!=', 'refused')]
+            ])
             duplicates_ids = self.env['hr.applicant'].search(duplicate_domain)
             refused_applications |= duplicates_ids
             refuse_bodies = {}


### PR DESCRIPTION
When the user refuses the application with its duplicate application,
a traceback will appear.

Steps to reproduce the error:
- Go to Recruitment > All Applications >
  Create 2 applications with the same candidate
- Open that application > Refuse > Select refuse reason >
  Select other Duplicate application > Refuse

Traceback:
```
AttributeError: 'hr.applicant' object has no attribute '_get_similar_applicants_domain'
  File "odoo/http.py", line 2364, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1891, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1954, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 137, in retrying
    result = func()
  File "odoo/http.py", line 1921, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2168, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 330, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 728, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 40, in call_button
    action = call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 517, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/hr_recruitment/wizard/applicant_refuse_reason.py", line 75, in action_refuse_reason_apply
    duplicate_domain = self.applicant_ids._get_similar_applicants_domain()
```

https://github.com/odoo/odoo/blob/e4a4806e5c58c599815204a73c78a228ee230613/addons/hr_recruitment/wizard/applicant_refuse_reason.py#L75
``_get_similar_applicants_domain`` method is removed in this commit 9359d08d331beac389fde0e6c82c895341f7dbc5 but still used here.
So, it will lead to the above traceback.

sentry-5986653915

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
