### PR TITLE
[FIX] mail: handle messages without origin thread

### DIFF
--- a/addons/mail/static/src/core/web/mail_core_web_service.js
+++ b/addons/mail/static/src/core/web/mail_core_web_service.js
@@ -48,6 +48,9 @@ export class MailCoreWeb {
                 }
                 inbox.messages.add(message);
                 const thread = message.originThread;
+                if (!thread) {
+                    return;
+                }
                 if (message.notIn(thread.needactionMessages)) {
                     thread.message_needaction_counter++;
                 }


### PR DESCRIPTION
Reproduce
---
- -i hr_holidays
- open two secure user sessions
- 1st user session: set to handle notifications in odoo
- 2nd user session: tag 1st user in the chatter of a approved time off
- 1st user session: receives notification just fine
- 2nd user session: Refuse opened time off
- 1st user session: Traceback

opw-4138108

