### PR TITLE
[IMP] account: Write on account.code by creating code_mapping_ids

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -373,6 +373,7 @@ class AccountAccount(models.Model):
             raise ValidationError(_("You cannot change the type of an account set as Bank Account on a journal to Receivable or Payable."))
 
     @api.depends_context('company')
+    @api.depends('code_store')
     def _compute_code(self):
         for record, record_root in zip(self, self.with_company(self.env.company.root_id).sudo()):
             # Need to set record.code with `company = self.env.company`, not `self.env.company.root_id`
@@ -484,8 +485,8 @@ class AccountAccount(models.Model):
 
     @api.model
     def _search_new_account_code(self, start_code, cache=None):
-        """ Get an available account code by starting from an existing code
-            and incrementing it until an available code is found.
+        """ Get an account code that is available for creating a new account in the active
+            company by starting from an existing code and incrementing it.
 
             Examples:
                 |  start_code  |  codes checked for availability                            |
@@ -507,7 +508,7 @@ class AccountAccount(models.Model):
                                     If you want the method to start at start_code, you should
                                     explicitly pass cache={}.
 
-            :return str: an available new account code for `company`.
+            :return str: an available new account code for the active company.
                          It will normally have length `len(start_code)`.
                          If incrementing the last digits starting from `start_code` does
                          not work, the method will try as a fallback
@@ -517,7 +518,23 @@ class AccountAccount(models.Model):
             cache = {start_code}
 
         def code_is_available(new_code):
-            return new_code not in cache and not self.search_count([('code', '=', new_code)], limit=1)
+            """ Determine whether `new_code` is available in the active company.
+
+                A code is available for creating a new account in a company if no account
+                with the same code belongs to a parent or a child company.
+
+                We use the same definition of availability in `_ensure_code_is_unique`
+                and both methods need to be kept in sync.
+            """
+            return (
+                new_code not in cache
+                and not self.sudo().search_count([
+                    ('code', '=', new_code),
+                    '|',
+                    ('company_ids', 'parent_of', self.env.company.id),
+                    ('company_ids', 'child_of', self.env.company.id),
+                ], limit=1)
+            )
 
         if code_is_available(start_code):
             return start_code
@@ -714,7 +731,7 @@ class AccountAccount(models.Model):
                     default_code = int(default_name)
                 if default_code:
                     default_name = False
-            context.update({'default_name': default_name, 'default_code': default_code})
+                context.update({'default_name': default_name, 'default_code': default_code})
 
         defaults = super(AccountAccount, self.with_context(**context)).default_get(default_fields)
 
@@ -832,7 +849,7 @@ class AccountAccount(models.Model):
         cache = defaultdict(set)
 
         for account, vals in zip(self, vals_list):
-            company_ids = self._fields['company_ids'].convert_to_cache(vals['company_ids'], account)
+            company_ids = self._fields['company_ids'].convert_to_cache(vals['company_ids'], self.browse())
             companies = self.env['res.company'].browse(company_ids)
 
             if 'code_mapping_ids' not in default and ('code' not in default or len(companies) > 1):
@@ -936,20 +953,16 @@ class AccountAccount(models.Model):
     def create(self, vals_list):
         records_list = []
 
-        # As we are creating accounts with a single company at first, check_company fields will need to be added
-        # at the end to avoid triggering the check_company constraint.
-        check_company_fields = {fname for fname, field in self._fields.items() if field.relational and field.check_company}
-
         for company_ids, vals_list_for_company in itertools.groupby(vals_list, lambda v: v.get('company_ids', [])):
             cache = set()
             vals_list_for_company = list(vals_list_for_company)
 
-            # Determine the companies the new accounts will have. The first one will be used to create the accounts, the others added later.
+            # Determine the companies the new accounts will have.
             company_ids = self._fields['company_ids'].convert_to_cache(company_ids, self.browse())
-            companies = self.env['res.company'].browse(company_ids) or self.env.company
+            companies = self.env['res.company'].browse(company_ids)
+            if self.env.company in companies or not companies:
+                companies = self.env.company | companies  # The currently active company comes first.
 
-            # Create the accounts with a single company and a single code.
-            code_by_company_list = []
             for vals in vals_list_for_company:
                 if 'prefix' in vals:
                     prefix, digits = vals.pop('prefix'), vals.pop('code_digits')
