### PR TITLE
[IMP] core, *: rename type='json' to type='jsonrpc'

### DIFF
--- a/addons/account/controllers/tests_shared_js_python.py
+++ b/addons/account/controllers/tests_shared_js_python.py
@@ -11,6 +11,6 @@ class TestsSharedJsPython(http.Controller):
         tests = json.loads(request.env['ir.config_parameter'].get_param('account.tests_shared_js_python', '[]'))
         return request.render('account.tests_shared_js_python', {'props': {'tests': tests}})
 
-    @http.route('/account/post_tests_shared_js_python', type='json', auth='user')
+    @http.route('/account/post_tests_shared_js_python', type='jsonrpc', auth='user')
     def route_post_tests_shared_js_python(self, results):
         request.env['ir.config_parameter'].set_param('account.tests_shared_js_python', json.dumps(results or []))

--- a/addons/account_payment/controllers/payment.py
+++ b/addons/account_payment/controllers/payment.py
@@ -11,7 +11,7 @@ from odoo.addons.payment.controllers import portal as payment_portal
 
 class PaymentPortal(payment_portal.PaymentPortal):
 
-    @route('/invoice/transaction/<int:invoice_id>', type='json', auth='public')
+    @route('/invoice/transaction/<int:invoice_id>', type='jsonrpc', auth='public')
     def invoice_transaction(self, invoice_id, access_token, **kwargs):
         """ Create a draft transaction and return its processing values.
 
@@ -35,7 +35,7 @@ class PaymentPortal(payment_portal.PaymentPortal):
         self._validate_transaction_kwargs(kwargs, additional_allowed_keys={'name_next_installment'})
         return self._process_transaction(partner_sudo.id, invoice_sudo.currency_id.id, [invoice_id], False, **kwargs)
 
-    @route('/invoice/transaction/overdue', type='json', auth='public')
+    @route('/invoice/transaction/overdue', type='jsonrpc', auth='public')
     def overdue_invoices_transaction(self, payment_reference, **kwargs):
         """ Create a draft transaction for overdue invoices and return its processing values.
 

--- a/addons/auth_passkey/controllers/main.py
+++ b/addons/auth_passkey/controllers/main.py
@@ -7,7 +7,7 @@ CREDENTIAL_PARAMS.append('webauthn_response')
 
 
 class WebauthnController(http.Controller):
-    @http.route(['/auth/passkey/start-auth'], type='json', auth='public')
+    @http.route(['/auth/passkey/start-auth'], type='jsonrpc', auth='public')
     def json_start_authentication(self):
         auth_options = request.env['auth.passkey.key']._start_auth()
         return auth_options

--- a/addons/auth_totp/tests/test_totp.py
+++ b/addons/auth_totp/tests/test_totp.py
@@ -35,7 +35,7 @@ class TestTOTPMixin:
         totp_hook.routing_type = 'json'
         self.env.registry.clear_cache('routing')
         # patch Home to add test endpoint
-        Home.totp_hook = http.route('/totphook', type='json', auth='none')(totp_hook)
+        Home.totp_hook = http.route('/totphook', type='jsonrpc', auth='none')(totp_hook)
         # remove endpoint and destroy routing map
         @self.addCleanup
         def _cleanup():

--- a/addons/base_setup/controllers/main.py
+++ b/addons/base_setup/controllers/main.py
@@ -7,7 +7,7 @@ from odoo.http import request
 
 
 class BaseSetup(http.Controller):
-    @http.route('/base_setup/data', type='json', auth='user')
+    @http.route('/base_setup/data', type='jsonrpc', auth='user')
     def base_setup_data(self, **kw):
         if not request.env.user.has_group('base.group_erp_manager'):
             raise AccessError(_("Access Denied"))
@@ -50,7 +50,7 @@ class BaseSetup(http.Controller):
             'action_pending_users': action_pending_users,
         }
 
-    @http.route('/base_setup/demo_active', type='json', auth='user')
+    @http.route('/base_setup/demo_active', type='jsonrpc', auth='user')
     def base_setup_is_demo(self, **kwargs):
         # We assume that if there's at least one module with demo data active, then the db was
         # initialized with demo=True or it has been force-activated by the `Load demo data` button

--- a/addons/board/controllers/main.py
+++ b/addons/board/controllers/main.py
@@ -8,7 +8,7 @@ from odoo.http import Controller, route, request
 
 class Board(Controller):
 
-    @route('/board/add_to_dashboard', type='json', auth='user')
+    @route('/board/add_to_dashboard', type='jsonrpc', auth='user')
     def add_to_dashboard(self, action_id, context_to_save, domain, view_mode, name=''):
         # Retrieve the 'My Dashboard' action from its xmlid
         action = request.env.ref('board.open_board_my_dash_action').sudo()

--- a/addons/bus/controllers/websocket.py
+++ b/addons/bus/controllers/websocket.py
@@ -28,7 +28,7 @@ class WebsocketController(Controller):
                    ('Cache-Control', 'no-store')]
         return request.make_response(data, headers)
 
-    @route('/websocket/peek_notifications', type='json', auth='public', cors='*')
+    @route('/websocket/peek_notifications', type='jsonrpc', auth='public', cors='*')
     def peek_notifications(self, channels, last, is_first_poll=False):
         if is_first_poll:
             # Used to detect when the current session is expired.
@@ -42,14 +42,14 @@ class WebsocketController(Controller):
         notifications = request.env["bus.bus"]._poll(channels_with_db, subscribe_data["last"])
         return {"channels": channels_with_db, "notifications": notifications}
 
-    @route('/websocket/update_bus_presence', type='json', auth='public', cors='*')
+    @route('/websocket/update_bus_presence', type='jsonrpc', auth='public', cors='*')
     def update_bus_presence(self, inactivity_period, im_status_ids_by_model):
         if 'is_websocket_session' not in request.session:
             raise SessionExpiredException()
         request.env['ir.websocket']._update_bus_presence(int(inactivity_period), im_status_ids_by_model)
         return {}
 
-    @route("/websocket/on_closed", type="json", auth="public", cors="*")
+    @route("/websocket/on_closed", type="jsonrpc", auth="public", cors="*")
     def on_websocket_closed(self):
         request.env["ir.websocket"]._on_websocket_closed(request.cookies)
 

--- a/addons/calendar/controllers/main.py
+++ b/addons/calendar/controllers/main.py
@@ -94,11 +94,11 @@ class CalendarController(http.Controller):
         return request.redirect('/calendar/meeting/view?token=%s&id=%s' % (attendee.access_token, event.id))
 
     # Function used, in RPC to check every 5 minutes, if notification to do for an event or not
-    @http.route('/calendar/notify', type='json', auth="user")
+    @http.route('/calendar/notify', type='jsonrpc', auth="user")
     def notify(self):
         return request.env['calendar.alarm_manager'].get_next_notif()
 
-    @http.route('/calendar/notify_ack', type='json', auth="user")
+    @http.route('/calendar/notify_ack', type='jsonrpc', auth="user")
     def notify_ack(self):
         return request.env['res.partner'].sudo()._set_calendar_last_notif_ack()
 
@@ -114,7 +114,7 @@ class CalendarController(http.Controller):
 
         return request.redirect(event.videocall_channel_id.invitation_url)
 
-    @http.route('/calendar/check_credentials', type='json', auth='user')
+    @http.route('/calendar/check_credentials', type='jsonrpc', auth='user')
     def check_calendar_credentials(self):
         # method should be overwritten by sync providers
         return request.env['res.users'].check_calendar_credentials()

--- a/addons/crm_mail_plugin/controllers/crm_client.py
+++ b/addons/crm_mail_plugin/controllers/crm_client.py
@@ -11,7 +11,7 @@ from .mail_plugin import MailPluginController
 class CrmClient(MailPluginController):
 
     @http.route(route='/mail_client_extension/log_single_mail_content',
-                type="json", auth="outlook", cors="*")
+                type="jsonrpc", auth="outlook", cors="*")
     def log_single_mail_content(self, lead, message, **kw):
         """
             deprecated as of saas-14.3, not needed for newer versions of the mail plugin but necessary
@@ -20,7 +20,7 @@ class CrmClient(MailPluginController):
         crm_lead = request.env['crm.lead'].browse(lead)
         crm_lead.message_post(body=message)
 
-    @http.route('/mail_client_extension/lead/get_by_partner_id', type="json", auth="outlook", cors="*")
+    @http.route('/mail_client_extension/lead/get_by_partner_id', type="jsonrpc", auth="outlook", cors="*")
     def crm_lead_get_by_partner_id(self, partner, limit=5, offset=0, **kwargs):
         """
             deprecated as of saas-14.3, not needed for newer versions of the mail plugin but necessary
@@ -39,7 +39,7 @@ class CrmClient(MailPluginController):
         return request.redirect(
             '/odoo/action-%s?partner_id=%s' % (server_action.id, int(partner_id)))
 
-    @http.route('/mail_plugin/lead/create', type='json', auth='outlook', cors="*")
+    @http.route('/mail_plugin/lead/create', type='jsonrpc', auth='outlook', cors="*")
     def crm_lead_create(self, partner_id, email_body, email_subject):
         partner = request.env['res.partner'].browse(partner_id).exists()
         if not partner:

--- a/addons/delivery/controllers/location_selector.py
+++ b/addons/delivery/controllers/location_selector.py
@@ -5,7 +5,7 @@ from odoo.http import Controller, request, route
 
 class LocationSelectorController(Controller):
 
-    @route('/delivery/set_pickup_location', type='json', auth='user')
+    @route('/delivery/set_pickup_location', type='jsonrpc', auth='user')
     def delivery_set_pickup_location(self, order_id, pickup_location_data):
         """ Fetch the order and set the pickup location on the current order.
 
@@ -16,7 +16,7 @@ class LocationSelectorController(Controller):
         order = request.env['sale.order'].browse(order_id)
         order._set_pickup_location(pickup_location_data)
 
-    @route('/delivery/get_pickup_locations', type='json', auth='user')
+    @route('/delivery/get_pickup_locations', type='jsonrpc', auth='user')
     def delivery_get_pickup_locations(self, order_id, zip_code=None):
         """ Fetch the order and return the pickup locations close to a given zip code.
 

--- a/addons/event/controllers/main.py
+++ b/addons/event/controllers/main.py
@@ -76,7 +76,7 @@ class EventController(Controller):
         ]
         return request.make_response(pdf, headers=pdfhttpheaders)
 
-    @http.route(['/event/init_barcode_interface'], type='json', auth="user")
+    @http.route(['/event/init_barcode_interface'], type='jsonrpc', auth="user")
     def init_barcode_interface(self, event_id):
         event = request.env['event.event'].browse(event_id).exists() if event_id else False
         if event:

--- a/addons/google_calendar/controllers/main.py
+++ b/addons/google_calendar/controllers/main.py
@@ -10,7 +10,7 @@ from odoo.addons.google_account.models.google_service import _get_client_secret
 
 class GoogleCalendarController(CalendarController):
 
-    @http.route('/google_calendar/sync_data', type='json', auth='user')
+    @http.route('/google_calendar/sync_data', type='jsonrpc', auth='user')
     def google_calendar_sync_data(self, model, **kw):
         """ This route/function is called when we want to synchronize Odoo
             calendar with Google Calendar.

--- a/addons/hr_attendance/controllers/main.py
+++ b/addons/hr_attendance/controllers/main.py
@@ -74,7 +74,7 @@ class HrAttendance(http.Controller):
         else:
             return request.not_found()
 
-    @http.route('/hr_attendance/kiosk_keepalive', auth='user', type='json')
+    @http.route('/hr_attendance/kiosk_keepalive', auth='user', type='jsonrpc')
     def kiosk_keepalive(self):
         request.session.touch()
         return {}
@@ -117,7 +117,7 @@ class HrAttendance(http.Controller):
                 }
             )
 
-    @http.route('/hr_attendance/attendance_employee_data', type="json", auth="public")
+    @http.route('/hr_attendance/attendance_employee_data', type="jsonrpc", auth="public")
     def employee_attendance_data(self, token, employee_id):
         company = self._get_company(token)
         if company:
@@ -126,7 +126,7 @@ class HrAttendance(http.Controller):
                 return self._get_employee_info_response(employee)
         return {}
 
-    @http.route('/hr_attendance/attendance_barcode_scanned', type="json", auth="public")
+    @http.route('/hr_attendance/attendance_barcode_scanned', type="jsonrpc", auth="public")
     def scan_barcode(self, token, barcode):
         company = self._get_company(token)
         if company:
@@ -136,7 +136,7 @@ class HrAttendance(http.Controller):
                 return self._get_employee_info_response(employee)
         return {}
 
-    @http.route('/hr_attendance/manual_selection', type="json", auth="public")
+    @http.route('/hr_attendance/manual_selection', type="jsonrpc", auth="public")
     def manual_selection(self, token, employee_id, pin_code):
         company = self._get_company(token)
         if company:
@@ -146,7 +146,7 @@ class HrAttendance(http.Controller):
                 return self._get_employee_info_response(employee)
         return {}
 
-    @http.route('/hr_attendance/employees_infos', type="json", auth="public")
+    @http.route('/hr_attendance/employees_infos', type="jsonrpc", auth="public")
     def employees_infos(self, token, limit, offset, domain):
         company = self._get_company(token)
         if company:
@@ -162,7 +162,7 @@ class HrAttendance(http.Controller):
             return {'records': employees_data, 'length': request.env['hr.employee'].sudo().search_count(domain)}
         return []
 
-    @http.route('/hr_attendance/systray_check_in_out', type="json", auth="user")
+    @http.route('/hr_attendance/systray_check_in_out', type="jsonrpc", auth="user")
     def systray_attendance(self, latitude=False, longitude=False):
         employee = request.env.user.employee_id
         geo_ip_response = self._get_geoip_response(mode='systray',
@@ -171,7 +171,7 @@ class HrAttendance(http.Controller):
         employee._attendance_action_change(geo_ip_response)
         return self._get_employee_info_response(employee)
 
-    @http.route('/hr_attendance/attendance_user_data', type="json", auth="user")
+    @http.route('/hr_attendance/attendance_user_data', type="jsonrpc", auth="user")
     def user_attendance_data(self):
         employee = request.env.user.employee_id
         return self._get_user_attendance_data(employee)
@@ -189,7 +189,7 @@ class HrAttendance(http.Controller):
                 ''', user_id=request.env.user.id))
         return bool(request.env.cr.fetchone()[0])
 
-    @http.route('/hr_attendance/is_fresh_db', type="json", auth="public")
+    @http.route('/hr_attendance/is_fresh_db', type="jsonrpc", auth="public")
     def is_fresh_db(self, token):
         company = self._get_company(token)
         if company:
@@ -197,7 +197,7 @@ class HrAttendance(http.Controller):
             return len(users) == 1 and not users[0].employee_id.barcode
         return False
 
-    @http.route('/hr_attendance/set_user_barcode', type="json", auth="public")
+    @http.route('/hr_attendance/set_user_barcode', type="jsonrpc", auth="public")
     def set_user_barcode(self, token, barcode):
         company = self._get_company(token)
         if company and self.is_fresh_db(token):
@@ -205,7 +205,7 @@ class HrAttendance(http.Controller):
             return True
         return False
 
-    @http.route('/hr_attendance/set_settings', type="json", auth="public")
+    @http.route('/hr_attendance/set_settings', type="jsonrpc", auth="public")
     def set_attendance_settings(self, token, mode):
         company = self._get_company(token)
         if company:

--- a/addons/hr_org_chart/controllers/hr_org_chart.py
+++ b/addons/hr_org_chart/controllers/hr_org_chart.py
@@ -38,13 +38,13 @@ class HrOrgChartController(http.Controller):
             indirect_sub_count=employee.child_all_count,
         )
 
-    @http.route('/hr/get_redirect_model', type='json', auth='user')
+    @http.route('/hr/get_redirect_model', type='jsonrpc', auth='user')
     def get_redirect_model(self):
         if request.env['hr.employee'].has_access('read'):
             return 'hr.employee'
         return 'hr.employee.public'
 
-    @http.route('/hr/get_org_chart', type='json', auth='user')
+    @http.route('/hr/get_org_chart', type='jsonrpc', auth='user')
     def get_org_chart(self, employee_id, **kw):
 
         employee = self._check_employee(employee_id, **kw)
@@ -73,7 +73,7 @@ class HrOrgChartController(http.Controller):
         values['managers'].reverse()
         return values
 
-    @http.route('/hr/get_subordinates', type='json', auth='user')
+    @http.route('/hr/get_subordinates', type='jsonrpc', auth='user')
     def get_subordinates(self, employee_id, subordinates_type=None, **kw):
         """
         Get employee subordinates.

--- a/addons/html_editor/controllers/main.py
+++ b/addons/html_editor/controllers/main.py
@@ -278,7 +278,7 @@ class HTML_Editor(http.Controller):
 
         return attachment
 
-    @http.route(['/web_editor/get_image_info', '/html_editor/get_image_info'], type='json', auth='user', website=True)
+    @http.route(['/web_editor/get_image_info', '/html_editor/get_image_info'], type='jsonrpc', auth='user', website=True)
     def get_image_info(self, src=''):
         """This route is used to determine the information of an attachment so that
         it can be used as a base to modify it again (crop/optimization/filters).
@@ -312,7 +312,7 @@ class HTML_Editor(http.Controller):
             'original': (attachment.original_id or attachment).read(['id', 'image_src', 'mimetype'])[0],
         }
 
-    @http.route(['/web_editor/video_url/data', '/html_editor/video_url/data'], type='json', auth='user', website=True)
+    @http.route(['/web_editor/video_url/data', '/html_editor/video_url/data'], type='jsonrpc', auth='user', website=True)
     def video_url_data(self, video_url, autoplay=False, loop=False,
                        hide_controls=False, hide_fullscreen=False,
                        hide_dm_logo=False, hide_dm_share=False):
@@ -322,7 +322,7 @@ class HTML_Editor(http.Controller):
             hide_dm_logo=hide_dm_logo, hide_dm_share=hide_dm_share
         )
 
-    @http.route(['/web_editor/attachment/add_data', '/html_editor/attachment/add_data'], type='json', auth='user', methods=['POST'], website=True)
+    @http.route(['/web_editor/attachment/add_data', '/html_editor/attachment/add_data'], type='jsonrpc', auth='user', methods=['POST'], website=True)
     def add_data(self, name, data, is_image, quality=0, width=0, height=0, res_id=False, res_model='ir.ui.view', **kwargs):
         data = b64decode(data)
         if is_image:
@@ -349,13 +349,13 @@ class HTML_Editor(http.Controller):
         attachment = self._attachment_create(name=name, data=data, res_id=res_id, res_model=res_model)
         return attachment._get_media_info()
 
-    @http.route(['/web_editor/attachment/add_url', '/html_editor/attachment/add_url'], type='json', auth='user', methods=['POST'], website=True)
+    @http.route(['/web_editor/attachment/add_url', '/html_editor/attachment/add_url'], type='jsonrpc', auth='user', methods=['POST'], website=True)
     def add_url(self, url, res_id=False, res_model='ir.ui.view', **kwargs):
         self._clean_context()
         attachment = self._attachment_create(url=url, res_id=res_id, res_model=res_model)
         return attachment._get_media_info()
 
-    @http.route(['/web_editor/modify_image/<model("ir.attachment"):attachment>', '/html_editor/modify_image/<model("ir.attachment"):attachment>'], type="json", auth="user", website=True)
+    @http.route(['/web_editor/modify_image/<model("ir.attachment"):attachment>', '/html_editor/modify_image/<model("ir.attachment"):attachment>'], type="jsonrpc", auth="user", website=True)
     def modify_image(self, attachment, res_model=None, res_id=None, name=None, data=None, original_id=None, mimetype=None, alt_data=None):
         """
         Creates a modified copy of an attachment and returns its image_src to be
@@ -421,7 +421,7 @@ class HTML_Editor(http.Controller):
         attachment.generate_access_token()
         return '%s?access_token=%s' % (attachment.image_src, attachment.access_token)
 
-    @http.route(['/web_editor/save_library_media', '/html_editor/save_library_media'], type='json', auth='user', methods=['POST'])
+    @http.route(['/web_editor/save_library_media', '/html_editor/save_library_media'], type='jsonrpc', auth='user', methods=['POST'])
     def save_library_media(self, media):
         """
         Saves images from the media library as new attachments, making them
@@ -518,7 +518,7 @@ class HTML_Editor(http.Controller):
             ('Cache-control', 'max-age=%s' % http.STATIC_CACHE_LONG),
         ])
 
-    @http.route(["/web_editor/generate_text", "/html_editor/generate_text"], type="json", auth="user")
+    @http.route(["/web_editor/generate_text", "/html_editor/generate_text"], type="jsonrpc", auth="user")
     def generate_text(self, prompt, conversation_history):
         try:
             IrConfigParameter = request.env['ir.config_parameter'].sudo()
@@ -540,11 +540,11 @@ class HTML_Editor(http.Controller):
         except AccessError:
             raise AccessError(_("Oops, it looks like our AI is unreachable!"))
 
-    @http.route(["/web_editor/get_ice_servers", "/html_editor/get_ice_servers"], type='json', auth="user")
+    @http.route(["/web_editor/get_ice_servers", "/html_editor/get_ice_servers"], type='jsonrpc', auth="user")
     def get_ice_servers(self):
         return request.env['mail.ice.server']._get_ice_servers()
 
-    @http.route(["/web_editor/bus_broadcast", "/html_editor/bus_broadcast"], type="json", auth="user")
+    @http.route(["/web_editor/bus_broadcast", "/html_editor/bus_broadcast"], type="jsonrpc", auth="user")
     def bus_broadcast(self, model_name, field_name, res_id, bus_data):
         document = request.env[model_name].browse([res_id])
 
@@ -557,11 +557,11 @@ class HTML_Editor(http.Controller):
         bus_data.update({'model_name': model_name, 'field_name': field_name, 'res_id': res_id})
         request.env['bus.bus']._sendone(channel, 'editor_collaboration', bus_data)
 
-    @http.route('/html_editor/link_preview_external', type="json", auth="public", methods=['POST'])
+    @http.route('/html_editor/link_preview_external', type="jsonrpc", auth="public", methods=['POST'])
     def link_preview_metadata(self, preview_url):
         return link_preview.get_link_preview_from_url(preview_url)
 
-    @http.route('/html_editor/link_preview_internal', type="json", auth="user", methods=['POST'])
+    @http.route('/html_editor/link_preview_internal', type="jsonrpc", auth="user", methods=['POST'])
     def link_preview_metadata_internal(self, preview_url):
         try:
             Actions = request.env['ir.actions.actions']

--- a/addons/hw_drivers/controllers/driver.py
+++ b/addons/hw_drivers/controllers/driver.py
@@ -22,7 +22,7 @@ _logger = logging.getLogger(__name__)
 
 
 class DriverController(http.Controller):
-    @http.route('/hw_drivers/action', type='json', auth='none', cors='*', csrf=False, save_session=False)
+    @http.route('/hw_drivers/action', type='jsonrpc', auth='none', cors='*', csrf=False, save_session=False)
     def action(self, session_id, device_identifier, data):
         """
         This route is called when we want to make a action with device (take picture, printing,...)
@@ -54,7 +54,7 @@ class DriverController(http.Controller):
         """
         helpers.get_certificate_status()
 
-    @http.route('/hw_drivers/event', type='json', auth='none', cors='*', csrf=False, save_session=False)
+    @http.route('/hw_drivers/event', type='jsonrpc', auth='none', cors='*', csrf=False, save_session=False)
     def event(self, listener):
         """
         listener is a dict in witch there are a sessions_id and a dict of device_identifier to listen

--- a/addons/hw_drivers/controllers/proxy.py
+++ b/addons/hw_drivers/controllers/proxy.py
@@ -10,11 +10,11 @@ class ProxyController(http.Controller):
     def hello(self):
         return "ping"
 
-    @http.route('/hw_proxy/handshake', type='json', auth='none', cors='*')
+    @http.route('/hw_proxy/handshake', type='jsonrpc', auth='none', cors='*')
     def handshake(self):
         return True
 
