### PR TITLE
[FIX] hr_contract: do not split work entry on lunch for flexible hours

### DIFF
--- a/addons/hr_contract/models/hr_employee.py
+++ b/addons/hr_contract/models/hr_employee.py
@@ -231,12 +231,13 @@ class Employee(models.Model):
                 contract_start = datetime.combine(contract.date_start, time.min, employee_tz)
                 contract_end = datetime.combine(contract.date_end or date.max, time.max, employee_tz)
                 calendar = contract.resource_calendar_id or contract.company_id.resource_calendar_id
-                lunch_intervals = calendar._attendance_intervals_batch(
-                    max(start, contract_start),
-                    min(stop, contract_end),
-                    resources=self.resource_id,
-                    lunch=True)[self.resource_id.id]
-                duration_data = duration_data | lunch_intervals
+                if not calendar.flexible_hours:
+                    lunch_intervals = calendar._attendance_intervals_batch(
+                        max(start, contract_start),
+                        min(stop, contract_end),
+                        resources=self.resource_id,
+                        lunch=True)[self.resource_id.id]
+                    duration_data = duration_data | lunch_intervals
             return duration_data
 
     def _get_expected_attendances(self, date_from, date_to):


### PR DESCRIPTION
Steps
---
* Create a flexible hours working schedule
* Create a running contract for some employee that uses this schedule 
  * `work_entry_source = 'attendance'`
* Create an attendance overlapping lunch for the employee 
  * (e.g 10:00 -> 20:00)
* => 2 work entries are generated. But we want only one (10 - 20). 
  * 10 - 12 
  * 13 - 20 
