### PR TITLE
[FIX] account: prevent error when register a payment

### DIFF
--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -1107,7 +1107,7 @@ class AccountPaymentRegister(models.TransientModel):
                 if payment.currency_id != lines.currency_id:
                     liquidity_lines, counterpart_lines, writeoff_lines = payment._seek_for_lines()
                     source_balance = abs(sum(lines.mapped('amount_residual')))
-                    if liquidity_lines[0].balance:
+                    if liquidity_lines and liquidity_lines[0].balance:
                         payment_rate = liquidity_lines[0].amount_currency / liquidity_lines[0].balance
                     else:
                         payment_rate = 0.0


### PR DESCRIPTION
Currently, an error occurs when register a payment for an invoice in a different currency.

Step to produce:

- Install the ```account``` module.
- Activate multicurrency
- Create a new invoice(in USD), add an invoice line and customer, and confirm it.
- Change the currency to EUR when making an invoice payment.

```IndexError: tuple index out of range```

An error occurs when the system tries to get a move line at [1], 'move_id' for a payment is not available

Link [1]:  https://github.com/odoo/odoo/blob/8e95527210a40f354ffb3c57e49f6580252edbfa/addons/account/wizard/account_payment_register.py#L1110

To handle this issue, add a condition to retrieve the move line value if an invoice is available for payment.

Sentry-5989418366

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
