### PR TITLE
[FIX] mail: less persistent unread messages banner

### DIFF
--- a/addons/mail/static/src/core/common/channel_member_model.js
+++ b/addons/mail/static/src/core/common/channel_member_model.js
@@ -58,6 +58,17 @@ export class ChannelMember extends Record {
             }
         },
     });
+    unreadSynced = Record.attr(true, {
+        compute() {
+            return this.localNewMessageSeparator === this.new_message_separator;
+        },
+        onUpdate() {
+            if (this.unreadSynced) {
+                this.hideUnreadBanner = false;
+            }
+        },
+    });
+    hideUnreadBanner = false;
     localMessageUnreadCounter = 0;
     localNewMessageSeparator = null;
     message_unread_counter = 0;

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -20,7 +20,7 @@ import {
 
 import { _t } from "@web/core/l10n/translation";
 import { Transition } from "@web/core/transition";
-import { useBus, useService } from "@web/core/utils/hooks";
+import { useBus, useRefListener, useService } from "@web/core/utils/hooks";
 import { escape } from "@web/core/utils/strings";
 
 export const PRESENT_VIEWPORT_THRESHOLD = 3;
@@ -73,6 +73,7 @@ export class Thread extends Component {
             isReplyingTo: false,
             mountedAndLoaded: false,
             showJumpPresent: false,
+            scrollTop: null,
         });
         this.lastJumpPresent = this.props.jumpPresent;
         this.orm = useService("orm");
