### PR TITLE
[FIX] mail: change default (incoming) server type to IMAP

### DIFF
--- a/addons/mail/models/fetchmail.py
+++ b/addons/mail/models/fetchmail.py
@@ -79,7 +79,7 @@ class FetchmailServer(models.Model):
         ('imap', 'IMAP Server'),
         ('pop', 'POP Server'),
         ('local', 'Local Server'),
-    ], string='Server Type', index=True, required=True, default='pop')
+    ], string='Server Type', index=True, required=True, default='imap')
     server_type_info = fields.Text('Server Type Info', compute='_compute_server_type_info')
     is_ssl = fields.Boolean('SSL/TLS', help="Connections are encrypted with SSL/TLS through a dedicated port (default: IMAPS=993, POP3S=995)")
     attach = fields.Boolean('Keep Attachments', help="Whether attachments should be downloaded. "


### PR DESCRIPTION
Context:
The commit https://github.com/odoo/odoo/commit/eb2dd1d67464b75c0e480ebad95bc6cdb7372685 changed the order of the `server_type` selection to account for most used and/or most "logical" default protocol for mail fetching.

But one might argue we should also have changed the defaul to "imap" so that new incoming severs actually pre-select the IMAP protocol.

From experience, in real life use cases, 99% of the time we want IMAP for mail fetching because:
* Only unread mails are fetched (no fetching of unnecessary emails)
* Email are marked as read after processing and NOT deleted

Drawbacks of POP protocol that most end users are not necessarily aware of:
* After fetching emails are deleted on the fetched mail server, i.e. no hard copy of the original mail is kept which might be an issue if a bug in Odoo fetches the mail "correctly" (routing succeeded), but a downstream bug creates side effects (attachments deleted, wrong record creted)
* Since POP will try to fetch ALL mails in the inbox, if the customer (un)purposely hoards Odoo unrelated emails, these will be always fetched but never routed -> time spend for nothing routing, logs are spammed and percieved delay for fetching new emails (since older ones are processed for nothing over and over again)

Proposed solution:
Change `default` parameter to `imap` argument.
Will not change old records ad-hoc, but preset new incoming email servers. User is free to still change the server type if they feel the need to use the POP protocol.

Recent support tickets with related issues:
OPW-4206157
OPW-4229682

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
