### PR TITLE
[IMP] base, hr: add phone in user preferences

### DIFF
--- a/addons/hr/tests/test_self_user_access.py
+++ b/addons/hr/tests/test_self_user_access.py
@@ -188,6 +188,7 @@ class TestSelfAccessRights(TestHrCommon):
         vals = [
             {'tz': "Australia/Sydney"},
             {'email': "new@example.com"},
+            {'phone': "2154545"},
             {'signature': "<p>I'm Richard!</p>"},
             {'notification_type': "email"},
         ]
@@ -208,12 +209,6 @@ class TestSelfAccessRights(TestHrCommon):
         for v in vals:
             with self.assertRaises(AccessError):
                 self.hubert.with_user(self.richard).write(v)
-
-    def testWriteSelfPhoneEmployee(self):
-        # phone is a related from res.partner (from base) but added in SELF_READABLE_FIELDS
-        self.env['ir.config_parameter'].set_param('hr.hr_employee_self_edit', False)
-        with self.assertRaises(AccessError):
-            self.richard.with_user(self.richard).write({'phone': '2154545'})
 
     def testWriteOtherUserEmployee(self):
         for f in self.self_protected_fields_user:

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -349,7 +349,7 @@ class ResUsers(models.Model):
             'image_1024', 'image_512', 'image_256', 'image_128', 'lang', 'tz',
             'tz_offset', 'groups_id', 'partner_id', 'write_date', 'action_id',
             'avatar_1920', 'avatar_1024', 'avatar_512', 'avatar_256', 'avatar_128',
-            'share', 'device_ids', 'api_key_ids',
+            'share', 'device_ids', 'api_key_ids', 'phone',
         ]
 
     @property
@@ -357,7 +357,7 @@ class ResUsers(models.Model):
         """ The list of fields a user can write on their own user record.
         In order to add fields, please override this property on model extensions.
         """
-        return ['signature', 'action_id', 'company_id', 'email', 'name', 'image_1920', 'lang', 'tz', 'api_key_ids']
+        return ['signature', 'action_id', 'company_id', 'email', 'name', 'image_1920', 'lang', 'tz', 'api_key_ids', 'phone']
 
     def _default_groups(self):
         """Default groups for employees
@@ -408,6 +408,7 @@ class ResUsers(models.Model):
     # access to the user but not its corresponding partner
     name = fields.Char(related='partner_id.name', inherited=True, readonly=False)
     email = fields.Char(related='partner_id.email', inherited=True, readonly=False)
+    phone = fields.Char(related='partner_id.phone', inherited=True, readonly=False)
 
     accesses_count = fields.Integer('# Access Rights', help='Number of access rights that apply to the current user',
                                     compute='_compute_accesses_count', compute_sudo=True)

--- a/odoo/addons/base/tests/test_res_users.py
+++ b/odoo/addons/base/tests/test_res_users.py
@@ -266,6 +266,18 @@ class TestUsers(UsersCommonCase):
 
         self.assertEqual(user.context_get()['lang'], 'en_US')
 
+    def test_user_self_update(self):
+        """ Check that the user has access to write his phone. """
+        test_user = self.env['res.users'].create({'name': 'John Smith', 'login': 'jsmith'})
+        self.assertFalse(test_user.phone)
+        test_user.with_user(test_user).write({'phone': '2387478'})
+
+        self.assertEqual(
+            test_user.partner_id.phone,
+            '2387478',
+            "The phone of the partner_id shall be updated."
+        )
+
 @tagged('post_install', '-at_install')
 class TestUsers2(UsersCommonCase):
 

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -203,8 +203,16 @@
                             <label for="name"/>
                             <h1><field name="name" placeholder="e.g. John Doe" required="1"/></h1>
                             <field name="email" invisible="1"/><!-- needed to update partner's email from on_change_login() -->
-                            <label for="login" string="Email Address"/>
-                            <h2><field name="login" placeholder="e.g. email@yourcompany.com"/></h2>
+                            <div class="d-flex">
+                                <div class="col-7 me-5">
+                                    <label for="login" string="Email Address"/>
+                                    <h2><field name="login" placeholder="e.g. email@yourcompany.com"/></h2>
+                                </div>
+                                <div class="col-3 ms-5 w-100">
+                                    <label for="phone" string="Phone"/>
+                                    <h2><field name="phone" placeholder="e.g. 555-1234" widget="phone"/></h2>
+                                </div>
+                            </div>
                             <group>
                                 <field name="partner_id" groups="base.group_no_one"
                                         readonly="1"
@@ -432,6 +440,7 @@
                             <group name="preferences">
                                 <group>
                                     <field name="email" widget="email" readonly="0"/>
+                                    <field name="phone"/>
                                 </group>
                                 <group>
                                     <label for="lang"/>


### PR DESCRIPTION
**PURPOSE:**
Enable users to easily update their phone number even if the "Contacts" app is not available.

**SPECIFICATIONS:**
Adding the phone field below the email field in preferences.

Task-4247284