### PR TITLE
[FIX] l10n_it_edi{_pa}: include split payment tax in credit note

### DIFF
--- a/addons/l10n_it_edi/models/account_invoice.py
+++ b/addons/l10n_it_edi/models/account_invoice.py
@@ -35,10 +35,13 @@ class AccountMove(models.Model):
     def _get_l10n_it_amount_split_payment(self):
         self.ensure_one()
         amount = 0.0
-        if self.is_invoice(True):
-            for line in [line for line in self.line_ids if line.tax_line_id]:
-                if line.tax_line_id._l10n_it_is_split_payment() and line.credit > 0.0:
-                    amount += line.credit
+        if self.is_sale_document(False):
+            for line in self.line_ids:
+                if line.tax_line_id and line.tax_line_id._l10n_it_is_split_payment():
+                    if self.move_type  == 'out_invoice':
+                        amount += line.credit
+                    else:
+                        amount += line.debit
         return amount
 
     @api.depends('edi_document_ids', 'edi_document_ids.attachment_id')

--- a/addons/l10n_it_edi/tests/expected_xmls/split_payment_cn.xml
+++ b/addons/l10n_it_edi/tests/expected_xmls/split_payment_cn.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<p:FatturaElettronica xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd" versione="FPA12">
+    <FatturaElettronicaHeader>
+        <DatiTrasmissione>
+            <IdTrasmittente>
+                <IdPaese>IT</IdPaese>
+                <IdCodice>01234560157</IdCodice>
+            </IdTrasmittente>
+            <FormatoTrasmissione>FPA12</FormatoTrasmissione>
+            <CodiceDestinatario>123456</CodiceDestinatario>
+            <ContattiTrasmittente>
+            </ContattiTrasmittente>
+        </DatiTrasmissione>
+        <CedentePrestatore>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>01234560157</IdCodice>
+                </IdFiscaleIVA>
+                <CodiceFiscale>01234560157</CodiceFiscale>
+                <Anagrafica>
+                    <Denominazione>company_2_data</Denominazione>
+                </Anagrafica>
+                <RegimeFiscale>RF01</RegimeFiscale>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>1234 Test Street </Indirizzo>
+                <CAP>12345</CAP>
+                <Comune>Prova</Comune>
+                <Nazione>IT</Nazione>
+            </Sede>
+        </CedentePrestatore>
+        <CessionarioCommittente>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>06655971007</IdCodice>
+                </IdFiscaleIVA>
+                <CodiceFiscale>06655971007</CodiceFiscale>
+                <Anagrafica>
+                        <Denominazione>pa partner</Denominazione>
+                </Anagrafica>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>Via Test PA </Indirizzo>
+                <CAP>32121</CAP>
+                <Comune>PA Town</Comune>
+                <Nazione>IT</Nazione>
+            </Sede>
+        </CessionarioCommittente>
+    </FatturaElettronicaHeader>
+    <FatturaElettronicaBody>
+        <DatiGenerali>
+            <DatiGeneraliDocumento>
+                <TipoDocumento>TD04</TipoDocumento>
+                <Divisa>EUR</Divisa>
+                <Data>2022-03-25</Data>
+                <Numero>RINV/2022/00001</Numero>
+                <ImportoTotaleDocumento>976.49</ImportoTotaleDocumento>
+            </DatiGeneraliDocumento>
+            <DatiFattureCollegate>
+                <IdDocumento>INV/2022/00001</IdDocumento>
+                <Data>2022-03-24</Data>
+            </DatiFattureCollegate>
+        </DatiGenerali>
+        <DatiBeniServizi>
+            <DettaglioLinee>
+                <NumeroLinea>1</NumeroLinea>
+                <Descrizione>standard_line</Descrizione>
+                <Quantita>1.00</Quantita>
+                <PrezzoUnitario>800.400000</PrezzoUnitario>
+                <PrezzoTotale>800.40</PrezzoTotale>
+                <AliquotaIVA>22.00</AliquotaIVA>
+            </DettaglioLinee>
+            <DatiRiepilogo>
+                <AliquotaIVA>22.00</AliquotaIVA>
+                    <ImponibileImporto>800.40</ImponibileImporto>
+                    <Imposta>176.09</Imposta>
+                <EsigibilitaIVA>S</EsigibilitaIVA>
+            </DatiRiepilogo>
+        </DatiBeniServizi>
+    </FatturaElettronicaBody>
+</p:FatturaElettronica>


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting and l10n_it_edi
- Switch to an Italian company (e.g. IT Company)
- Create an invoice:
  * Customer: [an Italian customer]
  * Product: [any]
  * Taxes: [a split payment tax] (e.g. 22% SP)
- Confirm the invoice
- Process to E-invoicing service
- Check the XML of the electronic invoice => <ImportoTotaleDocumento> node is including the tax amount
- Create a credit note (Full refund)
- Confirm the credit note
- Process to E-invoicing service
- Check the XML of the credit note

**Issue:**
<ImportoTotaleDocumento> node is not including the tax amount.

Task [link](https://www.odoo.com/odoo/project/967/tasks/4161435)
opw-4161435

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
