### PR TITLE
[FIX] mrp: traceback on generating wip entry

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -576,7 +576,7 @@ class MrpWorkorder(models.Model):
         total = 0
         for wo in self:
             if date:
-                duration = sum(wo.time_ids.filtered(lambda t: t.date_end <= date).mapped('duration'))
+                duration = sum(wo.time_ids.filtered(lambda t: t.date_end and t.date_end <= date).mapped('duration'))
             else:
                 duration = sum(wo.time_ids.mapped('duration'))
             total += (duration / 60.0) * wo.workcenter_id.costs_hour


### PR DESCRIPTION
before this commit, if user tries to open/generate WIP entry for manufacturing 
without recording the end time in the time tracking inside the work
order a traceback is shown to user

* create a manufacturing order that generate work order
* in the work orders generated, start a work order
* now click on POST WIP accounting entry from action
* traceback is shown

![Screenshot from 2024-10-15 11-09-44](https://github.com/user-attachments/assets/d491acf0-762d-4886-af1a-c1148d771932)


after this commit, no traceback wont be shown in the above scenario

Related EE: https://github.com/odoo/enterprise/pull/72070

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
