### PR TITLE
[FIX] web_editor: fix cropper offset

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop.js
@@ -181,12 +181,13 @@ export class ImageCrop extends Component {
         this.$cropperImage = this.$('.o_we_cropper_img');
         const cropperImage = this.$cropperImage[0];
         [cropperImage.style.width, cropperImage.style.height] = [this.$media.width() + 'px', this.$media.height() + 'px'];
-        
+
         const sel = this.document.getSelection();
         sel && sel.removeAllRanges();
 
         // Overlaying the cropper image over the real image
-        const offset = this.$media.offset();
+        const mediaRect = this.media.getBoundingClientRect();
+        const offset = { left: mediaRect.left, top: mediaRect.top };
         offset.left += parseInt(this.$media.css('padding-left'));
         offset.top += parseInt(this.$media.css('padding-right'));
         const frameElement = this.$media[0].ownerDocument.defaultView.frameElement


### PR DESCRIPTION
Following commit [https://github.com/odoo/odoo/commit/189a7c96e6e26825dc05c0c6466576fe63aa091e] which removed the scroll from the
`#wrapwrap` element, the cropper offsets were wrongly calculated.

Steps to reproduce:
- Drop a random snippet
- Drop an image snippet below the other one
- Crop the image of the image snippet
=> The cropper preview is outside of the window, you have to scroll to
reach it.

[https://github.com/odoo/odoo/commit/189a7c96e6e26825dc05c0c6466576fe63aa091e]: https://github.com/odoo/odoo/commit/189a7c96e6e26825dc05c0c6466576fe63aa091e

task-4190506
opw-4333004