### PR TITLE
[FIX] pos_self_order: prevent multiple payment page renders

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.js
+++ b/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.js
@@ -1,4 +1,4 @@
-import { Component, onWillStart, onWillUnmount, useState } from "@odoo/owl";
+import { Component, onMounted, onWillUnmount, useState } from "@odoo/owl";
 import { useSelfOrder } from "@pos_self_order/app/self_order_service";
 import { rpc } from "@web/core/network/rpc";
 import { useService } from "@web/core/utils/hooks";
@@ -17,14 +17,14 @@ export class PaymentPage extends Component {
             paymentMethodId: null,
         });
 
-        onWillUnmount(() => {
-            this.selfOrder.paymentError = false;
-        });
-
-        onWillStart(async () => {
+        onMounted(() => {
             if (this.selfOrder.models["pos.payment.method"].length === 1) {
                 this.selectMethod(this.selfOrder.models["pos.payment.method"].getFirst().id);
             }
+        });
+
+        onWillUnmount(() => {
+            this.selfOrder.paymentError = false;
         });
     }
 


### PR DESCRIPTION
Before this commit:
===================
The payment page was being rendered multiple times due to the `onWillStart` method triggering the `startPayment` method multiple times. This led to multiple requests being sent to the Razorpay terminal for the same order.

After this commit:
==================
Replaced `onWillStart` with `onMounted` to initiate the `startPayment` method. This prevents duplicate requests to the Razorpay terminal for the same order, ensuring the payment process is handled efficiently.

Task- 4254682
