### PR TITLE
[IMP] core: Deprecate toggle_active()

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -982,17 +982,19 @@ class CrmLead(models.Model):
     # ACTIONS
     # ------------------------------------------------------------
 
-    def toggle_active(self):
-        """ When archiving: mark probability as 0. When re-activating
-        update probability again, for leads and opportunities. """
-        res = super().toggle_active()
-        activated = self.filtered(lambda lead: lead.active)
-        archived = self.filtered(lambda lead: not lead.active)
+    def action_archive(self):
+        """ When archiving: mark probability as 0."""
+        res = super().action_archive()
+        self.write({'probability': 0, 'automated_probability': 0})
+        return res
+
+    def action_unarchive(self):
+        """ When re-activating update probability again, for leads and opportunities. """
+        activated = self.filtered(lambda rec: not rec.active)
+        res = super().action_unarchive()
         if activated:
             activated.write({'lost_reason_id': False})
             activated._compute_probabilities()
-        if archived:
-            archived.write({'probability': 0, 'automated_probability': 0})
         return res
 
     def action_set_lost(self, **additional_values):

--- a/addons/crm/tests/test_crm_pls.py
+++ b/addons/crm/tests/test_crm_pls.py
@@ -283,7 +283,7 @@ class TestCRMPLS(TransactionCase):
         self.assertEqual(leads[8].is_automated_probability, True)
 
         # Restore -> Should decrease lost
-        leads[4].toggle_active()
+        leads[4].action_unarchive()
         self.assertEqual(lead_4_stage_0_freq.won_count, 1.1)  # unchanged
         self.assertEqual(lead_4_stage_won_freq.won_count, 1.1)  # unchanged
         self.assertEqual(lead_4_country_freq.won_count, 0.1)  # unchanged
@@ -314,7 +314,7 @@ class TestCRMPLS(TransactionCase):
         self.assertEqual(lead_4_email_state_freq.lost_count, 2.1)  # unchanged
 
         # Archive (was won, now lost) -> Should decrease won and increase lost
-        leads[4].toggle_active()
+        leads[4].action_archive()
         self.assertEqual(lead_4_stage_0_freq.won_count, 1.1)  # - 1
         self.assertEqual(lead_4_stage_won_freq.won_count, 1.1)  # - 1
         self.assertEqual(lead_4_country_freq.won_count, 0.1)  # - 1
@@ -336,7 +336,7 @@ class TestCRMPLS(TransactionCase):
         self.assertEqual(lead_4_email_state_freq.lost_count, 3.1)  # unchanged
 
         # Restore -> Should decrease lost - at the end, frequencies should be like first frequencyes tests (except for 0.0 -> 0.1)
-        leads[4].toggle_active()
+        leads[4].action_unarchive()
         self.assertEqual(lead_4_stage_0_freq.won_count, 1.1)  # unchanged
         self.assertEqual(lead_4_stage_won_freq.won_count, 1.1)  # unchanged
         self.assertEqual(lead_4_country_freq.won_count, 0.1)  # unchanged

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -13,7 +13,7 @@
                             type="action" invisible="type == 'lead' or not active and probability &lt; 100"/>
                         <button name="%(crm.action_crm_lead2opportunity_partner)d" string="Convert to Opportunity" type="action"
                             class="oe_highlight" invisible="type == 'opportunity' or not active" data-hotkey="v"/>
-                        <button name="toggle_active" string="Restore" type="object" data-hotkey="x"
+                        <button name="action_unarchive" string="Restore" type="object" data-hotkey="x"
                             invisible="probability &gt; 0 or active"/>
                         <button name="%(crm.crm_lead_lost_action)d" string="Lost" type="action"  data-hotkey="l" title="Mark as lost"
                             invisible="type == 'opportunity' or probability == 0 and not active"/>

--- a/addons/data_recycle/models/data_recycle_record.py
+++ b/addons/data_recycle/models/data_recycle_record.py
@@ -77,7 +77,7 @@ class Data_RecycleRecord(models.Model):
             elif record.recycle_model_id.recycle_action == "unlink":
                 record_ids_to_unlink[original_record._name].append(original_record.id)
         for model_name, ids in record_ids_to_archive.items():
-            self.env[model_name].sudo().browse(ids).toggle_active()
+            self.env[model_name].sudo().browse(ids).action_archive()
         for model_name, ids in record_ids_to_unlink.items():
             self.env[model_name].sudo().browse(ids).unlink()
         records_done.unlink()

--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -243,14 +243,14 @@ class EventRegistration(models.Model):
         for registration in self:
             registration.display_name = registration.name or f"#{registration.id}"
 
-    def toggle_active(self):
-        pre_inactive = self - self.filtered(self._active_name)
-        super().toggle_active()
+    def action_unarchive(self):
+        res = super().action_unarchive()
         # Necessary triggers as changing registration states cannot be used as triggers for the
         # Event(Ticket) models constraints.
-        if pre_inactive:
-            pre_inactive.event_id._check_seats_availability()
-            pre_inactive.event_ticket_id._check_seats_availability()
+        if unarchived := self.filtered(self._active_name):
+            unarchived.event_id._check_seats_availability()
+            unarchived.event_ticket_id._check_seats_availability()
+        return res
 
     # ------------------------------------------------------------
     # ACTIONS / BUSINESS

