### PR TITLE
[FIX] l10n_it_edi_ndd: Payment method, state is already paid

### DIFF
--- a/addons/l10n_it_edi_ndd/models/account_move.py
+++ b/addons/l10n_it_edi_ndd/models/account_move.py
@@ -39,7 +39,7 @@ class AccountMove(models.Model):
                     if payment_method_line:
                         move.l10n_it_payment_method = payment_method_line.l10n_it_payment_method
                         continue  # Skip to the next move
-            if linked_payment := move.matched_payment_ids.filtered(lambda p: p.state == 'in_process')[:1]:
+            if linked_payment := move.matched_payment_ids.filtered(lambda p: p.state != 'draft')[:1]:
                 move.l10n_it_payment_method = linked_payment.payment_method_line_id.l10n_it_payment_method
                 continue
 


### PR DESCRIPTION
When computing the payment method, we searched for `in_process` but now we consider them `paid`, so we're just checking for `not draft` payments instead.

Related PR: odoo/odoo#178235

Runbot link: https://runbot.odoo.com/web#id=76193&model=runbot.build.error&menu_id=405
runbot-76193