### PR TITLE
[FIX] website: fix auto-slide not working in carousel snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -157,6 +157,7 @@
             'website/static/src/xml/website.cookies_warning.xml',
             'website/static/src/js/text_processing.js',
             'website/static/src/snippets/observing_cookie_mixin.js',
+            'website/static/src/snippets/s_carousel/000.js'
         ],
         'web.assets_frontend_minimal': [
             'website/static/src/js/content/inject_dom.js',

--- a/addons/website/static/src/snippets/s_carousel/000.js
+++ b/addons/website/static/src/snippets/s_carousel/000.js
@@ -1,0 +1,18 @@
+/** @odoo-module **/
+
+import publicWidget from "@web/legacy/js/public/public_widget";
+
+publicWidget.registry.Carousel = publicWidget.Widget.extend({
+    selector: ".s_carousel_wrapper",
+
+    /**
+     * @override
+     */
+    willStart() {
+        // TODO: remove in master
+        this.el.querySelector(".carousel").setAttribute("data-bs-ride", "carousel");
+        return this._super(...arguments);
+    },
+});
+
+export default publicWidget.registry.Carousel;


### PR DESCRIPTION
Previously, the carousel snippet was not auto-sliding after the speed set in the options.

This fix ensures that the carousel snippet auto-slides according to the configured speed. The Bootstrap attribute responsible for auto-slide was missing from the template. Adding this missing attribute restored the auto-slide functionality.

Additionally, auto-sliding is now prevented in edit mode, allowing manual control during editing, as this aligns with the current behavior of the existing code.

task-4251038