-    @http.route('/hw_proxy/status_json', type='json', auth='none', cors='*')
+    @http.route('/hw_proxy/status_json', type='jsonrpc', auth='none', cors='*')
     def status_json(self):
         statuses = {}
         for driver in proxy_drivers:

--- a/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
@@ -127,7 +127,7 @@ class DisplayDriver(Driver):
 
 
 class DisplayController(http.Controller):
-    @http.route('/hw_proxy/customer_facing_display', type='json', auth='none', cors='*')
+    @http.route('/hw_proxy/customer_facing_display', type='jsonrpc', auth='none', cors='*')
     def customer_facing_display(self, action, pos_id=None, access_token=None, data=None):
         display = self.ensure_display()
         if action in ['open', 'open_kiosk']:
@@ -192,7 +192,7 @@ class DisplayController(http.Controller):
             'pairing_code': connection_manager.pairing_code,
         })
 
-    @http.route('/point_of_sale/iot_devices', type='json', auth='none', methods=['POST'])
+    @http.route('/point_of_sale/iot_devices', type='jsonrpc', auth='none', methods=['POST'])
     def get_iot_devices(self):
         iot_device = [{
             'name': iot_devices[device].device_name,

--- a/addons/hw_drivers/iot_handlers/drivers/KeyboardUSBDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/KeyboardUSBDriver_L.py
@@ -363,7 +363,7 @@ proxy_drivers['scanner'] = KeyboardUSBDriver
 
 
 class KeyboardUSBController(http.Controller):
-    @http.route('/hw_proxy/scanner', type='json', auth='none', cors='*')
+    @http.route('/hw_proxy/scanner', type='jsonrpc', auth='none', cors='*')
     def get_barcode(self):
         scanners = [iot_devices[d] for d in iot_devices if iot_devices[d].device_type == "scanner"]
         if scanners:

--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
@@ -404,7 +404,7 @@ class PrinterDriver(Driver):
 
 class PrinterController(http.Controller):
 
-    @http.route('/hw_proxy/default_printer_action', type='json', auth='none', cors='*')
+    @http.route('/hw_proxy/default_printer_action', type='jsonrpc', auth='none', cors='*')
     def default_printer_action(self, data):
         printer = next((d for d in iot_devices if iot_devices[d].device_type == 'printer' and iot_devices[d].device_connection == 'direct'), None)
         if printer:

--- a/addons/hw_drivers/iot_handlers/drivers/SerialScaleDriver.py
+++ b/addons/hw_drivers/iot_handlers/drivers/SerialScaleDriver.py
@@ -82,7 +82,7 @@ ADAMEquipmentProtocol = ScaleProtocol(
 
 # Ensures compatibility with older versions of Odoo
 class ScaleReadOldRoute(http.Controller):
-    @http.route('/hw_proxy/scale_read', type='json', auth='none', cors='*')
+    @http.route('/hw_proxy/scale_read', type='jsonrpc', auth='none', cors='*')
     def scale_read(self):
         if ACTIVE_SCALE:
             return {'weight': ACTIVE_SCALE._scale_read_old_route()}

--- a/addons/hw_escpos/controllers/main.py
+++ b/addons/hw_escpos/controllers/main.py
@@ -328,17 +328,17 @@ proxy.proxy_drivers['escpos'] = driver
 
 class EscposProxy(proxy.ProxyController):
     
-    @http.route('/hw_proxy/open_cashbox', type='json', auth='none', cors='*')
+    @http.route('/hw_proxy/open_cashbox', type='jsonrpc', auth='none', cors='*')
     def open_cashbox(self):
         _logger.info('ESC/POS: OPEN CASHBOX') 
         driver.push_task('cashbox')
         
-    @http.route('/hw_proxy/print_receipt', type='json', auth='none', cors='*')
+    @http.route('/hw_proxy/print_receipt', type='jsonrpc', auth='none', cors='*')
     def print_receipt(self, receipt):
         _logger.info('ESC/POS: PRINT RECEIPT') 
         driver.push_task('receipt',receipt)
 
-    @http.route('/hw_proxy/print_xml_receipt', type='json', auth='none', cors='*')
+    @http.route('/hw_proxy/print_xml_receipt', type='jsonrpc', auth='none', cors='*')
     def print_xml_receipt(self, receipt):
         _logger.info('ESC/POS: PRINT XML RECEIPT') 
         driver.push_task('xml_receipt',receipt)

--- a/addons/hw_posbox_homepage/controllers/homepage.py
+++ b/addons/hw_posbox_homepage/controllers/homepage.py
@@ -252,7 +252,7 @@ class IotBoxOwlHomePage(Home):
     # POST methods                                               #
     # -> Never use json.dumps() it will be done automatically    #
     # ---------------------------------------------------------- #
-    @http.route('/hw_posbox_homepage/six_payment_terminal_add', auth="none", type="json", methods=['POST'], cors='*')
+    @http.route('/hw_posbox_homepage/six_payment_terminal_add', auth="none", type="jsonrpc", methods=['POST'], cors='*')
     def add_six_terminal(self, terminal_id):
         if terminal_id.isdigit():
             helpers.update_conf({'six_payment_terminal': terminal_id})
@@ -264,7 +264,7 @@ class IotBoxOwlHomePage(Home):
             'message': 'Successfully saved Six Payment Terminal',
         }
 
-    @http.route('/hw_posbox_homepage/save_credential', auth="none", type="json", methods=['POST'], cors='*')
+    @http.route('/hw_posbox_homepage/save_credential', auth="none", type="jsonrpc", methods=['POST'], cors='*')
     def save_credential(self, db_uuid, enterprise_code):
         helpers.update_conf({
             'db_uuid': db_uuid,
@@ -276,7 +276,7 @@ class IotBoxOwlHomePage(Home):
             'message': 'Successfully saved credentials',
         }
 
-    @http.route('/hw_posbox_homepage/update_wifi', auth="none", type="json", methods=['POST'], cors='*')
+    @http.route('/hw_posbox_homepage/update_wifi', auth="none", type="jsonrpc", methods=['POST'], cors='*')
     def update_wifi(self, essid, password, persistent=False):
         persistent = "1" if persistent else ""
         subprocess.check_call([file_path(
@@ -294,7 +294,7 @@ class IotBoxOwlHomePage(Home):
 
         return res_payload
 
-    @http.route('/hw_posbox_homepage/enable_ngrok', auth="none", type="json", methods=['POST'], cors='*')
+    @http.route('/hw_posbox_homepage/enable_ngrok', auth="none", type="jsonrpc", methods=['POST'], cors='*')
     def enable_remote_connection(self, auth_token):
         if subprocess.call(['pgrep', 'ngrok']) == 1:
             subprocess.Popen(['ngrok', 'tcp', '--authtoken', auth_token, '--log', '/tmp/ngrok.log', '22'])
@@ -305,7 +305,7 @@ class IotBoxOwlHomePage(Home):
             'message': 'Ngrok tunnel is now enabled',
         }
 
-    @http.route('/hw_posbox_homepage/connect_to_server', auth="none", type="json", methods=['POST'], cors='*')
+    @http.route('/hw_posbox_homepage/connect_to_server', auth="none", type="jsonrpc", methods=['POST'], cors='*')
     def connect_to_odoo_server(self, token=False, iotname=False):
         if token:
             try:
@@ -341,7 +341,7 @@ class IotBoxOwlHomePage(Home):
             'message': 'Successfully connected to db, IoT will restart to update the configuration.',
         }
 
-    @http.route('/hw_posbox_homepage/log_levels_update', auth="none", type="json", methods=['POST'], cors='*')
+    @http.route('/hw_posbox_homepage/log_levels_update', auth="none", type="jsonrpc", methods=['POST'], cors='*')
     def update_log_level(self, name, value):
         if not name.startswith(IOT_LOGGING_PREFIX) and name != 'log-to-server':
             return {

--- a/addons/im_livechat/controllers/chatbot.py
+++ b/addons/im_livechat/controllers/chatbot.py
@@ -7,7 +7,7 @@ from odoo.addons.mail.tools.discuss import Store
 
 
 class LivechatChatbotScriptController(http.Controller):
-    @http.route("/chatbot/restart", type="json", auth="public")
+    @http.route("/chatbot/restart", type="jsonrpc", auth="public")
     @add_guest_to_context
     def chatbot_restart(self, channel_id, chatbot_script_id):
         discuss_channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
@@ -18,7 +18,7 @@ class LivechatChatbotScriptController(http.Controller):
         message = discuss_channel.with_context(lang=chatbot_language)._chatbot_restart(chatbot)
         return Store(message, for_current_user=True).get_result()
 
-    @http.route("/chatbot/answer/save", type="json", auth="public")
+    @http.route("/chatbot/answer/save", type="jsonrpc", auth="public")
     @add_guest_to_context
     def chatbot_save_answer(self, channel_id, message_id, selected_answer_id):
         discuss_channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
@@ -34,7 +34,7 @@ class LivechatChatbotScriptController(http.Controller):
         if selected_answer in chatbot_message.script_step_id.answer_ids:
             chatbot_message.write({'user_script_answer_id': selected_answer_id})
 
-    @http.route("/chatbot/step/trigger", type="json", auth="public")
+    @http.route("/chatbot/step/trigger", type="jsonrpc", auth="public")
     @add_guest_to_context
     def chatbot_trigger_step(self, channel_id, chatbot_script_id=None):
         chatbot_language = self._get_chatbot_language()
@@ -90,7 +90,7 @@ class LivechatChatbotScriptController(http.Controller):
         )
         return store.get_result()
 
-    @http.route("/chatbot/step/validate_email", type="json", auth="public")
+    @http.route("/chatbot/step/validate_email", type="jsonrpc", auth="public")
     @add_guest_to_context
     def chatbot_validate_email(self, channel_id):
         discuss_channel = request.env["discuss.channel"].search(

--- a/addons/im_livechat/controllers/cors/attachment.py
+++ b/addons/im_livechat/controllers/cors/attachment.py
@@ -9,7 +9,7 @@ class LivechatAttachmentController(AttachmentController):
         force_guest_env(guest_token)
         return self.mail_attachment_upload(ufile, thread_id, thread_model, is_pending, **kwargs)
 
-    @route("/im_livechat/cors/attachment/delete", methods=["POST"], type="json", auth="public", cors="*")
+    @route("/im_livechat/cors/attachment/delete", methods=["POST"], type="jsonrpc", auth="public", cors="*")
     def im_livechat_attachment_delete(self, guest_token, attachment_id, access_token=None):
         force_guest_env(guest_token)
         return self.mail_attachment_delete(attachment_id, access_token)

--- a/addons/im_livechat/controllers/cors/channel.py
+++ b/addons/im_livechat/controllers/cors/channel.py
@@ -6,22 +6,22 @@ from odoo.addons.im_livechat.tools.misc import force_guest_env
 
 
 class LivechatChannelController(ChannelController):
-    @route("/im_livechat/cors/channel/messages", methods=["POST"], type="json", auth="public", cors="*")
+    @route("/im_livechat/cors/channel/messages", methods=["POST"], type="jsonrpc", auth="public", cors="*")
     def livechat_channel_messages(self, guest_token, channel_id, before=None, after=None, limit=30, around=None):
         force_guest_env(guest_token)
         return self.discuss_channel_messages(channel_id, before, after, limit, around)
 
-    @route("/im_livechat/cors/channel/mark_as_read", methods=["POST"], type="json", auth="public", cors="*")
+    @route("/im_livechat/cors/channel/mark_as_read", methods=["POST"], type="jsonrpc", auth="public", cors="*")
     def livechat_channel_mark_as_read(self, guest_token, **kwargs):
         force_guest_env(guest_token)
         return self.discuss_channel_mark_as_read(**kwargs)
 
-    @route("/im_livechat/cors/channel/fold", methods=["POST"], type="json", auth="public", cors="*")
+    @route("/im_livechat/cors/channel/fold", methods=["POST"], type="jsonrpc", auth="public", cors="*")
     def livechat_channel_fold(self, guest_token, channel_id, state, state_count):
         force_guest_env(guest_token)
         return self.discuss_channel_fold(channel_id, state, state_count)
 
-    @route("/im_livechat/cors/channel/notify_typing", methods=["POST"], type="json", auth="public", cors="*")
+    @route("/im_livechat/cors/channel/notify_typing", methods=["POST"], type="jsonrpc", auth="public", cors="*")
     def livechat_channel_notify_typing(self, guest_token, channel_id, is_typing):
         force_guest_env(guest_token)
         return self.discuss_channel_notify_typing(channel_id, is_typing)

--- a/addons/im_livechat/controllers/cors/chatbot.py
+++ b/addons/im_livechat/controllers/cors/chatbot.py
@@ -6,22 +6,22 @@ from odoo.addons.im_livechat.tools.misc import force_guest_env
 
 
 class CorsLivechatChatbotScriptController(LivechatChatbotScriptController):
-    @route("/chatbot/cors/restart", type="json", auth="public", cors="*")
+    @route("/chatbot/cors/restart", type="jsonrpc", auth="public", cors="*")
     def cors_chatbot_restart(self, guest_token, channel_id, chatbot_script_id):
         force_guest_env(guest_token)
         return self.chatbot_restart(channel_id, chatbot_script_id)
 
-    @route("/chatbot/cors/answer/save", type="json", auth="public", cors="*")
+    @route("/chatbot/cors/answer/save", type="jsonrpc", auth="public", cors="*")
     def cors_chatbot_save_answer(self, guest_token, channel_id, message_id, selected_answer_id):
         force_guest_env(guest_token)
         return self.chatbot_save_answer(channel_id, message_id, selected_answer_id)
 
-    @route("/chatbot/cors/step/trigger", type="json", auth="public", cors="*")
+    @route("/chatbot/cors/step/trigger", type="jsonrpc", auth="public", cors="*")
     def cors_chatbot_trigger_step(self, guest_token, channel_id, chatbot_script_id=None):
         force_guest_env(guest_token)
         return self.chatbot_trigger_step(channel_id, chatbot_script_id)
 
-    @route("/chatbot/cors/step/validate_email", type="json", auth="public", cors="*")
+    @route("/chatbot/cors/step/validate_email", type="jsonrpc", auth="public", cors="*")
     def cors_chatbot_validate_email(self, guest_token, channel_id):
         force_guest_env(guest_token)
         return self.chatbot_validate_email(channel_id)

--- a/addons/im_livechat/controllers/cors/link_preview.py
+++ b/addons/im_livechat/controllers/cors/link_preview.py
@@ -6,12 +6,12 @@ from odoo.addons.im_livechat.tools.misc import force_guest_env
 
 
 class LivechatLinkPreviewController(LinkPreviewController):
-    @route("/im_livechat/cors/link_preview", methods=["POST"], type="json", auth="public", cors="*")
+    @route("/im_livechat/cors/link_preview", methods=["POST"], type="jsonrpc", auth="public", cors="*")
     def livechat_link_preview(self, guest_token, message_id):
         force_guest_env(guest_token)
         self.mail_link_preview(message_id)
 
-    @route("/im_livechat/cors/link_preview/hide", methods=["POST"], type="json", auth="public", cors="*")
+    @route("/im_livechat/cors/link_preview/hide", methods=["POST"], type="jsonrpc", auth="public", cors="*")
     def livechat_link_preview_hide(self, guest_token, link_preview_ids):
         force_guest_env(guest_token)
         self.mail_link_preview_hide(link_preview_ids)

--- a/addons/im_livechat/controllers/cors/main.py
+++ b/addons/im_livechat/controllers/cors/main.py
@@ -6,27 +6,27 @@ from odoo.addons.im_livechat.tools.misc import force_guest_env
 
 
 class CorsLivechatController(LivechatController):
-    @route("/im_livechat/cors/visitor_leave_session", type="json", auth="public", cors="*")
+    @route("/im_livechat/cors/visitor_leave_session", type="jsonrpc", auth="public", cors="*")
     def cors_visitor_leave_session(self, guest_token, channel_id):
         force_guest_env(guest_token)
         self.visitor_leave_session(channel_id)
 
-    @route("/im_livechat/cors/feedback", type="json", auth="public", cors="*")
+    @route("/im_livechat/cors/feedback", type="jsonrpc", auth="public", cors="*")
     def cors_feedback(self, guest_token, channel_id, rate, reason=None):
         force_guest_env(guest_token)
         self.feedback(channel_id, rate, reason)
 
-    @route("/im_livechat/cors/history", type="json", auth="public", cors="*")
+    @route("/im_livechat/cors/history", type="jsonrpc", auth="public", cors="*")
     def cors_history_pages(self, guest_token, pid, channel_id, page_history=None):
         force_guest_env(guest_token)
         return self.history_pages(pid, channel_id, page_history)
 
-    @route("/im_livechat/cors/email_livechat_transcript", type="json", auth="public", cors="*")
+    @route("/im_livechat/cors/email_livechat_transcript", type="jsonrpc", auth="public", cors="*")
     def cors_email_livechat_transcript(self, guest_token, channel_id, email):
         force_guest_env(guest_token)
         return self.email_livechat_transcript(channel_id, email)
 
-    @route("/im_livechat/cors/get_session", methods=["POST"], type="json", auth="public", cors="*")
+    @route("/im_livechat/cors/get_session", methods=["POST"], type="jsonrpc", auth="public", cors="*")
     def cors_get_session(
         self, channel_id, anonymous_name, previous_operator_id=None, chatbot_script_id=None, persisted=True, **kwargs
     ):
@@ -35,7 +35,7 @@ class CorsLivechatController(LivechatController):
             channel_id, anonymous_name, previous_operator_id, chatbot_script_id, persisted, **kwargs
         )
 
-    @route("/im_livechat/cors/init", type="json", auth="public", cors="*")
+    @route("/im_livechat/cors/init", type="jsonrpc", auth="public", cors="*")
     def cors_livechat_init(self, channel_id, guest_token=""):
         force_guest_env(guest_token, raise_if_not_found=False)
         return self.livechat_init(channel_id)

--- a/addons/im_livechat/controllers/cors/message_reaction.py
+++ b/addons/im_livechat/controllers/cors/message_reaction.py
@@ -6,7 +6,7 @@ from odoo.addons.im_livechat.tools.misc import force_guest_env
 
 
 class LivechatMessageReactionController(MessageReactionController):
-    @route("/im_livechat/cors/message/reaction", methods=["POST"], type="json", auth="public", cors="*")
+    @route("/im_livechat/cors/message/reaction", methods=["POST"], type="jsonrpc", auth="public", cors="*")
     def livechat_message_reaction(self, guest_token, message_id, content, action, **kwargs):
         force_guest_env(guest_token)
         return self.mail_message_reaction(message_id, content, action, **kwargs)

--- a/addons/im_livechat/controllers/cors/rtc.py
+++ b/addons/im_livechat/controllers/cors/rtc.py
@@ -6,27 +6,27 @@ from odoo.addons.im_livechat.tools.misc import force_guest_env
 
 
 class LivechatRtcController(RtcController):
-    @route("/im_livechat/cors/rtc/channel/join_call", methods=["POST"], type="json", auth="public", cors="*")
+    @route("/im_livechat/cors/rtc/channel/join_call", methods=["POST"], type="jsonrpc", auth="public", cors="*")
     def livechat_channel_call_join(self, guest_token, channel_id, check_rtc_session_ids=None):
         force_guest_env(guest_token)
         return self.channel_call_join(channel_id, check_rtc_session_ids)
 
-    @route("/im_livechat/cors/rtc/channel/leave_call", methods=["POST"], type="json", auth="public", cors="*")
+    @route("/im_livechat/cors/rtc/channel/leave_call", methods=["POST"], type="jsonrpc", auth="public", cors="*")
     def livechat_channel_call_leave(self, guest_token, channel_id):
         force_guest_env(guest_token)
         return self.channel_call_leave(channel_id)
 
-    @route("/im_livechat/cors/rtc/session/update_and_broadcast", methods=["POST"], type="json", auth="public", cors="*")
+    @route("/im_livechat/cors/rtc/session/update_and_broadcast", methods=["POST"], type="jsonrpc", auth="public", cors="*")
     def livechat_session_update_and_broadcast(self, guest_token, session_id, values):
         force_guest_env(guest_token)
         self.session_update_and_broadcast(session_id, values)
 
-    @route("/im_livechat/cors/rtc/session/notify_call_members", methods=["POST"], type="json", auth="public", cors="*")
+    @route("/im_livechat/cors/rtc/session/notify_call_members", methods=["POST"], type="jsonrpc", auth="public", cors="*")
     def livechat_session_call_notify(self, guest_token, peer_notifications):
         force_guest_env(guest_token)
         self.session_call_notify(peer_notifications)
 
-    @route("/im_livechat/cors/channel/ping", methods=["POST"], type="json", auth="public", cors="*")
+    @route("/im_livechat/cors/channel/ping", methods=["POST"], type="jsonrpc", auth="public", cors="*")
     def livechat_channel_ping(self, guest_token, channel_id, rtc_session_id=None, check_rtc_session_ids=None):
         force_guest_env(guest_token)
         return self.channel_ping(channel_id, rtc_session_id, check_rtc_session_ids)

--- a/addons/im_livechat/controllers/cors/thread.py
+++ b/addons/im_livechat/controllers/cors/thread.py
@@ -6,12 +6,12 @@ from odoo.addons.im_livechat.tools.misc import force_guest_env
 
 
 class LivechatThreadController(ThreadController):
-    @route("/im_livechat/cors/message/post", methods=["POST"], type="json", auth="public", cors="*")
+    @route("/im_livechat/cors/message/post", methods=["POST"], type="jsonrpc", auth="public", cors="*")
     def livechat_message_post(self, guest_token, thread_model, thread_id, post_data, context=None, **kwargs):
         force_guest_env(guest_token)
         return self.mail_message_post(thread_model, thread_id, post_data, context, **kwargs)
 
-    @route("/im_livechat/cors/message/update_content", methods=["POST"], type="json", auth="public", cors="*")
+    @route("/im_livechat/cors/message/update_content", methods=["POST"], type="jsonrpc", auth="public", cors="*")
     def livechat_message_update_content(
         self, guest_token, message_id, body, attachment_ids, attachment_tokens=None, partner_ids=None
     ):

--- a/addons/im_livechat/controllers/cors/webclient.py
+++ b/addons/im_livechat/controllers/cors/webclient.py
@@ -8,12 +8,12 @@ from odoo.addons.im_livechat.tools.misc import force_guest_env
 class WebClient(WebclientController):
     """Override to add CORS support."""
 
-    @route("/im_livechat/cors/action", methods=["POST"], type="json", auth="public", cors="*")
+    @route("/im_livechat/cors/action", methods=["POST"], type="jsonrpc", auth="public", cors="*")
     def livechat_action(self, guest_token, **kwargs):
         force_guest_env(guest_token)
         return self.mail_action(**kwargs)
 
-    @route("/im_livechat/cors/data", methods=["POST"], type="json", auth="public", cors="*", readonly=True)
+    @route("/im_livechat/cors/data", methods=["POST"], type="jsonrpc", auth="public", cors="*", readonly=True)
     def livechat_data(self, guest_token, **kwargs):
         force_guest_env(guest_token)
         return self.mail_data(**kwargs)

--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -71,7 +71,7 @@ class LivechatController(http.Controller):
         info = channel.get_livechat_info(username=username)
         return request.render('im_livechat.loader', {'info': info}, headers=[('Content-Type', 'application/javascript')])
 
-    @http.route('/im_livechat/init', type='json', auth="public")
+    @http.route('/im_livechat/init', type='jsonrpc', auth="public")
     @add_guest_to_context
     def livechat_init(self, channel_id):
         operator_available = len(request.env['im_livechat.channel'].sudo().browse(channel_id).available_operator_ids)
@@ -107,7 +107,7 @@ class LivechatController(http.Controller):
     def _get_guest_name(self):
         return _("Visitor")
 
-    @http.route('/im_livechat/get_session', methods=["POST"], type="json", auth='public')
+    @http.route('/im_livechat/get_session', methods=["POST"], type="jsonrpc", auth='public')
     @add_guest_to_context
     def get_session(self, channel_id, anonymous_name, previous_operator_id=None, chatbot_script_id=None, persisted=True, **kwargs):
         store = Store()
@@ -212,7 +212,7 @@ class LivechatController(http.Controller):
             subtype_xmlid="mail.mt_comment",
         )
 
-    @http.route("/im_livechat/feedback", type="json", auth="public")
+    @http.route("/im_livechat/feedback", type="jsonrpc", auth="public")
     @add_guest_to_context
     def feedback(self, channel_id, rate, reason=None, **kwargs):
         if channel := request.env["discuss.channel"].search([("id", "=", channel_id)]):
@@ -245,20 +245,20 @@ class LivechatController(http.Controller):
             return rating.id
         return False
 
-    @http.route("/im_livechat/history", type="json", auth="public")
+    @http.route("/im_livechat/history", type="jsonrpc", auth="public")
     @add_guest_to_context
     def history_pages(self, pid, channel_id, page_history=None):
         if channel := request.env["discuss.channel"].search([("id", "=", channel_id)]):
             if pid in channel.sudo().channel_member_ids.partner_id.ids:
                 request.env["res.partner"].browse(pid)._bus_send_history_message(channel, page_history)
 
-    @http.route("/im_livechat/email_livechat_transcript", type="json", auth="public")
+    @http.route("/im_livechat/email_livechat_transcript", type="jsonrpc", auth="public")
     @add_guest_to_context
     def email_livechat_transcript(self, channel_id, email):
         if channel := request.env["discuss.channel"].search([("id", "=", channel_id)]):
             channel._email_livechat_transcript(email)
 
-    @http.route("/im_livechat/visitor_leave_session", type="json", auth="public")
+    @http.route("/im_livechat/visitor_leave_session", type="jsonrpc", auth="public")
     @add_guest_to_context
     def visitor_leave_session(self, channel_id):
         """Called when the livechat visitor leaves the conversation.

--- a/addons/l10n_pe_website_sale/controllers/main.py
+++ b/addons/l10n_pe_website_sale/controllers/main.py
@@ -68,7 +68,7 @@ class L10nPEWebsiteSale(WebsiteSale):
 
     @route(
         '/shop/state_infos/<model("res.country.state"):state>',
-        type='json',
+        type='jsonrpc',
         auth='public',
         methods=['POST'],
         website=True,
@@ -79,7 +79,7 @@ class L10nPEWebsiteSale(WebsiteSale):
 
     @route(
         '/shop/city_infos/<model("res.city"):city>',
-        type='json',
+        type='jsonrpc',
         auth='public',
         methods=['POST'],
         website=True,

--- a/addons/loyalty/controllers/portal.py
+++ b/addons/loyalty/controllers/portal.py
@@ -83,7 +83,7 @@ class CustomerPortalLoyalty(CustomerPortal):
 
         return request.render('loyalty.loyalty_card_history_template', values)
 
-    @route('/my/loyalty_card/<int:card_id>/values', type='json', auth='user')
+    @route('/my/loyalty_card/<int:card_id>/values', type='jsonrpc', auth='user')
     def portal_get_card_history_values(self, card_id):
         card_sudo = request.env['loyalty.card'].sudo().search([
             ('id', '=', int(card_id)),

--- a/addons/lunch/controllers/main.py
+++ b/addons/lunch/controllers/main.py
@@ -9,7 +9,7 @@ from odoo.tools import float_round, float_repr
 
 
 class LunchController(http.Controller):
-    @http.route('/lunch/infos', type='json', auth='user')
+    @http.route('/lunch/infos', type='jsonrpc', auth='user')
     def infos(self, user_id=None, context=None):
         if context:
             request.update_context(**context)
@@ -49,7 +49,7 @@ class LunchController(http.Controller):
             })
         return infos
 
-    @http.route('/lunch/trash', type='json', auth='user')
+    @http.route('/lunch/trash', type='jsonrpc', auth='user')
     def trash(self, user_id=None, context=None):
         if context:
             request.update_context(**context)
@@ -61,7 +61,7 @@ class LunchController(http.Controller):
         lines.action_cancel()
         lines.unlink()
 
-    @http.route('/lunch/pay', type='json', auth='user')
+    @http.route('/lunch/pay', type='jsonrpc', auth='user')
     def pay(self, user_id=None, context=None):
         if context:
             request.update_context(**context)
@@ -76,11 +76,11 @@ class LunchController(http.Controller):
 
         return False
 
-    @http.route('/lunch/payment_message', type='json', auth='user')
+    @http.route('/lunch/payment_message', type='jsonrpc', auth='user')
     def payment_message(self):
         return {'message': request.env['ir.qweb']._render('lunch.lunch_payment_dialog', {})}
 
-    @http.route('/lunch/user_location_set', type='json', auth='user')
+    @http.route('/lunch/user_location_set', type='jsonrpc', auth='user')
     def set_user_location(self, location_id=None, user_id=None, context=None):
         if context:
             request.update_context(**context)
@@ -90,7 +90,7 @@ class LunchController(http.Controller):
         user.sudo().last_lunch_location_id = request.env['lunch.location'].browse(location_id)
         return True
 
-    @http.route('/lunch/user_location_get', type='json', auth='user')
+    @http.route('/lunch/user_location_get', type='jsonrpc', auth='user')
     def get_user_location(self, user_id=None, context=None):
         if context:
             request.update_context(**context)

--- a/addons/mail/controllers/attachment.py
+++ b/addons/mail/controllers/attachment.py
@@ -82,7 +82,7 @@ class AttachmentController(http.Controller):
             res = {"error": _("You are not allowed to upload an attachment here.")}
         return request.make_json_response(res)
 
-    @http.route("/mail/attachment/delete", methods=["POST"], type="json", auth="public")
+    @http.route("/mail/attachment/delete", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
     def mail_attachment_delete(self, attachment_id, access_token=None, **kwargs):
         attachment = request.env["ir.attachment"].browse(int(attachment_id)).exists()

--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -23,7 +23,7 @@ class DiscussChannelWebclientController(WebclientController):
 
 
 class ChannelController(http.Controller):
-    @http.route("/discuss/channel/members", methods=["POST"], type="json", auth="public", readonly=True)
+    @http.route("/discuss/channel/members", methods=["POST"], type="jsonrpc", auth="public", readonly=True)
     @add_guest_to_context
     def discuss_channel_members(self, channel_id, known_member_ids):
         channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
@@ -31,14 +31,14 @@ class ChannelController(http.Controller):
             raise NotFound()
         return channel._load_more_members(known_member_ids)
 
-    @http.route("/discuss/channel/update_avatar", methods=["POST"], type="json")
+    @http.route("/discuss/channel/update_avatar", methods=["POST"], type="jsonrpc")
     def discuss_channel_avatar_update(self, channel_id, data):
         channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
         if not channel or not data:
             raise NotFound()
         channel.write({"image_128": data})
 
-    @http.route("/discuss/channel/info", methods=["POST"], type="json", auth="public", readonly=True)
+    @http.route("/discuss/channel/info", methods=["POST"], type="jsonrpc", auth="public", readonly=True)
     @add_guest_to_context
     def discuss_channel_info(self, channel_id):
         channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
@@ -46,7 +46,7 @@ class ChannelController(http.Controller):
             return
         return Store(channel).get_result()
 
-    @http.route("/discuss/channel/messages", methods=["POST"], type="json", auth="public")
+    @http.route("/discuss/channel/messages", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
     def discuss_channel_messages(self, channel_id, search_term=None, before=None, after=None, limit=30, around=None):
         channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
@@ -69,7 +69,7 @@ class ChannelController(http.Controller):
             "messages": Store.many_ids(messages),
         }
 
-    @http.route("/discuss/channel/pinned_messages", methods=["POST"], type="json", auth="public", readonly=True)
+    @http.route("/discuss/channel/pinned_messages", methods=["POST"], type="jsonrpc", auth="public", readonly=True)
     @add_guest_to_context
     def discuss_channel_pins(self, channel_id):
         channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
@@ -78,7 +78,7 @@ class ChannelController(http.Controller):
         messages = channel.pinned_message_ids.sorted(key="pinned_at", reverse=True)
         return Store(messages, for_current_user=True).get_result()
 
-    @http.route("/discuss/channel/mark_as_read", methods=["POST"], type="json", auth="public")
+    @http.route("/discuss/channel/mark_as_read", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
     def discuss_channel_mark_as_read(self, channel_id, last_message_id, sync=False):
         member = request.env["discuss.channel.member"].search([
@@ -89,7 +89,7 @@ class ChannelController(http.Controller):
             return  # ignore if the member left in the meantime
         member._mark_as_read(last_message_id, sync=sync)
 
-    @http.route("/discuss/channel/mark_as_unread", methods=["POST"], type="json", auth="public")
+    @http.route("/discuss/channel/mark_as_unread", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
     def discuss_channel_mark_as_unread(self, channel_id, message_id):
         member = request.env["discuss.channel.member"].search([
@@ -100,7 +100,7 @@ class ChannelController(http.Controller):
             raise NotFound()
         return member._set_new_message_separator(message_id, sync=True)
 
-    @http.route("/discuss/channel/notify_typing", methods=["POST"], type="json", auth="public")
+    @http.route("/discuss/channel/notify_typing", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
     def discuss_channel_notify_typing(self, channel_id, is_typing):
         channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
@@ -111,7 +111,7 @@ class ChannelController(http.Controller):
             raise NotFound()
         member._notify_typing(is_typing)
 
-    @http.route("/discuss/channel/attachments", methods=["POST"], type="json", auth="public", readonly=True)
+    @http.route("/discuss/channel/attachments", methods=["POST"], type="jsonrpc", auth="public", readonly=True)
     @add_guest_to_context
     def load_attachments(self, channel_id, limit=30, before=None):
         """Load attachments of a channel. If before is set, load attachments
@@ -134,7 +134,7 @@ class ChannelController(http.Controller):
             request.env["ir.attachment"].sudo().search(domain, limit=limit, order="id DESC")
         ).get_result()
 
-    @http.route("/discuss/channel/fold", methods=["POST"], type="json", auth="public")
+    @http.route("/discuss/channel/fold", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
     def discuss_channel_fold(self, channel_id, state, state_count):
         member = request.env["discuss.channel.member"].search([("channel_id", "=", channel_id), ("is_self", "=", True)])
@@ -142,7 +142,7 @@ class ChannelController(http.Controller):
             raise NotFound()
         return member._channel_fold(state, state_count)
 
-    @http.route("/discuss/channel/join", methods=["POST"], type="json", auth="public")
+    @http.route("/discuss/channel/join", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
     def discuss_channel_join(self, channel_id):
         channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
@@ -151,7 +151,7 @@ class ChannelController(http.Controller):
         channel._find_or_create_member_for_self()
         return Store(channel).get_result()
 
-    @http.route("/discuss/channel/sub_channel/create", methods=["POST"], type="json", auth="public")
+    @http.route("/discuss/channel/sub_channel/create", methods=["POST"], type="jsonrpc", auth="public")
     def discuss_channel_sub_channel_create(self, parent_channel_id, from_message_id=None, name=None):
         channel = request.env["discuss.channel"].search([("id", "=", parent_channel_id)])
         if not channel:
@@ -162,7 +162,7 @@ class ChannelController(http.Controller):
             "sub_channel": Store.one_id(sub_channel),
         }
 
-    @http.route("/discuss/channel/sub_channel/fetch", methods=["POST"], type="json", auth="public")
+    @http.route("/discuss/channel/sub_channel/fetch", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
     def discuss_channel_sub_channel_fetch(self, parent_channel_id, search_term=None, before=None, limit=30):
         channel = request.env["discuss.channel"].search([("id", "=", parent_channel_id)])

--- a/addons/mail/controllers/discuss/gif.py
+++ b/addons/mail/controllers/discuss/gif.py
@@ -14,7 +14,7 @@ class DiscussGifController(Controller):
         response.raise_for_status()
         return response
 
-    @route("/discuss/gif/search", type="json", auth="user")
+    @route("/discuss/gif/search", type="jsonrpc", auth="user")
     def search(self, search_term, locale="en", country="US", position=None, readonly=True):
         # sudo: ir.config_parameter - read keys are hard-coded and values are only used for server requests
         ir_config = request.env["ir.config_parameter"].sudo()
@@ -35,7 +35,7 @@ class DiscussGifController(Controller):
         if response:
             return response.json()
 
-    @route("/discuss/gif/categories", type="json", auth="user", readonly=True)
+    @route("/discuss/gif/categories", type="jsonrpc", auth="user", readonly=True)
     def categories(self, locale="en", country="US"):
         # sudo: ir.config_parameter - read keys are hard-coded and values are only used for server requests
         ir_config = request.env["ir.config_parameter"].sudo()
@@ -53,7 +53,7 @@ class DiscussGifController(Controller):
         if response:
             return response.json()
 
-    @route("/discuss/gif/add_favorite", type="json", auth="user")
+    @route("/discuss/gif/add_favorite", type="jsonrpc", auth="user")
     def add_favorite(self, tenor_gif_id):
         request.env["discuss.gif.favorite"].create({"tenor_gif_id": tenor_gif_id})
 
@@ -72,14 +72,14 @@ class DiscussGifController(Controller):
         if response:
             return response.json()["results"]
 
-    @route("/discuss/gif/favorites", type="json", auth="user", readonly=True)
+    @route("/discuss/gif/favorites", type="jsonrpc", auth="user", readonly=True)
     def get_favorites(self, offset=0):
         tenor_gif_ids = request.env["discuss.gif.favorite"].search(
             [("create_uid", "=", request.env.user.id)], limit=20, offset=offset
         )
         return (self._gif_posts(tenor_gif_ids.mapped("tenor_gif_id")) or [],)
 
-    @route("/discuss/gif/remove_favorite", type="json", auth="user")
+    @route("/discuss/gif/remove_favorite", type="jsonrpc", auth="user")
     def remove_favorite(self, tenor_gif_id):
         request.env["discuss.gif.favorite"].search(
             [

--- a/addons/mail/controllers/discuss/rtc.py
+++ b/addons/mail/controllers/discuss/rtc.py
@@ -11,7 +11,7 @@ from odoo.addons.mail.tools.discuss import Store
 
 
 class RtcController(http.Controller):
-    @http.route("/mail/rtc/session/notify_call_members", methods=["POST"], type="json", auth="public")
+    @http.route("/mail/rtc/session/notify_call_members", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
     def session_call_notify(self, peer_notifications):
         """Sends content to other session of the same channel, only works if the user is the user of that session.
@@ -37,7 +37,7 @@ class RtcController(http.Controller):
         for session_sudo, notifications in notifications_by_session.items():
             session_sudo._notify_peers(notifications)
 
-    @http.route("/mail/rtc/session/update_and_broadcast", methods=["POST"], type="json", auth="public")
+    @http.route("/mail/rtc/session/update_and_broadcast", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
     def session_update_and_broadcast(self, session_id, values):
         """Update a RTC session and broadcasts the changes to the members of its channel,
@@ -59,7 +59,7 @@ class RtcController(http.Controller):
         if session and session.partner_id == request.env.user.partner_id:
             session._update_and_broadcast(values)
 
-    @http.route("/mail/rtc/channel/join_call", methods=["POST"], type="json", auth="public")
+    @http.route("/mail/rtc/channel/join_call", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
     def channel_call_join(self, channel_id, check_rtc_session_ids=None):
         """Joins the RTC call of a channel if the user is a member of that channel
@@ -76,7 +76,7 @@ class RtcController(http.Controller):
         member.sudo()._rtc_join_call(store, check_rtc_session_ids=check_rtc_session_ids)
         return store.get_result()
 
-    @http.route("/mail/rtc/channel/leave_call", methods=["POST"], type="json", auth="public")
+    @http.route("/mail/rtc/channel/leave_call", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
     def channel_call_leave(self, channel_id):
         """Disconnects the current user from a rtc call and clears any invitation sent to that user on this channel
@@ -88,7 +88,7 @@ class RtcController(http.Controller):
         # sudo: discuss.channel.rtc.session - member of current user can leave call
         member.sudo()._rtc_leave_call()
 
-    @http.route("/mail/rtc/channel/cancel_call_invitation", methods=["POST"], type="json", auth="public")
+    @http.route("/mail/rtc/channel/cancel_call_invitation", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
     def channel_call_cancel_invitation(self, channel_id, member_ids=None):
         """
@@ -115,7 +115,7 @@ class RtcController(http.Controller):
             ],
         )
 
-    @http.route("/discuss/channel/ping", methods=["POST"], type="json", auth="public")
+    @http.route("/discuss/channel/ping", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
     def channel_ping(self, channel_id, rtc_session_id=None, check_rtc_session_ids=None):
         member = request.env["discuss.channel.member"].search([("channel_id", "=", channel_id), ("is_self", "=", True)])

--- a/addons/mail/controllers/discuss/search.py
+++ b/addons/mail/controllers/discuss/search.py
@@ -8,7 +8,7 @@ from odoo.addons.mail.tools.discuss import Store
 
 
 class SearchController(http.Controller):
-    @http.route("/discuss/search", methods=["POST"], type="json", auth="public")
+    @http.route("/discuss/search", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
     def search(self, term, category_id=None, limit=8):
         store = Store()

--- a/addons/mail/controllers/discuss/settings.py
+++ b/addons/mail/controllers/discuss/settings.py
@@ -8,7 +8,7 @@ from odoo.http import request, route, Controller
 
 
 class DiscussSettingsController(Controller):
-    @route("/discuss/settings/mute", methods=["POST"], type="json", auth="user")
+    @route("/discuss/settings/mute", methods=["POST"], type="jsonrpc", auth="user")
     def discuss_mute(self, minutes, channel_id=None):
         """Mute notifications for the given number of minutes.
         :param minutes: (integer) number of minutes to mute notifications, -1 means mute until the user unmutes
@@ -31,7 +31,7 @@ class DiscussSettingsController(Controller):
             record.mute_until_dt = False
         record._notify_mute()
 
-    @route("/discuss/settings/custom_notifications", methods=["POST"], type="json", auth="user")
+    @route("/discuss/settings/custom_notifications", methods=["POST"], type="jsonrpc", auth="user")
     def discuss_custom_notifications(self, custom_notifications, channel_id=None):
         """Set custom notifications for the given channel or general user settings.
         :param custom_notifications: (false|all|mentions|no_notif) custom notifications to set

--- a/addons/mail/controllers/google_translate.py
+++ b/addons/mail/controllers/google_translate.py
@@ -7,7 +7,7 @@ from odoo.http import request, route, Controller
 
 
 class GoogleTranslateController(Controller):
-    @route("/mail/message/translate", type="json", auth="user")
+    @route("/mail/message/translate", type="jsonrpc", auth="user")
     def translate(self, message_id):
         message = request.env["mail.message"].search([("id", "=", message_id)])
         if not message:

--- a/addons/mail/controllers/guest.py
+++ b/addons/mail/controllers/guest.py
@@ -8,7 +8,7 @@ from odoo.addons.mail.models.discuss.mail_guest import add_guest_to_context
 
 
 class GuestController(http.Controller):
-    @http.route("/mail/guest/update_name", methods=["POST"], type="json", auth="public")
+    @http.route("/mail/guest/update_name", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
     def mail_guest_update_name(self, guest_id, name):
         guest = request.env["mail.guest"]._get_guest_from_context()

--- a/addons/mail/controllers/link_preview.py
+++ b/addons/mail/controllers/link_preview.py
@@ -6,7 +6,7 @@ from odoo.addons.mail.models.discuss.mail_guest import add_guest_to_context
 
 
 class LinkPreviewController(http.Controller):
-    @http.route("/mail/link_preview", methods=["POST"], type="json", auth="public")
+    @http.route("/mail/link_preview", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
     def mail_link_preview(self, message_id):
         if not request.env["mail.link.preview"]._is_link_preview_enabled():
@@ -21,7 +21,7 @@ class LinkPreviewController(http.Controller):
             message, request_url=request.httprequest.url_root
         )
 
-    @http.route("/mail/link_preview/hide", methods=["POST"], type="json", auth="public")
+    @http.route("/mail/link_preview/hide", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
     def mail_link_preview_hide(self, link_preview_ids):
         guest = request.env["mail.guest"]._get_guest_from_context()

--- a/addons/mail/controllers/mailbox.py
+++ b/addons/mail/controllers/mailbox.py
@@ -6,7 +6,7 @@ from odoo.addons.mail.tools.discuss import Store
 
 
 class MailboxController(http.Controller):
-    @http.route("/mail/inbox/messages", methods=["POST"], type="json", auth="user")
+    @http.route("/mail/inbox/messages", methods=["POST"], type="jsonrpc", auth="user")
     def discuss_inbox_messages(self, search_term=None, before=None, after=None, limit=30, around=None):
         domain = [("needaction", "=", True)]
         res = request.env["mail.message"]._message_fetch(domain, search_term=search_term, before=before, after=after, around=around, limit=limit)
@@ -17,7 +17,7 @@ class MailboxController(http.Controller):
             "messages": Store.many_ids(messages),
         }
 
-    @http.route("/mail/history/messages", methods=["POST"], type="json", auth="user")
+    @http.route("/mail/history/messages", methods=["POST"], type="jsonrpc", auth="user")
     def discuss_history_messages(self, search_term=None, before=None, after=None, limit=30, around=None):
         domain = [("needaction", "=", False)]
         res = request.env["mail.message"]._message_fetch(domain, search_term=search_term, before=before, after=after, around=around, limit=limit)
@@ -28,7 +28,7 @@ class MailboxController(http.Controller):
             "messages": Store.many_ids(messages),
         }
 
-    @http.route("/mail/starred/messages", methods=["POST"], type="json", auth="user")
+    @http.route("/mail/starred/messages", methods=["POST"], type="jsonrpc", auth="user")
     def discuss_starred_messages(self, search_term=None, before=None, after=None, limit=30, around=None):
         domain = [("starred_partner_ids", "in", [request.env.user.partner_id.id])]
         res = request.env["mail.message"]._message_fetch(domain, search_term=search_term, before=before, after=after, around=around, limit=limit)

--- a/addons/mail/controllers/message_reaction.py
+++ b/addons/mail/controllers/message_reaction.py
@@ -9,7 +9,7 @@ from odoo.addons.mail.tools.discuss import Store
 
 
 class MessageReactionController(http.Controller):
-    @http.route("/mail/message/reaction", methods=["POST"], type="json", auth="public")
+    @http.route("/mail/message/reaction", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
     def mail_message_reaction(self, message_id, content, action, **kwargs):
         message = request.env["mail.message"]._get_with_access(int(message_id), "create", **kwargs)

--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -12,7 +12,7 @@ from odoo.addons.mail.tools.discuss import Store
 
 
 class ThreadController(http.Controller):
-    @http.route("/mail/thread/data", methods=["POST"], type="json", auth="public")
+    @http.route("/mail/thread/data", methods=["POST"], type="jsonrpc", auth="public")
     def mail_thread_data(self, thread_model, thread_id, request_list, **kwargs):
         thread = request.env[thread_model]._get_thread_with_access(thread_id, **kwargs)
         if not thread:
@@ -23,7 +23,7 @@ class ThreadController(http.Controller):
             ).get_result()
         return Store(thread, as_thread=True, request_list=request_list).get_result()
 
-    @http.route("/mail/thread/messages", methods=["POST"], type="json", auth="user")
+    @http.route("/mail/thread/messages", methods=["POST"], type="jsonrpc", auth="user")
     def mail_thread_messages(self, thread_model, thread_id, search_term=None, before=None, after=None, around=None, limit=30):
         domain = [
             ("res_id", "=", int(thread_id)),
@@ -40,7 +40,7 @@ class ThreadController(http.Controller):
             "messages": Store.many_ids(messages),
         }
 
-    @http.route("/mail/partner/from_email", methods=["POST"], type="json", auth="user")
+    @http.route("/mail/partner/from_email", methods=["POST"], type="jsonrpc", auth="user")
     def mail_thread_partner_from_email(self, emails, additional_values=None):
         partners = [
             {"id": partner.id, "name": partner.name, "email": partner.email}
@@ -48,7 +48,7 @@ class ThreadController(http.Controller):
         ]
         return partners
 
-    @http.route("/mail/read_subscription_data", methods=["POST"], type="json", auth="user")
+    @http.route("/mail/read_subscription_data", methods=["POST"], type="jsonrpc", auth="user")
     def read_subscription_data(self, follower_id):
         """Computes:
         - message_subtype_data: data about document subtypes: which are
@@ -104,7 +104,7 @@ class ThreadController(http.Controller):
         # sudo: mail.followers - filtering partners that are followers is acceptable
         return request.env["mail.followers"].sudo().search(domain).partner_id
 
-    @http.route("/mail/message/post", methods=["POST"], type="json", auth="public")
+    @http.route("/mail/message/post", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
     def mail_message_post(self, thread_model, thread_id, post_data, context=None, **kwargs):
         guest = request.env["mail.guest"]._get_guest_from_context()
@@ -145,7 +145,7 @@ class ThreadController(http.Controller):
         message = thread.sudo().message_post(**self._prepare_post_data(post_data, thread, **kwargs))
         return Store(message, for_current_user=True).get_result()
 
-    @http.route("/mail/message/update_content", methods=["POST"], type="json", auth="public")
+    @http.route("/mail/message/update_content", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
     def mail_message_update_content(self, message_id, body, attachment_ids, attachment_tokens=None, partner_ids=None, **kwargs):
         guest = request.env["mail.guest"]._get_guest_from_context()

--- a/addons/mail/controllers/webclient.py
+++ b/addons/mail/controllers/webclient.py
@@ -12,7 +12,7 @@ from odoo.osv import expression
 class WebclientController(http.Controller):
     """Routes for the web client."""
 
-    @http.route("/mail/action", methods=["POST"], type="json", auth="public")
+    @http.route("/mail/action", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
     def mail_action(self, **kwargs):
         """Execute actions and returns data depending on request parameters.
@@ -20,7 +20,7 @@ class WebclientController(http.Controller):
         """
         return self._process_request(**kwargs)
 
-    @http.route("/mail/data", methods=["POST"], type="json", auth="public", readonly=True)
+    @http.route("/mail/data", methods=["POST"], type="jsonrpc", auth="public", readonly=True)
     @add_guest_to_context
     def mail_data(self, **kwargs):
         """Returns data depending on request parameters.

--- a/addons/mail_group/controllers/portal.py
+++ b/addons/mail_group/controllers/portal.py
@@ -178,7 +178,7 @@ class PortalMailGroup(http.Controller):
         return request.render('mail_group.group_message', values)
 
     @http.route('/groups/<model("mail.group"):group>/<model("mail.group.message"):message>/get_replies',
-                type='json', auth='public', methods=['POST'], website=True)
+                type='jsonrpc', auth='public', methods=['POST'], website=True)
     def group_message_get_replies(self, group, message, last_displayed_id, **post):
         if group != message.mail_group_id:
             raise werkzeug.exceptions.NotFound()
@@ -236,7 +236,7 @@ class PortalMailGroup(http.Controller):
             raise werkzeug.exceptions.NotFound()
         return Response(status=200)
 
-    @http.route('/group/subscribe', type='json', auth='public', website=True)
+    @http.route('/group/subscribe', type='jsonrpc', auth='public', website=True)
     def group_subscribe(self, group_id=0, email=None, token=None, **kw):
         """Subscribe the current logged user or the given email address to the mailing list.
 
@@ -270,7 +270,7 @@ class PortalMailGroup(http.Controller):
         group_sudo._send_subscribe_confirmation_email(email)
         return 'email_sent'
 
-    @http.route('/group/unsubscribe', type='json', auth='public', website=True)
+    @http.route('/group/unsubscribe', type='jsonrpc', auth='public', website=True)
     def group_unsubscribe(self, group_id=0, email=None, token=None, **kw):
         """Unsubscribe the current logged user or the given email address to the mailing list.
 

--- a/addons/mail_plugin/controllers/authenticate.py
+++ b/addons/mail_plugin/controllers/authenticate.py
@@ -56,7 +56,7 @@ class Authenticate(http.Controller):
         return request.redirect(updated_redirect.to_url(), local=False)
 
     # In this case, an exception will be thrown in case of preflight request if only POST is allowed.
-    @http.route(['/mail_client_extension/auth/access_token', '/mail_plugin/auth/access_token'], type='json', auth="none", cors="*",
+    @http.route(['/mail_client_extension/auth/access_token', '/mail_plugin/auth/access_token'], type='jsonrpc', auth="none", cors="*",
                 methods=['POST', 'OPTIONS'])
     def auth_access_token(self, auth_code='', **kw):
         """

--- a/addons/mail_plugin/controllers/mail_plugin.py
+++ b/addons/mail_plugin/controllers/mail_plugin.py
@@ -18,7 +18,7 @@ _logger = logging.getLogger(__name__)
 
 class MailPluginController(http.Controller):
 
-    @http.route('/mail_client_extension/modules/get', type="json", auth="outlook", csrf=False, cors="*")
+    @http.route('/mail_client_extension/modules/get', type="jsonrpc", auth="outlook", csrf=False, cors="*")
     def modules_get(self, **kwargs):
         """
             deprecated as of saas-14.3, not needed for newer versions of the mail plugin but necessary
@@ -27,7 +27,7 @@ class MailPluginController(http.Controller):
         return {'modules': ['contacts', 'crm']}
 
     @http.route('/mail_plugin/partner/enrich_and_create_company',
-                type="json", auth="outlook", cors="*")
+                type="jsonrpc", auth="outlook", cors="*")
     def res_partner_enrich_and_create_company(self, partner_id):
         """
         Route used when the user clicks on the create and enrich partner button
@@ -57,7 +57,7 @@ class MailPluginController(http.Controller):
             'company': self._get_company_data(company),
         }
 
-    @http.route('/mail_plugin/partner/enrich_and_update_company', type='json', auth='outlook', cors='*')
+    @http.route('/mail_plugin/partner/enrich_and_update_company', type='jsonrpc', auth='outlook', cors='*')
     def res_partner_enrich_and_update_company(self, partner_id):
         """
         Enriches an existing company using IAP
@@ -130,7 +130,7 @@ class MailPluginController(http.Controller):
         }
 
     @http.route(['/mail_client_extension/partner/get', '/mail_plugin/partner/get']
-        , type="json", auth="outlook", cors="*")
+        , type="jsonrpc", auth="outlook", cors="*")
     def res_partner_get(self, email=None, name=None, partner_id=None, **kwargs):
         """
         returns a partner given it's id or an email and a name.
@@ -192,7 +192,7 @@ class MailPluginController(http.Controller):
 
         return response
 
-    @http.route('/mail_plugin/partner/search', type="json", auth="outlook", cors="*")
+    @http.route('/mail_plugin/partner/search', type="jsonrpc", auth="outlook", cors="*")
     def res_partners_search(self, search_term, limit=30, **kwargs):
         """
         Used for the plugin search contact functionality where the user types a string query in order to search for
@@ -220,7 +220,7 @@ class MailPluginController(http.Controller):
         return {"partners": partners}
 
     @http.route(['/mail_client_extension/partner/create', '/mail_plugin/partner/create'],
-                type="json", auth="outlook", cors="*")
+                type="jsonrpc", auth="outlook", cors="*")
     def res_partner_create(self, email, name, company):
         """
         params email: email of the new partner
@@ -247,7 +247,7 @@ class MailPluginController(http.Controller):
         response = {'id': partner.id}
         return response
 
-    @http.route('/mail_plugin/log_mail_content', type="json", auth="outlook", cors="*")
+    @http.route('/mail_plugin/log_mail_content', type="jsonrpc", auth="outlook", cors="*")
     def log_mail_content(self, model, res_id, message, attachments=None):
         """Log the email on the given record.
 
@@ -269,7 +269,7 @@ class MailPluginController(http.Controller):
         request.env[model].browse(res_id).message_post(body=Markup(message), attachments=attachments)
         return True
 
-    @http.route('/mail_plugin/get_translations', type="json", auth="outlook", cors="*")
+    @http.route('/mail_plugin/get_translations', type="jsonrpc", auth="outlook", cors="*")
     def get_translations(self):
         return self._prepare_translations()
 

--- a/addons/mass_mailing/controllers/main.py
+++ b/addons/mass_mailing/controllers/main.py
@@ -223,7 +223,7 @@ class MassMailController(http.Controller):
             'lists_public': lists_public,
         }
 
-    @http.route('/mailing/list/update', type='json', auth='public', csrf=True)
+    @http.route('/mailing/list/update', type='jsonrpc', auth='public', csrf=True)
     def mailing_update_list_subscription(self, mailing_id=None, document_id=None,
                                          email=None, hash_token=None,
                                          lists_optin_ids=None, **post):
@@ -254,7 +254,7 @@ class MassMailController(http.Controller):
 
         return len(lists_to_optout)
 
-    @http.route('/mailing/feedback', type='json', auth='public', csrf=True)
+    @http.route('/mailing/feedback', type='jsonrpc', auth='public', csrf=True)
     def mailing_send_feedback(self, mailing_id=None, document_id=None,
                               email=None, hash_token=None,
                               last_action=None,
@@ -431,7 +431,7 @@ class MassMailController(http.Controller):
     # BLACKLIST
     # ------------------------------------------------------------
 
-    @http.route('/mailing/blocklist/add', type='json', auth='public')
+    @http.route('/mailing/blocklist/add', type='jsonrpc', auth='public')
     def mail_blocklist_add(self, mailing_id=None, document_id=None,
                            email=None, hash_token=None):
         email_found, hash_token_found = self._fetch_user_information(email, hash_token)
@@ -458,7 +458,7 @@ class MassMailController(http.Controller):
         _blocklist_rec = request.env['mail.blacklist'].sudo()._add(email_found, message=message)
         return True
 
-    @http.route('/mailing/blocklist/remove', type='json', auth='public')
+    @http.route('/mailing/blocklist/remove', type='jsonrpc', auth='public')
     def mail_blocklist_remove(self, mailing_id=None, document_id=None,
                               email=None, hash_token=None):
         email_found, hash_token_found = self._fetch_user_information(email, hash_token)

--- a/addons/microsoft_calendar/controllers/main.py
+++ b/addons/microsoft_calendar/controllers/main.py
@@ -8,7 +8,7 @@ from odoo.addons.calendar.controllers.main import CalendarController
 
 class MicrosoftCalendarController(CalendarController):
 
-    @http.route('/microsoft_calendar/sync_data', type='json', auth='user')
+    @http.route('/microsoft_calendar/sync_data', type='jsonrpc', auth='user')
     def microsoft_calendar_sync_data(self, model, **kw):
         """ This route/function is called when we want to synchronize Odoo
             calendar with Microsoft Calendar.

--- a/addons/payment/controllers/portal.py
+++ b/addons/payment/controllers/portal.py
@@ -255,7 +255,7 @@ class PaymentPortal(portal.CustomerPortal):
         """
         return {}
 
-    @http.route('/payment/transaction', type='json', auth='public')
+    @http.route('/payment/transaction', type='jsonrpc', auth='public')
     def payment_transaction(self, amount, currency_id, partner_id, access_token, **kwargs):
         """ Create a draft transaction and return its processing values.
 
@@ -422,7 +422,7 @@ class PaymentPortal(portal.CustomerPortal):
             # Display the portal homepage to the user
             return request.redirect('/my/home')
 
-    @http.route('/payment/archive_token', type='json', auth='user')
+    @http.route('/payment/archive_token', type='jsonrpc', auth='user')
     def archive_token(self, token_id):
         """ Check that a user has write access on a token and archive the token if so.
 

--- a/addons/payment/controllers/post_processing.py
+++ b/addons/payment/controllers/post_processing.py
@@ -36,7 +36,7 @@ class PaymentPostProcessing(http.Controller):
         values = {'tx': monitored_tx} if monitored_tx else {'payment_not_found': True}
         return request.render('payment.payment_status', values)
 
-    @http.route('/payment/status/poll', type='json', auth='public')
+    @http.route('/payment/status/poll', type='jsonrpc', auth='public')
     def poll_status(self, **_kwargs):
         """ Fetch the transaction and trigger its post-processing.
 

--- a/addons/payment_adyen/controllers/main.py
+++ b/addons/payment_adyen/controllers/main.py
@@ -25,7 +25,7 @@ class AdyenController(http.Controller):
 
     _webhook_url = '/payment/adyen/notification'
 
-    @http.route('/payment/adyen/payment_methods', type='json', auth='public')
+    @http.route('/payment/adyen/payment_methods', type='jsonrpc', auth='public')
     def adyen_payment_methods(self, provider_id, formatted_amount=None, partner_id=None):
         """ Query the available payment methods based on the payment context.
 
@@ -58,7 +58,7 @@ class AdyenController(http.Controller):
         _logger.info("paymentMethods request response:\n%s", pprint.pformat(response_content))
         return response_content
 
-    @http.route('/payment/adyen/payments', type='json', auth='public')
+    @http.route('/payment/adyen/payments', type='jsonrpc', auth='public')
     def adyen_payments(
         self, provider_id, reference, converted_amount, currency_id, partner_id, payment_method,
         access_token, browser_info=None
@@ -143,7 +143,7 @@ class AdyenController(http.Controller):
         )
         return response_content
 
-    @http.route('/payment/adyen/payments/details', type='json', auth='public')
+    @http.route('/payment/adyen/payments/details', type='jsonrpc', auth='public')
     def adyen_payment_details(self, provider_id, reference, payment_details):
         """ Submit the details of the additional actions and handle the notification data.
 

--- a/addons/payment_authorize/controllers/main.py
+++ b/addons/payment_authorize/controllers/main.py
@@ -14,7 +14,7 @@ _logger = logging.getLogger(__name__)
 
 class AuthorizeController(http.Controller):
 
-    @http.route('/payment/authorize/payment', type='json', auth='public')
+    @http.route('/payment/authorize/payment', type='jsonrpc', auth='public')
     def authorize_payment(self, reference, partner_id, access_token, opaque_data):
         """ Make a payment request and handle the response.
 

--- a/addons/payment_demo/controllers/main.py
+++ b/addons/payment_demo/controllers/main.py
@@ -7,7 +7,7 @@ from odoo.http import request
 class PaymentDemoController(http.Controller):
     _simulation_url = '/payment/demo/simulate_payment'
 
-    @http.route(_simulation_url, type='json', auth='public')
+    @http.route(_simulation_url, type='jsonrpc', auth='public')
     def demo_simulate_payment(self, **data):
         """ Simulate the response of a payment request.
 

--- a/addons/payment_paypal/controllers/main.py
+++ b/addons/payment_paypal/controllers/main.py
@@ -20,7 +20,7 @@ class PaypalController(http.Controller):
     _complete_url = '/payment/paypal/complete_order'
     _webhook_url = '/payment/paypal/webhook/'
 
-    @http.route(_complete_url, type='json', auth='public', methods=['POST'])
+    @http.route(_complete_url, type='jsonrpc', auth='public', methods=['POST'])
     def paypal_complete_order(self, provider_id, order_id):
         """ Make a capture request and handle the notification data.
 

--- a/addons/payment_xendit/controllers/main.py
+++ b/addons/payment_xendit/controllers/main.py
@@ -18,7 +18,7 @@ class XenditController(http.Controller):
 
     _webhook_url = '/payment/xendit/webhook'
 
-    @http.route('/payment/xendit/payment', type='json', auth='public')
+    @http.route('/payment/xendit/payment', type='jsonrpc', auth='public')
     def xendit_payment(self, reference, token_ref):
         """ Make a payment by token request and handle the response.
 

--- a/addons/portal/controllers/mail.py
+++ b/addons/portal/controllers/mail.py
@@ -39,7 +39,7 @@ class PortalChatter(http.Controller):
         )
         return stream.get_response()
 
-    @http.route("/portal/chatter_init", type="json", auth="public", website=True)
+    @http.route("/portal/chatter_init", type="jsonrpc", auth="public", website=True)
     def portal_chatter_init(self, thread_model, thread_id, **kwargs):
         store = Store()
         thread = request.env[thread_model]._get_thread_with_access(thread_id, **kwargs)
@@ -56,7 +56,7 @@ class PortalChatter(http.Controller):
             store.add(partner, {"is_user_publisher": True})
         return store.get_result()
 
-    @http.route('/mail/chatter_fetch', type='json', auth='public', website=True)
+    @http.route('/mail/chatter_fetch', type='jsonrpc', auth='public', website=True)
     def portal_message_fetch(
             self, thread_model, thread_id, limit=10, after=None, before=None, **kw
     ):
@@ -94,7 +94,7 @@ class PortalChatter(http.Controller):
     def _setup_portal_message_fetch_extra_domain(self, data):
         return []
 
-    @http.route(['/mail/update_is_internal'], type='json', auth="user", website=True)
+    @http.route(['/mail/update_is_internal'], type='jsonrpc', auth="user", website=True)
     def portal_message_update_is_internal(self, message_id, is_internal):
         message = request.env['mail.message'].browse(int(message_id))
         message.write({'is_internal': is_internal})

--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -161,7 +161,7 @@ class CustomerPortal(Controller):
         """
         return {}
 
-    @route(['/my/counters'], type='json', auth="user", website=True)
+    @route(['/my/counters'], type='jsonrpc', auth="user", website=True)
     def counters(self, counters, **kw):
         cache = (request.session.portal_counters or {}).copy()
         res = self._prepare_home_portal_values(counters)
@@ -296,7 +296,7 @@ class CustomerPortal(Controller):
             'Content-Security-Policy': "frame-ancestors 'self'",
         })
 
-    @http.route('/portal/attachment/remove', type='json', auth='public')
+    @http.route('/portal/attachment/remove', type='jsonrpc', auth='public')
     def attachment_remove(self, attachment_id, access_token=None):
         """Remove the given `attachment_id`, only if it is in a "pending" state.
 

--- a/addons/portal_rating/controllers/portal_rating.py
+++ b/addons/portal_rating/controllers/portal_rating.py
@@ -7,7 +7,7 @@ from odoo.http import request
 
 class PortalRating(http.Controller):
 
-    @http.route(['/website/rating/comment'], type='json', auth="user", methods=['POST'], website=True)
+    @http.route(['/website/rating/comment'], type='jsonrpc', auth="user", methods=['POST'], website=True)
     def publish_rating_comment(self, rating_id, publisher_comment):
         rating = request.env['rating.rating'].search_fetch(
             [('id', '=', int(rating_id))],

--- a/addons/pos_adyen/controllers/main.py
+++ b/addons/pos_adyen/controllers/main.py
@@ -12,7 +12,7 @@ _logger = logging.getLogger(__name__)
 
 class PosAdyenController(http.Controller):
 
-    @http.route('/pos_adyen/notification', type='json', methods=['POST'], auth='public', csrf=False, save_session=False)
+    @http.route('/pos_adyen/notification', type='jsonrpc', methods=['POST'], auth='public', csrf=False, save_session=False)
     def notification(self):
         data = json.loads(request.httprequest.data)
 

--- a/addons/pos_online_payment/controllers/payment_portal.py
+++ b/addons/pos_online_payment/controllers/payment_portal.py
@@ -158,7 +158,7 @@ class PaymentPortal(payment_portal.PaymentPortal):
     def _render_pay(self, rendering_context):
         return request.render('pos_online_payment.pay', rendering_context)
 
-    @http.route('/pos/pay/transaction/<int:pos_order_id>', type='json', auth='public', website=True, sitemap=False)
+    @http.route('/pos/pay/transaction/<int:pos_order_id>', type='jsonrpc', auth='public', website=True, sitemap=False)
     def pos_order_pay_transaction(self, pos_order_id, access_token=None, **kwargs):
         """ Behaves like payment.PaymentPortal.payment_transaction but for POS online payment.
 

--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -7,7 +7,7 @@ from odoo.tools import float_round
 from werkzeug.exceptions import NotFound, BadRequest, Unauthorized
 
 class PosSelfOrderController(http.Controller):
-    @http.route("/pos-self-order/process-order/<device_type>/", auth="public", type="json", website=True)
+    @http.route("/pos-self-order/process-order/<device_type>/", auth="public", type="jsonrpc", website=True)
     def process_order(self, order, access_token, table_identifier, device_type):
         is_takeaway = order.get('takeaway')
         pos_config, table = self._verify_authorization(access_token, table_identifier, is_takeaway)
@@ -115,7 +115,7 @@ class PosSelfOrderController(http.Controller):
                     })
                 lst_price = 0
 
-    @http.route('/pos-self-order/get-orders', auth='public', type='json', website=True)
+    @http.route('/pos-self-order/get-orders', auth='public', type='jsonrpc', website=True)
     def get_orders_by_access_token(self, access_token, order_access_tokens):
         pos_config = self._verify_pos_config(access_token)
         session = pos_config.current_session_id
@@ -129,7 +129,7 @@ class PosSelfOrderController(http.Controller):
 
         return self._generate_return_values(orders, pos_config)
 
-    @http.route('/kiosk/payment/<int:pos_config_id>/<device_type>', auth='public', type='json', website=True)
+    @http.route('/kiosk/payment/<int:pos_config_id>/<device_type>', auth='public', type='jsonrpc', website=True)
     def pos_self_order_kiosk_payment(self, pos_config_id, order, payment_method_id, access_token, device_type):
         pos_config = self._verify_pos_config(access_token)
         results = self.process_order(order, access_token, None, device_type)
@@ -150,7 +150,7 @@ class PosSelfOrderController(http.Controller):
 
         return {'order': order_sudo.read(order_sudo._load_pos_data_fields(pos_config.id), load=False), 'payment_status': status}
 
-    @http.route('/pos-self-order/change-printer-status', auth='public', type='json', website=True)
+    @http.route('/pos-self-order/change-printer-status', auth='public', type='jsonrpc', website=True)
     def change_printer_status(self, access_token, has_paper):
         pos_config = self._verify_pos_config(access_token)
         if has_paper != pos_config.has_paper:

--- a/addons/pos_self_order/controllers/self_entry.py
+++ b/addons/pos_self_order/controllers/self_entry.py
@@ -26,7 +26,7 @@ class PosSelfKiosk(http.Controller):
                 }
             )
 
-    @http.route("/pos-self/data/<config_id>", type='json', auth='public')
+    @http.route("/pos-self/data/<config_id>", type='jsonrpc', auth='public')
     def get_self_ordering_data(self, config_id=None, access_token=None, table_identifier=None):
         pos_config, _, _ = self._verify_entry_access(config_id, access_token, table_identifier)
         data = pos_config.load_self_data()

--- a/addons/pos_self_order_razorpay/controllers/orders.py
+++ b/addons/pos_self_order_razorpay/controllers/orders.py
@@ -4,7 +4,7 @@ from werkzeug.exceptions import Unauthorized
 
 
 class PosSelfOrderControllerRazorpay(PosSelfOrderController):
-    @http.route("/pos-self-order/razorpay-fetch-payment-status/", auth="public", type="json", website=True)
+    @http.route("/pos-self-order/razorpay-fetch-payment-status/", auth="public", type="jsonrpc", website=True)
     def razorpay_payment_status(self, access_token, order_id, payment_data, payment_method_id):
         pos_config = self._verify_pos_config(access_token)
         order = pos_config.env['pos.order'].search([
@@ -43,7 +43,7 @@ class PosSelfOrderControllerRazorpay(PosSelfOrderController):
             self.call_bus_service(order, payment_result='fail')
         return razorpay_status_response
 
-    @http.route("/pos-self-order/razorpay-cancel-transaction/", auth="public", type="json", website=True)
+    @http.route("/pos-self-order/razorpay-cancel-transaction/", auth="public", type="jsonrpc", website=True)
     def razorpay_cancel_status(self, access_token, order_id, payment_data, payment_method_id):
         pos_config = self._verify_pos_config(access_token)
         order = pos_config.env['pos.order'].search([

--- a/addons/pos_self_order_stripe/controllers/orders.py
+++ b/addons/pos_self_order_stripe/controllers/orders.py
@@ -6,14 +6,14 @@ from odoo.addons.pos_self_order.controllers.orders import PosSelfOrderController
 from werkzeug.exceptions import Unauthorized
 
 class PosSelfOrderControllerStripe(PosSelfOrderController):
-    @http.route("/pos-self-order/stripe-connection-token/", auth="public", type="json", website=True)
+    @http.route("/pos-self-order/stripe-connection-token/", auth="public", type="jsonrpc", website=True)
     def get_stripe_creditentials(self, access_token, payment_method_id):
         # stripe_connection_token
         pos_config, _ = self._verify_authorization(access_token, "", False)
         payment_method = pos_config.payment_method_ids.filtered(lambda p: p.id == payment_method_id)
         return payment_method.stripe_connection_token()
 
-    @http.route("/pos-self-order/stripe-capture-payment/", auth="public", type="json", website=True)
+    @http.route("/pos-self-order/stripe-capture-payment/", auth="public", type="jsonrpc", website=True)
     def stripe_capture_payment(self, access_token, order_access_token, payment_intent_id, payment_method_id):
         pos_config, _ = self._verify_authorization(access_token, "", False)
         stripe_confirmation = pos_config.env['pos.payment.method'].stripe_capture_payment(payment_intent_id)

--- a/addons/product/controllers/catalog.py
+++ b/addons/product/controllers/catalog.py
@@ -5,7 +5,7 @@ from odoo.http import request, route, Controller
 
 class ProductCatalogController(Controller):
 
-    @route('/product/catalog/order_lines_info', auth='user', type='json')
+    @route('/product/catalog/order_lines_info', auth='user', type='jsonrpc')
     def product_catalog_get_order_lines_info(self, res_model, order_id, product_ids, **kwargs):
         """ Returns products information to be shown in the catalog.
 
@@ -29,7 +29,7 @@ class ProductCatalogController(Controller):
             product_ids, **kwargs,
         )
 
-    @route('/product/catalog/update_order_line_info', auth='user', type='json')
+    @route('/product/catalog/update_order_line_info', auth='user', type='jsonrpc')
     def product_catalog_update_order_line_info(self, res_model, order_id, product_id, quantity=0, **kwargs):
         """ Update order line information on a given order for a given product.
 

--- a/addons/project_mail_plugin/controllers/project_client.py
+++ b/addons/project_mail_plugin/controllers/project_client.py
@@ -4,7 +4,7 @@ from odoo.http import request
 
 
 class ProjectClient(http.Controller):
-    @http.route('/mail_plugin/project/search', type='json', auth='outlook', cors="*")
+    @http.route('/mail_plugin/project/search', type='jsonrpc', auth='outlook', cors="*")
     def projects_search(self, search_term, limit=5):
         """
         Used in the plugin side when searching for projects.
@@ -22,7 +22,7 @@ class ProjectClient(http.Controller):
             for project in projects.sudo()
         ]
 
-    @http.route('/mail_plugin/task/create', type='json', auth='outlook', cors="*")
+    @http.route('/mail_plugin/task/create', type='jsonrpc', auth='outlook', cors="*")
     def task_create(self, email_subject, email_body, project_id, partner_id):
         partner = request.env['res.partner'].browse(partner_id).exists()
         if not partner:
@@ -44,7 +44,7 @@ class ProjectClient(http.Controller):
 
         return {'task_id': record.id, 'name': record.name}
 
-    @http.route('/mail_plugin/project/create', type='json', auth='outlook', cors="*")
+    @http.route('/mail_plugin/project/create', type='jsonrpc', auth='outlook', cors="*")
     def project_create(self, name):
         record = request.env['project.project'].create({'name': name})
         return {"project_id": record.id, "name": record.name}

--- a/addons/purchase/controllers/portal.py
+++ b/addons/purchase/controllers/portal.py
@@ -169,7 +169,7 @@ class CustomerPortal(portal.CustomerPortal):
             return request.render("purchase.portal_my_purchase_order_update_date", values)
         return request.render("purchase.portal_my_purchase_order", values)
 
-    @http.route(['/my/purchase/<int:order_id>/update'], type='json', auth="public", website=True)
+    @http.route(['/my/purchase/<int:order_id>/update'], type='jsonrpc', auth="public", website=True)
     def portal_my_purchase_order_update_dates(self, order_id=None, access_token=None, **kw):
         """User update scheduled date on purchase order line.
         """

--- a/addons/rpc/controllers.py
+++ b/addons/rpc/controllers.py
@@ -162,7 +162,7 @@ class RPC(Controller):
             response = xmlrpc_handle_exception_int(error)
         return Response(response=response, mimetype='text/xml')
 
-    @route('/jsonrpc', type='json', auth="none", save_session=False)
+    @route('/jsonrpc', type='jsonrpc', auth="none", save_session=False)
     def jsonrpc(self, service, method, args):
         """ Method used by client APIs to contact OpenERP. """
         _check_request()

--- a/addons/sale/controllers/combo_configurator.py
+++ b/addons/sale/controllers/combo_configurator.py
@@ -8,7 +8,7 @@ from odoo.tools import groupby
 
 class SaleComboConfiguratorController(Controller):
 
-    @route(route='/sale/combo_configurator/get_data', type='json', auth='user')
+    @route(route='/sale/combo_configurator/get_data', type='jsonrpc', auth='user')
     def sale_combo_configurator_get_data(
         self,
         product_tmpl_id,
@@ -85,7 +85,7 @@ class SaleComboConfiguratorController(Controller):
             ),
         }
 
-    @route(route='/sale/combo_configurator/get_price', type='json', auth='user')
+    @route(route='/sale/combo_configurator/get_price', type='jsonrpc', auth='user')
     def sale_combo_configurator_get_price(
         self,
         product_tmpl_id,

--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -261,7 +261,7 @@ class CustomerPortal(payment_portal.PaymentPortal):
             **self._get_extra_payment_form_values(**kwargs),
         }
 
-    @http.route(['/my/orders/<int:order_id>/accept'], type='json', auth="public", website=True)
+    @http.route(['/my/orders/<int:order_id>/accept'], type='jsonrpc', auth="public", website=True)
     def portal_quote_accept(self, order_id, access_token=None, name=None, signature=None):
         # get from query string if not on json param
         access_token = access_token or request.httprequest.args.get('access_token')
@@ -363,7 +363,7 @@ class CustomerPortal(payment_portal.PaymentPortal):
 
 class PaymentPortal(payment_portal.PaymentPortal):
 
-    @http.route('/my/orders/<int:order_id>/transaction', type='json', auth='public')
+    @http.route('/my/orders/<int:order_id>/transaction', type='jsonrpc', auth='public')
     def portal_order_transaction(self, order_id, access_token, **kwargs):
         """ Create a draft transaction and return its processing values.
 

--- a/addons/sale/controllers/product_configurator.py
+++ b/addons/sale/controllers/product_configurator.py
@@ -7,7 +7,7 @@ from odoo.http import Controller, request, route
 
 class SaleProductConfiguratorController(Controller):
 
-    @route(route='/sale/product_configurator/get_values', type='json', auth='user')
+    @route(route='/sale/product_configurator/get_values', type='jsonrpc', auth='user')
     def sale_product_configurator_get_values(
         self,
         product_template_id,
@@ -100,7 +100,7 @@ class SaleProductConfiguratorController(Controller):
 
     @route(
         route='/sale/product_configurator/create_product',
-        type='json',
+        type='jsonrpc',
         auth='user',
         methods=['POST'],
     )
@@ -121,7 +121,7 @@ class SaleProductConfiguratorController(Controller):
 
     @route(
         route='/sale/product_configurator/update_combination',
-        type='json',
+        type='jsonrpc',
         auth='user',
         methods=['POST'],
     )
@@ -174,7 +174,7 @@ class SaleProductConfiguratorController(Controller):
             **kwargs,
         )
 
-    @route(route='/sale/product_configurator/get_optional_products', type='json', auth='user')
+    @route(route='/sale/product_configurator/get_optional_products', type='jsonrpc', auth='user')
     def sale_product_configurator_get_optional_products(
         self,
         product_template_id,

--- a/addons/sale_management/controllers/portal.py
+++ b/addons/sale_management/controllers/portal.py
@@ -8,7 +8,7 @@ from odoo.addons.sale.controllers import portal
 
 class CustomerPortal(portal.CustomerPortal):
 
-    @route(['/my/orders/<int:order_id>/update_line_dict'], type='json', auth="public", website=True)
+    @route(['/my/orders/<int:order_id>/update_line_dict'], type='jsonrpc', auth="public", website=True)
     def portal_quote_option_update(self, order_id, line_id, access_token=None, remove=False, unlink=False, input_quantity=False, **kwargs):
         """ Update the quantity or Remove an optional SOline from a SO.
 
@@ -48,7 +48,7 @@ class CustomerPortal(portal.CustomerPortal):
         else:
             order_line.product_uom_qty = quantity
 
-    @route(["/my/orders/<int:order_id>/add_option/<int:option_id>"], type='json', auth="public", website=True)
+    @route(["/my/orders/<int:order_id>/add_option/<int:option_id>"], type='jsonrpc', auth="public", website=True)
     def portal_quote_add_option(self, order_id, option_id, access_token=None, **kwargs):
         """ Add the specified option to the specified order.
 

--- a/addons/sms/controllers/main.py
+++ b/addons/sms/controllers/main.py
@@ -11,7 +11,7 @@ _logger = logging.getLogger(__name__)
 
 class SmsController(Controller):
 
-    @route('/sms/status', type='json', auth='public')
+    @route('/sms/status', type='jsonrpc', auth='public')
     def update_sms_status(self, message_statuses):
         """Receive a batch of delivery reports from IAP
 

--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -453,7 +453,7 @@ class Survey(http.Controller):
     # JSON ROUTES to begin / continue survey (ajax navigation) + Tools
     # ----------------------------------------------------------------
 
-    @http.route('/survey/begin/<string:survey_token>/<string:answer_token>', type='json', auth='public', website=True)
+    @http.route('/survey/begin/<string:survey_token>/<string:answer_token>', type='jsonrpc', auth='public', website=True)
     def survey_begin(self, survey_token, answer_token, **post):
         """ Route used to start the survey user input and display the first survey page.
         Returns an empty dict for the correct answers and the first page html. """
@@ -468,7 +468,7 @@ class Survey(http.Controller):
         answer_sudo._mark_in_progress()
         return {}, self._prepare_question_html(survey_sudo, answer_sudo, **post)
 
-    @http.route('/survey/next_question/<string:survey_token>/<string:answer_token>', type='json', auth='public', website=True)
+    @http.route('/survey/next_question/<string:survey_token>/<string:answer_token>', type='jsonrpc', auth='public', website=True)
     def survey_next_question(self, survey_token, answer_token, **post):
         """ Method used to display the next survey question in an ongoing session.
         Triggered on all attendees screens when the host goes to the next question. """
@@ -482,7 +482,7 @@ class Survey(http.Controller):
 
         return {}, self._prepare_question_html(survey_sudo, answer_sudo, **post)
 
-    @http.route('/survey/submit/<string:survey_token>/<string:answer_token>', type='json', auth='public', website=True)
+    @http.route('/survey/submit/<string:survey_token>/<string:answer_token>', type='jsonrpc', auth='public', website=True)
     def survey_submit(self, survey_token, answer_token, **post):
         """ Submit a page from the survey.
         This will take into account the validation errors and store the answers to the questions.

--- a/addons/survey/controllers/survey_session_manage.py
+++ b/addons/survey/controllers/survey_session_manage.py
@@ -65,7 +65,7 @@ class UserInputSession(http.Controller):
         # Note that at this stage survey.session_state can be False meaning that the survey has ended (session closed)
         return request.render('survey.user_input_session_manage', self._prepare_manage_session_values(survey))
 
-    @http.route('/survey/session/next_question/<string:survey_token>', type='json', auth='user', website=True)
+    @http.route('/survey/session/next_question/<string:survey_token>', type='jsonrpc', auth='user', website=True)
     def survey_session_next_question(self, survey_token, go_back=False, **kwargs):
         """ This route is called when the host goes to the next question of the session.
 
@@ -120,7 +120,7 @@ class UserInputSession(http.Controller):
         else:
             return {}
 
-    @http.route('/survey/session/results/<string:survey_token>', type='json', auth='user', website=True)
+    @http.route('/survey/session/results/<string:survey_token>', type='jsonrpc', auth='user', website=True)
     def survey_session_results(self, survey_token, **kwargs):
         """ This route is called when the host shows the current question's results.
 
@@ -141,7 +141,7 @@ class UserInputSession(http.Controller):
 
         return self._prepare_question_results_values(survey, user_input_lines)
 
-    @http.route('/survey/session/leaderboard/<string:survey_token>', type='json', auth='user', website=True)
+    @http.route('/survey/session/leaderboard/<string:survey_token>', type='jsonrpc', auth='user', website=True)
     def survey_session_leaderboard(self, survey_token, **kwargs):
         """ This route is called when the host shows the current question's attendees leaderboard.
 
@@ -182,7 +182,7 @@ class UserInputSession(http.Controller):
                                   dict(**survey_error, session_code=session_code))
         return request.redirect(survey.get_start_url())
 
-    @http.route('/survey/check_session_code/<string:session_code>', type='json', auth='public', website=True)
+    @http.route('/survey/check_session_code/<string:session_code>', type='jsonrpc', auth='public', website=True)
     def survey_check_session_code(self, session_code):
         """ Checks if the given code is matching a survey session_code.
         If yes, redirect to /s/code route.

--- a/addons/test_website/controllers/main.py
+++ b/addons/test_website/controllers/main.py
@@ -50,7 +50,7 @@ class WebsiteTest(Home):
 
     # Test Session
 
-    @http.route('/test_get_dbname', type='json', auth='public', website=True, sitemap=False)
+    @http.route('/test_get_dbname', type='jsonrpc', auth='public', website=True, sitemap=False)
     def test_get_dbname(self, **kwargs):
         return request.env.cr.dbname
 
@@ -64,7 +64,7 @@ class WebsiteTest(Home):
     def test_user_error_http(self, **kwargs):
         raise UserError("This is a user http test")
 
-    @http.route('/test_user_error_json', type='json', auth='public', website=True, sitemap=False)
+    @http.route('/test_user_error_json', type='jsonrpc', auth='public', website=True, sitemap=False)
     def test_user_error_json(self, **kwargs):
         raise UserError("This is a user rpc test")
 
@@ -72,11 +72,11 @@ class WebsiteTest(Home):
     def test_validation_error_http(self, **kwargs):
         raise ValidationError("This is a validation http test")
 
-    @http.route('/test_validation_error_json', type='json', auth='public', website=True, sitemap=False)
+    @http.route('/test_validation_error_json', type='jsonrpc', auth='public', website=True, sitemap=False)
     def test_validation_error_json(self, **kwargs):
         raise ValidationError("This is a validation rpc test")
 
-    @http.route('/test_access_error_json', type='json', auth='public', website=True, sitemap=False)
+    @http.route('/test_access_error_json', type='jsonrpc', auth='public', website=True, sitemap=False)
     def test_access_error_json(self, **kwargs):
         raise AccessError("This is an access rpc test")
 
@@ -84,7 +84,7 @@ class WebsiteTest(Home):
     def test_access_error_http(self, **kwargs):
         raise AccessError("This is an access http test")
 
-    @http.route('/test_missing_error_json', type='json', auth='public', website=True, sitemap=False)
+    @http.route('/test_missing_error_json', type='jsonrpc', auth='public', website=True, sitemap=False)
     def test_missing_error_json(self, **kwargs):
         raise MissingError("This is a missing rpc test")
 
@@ -92,7 +92,7 @@ class WebsiteTest(Home):
     def test_missing_error_http(self, **kwargs):
         raise MissingError("This is a missing http test")
 
-    @http.route('/test_internal_error_json', type='json', auth='public', website=True, sitemap=False)
+    @http.route('/test_internal_error_json', type='jsonrpc', auth='public', website=True, sitemap=False)
     def test_internal_error_json(self, **kwargs):
         raise werkzeug.exceptions.InternalServerError()
 
@@ -100,7 +100,7 @@ class WebsiteTest(Home):
     def test_internal_error_http(self, **kwargs):
         raise werkzeug.exceptions.InternalServerError()
 
-    @http.route('/test_access_denied_json', type='json', auth='public', website=True, sitemap=False)
+    @http.route('/test_access_denied_json', type='jsonrpc', auth='public', website=True, sitemap=False)
     def test_denied_error_json(self, **kwargs):
         raise AccessDenied("This is an access denied rpc test")
 

--- a/addons/test_website/tests/test_image_upload_progress.py
+++ b/addons/test_website/tests/test_image_upload_progress.py
@@ -47,10 +47,10 @@ class TestImageUploadProgress(odoo.tests.HttpCase):
 
         # because not preprocessed by ControllerType metaclass
         fetch_unsplash_images.routing_type = 'json'
-        Web_Unsplash.fetch_unsplash_images = http.route("/web_unsplash/fetch_images", type='json', auth="user")(fetch_unsplash_images)
+        Web_Unsplash.fetch_unsplash_images = http.route("/web_unsplash/fetch_images", type='jsonrpc', auth="user")(fetch_unsplash_images)
 
         # disable undraw, no third party should be called in tests
         media_library_search.routing_type = 'json'
-        Web_Editor.media_library_search = http.route(['/web_editor/media_library_search'], type='json', auth="user", website=True)(media_library_search)
+        Web_Editor.media_library_search = http.route(['/web_editor/media_library_search'], type='jsonrpc', auth="user", website=True)(media_library_search)
 
         self.start_tour(self.env['website'].get_client_action_url('/test_image_progress'), 'test_image_upload_progress_unsplash', login="admin")

--- a/addons/web/controllers/action.py
+++ b/addons/web/controllers/action.py
@@ -19,7 +19,7 @@ class MissingActionError(UserError):
 
 class Action(Controller):
 
-    @route('/web/action/load', type='json', auth='user', readonly=True)
+    @route('/web/action/load', type='jsonrpc', auth='user', readonly=True)
     def load(self, action_id, context=None):
         if context:
             request.update_context(**context)
@@ -50,7 +50,7 @@ class Action(Controller):
         result = request.env[action_type].sudo().browse([action_id]).read()
         return clean_action(result[0], env=request.env) if result else False
 
-    @route('/web/action/run', type='json', auth="user")
+    @route('/web/action/run', type='jsonrpc', auth="user")
     def run(self, action_id, context=None):
         if context:
             request.update_context(**context)
@@ -58,7 +58,7 @@ class Action(Controller):
         result = action.run()
         return clean_action(result, env=action.env) if result else False
 
-    @route('/web/action/load_breadcrumbs', type='json', auth='user', readonly=True)
+    @route('/web/action/load_breadcrumbs', type='jsonrpc', auth='user', readonly=True)
     def load_breadcrumbs(self, actions):
         results = []
         for idx, action in enumerate(actions):

--- a/addons/web/controllers/binary.py
+++ b/addons/web/controllers/binary.py
@@ -305,7 +305,7 @@ class Binary(http.Controller):
     @http.route([
         '/web/sign/get_fonts',
         '/web/sign/get_fonts/<string:fontname>',
-    ], type='json', auth='none')
+    ], type='jsonrpc', auth='none')
     def get_fonts(self, fontname=None):
         """This route will return a list of base64 encoded fonts.
 

--- a/addons/web/controllers/database.py
+++ b/addons/web/controllers/database.py
@@ -171,7 +171,7 @@ class Database(http.Controller):
             error = "Master password update error: %s" % (str(e) or repr(e))
             return self._render_template(error=error)
 
-    @http.route('/web/database/list', type='json', auth='none')
+    @http.route('/web/database/list', type='jsonrpc', auth='none')
     def list(self):
         """
         Used by Mobile application for listing database

--- a/addons/web/controllers/dataset.py
+++ b/addons/web/controllers/dataset.py
@@ -29,12 +29,12 @@ class DataSet(http.Controller):
                 return method._readonly
         return False
 
-    @http.route(['/web/dataset/call_kw', '/web/dataset/call_kw/<path:path>'], type='json', auth="user", readonly=_call_kw_readonly)
+    @http.route(['/web/dataset/call_kw', '/web/dataset/call_kw/<path:path>'], type='jsonrpc', auth="user", readonly=_call_kw_readonly)
     def call_kw(self, model, method, args, kwargs, path=None):
         check_method_name(method)
         return call_kw(request.env[model], method, args, kwargs)
 
-    @http.route(['/web/dataset/call_button', '/web/dataset/call_button/<path:path>'], type='json', auth="user", readonly=_call_kw_readonly)
+    @http.route(['/web/dataset/call_button', '/web/dataset/call_button/<path:path>'], type='jsonrpc', auth="user", readonly=_call_kw_readonly)
     def call_button(self, model, method, args, kwargs, path=None):
         check_method_name(method)
         action = call_kw(request.env[model], method, args, kwargs)
@@ -42,7 +42,7 @@ class DataSet(http.Controller):
             return clean_action(action, env=request.env)
         return False
 
-    @http.route('/web/dataset/resequence', type='json', auth="user")
+    @http.route('/web/dataset/resequence', type='jsonrpc', auth="user")
     def resequence(self, model, ids, field='sequence', offset=0, context=None):
         """ Re-sequences a number of records in the model, by their ids
 

--- a/addons/web/controllers/domain.py
+++ b/addons/web/controllers/domain.py
@@ -8,7 +8,7 @@ from odoo.tools.misc import mute_logger
 
 class Domain(Controller):
 
-    @http.route('/web/domain/validate', type='json', auth="user")
+    @http.route('/web/domain/validate', type='jsonrpc', auth="user")
     def validate(self, model, domain):
         """ Parse `domain` and verify that it can be used to search on `model`
         :return: True when the domain is valid, otherwise False

--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -290,7 +290,7 @@ class GroupExportXlsxWriter(ExportXlsxWriter):
 
 class Export(http.Controller):
 
-    @http.route('/web/export/formats', type='json', auth='user', readonly=True)
+    @http.route('/web/export/formats', type='jsonrpc', auth='user', readonly=True)
     def formats(self):
         """ Returns all valid export formats
 
@@ -356,7 +356,7 @@ class Export(http.Controller):
 
         return property_fields
 
-    @http.route('/web/export/get_fields', type='json', auth='user', readonly=True)
+    @http.route('/web/export/get_fields', type='jsonrpc', auth='user', readonly=True)
     def get_fields(self, model, domain, prefix='', parent_name='',
                    import_compat=True, parent_field_type=None,
                    parent_field=None, exclude=None):
@@ -429,7 +429,7 @@ class Export(http.Controller):
 
         return result
 
-    @http.route('/web/export/namelist', type='json', auth='user', readonly=True)
+    @http.route('/web/export/namelist', type='jsonrpc', auth='user', readonly=True)
     def namelist(self, model, export_id):
         export = request.env['ir.exports'].browse([export_id])
         return self.fields_info(model, export.export_fields.mapped('name'))

--- a/addons/web/controllers/report.py
+++ b/addons/web/controllers/report.py
@@ -150,6 +150,6 @@ class ReportController(http.Controller):
             res = request.make_response(html_escape(json.dumps(error)))
             raise werkzeug.exceptions.InternalServerError(response=res) from e
 
-    @http.route(['/report/check_wkhtmltopdf'], type='json', auth='user', readonly=True)
+    @http.route(['/report/check_wkhtmltopdf'], type='jsonrpc', auth='user', readonly=True)
     def check_wkhtmltopdf(self):
         return request.env['ir.actions.report'].get_wkhtmltopdf_state()

--- a/addons/web/controllers/session.py
+++ b/addons/web/controllers/session.py
@@ -20,13 +20,13 @@ _logger = logging.getLogger(__name__)
 
 class Session(http.Controller):
 
-    @http.route('/web/session/get_session_info', type='json', auth='user', readonly=True)
+    @http.route('/web/session/get_session_info', type='jsonrpc', auth='user', readonly=True)
     def get_session_info(self):
         # Crapy workaround for unupdatable Odoo Mobile App iOS (Thanks Apple :@)
         request.session.touch()
         return request.env['ir.http'].session_info()
 
-    @http.route('/web/session/authenticate', type='json', auth="none")
+    @http.route('/web/session/authenticate', type='jsonrpc', auth="none")
     def authenticate(self, db, login, password, base_location=None):
         if request.db and request.db != db:
             request.env.cr.close()
@@ -55,23 +55,23 @@ class Session(http.Controller):
                 )
             return env['ir.http'].session_info()
 
-    @http.route('/web/session/get_lang_list', type='json', auth="none")
+    @http.route('/web/session/get_lang_list', type='jsonrpc', auth="none")
     def get_lang_list(self):
         try:
             return http.dispatch_rpc('db', 'list_lang', []) or []
         except Exception as e:
             return {"error": e, "title": _("Languages")}
 
-    @http.route('/web/session/modules', type='json', auth='user', readonly=True)
+    @http.route('/web/session/modules', type='jsonrpc', auth='user', readonly=True)
     def modules(self):
         # return all installed modules. Web client is smart enough to not load a module twice
         return list(request.env.registry._init_modules)
 
-    @http.route('/web/session/check', type='json', auth='user', readonly=True)
+    @http.route('/web/session/check', type='jsonrpc', auth='user', readonly=True)
     def check(self):
         return  # ir.http@_authenticate does the job
 
-    @http.route('/web/session/account', type='json', auth='user', readonly=True)
+    @http.route('/web/session/account', type='jsonrpc', auth='user', readonly=True)
     def account(self):
         ICP = request.env['ir.config_parameter'].sudo()
         params = {
@@ -82,7 +82,7 @@ class Session(http.Controller):
         }
         return 'https://accounts.odoo.com/oauth2/auth?' + url_encode(params)
 
-    @http.route('/web/session/destroy', type='json', auth='user', readonly=True)
+    @http.route('/web/session/destroy', type='jsonrpc', auth='user', readonly=True)
     def destroy(self):
         request.session.logout()
 

--- a/addons/web/controllers/view.py
+++ b/addons/web/controllers/view.py
@@ -7,7 +7,7 @@ from odoo.tools.translate import _
 
 class View(Controller):
 
-    @route('/web/view/edit_custom', type='json', auth="user")
+    @route('/web/view/edit_custom', type='jsonrpc', auth="user")
     def edit_custom(self, custom_id, arch):
         """
         Edit a custom view

--- a/addons/web/controllers/webclient.py
+++ b/addons/web/controllers/webclient.py
@@ -24,7 +24,7 @@ _logger = logging.getLogger(__name__)
 
 class WebClient(http.Controller):
 
-    @http.route('/web/webclient/bootstrap_translations', type='json', auth="none")
+    @http.route('/web/webclient/bootstrap_translations', type='jsonrpc', auth="none")
     def bootstrap_translations(self, mods=None):
         """ Load local translations from *.po files, as a temporary solution
             until we have established a valid session. This is meant only
@@ -84,7 +84,7 @@ class WebClient(http.Controller):
         ])
         return response
 
-    @http.route('/web/webclient/version_info', type='json', auth="none")
+    @http.route('/web/webclient/version_info', type='jsonrpc', auth="none")
     def version_info(self):
         return odoo.service.common.exp_version()
 

--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -162,7 +162,7 @@ class Web_Editor(http.Controller):
     #------------------------------------------------------
     # Update a checklist in the editor on check/uncheck
     #------------------------------------------------------
-    @http.route('/web_editor/checklist', type='json', auth='user')
+    @http.route('/web_editor/checklist', type='jsonrpc', auth='user')
     def update_checklist(self, res_model, res_id, filename, checklistId, checked, **kwargs):
         record = request.env[res_model].browse(res_id)
         value = filename in record._fields and record[filename]
@@ -192,7 +192,7 @@ class Web_Editor(http.Controller):
     #------------------------------------------------------
     # Update a stars rating in the editor on check/uncheck
     #------------------------------------------------------
-    @http.route('/web_editor/stars', type='json', auth='user')
+    @http.route('/web_editor/stars', type='jsonrpc', auth='user')
     def update_stars(self, res_model, res_id, filename, starsId, rating):
         record = request.env[res_model].browse(res_id)
         value = filename in record._fields and record[filename]
@@ -226,7 +226,7 @@ class Web_Editor(http.Controller):
 
         return value
 
-    @http.route('/web_editor/attachment/remove', type='json', auth='user', website=True)
+    @http.route('/web_editor/attachment/remove', type='jsonrpc', auth='user', website=True)
     def remove(self, ids, **kwargs):
         """ Removes a web-based image attachment if it is used by no view (template)
 
@@ -265,7 +265,7 @@ class Web_Editor(http.Controller):
         context.pop('allowed_company_ids', None)
         request.update_env(context=context)
 
-    @http.route("/web_editor/get_assets_editor_resources", type="json", auth="user", website=True)
+    @http.route("/web_editor/get_assets_editor_resources", type="jsonrpc", auth="user", website=True)
     def get_assets_editor_resources(self, key, get_views=True, get_scss=True, get_js=True, bundles=False, bundles_restriction=[], only_user_custom_files=True):
         """
         Transmit the resources the assets editor needs to work.
@@ -497,7 +497,7 @@ class Web_Editor(http.Controller):
             ('Cache-control', 'max-age=%s' % http.STATIC_CACHE_LONG),
         ])
 
-    @http.route(['/web_editor/media_library_search'], type='json', auth="user", website=True)
+    @http.route(['/web_editor/media_library_search'], type='jsonrpc', auth="user", website=True)
     def media_library_search(self, **params):
         ICP = request.env['ir.config_parameter'].sudo()
         endpoint = ICP.get_param('web_editor.media_library_endpoint', DEFAULT_LIBRARY_ENDPOINT)

--- a/addons/web_unsplash/controllers/main.py
+++ b/addons/web_unsplash/controllers/main.py
@@ -41,7 +41,7 @@ class Web_Unsplash(http.Controller):
     # ------------------------------------------------------
     # add unsplash image url
     # ------------------------------------------------------
-    @http.route('/web_unsplash/attachment/add', type='json', auth='user', methods=['POST'])
+    @http.route('/web_unsplash/attachment/add', type='jsonrpc', auth='user', methods=['POST'])
     def save_unsplash_url(self, unsplashurls=None, **kwargs):
         """
             unsplashurls = {
@@ -124,7 +124,7 @@ class Web_Unsplash(http.Controller):
 
         return uploads
 
-    @http.route("/web_unsplash/fetch_images", type='json', auth="user")
+    @http.route("/web_unsplash/fetch_images", type='jsonrpc', auth="user")
     def fetch_unsplash_images(self, **post):
         access_key = self._get_access_key()
         app_id = self.get_unsplash_app_id()
@@ -141,11 +141,11 @@ class Web_Unsplash(http.Controller):
                 return {'error': 'no_access'}
             return {'error': response.status_code}
 
-    @http.route("/web_unsplash/get_app_id", type='json', auth="public")
+    @http.route("/web_unsplash/get_app_id", type='jsonrpc', auth="public")
     def get_unsplash_app_id(self, **post):
         return request.env['ir.config_parameter'].sudo().get_param('unsplash.app_id')
 
-    @http.route("/web_unsplash/save_unsplash", type='json', auth="user")
+    @http.route("/web_unsplash/save_unsplash", type='jsonrpc', auth="user")
     def save_unsplash(self, **post):
         if request.env.user._can_manage_unsplash_settings():
             request.env['ir.config_parameter'].sudo().set_param('unsplash.app_id', post.get('appId'))

--- a/addons/website/controllers/backend.py
+++ b/addons/website/controllers/backend.py
@@ -8,7 +8,7 @@ from odoo.http import request
 
 class WebsiteBackend(http.Controller):
 
-    @http.route('/website/fetch_dashboard_data', type="json", auth='user')
+    @http.route('/website/fetch_dashboard_data', type="jsonrpc", auth='user')
     def fetch_dashboard_data(self, website_id):
         Website = request.env['website']
         has_group_system = request.env.user.has_group('base.group_system')
@@ -37,7 +37,7 @@ class WebsiteBackend(http.Controller):
     def get_iframe_fallback(self):
         return request.render('website.iframefallback')
 
-    @http.route('/website/check_new_content_access_rights', type="json", auth='user')
+    @http.route('/website/check_new_content_access_rights', type="jsonrpc", auth='user')
     def check_create_access_rights(self, models):
         """
         TODO: In master, remove this route and method and find a better way
@@ -54,7 +54,7 @@ class WebsiteBackend(http.Controller):
             for model in models
         }
 
-    @http.route('/website/track_installing_modules', type='json', auth='user')
+    @http.route('/website/track_installing_modules', type='jsonrpc', auth='user')
     def website_track_installing_modules(self, selected_features, total_features=None):
         """
         During the website configuration, this route allows to track the

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -199,7 +199,7 @@ class Website(Home):
     # Business
     # ------------------------------------------------------
 
-    @http.route('/website/get_languages', type='json', auth="user", website=True)
+    @http.route('/website/get_languages', type='jsonrpc', auth="user", website=True)
     def website_languages(self, **kwargs):
         return [(py_to_js_locale(lg.code), lg.url_code, lg.name) for lg in request.website.language_ids]
 
@@ -217,7 +217,7 @@ class Website(Home):
         redirect.set_cookie('frontend_lang', lang_code)
         return redirect
 
-    @http.route(['/website/country_infos/<model("res.country"):country>'], type='json', auth="public", methods=['POST'], website=True)
+    @http.route(['/website/country_infos/<model("res.country"):country>'], type='jsonrpc', auth="public", methods=['POST'], website=True)
     def country_infos(self, country, **kw):
         fields = country.get_address_fields()
         return dict(fields=fields, states=[(st.id, st.name, st.code) for st in country.state_ids], phone_code=country.phone_code)
@@ -356,7 +356,7 @@ class Website(Home):
             raise werkzeug.exceptions.NotFound()
         return request.redirect(url, local=False)
 
-    @http.route('/website/get_suggested_links', type='json', auth="user", website=True)
+    @http.route('/website/get_suggested_links', type='jsonrpc', auth="user", website=True)
     def get_suggested_link(self, needle, limit=10):
         current_website = request.website
 
@@ -396,19 +396,19 @@ class Website(Home):
             ]
         }
 
-    @http.route('/website/save_session_layout_mode', type='json', auth='public', website=True)
+    @http.route('/website/save_session_layout_mode', type='jsonrpc', auth='public', website=True)
     def save_session_layout_mode(self, layout_mode, view_id):
         assert layout_mode in ('grid', 'list'), "Invalid layout mode"
         request.session[f'website_{view_id}_layout_mode'] = layout_mode
 
-    @http.route('/website/snippet/filters', type='json', auth='public', website=True)
+    @http.route('/website/snippet/filters', type='jsonrpc', auth='public', website=True)
     def get_dynamic_filter(self, filter_id, template_key, limit=None, search_domain=None, with_sample=False, **custom_template_data):
         dynamic_filter = request.env['website.snippet.filter'].sudo().search(
             [('id', '=', filter_id)] + request.website.website_domain()
         )
         return dynamic_filter and dynamic_filter._render(template_key, limit, search_domain, with_sample, **custom_template_data) or []
 
-    @http.route('/website/snippet/options_filters', type='json', auth='user', website=True)
+    @http.route('/website/snippet/options_filters', type='jsonrpc', auth='user', website=True)
     def get_dynamic_snippet_filters(self, model_name=None, search_domain=None):
         domain = request.website.website_domain()
         if search_domain:
@@ -423,7 +423,7 @@ class Website(Home):
         )
         return dynamic_filter
 
-    @http.route('/website/snippet/filter_templates', type='json', auth='public', website=True)
+    @http.route('/website/snippet/filter_templates', type='jsonrpc', auth='public', website=True)
     def get_dynamic_snippet_templates(self, filter_name=False):
         domain = [['key', 'ilike', '.dynamic_filter_template_'], ['type', '=', 'qweb']]
         if filter_name:
@@ -443,7 +443,7 @@ class Website(Home):
             t['thumb'] = attribs.get('data-thumb')
         return templates
 
-    @http.route('/website/get_current_currency', type='json', auth="public", website=True)
+    @http.route('/website/get_current_currency', type='jsonrpc', auth="public", website=True)
     def get_current_currency(self, **kwargs):
         return {
             'id': request.website.company_id.currency_id.id,
@@ -461,7 +461,7 @@ class Website(Home):
         order = order or 'name ASC'
         return 'is_published desc, %s, id desc' % order
 
-    @http.route('/website/snippet/autocomplete', type='json', auth='public', website=True)
+    @http.route('/website/snippet/autocomplete', type='jsonrpc', auth='public', website=True)
     def autocomplete(self, search_type=None, term=None, order=None, limit=5, max_nb_chars=999, options=None):
         """
         Returns list of results according to the term and options
@@ -672,7 +672,7 @@ class Website(Home):
             return json.dumps({'view_id': page.get('view_id')})
         return json.dumps({'url': url})
 
-    @http.route('/website/get_new_page_templates', type='json', auth='user', website=True)
+    @http.route('/website/get_new_page_templates', type='jsonrpc', auth='user', website=True)
     def get_new_page_templates(self, **kw):
         View = request.env['ir.ui.view']
         result = []
@@ -729,13 +729,13 @@ class Website(Home):
                 result.append(group)
         return result
 
-    @http.route("/website/get_switchable_related_views", type="json", auth="user", website=True)
+    @http.route("/website/get_switchable_related_views", type="jsonrpc", auth="user", website=True)
     def get_switchable_related_views(self, key):
         views = request.env["ir.ui.view"].get_related_views(key, bundles=False).filtered(lambda v: v.customize_show)
         views = views.sorted(key=lambda v: (v.inherit_id.id, v.name))
         return views.with_context(display_website=False).read(['name', 'id', 'key', 'xml_id', 'active', 'inherit_id'])
 
-    @http.route('/website/reset_template', type='json', auth='user', methods=['POST'])
+    @http.route('/website/reset_template', type='jsonrpc', auth='user', methods=['POST'])
     def reset_template(self, view_id, mode='soft', **kwargs):
         """ This method will try to reset a broken view.
         Given the mode, the view can either be:
@@ -748,7 +748,7 @@ class Website(Home):
         view.with_context(website_id=None).reset_arch(mode)
         return True
 
-    @http.route(['/website/seo_suggest'], type='json', auth="user", website=True)
+    @http.route(['/website/seo_suggest'], type='jsonrpc', auth="user", website=True)
     def seo_suggest(self, keywords=None, lang=None):
         """
         Suggests search keywords based on a given input using Google's
@@ -793,7 +793,7 @@ class Website(Home):
         xmlroot = ET.fromstring(response)
         return json.dumps([sugg[0].attrib['data'] for sugg in xmlroot if len(sugg) and sugg[0].attrib['data']])
 
-    @http.route(['/website/get_seo_data'], type='json', auth="user", website=True)
+    @http.route(['/website/get_seo_data'], type='jsonrpc', auth="user", website=True)
     def get_seo_data(self, res_id, res_model):
         if not request.env.user.has_group('website.group_website_restricted_editor'):
             raise werkzeug.exceptions.Forbidden()
@@ -819,7 +819,7 @@ class Website(Home):
 
         return res
 
-    @http.route(['/website/check_can_modify_any'], type='json', auth="user", website=True)
+    @http.route(['/website/check_can_modify_any'], type='jsonrpc', auth="user", website=True)
     def check_can_modify_any(self, records):
         if not request.env.user.has_group('website.group_website_restricted_editor'):
             raise werkzeug.exceptions.Forbidden()
@@ -852,7 +852,7 @@ class Website(Home):
 
         return request.make_response("google-site-verification: %s" % request.website.google_search_console)
 
-    @http.route('/website/google_maps_api_key', type='json', auth='public', website=True)
+    @http.route('/website/google_maps_api_key', type='jsonrpc', auth='public', website=True)
     def google_maps_api_key(self):
         return json.dumps({
             'google_maps_api_key': request.website.google_maps_api_key or ''
@@ -862,7 +862,7 @@ class Website(Home):
     # Themes
     # ------------------------------------------------------
 
-    @http.route('/website/google_font_metadata', type='json', auth='user', website=True)
+    @http.route('/website/google_font_metadata', type='jsonrpc', auth='user', website=True)
     def google_font_metadata(self):
         """ Avoid CORS by caching google fonts metadata on server """
         Attachment = request.env['ir.attachment']
@@ -896,12 +896,12 @@ class Website(Home):
         domain = expression.AND([[("key", "in", keys)], request.website.website_domain()])
         return Model.search(domain).filter_duplicate()
 
-    @http.route(['/website/theme_customize_data_get'], type='json', auth='user', website=True)
+    @http.route(['/website/theme_customize_data_get'], type='jsonrpc', auth='user', website=True)
     def theme_customize_data_get(self, keys, is_view_data):
         records = self._get_customize_data(keys, is_view_data)
         return records.filtered('active').mapped('key')
 
-    @http.route(['/website/theme_customize_data'], type='json', auth='user', website=True)
+    @http.route(['/website/theme_customize_data'], type='jsonrpc', auth='user', website=True)
     def theme_customize_data(self, is_view_data, enable=None, disable=None, reset_view_arch=False):
         """
         Enables and/or disables views/assets according to list of keys.
@@ -921,7 +921,7 @@ class Website(Home):
             records = self._get_customize_data(enable, is_view_data)
             records.filtered(lambda x: not x.active).write({'active': True})
 
-    @http.route(['/website/theme_customize_bundle_reload'], type='json', auth='user', website=True)
+    @http.route(['/website/theme_customize_bundle_reload'], type='jsonrpc', auth='user', website=True)
     def theme_customize_bundle_reload(self):
         """
         Reloads asset bundles and returns their unique URLs.
@@ -934,7 +934,7 @@ class Website(Home):
     # Server actions
     # ------------------------------------------------------
 
-    @http.route(['/website/theme_upload_font'], type='json', auth='user', website=True)
+    @http.route(['/website/theme_upload_font'], type='jsonrpc', auth='user', website=True)
     def theme_upload_font(self, name, data):
         """
         Uploads font binary data and returns metadata about accessing individual fonts.

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -133,7 +133,7 @@ class TestUiHtmlEditor(HttpCaseWithUserDemo):
         # disable undraw, no third party should be called in tests
         # Mocked for the previews in the media dialog
         mock_media_library_search.routing_type = 'json'
-        Web_Editor.media_library_search = http.route(['/web_editor/media_library_search'], type='json', auth='user', website=True)(mock_media_library_search)
+        Web_Editor.media_library_search = http.route(['/web_editor/media_library_search'], type='jsonrpc', auth='user', website=True)(mock_media_library_search)
 
         self.start_tour("/", 'website_media_dialog_undraw', login='admin')
 

--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -234,7 +234,7 @@ class WebsiteEventController(http.Controller):
             'quantity': count,
         } for tid, count in ticket_order.items() if count]
 
-    @http.route(['/event/<model("event.event"):event>/registration/new'], type='json', auth="public", methods=['POST'], website=True)
+    @http.route(['/event/<model("event.event"):event>/registration/new'], type='jsonrpc', auth="public", methods=['POST'], website=True)
     def registration_new(self, event, **post):
         tickets = self._process_tickets_form(event, post)
         availability_check = True

--- a/addons/website_event_booth/controllers/event_booth.py
+++ b/addons/website_event_booth/controllers/event_booth.py
@@ -145,7 +145,7 @@ class WebsiteEventBoothController(WebsiteEventController):
             },
         })
 
-    @http.route('/event/booth/check_availability', type='json', auth='public', methods=['POST'])
+    @http.route('/event/booth/check_availability', type='jsonrpc', auth='public', methods=['POST'])
     def check_booths_availability(self, event_booth_ids=None):
         if not event_booth_ids:
             return {}
@@ -154,7 +154,7 @@ class WebsiteEventBoothController(WebsiteEventController):
             'unavailable_booths': booths.filtered(lambda booth: not booth.is_available).ids
         }
 
-    @http.route(['/event/booth_category/get_available_booths'], type='json', auth='public')
+    @http.route(['/event/booth_category/get_available_booths'], type='jsonrpc', auth='public')
     def get_booth_category_available_booths(self, event_id, booth_category_id):
         booth_ids = request.env['event.booth'].sudo().search([
             ('event_id', '=', int(event_id)),

--- a/addons/website_event_exhibitor/controllers/exhibitor.py
+++ b/addons/website_event_exhibitor/controllers/exhibitor.py
@@ -181,7 +181,7 @@ class ExhibitorController(WebsiteEventController):
     # BUSINESS / MISC
     # ------------------------------------------------------------
 
-    @http.route('/event_sponsor/<int:sponsor_id>/read', type='json', auth='public', website=True)
+    @http.route('/event_sponsor/<int:sponsor_id>/read', type='jsonrpc', auth='public', website=True)
     def event_sponsor_read(self, sponsor_id):
         """ Marshmalling data for "event not started / sponsor not available" modal """
         sponsor = request.env['event.sponsor'].browse(sponsor_id)

--- a/addons/website_event_meet/controllers/community.py
+++ b/addons/website_event_meet/controllers/community.py
@@ -102,7 +102,7 @@ class WebsiteEventMeetController(EventCommunityController):
 
         return request.redirect(f"/event/{request.env['ir.http']._slug(event)}/meeting_room/{request.env['ir.http']._slug(meeting_room)}")
 
-    @http.route(["/event/active_langs"], type="json", auth="public")
+    @http.route(["/event/active_langs"], type="jsonrpc", auth="public")
     def active_langs(self):
         return request.env["res.lang"].sudo().get_installed()
 

--- a/addons/website_event_track/controllers/event_track.py
+++ b/addons/website_event_track/controllers/event_track.py
@@ -391,7 +391,7 @@ class EventTrackController(http.Controller):
             'user_event_manager': request.env.user.has_group('event.group_event_manager'),
         }
 
-    @http.route("/event/track/toggle_reminder", type="json", auth="public", website=True)
+    @http.route("/event/track/toggle_reminder", type="jsonrpc", auth="public", website=True)
     def track_reminder_toggle(self, track_id, set_reminder_on):
         """ Set a reminder a track for current visitor. Track visitor is created or updated
         if it already exists. Exception made if un-favoriting and no track_visitor
@@ -489,7 +489,7 @@ class EventTrackController(http.Controller):
         return json.dumps({'success': True})
 
     # ACL : This route is necessary since rpc search_read method in js is not accessible to all users (e.g. public user).
-    @http.route(['''/event/track_tag/search_read'''], type='json', auth="public", website=True)
+    @http.route(['''/event/track_tag/search_read'''], type='jsonrpc', auth="public", website=True)
     def website_event_track_fetch_tags(self, domain, fields):
         return request.env['event.track.tag'].search_read(domain, fields)
 

--- a/addons/website_event_track_live/controllers/track_live.py
+++ b/addons/website_event_track_live/controllers/track_live.py
@@ -8,7 +8,7 @@ from odoo.osv import expression
 
 class EventTrackLiveController(EventTrackController):
 
-    @http.route('/event_track/get_track_suggestion', type='json', auth='public', website=True)
+    @http.route('/event_track/get_track_suggestion', type='jsonrpc', auth='public', website=True)
     def get_next_track_suggestion(self, track_id):
         track = self._fetch_track(track_id)
         track_suggestion = track._get_track_suggestions(

--- a/addons/website_event_track_quiz/controllers/event_track_quiz.py
+++ b/addons/website_event_track_quiz/controllers/event_track_quiz.py
@@ -13,7 +13,7 @@ class WebsiteEventTrackQuiz(EventTrackController):
     # QUIZZES IN PAGE
     # ----------------------------------------------------------
 
-    @http.route('/event_track/quiz/submit', type="json", auth="public", website=True)
+    @http.route('/event_track/quiz/submit', type="jsonrpc", auth="public", website=True)
     def event_track_quiz_submit(self, event_id, track_id, answer_ids):
         track = self._fetch_track(track_id)
         track_sudo = track.sudo()
@@ -46,7 +46,7 @@ class WebsiteEventTrackQuiz(EventTrackController):
         }
         return result
 
-    @http.route('/event_track/quiz/reset', type="json", auth="public", website=True)
+    @http.route('/event_track/quiz/reset', type="jsonrpc", auth="public", website=True)
     def quiz_reset(self, event_id, track_id):
         track = self._fetch_track(track_id)
         # When the 'unlimited tries' option is disabled and the user is not

--- a/addons/website_forum/controllers/website_forum.py
+++ b/addons/website_forum/controllers/website_forum.py
@@ -271,7 +271,7 @@ class WebsiteForum(WebsiteProfile):
     # Questions
     # --------------------------------------------------
 
-    @http.route('/forum/get_url_title', type='json', auth="user", methods=['POST'], website=True)
+    @http.route('/forum/get_url_title', type='jsonrpc', auth="user", methods=['POST'], website=True)
     def get_url_title(self, **kwargs):
         try:
             req = requests.get(kwargs.get('url'))
@@ -339,7 +339,7 @@ class WebsiteForum(WebsiteProfile):
 
         return request.render("website_forum.post_description_full", values)
 
-    @http.route('/forum/<model("forum.forum"):forum>/question/<model("forum.post"):question>/toggle_favourite', type='json', auth="user", methods=['POST'], website=True)
+    @http.route('/forum/<model("forum.forum"):forum>/question/<model("forum.post"):question>/toggle_favourite', type='jsonrpc', auth="user", methods=['POST'], website=True)
     def question_toggle_favorite(self, forum, question, **post):
         favourite = not question.user_favourite
         question.sudo().favourite_ids = [(favourite and 4 or 3, request.uid)]
@@ -449,7 +449,7 @@ class WebsiteForum(WebsiteProfile):
         slug = request.env['ir.http']._slug
         return request.redirect(f'/forum/{slug(forum)}/{slug(question)}')
 
-    @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/toggle_correct', type='json', auth="user", website=True)
+    @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/toggle_correct', type='jsonrpc', auth="user", website=True)
     def post_toggle_correct(self, forum, post, **kwargs):
         if post.parent_id is False:
             return request.redirect('/')
@@ -508,14 +508,14 @@ class WebsiteForum(WebsiteProfile):
     #  JSON utilities
     # --------------------------------------------------
 
-    @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/upvote', type='json', auth="user", website=True)
+    @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/upvote', type='jsonrpc', auth="user", website=True)
     def post_upvote(self, forum, post, **kwargs):
         if request.uid == post.create_uid.id:
             return {'error': 'own_post'}
         upvote = True if not post.user_vote > 0 else False
         return post.vote(upvote=upvote)
 
-    @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/downvote', type='json', auth="user", website=True)
+    @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/downvote', type='jsonrpc', auth="user", website=True)
     def post_downvote(self, forum, post, **kwargs):
         if request.uid == post.create_uid.id:
             return {'error': 'own_post'}
@@ -618,11 +618,11 @@ class WebsiteForum(WebsiteProfile):
         post._refuse()
         return self.question_ask_for_close(forum, post)
 
-    @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/flag', type='json', auth="user", website=True)
+    @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/flag', type='jsonrpc', auth="user", website=True)
     def post_flag(self, forum, post, **kwargs):
         return post._flag()[0]
 
-    @http.route('/forum/<model("forum.post"):post>/ask_for_mark_as_offensive', type='json', auth="user", website=True)
+    @http.route('/forum/<model("forum.post"):post>/ask_for_mark_as_offensive', type='jsonrpc', auth="user", website=True)
     def post_json_ask_for_mark_as_offensive(self, post, **kwargs):
         if not post.can_moderate:
             raise AccessError(_('%d karma required to mark a post as offensive.', post.forum_id.karma_moderate))
@@ -795,6 +795,6 @@ class WebsiteForum(WebsiteProfile):
             return request.redirect("/forum/%s" % slug(forum))
         return request.redirect("/forum/%s/%s" % (slug(forum), request.env['ir.http']._slug(question)))
 
-    @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/comment/<model("mail.message"):comment>/delete', type='json', auth="user", website=True)
+    @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/comment/<model("mail.message"):comment>/delete', type='jsonrpc', auth="user", website=True)
     def delete_comment(self, forum, post, comment, **kwarg):
         return post.unlink_comment(comment.id)[0]

--- a/addons/website_hr_recruitment/controllers/main.py
+++ b/addons/website_hr_recruitment/controllers/main.py
@@ -213,7 +213,7 @@ class WebsiteHrRecruitment(WebsiteForm):
             'count_per_employment_type': count_per_employment_type,
         })
 
-    @http.route('/jobs/add', type='json', auth="user", website=True)
+    @http.route('/jobs/add', type='jsonrpc', auth="user", website=True)
     def jobs_add(self, **kwargs):
         # avoid branding of website_description by setting rendering_bundle in context
         job = request.env['hr.job'].with_context(rendering_bundle=True).create({
@@ -246,7 +246,7 @@ class WebsiteHrRecruitment(WebsiteForm):
             'default': default,
         })
 
-    @http.route('/website_hr_recruitment/check_recent_application', type='json', auth="public", website=True)
+    @http.route('/website_hr_recruitment/check_recent_application', type='jsonrpc', auth="public", website=True)
     def check_recent_application(self, field, value, job_id):
         def refused_applicants_condition(applicant):
             return not applicant.active \

--- a/addons/website_jitsi/controllers/main.py
+++ b/addons/website_jitsi/controllers/main.py
@@ -9,7 +9,7 @@ from odoo.http import request
 
 class WebsiteJitsiController(http.Controller):
 
-    @http.route(["/jitsi/update_status"], type="json", auth="public")
+    @http.route(["/jitsi/update_status"], type="jsonrpc", auth="public")
     def jitsi_update_status(self, room_name, participant_count, joined):
         """ Update room status: participant count, max reached
 
@@ -47,7 +47,7 @@ class WebsiteJitsiController(http.Controller):
             [room_name, participant_count, participant_count]
         )
 
-    @http.route(["/jitsi/is_full"], type="json", auth="public")
+    @http.route(["/jitsi/is_full"], type="jsonrpc", auth="public")
     def jitsi_is_full(self, room_name):
         return self._chat_room_exists(room_name).is_full
 

--- a/addons/website_links/controller/main.py
+++ b/addons/website_links/controller/main.py
@@ -6,7 +6,7 @@ from odoo.http import request
 
 
 class WebsiteUrl(http.Controller):
-    @http.route('/website_links/new', type='json', auth='user', methods=['POST'])
+    @http.route('/website_links/new', type='jsonrpc', auth='user', methods=['POST'])
     def create_shorten_url(self, **post):
         if 'url' not in post or post['url'] == '':
             return {'error': 'empty_url'}
@@ -20,7 +20,7 @@ class WebsiteUrl(http.Controller):
             **post,
         })
 
-    @http.route('/website_links/add_code', type='json', auth='user')
+    @http.route('/website_links/add_code', type='jsonrpc', auth='user')
     def add_code(self, **post):
         link_id = request.env['link.tracker.code'].search([('code', '=', post['init_code'])], limit=1).link_id.id
         new_code = request.env['link.tracker.code'].search_count([('code', '=', post['new_code']), ('link_id', '=', link_id)])
@@ -29,7 +29,7 @@ class WebsiteUrl(http.Controller):
         else:
             return request.env['link.tracker.code'].create({'code': post['new_code'], 'link_id': link_id})[0].read()
 
-    @http.route('/website_links/recent_links', type='json', auth='user')
+    @http.route('/website_links/recent_links', type='jsonrpc', auth='user')
     def recent_links(self, **post):
         return request.env['link.tracker'].recent_links(post['filter'], post['limit'])
 

--- a/addons/website_livechat/controllers/test.py
+++ b/addons/website_livechat/controllers/test.py
@@ -14,6 +14,6 @@ class TestBusController(Controller):
     in test mode, we need to mock a 'message added' notification that is normally triggered by the bus.
     In Normal mode, the bus triggers itself the notification.
     """
-    @route('/bus/test_mode_activated', type="json", auth="public")
+    @route('/bus/test_mode_activated', type="jsonrpc", auth="public")
     def is_test_mode_activated(self):
         return request.registry.in_test_mode()

--- a/addons/website_mail/controllers/main.py
+++ b/addons/website_mail/controllers/main.py
@@ -8,7 +8,7 @@ from odoo.exceptions import UserError
 
 class WebsiteMail(http.Controller):
 
-    @http.route(['/website_mail/follow'], type='json', auth="public", website=True)
+    @http.route(['/website_mail/follow'], type='jsonrpc', auth="public", website=True)
     def website_message_subscribe(self, id=0, object=None, message_is_follower="on", email=False, **post):
         # TDE FIXME: check this method with new followers
         if not request.env['ir.http']._verify_request_recaptcha_token('website_mail_follow'):
@@ -40,7 +40,7 @@ class WebsiteMail(http.Controller):
             record.sudo().message_subscribe(partner_ids)
             return True
 
-    @http.route(['/website_mail/is_follower'], type='json', auth="public", website=True)
+    @http.route(['/website_mail/is_follower'], type='jsonrpc', auth="public", website=True)
     def is_follower(self, records, **post):
         """ Given a list of `models` containing a list of res_ids, return
             the res_ids for which the user is follower and some practical info.

--- a/addons/website_mail_group/controllers/main.py
+++ b/addons/website_mail_group/controllers/main.py
@@ -6,7 +6,7 @@ from odoo.http import request
 
 
 class WebsiteMailGroup(http.Controller):
-    @http.route('/group/is_member', type='json', auth='public', website=True)
+    @http.route('/group/is_member', type='jsonrpc', auth='public', website=True)
     def group_is_member(self, group_id=0, email=None, **kw):
         """Return the email of the member if found, otherwise None."""
         group = request.env['mail.group'].browse(int(group_id)).exists()

--- a/addons/website_mass_mailing/controllers/main.py
+++ b/addons/website_mass_mailing/controllers/main.py
@@ -8,7 +8,7 @@ from odoo.addons.mass_mailing.controllers import main
 
 class MassMailController(main.MassMailController):
 
-    @route('/website_mass_mailing/is_subscriber', type='json', website=True, auth='public')
+    @route('/website_mass_mailing/is_subscriber', type='jsonrpc', website=True, auth='public')
     def is_subscriber(self, list_id, subscription_type, **post):
         value = self._get_value(subscription_type)
         fname = self._get_fname(subscription_type)
@@ -32,7 +32,7 @@ class MassMailController(main.MassMailController):
     def _get_fname(self, subscription_type):
         return 'email' if subscription_type == 'email' else ''
 
-    @route('/website_mass_mailing/subscribe', type='json', website=True, auth='public')
+    @route('/website_mass_mailing/subscribe', type='jsonrpc', website=True, auth='public')
     def subscribe(self, list_id, value, subscription_type, **post):
         if not request.env['ir.http']._verify_request_recaptcha_token('website_mass_mailing_subscribe'):
             return {

--- a/addons/website_payment/controllers/portal.py
+++ b/addons/website_payment/controllers/portal.py
@@ -33,7 +33,7 @@ class PaymentPortal(payment_portal.PaymentPortal):
 
         return self.payment_pay(**kwargs)
 
-    @http.route('/donation/transaction/<minimum_amount>', type='json', auth='public', website=True, sitemap=False)
+    @http.route('/donation/transaction/<minimum_amount>', type='jsonrpc', auth='public', website=True, sitemap=False)
     def donation_transaction(self, amount, currency_id, partner_id, access_token, minimum_amount=0, **kwargs):
         if float(amount) < float(minimum_amount):
             raise ValidationError(_('Donation amount must be at least %.2f.', float(minimum_amount)))

--- a/addons/website_profile/controllers/main.py
+++ b/addons/website_profile/controllers/main.py
@@ -291,7 +291,7 @@ class WebsiteProfile(http.Controller):
     # User and validation
     # --------------------------------------------------
 
-    @http.route('/profile/send_validation_email', type='json', auth='user', website=True)
+    @http.route('/profile/send_validation_email', type='jsonrpc', auth='user', website=True)
     def send_validation_email(self, **kwargs):
         if request.env.uid != request.website.user_id.id:
             request.env.user._send_profile_validation_email(**kwargs)
@@ -306,7 +306,7 @@ class WebsiteProfile(http.Controller):
         url = kwargs.get('redirect_url', '/')
         return request.redirect(url)
 
-    @http.route('/profile/validate_email/close', type='json', auth='public', website=True)
+    @http.route('/profile/validate_email/close', type='jsonrpc', auth='public', website=True)
     def validate_email_done(self, **kwargs):
         request.session['validation_email_done'] = False
         return True

--- a/addons/website_sale/controllers/combo_configurator.py
+++ b/addons/website_sale/controllers/combo_configurator.py
@@ -10,7 +10,7 @@ class WebsiteSaleComboConfiguratorController(SaleComboConfiguratorController, We
 
     @route(
         route='/website_sale/combo_configurator/get_data',
-        type='json',
+        type='jsonrpc',
         auth='public',
         website=True,
     )
@@ -20,7 +20,7 @@ class WebsiteSaleComboConfiguratorController(SaleComboConfiguratorController, We
 
     @route(
         route='/website_sale/combo_configurator/get_price',
-        type='json',
+        type='jsonrpc',
         auth='public',
         website=True,
     )
@@ -30,7 +30,7 @@ class WebsiteSaleComboConfiguratorController(SaleComboConfiguratorController, We
 
     @route(
         route='/website_sale/combo_configurator/update_cart',
-        type='json',
+        type='jsonrpc',
         auth='public',
         methods=['POST'],
         website=True,

--- a/addons/website_sale/controllers/delivery.py
+++ b/addons/website_sale/controllers/delivery.py
@@ -11,7 +11,7 @@ from odoo.addons.website_sale.controllers.main import WebsiteSale
 class Delivery(WebsiteSale):
     _express_checkout_delivery_route = '/shop/express/shipping_address_change'
 
-    @route('/shop/delivery_methods', type='json', auth='public', website=True)
+    @route('/shop/delivery_methods', type='jsonrpc', auth='public', website=True)
     def shop_delivery_methods(self):
         """ Fetch available delivery methods and render them in the delivery form.
 
@@ -31,7 +31,7 @@ class Delivery(WebsiteSale):
         """ Hook to update values used for rendering the website_sale.delivery_form template. """
         return {}
 
-    @route('/shop/set_delivery_method', type='json', auth='public', website=True)
+    @route('/shop/set_delivery_method', type='jsonrpc', auth='public', website=True)
     def shop_set_delivery_method(self, dm_id=None, **kwargs):
         """ Set the delivery method on the current order and return the order summary values.
 
@@ -86,7 +86,7 @@ class Delivery(WebsiteSale):
             ),
         }
 
-    @route('/shop/get_delivery_rate', type='json', auth='public', methods=['POST'], website=True)
+    @route('/shop/get_delivery_rate', type='jsonrpc', auth='public', methods=['POST'], website=True)
     def shop_get_delivery_rate(self, dm_id):
         """ Return the delivery rate data for the given delivery method.
 
@@ -118,7 +118,7 @@ class Delivery(WebsiteSale):
             )
         return rate
 
