### PR TITLE
[FIX] core: avoid modifying shared fields

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -865,7 +865,7 @@ class IrModelFields(models.Model):
                 if field.state == 'manual' and field.ttype == 'many2many':
                     rel_name = field.relation_table or (is_model and model._fields[field.name].relation)
                     tables_to_drop.add(rel_name)
-            if field.state == 'manual' and is_model:
+            if is_model and (field.state == 'manual' or self._context.get(MODULE_UNINSTALL_FLAG)):
                 model._pop_field(field.name)
 
         if tables_to_drop:
@@ -2427,31 +2427,6 @@ class IrModelData(models.Model):
                 constraint_ids.append(data.res_id)
             else:
                 records_items.append((data.model, data.res_id))
-
-        # avoid prefetching fields that are going to be deleted: during uninstall, it is
-        # possible to perform a recompute (via flush) after the database columns have been
-        # deleted but before the new registry has been created, meaning the recompute will
-        # be executed on a stale registry, and if some of the data for executing the compute
-        # methods is not in cache it will be fetched, and fields that exist in the registry but not
-        # in the database will be prefetched, this will of course fail and prevent the uninstall.
-        has_shared_field = False
-        for ir_field in self.env['ir.model.fields'].browse(field_ids):
-            model = self.pool.get(ir_field.model)
-            if model is not None:
-                field = model._fields.get(ir_field.name)
-                if field is not None and field.prefetch:
-                    if field._toplevel:
-                        # the field is specific to this registry
-                        field.prefetch = False
-                    else:
-                        # the field is shared across registries; don't modify it
-                        Field = type(field)
-                        field_ = Field(_base_fields=[field, Field(prefetch=False)])
-                        self.env[ir_field.model]._add_field(ir_field.name, field_)
-                        field_.setup(model)
-                        has_shared_field = True
-        if has_shared_field:
-            lazy_property.reset_all(self.env.registry)
 
         # to collect external ids of records that cannot be deleted
         undeletable_ids = []

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -470,8 +470,7 @@ class IrModuleModule(models.Model):
         """
         modules_to_remove = self.mapped('name')
         self.env['ir.model.data']._module_data_uninstall(modules_to_remove)
-        # we deactivate prefetching to not try to read a column that has been deleted
-        self.with_context(prefetch_fields=False).write({'state': 'uninstalled', 'latest_version': False})
+        self.write({'state': 'uninstalled', 'latest_version': False})
         return True
 
     def _remove_copied_views(self):

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -778,6 +778,9 @@ class Field(MetaField('DummyField', (object,), {}), typing.Generic[T]):
                 try:
                     field = Model._fields[fname]
                 except KeyError:
+                    if registry.registry_invalidated:
+                        # the registry is modified and the field is popped
+                        break
                     raise ValueError(
                         f"Wrong @depends on '{self.compute}' (compute method of field {self}). "
                         f"Dependency field '{fname}' not found in model {model_name}."

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -596,19 +596,13 @@ class BaseModel(metaclass=MetaModel):
 
     @api.model
     def _pop_field(self, name):
-        """ Remove the field with the given ``name`` from the model.
-            This method should only be used for manual fields.
-        """
+        """ Remove the field with the given ``name`` from the model. """
         cls = self.env.registry[self._name]
         field = cls._fields.pop(name, None)
         discardattr(cls, name)
         if cls._rec_name == name:
             # fixup _rec_name and display_name's dependencies
             cls._rec_name = None
-            if cls.display_name in cls.pool.field_depends:
-                cls.pool.field_depends[cls.display_name] = tuple(
-                    dep for dep in cls.pool.field_depends[cls.display_name] if dep != name
-                )
         return field
 
     #


### PR DESCRIPTION
when a field object is not _toplevel, it may be shared with multiple registries and should be readonly in any case

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
