### PR TITLE
[FIX] base_automation: Remove non base dependency in test

### DIFF
--- a/addons/base_automation/tests/test_automation.py
+++ b/addons/base_automation/tests/test_automation.py
@@ -11,7 +11,7 @@ class TestAutomation(TransactionCaseWithUserDemo):
 
     def test_01_on_create(self):
         """ Simple on_create with admin user """
-        self.env["base.automation"].create([{
+        self.env["base.automation"].create({
             "name": "Force Archived Contacts",
             "trigger": "on_create_or_write",
             "model_id": self.env.ref("base.model_res_partner").id,
@@ -22,23 +22,7 @@ class TestAutomation(TransactionCaseWithUserDemo):
                 "evaluation_type": "equation",
                 "value": "False",
             })],
-        },
-        {
-            "name": "Bilbo time senstive reminder",
-            "trigger": "on_time",
-            "model_id": self.env.ref("hr_contract.model_hr_contract").id,
-            "type": "ir.actions.server",
-            "trigger_field_ids": [],
-            "trg_date_range": -7,
-            "trg_date_range_type": "day",
-            "trg_date_id": self.env.ref("hr_contract.field_hr_contract__date_end").id,
-            "fields_lines": [],
-        }])
-
-        # verify the "Base Action Rule: check and execute" frequency is set correctly with negative numbers.
-        cron = self.env["ir.cron"].search([("cron_name", "=", "Base Action Rule: check and execute")])
-        self.assertEqual(cron.interval_number, 240)
-        self.assertEqual(cron.interval_type, "minutes")
+        })
 
         # verify the partner can be created and the action still runs
         bilbo = self.env["res.partner"].create({"name": "Bilbo Baggins"})
@@ -51,29 +35,27 @@ class TestAutomation(TransactionCaseWithUserDemo):
 
         # verify the "Base Action Rule: check and execute" frequency is updated correctly when a new action is created.
         self.env["base.automation"].create([
-        {
-            "name": "Bilbo time senstive reminder in a hurry",
-            "trigger": "on_time",
-            "model_id": self.env.ref("hr_contract.model_hr_contract").id,
-            "type": "ir.actions.server",
-            "trigger_field_ids": [],
-            "trg_date_range": -60,
-            "trg_date_range_type": "minutes",
-            "trg_date_id": self.env.ref("hr_contract.field_hr_contract__date_end").id,
-            "fields_lines": [],
-        },
-         {
-            "name": "Bilbo time senstive reminder late",
-            "trigger": "on_time",
-            "model_id": self.env.ref("hr_contract.model_hr_contract").id,
-            "type": "ir.actions.server",
-            "trigger_field_ids": [],
-            "trg_date_range": 60,
-            "trg_date_range_type": "minutes",
-            "trg_date_id": self.env.ref("hr_contract.field_hr_contract__date_end").id,
-            "fields_lines": [],
-        }])
-        cron = self.env["ir.cron"].search([("cron_name", "=", "Base Action Rule: check and execute")])
+            {
+                "name": "Bilbo time senstive reminder in a hurry",
+                "trigger": "on_time",
+                "model_id": self.env.ref("base.model_res_partner").id,
+                "trigger_field_ids": [],
+                "trg_date_range": -60,
+                "trg_date_range_type": "minutes",
+                "trg_date_id": self.env.ref("base.field_res_partner__write_date").id,
+            },
+            {
+                "name": "Bilbo time senstive reminder late",
+                "trigger": "on_time",
+                "model_id": self.env.ref("base.model_res_partner").id,
+                "trigger_field_ids": [],
+                "trg_date_range": 60,
+                "trg_date_range_type": "minutes",
+                "trg_date_id": self.env.ref("base.field_res_partner__write_date").id,
+            }
+            ])
+
+        cron = self.env.ref('base_automation.ir_cron_data_base_automation_check', raise_if_not_found=False)
         self.assertEqual(cron.interval_number, 6)
         self.assertEqual(cron.interval_type, "minutes")
 
@@ -133,18 +115,3 @@ class TestAutomation(TransactionCaseWithUserDemo):
         # simulate a onchange call on name
         onchange = self_portal.onchange({}, [], {"name": "1", "active": ""})
         self.assertEqual(onchange["value"]["active"], False)
-
-    def test_04__get_cron_interval(self):
-        """ Simple on_create with admin user """
-        self.env["base.automation"].create({
-            "name": "Force Archived Contacts",
-            "trigger": "on_create_or_write",
-            "model_id": self.env.ref("base.model_res_partner").id,
-            "type": "ir.actions.server",
-            "trigger_field_ids": [(6, 0, [self.env.ref("base.field_res_partner__name").id])],
-            "fields_lines": [(0, 0, {
-                "col1": self.env.ref("base.field_res_partner__active").id,
-                "evaluation_type": "equation",
-                "value": "False",
-            })],
-        })


### PR DESCRIPTION
Remove Dependency on hr_contract model as it does exist in the dependent apps for base_automation which would allow tests to fail if the module was not installed.

To solve this, the test was compared against a base field instead.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
