### PR TITLE
[IMP] mail: can manually unpin a sub-thread 

### DIFF
--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -129,7 +129,9 @@ export class Thread extends Record {
         compute() {
             return (
                 this.is_pinned ||
-                (["channel", "group"].includes(this.channel_type) && this.hasSelfAsMember)
+                (["channel", "group"].includes(this.channel_type) &&
+                    this.hasSelfAsMember &&
+                    !this.parent_channel_id)
             );
         },
         onUpdate() {

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -68,7 +68,13 @@ export class DiscussCoreCommon {
             if (thread) {
                 thread.is_pinned = false;
                 this.notificationService.add(
-                    _t("You unpinned your conversation with %s", thread.displayName),
+                    thread.parent_channel_id
+                        ? _t(`You unpinned %(conversation_name)s`, {
+                              conversation_name: thread.displayName,
+                          })
+                        : _t(`You unpinned your conversation with %(user_name)s`, {
+                              user_name: thread.displayName,
+                          }),
                     { type: "info" }
                 );
             }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
@@ -38,6 +38,25 @@ export class DiscussSidebarSubchannel extends Component {
         return this.props.thread;
     }
 
+    get commands() {
+        const commands = [];
+        if (this.thread.canUnpin) {
+            commands.push({
+                onSelect: () => this.thread.unpin(),
+                label: _t("Unpin Thread"),
+                icon: "oi oi-close",
+                sequence: 20,
+            });
+        }
+        return commands;
+    }
+
+    get sortedCommands() {
+        const commands = [...this.commands];
+        commands.sort((c1, c2) => c1.sequence - c2.sequence);
+        return commands;
+    }
+
     /** @param {MouseEvent} ev */
     openThread(ev, thread) {
         markEventHandled(ev, "sidebar.openThread");

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -144,6 +144,7 @@
                     'text-muted': !(thread.selfMember?.message_unread_counter > 0 and !thread.isMuted),
                 }"/>
                 <span class="flex-grow-1"/>
+                <t t-if="!store.discuss.isSidebarCompact" t-call="mail.DiscussSidebarChannel.commands"/>
                 <span t-if="thread.importantCounter > 0" t-attf-class="o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge fw-bold top-0 {{thread.isMuted ? 'o-muted' : ''}}" t-att-class="{ 'mx-1': !store.discuss.isSidebarCompact, 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact }" t-esc="thread.importantCounter"/>
             </button>
             <t t-if="thread.selfMember?.message_unread_counter > 0 and !thread.isMuted and thread.importantCounter === 0" t-call="mail.DiscussSidebar.unreadIndicator"/>

--- a/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
@@ -66,6 +66,12 @@ patch(Thread.prototype, {
         this.loadSubChannelsDone = false;
         this.lastSubChannelLoaded = null;
     },
+    get canLeave() {
+        return !this.parent_channel_id && super.canLeave;
+    },
+    get canUnpin() {
+        return (this.parent_channel_id && this.importantCounter === 0) || super.canUnpin;
+    },
     get allowCalls() {
         return super.allowCalls && !this.parent_channel_id;
     },

--- a/addons/mail/static/tests/discuss/core/public_web/sub_channels.test.js
+++ b/addons/mail/static/tests/discuss/core/public_web/sub_channels.test.js
@@ -41,6 +41,22 @@ test("navigate to sub channel", async () => {
     await contains(".o-mail-Discuss-threadName", { value: "New Thread" });
 });
 
+test("can manually unpin a sub-thread", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    await start();
+    await openDiscuss(channelId);
+    // Open thread so this is pinned
+    await contains(".o-mail-Discuss-threadName", { value: "General" });
+    await click("button[title='Threads']");
+    await click("button[aria-label='Create Thread']");
+    await contains(".o-mail-Discuss-threadName", { value: "New Thread" });
+    await click("button[title='Unpin Thread']", {
+        parent: [".o-mail-DiscussSidebar-item", { text: "New Thread" }],
+    });
+    await contains(".o-mail-DiscussSidebar-item", { text: "New Thread", count: 0 });
+});
+
 test("open sub channel menu from notification", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });


### PR DESCRIPTION
Sub-thread is pinned by default and user couldn't unpin it.
This commit lets user unpin the sub-thread manually.