### PR TITLE
[FIX] sale_loyalty: only display tax_desc on line if there's multiple

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -416,7 +416,7 @@ class SaleOrder(models.Model):
                 continue
             mapped_taxes = self.fiscal_position_id.map_tax(tax)
             tax_desc = ''
-            if any(t.name for t in mapped_taxes):
+            if len(discountable_per_tax) > 1 and any(t.name for t in mapped_taxes):
                 tax_desc = _(
                     ' - On product with the following taxes: %(taxes)s',
                     taxes=", ".join(mapped_taxes.mapped('name')),


### PR DESCRIPTION
Versions
--------
- 16.0 up to saas-17.4

Steps
-----
1. Add one or more lines to an SO with the same tax;
2. apply a discount coupon.

Issue
-----
Tax gets mentioned in the discount line name, even though it isn't really necesarry in this scenario.

Cause
-----
When generating the discount line description, a `tax_desc` gets added for any tax with a name.

Solution
--------
Only add `tax_desc` if there's more than one discount line being generated due to multiple taxes.

opw-4072437