### PR TITLE
[FIX] stock: use res_model string directly as new resModel

### DIFF
--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.js
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.js
@@ -51,10 +51,7 @@ export class StockForecasted extends Component {
         //Following is used as a fallback when the forecast is not called by an action but through browser's history
         if (!this.resModel) {
             if (this.props.action.res_model) {
-                const actionModel = await this.orm.read('ir.model', [Number(this.props.action.res_model)], ['model']);
-                if (actionModel[0]?.model) {
-                    this.resModel = actionModel[0].model
-                }
+                this.resModel = this.props.action.res_model;
             } else if (this.props.action._originalAction) {
                 const originalContextAction = JSON.parse(this.props.action._originalAction).context;
                 if (typeof originalContextAction === "string") {


### PR DESCRIPTION
**Current behavior:**
Opening a purchase order, clicking on the forecast report for a
product in an orderline, then navigating to a "Used By" link,
then clicking the back button in browser will reusult in a
traceback when MRP is installed.

**Expected behavior:**
No traceback.

**Steps to reproduce:**
*install mrp,purchase*
*enable reception report in settings*

1. Open a purchase order with a product that is used in another
order

2. Click on the forecast report on the order line

3. Click on a linked record in the "Used by" column in the
report table

4. Click the browser back button -> traceback

**Cause of the issue:**
When trying to rebuild context, we get the actual model name
provided by this.props.action.res_model. This was invariably
treated as a stringified number in a read call to `ir.model` to
try to get the model name -> result of the read is nonsense and
when it is later used in an RPC, it tries to read fields from a
nonexistent model.

**Fix:**
Get rid of the String -> Number conversion, directly use the
value in `res_model` as the new `this.resModel`.

opw-4181590