### PR TITLE
[FIX] {l10n_ec,}website_sale: allow creation of new billing address

### DIFF
--- a/addons/l10n_ec_website_sale/static/tests/tours/website_sale_checkout_address.js
+++ b/addons/l10n_ec_website_sale/static/tests/tours/website_sale_checkout_address.js
@@ -24,3 +24,38 @@ registry.category("web_tour.tours").add("shop_checkout_address_ec", {
         },
     ],
 });
+
+registry.category("web_tour.tours").add("tour_new_billing_ec", {
+    test: true,
+    url: "/shop",
+    steps: () => [
+        ...tourUtils.addToCart({ productName: "Test Product" }),
+        tourUtils.goToCart({ quantity: 1 }),
+        {
+            content: "Go to checkout",
+            trigger: "a:contains('Checkout')",
+            run: "click",
+        },
+        {
+            content: "Fill vat",
+            trigger: "#o_vat",
+            run: "fill 111111111111",
+        },
+        {
+            content: "Save address",
+            trigger: "button#save_address",
+            run: "click",
+        },
+        {
+            content: "Add new billing address",
+            trigger: '.all_billing a[href^="/shop/address?address_type=billing"]:contains("Add address")',
+            run: "click",
+        },
+        ...tourUtils.fillAdressForm(),
+        {
+            content: "Save address",
+            trigger: "button#save_address",
+            run: "click",
+        },
+    ],
+});

--- a/addons/l10n_ec_website_sale/tests/test_l10n_ec_website_sale.py
+++ b/addons/l10n_ec_website_sale/tests/test_l10n_ec_website_sale.py
@@ -1,3 +1,5 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from odoo.tests.common import HttpCase, tagged
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
@@ -5,10 +7,6 @@ from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 @tagged('post_install_l10n', 'post_install', '-at_install')
 class TestUi(HttpCase, AccountTestInvoicingCommon):
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
 
     def test_checkout_address_ec(self):
         self.env.company.country_id = self.env.ref('base.ec').id
@@ -26,3 +24,32 @@ class TestUi(HttpCase, AccountTestInvoicingCommon):
         user_admin = self.env.ref('base.user_admin')
         user_admin.company_ids = user_admin.company_ids + self.env.company
         self.start_tour('/shop', 'shop_checkout_address_ec', login='admin')
+
+    def test_new_billing_ec(self):
+        self.env.company.country_id = self.env.ref('base.ec').id
+        self.env.ref('base.user_admin').write({
+            'company_id': self.env.company.id,
+            'company_ids': [(4, self.env.company.id)],
+        })
+        # Avoid Shipping/Billing address page
+        country_us_id = self.env['ir.model.data']._xmlid_to_res_id('base.us')
+        country_us_state_id = self.env['ir.model.data']._xmlid_to_res_id('base.state_us_39')
+        self.env.ref('base.partner_admin').write({
+            'street': '215 Vine St',
+            'city': 'Scranton',
+            'zip': '18503',
+            'country_id': country_us_id,
+            'state_id': country_us_state_id,
+            'phone': '+1 555-555-5555',
+            'email': 'admin@yourcompany.example.com',
+        })
+        self.env['product.product'].create({
+            'name': 'Test Product',
+            'sale_ok': True,
+            'website_published': True,
+        })
+        self.env['ir.config_parameter'].set_param('sale.automatic_invoice', True)
+        self.env['website'].get_current_website().company_id = self.env.company.id
+        user_admin = self.env.ref('base.user_admin')
+        user_admin.company_ids = user_admin.company_ids + self.env.company
+        self.start_tour('/shop', 'tour_new_billing_ec', login='admin')

--- a/addons/website_sale/static/src/js/address.js
+++ b/addons/website_sale/static/src/js/address.js
@@ -144,7 +144,7 @@ publicWidget.registry.websiteSaleAddress = publicWidget.Widget.extend({
 
     _getInputLabel(name) {
         const input = this.addressForm[name];
-        return input.parentElement.querySelector(`label[for='${input.id}']`);
+        return input?.parentElement.querySelector(`label[for='${input.id}']`);
     },
 
     _showInput(name) {
@@ -158,7 +158,10 @@ publicWidget.registry.websiteSaleAddress = publicWidget.Widget.extend({
     },
 
     _markRequired(name, required) {
-        this.addressForm[name].required = required;
+        const input = this.addressForm[name];
+        if (input) {
+            input.required = required;
+        }
         this._getInputLabel(name)?.classList.toggle('label-optional', !required);
     },
 


### PR DESCRIPTION
Steps to reproduce:
- Install `l10n_ec_website_sale`
- Change the company of the first website to 'EC Company'
- Change company of demo user to 'EC Company'
- Connect as demo
- Make a purchase
- Checkout and fill the address
- Create a new billing address

Issues:
A traceback appears, the reason is that `show_vat` is false here as we are editing a new billing address as such `partner_sudo != order_sudo.partner_id`.

https://github.com/odoo/odoo/blob/4c025f91d4a13c9a150c4c16ac9754da0b2c79e4/addons/website_sale/controllers/main.py#L1159-L1168

Since `show_vat` is False the VAT fields will not be shown.

https://github.com/odoo/odoo/blob/d61a8212ca795009ca4f39462991614a42e41700/addons/website_sale/views/templates.xml#L1990

However for ecuadorian company for example `vat` and `l10n_latam_identification_type_id` is set as mandatory.

https://github.com/odoo/odoo/blob/4c025f91d4a13c9a150c4c16ac9754da0b2c79e4/addons/l10n_ec_website_sale/controllers/main.py#L17-L18

This discrepancy causes a traceback later on as we are requiring a field which is not visible in the view.

https://github.com/odoo/odoo/blob/d61a8212ca795009ca4f39462991614a42e41700/addons/website_sale/static/src/js/address.js#L127-L135

opw-4139919