### PR TITLE
[IMP] point_of_sale: hide dismiss button for review order dialog

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
@@ -2,6 +2,7 @@ import { Dialog } from "@web/core/dialog/dialog";
 import { SaleDetailsButton } from "@point_of_sale/app/components/navbar/sale_details_button/sale_details_button";
 import { ConfirmationDialog, AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { MoneyDetailsPopup } from "@point_of_sale/app/components/popups/money_details_popup/money_details_popup";
+import { PosConfirmationDialog } from "@point_of_sale/app/components/popups/pos_dialog/pos_confirmation_dialog/pos_confirmation_dialog";
 import { useService } from "@web/core/utils/hooks";
 import { Component, useState } from "@odoo/owl";
 import { ConnectionLostError } from "@web/core/network/rpc";
@@ -280,7 +281,7 @@ export class ClosePosPopup extends Component {
         );
     }
     async handleClosingError(response) {
-        this.dialog.add(ConfirmationDialog, {
+        this.dialog.add(PosConfirmationDialog, {
             title: response.title || "Error",
             body: response.message,
             confirmLabel: _t("Review Orders"),
@@ -298,7 +299,7 @@ export class ClosePosPopup extends Component {
                     this.closeSession();
                 }
             },
-            dismiss: async () => {},
+            hideCloseButton: true,
         });
 
         if (response.redirect) {

--- a/addons/point_of_sale/static/src/app/components/popups/pos_dialog/pos_confirmation_dialog/pos_confirmation_dialog.js
+++ b/addons/point_of_sale/static/src/app/components/popups/pos_dialog/pos_confirmation_dialog/pos_confirmation_dialog.js
@@ -1,0 +1,17 @@
+import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+
+export class PosConfirmationDialog extends ConfirmationDialog {
+    static template = "point_of_sale.PosConfirmationDialog";
+    static props = {
+        ...ConfirmationDialog.props,
+        hideCloseButton: { type: Boolean, optional: true },
+    };
+    static defaultProps = {
+        ...ConfirmationDialog.defaultProps,
+        hideCloseButton: false,
+    };
+    setup() {
+        useHotkey("escape", () => {});
+    }
+}

--- a/addons/point_of_sale/static/src/app/components/popups/pos_dialog/pos_confirmation_dialog/pos_confirmation_dialog.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/pos_dialog/pos_confirmation_dialog/pos_confirmation_dialog.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+
+    <t t-name="point_of_sale.PosConfirmationDialog" t-inherit="web.ConfirmationDialog" t-inherit-mode="primary">
+        <xpath expr="//Dialog" position="attributes">
+            <attribute name="hideCloseButton">props.hideCloseButton</attribute>
+        </xpath>
+    </t>
+
+</templates>

--- a/addons/point_of_sale/static/src/app/components/popups/pos_dialog/pos_dialog.js
+++ b/addons/point_of_sale/static/src/app/components/popups/pos_dialog/pos_dialog.js
@@ -1,0 +1,13 @@
+import { Dialog } from "@web/core/dialog/dialog";
+import { patch } from "@web/core/utils/patch";
+
+patch(Dialog, {
+    props: {
+        ...Dialog.props,
+        hideCloseButton: { type: Boolean, optional: true },
+    },
+    defaultProps: {
+        ...Dialog.defaultProps,
+        hideCloseButton: false,
+    },
+});

--- a/addons/point_of_sale/static/src/app/components/popups/pos_dialog/pos_dialog.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/pos_dialog/pos_dialog.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+
+    <t t-name="point_of_sale.PosDialog" t-inherit="web.Dialog" t-inherit-mode="extension">
+        <xpath expr="//t[@t-slot='header']/t" position="before">
+            <t t-set="hideCloseButton" t-value="props.hideCloseButton"/>
+        </xpath>
+    </t>
+
+    <t t-name="point_of_sale.PosDialog.header" t-inherit="web.Dialog.header" t-inherit-mode="extension">
+        <xpath expr="//t[@t-if='!fullscreen']" position="attributes">
+            <attribute name="t-if">!fullscreen and !hideCloseButton</attribute>
+        </xpath>
+    </t>
+
+</templates>


### PR DESCRIPTION
Before this commit:
==
- The dismiss button on the review order popup is no longer required.

After this commit:
==
- Made a generic component for a confirmation dialog and use it in the review order dialog to achieve the functionality of hiding the dismiss button.

task-4246554


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
