### PR TITLE
[PERF] sale_stock: improve perf of _get_outgoing_incoming_moves

### DIFF
--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -284,8 +284,8 @@ class SaleOrderLine(models.Model):
         return qty
 
     def _get_outgoing_incoming_moves(self):
-        outgoing_moves = self.env['stock.move']
-        incoming_moves = self.env['stock.move']
+        outgoing_moves_ids = set()
+        incoming_moves_ids = set()
 
         moves = self.move_ids.filtered(lambda r: r.state != 'cancel' and not r.scrapped and self.product_id == r.product_id)
         if self._context.get('accrual_entry_date'):
@@ -294,11 +294,11 @@ class SaleOrderLine(models.Model):
         for move in moves:
             if move.location_dest_id.usage == "customer":
                 if not move.origin_returned_move_id or (move.origin_returned_move_id and move.to_refund):
-                    outgoing_moves |= move
+                    outgoing_moves_ids.add(move.id)
             elif move.location_dest_id.usage != "customer" and move.to_refund:
-                incoming_moves |= move
+                incoming_moves_ids.add(move.id)
 
-        return outgoing_moves, incoming_moves
+        return self.env['stock.move'].browse(outgoing_moves_ids), self.env['stock.move'].browse(incoming_moves_ids)
 
     def _get_procurement_group(self):
         return self.order_id.procurement_group_id


### PR DESCRIPTION
Issue -->

A noticeable amount of time is spent in the method `_get_outgoing_incoming_moves` when doing the `OR` operation on the stock.move recordsets when there is a large number of moves to iterate through.

Solution -->

Replace the odoo recordset operations with set operations.

Benchmarks -->

| # of moves | Before | After |
|--------|--------|--------|
| 32000 | 24.08s | 1.43s |
| 7300 | 1.74s | 0.40s | 

opw-4220302