--- a/addons/fleet/views/fleet_vehicle_model_views.xml
+++ b/addons/fleet/views/fleet_vehicle_model_views.xml
@@ -201,10 +201,8 @@
                 <templates>
                     <t t-name="menu">
                         <a role="menuitem" type="open" class="dropdown-item">Configuration</a>
-                        <a role="menuitem" type="object" name="toggle_active" class="dropdown-item">
-                            <t t-if="record.active.raw_value">Archive</t>
-                            <t t-else="">Restore</t>
-                        </a>
+                        <a role="menuitem" type="object" name="action_archive" class="dropdown-item" t-if="record.active.raw_value">Archive</a>
+                        <a role="menuitem" type="object" name="action_unarchive" class="dropdown-item" t-if="!record.active.raw_value">Restore</a>
                         <a role="menuitem" t-if="widget.deletable" type="delete" class="dropdown-item">Delete</a>
                     </t>
                     <t t-name="card" class="flex-row p-1">

--- a/addons/hr/static/src/views/archive_employee_hook.js
+++ b/addons/hr/static/src/views/archive_employee_hook.js
@@ -18,7 +18,7 @@ export function useArchiveEmployee() {
                 target: "new",
                 context: {
                     active_id: id,
-                    toggle_active: true,
+                    employee_termination: true,
                 },
             },
             {

--- a/addons/hr/wizard/hr_departure_wizard.py
+++ b/addons/hr/wizard/hr_departure_wizard.py
@@ -26,8 +26,8 @@ class HrDepartureWizard(models.TransientModel):
 
     def action_register_departure(self):
         employee = self.employee_id
-        if self.env.context.get('toggle_active', False) and employee.active:
-            employee.with_context(no_wizard=True).toggle_active()
+        if self.env.context.get('employee_termination', False) and employee.active:
+            employee.with_context(no_wizard=True).action_archive()
         employee.departure_reason_id = self.departure_reason_id
         employee.departure_description = self.departure_description
         employee.departure_date = self.departure_date

--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -671,13 +671,14 @@ class HrApplicant(models.Model):
                 {'stage_id': applicant.job_id.id and default_stage[applicant.job_id.id],
                  'refuse_reason_id': False})
 
-    def toggle_active(self):
-        self = self.with_context(just_unarchived=True)
-        res = super().toggle_active()
-        active_applicants = self.filtered(lambda applicant: applicant.active)
+    def action_archive(self):
+        return super(HrApplicant, self.with_context(just_unarchived=True)).action_archive()
+
+    def action_unarchive(self):
+        active_applicants = super(HrApplicant, self.with_context(just_unarchived=True)).action_unarchive()
         if active_applicants:
             active_applicants.reset_applicant()
-        return res
+        return active_applicants
 
     def action_send_email(self):
         return {

--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -66,7 +66,7 @@
                 <button string="Create Employee" name="create_employee_from_applicant" type="object" data-hotkey="q" groups="hr.group_hr_user"
                         class="o_create_employee" invisible="employee_id or not active or not date_closed"/>
                 <button string="Refuse" name="archive_applicant" type="object" invisible="not active" data-hotkey="d"/>
-                <button string="Restore" name="toggle_active" type="object" invisible="active" data-hotkey="x"/>
+                <button string="Restore" name="action_unarchive" type="object" invisible="active" data-hotkey="x"/>
                 <field name="stage_id" widget="statusbar_duration" options="{'clickable': '1', 'fold_field': 'fold'}" invisible="not active and not employee_id"/>
             </header>
             <sheet>

--- a/addons/hr_recruitment/views/hr_job_views.xml
+++ b/addons/hr_recruitment/views/hr_job_views.xml
@@ -64,7 +64,7 @@
                                 <div class="col-6" role="menuitem">
                                     <a class="dropdown-item" t-if="widget.editable" name="edit_job" type="open">Configuration</a>
                                     <a class="dropdown-item" t-if="record.active.raw_value" type="archive" >Archive</a>
-                                    <a class="dropdown-item" t-if="!record.active.raw_value" name="toggle_active" type="object">Unarchive</a>
+                                    <a class="dropdown-item" t-if="!record.active.raw_value" name="action_unarchive" type="object">Unarchive</a>
                                 </div>
                             </div>
                         </div>

--- a/addons/hr_timesheet/wizard/hr_employee_delete_wizard.py
+++ b/addons/hr_timesheet/wizard/hr_employee_delete_wizard.py
@@ -30,7 +30,7 @@ class HrEmployeeDeleteWizard(models.TransientModel):
     def action_archive(self):
         self.ensure_one()
         if len(self.employee_ids) != 1:
-            return self.employee_ids.toggle_active()
+            return self.employee_ids.action_archive()
         return {
             'name': _('Employee Termination'),
             'type': 'ir.actions.act_window',
@@ -40,7 +40,7 @@ class HrEmployeeDeleteWizard(models.TransientModel):
             'target': 'new',
             'context': {
                 'active_id': self.employee_ids.id,
-                'toggle_active': True,
+                'employee_termination': True,
             }
         }
 

--- a/addons/hr_work_entry_holidays/tests/test_leave.py
+++ b/addons/hr_work_entry_holidays/tests/test_leave.py
@@ -122,7 +122,7 @@ class TestWorkEntryLeave(TestWorkEntryHolidaysBase):
         work_entry = self.create_work_entry(datetime(2019, 10, 10, 9, 0), datetime(2019, 10, 10, 18, 0))
         self.assertTrue(work_entry.active)
         self.assertEqual(work_entry.state, 'conflict', "Attendance work entries should conflict with the leave")
-        work_entry.toggle_active()
+        work_entry.action_archive()
         self.assertEqual(work_entry.state, 'cancelled', "Attendance work entries should be cancelled and not conflict")
         self.assertFalse(work_entry.active)
 

--- a/addons/loyalty/tests/test_loyalty.py
+++ b/addons/loyalty/tests/test_loyalty.py
@@ -159,8 +159,8 @@ class TestLoyalty(TransactionCase):
             ],
         })
         before_archived_reward_ids = self.program.reward_ids
