### PR TITLE
[FIX] html_editor: correctly position powerbuttons for RTL languages

### DIFF
--- a/addons/html_editor/static/src/main/power_buttons_plugin.js
+++ b/addons/html_editor/static/src/main/power_buttons_plugin.js
@@ -66,10 +66,7 @@ export class PowerButtonsPlugin extends Plugin {
             )
         ) {
             this.powerButtons.classList.remove("d-none");
-            let direction = block.getAttribute("dir");
-            if (block.tagName === "LI") {
-                direction = block.parentElement.getAttribute("dir");
-            }
+            const direction = closestElement(element, "[dir]")?.getAttribute("dir");
             this.powerButtons.setAttribute("dir", direction);
             this.setPowerButtonsPosition(block, direction);
         }


### PR DESCRIPTION
Description of the issue this PR addresses:

Previously, the positioning of powerbuttons only considered the `dir` attribute on the closest block element. However for true RTL languages like Arabic, the `dir` attribute is applied to the editable container, not the individual nodes. This commit makes sure that `dir` attribute of editable is taken into account when the closest block does not have its own `dir` attribute.

task-4259040

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
