### PR TITLE
[FIX] mail: threads use real message in references

### DIFF
--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -659,7 +659,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def test_message_post_one_email_notification(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(admin=32, employee=32):
+        with self.assertQueryCount(admin=33, employee=33):
             record.message_post(
                 body='<p>Test Post Performances with an email ping</p>',
                 partner_ids=self.customer.ids,
@@ -863,7 +863,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         record = self.container.with_user(self.env.user)
 
         # about 20 (19?) queries per additional customer group
-        with self.assertQueryCount(admin=55, employee=54):
+        with self.assertQueryCount(admin=58, employee=57):
             record.message_post(
                 body='<p>Test Post Performances</p>',
                 message_type='comment',
@@ -881,7 +881,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         template_id = self.env.ref('test_mail.mail_test_container_tpl').id
 
         # about 20 (19 ?) queries per additional customer group
-        with self.assertQueryCount(admin=63, employee=62):
+        with self.assertQueryCount(admin=66, employee=65):
             record.message_post_with_template(template_id, message_type='comment', composition_mode='comment')
 
         self.assertEqual(record.message_ids[0].body, '<p>Adding stuff on %s</p>' % record.name)
@@ -1016,7 +1016,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.user_portal.partner_id | self.env.user.partner_id)
         self.assertEqual(len(rec1.message_ids), 1)
-        with self.assertQueryCount(admin=57, employee=57):
+        with self.assertQueryCount(admin=58, employee=58):
             rec.write({
                 'name': 'Test2',
                 'container_id': self.container.id,
@@ -1053,7 +1053,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.user_portal.partner_id | self.env.user.partner_id)
 
-        with self.assertQueryCount(admin=64, employee=64):
+        with self.assertQueryCount(admin=66, employee=66):
             rec.write({
                 'name': 'Test2',
                 'container_id': container_id,


### PR DESCRIPTION
message.parent_id can refer to an internal notification, meaning the other side of the conversation is unaware of the message_id. This causes problems with mail threads, where the references header is used in order to determine the correct mail thread.

This is especially problematic in a scenario where 2 Odoo systems are trying to talk to each other through the helpdesk app, because an internal notification is made upon creating a ticket:
![image](https://github.com/user-attachments/assets/3c8c9655-6f19-4ffd-a845-92231cb0e19a)
![image](https://github.com/user-attachments/assets/3ea3e25b-3c3c-4950-8afa-c6267e166a63)

Imagine a scenario where Woody opens a support ticket for Marie, both of which are using Odoo's helpdesk app to communicate.
- Woody sends a message, including the message id and the notification id in the references.
- Marie automatically creates a new ticket based on the message id, and replies
- Woody receives a reference to Marie's message id + Woody's message id
- Woody sends back a reply with the internal notification message id + the new message id
- Marie received an email with 2 unknown message ids, so it creates a new ticket