### PR TITLE
[FIX] pos_hr: handle non-existent employee across sessions

### DIFF
--- a/addons/pos_hr/static/src/overrides/components/navbar/closing_popup/close_pos_popup.js
+++ b/addons/pos_hr/static/src/overrides/components/navbar/closing_popup/close_pos_popup.js
@@ -4,7 +4,7 @@ import { patch } from "@web/core/utils/patch";
 
 patch(ClosePosPopup.prototype, {
     async closeSession() {
-        sessionStorage.removeItem("connected_cashier");
+        this.pos._resetConnectedCashier();
         super.closeSession();
     },
 });

--- a/addons/pos_hr/static/src/overrides/models/pos_store.js
+++ b/addons/pos_hr/static/src/overrides/models/pos_store.js
@@ -17,9 +17,9 @@ patch(PosStore.prototype, {
         if (this.config.module_pos_hr) {
             this.employees = loadedData["hr.employee"];
             this.employee_by_id = loadedData["employee_by_id"];
-            const saved_cashier_id = sessionStorage.getItem("connected_cashier");
-            if (saved_cashier_id) {
-                this.set_cashier(this.employee_by_id[saved_cashier_id]);
+            const savedCashier = this._getConnectedCashier();
+            if (savedCashier) {
+                this.set_cashier(savedCashier);
             } else {
                 this.reset_cashier();
             }
@@ -28,7 +28,7 @@ patch(PosStore.prototype, {
     async after_load_server_data() {
         await super.after_load_server_data(...arguments);
         if (this.config.module_pos_hr) {
-            const saved_cashier = sessionStorage.getItem("connected_cashier");
+            const saved_cashier = this._getConnectedCashier();
             this.hasLoggedIn = saved_cashier ? true : false;
         }
     },
@@ -41,11 +41,11 @@ patch(PosStore.prototype, {
             pin: null,
             role: null,
         };
-        sessionStorage.removeItem("connected_cashier");
+        this._resetConnectedCashier();
     },
     set_cashier(employee) {
         this.cashier = employee;
-        sessionStorage.setItem("connected_cashier", employee.id);
+        this._storeConnectedCashier(employee);
         const selectedOrder = this.get_order();
         if (selectedOrder && !selectedOrder.get_orderlines().length) {
             // Order without lines can be considered to be un-owned by any employee.
@@ -84,6 +84,19 @@ patch(PosStore.prototype, {
             message,
         ]);
     },
+    _getConnectedCashier() {
+        const cashier_id = sessionStorage.getItem(`connected_cashier_${this.config.id}`);
+        if (cashier_id && this.employee_by_id[cashier_id]) {
+            return this.employee_by_id[cashier_id];
+        }
+        return false;
+    },
+    _storeConnectedCashier(employee) {
+        sessionStorage.setItem(`connected_cashier_${this.config.id}`, employee.id);
+    },
+    _resetConnectedCashier() {
+        sessionStorage.removeItem(`connected_cashier_${this.config.id}`);
+    },
 
     /**
      * @override
@@ -93,5 +106,11 @@ patch(PosStore.prototype, {
             return super.shouldShowCashControl(...arguments) && this.hasLoggedIn;
         }
         return super.shouldShowCashControl(...arguments);
+    },
+    closePos() {
+        if (this.config.module_pos_hr) {
+            this._resetConnectedCashier();
+        }
+        return super.closePos(...arguments);
     },
 });


### PR DESCRIPTION
Before this commit, logging into the PoS with a user not present in another session and then navigating back to the backend to open a different session resulted in an error due to the missing employee. This commit resolves the issue by incorporating the confid ID when saving employee ID in sessionStorage, ensuring employee information is accurately maintained.

opw-4255768

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
