### PR TITLE
[FIX] account: Fixes to account.placeholder_code and display_name

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -48,7 +48,10 @@ class AccountAccount(models.Model):
     company_fiscal_country_code = fields.Char(compute='_compute_company_fiscal_country_code')
     code = fields.Char(string="Code", size=64, tracking=True, compute='_compute_code', search='_search_code', inverse='_inverse_code')
     code_store = fields.Char(company_dependent=True)
-    placeholder_code = fields.Char(string="Display code", compute='_compute_placeholder_code', search='_search_placeholder_code')
+    placeholder_code = fields.Char(
+        string="Placeholder code", compute='_compute_placeholder_code', search='_search_placeholder_code',
+        help="Code in a company to which the account belongs",
+    )
     deprecated = fields.Boolean(default=False, tracking=True)
     used = fields.Boolean(compute='_compute_used', search='_search_used')
     account_type = fields.Selection(
@@ -148,37 +151,37 @@ class AccountAccount(models.Model):
             return self.with_company(self.env.company.root_id).sudo()._field_to_sql(alias, 'code_store', query, flush)
         if fname == 'placeholder_code':
             query.add_join(
-                'JOIN',
+                'LEFT JOIN',
                 'account_first_company',
                 SQL(
                     """(
-                        SELECT DISTINCT ON (rel.account_account_id)
-                               rel.account_account_id AS account_id,
-                               rel.res_company_id AS company_id,
-                               SPLIT_PART(res_company.parent_path, '/', 1) AS root_company_id,
-                               res_company.name AS company_name
-                          FROM account_account_res_company_rel rel
-                          JOIN res_company
-                            ON res_company.id = rel.res_company_id
-                         WHERE rel.res_company_id IN %(authorized_company_ids)s
-                      ORDER BY rel.account_account_id, company_id
+                        SELECT DISTINCT ON (account_companies.account_account_id)
+                               account_companies.account_account_id AS account_id,
+                               account_companies.res_company_id AS company_id,
+                               SPLIT_PART(active_company.parent_path, '/', 1) AS root_company_id,
+                               active_company.name AS company_name
+                          FROM unnest(%(authorized_company_ids)s) WITH ORDINALITY AS active_company_ordering(id, idx)
+                          JOIN res_company active_company
+                            ON active_company.id = active_company_ordering.id
+                    CROSS JOIN unnest(string_to_array(active_company.parent_path, '/')) WITH ORDINALITY AS active_company_parent_ordering(id, idx)
+                          JOIN account_account_res_company_rel account_companies
+                            ON account_companies.res_company_id::text = active_company_parent_ordering.id
+                      ORDER BY account_companies.account_account_id,
+                               active_company_ordering.idx,
+                               active_company_parent_ordering.idx DESC
                     )""",
-                    authorized_company_ids=self.env.user._get_company_ids(),
+                    authorized_company_ids=list(self.env.companies.ids),
+                    to_flush=self._fields['company_ids'],
                 ),
                 SQL('account_first_company.account_id = %(account_id)s', account_id=SQL.identifier(alias, 'id')),
             )
 
-            # Can't have spaces because of how stupidly the `Model._read_group_orderby` method is written
-            # see https://github.com/odoo/odoo/blob/2a3466e8f86bc08594391658e08ba3416fb8307b/odoo/models.py#L2222
             return SQL(
-                "COALESCE("
-                "%(code_store)s->>%(active_company_root_id)s,"
-                "%(code_store)s->>%(account_first_company_root_id)s||'('||%(account_first_company_name)s||')'"
-                ")",
+                "%(code_store)s->>%(account_first_company_root_id)s || ' (' || %(account_first_company_name)s || ')'",
                 code_store=SQL.identifier(alias, 'code_store'),
-                active_company_root_id=self.env.company.root_id.id,
                 account_first_company_name=SQL.identifier('account_first_company', 'company_name'),
                 account_first_company_root_id=SQL.identifier('account_first_company', 'root_company_id'),
+                to_flush=self._fields['code_store'],
             )
 
         return super()._field_to_sql(alias, fname, query, flush)
@@ -351,7 +354,7 @@ class AccountAccount(models.Model):
     @api.constrains('code')
     def _check_account_code(self):
         for account in self:
-            if account.code and not re.match(ACCOUNT_CODE_REGEX, account.code):
+            if account.code and not re.match(ACCOUNT_CODE_REGEX, account.code) and self.env.company in account.company_ids:
                 raise ValidationError(_(
                     "The account code can only contain alphanumeric characters and dots."
                 ))
@@ -387,36 +390,45 @@ class AccountAccount(models.Model):
             # Need to set record.code with `company = self.env.company`, not `self.env.company.root_id`
             record_root.code_store = record.code
 
-    @api.depends_context('company')
+    @api.depends_context('allowed_company_ids')
     @api.depends('code')
     def _compute_placeholder_code(self):
         self.placeholder_code = False
         for record in self:
-            if record.code:
-                record.placeholder_code = record.code
-            elif authorized_companies := (record.company_ids & self.env['res.company'].browse(self.env.user._get_company_ids())).sorted('id'):
-                company = authorized_companies[0]
-                if code := record.with_company(company).code:
-                    record.placeholder_code = f'{code} ({company.name})'
+            company = next((c for c in self.env.companies if c.parent_ids & record.company_ids), None)
+            if company and (code := record.with_company(company).code):
+                record.placeholder_code = f'{code} ({company.name})'
 
     def _search_placeholder_code(self, operator, value):
-        if operator != '=like':
+        if operator not in ('=', '=like', '=ilike'):
             raise NotImplementedError
         query = Query(self.env, 'account_account')
         placeholder_code_sql = self.env['account.account']._field_to_sql('account_account', 'placeholder_code', query)
-        query.add_where(SQL("%s LIKE %s", placeholder_code_sql, value))
+        sql_operators = {
+            '=': '=',
+            '=like': 'LIKE',
+            '=ilike': 'ILIKE',
+        }
+        query.add_where(SQL("%s %s %s", placeholder_code_sql, SQL(sql_operators[operator]), value))
         return [('id', 'in', query)]
 
     @api.depends_context('company')
     @api.depends('code')
     def _compute_account_root(self):
         for record in self:
-            record.root_id = self.env['account.root']._from_account_code(record.placeholder_code)
+            record.root_id = self.env['account.root']._from_account_code(record.code or record.placeholder_code)
 
     def _search_account_root(self, operator, value):
         if operator in ['=', 'child_of']:
             root = self.env['account.root'].browse(value)
-            return [('placeholder_code', '=like', root.name + ('' if operator == '=' and not root.parent_id else '%'))]
+            value = root.name + ('' if operator == '=' and not root.parent_id else '%')
+            return [
+                '|',
+                ('code', '=like', value),
+                '&',
+                ('code', '=', False),
+                ('placeholder_code', '=like', value),
+            ]
         raise NotImplementedError
 
     def _search_panel_domain_image(self, field_name, domain, set_count=False, limit=False):
@@ -427,12 +439,13 @@ class AccountAccount(models.Model):
             return {}
 
         query_account = self.env['account.account']._search(domain, limit=limit)
-        placeholder_code_alias = self.env['account.account']._field_to_sql('account_account', 'code', query_account)
+        code = self._field_to_sql('account_account', 'code', query_account)
+        placeholder_code = self._field_to_sql('account_account', 'placeholder_code', query_account)
 
-        placeholder_codes = self.env.execute_query(query_account.select(placeholder_code_alias))
+        codes_or_placeholder_codes = self.env.execute_query(query_account.select(SQL("COALESCE(%s, %s)", code, placeholder_code)))
         return {
             (root := self.env['account.root']._from_account_code(code)).id: {'id': root.id, 'display_name': root.display_name}
-            for code, in placeholder_codes if code
+            for code, in codes_or_placeholder_codes if code
         }
 
     @api.depends_context('company')
@@ -837,11 +850,18 @@ class AccountAccount(models.Model):
             self.name = name
             self.code = code
 
-    @api.depends_context('company')
+    @api.depends_context('allowed_company_ids')
     @api.depends('code')
     def _compute_display_name(self):
         for account in self:
-            account.display_name = f"{account.code} {account.name}" if account.code else account.name
+            try:
+                company = next(c for c in self.env.companies if c.parent_ids & account.company_ids)
+                display_name_elements = [account.with_company(company).code, account.name]
+                if company != self.env.company:
+                    display_name_elements.append(f"({company.display_name})")
+            except StopIteration:
+                display_name_elements = [account.name]
+            account.display_name = " ".join(x for x in display_name_elements if x)
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default)

