### PR TITLE
[FIX] mail, web: allow removing image attachments on mobile

### DIFF
--- a/addons/mail/static/src/core/common/attachment_list.xml
+++ b/addons/mail/static/src/core/common/attachment_list.xml
@@ -21,7 +21,7 @@
                     aria-label="View image"
                     role="menuitem"
                     t-att-data-mimetype="attachment.mimetype"
-                    t-on-click="() => this.fileViewer.open(attachment, props.attachments)"
+                    t-on-click="() => this.onOpen(attachment)"
                 >
                     <img
                         class="img img-fluid my-0 mx-auto o-viewable"
@@ -60,7 +60,7 @@
                     }"
                     t-attf-class="bg-300"
                     t-att-title="attachment.name ? attachment.name : undefined" role="menu" t-att-aria-label="attachment.name"
-                    t-on-click="() => this.fileViewer.open(attachment, props.attachments)"
+                    t-on-click="() => this.onOpen(attachment)"
                 >
                     <!-- o_image from mimetype.scss -->
                     <t t-ref="nonImageMain">

--- a/addons/mail/static/src/core/common/file_viewer.js
+++ b/addons/mail/static/src/core/common/file_viewer.js
@@ -1,0 +1,21 @@
+/* @odoo-module */
+
+import { FileViewer as WebFileViewer } from "@web/core/file_viewer/file_viewer";
+
+export class FileViewer extends WebFileViewer {
+
+    static template = "mail.FileViewer";
+
+    static props = [
+        ...WebFileViewer.props,
+        "onClickUnlink?"
+    ]
+
+    async onClickUnlink() {
+        const deleted = await this.props.onClickUnlink(this.state.file);
+        if (deleted) {
+           this.close();
+        }
+    }
+
+}

--- a/addons/mail/static/src/core/common/file_viewer.xml
+++ b/addons/mail/static/src/core/common/file_viewer.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="mail.FileViewer" t-inherit="web.FileViewer" t-inherit-mode="primary">
+    <xpath expr="//div[@role='toolbar']/div[@title='Download']" position="after">
+        <div t-if="ui.isSmall" class="o-FileViewer-toolbarButton p-3 rounded-0" t-on-click.stop="onClickUnlink" title="Remove" role="button">
+            <i class="fa fa-fw fa-trash" role="img"/>
+        </div>
+    </xpath>
+</t>
+
+</templates>

--- a/addons/web/static/src/core/file_viewer/file_viewer_hook.js
+++ b/addons/web/static/src/core/file_viewer/file_viewer_hook.js
@@ -11,8 +11,10 @@ export function useFileViewer() {
     /**
      * @param {import("@web/core/file_viewer/file_viewer").FileViewer.props.files[]} file
      * @param {import("@web/core/file_viewer/file_viewer").FileViewer.props.files} files
+     * @param {import("@web/core/file_viewer/file_viewer").FileViewer} Component
+     * @param {import("@web/core/file_viewer/file_viewer").FileViewer.props} extraProps
      */
-    function open(file, files = [file]) {
+    function open(file, files = [file], Component = FileViewer, ComponentProps = {}) {
         if (!file.isViewable) {
             return;
         }
@@ -20,8 +22,8 @@ export function useFileViewer() {
             const viewableFiles = files.filter((file) => file.isViewable);
             const index = viewableFiles.indexOf(file);
             registry.category("main_components").add(fileViewerId, {
-                Component: FileViewer,
-                props: { files: viewableFiles, startIndex: index, close },
+                Component,
+                props: { files: viewableFiles, startIndex: index, close, ...ComponentProps },
             });
         }
     }


### PR DESCRIPTION
Steps to reproduce
==================

- Use a mobile viewport
- Open a project task
- Upload an image attachment

=> You can't delete it

Cause of the issue
==================

On mobile, the download and remove buttons are not displayed on top of the image as they prevent clicks on the image itself.

It is still possible to download the image once opened, but it is not possible to remove it.

Solution
========

Add a remove button to the FileViewer

opw-4091877