### PR TITLE
[FIX] point_of_sale: prevent error on deleting one paid order

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -140,7 +140,7 @@ export class TicketScreen extends Component {
             if (!confirmed) {
                 return false;
             }
-            if (this.state.selectedOrder === order) {
+            if (this.state.selectedOrder?.id === order.id) {
                 this.state.selectedOrder = null;
             }
         }


### PR DESCRIPTION
Before this commit, attempting to delete the only order in the paid order list would result in an error. This was due to the ticket screen setting the current order to `selectedOrder` upon opening. However, when the order was fetched again, it replaced the previous order, leading to not setting 'selectedOrder` to null after deleting.

opw-4230543

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
