### PR TITLE
[FIX] web: list: monetary aggregate error message without aggregation

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -537,6 +537,11 @@ export class ListRenderer extends Component {
                 continue;
             }
             const { rawAttrs, widget } = this.props.list.activeFields[fieldName];
+            const func =
+                (rawAttrs.sum && "sum") ||
+                (rawAttrs.avg && "avg") ||
+                (rawAttrs.max && "max") ||
+                (rawAttrs.min && "min");
             let currencyId;
             if (type === "monetary" || widget === "monetary") {
                 const currencyField =
@@ -547,7 +552,7 @@ export class ListRenderer extends Component {
                     currencyField in this.props.list.activeFields &&
                     values[0][currencyField] &&
                     values[0][currencyField][0];
-                if (currencyId) {
+                if (currencyId && func) {
                     const sameCurrency = values.every(
                         (value) => currencyId === value[currencyField][0]
                     );
@@ -560,11 +565,6 @@ export class ListRenderer extends Component {
                     }
                 }
             }
-            const func =
-                (rawAttrs.sum && "sum") ||
-                (rawAttrs.avg && "avg") ||
-                (rawAttrs.max && "max") ||
-                (rawAttrs.min && "min");
             if (func) {
                 let aggregateValue = 0;
                 if (func === "max") {

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -3545,7 +3545,7 @@ QUnit.module("Views", (hooks) => {
                 <tree>
                     <field name="company_currency_id" invisible="1"/>
                     <field name="currency_id" invisible="1"/>
-                    <field name="amount"/>
+                    <field name="amount" sum="Sum"/>
                     <field name="amount_currency"/>
                 </tree>`,
             });
@@ -3564,6 +3564,12 @@ QUnit.module("Views", (hooks) => {
                 target.querySelectorAll("tfoot td")[1].textContent,
                 "—",
                 "aggregates monetary should never work if different currencies are used"
+            );
+            assert.strictEqual(
+                target.querySelectorAll("tfoot td")[2].textContent,
+                "",
+                "monetary aggregation should only be attempted with an active aggregation function" +
+                    " when using different currencies"
             );
         }
     );

--- a/doc/cla/individual/EluciferE.md
+++ b/doc/cla/individual/EluciferE.md
@@ -1,0 +1,11 @@
+Kazakhstan, 18/08/2023
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Evgeniy Lyuts. luciferevgeniy@bk.ru https://github.com/EluciferE


### PR DESCRIPTION
This commit fixes an issue with the display of list monetary aggregates where the error message saying that different currencies cannot be aggregated would show even when no aggregate method is set.

Steps to reproduce:
- Create a list view with monetary field and different currencies
- Don't set an aggregation method
- An aggregation row is wrongly added and contains the error message

Original PR: https://github.com/odoo/odoo/pull/132272
