### PR TITLE
[FIX] account: wrong comparison in bank account

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -448,7 +448,7 @@ class AccountBankStatementLine(models.Model):
                 'partner_id': self.partner_id.id,
                 'journal_id': None,
             })
-        return bank_account.filtered(lambda x: x.company_id in (False, self.company_id))
+        return bank_account.filtered(lambda x: x.company_id.id in (False, self.company_id.id))
 
     def _get_amounts_with_currencies(self):
         """


### PR DESCRIPTION
The check is comparing an empty recordset to False, which is not equal.

Credits to @JZorko
https://github.com/odoo/odoo/pull/171478

task-no