### PR TITLE
[IMP] Improve accessibility of ConfirmationDialog and TranslationButton

### DIFF
--- a/addons/html_editor/static/src/fields/html_field.scss
+++ b/addons/html_editor/static/src/fields/html_field.scss
@@ -7,14 +7,14 @@ textarea.o_codeview {
 }
 
 div.o_field_html {
-    span.o_field_translate {
+    button.o_field_translate {
         font-size: 15px;
         position: absolute;
         right: 5px;
         top: 5px;
     }
 
-    .o_show_codeview span.o_field_translate {
+    .o_show_codeview button.o_field_translate {
         right: 40px;
     }
 

--- a/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.xml
+++ b/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.xml
@@ -5,8 +5,8 @@
     <Dialog size="'md'" title="props.title" modalRef="modalRef">
       <p t-out="props.body" class="text-prewrap"/>
       <t t-set-slot="footer">
-        <button class="btn" t-att-class="props.confirmClass" t-on-click="_confirm" t-esc="props.confirmLabel"/>
-        <button t-if="props.cancel" class="btn btn-secondary" t-on-click="_cancel" t-esc="props.cancelLabel"/>
+        <button class="btn" t-att-class="props.confirmClass" t-on-click="_confirm" t-esc="props.confirmLabel" data-hotkey="q"/>
+        <button t-if="props.cancel" class="btn btn-secondary" t-on-click="_cancel" t-esc="props.cancelLabel" data-hotkey="x"/>
       </t>
     </Dialog>
   </t>

--- a/addons/web/static/src/views/fields/translation_button.xml
+++ b/addons/web/static/src/views/fields/translation_button.xml
@@ -3,9 +3,9 @@
 
     <t t-name="web.TranslationButton">
         <t t-if="isMultiLang">
-            <span class="o_field_translate btn btn-link" t-on-click.prevent="onClick">
+            <button class="o_field_translate btn btn-link" t-on-click.prevent="onClick">
                 <t t-esc="lang" />
-            </span>
+            </button>
         </t>
     </t>
 

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -649,7 +649,7 @@
     }
 
     // Translate icon
-    span.o_field_translate {
+    button.o_field_translate {
             padding: 0 $o-form-spacing-unit 0 0 !important;
             vertical-align: top;
             position: relative;
@@ -662,15 +662,15 @@
     }
 
     div {
-        div:focus-within > div.o_field_char_buttons > span.o_field_translate,
-        div:hover > div.o_field_char_buttons > span.o_field_translate {
+        div:focus-within > div.o_field_char_buttons > button.o_field_translate,
+        div:hover > div.o_field_char_buttons > button.o_field_translate {
             visibility: visible !important;
         }
     }
 
     div {
-        div:focus-within > span.o_field_translate,
-        div:hover > span.o_field_translate {
+        div:focus-within > button.o_field_translate,
+        div:hover > button.o_field_translate {
             visibility: visible !important;
         }
     }

--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -437,7 +437,7 @@
                 > input.o_field_translate,
                 textarea.o_field_translate {
                     padding-right: 25px;
-                    + span.o_field_translate {
+                    + button.o_field_translate {
                         margin-left: -35px;
                         padding: 0px 1px;
                         text-align: right;
@@ -582,7 +582,7 @@
         right: 0;
         left: 0;
         justify-content: center;
-        
+
         .o_list_selection_box {
             --#{$variable-prefix}list-group-active-color: #{$white};
             --#{$variable-prefix}list-group-active-border-color: RGB(var(--primary-rgb));

--- a/addons/web/static/tests/core/confirmation_dialog.test.js
+++ b/addons/web/static/tests/core/confirmation_dialog.test.js
@@ -166,6 +166,52 @@ test("clicking on 'Cancel'", async () => {
     expect.verifySteps(["Cancel action", "Close action"]);
 });
 
+test("hotkey on 'Ok'", async () => {
+    const env = await makeDialogMockEnv();
+    await mountWithCleanup(ConfirmationDialog, {
+        env,
+        props: {
+            body: "Some content",
+            title: "Confirmation",
+            close: () => {
+                expect.step("Close action");
+            },
+            confirm: () => {
+                expect.step("Confirm action");
+            },
+            cancel: () => {
+                throw new Error("should not be called");
+            },
+        },
+    });
+    expect.verifySteps([]);
+    await press("alt+q");
+    expect.verifySteps(["Confirm action", "Close action"]);
+});
+
+test("hotkey on 'Cancel'", async () => {
+    const env = await makeDialogMockEnv();
+    await mountWithCleanup(ConfirmationDialog, {
+        env,
+        props: {
+            body: "Some content",
+            title: "Confirmation",
+            close: () => {
+                expect.step("Close action");
+            },
+            confirm: () => {
+                throw new Error("should not be called");
+            },
+            cancel: () => {
+                expect.step("Cancel action");
+            },
+        },
+    });
+    expect.verifySteps([]);
+    await press("alt+x");
+    expect.verifySteps(["Cancel action", "Close action"]);
+});
+
 test("can't click twice on 'Ok'", async () => {
     const env = await makeDialogMockEnv();
     await mountWithCleanup(ConfirmationDialog, {

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -8673,9 +8673,9 @@ test(`translate event correctly handled with multiple controllers`, async () => 
 
     await contains(`[name="product_id"] .o_external_button`, { visible: false }).click();
     await contains(`.o_field_translate`).click();
-    expect(`.o_dialog:eq(1) span.o_field_translate`).toHaveCount(1);
+    expect(`.o_dialog:eq(1) button.o_field_translate`).toHaveCount(1);
 
-    await contains(`.o_dialog:eq(1) span.o_field_translate`).click();
+    await contains(`.o_dialog:eq(1) button.o_field_translate`).click();
     expect.verifySteps(["get_field_translations"]);
 });
 

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -4432,7 +4432,7 @@ test(`fields are translatable in list view`, async () => {
     await contains(`.o_data_row .o_data_cell`).click();
     expect(`.o_data_row:eq(0)`).toHaveClass("o_selected_row");
 
-    await contains(`span.o_field_translate`).click();
+    await contains(`button.o_field_translate`).click();
     expect(`.o_translation_dialog`).toHaveCount(1);
     expect(`.o_translation_dialog .translation > input.o_field_char`).toHaveCount(2, {
         message: "modal should have 2 languages to translate",


### PR DESCRIPTION
This PR improve the accessibility of:

- `TranslationButton`: by turning it into a true `<button>` to allow keyboard interaction and have the right role
- `ConfirmationDialog`: by adding default hotkeys on the save and cancel buttons.

task-3680626