### PR TITLE
[FIX] mrp: update raw move quantity after creation

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2896,9 +2896,11 @@ class MrpProduction(models.Model):
             else:
                 entity.unlink()
         elif quantity > 0:
-            new_line = self._get_new_catalog_line_values(product_id, quantity, **kwargs)
-            command = Command.create(new_line)
+            new_line_vals = self._get_new_catalog_line_values(product_id, quantity, **kwargs)
+            command = Command.create(new_line_vals)
             self.write({child_field: [command]})
+            new_line = self[child_field].filtered(lambda mv: mv.product_id.id == product_id)[-1:]
+            self._update_catalog_line_quantity(new_line, quantity, **kwargs)
 
         return self.env['product.product'].browse(product_id).standard_price
 


### PR DESCRIPTION
When created through the catalog, updates the raw move after its creation, that way the logic is the same regardless the move is created or updated.
It fixes an issue in the Shop Floor where created raw move doesn't trigger the creation of the Pick Component operation when manufacture is in 2 steps.
See Enterprise PR for more information.

Enterprise PR: odoo/enterprise#71791