### PR TITLE
[FIX] purchase_stock: set replenish date based on action buy/manufacture

### DIFF
--- a/addons/mrp/wizard/product_replenish.py
+++ b/addons/mrp/wizard/product_replenish.py
@@ -11,7 +11,7 @@ class ProductReplenish(models.TransientModel):
     def _compute_date_planned(self):
         super()._compute_date_planned()
         for rec in self:
-            if self.route_id.name == "Manufacture":
+            if 'manufacture' in rec.route_id.rule_ids.mapped('action'):
                 rec.date_planned = rec._get_date_planned(rec.route_id, product_tmpl_id=rec.product_tmpl_id)
 
     def _get_record_to_notify(self, date):
@@ -29,7 +29,7 @@ class ProductReplenish(models.TransientModel):
 
     def _get_date_planned(self, route_id, **kwargs):
         date = super()._get_date_planned(route_id, **kwargs)
-        if route_id.name != 'Manufacture':
+        if 'manufacture' not in route_id.rule_ids.mapped('action'):
             return date
         delay = 0
         product_tmpl_id = kwargs.get('product_tmpl_id') or self.product_tmpl_id

--- a/addons/purchase_stock/wizard/product_replenish.py
+++ b/addons/purchase_stock/wizard/product_replenish.py
@@ -34,7 +34,7 @@ class ProductReplenish(models.TransientModel):
     def _compute_date_planned(self):
         super()._compute_date_planned()
         for rec in self:
-            if rec.route_id.name == 'Buy':
+            if 'buy' in rec.route_id.rule_ids.mapped('action'):
                 rec.date_planned = rec._get_date_planned(rec.route_id, supplier=rec.supplier_id, show_vendor=rec.show_vendor)
 
     @api.depends('route_id')
@@ -85,7 +85,7 @@ class ProductReplenish(models.TransientModel):
 
     def _get_date_planned(self, route_id, **kwargs):
         date = super()._get_date_planned(route_id, **kwargs)
-        if route_id.name != 'Buy':
+        if 'buy' not in route_id.rule_ids.mapped('action'):
             return date
 
         supplier = kwargs.get('supplier')


### PR DESCRIPTION
## Issue:
- When a database is set to a language other than English, the 'Expected Date' for product replenishment does not adapt according to the set vendor lead time. This issue does not occur when the database is set to English.

## Steps To Reproduce:
- Create a storable product.
- Define a vendor for this product and add a delivery lead time.
- Navigate to the product template and click on the "Replenish" button.
- Observe that in an English language setting, the schedule date is calculated correctly considering the vendor's delivery lead time.
- Change the language of the database to a different language.
- Repeat the replenish process.
- Observe that the schedule date is not calculated correctly.

## Solution:
- Replaced route name check with action check in `_get_date_planned` for better reliability, as action-based conditions reduce errors compared to route name comparisons..

opw-4199660

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