-        self.program.toggle_active()
-        self.program.toggle_active()
+        self.program.action_archive()
+        self.program.action_unarchive()
         after_archived_reward_ids = self.program.reward_ids
         self.assertEqual(before_archived_reward_ids, after_archived_reward_ids)
 

--- a/addons/lunch/models/lunch_product.py
+++ b/addons/lunch/models/lunch_product.py
@@ -98,16 +98,20 @@ class LunchProduct(models.Model):
 
     def _sync_active_from_related(self):
         """ Archive/unarchive product after related field is archived/unarchived """
-        return self.filtered(lambda p: (p.category_id.active and p.supplier_id.active) != p.active).toggle_active()
+        self.filtered(lambda p: p.active and not (p.category_id.active and p.supplier_id.active)).action_archive()
+        self.filtered(lambda p: not p.active and (p.category_id.active and p.supplier_id.active)).action_unarchive()
 
-    def toggle_active(self):
-        invalid_products = self.filtered(lambda product: not product.active and not product.category_id.active)
+    @api.constrains('active', 'category_id')
+    def _check_active(self):
+        invalid_products = self.filtered(lambda product: product.active and not product.category_id.active)
         if invalid_products:
             raise UserError(_("The following product categories are archived. You should either unarchive the categories or change the category of the product.\n%s", '\n'.join(invalid_products.category_id.mapped('name'))))
-        invalid_products = self.filtered(lambda product: not product.active and not product.supplier_id.active)
+
+    @api.constrains('active', 'supplier_id')
+    def _check_active(self):
+        invalid_products = self.filtered(lambda product: product.active and not product.supplier_id.active)
         if invalid_products:
             raise UserError(_("The following suppliers are archived. You should either unarchive the suppliers or change the supplier of the product.\n%s", '\n'.join(invalid_products.supplier_id.mapped('name'))))
-        return super().toggle_active()
 
     def _inverse_is_favorite(self):
         """ Handled in the write() """

--- a/addons/lunch/models/lunch_product_category.py
+++ b/addons/lunch/models/lunch_product_category.py
@@ -30,10 +30,16 @@ class LunchProductCategory(models.Model):
         for category in self:
             category.product_count = data.get(category.id, 0)
 
-    def toggle_active(self):
+    def _sync_active_products(self):
         """ Archiving related lunch product """
-        res = super().toggle_active()
         Product = self.env['lunch.product'].with_context(active_test=False)
         all_products = Product.search([('category_id', 'in', self.ids)])
         all_products._sync_active_from_related()
-        return res
+
+    def action_archive(self):
+        super().action_archive()
+        self._sync_active_products()
+
+    def action_unarchive(self):
+        super().action_unarchive()
+        self._sync_active_products()

--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -283,18 +283,19 @@ class MailActivityMixin(models.AbstractModel):
 
         return SQL.identifier(alias, 'activity_state')
 
-    def toggle_active(self):
+    def action_archive(self):
         """ Before archiving the record we should also remove its ongoing
         activities. Otherwise they stay in the systray and concerning archived
         records it makes no sense. """
-        record_to_deactivate = self.filtered(lambda rec: rec[rec._active_name])
-        if record_to_deactivate:
+        records = self.filtered(self._active_name)
+        res = super(MailActivityMixin, records).action_archive()
+        if records:
             # use a sudo to bypass every access rights; all activities should be removed
             self.env['mail.activity'].sudo().search([
                 ('res_model', '=', self._name),
-                ('res_id', 'in', record_to_deactivate.ids)
+                ('res_id', 'in', records.ids)
             ]).unlink()
