### PR TITLE
[FIX] website: fix text highlighting issue when undoing snippet

### DIFF
--- a/addons/website/static/src/js/text_processing.js
+++ b/addons/website/static/src/js/text_processing.js
@@ -297,7 +297,7 @@ export function applyTextHighlight(topTextEl, highlightID) {
         return;
     }
     const style = window.getComputedStyle(topTextEl);
-    if (!style.getPropertyValue("--text-highlight-width")) {
+    if (!style.getPropertyValue("--text-highlight-width") && style.fontSize) {
         // The default value for `--text-highlight-width` is 0.1em.
         topTextEl.style.setProperty("--text-highlight-width", `${Math.round(parseFloat(style.fontSize) * 0.1)}px`);
     }


### PR DESCRIPTION
Steps to reproduce:
- Drop  "Title" snippet.
- Select "Highlight" from toolbar.
- Select those highlight which have underline thickness of non zero.
- Now use swap snippet button. (yellow button)
- Now undo the last step.
- Notice underline has lost its thickness.

After this commit:
- highlighted text is no longer losing thickness of underline after
swapping and undo.

task-4219461


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
