### PR TITLE
[FIX] website: prevent error when saving page properties without page title

### DIFF
--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -155,7 +155,7 @@ class Page(models.Model):
 
             # If name has changed, check for key uniqueness
             if 'name' in vals and page.name != vals['name']:
-                vals['key'] = self.env['website'].with_context(website_id=website_id).get_unique_key(self.env['ir.http']._slugify(vals['name']))
+                vals['key'] = self.env['website'].with_context(website_id=website_id).get_unique_key(self.env['ir.http']._slugify(vals['name'] or ''))
             if 'visibility' in vals:
                 if vals['visibility'] != 'restricted_group':
                     vals['groups_id'] = False


### PR DESCRIPTION
When the user tries to save page properties without a Page Title,
a traceback will appear.

Steps to reproduce the error:
- Go to Website > Site > Properties > Remove the Page Title > Save & Close

Traceback:
```
TypeError: normalize() argument 2 must be str, not bool
  File "odoo/http.py", line 2364, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1891, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1954, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 137, in retrying
    result = func()
  File "odoo/http.py", line 1921, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2168, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 330, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 728, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 35, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 517, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/web/models/models.py", line 70, in web_save
    self.write(vals)
  File "addons/website/models/website_page_properties.py", line 179, in write
    write_result = super().write(vals)
  File "odoo/models.py", line 4786, in write
    fields[0].determine_inverse(real_recs)
  File "odoo/fields.py", line 1478, in determine_inverse
    determine(self.inverse, records)
  File "odoo/fields.py", line 112, in determine
    return needle(records, *args)
  File "odoo/fields.py", line 724, in _inverse_related
    target[field.name] = record_value[record]
  File "odoo/models.py", line 7009, in __setitem__
    return self._fields[key].__set__(self, value)
  File "odoo/fields.py", line 1402, in __set__
    records.write({self.name: write_value})
  File "addons/website/models/website_page.py", line 158, in write
    vals['key'] = self.env['website'].with_context(website_id=website_id).get_unique_key(self.env['ir.http']._slugify(vals['name']))
  File "odoo/addons/base/models/ir_http.py", line 161, in _slugify
    return cls._slugify_one(value, max_length=max_length)
  File "odoo/addons/base/models/ir_http.py", line 154, in _slugify_one
    uni = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore').decode('ascii')
```

This error generates after this commit: https://github.com/odoo/odoo/commit/58705803a9e7ef0b0f5ff9e8b82d52ad1321b64a

https://github.com/odoo/odoo/blob/4b99aa4e48158ddc7cea8910c0f610e62778bc9c/addons/website/models/website_page.py#L158
When, user tries to save page properties without a page title,
``vals['name']`` will be False,
So, It will lead to the above traceback.

sentry-5989403584

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