--- a/addons/account/views/account_account_views.xml
+++ b/addons/account/views/account_account_views.xml
@@ -142,7 +142,7 @@
             <field name="model">account.account</field>
             <field name="arch" type="xml">
                 <search string="Accounts">
-                    <field name="name" filter_domain="['|', ('name', 'ilike', self), ('code', '=ilike', self + '%')]" string="Account"/>
+                    <field name="name" filter_domain="['|', '|', ('name', 'ilike', self), ('code', '=ilike', self + '%'), ('placeholder_code', '=ilike', self + '%')]" string="Account"/>
                     <filter string="Receivable" name="receivableacc" domain="[('account_type','=','asset_receivable')]"/>
                     <filter string="Payable" name="payableacc" domain="[('account_type','=','liability_payable')]"/>
                     <filter string="Equity" name="equityacc" domain="[('internal_group','=', 'equity')]"/>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -24,7 +24,7 @@
                             <page string="Information" name="information">
                                 <group>
                                     <group string="Amount">
-                                        <field name="account_id" options="{'no_create': True}" domain="[('deprecated', '=', False)]" readonly="1"/>
+                                        <field name="account_id" options="{'no_create': True}" domain="[('deprecated', '=', False), ('company_ids', 'parent_of', company_id)]" readonly="1"/>
                                         <field name="debit" readonly="1"/>
                                         <field name="credit" readonly="1"/>
                                         <field name="balance" readonly="1"/>