-    @route('/website_sale/set_pickup_location', type='json', auth='public', website=True)
+    @route('/website_sale/set_pickup_location', type='jsonrpc', auth='public', website=True)
     def website_sale_set_pickup_location(self, pickup_location_data):
         """ Fetch the order from the request and set the pickup location on the current order.
 
@@ -128,7 +128,7 @@ class Delivery(WebsiteSale):
         order_sudo = request.website.sale_get_order()
         order_sudo._set_pickup_location(pickup_location_data)
 
-    @route('/website_sale/get_pickup_locations', type='json', auth='public', website=True)
+    @route('/website_sale/get_pickup_locations', type='jsonrpc', auth='public', website=True)
     def website_sale_get_pickup_locations(self, zip_code=None, **kwargs):
         """ Fetch the order from the request and return the pickup locations close to the zip code.
 
@@ -142,7 +142,7 @@ class Delivery(WebsiteSale):
         country = order_sudo.partner_shipping_id.country_id
         return order_sudo._get_pickup_locations(zip_code, country, **kwargs)
 
-    @route(_express_checkout_delivery_route, type='json', auth='public', website=True)
+    @route(_express_checkout_delivery_route, type='jsonrpc', auth='public', website=True)
     def express_checkout_process_delivery_address(self, partial_delivery_address):
         """ Process the shipping address and return the available delivery methods.
 

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -484,7 +484,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         # Compatibility pre-v14
         return request.redirect(_build_url_w_params("/shop/%s" % request.env['ir.http']._slug(product), request.params), code=301)
 
-    @route(['/shop/product/extra-images'], type='json', auth='user', website=True)
+    @route(['/shop/product/extra-images'], type='jsonrpc', auth='user', website=True)
     def add_product_images(self, images, product_product_id, product_template_id, combination_ids=None):
         """
         Turns a list of image ids refering to ir.attachments to product.images,
