### PR TITLE
[FIX] stock_account: fix error when clicking on Valuation by Lot/Serial number

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -79,7 +79,7 @@ will update the cost of every lot/serial number in stock."),
                     out_stock_valuation_layers = SVL.create(out_svl_vals_list)
                     if tmpl.valuation == 'real_time':
                         move_vals_list += Product._svl_empty_stock_am(out_stock_valuation_layers)
-                impacted_templates[tmpl] = (products, description, products_orig_quantity_svl)
+                    impacted_templates[tmpl] = (products, description, products_orig_quantity_svl)
 
         res = super(ProductTemplate, self).write(vals)
 


### PR DESCRIPTION
When the user clicks on the checkbox of ``Valuation by Lot/Serial number``,
a traceback will appear.

Steps to reproduce the error:

- Install ``stock_account`` module
- Create a product(type : Goods) > Track Inventory: ``By Unique Serial Number``
- Create one variant of that product
- Now, Open the product in one tab and open the product variant in another tab
- Click on the checkbox of ``Valuation by Lot/Serial number`` in both tabs

Traceback:
```
UnboundLocalError: cannot access local variable 'products' where it is not associated with a value
  File "odoo/http.py", line 2364, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1891, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1954, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 137, in retrying
    result = func()
  File "odoo/http.py", line 1921, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2168, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 330, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 728, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 35, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 517, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/sale_project/models/product_template.py", line 137, in write
    return super().write(vals)
  File "addons/stock_account/models/product.py", line 82, in write
    impacted_templates[tmpl] = (products, description, products_orig_quantity_svl)
```

https://github.com/odoo/odoo/blob/09fa1db600c31d2d04f0504f0412cbbc85ff7e3d/addons/stock_account/models/product.py#L77-L82
Here, the ``products`` variable is referenced before the assignment,
So, it will lead to the above traceback.

sentry-5991310335

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