@@ -957,35 +970,24 @@ class AccountAccount(models.Model):
                     vals['code'] = self.with_company(companies[0])._search_new_account_code(start_code, cache)
                     cache.add(vals['code'])
 
-                # Intercept any values in `code_mapping_ids` to write the codes on the newly-created accounts.
-                # note: 'code_mapping_ids' should contain only CREATEs.
-                code_by_company = {v[2]['company_id']: v[2]['code'] for v in vals.get('code_mapping_ids', [])}
-                vals['code_mapping_ids'] = []  # Prevent requesting a default for `code_mapping_ids` in super().create()
-                if code_by_company and 'code' not in vals:
-                    vals['code'] = code_by_company[companies[0].id]
-                code_by_company_list.append(code_by_company)
+                if 'code' not in vals:  # prepopulate the code for precomputed fields depending on it
+                    for mapping_command in vals.get('code_mapping_ids', []):
+                        match mapping_command:
+                            case Command.CREATE, _, {'company_id': company_id, 'code': code} if company_id == companies[0].id:
+                                vals['code'] = code
+                                break
 
-                vals['company_ids'] = [Command.set(companies[0].ids)]
-
-            check_company_vals_list = [{fname: vals.pop(fname) for fname in check_company_fields if fname in vals} for vals in vals_list_for_company]
-
-            new_accounts = super(AccountAccount, self.with_context({**self.env.context, 'allowed_company_ids': companies.ids})) \
-                                .create(vals_list_for_company)
-
-            # Add the other codes, companies and check_company fields on each account.
-            for new_account, code_by_company, check_company_vals in zip(new_accounts, code_by_company_list, check_company_vals_list):
-                for company_id, code in code_by_company.items():
-                    if company_id != companies[0].id:
-                        new_account.with_context({'allowed_company_ids': [company_id, companies[0].id]}).code = code
-                if len(companies) > 1:
-                    check_company_vals['company_ids'] = [Command.link(company.id) for company in companies[1:]]
-                if check_company_vals:
-                    new_account.write(check_company_vals)
+            new_accounts = super(AccountAccount, self.with_context(
+                allowed_company_ids=companies.ids,
+                defer_account_code_checks=True,
+                # Don't get a default value for `code_mapping_ids` from default_get
+                default_code_mapping_ids=self.env.context.get('default_code_mapping_ids', []),
+            )).create(vals_list_for_company)
 
             records_list.append(new_accounts)
 
         records = self.env['account.account'].union(*records_list)
-        records.with_context(allowed_company_ids=records.company_ids.ids)._ensure_code_is_unique()
+        records._ensure_code_is_unique()
         return records
 
     def write(self, vals):
@@ -999,37 +1001,65 @@ class AccountAccount(models.Model):
             for account in self:
                 if self.env['account.move.line'].search_count([('account_id', '=', account.id), ('currency_id', 'not in', (False, vals['currency_id']))]):
                     raise UserError(_('You cannot set a currency on this account as it already has some journal entries having a different foreign currency.'))
-        res = super().write(vals)
-        if {'company_ids', 'code'} & vals.keys():
+
+        res = super(AccountAccount, self.with_context(defer_account_code_checks=True)).write(vals)
+
+        if not self.env.context.get('defer_account_code_checks') and {'company_ids', 'code', 'code_mapping_ids'} & vals.keys():
             self._ensure_code_is_unique()
+
         return res
 
     def _ensure_code_is_unique(self):
-        """ Ensure that for each company to which the account belongs, the code is set
-        and that codes are unique per-company. """
-        accounts = self.sudo()
-        for account in accounts:
-            for company in account.company_ids:
+        """ Check account codes per companies. These are the checks:
+
+            1. Check that the code is set for each of the account's companies.
+
+            2. Check that no child or parent companies have another account with the same code
+               as the account.
+
+               The definition of availability is the same as the one used by _search_new_account_code
+               and both methods need to be kept in sync.
+        """
+        # Check 1: Check that the code is set.
+        for account in self.sudo():
+            for company in account.company_ids.root_id:
                 if not account.with_company(company).code:
                     raise ValidationError(_("The code must be set for every company to which this account belongs."))