@@ -521,7 +521,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
                 'product_template_image_ids': image_create_data
             })
 
-    @route(['/shop/product/clear-images'], type='json', auth='user', website=True)
+    @route(['/shop/product/clear-images'], type='jsonrpc', auth='user', website=True)
     def clear_product_images(self, product_product_id, product_template_id):
         """
         Unlinks all images from the product.
@@ -540,7 +540,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         else:
             product_template.product_template_image_ids.unlink()
 
-    @route(['/shop/product/resequence-image'], type='json', auth='user', website=True)
+    @route(['/shop/product/resequence-image'], type='jsonrpc', auth='user', website=True)
     def resequence_product_image(self, image_res_model, image_res_id, move):
         """
         Move the product image in the given direction and update all images' sequence.
@@ -623,7 +623,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             if product_image._name == 'product.image':
                 product_image.sequence = idx
 
-    @route(['/shop/product/is_add_to_cart_allowed'], type='json', auth="public", website=True)
+    @route(['/shop/product/is_add_to_cart_allowed'], type='jsonrpc', auth="public", website=True)
     def is_add_to_cart_allowed(self, product_id, **kwargs):
         product = request.env['product.product'].browse(product_id)
         return product._is_add_to_cart_allowed()
@@ -817,7 +817,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
         return request.redirect("/shop/cart")
 