-        return super(MailActivityMixin, self).toggle_active()
+        return res
 
     def activity_send_mail(self, template_id):
         """ Automatically send an email based on the given mail.template, given

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -408,10 +408,8 @@
                             <t t-if="widget.deletable">
                                 <a role="menuitem" type="delete" class="dropdown-item">Delete</a>
                             </t>
-                            <a role="menuitem" class="dropdown-item o_kanban_mailing_active" name="toggle_active" type="object">
-                                <t t-if="record.active.raw_value">Archive</t>
-                                <t t-if="!record.active.raw_value">Restore</t>
-                            </a>
+                            <a role="menuitem" type="object" name="action_archive" class="dropdown-item o_kanban_mailing_active" t-if="record.active.raw_value">Archive</a>
+                            <a role="menuitem" type="object" name="action_unarchive" class="dropdown-item o_kanban_mailing_active" t-if="!record.active.raw_value">Restore</a>
                         </t>
                         <t t-name="card">
                             <field name="subject" class="my-1 text-truncate fs-3 fw-bold"/>

--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -282,9 +282,13 @@ class MrpBom(models.Model):
             raise UserError(_("You cannot create a new Bill of Material from here."))
         return super(MrpBom, self).name_create(name)
 
-    def toggle_active(self):
-        self.with_context({'active_test': False}).operation_ids.toggle_active()
-        return super().toggle_active()
+    def action_archive(self):
+        self.with_context(active_test=False).operation_ids.action_archive()
+        return super().action_archive()
+
+    def action_unarchive(self):
+        self.with_context(active_test=False).operation_ids.action_unarchive()
+        return super().action_unarchive()
 
     @api.depends('code')
     def _compute_display_name(self):

--- a/addons/product/tests/test_variants.py
+++ b/addons/product/tests/test_variants.py
@@ -300,12 +300,12 @@ class TestVariants(ProductVariantsCommon):
         })
         self.assertEqual(len(template.product_variant_ids), 2)
         variant_1 = template.product_variant_ids[0]
-        variant_1.toggle_active()
+        variant_1.action_archive()
         self.assertFalse(variant_1.active)
         self.assertEqual(len(template.product_variant_ids), 1)
         self.assertEqual(len(template.with_context(
             active_test=False).product_variant_ids), 2)
-        variant_1.toggle_active()
+        variant_1.action_unarchive()
         self.assertTrue(variant_1.active)
         self.assertTrue(template.active)
 
@@ -369,10 +369,10 @@ class TestVariants(ProductVariantsCommon):
         self.assertEqual(len(template.product_variant_ids), 2)
         variant_1 = template.product_variant_ids[0]
         variant_2 = template.product_variant_ids[1]
-        template.product_variant_ids.toggle_active()
+        template.product_variant_ids.action_archive()
         self.assertFalse(variant_1.active, 'Should archive all variants')
         self.assertFalse(template.active, 'Should archive related template')
-        variant_1.toggle_active()
+        variant_1.action_unarchive()
         self.assertTrue(variant_1.active, 'Should activate variant')
         self.assertFalse(variant_2.active, 'Should not re-activate other variant')
         self.assertTrue(template.active, 'Should re-activate template')
@@ -1241,7 +1241,7 @@ class TestVariantsArchive(ProductVariantsCommon):
         self.assertEqual(tmpl.barcode, '123')
         self.assertEqual(self.product.barcode, '123')
 
-        tmpl.toggle_active()
+        tmpl.action_archive()
 
         tmpl.barcode = '456'
         tmpl.invalidate_recordset(fnames=['barcode'])

--- a/addons/project/models/project_project_stage.py
+++ b/addons/project/models/project_project_stage.py
@@ -59,12 +59,12 @@ class ProjectProjectStage(models.Model):
             self.env['project.project'].search([('stage_id', 'in', self.ids)]).write({'active': False})
         return super().write(vals)
 
-    def toggle_active(self):
-        res = super().toggle_active()
-        stage_active = self.filtered('active')
-        inactive_projects = self.env['project.project'].with_context(active_test=False).search(
-            [('active', '=', False), ('stage_id', 'in', stage_active.ids)], limit=1)
-        if stage_active and inactive_projects:
+    def action_unarchive(self):
+        res = super().action_unarchive()
+        stage_active = self.filtered(self._active_name)
+        if stage_active and self.env['project.project'].with_context(active_test=False).search_count(
+            [('active', '=', False), ('stage_id', 'in', stage_active.ids)], limit=1
+        ):
             wizard = self.env['project.project.stage.delete.wizard'].create({
                 'stage_ids': stage_active.ids,
             })

--- a/addons/project/models/project_task_type.py
+++ b/addons/project/models/project_task_type.py
@@ -139,12 +139,12 @@ class ProjectTaskType(models.Model):
             if stage['id'] in personal_stages_by_stage:
                 personal_stages_by_stage[stage['id']].stage_id = replacement_stage_id
 
-    def toggle_active(self):
-        res = super().toggle_active()
-        stage_active = self.filtered('active')
-        inactive_tasks = self.env['project.task'].with_context(active_test=False).search(
-            [('active', '=', False), ('stage_id', 'in', stage_active.ids)], limit=1)
-        if stage_active and inactive_tasks:
+    def action_unarchive(self):
+        res = super().action_unarchive()
+        stage_active = self.filtered(self._active_name)
+        if stage_active and self.env['project.task'].with_context(active_test=False).search_count(
+            [('active', '=', False), ('stage_id', 'in', stage_active.ids)], limit=1
+        ):
             wizard = self.env['project.task.type.delete.wizard'].create({
                 'stage_ids': stage_active.ids,
             })

--- a/addons/sale_mrp/models/mrp_bom.py
+++ b/addons/sale_mrp/models/mrp_bom.py
@@ -8,12 +8,8 @@ from odoo.exceptions import UserError
 class MrpBom(models.Model):
     _inherit = ['mrp.bom']
 
-    def toggle_active(self):
-        self.filtered(lambda bom: bom.active)._ensure_bom_is_free()
-        return super().toggle_active()
-
     def write(self, vals):
-        if 'phantom' in self.mapped('type') and vals.get('type', 'phantom') != 'phantom':
+        if not vals.get('active', True) or ('phantom' in self.mapped('type') and vals.get('type', 'phantom') != 'phantom'):
             self._ensure_bom_is_free()
         return super().write(vals)
 
@@ -24,7 +20,7 @@ class MrpBom(models.Model):
     def _ensure_bom_is_free(self):
         product_ids = []
         for bom in self:
-            if bom.type != 'phantom':
+            if not bom.active or bom.type != 'phantom':
                 continue
             product_ids += bom.product_id.ids or bom.product_tmpl_id.product_variant_ids.ids
         if not product_ids:

--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -1912,7 +1912,8 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
         Business Flow:
             create SO
             validate the delivery
-            archive the BOM and create a new one
+            (cannot archive the BOM, because it is used in a non-invoiced line)
+            update the BOM and create a new one
             create the invoice
             post the invoice
         """