-        accounts_to_check = accounts.filtered(lambda a: a.code and self.env.company in a.company_ids)
-        accounts_by_code = accounts_to_check.grouped('code')
-        duplicate_codes = None
-        if len(accounts_by_code) < len(accounts_to_check):
-            duplicate_codes = [code for code, accounts in accounts_by_code.items() if len(accounts) > 1]
-        # search for duplicates of self in database
-        elif duplicates := self.sudo().search_fetch(
-            [
-                ('code', 'in', list(accounts_by_code)),
-                ('id', 'not in', self.ids),
-            ],
-            ['code'],
-        ):
-            duplicate_codes = duplicates.mapped('code')
-        if duplicate_codes:
-            raise ValidationError(
-                _("Account codes must be unique. You can't create accounts with these duplicate codes: %s", ", ".join(duplicate_codes))
-            )
+
+        # Check 2: Check that no child or parent companies have an account with the same code.
+
+        # Do a grouping by companies in `company_ids`.
+        account_ids_to_check_by_company = defaultdict(list)
+        for account in self.sudo():
+            companies_to_check = account.company_ids
+            for company in companies_to_check:
+                account_ids_to_check_by_company[company].append(account.id)
+
+        for company, account_ids in account_ids_to_check_by_company.items():
+            accounts = self.browse(account_ids).with_prefetch(self.ids).sudo()
+
+            # Check 2.1: Check that there are no duplicates in the given recordset.
+            accounts_by_code = accounts.with_company(company).grouped('code')
+            duplicate_codes = None
+            if len(accounts_by_code) < len(accounts):
+                duplicate_codes = [code for code, accounts in accounts_by_code.items() if len(accounts) > 1]
+
+            # Check 2.2: Check that there are no duplicates in database
+            elif duplicates := self.with_company(company).sudo().search_fetch(
+                [
+                    ('code', 'in', list(accounts_by_code)),
+                    ('id', 'not in', self.ids),
+                    '|',
+                    ('company_ids', 'parent_of', company.ids),
+                    ('company_ids', 'child_of', company.ids),
+                ],
+                ['code_store'],
+            ):
+                duplicate_codes = duplicates.mapped('code')
+            if duplicate_codes:
+                raise ValidationError(
+                    _("Account codes must be unique. You can't create accounts with these duplicate codes: %s", ", ".join(duplicate_codes))
+                )
 
     def _load_records_write(self, values):
         if 'prefix' in values:

--- a/addons/account/tests/test_account_account.py
+++ b/addons/account/tests/test_account_account.py
@@ -16,13 +16,12 @@ class TestAccountAccount(TestAccountMergeCommon):
         cls.company_data_2 = cls.setup_other_company()
         cls.other_currency = cls.setup_other_currency('EUR')
 