-    @route(['/shop/cart/update_json'], type='json', auth="public", methods=['POST'], website=True)
+    @route(['/shop/cart/update_json'], type='jsonrpc', auth="public", methods=['POST'], website=True)
     def cart_update_json(
         self, product_id, line_id=None, add_qty=None, set_qty=None, display=True,
         product_custom_attribute_values=None, no_variant_attribute_value_ids=None, **kwargs
@@ -900,18 +900,18 @@ class WebsiteSale(payment_portal.PaymentPortal):
         )
         return values
 
-    @route('/shop/save_shop_layout_mode', type='json', auth='public', website=True)
+    @route('/shop/save_shop_layout_mode', type='jsonrpc', auth='public', website=True)
     def save_shop_layout_mode(self, layout_mode):
         assert layout_mode in ('grid', 'list'), "Invalid shop layout mode"
         request.session['website_sale_shop_layout_mode'] = layout_mode
 
-    @route(['/shop/cart/quantity'], type='json', auth="public", methods=['POST'], website=True)
+    @route(['/shop/cart/quantity'], type='jsonrpc', auth="public", methods=['POST'], website=True)
     def cart_quantity(self):
         if 'website_sale_cart_quantity' not in request.session:
             return request.website.sale_get_order().cart_quantity
         return request.session['website_sale_cart_quantity']
 
