### PR TITLE
[FIX] l10n_es_pos: not invoice when settling customer accounts

### DIFF
--- a/addons/l10n_es_pos/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/l10n_es_pos/static/src/overrides/components/payment_screen/payment_screen.js
@@ -6,7 +6,7 @@ import { PaymentScreen } from "@point_of_sale/app/screens/payment_screen/payment
 
 patch(PaymentScreen.prototype, {
     async validateOrder(isForceValidate) {
-        if (this.pos.config.is_spanish) {
+        if (this.pos.config.is_spanish && !this.skipAutomaticInvoicing()) {
             const order = this.currentOrder;
             order.is_l10n_es_simplified_invoice = order.canBeSimplifiedInvoiced() && !order.to_invoice;
             if (!order.is_l10n_es_simplified_invoice && !order.to_invoice) {
@@ -25,6 +25,18 @@ patch(PaymentScreen.prototype, {
             }
         }
         return await super.validateOrder(...arguments);
+    },
+    skipAutomaticInvoicing() {
+        const order = this.currentOrder;
+        if (
+            this.pos.config.is_spanish &&
+            order.is_settling_account &&
+            order.orderlines.length === 0 &&
+            !order.to_invoice
+        ) {
+            return true;
+        }
+        return false;
     },
     shouldDownloadInvoice() {
         return this.pos.config.is_spanish

--- a/addons/l10n_es_pos/static/tests/tours/spanish_pos_tour.js
+++ b/addons/l10n_es_pos/static/tests/tours/spanish_pos_tour.js
@@ -5,6 +5,8 @@ import * as ProductScreen from "@point_of_sale/../tests/tours/helpers/ProductScr
 import * as ReceiptScreen from "@point_of_sale/../tests/tours/helpers/ReceiptScreenTourMethods";
 import * as PaymentScreen from "@point_of_sale/../tests/tours/helpers/PaymentScreenTourMethods";
 import * as PartnerListScreen from "@point_of_sale/../tests/tours/helpers/PartnerListScreenTourMethods";
+import * as Chrome from "@point_of_sale/../tests/tours/helpers/ChromeTourMethods";
+import * as Utils from "@point_of_sale/../tests/tours/helpers/utils";
 import { registry } from "@web/core/registry";
 import { checkSimplifiedInvoiceNumber, pay } from "./helpers/receipt_helpers";
 
@@ -62,6 +64,22 @@ registry.category("web_tour.tours").add("spanish_pos_tour", {
             content: "verify that the pos requires the selection of a partner",
             trigger: `div.popup.popup-confirm .modal-header:contains('Customer Required')`,
         },
-
     ],
+});
+
+registry.category("web_tour.tours").add("l10n_es_pos_settle_account_due", {
+    test: true,
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.clickPartnerButton(),
+            PartnerListScreen.clickPartnerDetailsButton("Partner Test 1"),
+            {
+                trigger: `.button:contains("Settle due accounts")`,
+            },
+            Utils.selectButton("Bank"),
+            PaymentScreen.clickValidate(),
+            Chrome.confirmPopup(),
+            ReceiptScreen.isShown(),
+        ].flat(),
 });

--- a/addons/l10n_es_pos/tests/test_frontend.py
+++ b/addons/l10n_es_pos/tests/test_frontend.py
@@ -41,6 +41,58 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.assertEqual(num_of_simp_invoices, 3)
         self.assertEqual(num_of_regular_invoices, 1)
 
+    def test_l10n_es_pos_reconcile(self):
+        if not self.env["ir.module.module"].search([("name", "=", "pos_settle_due"), ("state", "=", "installed")]):
+            self.skipTest("pos_settle_due module is required for this test")
+
+        # create customer account payment method
+        self.customer_account_payment_method = self.env['pos.payment.method'].create({
+            'name': 'Customer Account',
+            'split_transactions': True,
+        })
+        # add customer account payment method to pos config
+        self.main_pos_config.write({
+            'payment_method_ids': [Command.link(self.customer_account_payment_method.id)],
+        })
+
+        self.assertEqual(self.partner_test_1.total_due, 0)
+
+        self.main_pos_config.with_user(self.pos_admin).open_ui()
+        current_session = self.main_pos_config.current_session_id
+
+        order = self.env['pos.order'].create({
+            'company_id': self.env.company.id,
+            'session_id': current_session.id,
+            'partner_id': self.partner_test_1.id,
+            'lines': [Command.create({
+                'product_id': self.product_a.id,
+                'price_unit': 10,
+                'discount': 0,
+                'qty': 1,
+                'price_subtotal': 10,
+                'price_subtotal_incl': 10,
+            })],
+            'amount_paid': 10.0,
+            'amount_total': 10.0,
+            'amount_tax': 0.0,
+            'amount_return': 0.0,
+            'to_invoice': True,
+            'last_order_preparation_change': '{}'
+        })
+
+        payment_context = {"active_ids": order.ids, "active_id": order.id}
+        order_payment = self.env['pos.make.payment'].with_context(**payment_context).create({
+            'amount': 10.0,
+            'payment_method_id': self.customer_account_payment_method.id
+        })
+        order_payment.with_context(**payment_context).check()
+
+        self.assertEqual(self.partner_test_1.total_due, 10)
+        current_session.action_pos_session_closing_control()
+
+        self.main_pos_config.with_user(self.user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'l10n_es_pos_settle_account_due', login="accountman")
+
     def test_spanish_pos_invoice_no_certificate(self):
         """This test make sure that the invoice generated in spanish PoS are not proforma invoices"""
         self.partner_a.write({

--- a/addons/point_of_sale/static/tests/tours/helpers/utils.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/utils.js
@@ -29,6 +29,13 @@ export function negateStep(step) {
     };
 }
 
+export function selectButton(name) {
+    return {
+        content: `Select button ${name}`,
+        trigger: `button:contains("${name}")`,
+    };
+}
+
 export function scan_barcode(barcode) {
     return [
         {


### PR DESCRIPTION
Currently when settling a customer account, we try to create a simplified invoice which is nt possible since we do not have products in the order. Users using the Spanish localization cannot settle customer accounts.

Steps to reproduce:
-------------------
* Install **l10n_es_pos** and switch to the ES Company
* Open shop session
* Add products to the order, select any customer, pay with customer account
* Select **New order**
* Select the previous customer and select **Settle due accounts**
* Select any payment method
* Validate order -> Yes
> Observation: Cannot invoice empty order

Why the fix:
------------
Spain requires to invoice all orders. In Pos, everything is considered as an order but settling customer accounts does not fall under the definition of an order outside of Odoo (no transfer of product, amount=0).

Therefore when we settle customer account we skip the automatic invoicing and fallback on the pos bahavior without the localization.

opw-4185144

Enterprise PR: https://github.com/odoo/enterprise/pull/71958
