### PR TITLE
[FIX] pos_restaurant: floating order still displayed after payment

### DIFF
--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
@@ -362,10 +362,7 @@ export class FloorScreen extends Component {
     }
     async onWillStart() {
         this.pos.searchProductWord = "";
-        const table = this.pos.selectedTable;
-        if (table) {
-            await this.pos.unsetTable();
-        }
+        await this.pos.unsetTable();
     }
     get floorBackround() {
         return this.activeFloor.floor_background_image

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -69,6 +69,8 @@ registry.category("web_tour.tours").add("pos_restaurant_sync", {
             ProductScreen.clickDisplayedProduct("Coca-Cola"),
             ProductScreen.clickDisplayedProduct("Coca-Cola"),
             Chrome.clickPlanButton(),
+            // Check if there is no active Order
+            Chrome.activeTableOrOrderIs("Table"),
 
             // Create first order
             FloorScreen.clickTable("5"),
@@ -109,6 +111,8 @@ registry.category("web_tour.tours").add("pos_restaurant_sync", {
                     "acknowledge printing error ( because we don't have printer in the test. )",
             },
             ReceiptScreen.clickNextOrder(),
+            // Check if there ids no active Order
+            Chrome.activeTableOrOrderIs("Table"),
 
             // order on another table with a product variant
             FloorScreen.orderCountSyncedInTableIs("5", "1"),


### PR DESCRIPTION

Steps:
- Open the restaurant.
- Create a floating order and validate it.
- Navigate to the floor screen.
- Floating order is still displayed.

Issue:
- Floating orders remain visible on the floor screen after payment.

Cause:
- The selected order does not reset when order has no assigned table.

Fix:
- Reset the selected order for all restaurant orders.


Task-4251902

