### PR TITLE
[FIX] account_peppol: wrong computation of the default send peppol ch…

### DIFF
--- a/addons/account_peppol/models/account_move.py
+++ b/addons/account_peppol/models/account_move.py
@@ -50,3 +50,11 @@ class AccountMove(models.Model):
                 move.peppol_move_state = False
             else:
                 move.peppol_move_state = move.peppol_move_state
+
+    def _is_peppol_enabled_by_default(self):
+        """ Tells if Peppol can be used by default on the move (the configuration is correct).
+        This is mainly used in account.move.send to preset checkboxes in the wizard, and defines the
+        behavior in automatic invoicing flows.
+        """
+        self.ensure_one()
+        return self.peppol_move_state == 'ready'

--- a/addons/account_peppol/wizard/account_move_send.py
+++ b/addons/account_peppol/wizard/account_move_send.py
@@ -39,7 +39,7 @@ class AccountMoveSend(models.TransientModel):
     @api.depends('enable_peppol')
     def _compute_checkbox_send_peppol(self):
         for wizard in self:
-            wizard.checkbox_send_peppol = wizard.enable_peppol and (not wizard.warnings or all('account_peppol' not in key for key in wizard.warnings))
+            wizard.checkbox_send_peppol = wizard.enable_peppol and any(move._is_peppol_enabled_by_default() for move in wizard.move_ids)
 
     def _compute_checkbox_send_mail(self):
         super()._compute_checkbox_send_mail()


### PR DESCRIPTION
…eckbox

The default value of the Peppol checkbox in the Print & Send wizard depends on the presence/absence of warnings. In [the refactoring of warnings][1], we broke the previous behavior.

We decided to show the warnings only when relevant, thus only when the checkbox is selected. Since the computation of the "checked" valued is based on the warnings, there is kind of a bad cyclic dependency. The warnings won't be set, therefore the checkbox will be checked on invoices where it shouldn't. This is particularly problematic for automatic flows.

It was a bad design to have a computation that depends on the warnings, both shouldn't be directly linked.

[1]: <https://github.com/odoo/odoo/commit/7dbcdd24cd3d8e0b6744847234a983f3361e296a>
task-no

