### PR TITLE
[FIX] account: Change default readonly of invoice_user_id to False

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -503,6 +503,7 @@ class AccountMove(models.Model):
         tracking=True,
         compute='_compute_invoice_default_sale_person',
         store=True,
+        readonly=False,
     )
     # Technical field used to fit the generic behavior in mail templates.
     user_id = fields.Many2one(string='User', related='invoice_user_id')


### PR DESCRIPTION
A previous commit(88388031035f834203720cd9a0c966852e04525b) added a compute on invoice_user_id fields to
guess the Sale Person. The problem is that by adding the compute on the field, the readonly default value changes for True. It causes that user can't change the sale person anymore.

no task id

backport of 83b089d4ac02863affb2c789b0d1a533e3965510

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
