### PR TITLE
[IMP] website_sale_collect_wishlist: add wishlist to cart page

### DIFF
--- a/addons/website_sale_collect/static/src/js/checkout.js
+++ b/addons/website_sale_collect/static/src/js/checkout.js
@@ -3,7 +3,7 @@ import publicWidget from '@web/legacy/js/public/public_widget';
 
 publicWidget.registry.WebsiteSaleCheckout.include({
     events: Object.assign({}, publicWidget.registry.WebsiteSaleCheckout.prototype.events, {
-        'click .js_delete_product': '_onClickDeleteProduct',
+        'click .js_wsc_delete_product': '_onClickDeleteProduct',
     }),
 
     // #=== EVENT HANDLERS ===#

--- a/addons/website_sale_collect/views/delivery_form_templates.xml
+++ b/addons/website_sale_collect/views/delivery_form_templates.xml
@@ -7,7 +7,7 @@
             <div
                 t-foreach="unavailable_order_lines"
                 t-as="order_line"
-                t-attf-class="d-flex m-2 position-relative"
+                t-attf-class="d-flex gap-3 m-2 position-relative"
             >
                 <div class="d-flex align-items-center gap-2">
                     <a t-att-href="order_line.product_id.website_url">
@@ -16,18 +16,31 @@
                             t-options="{'widget': 'image', 'qweb_img_responsive': False, 'class': 'o_image_64_max rounded'}"
                         />
                     </a>
-                    <t t-out="order_line.product_id.name"/>
-                    <a
-                        href='#'
-                        class="js_delete_product small"
-                        aria-label="Remove from cart"
-                        title="Remove from cart"
-                    >
-                        <i t-att-data-product-id="order_line.product_id.id" class="fa fa-trash"/>
-                    </a>
-                     ( <t t-out="order_line.shop_warning"/> )
                 </div>
-             </div>
+                <div>
+                    <t t-out="order_line.product_id.name"/>
+                    ( <t t-out="order_line.shop_warning"/> )
+                    <div name="o_wsale_unavailable_line_button_container">
+                        <a
+                            title="Remove from cart"
+                            href='#'
+                            class="js_wsc_delete_product d-none d-md-inline-block small"
+                            aria-label="Remove from cart"
+                        >
+                            <span t-att-data-product-id="order_line.product_id.id">Remove</span>
+                        </a>
+                        <button
+                            title="Remove from cart"
+                            class="js_wsc_delete_product btn btn-light d-inline-block d-md-none"
+                        >
+                            <i
+                                class="fa fa-trash-o"
+                                t-att-data-product-id="order_line.product_id.id"
+                            />
+                        </button>
+                    </div>
+                </div>
+            </div>
         </div>
     </template>
 

--- a/addons/website_sale_collect_wishlist/__init__.py
+++ b/addons/website_sale_collect_wishlist/__init__.py
@@ -1,0 +1,1 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.

--- a/addons/website_sale_collect_wishlist/__manifest__.py
+++ b/addons/website_sale_collect_wishlist/__manifest__.py
@@ -1,0 +1,16 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': "Collect & Wishlist",
+    'category': 'Website/Website',
+    'summary': "Bridge module between Click & Collect and Wishlist",
+    'description': """
+Allow users to add a product to wishlist if the product is not available for the selected pickup location.
+    """,
+    'depends': ['website_sale_wishlist', 'website_sale_collect'],
+    'data': [
+        'views/delivery_form_templates.xml',
+    ],
+    'auto_install': True,
+    'license': 'LGPL-3',
+}

--- a/addons/website_sale_collect_wishlist/views/delivery_form_templates.xml
+++ b/addons/website_sale_collect_wishlist/views/delivery_form_templates.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template
+        id="unavailable_products_warning"
+        inherit_id="website_sale_collect.unavailable_products_warning"
+    >
+        <div name="o_wsale_unavailable_line_button_container" position="inside">
+            <span class="d-none d-md-inline-block ms-1">
+                <a
+                    title="Add to Wishlist"
+                    href="#"
+                    class="o_add_wishlist js_wsc_delete_product small px-2 border-start"
+                    t-att-data-product-template-id="order_line.product_id.product_tmpl_id.id"
+                    t-att-data-product-product-id="order_line.product_id.id"
+                    data-action="o_wishlist"
+                >
+                    <span t-att-data-product-id="order_line.product_id.id">Save for Later</span>
+                </a>
+            </span>
+            <button
+                title="Add to Wishlist"
+                class="o_add_wishlist js_wsc_delete_product small btn btn-light d-md-none"
+                t-att-data-product-template-id="order_line.product_id.product_tmpl_id.id"
+                t-att-data-product-product-id="order_line.product_id.id"
+                data-action="o_wishlist"
+            >
+                <i class="fa fa-heart-o" t-att-data-product-id="order_line.product_id.id"/>
+            </button>
+        </div>
+    </template>
+</odoo>


### PR DESCRIPTION
**Issue:**
- When a product is not available to be picked up in the store, the customer must remove the product from his cart to validate the order, but there is no way for him to save it for later in order to avoid having to search for that product again, it can be painful when a lot of variant for the same product

**Prior to this commit:**
- The checkout page did not support save for later/ add to wishlist option during click and collect when a product is not available for the delivery location of pick up in store

**Post this commit:**
- Add to wishlist button is added to checkout warning.
- On clicking, product will be removed from the cart and moved to the wishlist.

**Affected version**-master
Task-4199055