### PR TITLE
[FIX] web: don't always open default form view

### DIFF
--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -275,7 +275,7 @@ export class ListController extends Component {
         }
     }
 
-    async openRecord(record) {
+    async openRecord(record, force = false) {
         await record.save();
         if (this.archInfo.openAction) {
             this.actionService.doActionButton({
@@ -291,7 +291,7 @@ export class ListController extends Component {
             });
         } else {
             const activeIds = this.model.root.records.map((datapoint) => datapoint.resId);
-            this.props.selectRecord(record.resId, { activeIds });
+            this.props.selectRecord(record.resId, { activeIds, force });
         }
     }
 
@@ -524,7 +524,7 @@ export class ListController extends Component {
         if (!this.isDomainSelected) {
             const resIds = await this.getSelectedResIds();
             const ids = resIds.length > 0 && resIds;
-            domain = [['id', 'in', ids]]
+            domain = [["id", "in", ids]];
         }
         return await rpc("/web/export/get_fields", {
             ...parentParams,

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -286,7 +286,7 @@
             <t t-if="hasOpenFormViewColumn">
                 <td class="o_list_record_open_form_view w-print-0 p-print-0 text-center"
                     t-on-keydown="(ev) => this.onCellKeydown(ev, group, record)"
-                    t-on-click.stop="() => isX2Many and record.isNew ? this.displaySaveNotification() : props.onOpenFormView(record)"
+                    t-on-click.stop="() => isX2Many and record.isNew ? this.displaySaveNotification() : props.onOpenFormView(record, true)"
                     tabindex="-1"
                 >
                     <button class="btn btn-link align-top text-end"

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -622,11 +622,11 @@ export function makeActionManager(env, router = _router) {
         if (typeof groupBy === "string") {
             groupBy = [groupBy];
         }
-        const openFormView = (resId, { activeIds, mode } = {}) => {
+        const openFormView = (resId, { activeIds, mode, force } = {}) => {
             if (target !== "new") {
                 if (_getView("form")) {
                     return switchView("form", { mode, resId, resIds: activeIds });
-                } else {
+                } else if (force || !resId) {
                     return doAction(
                         {
                             type: "ir.actions.act_window",

--- a/addons/web/static/tests/webclient/actions/window_action.test.js
+++ b/addons/web/static/tests/webclient/actions/window_action.test.js
@@ -213,7 +213,7 @@ test("can execute act_window actions from db ID", async () => {
     ]);
 });
 
-test("can open default form view with selectRecord when there is none in the action", async () => {
+test("click on a list row when there is no form in the action", async () => {
     stepAllNetworkCalls();
     await mountWithCleanup(WebClient);
     await getService("action").doAction(9);
@@ -226,11 +226,30 @@ test("can open default form view with selectRecord when there is none in the act
         "has_group",
     ]);
     await contains(".o_data_row:eq(0) .o_data_cell").click();
+    expect.verifySteps([]);
+});
+
+test("click on open form view button when there is no form in the action", async () => {
+    Pony._views[
+        "list,false"
+    ] = `<list editable="top" open_form_view="1"><field name="name"/></list>`;
+    stepAllNetworkCalls();
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction(9);
+    expect.verifySteps([
+        "/web/webclient/translations",
+        "/web/webclient/load_menus",
+        "/web/action/load",
+        "get_views",
+        "web_search_read",
+        "has_group",
+    ]);
+    await contains(".o_data_row:eq(0) .o_list_record_open_form_view").click();
     expect(".o_form_view").toHaveCount(1, { message: "should display the form view" });
     expect.verifySteps(["get_views", "web_read"]);
 });
 
-test("can open default form view with createRecord when there is none in the action", async () => {
+test("click on new record button in list when there is no form in the action", async () => {
     stepAllNetworkCalls();
     await mountWithCleanup(WebClient);
     await getService("action").doAction(9);


### PR DESCRIPTION
This commit tweaks the behavior of the openFormView function introduced in https://github.com/odoo/odoo/pull/176707 by making it fallback on the default form view only in create mode or when the caller explicitly wants it to (using the force parameter). This solves issues with some list views where we don't want to show the form view on click while keeping the spec intact in case of list's open_form_view button.

Task-4164683
