### PR TITLE
[FIX] point_of_sale: handle missing l10n_in_hsn_code

### DIFF
--- a/addons/l10n_in_pos/static/src/overrides/models/pos_order_line.js
+++ b/addons/l10n_in_pos/static/src/overrides/models/pos_order_line.js
@@ -10,7 +10,7 @@ patch(PosOrderline.prototype, {
     getDisplayData() {
         return {
             ...super.getDisplayData(),
-            l10n_in_hsn_code: this.get_product().l10n_in_hsn_code,
+            l10n_in_hsn_code: this.get_product().l10n_in_hsn_code || "",
         };
     },
 });


### PR DESCRIPTION
Before this commit, adding a product without the l10n_in_hsn_code field to an order would cause an error, as the system expected this field to be a string.

opw-4254897

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
