### PR TITLE
[FIX] hr_expense: only purchase journals in employee's expense journal settings

### DIFF
--- a/addons/hr_expense/models/res_config_settings.py
+++ b/addons/hr_expense/models/res_config_settings.py
@@ -15,7 +15,7 @@ class ResConfigSettings(models.TransientModel):
                                              config_parameter='hr_expense.use_mailgateway')
     module_hr_payroll_expense = fields.Boolean(string='Reimburse Expenses in Payslip')
     module_hr_expense_extract = fields.Boolean(string='Send bills to OCR to generate expenses')
-    expense_journal_id = fields.Many2one('account.journal', related='company_id.expense_journal_id', readonly=False, check_company=True)
+    expense_journal_id = fields.Many2one('account.journal', related='company_id.expense_journal_id', readonly=False, check_company=True, domain="[('type', '=', 'purchase')]")
     company_expense_allowed_payment_method_line_ids = fields.Many2many(
         comodel_name='account.payment.method.line',
         check_company=True,


### PR DESCRIPTION
## Steps:

1- Expenses
2- Settings
3- Employee Expense Journal: all the journals can be selected. It should be only "Purchase" journals.

This PR adds a filtering domain to the `expense_journal_id` field to filter out non 'purchase' journals.

opw-4251517

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
