### PR TITLE
[FIX] pos_self_order: prevent websocket to prematuraly close

### DIFF
--- a/addons/pos_self_order/controllers/self_entry.py
+++ b/addons/pos_self_order/controllers/self_entry.py
@@ -58,6 +58,7 @@ class PosSelfKiosk(http.Controller):
                             **pos_config._get_self_ordering_data(),
                         },
                         "base_url": request.env['pos.session'].get_base_url(),
+                        "db": request.env.cr.dbname,
                     }
                 }
             )


### PR DESCRIPTION
To reproduce (17.0 and >):
1. Install PoS
2. Open a restaurant session = S1
3. Open the same restaurant session in another browser session (e.g: private navigation) = S2
4. Make an order from S2 -> The order sync on S1 (thanks to websockets) => OK!
5. On another tab of S1, go to Settings > Self-Ordering / Preview Web interface
6. Make an order from S2 -> The order DO NOT sync from S2 => Not Ok

Note: in practice, it goes beyond than just order not syncing, any previous websockets interaction will fail which includes:
- some payment method callback (Adyen, Vivawallet)
- IoT printing requests
- chatter messages ...

Reasons of the issue:
The issue happen as the websocket use a shared workers and certain operation (like here opening self-order), will interupt the current websocket to open a new one on which previously subscribed channel will be missing (explaining why the PoS session won't sync orders).

The shared worker decided to interupt the previous websocket and create a new one as the "db" information was missing from the `session_info`, see:
https://github.com/odoo/odoo/blob/dfdea9704a13c259cc1d49d6bd3a3fa4d93307b6/addons/bus/static/src/workers/websocket_worker.js#L257

After this commit:
PoS orders continue to sync even if the kiosk view is opened on the same browser session

opw-4233060