### PR TITLE
[FIX] pos_event: fix remaining seats calculation

### DIFF
--- a/addons/pos_event/static/src/app/generic_components/product_card/product_card.js
+++ b/addons/pos_event/static/src/app/generic_components/product_card/product_card.js
@@ -4,6 +4,14 @@ import { patch } from "@web/core/utils/patch";
 
 patch(ProductCard.prototype, {
     get displayRemainingSeats() {
-        return Boolean(this.props.product.event_id) && this.props.product.event_id.seats_limited;
+        return Boolean(this.props.product.event_id);
+    },
+    get totalTicketSeats() {
+        return (
+            this.props.product.event_id?.event_ticket_ids?.reduce(
+                (acc, ticket) => acc + ticket.seats_available,
+                0
+            ) || 0
+        );
     },
 });

--- a/addons/pos_event/static/src/app/generic_components/product_card/product_card.xml
+++ b/addons/pos_event/static/src/app/generic_components/product_card/product_card.xml
@@ -5,10 +5,12 @@
             <attribute name="t-if" add="!this.props.product.event_id" separator=" and " />
         </xpath>
         <xpath expr="//div[hasclass('product-information-tag')]" position="after">
-            <div t-if="displayRemainingSeats"
-                class="shadow-sm m-1 py-1 px-2 rounded position-absolute top-0 end-0"
-                t-attf-class="{{ this.props.product.event_id.seats_available === 0 ? 'bg-danger text-white' : 'bg-white'}}">
-                <span t-esc="this.props.product.event_id.seats_available" /> left
+            <t t-set="availableSeats" t-value="this.totalTicketSeats" />
+            <div t-if="displayRemainingSeats" class="shadow-sm m-1 py-1 px-2 rounded position-absolute top-0 end-0 bg-white">
+                <span t-if="availableSeats > 0">
+                    <t t-esc="availableSeats" /> left
+                </span>
+                <span t-else="">Unlimited</span>
             </div>
         </xpath>
     </t>


### PR DESCRIPTION
Before this commit, we was using remaining seat information from the event itself. But event can have a global limitation of seats, and another limitation per ticket. So the information of remaining seats on the product_card on product_screen wasn't aligned on remanaining seats of all tickets.

This commit fix this by usging a sum of the remaining seats of all tickets.

taskId: 4259409

