### PR TITLE
[FIX] l10n_es: try loading the coa using parent company first

### DIFF
--- a/addons/l10n_es/migrations/5.4/end-migrate.py
+++ b/addons/l10n_es/migrations/5.4/end-migrate.py
@@ -3,5 +3,5 @@ from odoo import api, SUPERUSER_ID
 
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    for company in env['res.company'].search([('chart_template', 'like', r'es\_%')]):
+    for company in env['res.company'].search([('chart_template', 'like', r'es\_%')], order="parent_path"):
         env['account.chart.template'].try_loading(company.chart_template, company)


### PR DESCRIPTION
In migration and init scripts, when loading the chart of accounts or parts of it, we should always start with the parent companies to avoid creating duplicate chart records.This [file](https://github.com/odoo/odoo/pull/180029/commits/7b6fb92891e58c3d1de1cb9bd9b4c28354ba6f92) was merged last week.

comm PR odoo/odoo#182706
ent PR odoo/enterprise#71421

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
