### PR TITLE
[IMP] project_{*}: propagate project field on MTO replenishment

### DIFF
--- a/addons/project_mrp/models/__init__.py
+++ b/addons/project_mrp/models/__init__.py
@@ -3,3 +3,4 @@
 from . import mrp_bom
 from . import mrp_production
 from . import project_project
+from . import stock

--- a/addons/project_mrp/models/stock.py
+++ b/addons/project_mrp/models/stock.py
@@ -1,0 +1,23 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class StockRule(models.Model):
+    _inherit = 'stock.rule'
+
+    def _prepare_mo_vals(self, product_id, product_qty, product_uom, location_id, name, origin, company_id, values, bom):
+        res = super()._prepare_mo_vals(product_id, product_qty, product_uom, location_id, name, origin, company_id, values, bom)
+        if values.get('project_id'):
+            res['project_id'] = values.get('project_id')
+        return res
+
+
+class StockMove(models.Model):
+    _inherit = 'stock.move'
+
+    def _prepare_procurement_values(self):
+        res = super()._prepare_procurement_values()
+        if res.get('group_id') and len(res['group_id'].mrp_production_ids) == 1:
+            res['project_id'] = res['group_id'].mrp_production_ids.project_id.id
+        return res

--- a/addons/project_purchase_stock/models/__init__.py
+++ b/addons/project_purchase_stock/models/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import purchase_order
+from . import stock_rule

--- a/addons/project_purchase_stock/models/stock_rule.py
+++ b/addons/project_purchase_stock/models/stock_rule.py
@@ -1,0 +1,13 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class StockRule(models.Model):
+    _inherit = 'stock.rule'
+
+    def _prepare_purchase_order(self, company_id, origins, values):
+        res = super()._prepare_purchase_order(company_id, origins, values)
+        if values[0].get('project_id'):
+            res['project_id'] = values[0].get('project_id')
+        return res

--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -416,3 +416,9 @@ class SaleOrderLine(models.Model):
             :returns: Dict containing id of SOL as key and the action as value
         """
         return {}
+
+    def _prepare_procurement_values(self, group_id=False):
+        values = super()._prepare_procurement_values(group_id=group_id)
+        if self.project_id:
+            values['project_id'] = self.order_id.project_id.id
+        return values


### PR DESCRIPTION
This PR ensures that the project field is propagated in different MTO scenarios. This commit specifically focuses on: MO -> Child MO, MO -> PO, SO -> PO scenarios.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
