### PR TITLE
[FIX] website: traceback after image upload

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/file_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/file_selector.js
@@ -126,7 +126,10 @@ export class FileSelectorControlPanel extends Component {
             return;
         }
         await this.props.uploadFiles(inputFiles);
-        this.fileInput.el.value = '';
+        const fileInputEl = this.fileInput.el;
+        if (fileInputEl) {
+            fileInputEl.value = "";
+        }
     }
 }
 FileSelectorControlPanel.template = 'web_editor.FileSelectorControlPanel';


### PR DESCRIPTION
Specification:

This PR aims to resolve the issue occured while discarding the upload process the `this.fileInput.el` becomes undefined as image is discarded which resulted in traceback.

task-4255826