### PR TITLE
[FIX] sale_stock: update warning message for unset WH on SO

### DIFF
--- a/addons/sale_stock/i18n/sale_stock.pot
+++ b/addons/sale_stock/i18n/sale_stock.pot
@@ -741,6 +741,13 @@ msgid ""
 "You must have a warehouse for line using a delivery in different company."
 msgstr ""
 
+
+#. module: sale_stock
+#. odoo-python
+#: code:addons/sale_stock/models/sale_order.py:0
+msgid "You must set a warehouse on your sale order to proceed."
+msgstr ""
+
 #. module: sale_stock
 #: model_terms:ir.ui.view,arch_db:sale_stock.exception_on_so
 msgid "cancelled"

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -103,6 +103,7 @@ class SaleOrder(models.Model):
     def _check_warehouse(self):
         """ Ensure that the warehouse is set in case of storable products """
         orders_without_wh = self.filtered(lambda order: order.state not in ('draft', 'cancel') and not order.warehouse_id)
+        company_ids_with_wh = {group['company_id'][0] for group in self.env['stock.warehouse'].read_group(domain=[('company_id', 'in', orders_without_wh.mapped('company_id').ids)], fields=['id:recordset'], groupby=['company_id'])} if orders_without_wh else {}
         other_company = set()
         for order_line in orders_without_wh.order_line:
             if order_line.product_id.type != 'consu':
@@ -110,6 +111,8 @@ class SaleOrder(models.Model):
             if order_line.route_id.company_id and order_line.route_id.company_id != order_line.company_id:
                 other_company.add(order_line.route_id.company_id.id)
                 continue
+            if order_line.order_id.company_id.id in company_ids_with_wh:
+                raise UserError(_('You must set a warehouse on your sale order to proceed.'))
             self.env['stock.warehouse'].with_company(order_line.order_id.company_id)._warehouse_redirect_warning()
         other_company_warehouses = self.env['stock.warehouse'].search([('company_id', 'in', list(other_company))])
         if any(c not in other_company_warehouses.company_id.ids for c in other_company):


### PR DESCRIPTION
### Steps to reproduce:

- Create a new company
- With this new company, create an SO for a storable product
- Try to confirm the SO
#### > A redirect warning is raised: "Please create a warehouse ..."
- Go to warehouses and create such a warehouse
- Try to confirm the SO once more
#### > The same warning is raised: "Please create a warehouse ..."

### Cause of the issue:

The redirect warning that asks you to create a warehouse is raised when you try to confirm an SO wihtout a set "warehouse_id": https://github.com/odoo/odoo/blob/114b476755c37ae670f613200ffcc03377258873/addons/sale_stock/models/sale_order.py#L102-L113 https://github.com/odoo/odoo/blob/114b476755c37ae670f613200ffcc03377258873/addons/stock/models/stock_warehouse.py#L166-L172 Since you created the SO before the warehouse, the SO is curently not linked to any warehouse. Furthermove, when you created the warehouse, it did not update the 'warehouse_id' so that the exact same warning will be raised after the warehouse creation.

opw-4250791
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
