### PR TITLE
[FIX] web_editor: link not getting selected from dropdown

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
@@ -77,6 +77,12 @@ export class LinkDialog extends Link {
         this.props.close();
     }
 
+    onUrlKeydown(ev) {
+        const isAutoCompleteDropdownOpen = document.querySelector(".o-autocomplete--dropdown-menu");
+        if (ev.key === "Enter" && !isAutoCompleteDropdownOpen) {
+            this.onSave(ev);
+        }
+    }
     //--------------------------------------------------------------------------
     // Private
     //--------------------------------------------------------------------------

--- a/addons/web_editor/static/src/xml/wysiwyg.xml
+++ b/addons/web_editor/static/src/xml/wysiwyg.xml
@@ -45,7 +45,7 @@
                         <div t-attf-class="mb-3 row o_url_input#{state.isButton ? ' d-none' : ''}">
                             <label class="col-form-label col-md-3" for="o_link_dialog_url_input">URL or Email</label>
                             <div class="col-md-9">
-                                <input type="text" name="url" class="form-control" id="o_link_dialog_url_input" required="required" t-ref="inputUrl" t-on-keypress="ev => ev.key === 'Enter' &amp;&amp; this.onSave(ev)"/>
+                                <input type="text" name="url" class="form-control" id="o_link_dialog_url_input" required="required" t-ref="inputUrl" t-on-keydown="onUrlKeydown"/>
                                 <div class="form-check o_strip_domain d-none">
                                     <input type="checkbox" id="o_link_dialog_url_strip_domain" checked="checked" class="form-check-input"/>
                                     <label for="o_link_dialog_url_strip_domain" class="form-check-label fw-normal">


### PR DESCRIPTION
### Steps to reproduce:

- Open the To-do app.
- Enter /link and provide a label.
- Type / (e.g., /web) in the link dialog to preload available links.
- Use the arrow keys to select a link from the dropdown.
- Press Enter.
- Edit the link again and check the result.

### Description of the issue/feature this PR addresses:

Selecting a link from the dropdown with Enter would directly apply the link in the dialog, ignoring the selected dropdown link.

### Desired behavior after PR is merged:

Selecting a link from dropdown with Enter now correctly updates the link dialog with the selected link, and pressing Enter again applies the updated link.