-    @route(['/shop/cart/clear'], type='json', auth="public", website=True)
+    @route(['/shop/cart/clear'], type='jsonrpc', auth="public", website=True)
     def clear_cart(self):
         order = request.website.sale_get_order()
         for line in order.order_line:
@@ -1559,7 +1559,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         pass
 
     @route(
-        _express_checkout_route, type='json', methods=['POST'], auth="public", website=True,
+        _express_checkout_route, type='jsonrpc', methods=['POST'], auth="public", website=True,
         sitemap=False
     )
     def process_express_checkout(
@@ -1696,7 +1696,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         ], limit=1)
         address.update(country_id=country.id, state_id=state.id)
 
-    @route('/shop/update_address', type='json', auth='public', website=True)
+    @route('/shop/update_address', type='jsonrpc', auth='public', website=True)
     def shop_update_address(self, partner_id, address_type='billing', **kw):
         partner_id = int(partner_id)
 
@@ -2084,7 +2084,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
     # Edit
     # ------------------------------------------------------
 
-    @route(['/shop/config/product'], type='json', auth='user')
+    @route(['/shop/config/product'], type='jsonrpc', auth='user')
     def change_product_config(self, product_id, **options):
         if not request.env.user.has_group('website.group_website_restricted_editor'):
             raise NotFound()