@@ -2011,8 +2012,7 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
         # Deliver the products
         pick = so.picking_ids
         pick.button_validate()
-        # archive bOM and update it
-        bom.active = False
+        # Update BOM
         bom_updated = self.env['mrp.bom'].create({
             'product_tmpl_id': self.product_template.id,
             'product_id': self.variant_KIT_A.id,
@@ -2415,14 +2415,14 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
                     'tax_id': False,
                 })],
         })
-        self.bom_kit_1.toggle_active()
-        self.bom_kit_1.toggle_active()
+        self.bom_kit_1.action_archive()
+        self.bom_kit_1.action_unarchive()
 
         so.action_confirm()
         with self.assertRaises(UserError):
             self.bom_kit_1.write({'type': 'normal'})
         with self.assertRaises(UserError):
-            self.bom_kit_1.toggle_active()
+            self.bom_kit_1.action_archive()
         with self.assertRaises(UserError):
             self.bom_kit_1.unlink()
 
@@ -2434,7 +2434,7 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
         with self.assertRaises(UserError):
             self.bom_kit_1.write({'type': 'normal'})
         with self.assertRaises(UserError):
-            self.bom_kit_1.toggle_active()
+            self.bom_kit_1.action_archive()
         with self.assertRaises(UserError):
             self.bom_kit_1.unlink()
 
@@ -2442,8 +2442,8 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
         invoice.action_post()
 
         self.assertEqual(invoice.state, 'posted')
-        self.bom_kit_1.toggle_active()
-        self.bom_kit_1.toggle_active()
+        self.bom_kit_1.action_archive()
+        self.bom_kit_1.action_unarchive()
         self.bom_kit_1.write({'type': 'normal'})
         self.bom_kit_1.write({'type': 'phantom'})
         self.bom_kit_1.unlink()

--- a/addons/sales_team/tests/test_sales_team_membership.py
+++ b/addons/sales_team/tests/test_sales_team_membership.py
@@ -153,19 +153,19 @@ class TestMembership(TestSalesCommon):
         self.assertEqual(sales_team_1.member_ids, self.user_admin | self.user_sales_leads)
 
         # activate another team membership: previous team membership should be de activated
-        new_nt.toggle_active()
+        new_nt.action_unarchive()
         self.assertTrue(new_nt.active)
         self.assertFalse(old_st_1.active)
         self.assertFalse(new_st_1.active)
         # activate another team membership: previous team membership should be de activated
-        old_st_1.toggle_active()
+        old_st_1.action_unarchive()
         self.assertFalse(new_nt.active)
         self.assertTrue(old_st_1.active)
         self.assertFalse(new_st_1.active)
 
         # try to activate duplicate memberships again, which should trigger issues
         with self.assertRaises(exceptions.UserError):
-            new_st_1.toggle_active()
+            new_st_1.action_unarchive()
 
     @users('user_sales_manager')
     def test_memberships_multi(self):
@@ -211,7 +211,7 @@ class TestMembership(TestSalesCommon):
 
         # try to activate duplicate memberships again, which should trigger issues
         with self.assertRaises(exceptions.UserError):
-            old_st_1.toggle_active()
+            old_st_1.action_unarchive()
 
     @users('user_sales_manager')
     def test_memberships_sync(self):

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -557,10 +557,14 @@ class StockRoute(models.Model):
         if not self.warehouse_selectable:
             self.warehouse_ids = [(5, 0, 0)]
 
-    def toggle_active(self):
-        for route in self:
-            route.with_context(active_test=False).rule_ids.filtered(lambda ru: ru.active == route.active).toggle_active()
-        super().toggle_active()
+    def write(self, vals):
+        if 'active' in vals:
+            rules = self.with_context(active_test=False).rule_ids
+            if vals['active']:
+                rules.action_unarchive()
+            else:
+                rules.action_archive()
+        return super().write(vals)
 
     @api.constrains('company_id')
     def _check_company_consistency(self):

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -295,8 +295,7 @@ class StockWarehouse(models.Model):
                         ('supplier_wh_id', 'in', to_add.ids),
                         ('active', '=', False)
                     ])
