### PR TITLE
[FIX] mail: threads use real message in references

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3611,7 +3611,17 @@ class MailThread(models.AbstractModel):
         # SES SMTP may replace Message-Id and In-Reply-To refers an internal ID not stored in Odoo)
         message_sudo = message.sudo()
         if message_sudo.parent_id:
-            references = f'{message_sudo.parent_id.message_id} {message_sudo.message_id}'
+            invalid_parent = message_sudo.parent_id.message_type in ["notification", "user_notification"]
+            real_message = message_sudo.search(
+                [("message_type", "not in", ["notification", "user_notification"]),
+                 ("id", "in", message_sudo.parent_id.child_ids.ids)],
+                limit=1,
+                order="id asc"
+            )
+            if real_message and invalid_parent:
+                references = f'{real_message.message_id} {message_sudo.message_id}'
+            else:
+                references = f'{message_sudo.parent_id.message_id} {message_sudo.message_id}'
         else:
             references = message_sudo.message_id
         # prepare notification mail values


### PR DESCRIPTION
message.parent_id can refer to an internal notification, meaning the other side of the conversation is unaware of the message_id. This causes problems with mail threads, where the references header is used in order to determine the correct mail thread.

This is especially problematic in a scenario where 2 Odoo systems are trying to talk to each other through the helpdesk app, because an internal notification is made upon creating a ticket:
![image](https://github.com/user-attachments/assets/3c8c9655-6f19-4ffd-a845-92231cb0e19a)
![image](https://github.com/user-attachments/assets/3ea3e25b-3c3c-4950-8afa-c6267e166a63)

Imagine a scenario where Woody opens a support ticket for Marie, both of which are using Odoo's helpdesk app to communicate.
- Woody sends a message, including the message id and the notification id in the references.
- Marie automatically creates a new ticket based on the message id, and replies
- Woody receives a reference to Marie's message id + Woody's message id
- Woody sends back a reply with the internal notification message id + the new message id
- Marie received an email with 2 unknown message ids, so it creates a new ticket