### PR TITLE
[FIX] portal_rating: rating stats data is properly sent to frontend

### DIFF
--- a/addons/portal_rating/static/src/js/portal_chatter.js
+++ b/addons/portal_rating/static/src/js/portal_chatter.js
@@ -124,21 +124,22 @@ PortalChatter.include({
      * @private
      */
     _updateRatingCardValues: function (result) {
-        if (!result['rating_stats']) {
+        if (!result['messages'][0]?.rating_stats) {
             return;
         }
+        const ratingStats = result['messages'][0].rating_stats;
         const self = this;
         const ratingData = {
-            'avg': Math.round(result['rating_stats']['avg'] * 100) / 100,
+            'avg': Math.round(ratingStats['avg'] * 100) / 100,
             'percent': [],
         };
-        Object.keys(result["rating_stats"]["percent"])
+        Object.keys(ratingStats['percent'])
             .sort()
             .reverse()
             .forEach((rating) => {
                 ratingData["percent"].push({
                     num: self.roundToHalf(rating),
-                    percent: roundPrecision(result["rating_stats"]["percent"][rating], 0.01),
+                    percent: roundPrecision(ratingStats['percent'][rating], 0.01),
                 });
             });
         this.set('rating_card_values', ratingData);


### PR DESCRIPTION
Steps to reproduce:

1.- Install ecommerce.
2.- On the top right we click on edit.
3.- Go to customize > Customers > Rating.
4.- Now go to the bottom of the page and open the ratings.

Issue:

After the changes done in odoo#121104 we have change a few things, between those things, we are passing the rating stats inside the message when previously we used to add it as another key, also we are computing the same stats for all the messages that we have when we only need it 1 time.

Solution:

Adapt frontend to properly get the rating_stats and avoid computing them more than what is needed.

opw-4155895