### PR TITLE
[IMP] loyalty,website_sale_loyalty: wallet topup on portal

### DIFF
--- a/addons/loyalty/controllers/portal.py
+++ b/addons/loyalty/controllers/portal.py
@@ -85,6 +85,11 @@ class CustomerPortalLoyalty(CustomerPortal):
 
     @route('/my/loyalty_card/<int:card_id>/values', type='jsonrpc', auth='user')
     def portal_get_card_history_values(self, card_id):
+        """Retrieve card history values for portal card dialog.
+
+        :param card_id(str): The ID of the loyalty card.
+        :return(dict): A dictionary with card history values.
+        """
         card_sudo = request.env['loyalty.card'].sudo().search([
             ('id', '=', int(card_id)),
             ('partner_id', '=', request.env.user.partner_id.id)

--- a/addons/loyalty/static/src/js/portal/loyalty_card_dialog/loyalty_card_dialog.xml
+++ b/addons/loyalty/static/src/js/portal/loyalty_card_dialog/loyalty_card_dialog.xml
@@ -36,7 +36,7 @@
                             t-key="line_index"
                             class="row px-2"
                         >
-                            <div class="col-7">
+                            <div class="col-7 text-truncate">
                                 <t t-if="line.order_id and line.order_portal_url">
                                     <a t-att-href="line.order_portal_url">
                                         <t t-out="line.description"/>

--- a/addons/loyalty/views/loyalty_program_views.xml
+++ b/addons/loyalty/views/loyalty_program_views.xml
@@ -80,8 +80,22 @@
                                     Then, eWallets are proposed during the checkout, to pay orders.
                                 </p>
                             </div>
-                            <field name="trigger_product_ids" string="Gift Card Products" widget="many2many_tags" invisible="program_type != 'gift_card'"/>
-                            <field name="trigger_product_ids" string="eWallet Products" widget="many2many_tags" invisible="program_type != 'ewallet'"/>
+                            <label
+                                string="Gift Card Products"
+                                invisible="program_type != 'gift_card'"
+                                for="trigger_product_ids"
+                            />
+                            <label
+                                string="eWallet Products"
+                                invisible="program_type != 'ewallet'"
+                                for="trigger_product_ids"
+                            />
+                            <div
+                                id="trigger_products"
+                                invisible="program_type not in ['gift_card', 'ewallet']"
+                            >
+                                <field name="trigger_product_ids" widget="many2many_tags"/>
+                            </div>
                             <field name="payment_program_discount_product_id" groups="base.group_no_one" invisible="program_type not in ('gift_card', 'ewallet')"/>
                             <field name="mail_template_id" invisible="program_type not in ('gift_card', 'ewallet')"/>
                             <field name="currency_id"/>

--- a/addons/loyalty/views/portal_templates.xml
+++ b/addons/loyalty/views/portal_templates.xml
@@ -81,7 +81,7 @@
                             </t>
                         </td>
                         <td t-else=""/>
-                        <td><span t-out="line.create_date"/></td>
+                        <td><t t-out="line.create_date" t-options='{"widget": "datetime", "format": "short"}'/></td>
                         <td><span t-out="line.card_id._format_points(line.issued)"/></td>
                         <td><span t-out="line.card_id._format_points(line.used)"/></td>
                     </tr>

--- a/addons/website_sale_loyalty/controllers/__init__.py
+++ b/addons/website_sale_loyalty/controllers/__init__.py
@@ -4,3 +4,4 @@ from . import cart
 from . import delivery
 from . import main
 from . import payment
+from . import portal

--- a/addons/website_sale_loyalty/controllers/cart.py
+++ b/addons/website_sale_loyalty/controllers/cart.py
@@ -13,3 +13,9 @@ class Cart(WebsiteSaleCart):
             order_sudo._update_programs_and_rewards()
             order_sudo._auto_apply_rewards()
         return super().cart(**post)
+
+    @route('/wallet/top_up', type='http', auth='user', website=True, sitemap=False)
+    def wallet_top_up(self, **kwargs):
+        product = self.env['product.product'].browse(int(kwargs['trigger_product_id']))
+        self.add_to_cart(product.product_tmpl_id.id, product.id, 1)
+        return request.redirect('/shop/cart')

--- a/addons/website_sale_loyalty/controllers/portal.py
+++ b/addons/website_sale_loyalty/controllers/portal.py
@@ -1,0 +1,25 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.http import request, route
+from odoo.tools.misc import format_amount
+
+from odoo.addons.loyalty.controllers import portal as loyalty_portal
+
+
+class CustomerPortalLoyalty(loyalty_portal.CustomerPortalLoyalty):
+
+    @route()
+    def portal_get_card_history_values(self, card_id):
+        """Add published trigger products for the loyalty program."""
+        res = super().portal_get_card_history_values(card_id)
+        program_sudo = request.env['loyalty.program'].sudo().search([
+            ('coupon_ids', '=', int(card_id)),
+        ])
+        if not program_sudo:
+            return res
+
+        currency = request.env.company.currency_id
+        res['program']['trigger_products'] = [{
+            'id': product.id, 'total_price': format_amount(self.env, product.lst_price, currency)
+        } for product in program_sudo.trigger_product_ids if product.website_published]
+        return res

--- a/addons/website_sale_loyalty/models/loyalty_program.py
+++ b/addons/website_sale_loyalty/models/loyalty_program.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class LoyaltyProgram(models.Model):
@@ -8,6 +8,15 @@ class LoyaltyProgram(models.Model):
     _inherit = ['loyalty.program', 'website.multi.mixin']
 
     ecommerce_ok = fields.Boolean("Available on Website", default=True)
+    show_non_published_product_warning = fields.Boolean(compute='_compute_show_non_published_product_warning')
+
+    @api.depends('program_type', 'trigger_product_ids.website_published')
+    def _compute_show_non_published_product_warning(self):
+        for program in self:
+            program.show_non_published_product_warning = (
+                program.program_type == 'ewallet'
+                and any(not product.website_published for product in program.trigger_product_ids)
+            )
 
     def action_program_share(self):
         self.ensure_one()

--- a/addons/website_sale_loyalty/static/src/js/portal_loyalty_card.xml
+++ b/addons/website_sale_loyalty/static/src/js/portal_loyalty_card.xml
@@ -26,6 +26,30 @@
                     Claim
                 </a>
             </div>
+            <div
+                t-if="props.program.program_type == 'ewallet'
+                and props.program.trigger_products.length"
+            >
+                <form
+                    method="post"
+                    action="/wallet/top_up"
+                    class="d-flex w-75 w-md-50 m-auto gap-1"
+                >
+                    <input type="hidden" name="csrf_token" t-att-value="csrf_token"/>
+                    <select name="trigger_product_id" class="form-select">
+                        <t
+                            t-foreach="props.program.trigger_products"
+                            t-as="product"
+                            t-key="product_index"
+                        >
+                            <option t-att-value="product.id">
+                                <t t-esc="product.total_price"/>
+                            </option>
+                        </t>
+                    </select>
+                    <button type="submit" class="btn btn-primary text-nowrap">Top Up</button>
+                </form>
+            </div>
         </div>
     </t>
 

--- a/addons/website_sale_loyalty/views/loyalty_program_views.xml
+++ b/addons/website_sale_loyalty/views/loyalty_program_views.xml
@@ -21,6 +21,16 @@
             <xpath expr="//div[@id='o_loyalty_program_availabilities']" position="after">
                 <field name="website_id" invisible="not ecommerce_ok" options="{'no_create': True}" groups="website.group_multi_website" placeholder="All websites"/>
             </xpath>
+            <div id="trigger_products" position="inside">
+                <div
+                    invisible="not show_non_published_product_warning"
+                    class="alert alert-warning mt-1"
+                    role="alert"
+                >
+                    To be able to top up eWallet from the portal, eWallet products must be
+                     published.
+                </div>
+            </div>
         </field>
     </record>
 


### PR DESCRIPTION
Prior this commit:
- Portal users could not topup their wallet directly from portal page

Post this commit:
- Added Topup option for wallet on portal card dialog
- This option will lead to an ecom cart containing the top up wallet product

task-4243458

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
