### PR TITLE
[FIX] website_sale: handle combos in eCommerce snippets

### DIFF
--- a/addons/website_sale/data/product_snippet_template_data.xml
+++ b/addons/website_sale/data/product_snippet_template_data.xml
@@ -41,6 +41,7 @@
                                     t-att-data-product-id="product_id"
                                     t-att-data-product-template-id="product_template_id"
                                     t-att-data-product-selected="record.is_product_variant"
+                                    t-att-data-is-combo="record.type == 'combo'"
                                 >
                                     <i class="fa fa-fw fa-shopping-cart"/>
                                 </button>
@@ -234,6 +235,7 @@
                                 t-att-data-product-id="product_id"
                                 t-att-data-product-template-id="product_template_id"
                                 t-att-data-product-selected="record.is_product_variant"
+                                t-att-data-is-combo="record.type == 'combo'"
                             >
                                 Add to Cart
                             </button>
@@ -279,6 +281,7 @@
                                         t-att-data-product-id="product_id"
                                         t-att-data-product-template-id="product_template_id"
                                         t-att-data-product-selected="record.is_product_variant"
+                                        t-att-data-is-combo="record.type == 'combo'"
                                     >
                                         Add to Cart
                                     </button>
@@ -336,6 +339,7 @@
                                             t-att-data-product-id="product_id"
                                             t-att-data-product-template-id="product_template_id"
                                             t-att-data-product-selected="record.is_product_variant"
+                                            t-att-data-is-combo="record.type == 'combo'"
                                         >
                                             <i class="fa fa-fw fa-shopping-cart"/>
                                         </button>
@@ -385,6 +389,7 @@
                                     t-att-data-product-id="product_id"
                                     t-att-data-product-template-id="product_template_id"
                                     t-att-data-product-selected="record.is_product_variant"
+                                    t-att-data-is-combo="record.type == 'combo'"
                                 >
                                     Add to Cart
                                 </button>

--- a/addons/website_sale/static/src/snippets/s_add_to_cart/000.js
+++ b/addons/website_sale/static/src/snippets/s_add_to_cart/000.js
@@ -23,9 +23,11 @@ publicWidget.registry.AddToCartSnippet = WebsiteSale.extend(cartHandlerMixin, {
         const action = dataset.action;
         const productId = parseInt(dataset.productVariantId);
         const productTemplateId = parseInt(dataset.productTemplateId);
+        const isCombo = dataset.isCombo;
 
-        if (!productId) {
+        if (!productId || isCombo) {
             this.rootProduct = {
+                product_id: productId,
                 product_template_id: productTemplateId,
                 quantity: 1,
                 product_custom_attribute_values: [],

--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.js
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.js
@@ -145,7 +145,7 @@ const DynamicSnippetProductsCard = WebsiteSale.extend({
      */
     async _onClickAddToCart(ev) {
         const button = ev.currentTarget
-        if (!button.dataset.productSelected) {
+        if (!button.dataset.productSelected || button.dataset.isCombo) {
             const dummy_form = document.createElement('form');
             dummy_form.setAttribute('method', 'post');
             dummy_form.setAttribute('action', '/shop/cart/update');


### PR DESCRIPTION
The "add to cart" and "products" snippets didn't handle combo products
correctly. This fix opens the combo configurator when a combo product is added
to the cart via one of those snippets.

opw-4250695