### PR TITLE
[IMP] web: add utc_now python builtins

### DIFF
--- a/addons/web/static/src/core/py_js/py_builtin.js
+++ b/addons/web/static/src/core/py_js/py_builtin.js
@@ -99,6 +99,10 @@ export const BUILTINS = {
         return PyDateTime.now().strftime("%Y-%m-%d %H:%M:%S");
     },
 
+    get utc_now() {
+        return PyDateTime.now().to_utc().strftime("%Y-%m-%d %H:%M:%S");
+    },
+
     datetime: {
         time: PyTime,
         timedelta: PyTimeDelta,

--- a/odoo/tools/view_validation.py
+++ b/odoo/tools/view_validation.py
@@ -33,6 +33,7 @@ IGNORED_IN_EXPRESSION = {
     'current_date',
     'today',
     'now',
+    'utc_now',
     'abs',
     'len',
     'bool',


### PR DESCRIPTION
Purpose
=======
Add a 'utc_now' python builtins to be used in views.

Specifications
==============
The existing 'now' builtin is specific to the current user local timezone. Datetime fields, on the contrary, are in UTC.
This means that when comparing datetime fields with the 'now' built-in, their values are expressed in different timezones, leading to incorrect comparison results.
=> Adding a 'utc_now' builtin for those cases.

Using 'datetime.datetime.now()' is not a solution as this is also expressed in the local timezone. The canonical way to convert it to UTC in python is 'datetime.datetime.now(datetime.timezone.utc)' but the timezone module isn't recognized in views.

Task-4182164

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
