### PR TITLE
[FIX] l10n_ar_withholding: multicurrency fix

### DIFF
--- a/addons/l10n_ar_withholding/wizards/account_payment_register.py
+++ b/addons/l10n_ar_withholding/wizards/account_payment_register.py
@@ -78,10 +78,10 @@ class AccountPaymentRegister(models.TransientModel):
 
     def _get_conversion_rate(self):
         self.ensure_one()
-        if self.currency_id != self.source_currency_id:
+        if self.currency_id != self.company_id.currency_id:
             return self.env['res.currency']._get_conversion_rate(
                 self.currency_id,
-                self.source_currency_id,
+                self.company_id.currency_id,
                 self.company_id,
                 self.payment_date,
             )


### PR DESCRIPTION
Use Case :

Argentinian Company (pesos)

Invoice in USD
Payment received in USD, with withholding tax on it

The current logic will convert the withholding values from USD (payment currency) to USD (invoice currency) instead of converting to ARS (company currency) and set this value as balance.

This is of course incorrect.

opw-4150317

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
