### PR TITLE
[FIX] website: open optimize SEO without blog name

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -814,7 +814,7 @@ class Website(Home):
         res['has_social_default_image'] = request.website.has_social_default_image
 
         if res_model not in ('website.page', 'ir.ui.view') and 'seo_name' in record:  # allow custom slugify
-            res['seo_name_default'] = request.env['ir.http']._slugify(record.display_name)  # default slug, if seo_name become empty
+            res['seo_name_default'] = request.env['ir.http']._slugify(record.display_name or '')  # default slug, if seo_name become empty
             res['seo_name'] = record.seo_name and request.env['ir.http']._slugify(record.seo_name) or ''
 
         return res


### PR DESCRIPTION
Steps to reproduce:
---
- Install the ``website_blog`` module
- Click on ``Blog`` > Open editor > Click on blog name(eg: Travel)
- Remove that blog name and Save

Traceback:
---
``TypeErrornormalize() argument 2 must be str, not bool``

This error comes after this commit https://github.com/odoo/odoo/commit/25abac896f53240b08dd38a89110ec811132ee1d

Previous Behaviour:
---
When trying to open optimize SEO without a blog name at [1] we are getting ``record.display_name`` as false.

[1]- https://github.com/odoo/odoo/blob/e4a4806e5c58c599815204a73c78a228ee230613/addons/website/controllers/main.py#L785-L786

sentry-5967410495

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