@@ -165,7 +165,7 @@
                     <field name="company_id" groups="base.group_multi_company" readonly="1" optional="hide"/>
                     <field name="journal_id" readonly="1" options='{"no_open":True}' optional="hide"/>
                     <field name="move_name" string="Journal Entry" widget="open_move_widget"/>
-                    <field name="account_id" options="{'no_open': True, 'no_create': True}" domain="[('deprecated', '=', False)]" groups="account.group_account_readonly"/>
+                    <field name="account_id" options="{'no_open': True, 'no_create': True}" domain="[('deprecated', '=', False), ('company_ids', 'parent_of', company_id)]" groups="account.group_account_readonly"/>
                     <field name="partner_id" optional="show" readonly="move_type != 'entry'"/>
                     <field name="ref" optional="hide" readonly="False"/>
                     <field name="product_id" readonly="1" optional="hide"/>
@@ -1120,7 +1120,7 @@
                                                context="{'partner_id': partner_id, 'move_type': parent.move_type}"
                                                groups="account.group_account_readonly"
                                                options="{'no_quick_create': True}"
-                                               domain="[('deprecated', '=', False), ('account_type', 'not in', ('asset_receivable', 'liability_payable', 'off_balance'))]"
+                                               domain="[('deprecated', '=', False), ('company_ids', 'parent_of', company_id), ('account_type', 'not in', ('asset_receivable', 'liability_payable', 'off_balance'))]"
                                                required="display_type not in ('line_note', 'line_section')"/>
                                         <field name="analytic_distribution" widget="analytic_distribution"
                                                string="Analytic"
@@ -1225,7 +1225,7 @@
                                                 <field name="discount" string="Disc.%"/>
                                             </group>
                                             <group>
-                                                <field name="account_id" domain="[('deprecated', '=', False)]" options="{'no_create': True}" context="{'partner_id': partner_id, 'move_type': parent.move_type}"/>
+                                                <field name="account_id" domain="[('deprecated', '=', False), ('company_ids', 'parent_of', company_id)]" options="{'no_create': True}" context="{'partner_id': partner_id, 'move_type': parent.move_type}"/>
                                                 <field name="tax_ids" widget="many2many_tags"/>
                                                 <field name="analytic_distribution" widget="analytic_distribution" groups="analytic.group_analytic_accounting"/>
                                             </group>
@@ -1280,7 +1280,7 @@
                                         <field name="account_id"
                                                invisible="display_type in ('line_section', 'line_note')"
                                                required="display_type not in ('line_section', 'line_note')"
-                                               domain="[('deprecated', '=', False)]" />
+                                               domain="[('deprecated', '=', False), ('company_ids', 'parent_of', company_id)]" />
                                         <field name="partner_id"
                                                optional="show"
                                                domain="['|', ('parent_id', '=', False), ('is_company', '=', True)]"
@@ -1363,7 +1363,7 @@
                                     <!-- Form view to cover mobile use -->
                                     <form>
                                       <group>
-                                        <field name="account_id" domain="[('deprecated', '=', False)]"/>
+                                        <field name="account_id" domain="[('deprecated', '=', False), ('company_ids', 'parent_of', company_id)]"/>
                                         <field name="partner_id" domain="['|', ('parent_id', '=', False), ('is_company', '=', True)]"/>
                                         <field name="name"/>
                                         <field name="analytic_distribution" widget="analytic_distribution" groups="analytic.group_analytic_accounting"/>

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -249,7 +249,7 @@
                                    invisible="not accounting_date or state not in ['approved', 'done']"
                                    readonly="not is_editable"/>
                             <field name="account_id" options="{'no_create': True}"
-                                   domain="[('account_type', 'not in', ('asset_receivable','liability_payable','asset_cash','liability_credit_card')), ('deprecated', '=', False)]"
+                                   domain="[('account_type', 'not in', ('asset_receivable','liability_payable','asset_cash','liability_credit_card')), ('deprecated', '=', False), ('company_ids', 'parent_of', company_id)]"
                                    groups="account.group_account_readonly" readonly="not is_editable"
                                    context="{'default_company_id': company_id}"/>
                             <field name="analytic_distribution" widget="analytic_distribution"


### PR DESCRIPTION
- Fixed the `_field_to_sql` method so that `placeholder_code` doesn't show the company name if the account belongs to the active company;
- Fixed `_field_to_sql` to add a space in `placeholder_code`;
- Allow searching on `placeholder_code` with the `=` operator - this  allows the `account_id.placeholder_code` field to be used as a grouping key on reports.
- Changed the account's display_name so that if it belongs to other companies than the active one, the company names are displayed (in parentheses).
- Changed the `placeholder_code` so that it shows the code for one of the active companies (if the account is visible, then it must have a code in at least one of the active companies) rather than for one of the companies accessible to the user.
- Fix the `_field_to_sql` for `placeholder_code` so that we do a LEFT JOIN on the first company of the account that is in the environment. This avoids excluding accounts simply because none of the account's `company_ids` is present among the active companies (e.g. a search might be done with `sudo` in which case the active companies shouldn't restrict the results returned).

Enterprise PR: https://github.com/odoo/enterprise/pull/71813

task-4259552