### PR TITLE
[FIX] html_editor: maintain image style after transformation

### DIFF
--- a/addons/html_editor/static/src/main/media/image_transformation.js
+++ b/addons/html_editor/static/src/main/media/image_transformation.js
@@ -261,7 +261,6 @@ export class ImageTransformation extends Component {
         settings.translatexp = Math.round((settings.translatex / width) * 1000) / 10;
         settings.translateyp = Math.round((settings.translatey / height) * 1000) / 10;
 
-        this.image.style = settings.style;
         this.setImageTransformation(this.image);
 
         this.transfoContainer.el.style.position = "absolute";

--- a/addons/html_editor/static/tests/image.test.js
+++ b/addons/html_editor/static/tests/image.test.js
@@ -328,6 +328,27 @@ test("Image transformation disappear on escape", async () => {
     expect(transfoContainers.length).toBe(0);
 });
 
+test("Image should retain style during transformation", async () => {
+    await setupEditor(`
+        <p><img class="img-fluid test-image" src="${base64Img}"></p>
+    `);
+    await click("img.test-image");
+    await waitFor(".o-we-toolbar");
+    let toolbar = document.querySelectorAll(".o-we-toolbar");
+    expect(toolbar.length).toBe(1);
+    await click(".o-we-toolbar button[name='resize_50']");
+    await animationFrame();
+    expect(queryOne("img").style.width).toBe("50%");
+    expect(".o-we-toolbar button[name='resize_50']").toHaveClass("active");
+    await click(".o-we-toolbar button[name='image_transform']");
+    await animationFrame();
+    toolbar = document.querySelectorAll(".o-we-toolbar");
+    expect(toolbar.length).toBe(0);
+    const transfoContainers = document.querySelectorAll(".transfo-container");
+    expect(transfoContainers).toHaveCount(1);
+    expect(queryOne("img").style.width).toBe("50%");
+});
+
 test("Can delete an image", async () => {
     await setupEditor(`
         <p> <img class="img-fluid test-image" src="${base64Img}"> </p>


### PR DESCRIPTION
### Steps to Reproduce:

- Open the To-Do App.
- Upload an image (e.g., `/image`).
- Resize the image to 25%, 50%, or 100%.
- Click the `Transform` button in the toolbar.

### Approach:

- Initially, `this.transfo.settings.style = this.image.style` created a shared reference to the same 
`CSSStyleDeclaration` object, meaning changes to one were reflected in both.

- Later, when `this.image.style = settings.style` was executed, the inline styles were lost because it reassigned the same reference instead of copying the styles individually, resulting in properties like `width` being reset.

### Description of the issue/feature this PR addresses:

- Resizing an image (e.g., 25%, 50%, or 100%) would revert it to its original size after clicking the `Transform` button.
- Rotating the image would cause it to be misplaced.

### Desired behavior after PR is merged:

- The image retains its resized dimensions after transformation.
- The image remains correctly positioned during rotation.

task-4251410