-                    if existing_routes:
-                        existing_routes.toggle_active()
+                    existing_routes.action_unarchive()
                     remaining_to_add = to_add - existing_routes.supplier_wh_id
                     if remaining_to_add:
                         warehouse.create_resupply_routes(remaining_to_add)
@@ -306,7 +305,7 @@ class StockWarehouse(models.Model):
                         ('supplier_wh_id', 'in', to_remove.ids),
                         ('active', '=', True)
                     ])
-                    to_disable_route_ids.toggle_active()
+                    to_disable_route_ids.action_archive()
 
         if 'active' in vals:
             self._check_multiwarehouse_group()

--- a/addons/stock/tests/test_warehouse.py
+++ b/addons/stock/tests/test_warehouse.py
@@ -655,7 +655,7 @@ class TestWarehouse(TestStockCommon):
         custom_location = custom_location.save()
 
         # Archive warehouse
-        warehouse.toggle_active()
+        warehouse.action_archive()
         # Global rule
         self.assertFalse(warehouse.mto_pull_id.active)
 
@@ -679,7 +679,7 @@ class TestWarehouse(TestStockCommon):
         self.assertFalse(warehouse.pack_type_id.active)
 
         # Active warehouse
-        warehouse.toggle_active()
+        warehouse.action_unarchive()
         # Global rule
         self.assertTrue(warehouse.mto_pull_id.active)
 
@@ -731,11 +731,11 @@ class TestWarehouse(TestStockCommon):
         route.warehouse_ids = [(6, 0, [warehouse.id, self.warehouse_1.id])]
 
         # Pre archive a location and a route
-        warehouse.delivery_route_id.toggle_active()
-        warehouse.wh_pack_stock_loc_id.toggle_active()
+        warehouse.delivery_route_id.action_archive()
+        warehouse.wh_pack_stock_loc_id.action_archive()
 
         # Archive warehouse
-        warehouse.toggle_active()
+        warehouse.action_archive()
         # Global rule
         self.assertFalse(warehouse.mto_pull_id.active)
 
@@ -760,7 +760,7 @@ class TestWarehouse(TestStockCommon):
         self.assertFalse(warehouse.pack_type_id.active)
 
         # Active warehouse
-        warehouse.toggle_active()
+        warehouse.action_unarchive()
         # Global rule
         self.assertTrue(warehouse.mto_pull_id.active)
 

--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -496,11 +496,13 @@ class SurveySurvey(models.Model):
         vals_list = super().copy_data(default=default)
         return [dict(vals, title=self.env._("%s (copy)", survey.title)) for survey, vals in zip(self, vals_list)]
 
-    def toggle_active(self):
-        super().toggle_active()
-        activated = self.filtered(lambda survey: survey.active)
-        activated.certification_badge_id.action_unarchive()
-        (self - activated).certification_badge_id.action_archive()
+    def action_archive(self):
+        super().action_archive()
+        self.certification_badge_id.action_archive()
+
+    def action_unarchive(self):
+        super().action_unarchive()
+        self.certification_badge_id.action_unarchive()
 
     # ------------------------------------------------------------
     # ANSWER MANAGEMENT

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -397,10 +397,10 @@ class TestActivityMixin(TestActivityCommon):
             'test_mail.mail_act_test_todo',
             user_id=self.user_admin.id)
         self.assertEqual(rec.activity_ids, new_act)
-        rec.toggle_active()
+        rec.action_archive()
         self.assertEqual(rec.active, False)
         self.assertEqual(rec.activity_ids, self.env['mail.activity'])
-        rec.toggle_active()
+        rec.action_unarchive()
         self.assertEqual(rec.active, True)
         self.assertEqual(rec.activity_ids, self.env['mail.activity'])
 

--- a/addons/utm/views/utm_campaign_views.xml
+++ b/addons/utm/views/utm_campaign_views.xml
@@ -97,10 +97,8 @@
                         <t t-if="widget.deletable">
                             <a role="menuitem" type="delete" class="dropdown-item">Delete</a>
                         </t>
