### PR TITLE
[FIX] website_slides: fix nondeterministic failure of fullscreen tour

### DIFF
--- a/addons/website_slides/static/tests/tours/slides_full_screen_web_editor.js
+++ b/addons/website_slides/static/tests/tours/slides_full_screen_web_editor.js
@@ -26,7 +26,7 @@ registerWebsitePreviewTour('full_screen_web_editor', {
     // click on a slide to open the fullscreen view
     trigger: ':iframe a.o_wslides_js_slides_list_slide_link:contains("Home Gardening")',
     run: "click",
-}, stepUtils.waitIframeIsReady(), {
+}, {
     // check we land on the fullscreen view
     trigger: ':iframe .o_wslides_fs_main',
 },

--- a/addons/website_slides/static/tests/tours/slides_full_screen_web_editor.js
+++ b/addons/website_slides/static/tests/tours/slides_full_screen_web_editor.js
@@ -24,7 +24,7 @@ registerWebsitePreviewTour('full_screen_web_editor', {
     run: "click",
 }, {
     // click on a slide to open the fullscreen view
-    trigger: ':iframe a.o_wslides_js_slides_list_slide_link:contains("Home Gardening")',
+    trigger: ':iframe a.o_wslides_js_slides_list_slide_link:contains("Home Gardening")[href*="fullscreen=1"]',
     run: "click",
 }, {
     // check we land on the fullscreen view


### PR DESCRIPTION
The tour "full_screen_web_editor" is failing randomly on the runbot because the
step that clicks on the "Home Gardening" slide doesn't open it in fullscreen
(as seen in a screenshot of a failing runbot). It is very likely because the
fullscreen parameter on the "Home Gardening" link is added afterward in
javascript and is not yet present when it is clicked in the test
(see function _updateHref of websiteSlidesCourseSlidesList widget).

To solve the problem we change the selector that clicks on the "Home Gardening"
link to ensure the fullscreen parameter is present in the link.

Task-4222573