@@ -2103,7 +2103,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         if {"x", "y"} <= set(options):
             product.write({'website_size_x': options["x"], 'website_size_y': options["y"]})
 
-    @route(['/shop/config/attribute'], type='json', auth='user')
+    @route(['/shop/config/attribute'], type='jsonrpc', auth='user')
     def change_attribute_config(self, attribute_id, **options):
         if not request.env.user.has_group('website.group_website_restricted_editor'):
             raise NotFound()
@@ -2113,7 +2113,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             attribute.write({'display_type': options['display_type']})
             request.env.registry.clear_cache('templates')
 
-    @route(['/shop/config/website'], type='json', auth='user')
+    @route(['/shop/config/website'], type='jsonrpc', auth='user')
     def _change_website_config(self, **options):
         if not request.env.user.has_group('website.group_website_restricted_editor'):
             raise NotFound()
@@ -2164,7 +2164,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             tracking_cart_dict['shipping'] = delivery_line.price_unit
         return tracking_cart_dict
 
-    @route(['/shop/country_info/<model("res.country"):country>'], type='json', auth="public", methods=['POST'], website=True)
+    @route(['/shop/country_info/<model("res.country"):country>'], type='jsonrpc', auth="public", methods=['POST'], website=True)
     def shop_country_info(self, country, address_type, **kw):
         address_fields = country.get_address_fields()
         if address_type == 'billing':
@@ -2185,14 +2185,14 @@ class WebsiteSale(payment_portal.PaymentPortal):
     # --------------------------------------------------------------------------
     # Products Recently Viewed
     # --------------------------------------------------------------------------
-    @route('/shop/products/recently_viewed_update', type='json', auth='public', website=True)
+    @route('/shop/products/recently_viewed_update', type='jsonrpc', auth='public', website=True)
     def products_recently_viewed_update(self, product_id, **kwargs):
         res = {}
         visitor_sudo = request.env['website.visitor']._get_visitor_from_request(force_create=True)
         visitor_sudo._add_viewed_product(product_id)
         return res
 
-    @route('/shop/products/recently_viewed_delete', type='json', auth='public', website=True)
+    @route('/shop/products/recently_viewed_delete', type='jsonrpc', auth='public', website=True)
     def products_recently_viewed_delete(self, product_id=None, product_template_id=None, **kwargs):
         if not (product_id or product_template_id):
             return

--- a/addons/website_sale/controllers/payment.py
+++ b/addons/website_sale/controllers/payment.py
@@ -19,7 +19,7 @@ class PaymentPortal(payment_portal.PaymentPortal):
         """
         return
 
-    @route('/shop/payment/transaction/<int:order_id>', type='json', auth='public', website=True)
+    @route('/shop/payment/transaction/<int:order_id>', type='jsonrpc', auth='public', website=True)
     def shop_payment_transaction(self, order_id, access_token, **kwargs):
         """ Create a draft transaction and return its processing values.
 

