### PR TITLE
[PERF] spreadsheet: avoid useless encoding and decoding

### DIFF
--- a/addons/spreadsheet/models/spreadsheet_mixin.py
+++ b/addons/spreadsheet/models/spreadsheet_mixin.py
@@ -71,11 +71,17 @@ class SpreadsheetMixin(models.AbstractModel):
 
     @api.depends("spreadsheet_binary_data")
     def _compute_spreadsheet_data(self):
-        for spreadsheet in self.with_context(bin_size=False):
-            if not spreadsheet.spreadsheet_binary_data:
-                spreadsheet.spreadsheet_data = False
-            else:
-                spreadsheet.spreadsheet_data = base64.b64decode(spreadsheet.spreadsheet_binary_data).decode()
+        attachments = self.env['ir.attachment'].with_context(bin_size=False).search([
+            ('res_model', '=', self._name),
+            ('res_field', '=', 'spreadsheet_binary_data'),
+            ('res_id', 'in', self.ids),
+        ])
+        data = {
+            attachment.res_id: attachment.raw
+            for attachment in attachments
+        }
+        for spreadsheet in self:
+            spreadsheet.spreadsheet_data = data.get(spreadsheet.id, False)
 
     def _inverse_spreadsheet_data(self):
         for spreadsheet in self:


### PR DESCRIPTION
This commit removes unnecessary base64 encoding and decoding operations when computing `spreadsheet_data` which contains the serialised json data.

Previously, the binary field `spreadsheet_binary_data` was base64-encoded (as is the case with all binary fields), meaning the file was read, encoded to base64, and assigned to `spreadsheet_binary_data`. To retrieve the serialized JSON, it then had to be decoded again.

By avoiding this redundant steps, we optimize the time spent in `_compute_spreadsheet_data`:

before: ~100ms
after: ~30ms

Task: 4256155

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
