### PR TITLE
[IMP] website: introduce `s_website_form_overlay` snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -147,6 +147,7 @@
         'views/snippets/s_embed_code.xml',
         'views/snippets/s_website_controller_page_listing_layout.xml',
         'views/snippets/s_website_form.xml',
+        'views/snippets/s_website_form_overlay.xml',
         'views/snippets/s_title_form.xml',
         'views/snippets/s_searchbar.xml',
         'views/snippets/s_button.xml',

--- a/addons/website/data/image_library.xml
+++ b/addons/website/data/image_library.xml
@@ -1021,5 +1021,11 @@
     <field name="type">url</field>
     <field name="url">/website/static/src/img/snippets_demo/s_empowerment_default_image.jpg</field>
 </record>
+<record id="website.s_website_form_overlay_default_image" model="ir.attachment">
+    <field name="public" eval="True"/>
+    <field name="name">s_website_form_overlay_default_image.jpg</field>
+    <field name="type">url</field>
+    <field name="url">/website/static/src/img/snippets_demo/s_cover.jpg</field>
+</record>
 
 </odoo>

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1027,7 +1027,7 @@ class Website(models.Model):
             fallback_create_missing_industry_image('s_carousel_intro_default_image_1', 's_cover_default_image')
             fallback_create_missing_industry_image('s_carousel_intro_default_image_2', 's_image_text_default_image')
             fallback_create_missing_industry_image('s_carousel_intro_default_image_3', 's_text_image_default_image')
-
+            fallback_create_missing_industry_image('s_website_form_overlay_default_image', 's_cover_default_image')
             fallback_create_missing_industry_image('s_framed_intro_default_image', 's_cover_default_image')
             fallback_create_missing_industry_image('s_wavy_grid_default_image_1', 's_cover_default_image')
             fallback_create_missing_industry_image('s_wavy_grid_default_image_2', 's_image_text_default_image')

--- a/addons/website/views/snippets/s_website_form_overlay.xml
+++ b/addons/website/views/snippets/s_website_form_overlay.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_website_form_overlay" name="Form Overlay">
+    <section class="s_website_form_overlay pt64 pb64 oe_img_bg o_bg_img_center o_colored_level" style="background-image: url('/web/image/website.s_website_form_overlay_default_image');">
+        <div class="o_we_bg_filter bg-black-50"/>
+        <div class="container">
+            <div class="row">
+                <div class="o_cc o_cc1 col-lg-6 offset-lg-6 rounded px-3 px-lg-4 pt40 pb16">
+                    <h2>Send us a message</h2>
+                    <p class="lead">Get in touch with your customers to provide them with better service. You can modify the form fields to gather more precise information.</p>
+                    <t t-snippet-call="website.s_website_form"/>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -327,6 +327,9 @@
                 </t>
                 <t t-snippet="website.s_opening_hours" string="Opening Hours" group="contact_and_forms"/>
                 <t t-snippet="website.s_contact_info" string="Contact Info" group="contact_and_forms"/>
+                <t t-snippet="website.s_website_form_overlay" string="Form Overlay" group="contact_and_forms">
+                    <keywords>contact, collect, submission, input, fields, questionnaire, survey, registration, request</keywords>
+                </t>
 
                 <!-- Products group -->
                 <t id="sale_products_hook"/>


### PR DESCRIPTION
This commit adds the new `s_website_form_overlay` snippet.

task-4138795
Part of task-4077427

Requires:
- https://github.com/odoo/design-themes/pull/989

---
![Capture d’écran 2024-10-14 à 15 15 57](https://github.com/user-attachments/assets/9dacc984-2a95-41f6-89b1-9d72adbce1af)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
