### PR TITLE
[FIX] l10n_de: fix the deletion of invoices that have corrupted attachments

### DIFF
--- a/addons/l10n_de/models/ir_attachment.py
+++ b/addons/l10n_de/models/ir_attachment.py
@@ -14,6 +14,7 @@ class IrAttachment(models.Model):
         audit_trail_attachments = self.filtered(lambda attachment:
             attachment.res_model == 'account.move'
             and attachment.res_id
+            and attachment.raw
             and guess_mimetype(attachment.raw) in (
                 'application/pdf',
                 'application/xml',


### PR DESCRIPTION
Before this commit:
Steps
1) Switch to DE company
2) Upload invoice using corrupted PDF (size = 0 KB)
3) Delete that invoice 
=> It shows an error with a traceback
File "/data/build/odoo/addons/l10n_de/models/ir_attachment.py", line 17, in <lambda> and guess_mimetype(attachment.raw) in (
  File "/data/build/odoo/odoo/tools/mimetypes.py", line 156, in _odoo_guess_mimetype if bin_data.startswith(signature):
AttributeError: 'bool' object has no attribute 'startswith'

After this commit:
Invoices in l10n_de with corrupted attachments will be deleted without errors

screen recording: https://drive.google.com/file/d/1TMjkwYbLZwEXyLfbSzjmDaO6jOrRk2RO/view?usp=sharing

opw-4115496
