### PR TITLE
[FIX] point_of_sale: ensure pricelist updates on product search

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -194,14 +194,14 @@ export class PosStore extends Reactive {
         this.config.iface_printers = !!this.unwatched.printers.length;
 
         // Monitor product pricelist
-        this.models["product.product"].addEventListener(
-            "create",
-            this.computeProductPricelistCache.bind(this)
-        );
-        this.models["product.pricelist.item"].addEventListener(
-            "create",
-            this.computeProductPricelistCache.bind(this)
-        );
+        ["product.product", "product.pricelist.item"].forEach((model) => {
+            ["create", "update"].forEach((event) => {
+                this.models[model].addEventListener(
+                    event,
+                    this.computeProductPricelistCache.bind(this)
+                );
+            });
+        });
         if (this.data.loadedIndexedDBProducts && this.data.loadedIndexedDBProducts.length > 0) {
             await this._loadMissingPricelistItems(this.data.loadedIndexedDBProducts);
             delete this.data.loadedIndexedDBProducts;


### PR DESCRIPTION
Before this commit, searching for an existing product in the PoS and selecting 'search more' would cause pricelist rules to stop applying. This issue arose because a new product object was created without triggering the create event. This commit addresses the problem by ensuring pricelist computation occurs upon product update events.

opw-4214963

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