-                        <a role="menuitem" class="dropdown-item o_kanban_mailing_active" name="toggle_active" type="object">
-                            <t t-if="record.active.raw_value">Archive</t>
-                            <t t-else="">Restore</t>
-                        </a>
+                        <a role="menuitem" class="dropdown-item o_kanban_mailing_active" name="action_archive" type="object" t-if="record.active.raw_value">>Archive</a>
+                        <a role="menuitem" class="dropdown-item o_kanban_mailing_active" name="action_unarchive" type="object" t-if="!record.active.raw_value">>Restore</a>
                         <div role="separator" class="dropdown-divider"/>
                         <field name="color" widget="kanban_color_picker"/>
                     </t>

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -7653,7 +7653,7 @@ test("button executes action and check domain", async () => {
                     <div t-name="card">
                         <field name="foo"/>
                         <button type="object" name="a1" />
-                        <button type="object" name="toggle_active" class="toggle-active" />
+                        <button type="object" name="action_archive" class="action-archive" />
                     </div>
                 </templates>
             </kanban>`,
@@ -7662,7 +7662,7 @@ test("button executes action and check domain", async () => {
     expect(queryText("span", { root: getKanbanRecord({ index: 0 }) })).toBe("yop", {
         message: "should display 'yop' record",
     });
-    await contains("button.toggle-active", { root: getKanbanRecord({ index: 0 }) }).click();
+    await contains("button.action-archive", { root: getKanbanRecord({ index: 0 }) }).click();
     expect(queryText("span", { root: getKanbanRecord({ index: 0 }) })).not.toBe("yop", {
         message: "should have removed 'yop' record from the view",
     });

--- a/addons/website_hr_recruitment/models/hr_job.py
+++ b/addons/website_hr_recruitment/models/hr_job.py
@@ -79,9 +79,9 @@ class HrJob(models.Model):
     def get_backend_menu_id(self):
         return self.env.ref('hr_recruitment.menu_hr_recruitment_root').id
 
-    def toggle_active(self):
+    def action_archive(self):
         self.filtered('active').website_published = False
-        return super().toggle_active()
+        return super().action_archive()
 
     @api.model
     def _search_get_detail(self, website, order, options):

--- a/addons/website_sale/tests/test_website_sale_image.py
+++ b/addons/website_sale/tests/test_website_sale_image.py
@@ -326,7 +326,7 @@ class TestWebsiteSaleImage(HttpCase):
         # when there are no template image but there are variants, the image must be obtained from the first variant
         self.assertEqual(product_red, template._get_image_holder())
 
-        product_red.toggle_active()
+        product_red.action_archive()
 
         # but when some variants are not available, the image must be obtained from the first available variant
         self.assertEqual(product_green, template._get_image_holder())

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -667,6 +667,7 @@ class SlideSlide(models.Model):
                 values = {'html_content': False, **values}
 
         res = super().write(values)
+
         if values.get('is_published'):
             self.date_published = datetime.datetime.now()
             self._post_publication()
@@ -686,6 +687,8 @@ class SlideSlide(models.Model):
                 })
 
         if 'is_published' in values or 'active' in values:
+            # archiving a channel unpublishes its slides
+            self.filtered(lambda slide: not slide.active and not slide.is_category and slide.is_published).is_published = False
             # recompute the completion for all partners of the channel
             self.channel_id.channel_partner_ids._recompute_completion()
 
@@ -704,14 +707,6 @@ class SlideSlide(models.Model):
         channel_partner_ids = self.channel_id.channel_partner_ids
         res = super().unlink()
         channel_partner_ids._recompute_completion()
-        return res
-
-    def toggle_active(self):
-        # archiving/unarchiving a channel does it on its slides, too
-        to_archive = self.filtered(lambda slide: slide.active)
-        res = super().toggle_active()
-        if to_archive:
-            to_archive.filtered(lambda slide: not slide.is_category).is_published = False
         return res
 
     # ---------------------------------------------------------

--- a/addons/website_slides/tests/test_slide_channel.py
+++ b/addons/website_slides/tests/test_slide_channel.py
@@ -41,7 +41,7 @@ class TestSlidesManagement(slides_common.SlidesCase):
             self.assertTrue(slide.active, "All slide should be archived when a channel is archived")
             self.assertTrue(slide.is_published, "All slide should be unpublished when a channel is archived")
 
-        self.channel.toggle_active()
+        self.channel.action_archive()
         self.assertFalse(self.channel.active)
         self.assertFalse(self.channel.is_published)
         # channel_partner should still NOT be marked as completed

--- a/addons/website_slides/tests/test_statistics.py
+++ b/addons/website_slides/tests/test_statistics.py
@@ -92,14 +92,13 @@ class TestChannelStatistics(common.SlidesCase):
         self.assertEqual(channel_emp.completion, 100)
         self.assertTrue(channel_emp.completed)
 
-        self.slide_3.is_published = True
         self.slide_3.active = False
+        # slide_3 is not active, so it cannot be published yet
         self.assertEqual(member_emp.completion, 100)
         self.assertEqual(channel_emp.completion, 100)
         self.assertTrue(channel_emp.completed)
 
         # Should update completion when slide is marked as completed
-
         self.assertEqual(member_publisher.completion, 0)
         self.assertEqual(channel_publisher.completion, 0)
         self.slide.with_user(self.user_officer).action_mark_completed()
@@ -108,6 +107,7 @@ class TestChannelStatistics(common.SlidesCase):
 
         # Should update completion when slide is (un)archived
         self.slide_3.active = True
+        self.slide_3.is_published = True  # set the published flag to True again
         self.assertEqual(member_emp.completion, 100)
         self.assertEqual(channel_emp.completion, 100)
         self.assertEqual(member_publisher.completion, 33)

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -634,12 +634,6 @@ class ResUsers(models.Model):
         LIMIT 1
         """, tuple(group_ids), user_condition)))
 
-    def toggle_active(self):
-        for user in self:
-            if not user.active and not user.partner_id.active:
-                user.partner_id.toggle_active()
-        super().toggle_active()
-
     def onchange(self, values, field_names, fields_spec):
         # Hacky fix to access fields in `SELF_READABLE_FIELDS` in the onchange logic.
         # Put field values in the cache.
@@ -722,9 +716,8 @@ class ResUsers(models.Model):
             raise UserError(_("You cannot deactivate the user you're currently logged in as."))
 
         if values.get('active'):
-            for user in self:
-                if not user.active and not user.partner_id.active:
-                    user.partner_id.toggle_active()
+            # unarchive partners before unarchiving the users
+            self.partner_id.action_unarchive()
         if self == self.env.user:
             writeable = self.SELF_WRITEABLE_FIELDS
             for key in list(values):

--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -65,19 +65,19 @@ class TestPartner(TransactionCaseWithUserDemo):
                                 })
         # Cannot archive the partner
         with self.assertRaises(RedirectWarning):
-            test_partner.with_user(self.env.ref('base.user_admin')).toggle_active()
+            test_partner.with_user(self.env.ref('base.user_admin')).action_archive()
         with self.assertRaises(ValidationError):
-            test_partner.with_user(self.user_demo).toggle_active()
+            test_partner.with_user(self.user_demo).action_archive()
 
         # Can archive the user but the partner stays active
-        test_user.toggle_active()
+        test_user.action_archive()
         self.assertTrue(test_partner.active, 'Parter related to user should remain active')
 
         # Now we can archive the partner
-        test_partner.toggle_active()
+        test_partner.action_archive()
 
         # Activate the user should reactivate the partner
-        test_user.toggle_active()
+        test_user.action_unarchive()
         self.assertTrue(test_partner.active, 'Activating user must active related partner')
 
     def test_email_formatted(self):

--- a/odoo/addons/base/tests/test_translate.py
+++ b/odoo/addons/base/tests/test_translate.py
@@ -1696,7 +1696,7 @@ class TestLanguageInstallPerformance(TransactionCase):
         self.assertFalse(fr_BE.active)
 
         t0 = time.time()
-        fr_BE.toggle_active()
+        fr_BE.action_unarchive()
         t1 = time.time()
         _stats_logger.info("installed language fr_BE in %.3fs", t1 - t0)
 

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -4078,7 +4078,7 @@ class TestOptionalViews(ViewCase):
         """ Change active states of v2 and v3, check that the results
         are as expected
         """
-        self.v2.toggle_active()
+        self.v2.action_archive()
         context = {'check_view_ids': self.View.search([]).ids}
         arch = self.v0.with_context(context).get_combined_arch()
         self.assertEqual(
@@ -4089,7 +4089,7 @@ class TestOptionalViews(ViewCase):
             )
         )
 
-        self.v3.toggle_active()
+        self.v3.action_unarchive()
         context = {'check_view_ids': self.View.search([]).ids}
         arch = self.v0.with_context(context).get_combined_arch()
         self.assertEqual(
@@ -4101,7 +4101,7 @@ class TestOptionalViews(ViewCase):
             )
         )
 
-        self.v2.toggle_active()
+        self.v2.action_unarchive()
         context = {'check_view_ids': self.View.search([]).ids}
         arch = self.v0.with_context(context).get_combined_arch()
         self.assertEqual(

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -5976,24 +5976,33 @@ class BaseModel(metaclass=MetaModel):
 
     def toggle_active(self):
         "Inverses the value of :attr:`active` on the records in ``self``."
+        warnings.warn("Deprecated since 19.0, use action_archive or action_unarchive", DeprecationWarning)
         assert self._active_name, f"No 'active' field on model {self._name}"
         active_recs = self.filtered(self._active_name)
-        active_recs[self._active_name] = False
-        (self - active_recs)[self._active_name] = True
+        active_recs.action_archive()
+        (self - active_recs).action_unarchive()
 
     def action_archive(self):
-        """Sets :attr:`active` to ``False`` on a recordset, by calling
-         :meth:`toggle_active` on its currently active records.
+        """Sets :attr:`active` to ``False`` on a recordset for active records.
+
+        Note, you probably want to override `write()` method if you want to take
+        action once the active field changes.
         """
-        assert self._active_name, f"No 'active' field on model {self._name}"
-        return self.filtered(lambda record: record[self._active_name]).toggle_active()
+        field_name = self._active_name
+        assert field_name, f"No 'active' field on model {self._name}"
+        active_recs = self.filtered(lambda record: record[field_name])
+        active_recs[field_name] = False
 
     def action_unarchive(self):
-        """Sets :attr:`active` to ``True`` on a recordset, by calling
-        :meth:`toggle_active` on its currently inactive records.
+        """Sets :attr:`active` to ``True`` on a recordset for inactive records.
+
+        Note, you probably want to override `write()` method if you want to take
+        action once the active field changes.
         """
-        assert self._active_name, f"No 'active' field on model {self._name}"
-        return self.filtered(lambda record: not record[self._active_name]).toggle_active()
+        field_name = self._active_name
+        assert field_name, f"No 'active' field on model {self._name}"
+        inactive_recs = self.filtered(lambda record: not record[field_name])
+        inactive_recs[field_name] = True
 
     def _register_hook(self):
         """ stuff to do right after the registry is built """


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
`toggle_active()` is not idempotent, users should either archive or unarchive explicitely. Moreover, the actions only write a value on the active field; since you can also write that value directly, when possible, it is advised to check the active value during `write()` instead of overriding the activation methods.

Current behavior before PR:
3 functions are available: `toggle_active`, `action_archive`, `action_unarchive`.

Desired behavior after PR is merged:
The first one is not idempotent and duplicates the functionality of the 2 other functions. Moreover, if we want to perform an action after a record is deactivated, we should  overwrite the write method instead of the action.


odoo/enterprise#71963
odoo/documentation#11261
task-3983933

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
