### PR TITLE
[FIX] pos_self_order: allow disabling of preparation display option

### DIFF
--- a/addons/pos_self_order/models/res_config_settings.py
+++ b/addons/pos_self_order/models/res_config_settings.py
@@ -67,7 +67,7 @@ class ResConfigSettings(models.TransientModel):
         if self.pos_self_ordering_service_mode == 'counter' and self.pos_self_ordering_mode == 'mobile':
             self.pos_self_ordering_pay_after = "each"
 
-        if self.pos_self_ordering_pay_after == "each" and not self.module_pos_preparation_display:
+        if self.pos_self_ordering_mode not in ['nothing', 'consultation'] and self.pos_self_ordering_pay_after == "each" and not self.module_pos_preparation_display:
             self.module_pos_preparation_display = True
 
     def custom_link_action(self):

--- a/addons/pos_self_order/tests/test_self_order_common.py
+++ b/addons/pos_self_order/tests/test_self_order_common.py
@@ -50,3 +50,26 @@ class TestSelfOrderCommon(SelfOrderCommonTest):
         for mode in ("mobile", "consultation", "kiosk"):
             self.pos_config.write({"self_ordering_mode": mode})
             self.start_tour(self_route, "self_order_pos_is_closed")
+
+    def test_self_order_preparation_disabling_preparation_display(self):
+        """
+        This test ensures that the preparation display option can be disabled when the self_ordering_mode is set to 'nothing'.
+        It also tests that the preparation display option is enabled automatically when the self_ordering_mode is set to 'kiosk'.
+        """
+        self.pos_config.self_ordering_pay_after = 'each'
+
+        with odoo.tests.Form(self.env['res.config.settings']) as form:
+            with self.assertLogs(level="WARNING"):
+                form.module_pos_preparation_display = False
+
+            self.pos_config.write({
+                'self_ordering_mode': 'nothing',
+            })
+            form.pos_config_id = self.pos_config
+            self.assertEqual(form.module_pos_preparation_display, False)
+
+            self.pos_config.write({
+                'self_ordering_mode': 'kiosk',
+            })
+            form.pos_config_id = self.pos_config
+            self.assertEqual(form.module_pos_preparation_display, True)


### PR DESCRIPTION
Issue: In the POS settings, even after disabling the preparation display option, it remains enabled after saving.

Steps to reproduce:
-In POS configuration
-Ensure the Pay after option is set to each order.
-Disable self ordering and uncheck the preparation display option, save.

Explanation: In res_config_settings.py of pos_self_order, https://github.com/odoo/odoo/commit/8ee8010cf67f20c4eb28a334cc943bfedf2dd0d1 added a check to ensure that the preparation display is enabled if self-ordering is active. However, it was still automatically enabling the preparation display even when self-ordering was disabled.

opw-4225668

(This pr was merged but introduced an error with the test which was fixed in a separate pr: https://github.com/odoo/odoo/pull/186539)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
