### PR TITLE
[FIX] base: test do not depend on master data

### DIFF
--- a/odoo/addons/base/tests/common.py
+++ b/odoo/addons/base/tests/common.py
@@ -39,6 +39,13 @@ class BaseCommon(TransactionCase):
             # avoid using the context to assign companies
             cls.env.user.company_id = independent_company
             cls.env.user.company_ids = [Command.set(independent_company.ids)]
+            # Ensure that the main company's data doesn't impact tests.
+            # Instead we set it to be the main test company instead.
+            # This is a an additional layer to avoid any side effect from (demo) data
+            # or how the database was initialized.
+            patch_main_company = patch('odoo.addons.base.models.res_company.Company._get_main_company', return_value=independent_company)
+            patch_main_company.start()
+            cls.addClassCleanup(patch_main_company.stop)
         else:
             cls.setup_main_company()
 


### PR DESCRIPTION
A case where the tests were still depending on the demo data was when we were relying on the main company, for instance to retrieve the currency on a product.

The currency of the product is either the currency of its company, or the currency of the main company. But since we have no control over the company of the main company, the price unit could sometimes be converted during tests.

An example was when running `TestAccountPaymentRegister.test_keep_user_amount` without demo data (they are setting a currency on the main company) when a chart of accounts is installed, because that CoA would then change the "main currency".

[runbot-98394](https://runbot.odoo.com/web/#id=98394&menu_id=424&cids=1&action=573&model=runbot.build.error&view_type=form)