-    def test_account_company(self):
+    def test_shared_accounts(self):
         ''' Test that creating an account with a given company in company_ids sets the code for that company.
         Test that copying an account creates a new account with the code set for the new account's company_ids company,
         and that copying an account that belongs to multiple companies works, even if the copied account had
         check_company fields that had values belonging to several companies.
-        Test that you can't have an account without a company set.
-        Test that you can't remove a company from an account if there are some journal items in the company. '''
+        '''
 
         company_1 = self.company_data['company']
         company_2 = self.company_data_2['company']
@@ -32,7 +31,6 @@ class TestAccountAccount(TestAccountMergeCommon):
         account = self.env['account.account'].create({
             'code': '180001',
             'name': 'My Account in Company 2',
-            'account_type': 'asset_current',
             'company_ids': [Command.link(company_2.id)]
         })
         self.assertRecordValues(
@@ -60,8 +58,8 @@ class TestAccountAccount(TestAccountMergeCommon):
                 Command.create({'company_id': company_3.id, 'code': '180023'}),
             ],
             'name': 'My second account',
-            'account_type': 'asset_current',
             'company_ids': [Command.set([company_1.id, company_2.id, company_3.id])],
+            'tax_ids': [Command.set([self.company_data_2['default_tax_sale'].id])],
         })
         self.assertRecordValues(account_2, [{'code': '180021', 'company_ids': [company_1.id, company_2.id, company_3.id]}])
         self.assertRecordValues(account_2.with_company(company_2), [{'code': '180022'}])
@@ -92,6 +90,112 @@ class TestAccountAccount(TestAccountMergeCommon):
         self.assertRecordValues(account_copy_3.with_company(company_2), [{'code': '180023'}])
         self.assertRecordValues(account_copy_3.with_company(company_3), [{'code': '180024'}])
 
+        # Test that you can modify the code of an account in another company by writing on `code_mapping_ids`.
+        account_copy_3.code_mapping_ids[2].code = '180025'
+        self.assertRecordValues(account_copy_3.with_company(company_3), [{'code': '180025'}])
+
+        # Test that you can modify the code of an account in another company by passing a CREATE value to `code_mapping_ids` (needed for import).
+        account_copy_3.write({'code_mapping_ids': [Command.create({'company_id': company_3.id, 'code': '180026'})]})
+        self.assertRecordValues(account_copy_3.with_company(company_3), [{'code': '180026'}])
+
+    def test_ensure_code_unique(self):
+        ''' Test the `_ensure_code_unique` check method.
+
+            Check that it allows a code to be set on an account if and only if
+            there is no other account accessible from the child or parent companies of the account
+            that has the same code in that company.
+
+            Simultaneously, check that the `_search_new_account_code` method proposes codes that
+            would be accepted and skips codes that would be disallowed.
+        '''
+        # Create company hierarchy:
+        # parent_company -> {child_company_1, child_company_2}
+        # other_company is disjoint.
+
+        parent_company = self.company_data['company']
+        child_company_1 = self.env['res.company'].create([{
+            'name': 'Child Company 1',
+            'parent_id': parent_company.id,
+        }])
+        child_company_2 = self.env['res.company'].create([{
+            'name': 'Child Company 2',
+            'parent_id': parent_company.id,
+        }])
+        other_company = self.company_data_2['company']
+
+        # Set up an existing account in the other company.
+        self.env['account.account'].with_context({'allowed_company_ids': other_company.ids}).create([{
+            'name': 'Existing account in other company',
+            'company_ids': [Command.set(other_company.ids)],
+            'code_mapping_ids': [
+                Command.create({'company_id': other_company.id, 'code': '180001'}),
+                Command.create({'company_id': parent_company.id, 'code': '180001'}),
+            ]
+        }])
+
+        # 1. Check that the existing account in the other company does not prevent
+        # an account from being created with the same code in `parent_company`.
+        self.assertEqual(
+            self.env['account.account'].with_company(parent_company)._search_new_account_code('180001', cache=set()),
+            '180001',
+        )
+        self.env['account.account'].create([{
+            'name': 'Account in parent company',
+            'code': '180001',
+            'company_ids': [Command.set(parent_company.ids)],
+        }])
+
+        # 2. Check that now that there is an account in `parent_company` with code
+        # 180001, because that account is accessible in `child_company_1`, we cannot
+        # create another account with the same code in `child_company_1`.
+        self.assertEqual(
+            self.env['account.account'].with_company(child_company_1)._search_new_account_code('180001', cache=set()),
+            '180002',
+        )
+        with self.assertRaises(ValidationError):
+            self.env['account.account'].create([{
+                'name': 'Account in child company 1 (this should fail)',
+                'code': '180001',
+                'company_ids': [Command.set(child_company_1.ids)],
+            }])
+
+        # Now, create an account in `child_company_1` with a new code.
+        self.env['account.account'].create([{
+            'name': 'Account in child company 1',
+            'code': '180002',
+            'company_ids': [Command.set(child_company_1.ids)],
+        }])
+
+        # 3. Check that now that there is an account in `child_company_1` with code
+        # 180002, because any new accounts in `parent_company` are also accessible
+        # from `child_company_1`, we cannot create another account with the same
+        # code in `parent_company`.
+        self.assertEqual(
+            self.env['account.account'].with_company(parent_company)._search_new_account_code('180002', cache=set()),
+            '180003',
+        )
+        with self.assertRaises(ValidationError):
+            self.env['account.account'].create([{
+                'name': 'Account in parent company (this should fail)',
+                'code': '180002',
+                'company_ids': [Command.set(child_company_1.ids)],
+            }])
+
+        # 4. Check that we can create an account in `child_company_2` with code
+        # 180002, because it will not interfere with the account in `child_company_1`
+        # with code 180002.
+        self.assertEqual(
+            self.env['account.account'].with_company(child_company_2)._search_new_account_code('180002', cache=set()),
+            '180002',
+        )
+        self.env['account.account'].create([{
+            'name': 'Account in child company 2',
+            'code': '180002',
+            'company_ids': [Command.set(child_company_2.ids)],
+        }])
+
+    def test_account_company(self):
+        ''' Test the constraint on `account.company_ids`. '''
         # Test that at least one company is required on accounts.
         with self.assertRaises(UserError):
             self.company_data['default_account_revenue'].company_ids = False
@@ -114,7 +218,7 @@ class TestAccountAccount(TestAccountMergeCommon):
         })
 
         with self.assertRaises(UserError):
-            self.company_data['default_account_revenue'].company_ids = company_2
+            self.company_data['default_account_revenue'].company_ids = self.company_data_2['company']
 
     def test_toggle_reconcile(self):
         ''' Test the feature when the user sets an account as reconcile/not reconcile with existing journal entries. '''
@@ -283,9 +387,6 @@ class TestAccountAccount(TestAccountMergeCommon):
             'name': 'This name will be erase',
         })
 
-        self.env['account.account']._get_closest_parent_account(account_to_process, "name", default_value='The name was not given by the parent')
-        self.assertEqual(account_to_process.name, 'This name will be transferred to the child one')
-
         #  The account type and tags will be transferred automatically with the computes
         self.assertEqual(account_to_process.account_type, 'expense')
         self.assertEqual(account_to_process.tag_ids.name, 'Test tag')
@@ -415,7 +516,11 @@ class TestAccountAccount(TestAccountMergeCommon):
         """
         Test various scenarios when creating an account via a form
         """
-        account_form = Form(self.env['account.account'])
+        # We set `allowed_company_ids` here so that the `with_company(other_company)` in
+        # `account.code.mapping._inverse_code` creates a context with both the first active
+        # company and the other company, rather than with just the other company.
+        # In a client-side form, 'allowed_company_ids' will always be set in the context.
+        account_form = Form(self.env['account.account'].with_context({'allowed_company_ids': self.env.company.ids}))
         account_form.name = "A New Account 1"
 
         # code should not be set

--- a/addons/account/views/account_account_views.xml
+++ b/addons/account/views/account_account_views.xml
@@ -77,7 +77,7 @@
                             <page name="mapping" string="Mapping" groups="base.group_multi_company" invisible="not display_mapping_tab">
                                 <field name="code_mapping_ids" nolabel="1">
                                     <list editable="bottom">
-                                        <field name="company_id"/>
+                                        <field name="company_id" force_save="1"/>
                                         <field name="code"/>
                                     </list>
                                 </field>

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1569,7 +1569,7 @@ class BaseModel(metaclass=MetaModel):
             xid = record.get('id', False)
             # dbid
             dbid = False
-            if '.id' in record:
+            if record.get('.id'):
                 try:
                     dbid = int(record['.id'])
                 except ValueError:


### PR DESCRIPTION
When exporting a CoA in Excel format, the user can export the code mapping for all the companies via the `code_mapping_ids/company_id` and `code_mapping_ids/code` columns.

However, importing these values fails because the import transforms these values into `CREATE` commands on `code_mapping_ids`, which are currently not handled.

With this commit, we catch those CREATE commands in `account.account` `create` and `write` methods and modify the account's code in the relevant company.

In addition, we take the opportunity to correctly rewrite the `_ensure_code_is_unique` check method.

In https://github.com/odoo/odoo/pull/181352, we relaxed the constraint that prevented accounts from being mapped to an account code in a company the account doesn't belong to, if there already exists an account in that company that already has that code.

However, the `_ensure_code_is_unique` wasn't rigorously rewritten, and it didn't apply the check in a consistent manner. We now rewrite it and provide tests for it.

We also modify the `_search_new_account_codes` method accordingly, such that it proposes the first non-reserved account code.

Enterprise PR: https://github.com/odoo/enterprise/pull/71910

task-4247869