### PR TITLE
[FIX] web: list: no layout issue when re-ordering records

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -147,6 +147,7 @@ export class ListRenderer extends Component {
             elements: ".o_row_draggable",
             handle: ".o_handle_cell",
             cursor: "grabbing",
+            placeholderClasses: ["d-table-row"],
             // Hooks
             onDragStart: (params) => {
                 const { element } = params;

--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -529,15 +529,6 @@
         }
     }
 
-    .o_data_row.o_dragged {
-        display: flex;
-
-        > td {
-            flex-grow: 0;
-            flex-shrink: 0;
-        }
-    }
-
     .o_optional_columns_dropdown .dropdown-item .o-checkbox .text-truncate {
         max-width: 30em;
     }


### PR DESCRIPTION
This is more a theoretical issue than a real issue per se. The list renderer has a flag (`useMagicColumnWidths`) that allows to disable the column widths logic. It is enabled by default, and there's only one usecase in Odoo where we disable it (and this usecase is very custom, and doesn't allow to d&d records). However, when the feature is disabled, the table layout is broken when the user drags a record.

This commit is a simple patch that ensures that the layout of the list remains intact when drag&dropping a record, whether the column widths logic is enabled or not.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