--- a/addons/website_sale/controllers/product_configurator.py
+++ b/addons/website_sale/controllers/product_configurator.py
@@ -11,7 +11,7 @@ class WebsiteSaleProductConfiguratorController(SaleProductConfiguratorController
 
     @route(
         route='/website_sale/should_show_product_configurator',
-        type='json',
+        type='jsonrpc',
         auth='public',
         website=True,
     )
@@ -44,7 +44,7 @@ class WebsiteSaleProductConfiguratorController(SaleProductConfiguratorController
 
     @route(
         route='/website_sale/product_configurator/get_values',
-        type='json',
+        type='jsonrpc',
         auth='public',
         website=True,
     )
@@ -54,7 +54,7 @@ class WebsiteSaleProductConfiguratorController(SaleProductConfiguratorController
 
     @route(
         route='/website_sale/product_configurator/create_product',
-        type='json',
+        type='jsonrpc',
         auth='public',
         methods=['POST'],
         website=True,
@@ -64,7 +64,7 @@ class WebsiteSaleProductConfiguratorController(SaleProductConfiguratorController
 
     @route(
         route='/website_sale/product_configurator/update_combination',
-        type='json',
+        type='jsonrpc',
         auth='public',
         methods=['POST'],
         website=True,
@@ -75,7 +75,7 @@ class WebsiteSaleProductConfiguratorController(SaleProductConfiguratorController
 
     @route(
         route='/website_sale/product_configurator/get_optional_products',
-        type='json',
+        type='jsonrpc',
         auth='public',
         website=True,
     )
@@ -85,7 +85,7 @@ class WebsiteSaleProductConfiguratorController(SaleProductConfiguratorController
 
     @route(
         route='/website_sale/product_configurator/update_cart',
-        type='json',
+        type='jsonrpc',
         auth='public',
         methods=['POST'],
         website=True,

--- a/addons/website_sale/controllers/reorder.py
+++ b/addons/website_sale/controllers/reorder.py
@@ -11,7 +11,7 @@ class CustomerPortal(sale_portal.CustomerPortal):
     def _sale_reorder_get_line_context(self):
         return {}
 
-    @route('/my/orders/reorder_modal_content', type='json', auth='public', website=True)
+    @route('/my/orders/reorder_modal_content', type='jsonrpc', auth='public', website=True)
     def my_orders_reorder_modal_content(self, order_id, access_token):
         try:
             sale_order = self._document_check_access('sale.order', order_id, access_token=access_token)

--- a/addons/website_sale/controllers/variant.py
+++ b/addons/website_sale/controllers/variant.py
@@ -7,7 +7,7 @@ from odoo.http import Controller, request, route
 
 class WebsiteSaleVariantController(Controller):
 
-    @route('/website_sale/get_combination_info', type='json', auth='public', methods=['POST'], website=True)
+    @route('/website_sale/get_combination_info', type='jsonrpc', auth='public', methods=['POST'], website=True)
     def get_combination_info_website(
         self, product_template_id, product_id, combination, add_qty, **kwargs
     ):
@@ -51,7 +51,7 @@ class WebsiteSaleVariantController(Controller):
             )
         return combination_info
 
-    @route('/sale/create_product_variant', type='json', auth='public', methods=['POST'])
+    @route('/sale/create_product_variant', type='jsonrpc', auth='public', methods=['POST'])
     def create_product_variant(self, product_template_id, product_template_attribute_value_ids, **kwargs):
         """Old product configurator logic, only used by frontend configurator, will be deprecated soon"""
         return request.env['product.template'].browse(

--- a/addons/website_sale_autocomplete/controllers/main.py
+++ b/addons/website_sale_autocomplete/controllers/main.py
@@ -160,12 +160,12 @@ class AutoCompleteController(http.Controller):
                 standard_address['formatted_street_number'] = formatted_manually
         return standard_address
 
-    @http.route('/autocomplete/address', methods=['POST'], type='json', auth='public', website=True)
+    @http.route('/autocomplete/address', methods=['POST'], type='jsonrpc', auth='public', website=True)
     def _autocomplete_address(self, partial_address, session_id=None):
         api_key = request.env['website'].get_current_website().sudo().google_places_api_key
         return self._perform_place_search(partial_address, session_id=session_id, api_key=api_key)
 
-    @http.route('/autocomplete/address_full', methods=['POST'], type='json', auth='public', website=True)
+    @http.route('/autocomplete/address_full', methods=['POST'], type='jsonrpc', auth='public', website=True)
     def _autocomplete_address_full(self, address, session_id=None, google_place_id=None, **kwargs):
         api_key = request.env['website'].get_current_website().sudo().google_places_api_key
         return self._perform_complete_place_search(address, google_place_id=google_place_id,

--- a/addons/website_sale_collect/controllers/delivery.py
+++ b/addons/website_sale_collect/controllers/delivery.py
@@ -19,7 +19,7 @@ class InStoreDelivery(Delivery):
                 order_sudo.set_delivery_line(in_store_dm, in_store_dm.product_id.list_price)
         return super().website_sale_get_pickup_locations(zip_code, **kwargs)
 
-    @route('/shop/set_click_and_collect_location', type='json', auth='public', website=True)
+    @route('/shop/set_click_and_collect_location', type='jsonrpc', auth='public', website=True)
     def shop_set_click_and_collect_location(self, pickup_location_data):
         """ Set the pickup location and the in-store delivery method on the current order.
 

--- a/addons/website_sale_comparison/controllers/main.py
+++ b/addons/website_sale_comparison/controllers/main.py
@@ -22,7 +22,7 @@ class WebsiteSaleProductComparison(Controller):
             }
         )
 
-    @route('/shop/get_product_data', type='json', auth='public', website=True)
+    @route('/shop/get_product_data', type='jsonrpc', auth='public', website=True)
     def get_product_data(self, product_ids, cookies=None):
         ret = {}
 

--- a/addons/website_sale_mondialrelay/controllers/controllers.py
+++ b/addons/website_sale_mondialrelay/controllers/controllers.py
@@ -9,7 +9,7 @@ from odoo.http import request
 
 class MondialRelay(http.Controller):
 
-    @http.route(['/website_sale_mondialrelay/update_shipping'], type='json', auth="public", website=True)
+    @http.route(['/website_sale_mondialrelay/update_shipping'], type='jsonrpc', auth="public", website=True)
     def mondial_relay_update_shipping(self, **data):
         order = request.website.sale_get_order()
 

--- a/addons/website_sale_slides/controllers/slides.py
+++ b/addons/website_sale_slides/controllers/slides.py
@@ -8,7 +8,7 @@ from odoo.tools import format_amount
 
 class WebsiteSaleSlides(WebsiteSlides):
 
-    @route('/slides/get_course_products', type='json', auth='user')
+    @route('/slides/get_course_products', type='jsonrpc', auth='user')
     def get_course_products(self):
         """Return a list of the course products values with formatted price."""
         products = request.env['product.product'].search([('service_tracking', '=', 'course')])

--- a/addons/website_sale_stock/controllers/main.py
+++ b/addons/website_sale_stock/controllers/main.py
@@ -9,7 +9,7 @@ from odoo.tools.mail import email_re
 
 class WebsiteSaleStock(Controller):
 
-    @route('/shop/add/stock_notification', type='json', auth='public', website=True)
+    @route('/shop/add/stock_notification', type='jsonrpc', auth='public', website=True)
     def add_stock_email_notification(self, email, product_id):
         if not email_re.match(email):
             raise BadRequest(_("Invalid Email"))

--- a/addons/website_sale_wishlist/controllers/main.py
+++ b/addons/website_sale_wishlist/controllers/main.py
@@ -7,7 +7,7 @@ from odoo.http import Controller, request, route
 
 class WebsiteSaleWishlist(Controller):
 
-    @route('/shop/wishlist/add', type='json', auth='public', website=True)
+    @route('/shop/wishlist/add', type='jsonrpc', auth='public', website=True)
     def add_to_wishlist(self, product_id, **kw):
         website = request.website
         pricelist = website.pricelist_id
@@ -52,7 +52,7 @@ class WebsiteSaleWishlist(Controller):
             }
         )
 
-    @route('/shop/wishlist/remove/<int:wish_id>', type='json', auth='public', website=True)
+    @route('/shop/wishlist/remove/<int:wish_id>', type='jsonrpc', auth='public', website=True)
     def remove_from_wishlist(self, wish_id, **kw):
         wish = request.env['product.wishlist'].browse(wish_id)
         if request.website.is_public_user():

--- a/addons/website_slides/controllers/mail.py
+++ b/addons/website_slides/controllers/mail.py
@@ -19,7 +19,7 @@ class SlidesPortalChatter(PortalChatter):
 
     @http.route([
         '/slides/mail/update_comment',
-        ], type='json', auth="user", methods=['POST'])
+        ], type='jsonrpc', auth="user", methods=['POST'])
     def mail_update_message(self, thread_model, thread_id, message_id, post_data, **post):
         # keep this mechanism intern to slide currently (saas 12.5) as it is
         # considered experimental

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -845,7 +845,7 @@ class WebsiteSlides(WebsiteProfile):
                 return request.redirect(f'/web/login?redirect=/slides/{channel_id}&auth_login={partner_sudo.user_ids[0].login}')
         return self._redirect_to_slides_main('identify_fail')
 
-    @http.route(['/slides/channel/join'], type='json', auth='public', website=True)
+    @http.route(['/slides/channel/join'], type='jsonrpc', auth='public', website=True)
     def slide_channel_join(self, channel_id):
         if request.website.is_public_user():
             return {
@@ -859,14 +859,14 @@ class WebsiteSlides(WebsiteProfile):
             success = channel._action_add_members(request.env.user.partner_id)
         return {'error': 'join_done'} if not success else success
 
-    @http.route(['/slides/channel/leave'], type='json', auth='user', website=True)
+    @http.route(['/slides/channel/leave'], type='jsonrpc', auth='user', website=True)
     def slide_channel_leave(self, channel_id):
         channel = request.env['slide.channel'].browse(channel_id)
         channel._remove_membership(request.env.user.partner_id.ids)
         self._channel_remove_session_answers(channel)
         return True
 
-    @http.route(['/slides/channel/tag/search_read'], type='json', auth='user', methods=['POST'], website=True)
+    @http.route(['/slides/channel/tag/search_read'], type='jsonrpc', auth='user', methods=['POST'], website=True)
     def slide_channel_tag_search_read(self, fields, domain):
         can_create = request.env['slide.channel.tag'].has_access('create')
         return {
@@ -874,7 +874,7 @@ class WebsiteSlides(WebsiteProfile):
             'can_create': can_create,
         }
 
-    @http.route(['/slides/channel/tag/group/search_read'], type='json', auth='user', methods=['POST'], website=True)
+    @http.route(['/slides/channel/tag/group/search_read'], type='jsonrpc', auth='user', methods=['POST'], website=True)
     def slide_channel_tag_group_search_read(self, fields, domain):
         can_create = request.env['slide.channel.tag.group'].has_access('create')
         return {
@@ -882,7 +882,7 @@ class WebsiteSlides(WebsiteProfile):
             'can_create': can_create,
         }
 
-    @http.route('/slides/channel/tag/add', type='json', auth='user', methods=['POST'], website=True)
+    @http.route('/slides/channel/tag/add', type='jsonrpc', auth='user', methods=['POST'], website=True)
     def slide_channel_tag_add(self, channel_id, tag_id=None, group_id=None):
         """ Adds a slide channel tag to the specified slide channel.
 
@@ -917,7 +917,7 @@ class WebsiteSlides(WebsiteProfile):
 
         return {'url': "/slides/%s" % (request.env['ir.http']._slug(channel))}
 
-    @http.route(['/slides/channel/send_share_email'], type='json', auth='user', website=True)
+    @http.route(['/slides/channel/send_share_email'], type='jsonrpc', auth='user', website=True)
     def slide_channel_send_share_email(self, channel_id, emails):
         if not email_normalize_all(emails):
             return False
@@ -925,7 +925,7 @@ class WebsiteSlides(WebsiteProfile):
         channel._send_share_email(emails)
         return True
 
-    @http.route(['/slides/channel/subscribe'], type='json', auth='user', website=True)
+    @http.route(['/slides/channel/subscribe'], type='jsonrpc', auth='user', website=True)
     def slide_channel_subscribe(self, channel_id):
         # Presentation Published subtype
         subtype = request.env.ref("website_slides.mt_channel_slide_published", raise_if_not_found=False)
@@ -934,7 +934,7 @@ class WebsiteSlides(WebsiteProfile):
                 partner_ids=[request.env.user.partner_id.id], subtype_ids=subtype.ids)
         return True
 
-    @http.route(['/slides/channel/unsubscribe'], type='json', auth='user', website=True)
+    @http.route(['/slides/channel/unsubscribe'], type='jsonrpc', auth='user', website=True)
     def slide_channel_unsubscribe(self, channel_id):
         request.env['slide.channel'].browse(channel_id).message_unsubscribe(partner_ids=[request.env.user.partner_id.id])
         return True
@@ -1032,7 +1032,7 @@ class WebsiteSlides(WebsiteProfile):
     # SLIDE.SLIDE UTILS
     # --------------------------------------------------
 
-    @http.route('/slides/slide/get_html_content', type="json", auth="public", website=True)
+    @http.route('/slides/slide/get_html_content', type="jsonrpc", auth="public", website=True)
     def get_html_content(self, slide_id):
         fetch_res = self._fetch_slide(slide_id)
         if fetch_res.get('error'):
@@ -1050,7 +1050,7 @@ class WebsiteSlides(WebsiteProfile):
             next_slide = self._fetch_slide(next_slide_id).get('slide', None)
         return request.redirect("/slides/slide/%s" % (request.env['ir.http']._slug(next_slide) if next_slide else request.env['ir.http']._slug(slide)))
 
-    @http.route('/slides/slide/set_completed', website=True, type="json", auth="public")
+    @http.route('/slides/slide/set_completed', website=True, type="jsonrpc", auth="public")
     def slide_set_completed(self, slide_id):
         if request.website.is_public_user():
             return {'error': 'public_user'}
@@ -1070,7 +1070,7 @@ class WebsiteSlides(WebsiteProfile):
         self._slide_mark_uncompleted(slide)
         return request.redirect(f'/slides/slide/{request.env["ir.http"]._slug(slide)}')
 
-    @http.route('/slides/slide/set_uncompleted', website=True, type='json', auth='public')
+    @http.route('/slides/slide/set_uncompleted', website=True, type='jsonrpc', auth='public')
     def slide_set_uncompleted(self, slide_id):
         if request.website.is_public_user():
             return {'error': 'public_user'}
@@ -1083,7 +1083,7 @@ class WebsiteSlides(WebsiteProfile):
             'next_category_id': False,
         }
 
-    @http.route('/slides/slide/like', type='json', auth="public", website=True)
+    @http.route('/slides/slide/like', type='jsonrpc', auth="public", website=True)
     def slide_like(self, slide_id, upvote):
         if request.website.is_public_user():
             return {'error': 'public_user', 'error_signup_allowed': request.env['res.users'].sudo()._get_signup_invitation_scope() == 'b2c'}
@@ -1112,7 +1112,7 @@ class WebsiteSlides(WebsiteProfile):
             'dislikes': tools.misc.format_decimalized_number(slide.dislikes),
         }
 
-    @http.route('/slides/slide/archive', type='json', auth='user', website=True)
+    @http.route('/slides/slide/archive', type='jsonrpc', auth='user', website=True)
     def slide_archive(self, slide_id):
         """ This route allows channel publishers to archive slides.
         It has to be done in sudo mode since only restricted_editors can write on slides in ACLs """
@@ -1123,14 +1123,14 @@ class WebsiteSlides(WebsiteProfile):
 
         return False
 
-    @http.route('/slides/slide/toggle_is_preview', type='json', auth='user', website=True)
+    @http.route('/slides/slide/toggle_is_preview', type='jsonrpc', auth='user', website=True)
     def slide_preview(self, slide_id):
         slide = request.env['slide.slide'].browse(int(slide_id))
         if slide.channel_id.can_publish:
             slide.is_preview = not slide.is_preview
         return slide.is_preview
 
-    @http.route(['/slides/slide/send_share_email'], type='json', auth='user', website=True)
+    @http.route(['/slides/slide/send_share_email'], type='jsonrpc', auth='user', website=True)
     def slide_send_share_email(self, slide_id, emails, fullscreen=False):
         if not email_normalize_all(emails):
             return False
@@ -1142,7 +1142,7 @@ class WebsiteSlides(WebsiteProfile):
     # TAGS SECTION
     # --------------------------------------------------
 
-    @http.route('/slide_channel_tag/add', type='json', auth='user', methods=['POST'], website=True)
+    @http.route('/slide_channel_tag/add', type='jsonrpc', auth='user', methods=['POST'], website=True)
     def slide_channel_tag_create_or_get(self, tag_id, group_id):
         tag = self._create_or_get_channel_tag(tag_id, group_id)
         return {'tag_id': tag.id}
@@ -1151,7 +1151,7 @@ class WebsiteSlides(WebsiteProfile):
     # QUIZ SECTION
     # --------------------------------------------------
 
-    @http.route('/slides/slide/quiz/question_add_or_update', type='json', methods=['POST'], auth='user', website=True)
+    @http.route('/slides/slide/quiz/question_add_or_update', type='jsonrpc', methods=['POST'], auth='user', website=True)
     def slide_quiz_question_add_or_update(self, slide_id, question, sequence, answer_ids, existing_question_id=None):
         """ Add a new question to an existing slide. Completed field of slide.partner
         link is set to False to make sure that the creator can take the quiz again.
@@ -1217,7 +1217,7 @@ class WebsiteSlides(WebsiteProfile):
             'question': slide_question,
         })
 
-    @http.route('/slides/slide/quiz/get', type="json", auth="public", website=True)
+    @http.route('/slides/slide/quiz/get', type="jsonrpc", auth="public", website=True)
     def slide_quiz_get(self, slide_id):
         fetch_res = self._fetch_slide(slide_id)
         if fetch_res.get('error'):
@@ -1225,7 +1225,7 @@ class WebsiteSlides(WebsiteProfile):
         slide = fetch_res['slide']
         return self._get_slide_quiz_data(slide)
 
-    @http.route('/slides/slide/quiz/reset', type="json", auth="user", website=True)
+    @http.route('/slides/slide/quiz/reset', type="jsonrpc", auth="user", website=True)
     def slide_quiz_reset(self, slide_id):
         fetch_res = self._fetch_slide(slide_id)
         if fetch_res.get('error'):
@@ -1235,7 +1235,7 @@ class WebsiteSlides(WebsiteProfile):
             ('partner_id', '=', request.env.user.partner_id.id)
         ]).write({'completed': False, 'quiz_attempts_count': 0})
 
-    @http.route('/slides/slide/quiz/submit', type="json", auth="public", website=True)
+    @http.route('/slides/slide/quiz/submit', type="jsonrpc", auth="public", website=True)
     def slide_quiz_submit(self, slide_id, answer_ids):
         if request.website.is_public_user():
             return {'error': 'public_user'}
@@ -1285,7 +1285,7 @@ class WebsiteSlides(WebsiteProfile):
             'rankProgress': rank_progress,
         }
 
-    @http.route(['/slides/slide/quiz/save_to_session'], type='json', auth='public', website=True)
+    @http.route(['/slides/slide/quiz/save_to_session'], type='jsonrpc', auth='public', website=True)
     def slide_quiz_save_to_session(self, quiz_answers):
         session_slide_answer_quiz = json.loads(request.session.get('slide_answer_quiz', '{}'))
         slide_id = quiz_answers['slide_id']
@@ -1310,7 +1310,7 @@ class WebsiteSlides(WebsiteProfile):
     # CATEGORY MANAGEMENT
     # --------------------------------------------------
 
-    @http.route(['/slides/category/search_read'], type='json', auth='user', methods=['POST'], website=True)
+    @http.route(['/slides/category/search_read'], type='jsonrpc', auth='user', methods=['POST'], website=True)
     def slide_category_search_read(self, fields, domain):
         category_slide_domain = domain if domain else []
         category_slide_domain = expression.AND([category_slide_domain, [('is_category', '=', True)]])
@@ -1336,7 +1336,7 @@ class WebsiteSlides(WebsiteProfile):
     # SLIDE.UPLOAD
     # --------------------------------------------------
 
-    @http.route(['/slides/prepare_preview'], type='json', auth='user', methods=['POST'], website=True)
+    @http.route(['/slides/prepare_preview'], type='jsonrpc', auth='user', methods=['POST'], website=True)
     def prepare_preview(self, channel_id, slide_category, url=None):
         """ Will attempt to fetch external metadata for this slide from the correct
         source (YouTube, Google Drive, ...).
@@ -1403,7 +1403,7 @@ class WebsiteSlides(WebsiteProfile):
 
         return slide_values
 
-    @http.route(['/slides/add_slide'], type='json', auth='user', methods=['POST'], website=True)
+    @http.route(['/slides/add_slide'], type='jsonrpc', auth='user', methods=['POST'], website=True)
     def create_slide(self, *args, **post):
         # check the size only when we upload a file.
         if post.get('binary_content'):
@@ -1475,7 +1475,7 @@ class WebsiteSlides(WebsiteProfile):
         return ['name', 'url', 'video_url', 'document_google_url', 'image_google_url', 'tag_ids', 'slide_category', 'channel_id',
             'is_preview', 'binary_content', 'description', 'image_1920', 'is_published', 'source_type']
 
-    @http.route(['/slides/tag/search_read'], type='json', auth='user', methods=['POST'], website=True)
+    @http.route(['/slides/tag/search_read'], type='jsonrpc', auth='user', methods=['POST'], website=True)
     def slide_tag_search_read(self, fields, domain):
         can_create = request.env['slide.tag'].has_access('create')
         return {

--- a/addons/website_slides_survey/controllers/slides.py
+++ b/addons/website_slides_survey/controllers/slides.py
@@ -29,7 +29,7 @@ class WebsiteSlidesSurvey(WebsiteSlides):
             raise werkzeug.exceptions.NotFound()
         return request.redirect(certification_url)
 
-    @http.route(['/slides_survey/certification/search_read'], type='json', auth='user', methods=['POST'], website=True)
+    @http.route(['/slides_survey/certification/search_read'], type='jsonrpc', auth='user', methods=['POST'], website=True)
     def slides_certification_search_read(self, fields):
         can_create = request.env['survey.survey'].has_access('create')
         return {

--- a/odoo/addons/test_auth_custom/__init__.py
+++ b/odoo/addons/test_auth_custom/__init__.py
@@ -17,6 +17,6 @@ class TestController(Controller):
     def _http(self):
         raise NotImplementedError
 
-    @route('/test_auth_custom/json', type="json", auth="thing", cors="*")
+    @route('/test_auth_custom/json', type="jsonrpc", auth="thing", cors="*")
     def _json(self):
         raise NotImplementedError

--- a/odoo/addons/test_http/controllers.py
+++ b/odoo/addons/test_http/controllers.py
@@ -93,11 +93,11 @@ class TestHttp(http.Controller):
     def echo_http_context_lang(self, **kwargs):
         return self.env.context.get('lang', '')
 
-    @http.route('/test_http/echo-json', type='json', auth='none', methods=['POST'], csrf=False)
+    @http.route('/test_http/echo-json', type='jsonrpc', auth='none', methods=['POST'], csrf=False)
     def echo_json(self, **kwargs):
         return kwargs
 
-    @http.route('/test_http/echo-json-context', type='json', auth='user', methods=['POST'], csrf=False, readonly=True)
+    @http.route('/test_http/echo-json-context', type='jsonrpc', auth='user', methods=['POST'], csrf=False, readonly=True)
     def echo_json_context(self, **kwargs):
         return self.env.context
 
@@ -151,7 +151,7 @@ class TestHttp(http.Controller):
     def cors_http_verbs(self, **kwargs):
         return "Hello"
 
-    @http.route('/test_http/cors_json', type='json', auth='none', cors='*')
+    @http.route('/test_http/cors_json', type='jsonrpc', auth='none', cors='*')
     def cors_json(self, **kwargs):
         return {}
 
@@ -195,7 +195,7 @@ class TestHttp(http.Controller):
         )
         raise request.not_found()
 
-    @http.route('/test_http/json_value_error', type='json', auth='none')
+    @http.route('/test_http/json_value_error', type='jsonrpc', auth='none')
     def json_value_error(self):
         raise ValueError('Unknown destination')
 

--- a/odoo/upgrade_code/18.1-02-route-jsonrpc.py
+++ b/odoo/upgrade_code/18.1-02-route-jsonrpc.py
@@ -1,0 +1,14 @@
+def upgrade(file_manager):
+    files = [
+        f for f in file_manager
+        if 'controllers' in f.path.parts
+        if f.path.suffix == '.py'
+    ]
+
+    for fileno, file in enumerate(files):
+        file.content = file.content.replace(
+            'type="json",', 'type="jsonrpc",'
+        ).replace(
+            "type='json',", "type='jsonrpc',"
+        )
+        file_manager.print_progress(fileno, len(files))


### PR DESCRIPTION
The json type is actually Odoo-RPC over Json-RPC. The `type='json'` name
has been a source of confusion for years now. Fix it.

If you want a cross-version compatible thing you can do:

```py
@route(type='json' if odoo.release.version_info < (18, 0) else 'jsonrpc')
```
or
```py
@route(type=odoo.http.JsonRPCDispatcher.routing_type)
```

A upgrade-code script exists '18.1-02-route-jsonrpc.py', use it via the
new command line: ./odoo-bin code_upgrade

See also https://github.com/odoo/odoo/pull/183902

task-4257153
