### PR TITLE
[IMP] point_of_sale: notify missing balance followup

### DIFF
--- a/addons/point_of_sale/models/__init__.py
+++ b/addons/point_of_sale/models/__init__.py
@@ -23,6 +23,7 @@ from . import product_combo_item
 from . import res_partner
 from . import res_company
 from . import res_config_settings
+from . import ir_module_module
 from . import stock_picking
 from . import stock_rule
 from . import stock_warehouse

--- a/addons/point_of_sale/models/ir_module_module.py
+++ b/addons/point_of_sale/models/ir_module_module.py
@@ -1,0 +1,21 @@
+from odoo import api, models
+
+
+class IrModuleModule(models.Model):
+    _inherit = 'ir.module.module'
+
+    @api.model
+    def _load_pos_data_fields(self):
+        return ['id', 'name', 'state']
+
+    @api.model
+    def _load_pos_data_domain(self):
+        return [('name', '=', 'pos_settle_due')]
+
+    def _load_pos_data(self, data):
+        domain = self._load_pos_data_domain()
+        fields = self._load_pos_data_fields()
+        return {
+            'data': self.search_read(domain, fields, load=False),
+            'fields': self._load_pos_data_fields(),
+        }

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -133,7 +133,7 @@ class PosSession(models.Model):
             'pos.category', 'pos.bill', 'res.company', 'account.tax', 'account.tax.group', 'product.product', 'product.attribute', 'product.attribute.custom.value',
             'product.template.attribute.line', 'product.template.attribute.value', 'product.combo', 'product.combo.item', 'product.packaging', 'res.users', 'res.partner',
             'decimal.precision', 'uom.uom', 'uom.category', 'res.country', 'res.country.state', 'res.lang', 'product.pricelist', 'product.pricelist.item', 'product.category',
-            'account.cash.rounding', 'account.fiscal.position', 'account.fiscal.position.tax', 'stock.picking.type', 'res.currency', 'pos.note', 'ir.ui.view']
+            'account.cash.rounding', 'account.fiscal.position', 'account.fiscal.position.tax', 'stock.picking.type', 'res.currency', 'pos.note', 'ir.ui.view', 'ir.module.module']
 
     @api.model
     def _load_pos_data_domain(self, data):

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -111,6 +111,19 @@ export class PaymentScreen extends Component {
         return this.currentOrder.get_selected_paymentline();
     }
     async addNewPaymentLine(paymentMethod) {
+        if (
+            paymentMethod.type === "pay_later" &&
+            (!this.currentOrder.to_invoice ||
+                this.pos.data["ir.module.module"].find((m) => m.name === "pos_settle_due")
+                    ?.state !== "installed")
+        ) {
+            this.notification.add(
+                _t(
+                    "To ensure due balance follow-up, generate an invoice or download the accounting application. "
+                ),
+                { autocloseDelay: 7000, title: _t("Warning") }
+            );
+        }
         if (this.pos.paymentTerminalInProgress && paymentMethod.use_payment_terminal) {
             this.dialog.add(AlertDialog, {
                 title: _t("Error"),


### PR DESCRIPTION
If a user uses the "customer account" payment method without having the `pos_settle_due` module installed or w\o invoicing the order, they will not be able to observe the due balance computation.

In this pr we add a notification that explains this to the user.

Task: 4251746

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
