### PR TITLE
[DRAFT][IMP] l10n_ua, sales: Improve pro-forma invoice template

### DIFF
--- a/addons/l10n_ua/models/__init__.py
+++ b/addons/l10n_ua/models/__init__.py
@@ -1,2 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import template_ua_psbo
+from . import res_company

--- a/addons/l10n_ua/models/res_company.py
+++ b/addons/l10n_ua/models/res_company.py
@@ -1,0 +1,17 @@
+from markupsafe import Markup
+
+from odoo import api, models, _, fields
+
+
+class BaseDocumentLayout(models.TransientModel):
+    _inherit = 'base.document.layout'
+
+    @api.model
+    def _default_company_details(self):
+        company_details = super()._default_company_details()
+        company = self.env.company
+        if company.country_code == 'UA' and company.company_registry:
+            company_details += Markup('<br/> %s') % _('Registry: %s', company.company_registry)
+        return company_details
+
+    company_details = fields.Html(default=_default_company_details)

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -64,6 +64,9 @@ class SaleOrder(models.Model):
             return ['name', 'partner_id.name']
         return ['name']
 
+    def _get_journal_domain(self):
+        return [('type', '=', 'sale')] if not self.env.user.has_group('sale.group_proforma_sales') else [('type', 'in', ('sale', 'bank'))]
+
     #=== FIELDS ===#
 
     name = fields.Char(
@@ -148,7 +151,7 @@ class SaleOrder(models.Model):
     journal_id = fields.Many2one(
         'account.journal', string="Invoicing Journal",
         compute="_compute_journal_id", store=True, readonly=False, precompute=True,
-        domain=[('type', '=', 'sale')], check_company=True,
+        domain=_get_journal_domain, check_company=True,
         help="If set, the SO will invoice in this journal; "
              "otherwise the sales journal with the lowest sequence is used.")
 

--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -121,7 +121,15 @@
                                 </td>
                                 <t t-set="taxes" t-value="', '.join([(tax.invoice_label or tax.name) for tax in line.tax_id])"/>
                                 <td name="td_taxes" t-attf-class="text-end {{ 'text-nowrap' if len(taxes) &lt; 10 else '' }}">
-                                    <span t-out="taxes">Tax 15%</span>
+                                    <t t-if="is_proforma">
+                                        <span t-out="round(line.price_tax / line.product_uom_qty, 2)">10</span>
+                                        <div class="fst-italic o_line_note text-muted fs-7">
+                                            <span t-out="taxes">Tax 15%</span>
+                                        </div>
+                                    </t>
+                                    <t t-else="">
+                                        <span t-out="taxes">Tax 15%</span>
+                                    </t>
                                 </td>
                                 <td t-if="not line.is_downpayment" name="td_subtotal" class="text-end o_price_total">
                                     <span t-field="line.price_subtotal">27.00</span>
@@ -180,6 +188,19 @@
                 </div>
             </div>
             <div class="oe_structure"></div>
+
+            <div class="oe_structure" t-if="is_proforma">
+                <div>
+                    <t t-set="move" t-value="doc.invoice_ids"/>
+                    <strong>Payment Details:</strong>
+                    <div t-field="doc.partner_id.name"/>
+                    <div t-field="doc.partner_id.vat"/>
+                    <div t-if="doc.journal_id">
+                        <div t-if="doc.journal_id.bank_account_id" t-field="doc.journal_id.bank_account_id.acc_number"/>
+                        <div t-if="doc.journal_id.bank_id" t-field="doc.journal_id.bank_id.name"/>
+                    </div>
+                </div>
+            </div>
 
             <div t-if="not doc.signature" class="oe_structure"></div>
             <div t-else="" class="mt-4 ml64 mr4" name="signature">


### PR DESCRIPTION
This commit add some information on the basic pro-forma invoice template, such as company registry, payment information and tax amount.

Also, it adds the possibility to choose a bank journal in the sale order form view, as long as the pro-forma invoice is enable in the settings.

task-4236713

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
