### PR TITLE
[FIX] project: correct typographical mistakes

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -39,7 +39,7 @@
                         <filter string="Customer" name="customer" context="{'group_by': 'partner_id'}"/>
                         <filter string="Company" name="company_id" context="{'group_by': 'company_id'}" groups="base.group_multi_company"/>
                         <filter string="Creation Date" name="create_date" context="{'group_by': 'create_date'}"/>
-                        <filter string="Assignement Date" name="date_assign" context="{'group_by': 'date_assign'}"/>
+                        <filter string="Assignment Date" name="date_assign" context="{'group_by': 'date_assign'}"/>
                         <filter string="Last Stage Update" name="last_stage_update" context="{'group_by': 'date_last_stage_update'}"/>
                     </group>
                 </search>


### PR DESCRIPTION
**Before this commit:**

The `date_assign` field string contained a minor typographical error in the
`project.task` **Group By**.

**After this commit:**

The typographical error in the `Group by` has been corrected.