### PR TITLE
[FIX] mass_mailing: fix overlap issues with mass_mailing_html_field (2)

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_wysiwyg.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_wysiwyg.js
@@ -104,6 +104,10 @@ export class MassMailingWysiwyg extends Wysiwyg {
         super.onToggleFullscreen(isFullscreen);
         const iframe = this.$iframe?.[0];
         if (iframe && iframe.isConnected) {
+            iframe.parentElement.classList.toggle(
+                "o_mass_mailing_iframe_ancestor_fullscreen",
+                isFullscreen
+            );
             const body = iframe.contentWindow.document.body;
             const scrollingElement = isFullscreen ? body : iframe;
             body.classList.toggle("o_mass_mailing_iframe_body_fullscreen", isFullscreen);

--- a/addons/mass_mailing/static/src/js/snippets.editor.js
+++ b/addons/mass_mailing/static/src/js/snippets.editor.js
@@ -185,7 +185,6 @@ export class MassMailingSnippetsMenu extends snippetsEditor.SnippetsMenu {
     _onFullscreenBtnClick(ev) {
         $("body").toggleClass("o_field_widgetTextHtml_fullscreen");
         const full = $("body").hasClass("o_field_widgetTextHtml_fullscreen");
-        this.options.wysiwyg.$iframe.parents().toggleClass("o_form_fullscreen_ancestor", full);
         $(window).trigger("resize"); // induce a resize() call and let other backend elements know (the navbar extra items management relies on this)
         if (this.env.onToggleFullscreen) {
             // `onToggleFullscreen` in the `env` is deprecated, use the wysiwyg function instead

--- a/addons/mass_mailing/static/src/scss/mass_mailing.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.scss
@@ -200,3 +200,7 @@ body.editor_has_snippets .o_field_mass_mailing_html div.d-flex:has(iframe) {
         min-height: 55vh;
     }
 }
+
+.o_dialog .o_content:has(.o_field_mass_mailing_html) {
+    overflow: unset;
+}

--- a/addons/mass_mailing/static/src/scss/mass_mailing.wysiwyg.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.wysiwyg.scss
@@ -33,7 +33,7 @@
     .wysiwyg_iframe.o_iframe.has_snippets_sidebar {
         border: none,
     }
-    .o_form_fullscreen_ancestor {
+    .o_mass_mailing_iframe_ancestor_fullscreen {
         // Prevent the website snippets sidebar from overlapping the template
         .wysiwyg_iframe.o_iframe.has_snippets_sidebar {
             padding-right: $o-we-sidebar-width !important;

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -3468,7 +3468,7 @@ class SnippetsMenu extends Component {
         if (!$scrollingElement[0]) {
             $scrollingElement = $(this.ownerDocument).find('.o_editable');
         }
-        const oNotebook = this.ownerDocument.querySelector(".o_notebook:not(.o_fullscreen_ancestor)");
+        const oNotebook = this.ownerDocument.querySelector(".o_notebook");
         if (oNotebook) {
             $scrollingElement = $(oNotebook);
         }

--- a/addons/web_editor/static/src/scss/web_editor.backend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.backend.scss
@@ -65,9 +65,9 @@
     }
 }
 
-.editor_has_snippets.o_field_widgetTextHtml_fullscreen .o_field_mass_mailing_html.o_form_fullscreen_ancestor {
+.editor_has_snippets.o_field_widgetTextHtml_fullscreen .o_field_mass_mailing_html {
 
-    iframe {
+    .o_mass_mailing_iframe_ancestor_fullscreen iframe {
         width: calc(100% - #{$o-we-sidebar-width});
     }
     #oe_snippets {
@@ -83,7 +83,7 @@
 }
 
 .o_field_widgetTextHtml_fullscreen {
-    .o_field_mass_mailing_html.o_form_fullscreen_ancestor iframe {
+    .o_field_mass_mailing_html .o_mass_mailing_iframe_ancestor_fullscreen iframe {
         position: absolute !important;
         left: 0 !important;
         right: 0 !important;
@@ -96,13 +96,15 @@
     .tooltip-field-info {
         display: none;
     }
-    .o_form_fullscreen_ancestor {
+    .o_mass_mailing_iframe_ancestor_fullscreen {
         display: block !important;
-        position: static !important;
+        position: fixed !important;
         top: 0 !important;
         left: 0 !important;
-        width: auto !important;
+        width: 100vw !important;
+        height: 100vh !important;
         overflow: hidden !important;
         transform: none !important;
+        z-index: $zindex-dropdown - 2; // oe_snippets has $zindex-dropdown - 1
     }
 }


### PR DESCRIPTION
This PR fixes multiple issues related to the mass_mailing_html_field used
in `marketing_automation` and in `mass_mailing` modules.
This PR is the continuation of https://github.com/odoo/odoo/pull/187134

1) The edition dialog for the marketing campaign overlaps the fullscreen editor
of the mail template destined to that marketing campaign.
- concerns: marketing_automation

2) The snippets sidebar in a dialog does not stick to the dialog title when
scrolling the dialog
- concerns: marketing_automation

See individual commits for further explanation.

task-4178640

Co-authored-by: Astik Singh <assi@odoo.com>
Co-authored-by: Damien Abeloos <abd@odoo.com>
Co-authored-by: Mahdi Cheikh Rouhou <macr@odoo.com>
Co-authored-by: Shubham Thanki <shut@odoo.com>