@@ -93,6 +94,34 @@ export class Thread extends Component {
          * scrollable (in other cases).
          */
         this.scrollableRef = this.props.scrollRef ?? useRef("messages");
+        useRefListener(
+            this.scrollableRef,
+            "scrollend",
+            () => (this.state.scrollTop = this.scrollableRef.el.scrollTop)
+        );
+        useEffect(
+            (loadNewer, mountedAndLoaded, unreadSynced) => {
+                if (
+                    loadNewer ||
+                    unreadSynced || // just marked as unread (local and server state are synced)
+                    !mountedAndLoaded ||
+                    !this.props.thread.selfMember ||
+                    !this.scrollableRef.el
+                ) {
+                    return;
+                }
+                const el = this.scrollableRef.el;
+                if (Math.abs(el.scrollTop + el.clientHeight - el.scrollHeight) <= 1) {
+                    this.props.thread.selfMember.hideUnreadBanner = true;
+                }
+            },
+            () => [
+                this.props.thread.loadNewer,
+                this.state.mountedAndLoaded,
+                this.props.thread.selfMember?.unreadSynced,
+                this.state.scrollTop,
+            ]
+        );
         this.loadOlderState = useVisible(
             "load-older",
             async () => {

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -13,7 +13,7 @@
                     <t t-if="props.thread.loadOlder and !props.thread.isTransient and !props.thread.hasLoadingFailed" t-call="mail.Thread.loadOlder"/>
                     <t t-if="props.thread.hasLoadingFailed" t-call="mail.Thread.loadingError"/>
                 </t>
-                <span t-else="" t-ref="load-newer"/>
+                <span t-else="" t-ref="load-newer" style="height: 1px;"/>
                 <t t-set="messages" t-value="props.order === 'asc' ? props.thread.nonEmptyMessages : [...props.thread.nonEmptyMessages].reverse()"/>
                 <t t-if="state.mountedAndLoaded" t-foreach="messages" t-as="msg" t-key="msg.id">
                     <t t-set="prevMsg" t-value="messages[msg_index -1]"/>
@@ -40,7 +40,7 @@
                         showDates="props.showDates"
                     />
                 </t>
-                <span t-if="props.order === 'asc'" t-ref="load-newer"/>
+                <span t-if="props.order === 'asc'" t-ref="load-newer" style="height: 1px;"/>
                 <t t-else="">
                     <t t-if="props.thread.loadOlder and !props.thread.isTransient and !props.thread.hasLoadingFailed" t-call="mail.Thread.loadOlder"/>
                     <t t-if="props.thread.hasLoadingFailed" t-call="mail.Thread.loadingError"/>

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -564,7 +564,7 @@ export class Thread extends Record {
     }
 
     get showUnreadBanner() {
-        return this.selfMember?.localMessageUnreadCounter > 0;
+        return !this.selfMember?.hideUnreadBanner && this.selfMember?.localMessageUnreadCounter > 0;
     }
 
     /** @type {undefined|number[]} */

--- a/addons/mail/static/tests/thread/unread_messages_banner.test.js
+++ b/addons/mail/static/tests/thread/unread_messages_banner.test.js
@@ -16,6 +16,7 @@ import { queryFirst } from "@odoo/hoot-dom";
 import { tick } from "@odoo/hoot-mock";
 import {
     getService,
+    onRpc,
     patchWithCleanup,
     serverState,
     withUser,
@@ -158,4 +159,77 @@ test("scroll to unread notification", async () => {
     });
     await assertSteps(["scrollend"]);
     expect(isInViewportOf(thread, message)).toBe(true);
+});
+
+test("remove banner when scrolling to bottom", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "general" });
+    for (let i = 0; i < 50; ++i) {
+        pyEnv["mail.message"].create({
+            author_id: serverState.partnerId,
+            body: `message ${i}`,
+            model: "discuss.channel",
+            res_id: channelId,
+        });
+    }
+    onRpc("/discuss/channel/mark_as_read", () => step("mark_as_read"));
+    await start();
+    await openDiscuss(channelId);
+    await assertSteps(["mark_as_read"]);
+    await contains(".o-mail-Message", { count: 30 });
+    await contains(".o-mail-Thread-banner", { text: "50 new messages" });
+    await contains(".o-mail-Thread-newMessage ~ .o-mail-Message", { text: "message 0" });
+    await tick(); // wait for the scroll to first unread to complete
+    await scroll(".o-mail-Thread", "bottom");
+    await contains(".o-mail-Message", { count: 50 });
+    // Banner is still present as there are more messages to load so we did not
+    // reach the actual bottom.
+    await contains(".o-mail-Thread-banner", { text: "50 new messages" });
+    await scroll(".o-mail-Thread", "bottom");
+    await contains(".o-mail-Thread-banner", { text: "50 new messages", count: 0 });
+});
+
+test("remove banner when opening thread at the bottom", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "general" });
+    const messageId = pyEnv["mail.message"].create({
+        author_id: serverState.partnerId,
+        body: `Hello World`,
+        model: "discuss.channel",
+        res_id: channelId,
+    });
+    const [selfMemberId] = pyEnv["discuss.channel.member"].search([
+        ["partner_id", "=", serverState.partnerId],
+        ["channel_id", "=", channelId],
+    ]);
+    pyEnv["discuss.channel.member"].write([selfMemberId], { new_message_separator: messageId + 1 });
+    await start();
+    await openDiscuss(channelId);
+    await click("[title='Expand']", { parent: [".o-mail-Message", { text: "Hello World" }] });
+    await click(".o-mail-Message-moreMenu [title='Mark as Unread']");
+    await contains(".o-mail-Thread-banner", { text: "1 new message" });
+    await click(".o-mail-DiscussSidebar-item", { text: "Inbox" });
+    await contains(".o-mail-Discuss-threadName[title='Inbox']");
+    await click(".o-mail-DiscussSidebarChannel", { text: "general" });
+    await contains(".o-mail-Discuss-threadName[title='general']");
+    await contains(".o-mail-Thread-banner", { text: "1 new message", count: 0 });
+});
+
+test("keep banner after mark as unread when scrolling to bottom", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "general" });
+    for (let i = 0; i < 30; ++i) {
+        pyEnv["mail.message"].create({
+            author_id: serverState.partnerId,
+            body: `message ${i}`,
+            model: "discuss.channel",
+            res_id: channelId,
+        });
+    }
+    await start();
+    await openDiscuss(channelId);
+    await click("[title='Expand']", { parent: [".o-mail-Message", { text: "message 29" }] });
+    await click(".o-mail-Message-moreMenu [title='Mark as Unread']");
+    await scroll(".o-mail-Thread", "bottom");
+    await contains(".o-mail-Thread-banner", { text: "30 new messages" });
 });


### PR DESCRIPTION
The "mark as read" banner helps users keep track of where they last
left off in a conversation. Currently, the banner is removed in the
following situations:

- When returning to the thread twice.
- When posting a message.
- When clicking on the "mark as read" button on the banner.

However, this approach is insufficient, as the banner appears too
frequently. This pull request streamlines the conditions under which
the banner disappears. The banner will now be removed wheni on top of
the other conditions:

- The user scrolls to the bottom of the thread.
- The user opens a thread that does not have a scrollbar.

Both circumstances are sufficient to indicate that the user has
actually read the messages.

task-4102924