### PR TITLE
[IMP] point_of_sale,pos_restaurant: badge on floating orders

### DIFF
--- a/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.xml
+++ b/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.xml
@@ -8,12 +8,14 @@
             forceSmall="ui.isSmall and !env.inDialog"
         >
             <t t-set="order" t-value="scope.item" />
-            <button t-esc="order.getName()"
-                t-att-class="{ 'active': pos.get_order()?.id === order.id }"
-                class="btn btn-lg btn-secondary text-truncate mx-1"
-                style="min-width: 4rem;"
-                t-on-click="() => this.selectFloatingOrder(order)"
-            />
+            <div id="floating-order-container" class="position-relative">
+                <button t-esc="order.getName()"
+                    t-att-class="{ 'active': pos.get_order()?.id === order.id }"
+                    class="btn btn-lg btn-secondary text-truncate mx-1"
+                    style="min-width: 4rem;"
+                    t-on-click="() => this.selectFloatingOrder(order)"
+                />
+            </div>
         </ListContainer>
     </t>
 </templates>

--- a/addons/point_of_sale/static/src/app/generic_components/list_container/list_container.js
+++ b/addons/point_of_sale/static/src/app/generic_components/list_container/list_container.js
@@ -34,12 +34,12 @@ export class ListContainer extends Component {
     };
     static template = xml`
         <div class="overflow-hidden d-flex flex-grow-1" t-attf-class="{{props.class}}">
-            <button t-if="props.onClickPlus" class="list-plus-btn btn btn-secondary btn-lg me-1" t-on-click="props.onClickPlus">
+            <button t-if="props.onClickPlus" class="list-plus-btn btn btn-secondary btn-lg me-1 my-2" t-on-click="props.onClickPlus">
                 <i class="fa fa-fw fa-plus-circle" aria-hidden="true"/>
             </button>
             <button t-if="this.sizing.isLarger or props.forceSmall" t-on-click="toggle"
-                class="btn btn-secondary mx-1 fa fa-caret-down" />
-            <div class="overflow-hidden w-100 position-relative">
+                class="btn btn-secondary mx-1 fa fa-caret-down my-2" />
+            <div class="overflow-hidden w-100 position-relative py-2">
                 <div t-ref="container" class="d-flex w-100">
                     <div t-if="!props.forceSmall" t-foreach="props.items" t-as="item" t-key="item_index" t-att-class="{'invisible': shouldBeInvisible(item_index)}">
                         <t t-slot="default" item="item"/>

--- a/addons/pos_restaurant/static/src/overrides/components/order_tabs/order_tabs.xml
+++ b/addons/pos_restaurant/static/src/overrides/components/order_tabs/order_tabs.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_restaurant.OrderTabs" t-inherit="point_of_sale.OrderTabs" t-inherit-mode="extension">
+       <xpath expr="//div[@id='floating-order-container']" position="before">
+            <t t-set="changes" t-value="this.pos.getOrderChanges(false, order)" />
+        </xpath>
+        <xpath expr="//div[@id='floating-order-container']" position="inside">
+            <div t-if="(changes.nbrOfChanges or changes.nbrOfSkipped) and this.pos.config.module_pos_restaurant"
+                class="position-absolute rounded-circle d-flex align-items-center justify-content-center"
+                style="top: -7px; right: -6px; width: 1.5rem; height: 1.5rem"
+                t-attf-class="{{ changes.nbrOfChanges ? 'text-bg-danger bg-danger' : 'text-bg-info bg-info'}}">
+                <span t-esc="changes.nbrOfChanges || changes.nbrOfSkipped" />
+            </div>
+        </xpath>
+        <xpath expr="//div[@id='floating-order-container']" position="attributes">
+            <attribute name="t-att-class">{'me-2': (changes.nbrOfChanges || changes.nbrOfSkipped) and this.pos.config.module_pos_restaurant}</attribute>
+        </xpath>
+    </t>
+</templates>


### PR DESCRIPTION
Before this commit, no badge was displayed on the floating orders in the POS. This badge is used to show the number of changes in the order of the floating orders. Like its already implemented in the normal table.

This commit adds the badge on the floating orders in the POS.

taskId: 4256801
