### PR TITLE
[IMP] html_editor: helper hint on empty column

### DIFF
--- a/addons/html_editor/static/src/main/hint.scss
+++ b/addons/html_editor/static/src/main/hint.scss
@@ -14,3 +14,9 @@
         width: 100%;
     }
 }
+
+div[class*="col-"][class*="o-we-hint"] {
+    &:after {
+        left: calc(var(--gutter-x, 0)* .5);
+    }
+}

--- a/addons/html_editor/static/src/main/hint_plugin.js
+++ b/addons/html_editor/static/src/main/hint_plugin.js
@@ -1,9 +1,8 @@
 import { Plugin } from "@html_editor/plugin";
 import { isEmptyBlock, isProtected } from "@html_editor/utils/dom_info";
 import { removeClass } from "@html_editor/utils/dom";
-import { childNodes, selectElements } from "@html_editor/utils/dom_traversal";
+import { selectElements } from "@html_editor/utils/dom_traversal";
 import { closestBlock } from "../utils/blocks";
-import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
 
 export class HintPlugin extends Plugin {
     static id = "hint";
@@ -19,31 +18,18 @@ export class HintPlugin extends Plugin {
         clean_for_save_handlers: ({ root }) => this.clearHints(root),
         content_updated_handlers: this.updateHints.bind(this),
 
+        hint_targets_providers: (selectionData, editable) => {
+            if (!selectionData.documentSelectionIsInEditable) {
+                return [];
+            }
+            const blockEl = closestBlock(selectionData.editableSelection.anchorNode);
+            return [blockEl];
+        },
         system_classes: ["o-we-hint"],
         system_attributes: ["o-we-hint-text"],
-        ...(this.config.placeholder && {
-            hints: [
-                {
-                    text: this.config.placeholder,
-                    target: (selectionData, editable) => {
-                        if (
-                            selectionData.documentSelectionIsInEditable ||
-                            childNodes(editable).length !== 1
-                        ) {
-                            return;
-                        }
-                        const el = editable.firstChild;
-                        if (isEmptyBlock(el) && el.matches(baseContainerGlobalSelector)) {
-                            return el;
-                        }
-                    },
-                },
-            ],
-        }),
     };
 
     setup() {
-        this.hint = null;
         this.updateHints(this.editable);
     }
 
@@ -53,7 +39,6 @@ export class HintPlugin extends Plugin {
     }
 
     normalize() {
-        this.hint = null;
         this.clearHints();
         this.updateHints();
     }
@@ -64,26 +49,14 @@ export class HintPlugin extends Plugin {
     updateHints() {
         const selectionData = this.dependencies.selection.getSelectionData();
         const editableSelection = selectionData.editableSelection;
-        if (this.hint) {
-            const blockEl = closestBlock(editableSelection.anchorNode);
-            this.removeHint(this.hint);
-            this.removeHint(blockEl);
-        }
+        this.clearHints();
         if (editableSelection.isCollapsed) {
-            for (const hint of this.getResource("hints")) {
-                if (hint.selector) {
-                    const el = closestBlock(editableSelection.anchorNode);
-                    if (el && el.matches(hint.selector) && !isProtected(el) && isEmptyBlock(el)) {
-                        this.makeHint(el, hint.text);
-                        this.hint = el;
-                    }
-                } else {
-                    const target = hint.target(selectionData, this.editable);
-                    // Do not replace an existing empty block hint by a temp hint.
-                    if (target && !target.classList.contains("o-we-hint")) {
-                        this.makeHint(target, hint.text);
-                        this.hint = target;
-                        return;
+            const hints = this.getResource("hints");
+            for (const provideTargets of this.getResource("hint_targets_providers")) {
+                for (const target of provideTargets(selectionData, this.editable)) {
+                    const nodeHint = hints.find((h) => target.matches(h.selector))?.text;
+                    if (target && nodeHint && isEmptyBlock(target) && !isProtected(target)) {
+                        this.makeHint(target, nodeHint);
                     }
                 }
             }
@@ -99,9 +72,7 @@ export class HintPlugin extends Plugin {
     removeHint(el) {
         el.removeAttribute("o-we-hint-text");
         removeClass(el, "o-we-hint");
-        if (this.hint === el) {
-            this.hint = null;
-        }
+        this.getResource("system_style_properties").forEach((n) => el.style.removeProperty(n));
     }
 
     clearHints(root = this.editable) {

--- a/addons/html_editor/static/src/main/placeholder_plugin.js
+++ b/addons/html_editor/static/src/main/placeholder_plugin.js
@@ -1,0 +1,32 @@
+import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
+import { Plugin } from "../plugin";
+import { childNodes } from "@html_editor/utils/dom_traversal";
+import { isEmptyBlock } from "@html_editor/utils/dom_info";
+import { withSequence } from "@html_editor/utils/resource";
+
+export class PlaceholderPlugin extends Plugin {
+    static id = "placeholder";
+    resources = {
+        ...(this.config.placeholder && {
+            hints: [
+                withSequence(1, {
+                    selector: `.odoo-editor-editable:not(:focus) > ${baseContainerGlobalSelector}:only-child`,
+                    text: this.config.placeholder,
+                }),
+            ],
+            hint_targets_providers: (selectionData, editable) => {
+                const el = editable.firstChild;
+                if (
+                    !selectionData.documentSelectionIsInEditable &&
+                    childNodes(editable).length === 1 &&
+                    isEmptyBlock(el) &&
+                    el.matches(baseContainerGlobalSelector)
+                ) {
+                    return [el];
+                } else {
+                    return [];
+                }
+            },
+        }),
+    };
+}

--- a/addons/html_editor/static/src/main/power_buttons_plugin.js
+++ b/addons/html_editor/static/src/main/power_buttons_plugin.js
@@ -116,7 +116,7 @@ export class PowerButtonsPlugin extends Plugin {
         const element = closestElement(editableSelection.anchorNode);
         if (
             editableSelection.isCollapsed &&
-            element?.matches(baseContainerGlobalSelector) &&
+            block?.matches(baseContainerGlobalSelector) &&
             isEmptyBlock(block) &&
             !this.services.ui.isSmall &&
             !closestElement(editableSelection.anchorNode, "td") &&

--- a/addons/html_editor/static/src/main/powerbox/powerbox_plugin.js
+++ b/addons/html_editor/static/src/main/powerbox/powerbox_plugin.js
@@ -1,5 +1,4 @@
 import { Plugin } from "@html_editor/plugin";
-import { isEmptyBlock } from "@html_editor/utils/dom_info";
 import { reactive } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { rotate } from "@web/core/utils/arrays";
@@ -78,21 +77,6 @@ import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
  */
 
 /**
- * @param {SelectionData} selectionData
- */
-function target(selectionData) {
-    const node = selectionData.editableSelection.anchorNode;
-    const el = node.nodeType === Node.ELEMENT_NODE ? node : node.parentElement;
-    if (
-        selectionData.documentSelectionIsInEditable &&
-        el.matches(baseContainerGlobalSelector) &&
-        isEmptyBlock(el)
-    ) {
-        return el;
-    }
-}
-
-/**
  * @typedef { Object } PowerboxShared
  * @property { PowerboxPlugin['closePowerbox'] } closePowerbox
  * @property { PowerboxPlugin['getAvailablePowerboxCommands'] } getAvailablePowerboxCommands
@@ -127,10 +111,10 @@ export class PowerboxPlugin extends Plugin {
             description: _t("More options"),
             icon: "oi-ellipsis-v",
         }),
-        hints: {
+        hints: withSequence(30, {
+            selector: baseContainerGlobalSelector,
             text: _t('Type "/" for commands'),
-            target,
-        },
+        }),
     };
 
     setup() {

--- a/addons/html_editor/static/src/plugin_sets.js
+++ b/addons/html_editor/static/src/plugin_sets.js
@@ -53,6 +53,7 @@ import { TabulationPlugin } from "./main/tabulation_plugin";
 import { TextDirectionPlugin } from "./main/text_direction_plugin";
 import { ToolbarPlugin } from "./main/toolbar/toolbar_plugin";
 import { YoutubePlugin } from "./main/youtube_plugin";
+import { PlaceholderPlugin } from "./main/placeholder_plugin";
 import { CollaborationOdooPlugin } from "./others/collaboration/collaboration_odoo_plugin";
 import { CollaborationPlugin } from "./others/collaboration/collaboration_plugin";
 import { CollaborationSelectionAvatarPlugin } from "./others/collaboration/collaboration_selection_avatar_plugin";
@@ -162,6 +163,7 @@ export const MAIN_PLUGINS = [
     InlineCodePlugin,
     TableResizePlugin,
     FilePlugin,
+    PlaceholderPlugin,
 ];
 
 export const COLLABORATION_PLUGINS = [

--- a/addons/html_editor/static/tests/collaboration.test.js
+++ b/addons/html_editor/static/tests/collaboration.test.js
@@ -514,7 +514,7 @@ describe("sanitize", () => {
                 execCommand(editor, "historyRedo");
             },
             contentAfter:
-                '<div contenteditable="true" class="o-paragraph o-we-hint" o-we-hint-text="Type &quot;/&quot; for commands">[c1}{c1]<br></div>',
+                '<div class="o-paragraph o-we-hint" contenteditable="true" o-we-hint-text="Type &quot;/&quot; for commands">[c1}{c1]<br></div>',
         });
     });
     test("should not sanitize the content of an element recursively when sanitizing an attribute", async () => {

--- a/addons/html_editor/static/tests/columnize.test.js
+++ b/addons/html_editor/static/tests/columnize.test.js
@@ -32,7 +32,7 @@ describe("2 columns", () => {
             contentAfterEdit:
                 columnsContainer(
                     column(6, `<p o-we-hint-text="Empty column" class="o-we-hint">[]<br></p>`) +
-                    column(6, `<p><br></p>`)
+                    column(6, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`)
                 ),
             /* eslint-enable */
         });
@@ -49,7 +49,7 @@ describe("2 columns", () => {
             contentAfterEdit:
                 columnsContainer(
                     column(6, `<table><tbody><tr><td><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></td><td><p><br></p></td></tr></tbody></table>`) +
-                    column(6, `<p><br></p>`)
+                    column(6, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`)
                 ),
             /* eslint-enable */
         });
@@ -75,7 +75,7 @@ describe("2 columns", () => {
             /* eslint-disable */
                 columnsContainer(
                     column(6, "<p>[]abcd</p>") +
-                    column(6, `<p><br></p>`)
+                    column(6, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`)
                 ) +
                 "<p><br></p>",
             contentAfter:
@@ -125,7 +125,7 @@ describe("2 columns", () => {
 
         await press("enter");
         expect(getContent(el)).toBe(
-            `<div class="container o_text_columns"><div class="row"><div class="col-6"><p>ab[]cd</p></div><div class="col-6"><p><br></p></div></div></div><p><br></p>`
+            `<div class="container o_text_columns"><div class="row"><div class="col-6"><p>ab[]cd</p></div><div class="col-6"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div></div></div><p><br></p>`
         );
 
         await insertText(editor, "/columns");
@@ -147,7 +147,7 @@ describe("3 columns", () => {
             contentBeforeEdit:
                 columnsContainer(
                     column(4, "<p>abcd</p>") +
-                    column(4, `<p><br></p>`) +
+                    column(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`) +
                     column(4, `<p o-we-hint-text="Empty column" class="o-we-hint">[]<br></p>`)
                 ),
             /* eslint-enable */
@@ -166,8 +166,8 @@ describe("3 columns", () => {
             contentAfterEdit:
                 columnsContainer(
                     column(4, "<p>ab[]cd</p>") +
-                    column(4, `<p><br></p>`) +
-                    column(4, `<p><br></p>`)
+                    column(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`) +
+                    column(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`)
                 ) + "<p><br></p>",
             contentAfter:
                 columnsContainer(
@@ -218,7 +218,7 @@ describe("3 columns", () => {
 
         await press("enter");
         expect(getContent(el)).toBe(
-            `<div class="container o_text_columns"><div class="row"><div class="col-4"><p>ab[]cd</p></div><div class="col-4"><p><br></p></div><div class="col-4"><p><br></p></div></div></div><p><br></p>`
+            `<div class="container o_text_columns"><div class="row"><div class="col-4"><p>ab[]cd</p></div><div class="col-4"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div><div class="col-4"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div></div></div><p><br></p>`
         );
 
         await insertText(editor, "/columns");
@@ -304,7 +304,7 @@ describe("4 columns", () => {
 
         await press("enter");
         expect(getContent(el)).toBe(
-            `<div class="container o_text_columns"><div class="row"><div class="col-3"><p>ab[]cd</p></div><div class="col-3"><p><br></p></div><div class="col-3"><p><br></p></div><div class="col-3"><p><br></p></div></div></div><p><br></p>`
+            `<div class="container o_text_columns"><div class="row"><div class="col-3"><p>ab[]cd</p></div><div class="col-3"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div><div class="col-3"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div><div class="col-3"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div></div></div><p><br></p>`
         );
 
         await insertText(editor, "/columns");
@@ -374,7 +374,7 @@ describe("remove columns", () => {
         // add 2 columns
         await press("enter");
         expect(getContent(el)).toBe(
-            `<div class="container o_text_columns"><div class="row"><div class="col-6"><p>ab[]cd</p></div><div class="col-6"><p><br></p></div></div></div><p><br></p>`
+            `<div class="container o_text_columns"><div class="row"><div class="col-6"><p>ab[]cd</p></div><div class="col-6"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div></div></div><p><br></p>`
         );
 
         await insertText(editor, "/removecolumns");
@@ -449,6 +449,65 @@ describe("undo", () => {
             contentAfter:
                 columnsContainer(column(6, "<p>x[]</p>") + column(6, "<p><br></p>")) +
                 "<p><br></p>",
+        });
+    });
+});
+
+describe("helper hint", () => {
+    test("should display helper hint in first block of each column", async () => {
+        await testEditor({
+            /* eslint-disable */
+            contentBefore:
+                columnsContainer(
+                    column(4, "<p>[]<br></p>") +
+                    column(4, "<h1><br></h1>" + "<h2><br></h2>") +
+                    column(4, "<p><br></p>")
+                ),
+            contentAfterEdit:
+                columnsContainer(
+                    column(4, `<p o-we-hint-text="Empty column" class="o-we-hint">[]<br></p>`) +
+                    column(4, `<h1 o-we-hint-text="Heading 1" class="o-we-hint"><br></h1>` + "<h2><br></h2>") +
+                    column(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`)
+                ),
+            /* eslint-enable */
+        });
+    });
+
+    test("should not display hint in first block if cursor is inside different block in same column", async () => {
+        await testEditor({
+            /* eslint-disable */
+            contentBefore:
+                columnsContainer(
+                    column(4, "<p><br></p>") +
+                    column(4, "<h1><br></h1>" + "<h2>[]<br></h2>") +
+                    column(4, "<p><br></p>")
+                ),
+            contentAfterEdit:
+                columnsContainer(
+                    column(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`) +
+                    column(4, "<h1><br></h1>" + `<h2 o-we-hint-text="Heading 2" class="o-we-hint">[]<br></h2>`) +
+                    column(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`)
+                ),
+            /* eslint-enable */
+        });
+    });
+
+    test("should display normal hint on focused paragraph if paragraph is not first block of column", async () => {
+        await testEditor({
+            /* eslint-disable */
+            contentBefore:
+                columnsContainer(
+                    column(4, "<p><br></p>" + "<p>[]<br></p>") +
+                    column(4, "<p><br></p>") +
+                    column(4, "<p><br></p>")
+                ),
+            contentAfterEdit:
+                columnsContainer(
+                    column(4, "<p><br></p>" + `<p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`) +
+                    column(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`) +
+                    column(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`)
+                ),
+            /* eslint-enable */
         });
     });
 });

--- a/addons/html_editor/static/tests/delete/delete_range.test.js
+++ b/addons/html_editor/static/tests/delete/delete_range.test.js
@@ -411,7 +411,7 @@ describe("deleteSelection", () => {
                         `<div class="container o_text_columns">
                             <div class="row">
                                 <div class="col-6">a[]</div>
-                                <div class="col-6"><br></div>
+                                <div class="col-6 o-we-hint" o-we-hint-text="Empty column"><br></div>
                             </div>
                         </div>
                         <p>i</p>`

--- a/addons/html_editor/static/tests/format/bold.test.js
+++ b/addons/html_editor/static/tests/format/bold.test.js
@@ -222,8 +222,8 @@ test("should make a few characters bold inside table (bold)", async () => {
     });
 });
 
-test("should insert a span zws when toggling a formatting command twice", () => {
-    return testEditor({
+test("should insert a span zws when toggling a formatting command twice", () =>
+    testEditor({
         contentBefore: `<p>[]<br></p>`,
         stepFunction: async (editor) => {
             bold(editor);
@@ -232,9 +232,11 @@ test("should insert a span zws when toggling a formatting command twice", () => 
         // todo: It would be better to remove the zws entirely so that
         // the P could have the "/" hint but that behavior might be
         // complex with the current implementation.
-        contentAfterEdit: `<p>${span(`[]\u200B`, "first")}</p>`,
-    });
-});
+        contentAfterEdit: `<p o-we-hint-text='Type "/" for commands' class="o-we-hint">${span(
+            `[]\u200B`,
+            "first"
+        )}</p>`,
+    }));
 
 // This test uses execCommand to reproduce as closely as possible the browser's
 // default behaviour when typing in a contenteditable=true zone.

--- a/addons/html_editor/static/tests/hint.test.js
+++ b/addons/html_editor/static/tests/hint.test.js
@@ -12,7 +12,9 @@ import { insertText } from "./_helpers/user_actions";
 
 test("hints are removed when editor is destroyed", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>", {});
-    expect(getContent(el)).toBe(`<p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]</p>`);
+    expect(getContent(el)).toBe(
+        `<p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]</p>`
+    );
     editor.destroy();
     expect(getContent(el)).toBe("<p>[]</p>");
 });
@@ -23,7 +25,9 @@ test("powerbox hint is display when the selection is in the editor", async () =>
 
     setContent(el, "<p>[]</p>");
     await tick();
-    expect(getContent(el)).toBe(`<p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]</p>`);
+    expect(getContent(el)).toBe(
+        `<p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]</p>`
+    );
 
     moveSelectionOutsideEditor();
     await tick();
@@ -31,14 +35,18 @@ test("powerbox hint is display when the selection is in the editor", async () =>
 });
 
 test("placeholder is display when the selection is outside of the editor", async () => {
-    const { el } = await setupEditor("<p></p>", { config: { placeholder: "test" } });
+    const { el, editor } = await setupEditor("<p></p>", { config: { placeholder: "test" } });
     expect(getContent(el)).toBe(`<p o-we-hint-text="test" class="o-we-hint"></p>`);
 
+    editor.editable.focus();
     setContent(el, "<p>[]</p>");
     await tick();
-    expect(getContent(el)).toBe(`<p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]</p>`);
+    expect(getContent(el)).toBe(
+        `<p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]</p>`
+    );
 
     moveSelectionOutsideEditor();
+    editor.editable.blur();
     await tick();
     expect(getContent(el)).toBe(`<p o-we-hint-text="test" class="o-we-hint"></p>`);
 });
@@ -66,7 +74,9 @@ test("should not display hint in paragraph with media content", async () => {
 
 test("should not lose track of temporary hints on split block", async () => {
     const { el, editor, plugins } = await setupEditor("<p>[]</p>", {});
-    expect(getContent(el)).toBe(`<p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]</p>`);
+    expect(getContent(el)).toBe(
+        `<p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]</p>`
+    );
     editor.shared.split.splitBlock();
     editor.shared.history.addStep();
     await animationFrame();

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -898,7 +898,10 @@ test("Embed video by pasting video URL", async () => {
     // Press Enter to select first option in the powerbox ("Embed Youtube Video").
     await press("Enter");
     await animationFrame();
-    expect(anchorNode.outerHTML).toBe("<p></p>");
+    const videoIframe = queryOne("div.media_iframe_video");
+    expect(videoIframe.nextElementSibling).toHaveOuterHTML(
+        `<p o-we-hint-text='Type "/" for commands' class="o-we-hint"><br></p>`
+    );
     expect(
         'div.media_iframe_video iframe[src="//www.youtube.com/embed/qxb74CMR748?rel=0&autoplay=0"]'
     ).toHaveCount(1);
@@ -1028,6 +1031,7 @@ test("html field with a placeholder", async () => {
     );
 
     moveSelectionOutsideEditor();
+    htmlEditor.editable.blur();
     await tick();
     expect(`[name="txt"] .odoo-editor-editable`).toHaveInnerHTML(
         '<div class="o-paragraph o-we-hint" o-we-hint-text="test"><br></div>',

--- a/addons/html_editor/static/tests/insert/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/insert/paragraph_break.test.js
@@ -439,21 +439,21 @@ describe("Selection collapsed", () => {
             await testEditor({
                 contentBefore: "<p><b>abc</b>[]</p>",
                 stepFunction: splitBlock,
-                contentAfterEdit: `<p><b>abc</b></p><p><b data-oe-zws-empty-inline="">[]\u200b</b><br></p>`,
+                contentAfterEdit: `<p><b>abc</b></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><b data-oe-zws-empty-inline="">[]\u200b</b><br></p>`,
                 contentAfter: "<p><b>abc</b></p><p>[]<br></p>",
             });
             await testEditor({
                 // That selection is equivalent to </b>[]
                 contentBefore: "<p><b>abc[]</b></p>",
                 stepFunction: splitBlock,
-                contentAfterEdit: `<p><b>abc</b></p><p><b data-oe-zws-empty-inline="">[]\u200b</b><br></p>`,
+                contentAfterEdit: `<p><b>abc</b></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><b data-oe-zws-empty-inline="">[]\u200b</b><br></p>`,
                 contentAfter: "<p><b>abc</b></p><p>[]<br></p>",
             });
             await testEditor({
                 contentBefore: "<p><b>abc[] </b></p>",
                 stepFunction: splitBlock,
                 // The space should have been parsed away.
-                contentAfterEdit: `<p><b>abc</b></p><p><b data-oe-zws-empty-inline="">[]\u200b</b><br></p>`,
+                contentAfterEdit: `<p><b>abc</b></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><b data-oe-zws-empty-inline="">[]\u200b</b><br></p>`,
                 contentAfter: "<p><b>abc</b></p><p>[]<br></p>",
             });
         });
@@ -591,7 +591,7 @@ describe("Selection collapsed", () => {
                 stepFunction: splitBlock,
                 contentAfterEdit:
                     '<h1><font style="color: red;" data-oe-zws-empty-inline="">\u200b</font><br></h1>' +
-                    '<p><font style="color: red;" data-oe-zws-empty-inline="">[]\u200b</font><br></p>',
+                    `<p o-we-hint-text='Type "/" for commands' class="o-we-hint"><font style="color: red;" data-oe-zws-empty-inline="">[]\u200b</font><br></p>`,
                 contentAfter: "<h1><br></h1><p>[]<br></p>",
             });
         });
@@ -617,19 +617,19 @@ describe("Selection collapsed", () => {
             await testEditor({
                 contentBefore: '<p><font style="color: red;">abc[]</font></p>',
                 stepFunction: splitBlock,
-                contentAfterEdit: `<p><font style="color: red;">abc</font></p><p><font style="color: red;" data-oe-zws-empty-inline="">[]\u200b</font><br></p>`,
+                contentAfterEdit: `<p><font style="color: red;">abc</font></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><font style="color: red;" data-oe-zws-empty-inline="">[]\u200b</font><br></p>`,
                 contentAfter: `<p><font style="color: red;">abc</font></p><p>[]<br></p>`,
             });
             await testEditor({
                 contentBefore: '<p><font style="background-color: red;">abc[]</font></p>',
                 stepFunction: splitBlock,
-                contentAfterEdit: `<p><font style="background-color: red;">abc</font></p><p><font style="background-color: red;" data-oe-zws-empty-inline="">[]\u200b</font><br></p>`,
+                contentAfterEdit: `<p><font style="background-color: red;">abc</font></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><font style="background-color: red;" data-oe-zws-empty-inline="">[]\u200b</font><br></p>`,
                 contentAfter: `<p><font style="background-color: red;">abc</font></p><p>[]<br></p>`,
             });
             await testEditor({
                 contentBefore: '<p><span style="font-size: 36px;">abc[]</span></p>',
                 stepFunction: splitBlock,
-                contentAfterEdit: `<p><span style="font-size: 36px;">abc</span></p><p><span style="font-size: 36px;" data-oe-zws-empty-inline="">[]\u200b</span><br></p>`,
+                contentAfterEdit: `<p><span style="font-size: 36px;">abc</span></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><span style="font-size: 36px;" data-oe-zws-empty-inline="">[]\u200b</span><br></p>`,
                 contentAfter: `<p><span style="font-size: 36px;">abc</span></p><p>[]<br></p>`,
             });
         });

--- a/addons/html_editor/static/tests/power_buttons.test.js
+++ b/addons/html_editor/static/tests/power_buttons.test.js
@@ -65,7 +65,7 @@ describe("visibility", () => {
         class TestPowerboxPlugin extends PowerboxPlugin {
             setup() {
                 super.setup();
-                this.resources.hints.text = placeholder;
+                this.resources.hints.object.text = placeholder;
             }
         }
         const tempP = document.createElement("p");


### PR DESCRIPTION
**Before this PR:**

After this commit [1] muted text is displayed on line which has focus while remaining absent from other lines. Due to this, when creating columns, it's hard to see where the columns are created and only column which gets focused shows hint.

**After this PR:**

- Now, when columns are created, the first empty block element of each column will have a hint. Due to this it will be easier to know where the columns are created.

- This PR adds a new resource `hint_targets_providers` which notifies the hint plugin to display hints on specific elements.

[1]: ab5ca2f6e3cc666354470aa5efc2250e805b11ad

task-4218913

Co-authored-by: Deependra Solanki <deso@odoo.com>


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
