### PR TITLE
[FIX] l10n_din5008{*}: fix incorrect din5008 report addressing

### DIFF
--- a/addons/l10n_din5008/__manifest__.py
+++ b/addons/l10n_din5008/__manifest__.py
@@ -9,6 +9,7 @@
     'depends': ['account'],
     'data': [
         'report/din5008_report.xml',
+        'report/din5008_account_move_layout.xml',
         'data/report_layout.xml',
     ],
     'assets': {

--- a/addons/l10n_din5008/i18n/de.po
+++ b/addons/l10n_din5008/i18n/de.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-15 13:26+0000\n"
+"POT-Creation-Date: 2024-10-15 12:05+0000\n"
 "PO-Revision-Date: 2024-02-15 15:59+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -115,6 +115,13 @@ msgstr "Banken"
 #. odoo-python
 #: code:addons/l10n_din5008/models/account_move.py:0
 #, python-format
+msgid "Beneficiary:"
+msgstr "Leistungsempfänger:"
+
+#. module: l10n_din5008
+#. odoo-python
+#: code:addons/l10n_din5008/models/account_move.py:0
+#, python-format
 msgid "Cancelled Invoice"
 msgstr "Stornierte Rechnung"
 
@@ -218,20 +225,6 @@ msgid "Invoice No."
 msgstr "Rechnungsnr."
 
 #. module: l10n_din5008
-#. odoo-python
-#: code:addons/l10n_din5008/models/account_move.py:0
-#, python-format
-msgid "Invoicing Address:"
-msgstr "Rechnungsadresse:"
-
-#. module: l10n_din5008
-#. odoo-python
-#: code:addons/l10n_din5008/models/account_move.py:0
-#, python-format
-msgid "Invoicing and Shipping Address:"
-msgstr "Rechnungs- und Lieferadresse:"
-
-#. module: l10n_din5008
 #: model:ir.model,name:l10n_din5008.model_account_move
 msgid "Journal Entry"
 msgstr "Journalbuchung"
@@ -305,6 +298,7 @@ msgstr "Straße 2"
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.external_layout_din5008
+#: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
 msgid "Tax ID"
 msgstr "USt-IdNr."
 

--- a/addons/l10n_din5008/i18n/fr.po
+++ b/addons/l10n_din5008/i18n/fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~16.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-20 12:12+0000\n"
+"POT-Creation-Date: 2024-10-15 12:05+0000\n"
 "PO-Revision-Date: 2024-02-14 09:13+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -83,6 +83,13 @@ msgstr "BIC :"
 #: model:ir.model.fields,field_description:l10n_din5008.field_base_document_layout__bank_ids
 msgid "Banks"
 msgstr "Banques"
+
+#. module: l10n_din5008
+#. odoo-python
+#: code:addons/l10n_din5008/models/account_move.py:0
+#, python-format
+msgid "Beneficiary:"
+msgstr "Bénéficiaire :"
 
 #. module: l10n_din5008
 #. odoo-python
@@ -191,20 +198,6 @@ msgid "Invoice No."
 msgstr "N° de facture"
 
 #. module: l10n_din5008
-#. odoo-python
-#: code:addons/l10n_din5008/models/account_move.py:0
-#, python-format
-msgid "Invoicing Address:"
-msgstr "Adresse de facturation :"
-
-#. module: l10n_din5008
-#. odoo-python
-#: code:addons/l10n_din5008/models/account_move.py:0
-#, python-format
-msgid "Invoicing and Shipping Address:"
-msgstr "Adresse de facturation et d'expédition :"
-
-#. module: l10n_din5008
 #: model:ir.model,name:l10n_din5008.model_account_move
 msgid "Journal Entry"
 msgstr "Pièce comptable"
@@ -278,6 +271,7 @@ msgstr "Rue 2"
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.external_layout_din5008
+#: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
 msgid "Tax ID"
 msgstr "N° de TVA"
 

--- a/addons/l10n_din5008/i18n/it.po
+++ b/addons/l10n_din5008/i18n/it.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~16.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-20 12:12+0000\n"
+"POT-Creation-Date: 2024-10-15 12:05+0000\n"
 "PO-Revision-Date: 2024-02-14 09:14+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -83,6 +83,13 @@ msgstr "BIC:"
 #: model:ir.model.fields,field_description:l10n_din5008.field_base_document_layout__bank_ids
 msgid "Banks"
 msgstr "Banche"
+
+#. module: l10n_din5008
+#. odoo-python
+#: code:addons/l10n_din5008/models/account_move.py:0
+#, python-format
+msgid "Beneficiary:"
+msgstr "Beneficiario:"
 
 #. module: l10n_din5008
 #. odoo-python
@@ -191,20 +198,6 @@ msgid "Invoice No."
 msgstr "Fattura n."
 
 #. module: l10n_din5008
-#. odoo-python
-#: code:addons/l10n_din5008/models/account_move.py:0
-#, python-format
-msgid "Invoicing Address:"
-msgstr "Indirizzo di fatturazione:"
-
-#. module: l10n_din5008
-#. odoo-python
-#: code:addons/l10n_din5008/models/account_move.py:0
-#, python-format
-msgid "Invoicing and Shipping Address:"
-msgstr "Indirizzo di fatturazione e spedizione:"
-
-#. module: l10n_din5008
 #: model:ir.model,name:l10n_din5008.model_account_move
 msgid "Journal Entry"
 msgstr "Registrazioni contabili"
@@ -278,6 +271,7 @@ msgstr "Strada 2"
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.external_layout_din5008
+#: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
 msgid "Tax ID"
 msgstr "Partita IVA"
 

--- a/addons/l10n_din5008/i18n/l10n_din5008.pot
+++ b/addons/l10n_din5008/i18n/l10n_din5008.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0\n"
+"Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-22 14:43+0000\n"
-"PO-Revision-Date: 2024-02-22 14:43+0000\n"
+"POT-Creation-Date: 2024-11-18 10:17+0000\n"
+"PO-Revision-Date: 2024-11-18 10:17+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -79,6 +79,13 @@ msgstr ""
 #. module: l10n_din5008
 #: model:ir.model.fields,field_description:l10n_din5008.field_base_document_layout__bank_ids
 msgid "Banks"
+msgstr ""
+
+#. module: l10n_din5008
+#. odoo-python
+#: code:addons/l10n_din5008/models/account_move.py:0
+#, python-format
+msgid "Beneficiary:"
 msgstr ""
 
 #. module: l10n_din5008
@@ -188,21 +195,6 @@ msgid "Invoice No."
 msgstr ""
 
 #. module: l10n_din5008
-#. odoo-python
-#: code:addons/l10n_din5008/models/account_move.py:0
-#: code:addons/l10n_din5008/models/account_move.py:0
-#, python-format
-msgid "Invoicing Address:"
-msgstr ""
-
-#. module: l10n_din5008
-#. odoo-python
-#: code:addons/l10n_din5008/models/account_move.py:0
-#, python-format
-msgid "Invoicing and Shipping Address:"
-msgstr ""
-
-#. module: l10n_din5008
 #: model:ir.model,name:l10n_din5008.model_account_move
 msgid "Journal Entry"
 msgstr ""
@@ -253,7 +245,6 @@ msgstr ""
 #. module: l10n_din5008
 #. odoo-python
 #: code:addons/l10n_din5008/models/account_move.py:0
-#: code:addons/l10n_din5008/models/account_move.py:0
 #, python-format
 msgid "Shipping Address:"
 msgstr ""
@@ -277,6 +268,7 @@ msgstr ""
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.external_layout_din5008
+#: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
 msgid "Tax ID"
 msgstr ""
 

--- a/addons/l10n_din5008/models/account_move.py
+++ b/addons/l10n_din5008/models/account_move.py
@@ -53,18 +53,18 @@ class AccountMove(models.Model):
             # To avoid repetition in the address block.
             if different_partner_count <= 1:
                 continue
-            elif different_partner_count == 3:
-                data.extend([(_("Shipping Address:"), delivery_partner), (_("Invoicing Address:"), invoice_partner)])
-                continue
-            elif commercial_partner == invoice_partner:
+
+            if delivery_partner and delivery_partner != commercial_partner:
                 data.append((_("Shipping Address:"), delivery_partner))
-                continue
-            elif commercial_partner == delivery_partner:
-                data.append((_("Invoicing Address:"), invoice_partner))
-                continue
-            elif invoice_partner == delivery_partner:
-                data.append((_("Invoicing and Shipping Address:"), invoice_partner))
-                continue
+            if invoice_partner and invoice_partner != commercial_partner:
+                data.append((
+                    _("Beneficiary:"),
+                    commercial_partner,
+                    # if the invoice address is different from the company address,
+                    # the main address block will be the invoice address, and the
+                    # vat number will only be shown in the beneficiary address block.
+                    {'show_tax_id': True},
+                ))
 
     def check_field_access_rights(self, operation, field_names):
         field_names = super().check_field_access_rights(operation, field_names)

--- a/addons/l10n_din5008/report/din5008_account_move_layout.xml
+++ b/addons/l10n_din5008/report/din5008_account_move_layout.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <data>
+        <template id="external_layout_din5008_account_move" inherit_id="l10n_din5008.external_layout_din5008">
+            <xpath expr="//t[@t-set='address']" position="before">
+                <t t-if="o and o._name == 'account.move' and o.partner_id">
+                    <t t-set="address">
+                        <address class="mb-0" t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True}'/>
+                        <div t-if="o.partner_id.commercial_partner_id == o.partner_id and o.partner_id.commercial_partner_id.vat" id="partner_vat_address_same_as_shipping">
+                            <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-out="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
+                            <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/>
+                        </div>
+                    </t>
+                </t>
+            </xpath>
+        </template>
+    </data>
+</odoo>

--- a/addons/l10n_din5008/report/din5008_report.xml
+++ b/addons/l10n_din5008/report/din5008_report.xml
@@ -70,7 +70,7 @@
                                         <span>|</span> <span t-field="company.country_id.name"/>
                                     </t>
                                     <hr class="company_invoice_line" />
-                                    <t t-if="o and 'l10n_din5008_addresses' in o" t-set="address">
+                                    <t t-if="not address and o and 'l10n_din5008_addresses' in o" t-set="address">
                                         <address class="mb-0" t-field="o.partner_id.commercial_partner_id" t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True}'/>
                                         <div t-if="o.partner_id.commercial_partner_id.vat" id="partner_vat_address_same_as_shipping">
                                             <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-out="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
@@ -105,6 +105,10 @@
                                         <div class="shipping_address">
                                             <strong><t t-esc="doc_address[0]"/></strong>
                                             <div t-esc="doc_address[1]" t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True}'/>
+                                            <div t-if="len(doc_address) > 2 and isinstance(doc_address[2], dict) and doc_address[2].get('show_tax_id')" id="partner_vat_address_same_as_shipping">
+                                                <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-out="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
+                                                <t t-else="">Tax ID</t>: <span t-field="doc_address[1].vat"/>
+                                            </div>
                                         </div>
                                     </td>
                                 </t>

--- a/addons/l10n_din5008_repair/__manifest__.py
+++ b/addons/l10n_din5008_repair/__manifest__.py
@@ -8,6 +8,9 @@
         'l10n_din5008',
         'repair',
     ],
+    'data': [
+        'report/din5008_repair_order_layout.xml',
+    ],
     'auto_install': True,
     'license': 'LGPL-3',
 }

--- a/addons/l10n_din5008_repair/i18n/de.po
+++ b/addons/l10n_din5008_repair/i18n/de.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~16.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-15 13:26+0000\n"
+"POT-Creation-Date: 2024-10-16 08:41+0000\n"
 "PO-Revision-Date: 2024-02-15 16:01+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -62,3 +62,8 @@ msgstr "Reparaturauftrag"
 #, python-format
 msgid "Repair Quotation"
 msgstr "Kostenvoranschlag"
+
+#. module: l10n_din5008_repair
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_repair.report_repairorder
+msgid "Tax ID"
+msgstr "USt-IdNr."

--- a/addons/l10n_din5008_repair/i18n/fr.po
+++ b/addons/l10n_din5008_repair/i18n/fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~16.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-15 13:26+0000\n"
+"POT-Creation-Date: 2024-10-16 08:41+0000\n"
 "PO-Revision-Date: 2024-02-14 09:19+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -62,3 +62,8 @@ msgstr "Ordre de réparation"
 #, python-format
 msgid "Repair Quotation"
 msgstr "Devis de réparation"
+
+#. module: l10n_din5008_repair
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_repair.report_repairorder
+msgid "Tax ID"
+msgstr "N° TVA"

--- a/addons/l10n_din5008_repair/i18n/it.po
+++ b/addons/l10n_din5008_repair/i18n/it.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~16.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-15 13:26+0000\n"
+"POT-Creation-Date: 2024-10-16 08:41+0000\n"
 "PO-Revision-Date: 2024-02-14 09:20+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -62,3 +62,8 @@ msgstr "Ordine di riparazione"
 #, python-format
 msgid "Repair Quotation"
 msgstr "Preventivo riparazione"
+
+#. module: l10n_din5008_repair
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_repair.report_repairorder
+msgid "Tax ID"
+msgstr "Partita IVA"

--- a/addons/l10n_din5008_repair/i18n/l10n_din5008_repair.pot
+++ b/addons/l10n_din5008_repair/i18n/l10n_din5008_repair.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server saas~16.2\n"
+"Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-20 12:12+0000\n"
-"PO-Revision-Date: 2024-02-20 12:12+0000\n"
+"POT-Creation-Date: 2024-10-16 08:41+0000\n"
+"PO-Revision-Date: 2024-10-16 08:41+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -59,4 +59,9 @@ msgstr ""
 #: code:addons/l10n_din5008_repair/models/repair.py:0
 #, python-format
 msgid "Repair Quotation"
+msgstr ""
+
+#. module: l10n_din5008_repair
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_repair.report_repairorder
+msgid "Tax ID"
 msgstr ""

--- a/addons/l10n_din5008_repair/report/din5008_repair_order_layout.xml
+++ b/addons/l10n_din5008_repair/report/din5008_repair_order_layout.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <template id="external_layout_din5008_repairorder" inherit_id="l10n_din5008.external_layout_din5008">
+            <xpath expr="//t[@t-set='address']" position="before">
+                <t t-if="o and o._name == 'repair.order' and o.partner_id">
+                    <t t-set="address">
+                        <address class="mb-0" t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True}'/>
+                        <div t-if="o.partner_id.vat">
+                            <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-out="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
+                            <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/>
+                        </div>
+                    </t>
+                </t>
+            </xpath>
+        </template>
+    </data>
+</odoo>

--- a/addons/l10n_din5008_sale/__manifest__.py
+++ b/addons/l10n_din5008_sale/__manifest__.py
@@ -8,6 +8,9 @@
         'l10n_din5008',
         'sale',
     ],
+    'data': [
+        'report/din5008_sale_order_layout.xml',
+    ],
     'auto_install': True,
     'license': 'LGPL-3',
 }

--- a/addons/l10n_din5008_sale/i18n/de.po
+++ b/addons/l10n_din5008_sale/i18n/de.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~16.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-24 10:21+0000\n"
+"POT-Creation-Date: 2024-10-15 12:11+0000\n"
 "PO-Revision-Date: 2022-11-15 09:41+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -16,6 +16,13 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4.2\n"
+
+#. module: l10n_din5008_sale
+#. odoo-python
+#: code:addons/l10n_din5008_sale/models/sale.py:0
+#, python-format
+msgid "Beneficiary:"
+msgstr "Leistungsempfänger:"
 
 #. module: l10n_din5008_sale
 #. odoo-python
@@ -130,3 +137,8 @@ msgstr "Vertriebsmitarbeiter"
 #, python-format
 msgid "Shipping Address:"
 msgstr "Lieferadresse:"
+
+#. module: l10n_din5008_sale
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_sale.report_saleorder_document
+msgid "Tax ID"
+msgstr "USt-IdNr."

--- a/addons/l10n_din5008_sale/i18n/fr.po
+++ b/addons/l10n_din5008_sale/i18n/fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~16.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-20 12:12+0000\n"
+"POT-Creation-Date: 2024-10-15 12:11+0000\n"
 "PO-Revision-Date: 2023-01-06 14:41+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -16,6 +16,13 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.4.2\n"
+
+#. module: l10n_din5008_sale
+#. odoo-python
+#: code:addons/l10n_din5008_sale/models/sale.py:0
+#, python-format
+msgid "Beneficiary:"
+msgstr "Bénéficiaire :"
 
 #. module: l10n_din5008_sale
 #. odoo-python
@@ -130,3 +137,8 @@ msgstr "Vendeur"
 #, python-format
 msgid "Shipping Address:"
 msgstr "Adresse de livraison :"
+
+#. module: l10n_din5008_sale
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_sale.report_saleorder_document
+msgid "Tax ID"
+msgstr "N° de TVA"

--- a/addons/l10n_din5008_sale/i18n/it.po
+++ b/addons/l10n_din5008_sale/i18n/it.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~16.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-20 12:12+0000\n"
+"POT-Creation-Date: 2024-10-15 12:11+0000\n"
 "PO-Revision-Date: 2023-01-06 14:40+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -16,6 +16,13 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4.2\n"
+
+#. module: l10n_din5008_sale
+#. odoo-python
+#: code:addons/l10n_din5008_sale/models/sale.py:0
+#, python-format
+msgid "Beneficiary:"
+msgstr "Beneficiario:"
 
 #. module: l10n_din5008_sale
 #. odoo-python
@@ -130,3 +137,8 @@ msgstr "Ordine di vendita"
 #, python-format
 msgid "Shipping Address:"
 msgstr "Indirizzo di spedizione:"
+
+#. module: l10n_din5008_sale
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_sale.report_saleorder_document
+msgid "Tax ID"
+msgstr "Partita IVA"

--- a/addons/l10n_din5008_sale/i18n/l10n_din5008_sale.pot
+++ b/addons/l10n_din5008_sale/i18n/l10n_din5008_sale.pot
@@ -4,16 +4,23 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server saas~16.2\n"
+"Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-20 12:12+0000\n"
-"PO-Revision-Date: 2024-02-20 12:12+0000\n"
+"POT-Creation-Date: 2024-11-18 10:17+0000\n"
+"PO-Revision-Date: 2024-11-18 10:17+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: l10n_din5008_sale
+#. odoo-python
+#: code:addons/l10n_din5008_sale/models/sale.py:0
+#, python-format
+msgid "Beneficiary:"
+msgstr ""
 
 #. module: l10n_din5008_sale
 #. odoo-python
@@ -38,7 +45,6 @@ msgstr ""
 
 #. module: l10n_din5008_sale
 #. odoo-python
-#: code:addons/l10n_din5008_sale/models/sale.py:0
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 #, python-format
 msgid "Invoicing Address:"
@@ -129,4 +135,9 @@ msgstr ""
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 #, python-format
 msgid "Shipping Address:"
+msgstr ""
+
+#. module: l10n_din5008_sale
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_sale.report_saleorder_document
+msgid "Tax ID"
 msgstr ""

--- a/addons/l10n_din5008_sale/models/sale.py
+++ b/addons/l10n_din5008_sale/models/sale.py
@@ -51,18 +51,22 @@ class SaleOrder(models.Model):
             # To avoid repetition in the address block.
             if different_partner_count <= 1:
                 continue
-            elif different_partner_count == 3:
-                data.extend([(_("Shipping Address:"), delivery_partner), (_("Invoicing Address:"), invoice_partner)])
-                continue
-            elif commercial_partner == invoice_partner:
-                data.append((_("Shipping Address:"), delivery_partner))
-                continue
-            elif commercial_partner == delivery_partner:
-                data.append((_("Invoicing Address:"), invoice_partner))
-                continue
-            elif invoice_partner == delivery_partner:
-                data.append((_("Invoicing and Shipping Address:"), invoice_partner))
-                continue
+
+            if self._context.get('proforma'):
+                if delivery_partner and delivery_partner != commercial_partner:
+                    data.append((_("Shipping Address:"), delivery_partner))
+                if invoice_partner and invoice_partner != commercial_partner:
+                    # if the proforma invoice has an invoice address different from the company address,
+                    # the company address will have its separate address block.
+                    # we will not display the VAT number in the main address block, but in the beneficiary block
+                    data.append((_("Beneficiary:"), commercial_partner, {'show_tax_id': True}))
+            else:
+                if invoice_partner != delivery_partner and delivery_partner != commercial_partner:
+                    data.append((_("Shipping Address:"), delivery_partner))
+                if invoice_partner != delivery_partner and invoice_partner != commercial_partner:
+                    data.append((_("Invoicing Address:"), invoice_partner))
+                if invoice_partner == delivery_partner and invoice_partner != commercial_partner:
+                    data.append((_("Invoicing and Shipping Address:"), invoice_partner))
 
     def check_field_access_rights(self, operation, field_names):
         field_names = super().check_field_access_rights(operation, field_names)

--- a/addons/l10n_din5008_sale/report/din5008_sale_order_layout.xml
+++ b/addons/l10n_din5008_sale/report/din5008_sale_order_layout.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <template id="external_layout_din5008_saleorder" inherit_id="l10n_din5008.external_layout_din5008">
+            <xpath expr="//t[@t-set='address']" position="before">
+                <t t-if="doc and doc._name == 'sale.order' and doc.partner_id">
+                    <t t-set="address">
+                        <t t-if="doc.env.context.get('proforma')">
+                            <address class="mb-0" t-field="doc.partner_invoice_id" t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True}'/>
+                            <t t-set="main_addr_id" t-value="doc.partner_invoice_id"/>
+                            <div t-if="doc.partner_id.commercial_partner_id == doc.partner_invoice_id and main_addr_id.vat" id="partner_vat_address_same_as_shipping">
+                                <t t-if="doc.company_id.account_fiscal_country_id.vat_label" t-out="doc.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
+                                <t t-else="">Tax ID</t>: <span t-field="main_addr_id.vat"/>
+                            </div>
+                        </t>
+                        <t t-else="">
+                            <address class="mb-0" t-field="doc.partner_id.commercial_partner_id" t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True}'/>
+                            <t t-set="main_addr_id" t-value="doc.partner_id.commercial_partner_id"/>
+                            <div t-if="main_addr_id.vat" id="partner_vat_address_same_as_shipping">
+                                <t t-if="doc.company_id.account_fiscal_country_id.vat_label" t-out="doc.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
+                                <t t-else="">Tax ID</t>: <span t-field="main_addr_id.vat"/>
+                            </div>
+                        </t>
+                    </t>
+                </t>
+            </xpath>
+        </template>
+    </data>
+</odoo>

--- a/addons/l10n_din5008_stock/__manifest__.py
+++ b/addons/l10n_din5008_stock/__manifest__.py
@@ -8,6 +8,9 @@
         'l10n_din5008',
         'stock',
     ],
+    'data': [
+        'report/din5008_stock_picking_layout.xml',
+    ],
     'auto_install': True,
     'license': 'LGPL-3',
 }

--- a/addons/l10n_din5008_stock/i18n/de.po
+++ b/addons/l10n_din5008_stock/i18n/de.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~16.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-15 15:33+0000\n"
+"POT-Creation-Date: 2024-10-15 12:11+0000\n"
 "PO-Revision-Date: 2024-02-15 16:01+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -21,20 +21,25 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_din5008_stock/models/stock.py:0
 #, python-format
-msgid "Customer Address:"
-msgstr "Adresse des Kunden:"
+msgid "Beneficiary:"
+msgstr "Leistungsempfänger:"
 
 #. module: l10n_din5008_stock
 #. odoo-python
 #: code:addons/l10n_din5008_stock/models/stock.py:0
 #, python-format
-msgid "Delivery Address:"
-msgstr "Lieferadresse:"
+msgid "Customer Address:"
+msgstr "Kundenadresse:"
 
 #. module: l10n_din5008_stock
 #: model:ir.model.fields,field_description:l10n_din5008_stock.field_stock_picking__l10n_din5008_addresses
 msgid "L10N Din5008 Addresses"
 msgstr "L10N Din5008 Adressen"
+
+#. module: l10n_din5008_stock
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_stock.report_deliveryslip
+msgid "Tax ID"
+msgstr "USt-IdNr."
 
 #. module: l10n_din5008_stock
 #: model:ir.model,name:l10n_din5008_stock.model_stock_picking

--- a/addons/l10n_din5008_stock/i18n/fr.po
+++ b/addons/l10n_din5008_stock/i18n/fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~16.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-15 15:33+0000\n"
+"POT-Creation-Date: 2024-10-15 12:11+0000\n"
 "PO-Revision-Date: 2024-02-14 09:23+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -21,20 +21,25 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_din5008_stock/models/stock.py:0
 #, python-format
-msgid "Customer Address:"
-msgstr "Adresse du client :"
+msgid "Beneficiary:"
+msgstr "Bénéficiaire :"
 
 #. module: l10n_din5008_stock
 #. odoo-python
 #: code:addons/l10n_din5008_stock/models/stock.py:0
 #, python-format
-msgid "Delivery Address:"
-msgstr "Adresse de livraison :"
+msgid "Customer Address:"
+msgstr "Adresse du client :"
 
 #. module: l10n_din5008_stock
 #: model:ir.model.fields,field_description:l10n_din5008_stock.field_stock_picking__l10n_din5008_addresses
 msgid "L10N Din5008 Addresses"
 msgstr "Adresses L10N Din5008"
+
+#. module: l10n_din5008_stock
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_stock.report_deliveryslip
+msgid "Tax ID"
+msgstr "N° de TVA"
 
 #. module: l10n_din5008_stock
 #: model:ir.model,name:l10n_din5008_stock.model_stock_picking

--- a/addons/l10n_din5008_stock/i18n/it.po
+++ b/addons/l10n_din5008_stock/i18n/it.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~16.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-15 15:33+0000\n"
+"POT-Creation-Date: 2024-10-15 12:11+0000\n"
 "PO-Revision-Date: 2024-02-14 09:23+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -21,20 +21,25 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_din5008_stock/models/stock.py:0
 #, python-format
-msgid "Customer Address:"
-msgstr "Indirizzo cliente:"
+msgid "Beneficiary:"
+msgstr "Beneficiario:"
 
 #. module: l10n_din5008_stock
 #. odoo-python
 #: code:addons/l10n_din5008_stock/models/stock.py:0
 #, python-format
-msgid "Delivery Address:"
-msgstr "Indirizzo di consegna:"
+msgid "Customer Address:"
+msgstr "Indirizzo cliente:"
 
 #. module: l10n_din5008_stock
 #: model:ir.model.fields,field_description:l10n_din5008_stock.field_stock_picking__l10n_din5008_addresses
 msgid "L10N Din5008 Addresses"
 msgstr "Indirizzi L10N Din5008"
+
+#. module: l10n_din5008_stock
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_stock.report_deliveryslip
+msgid "Tax ID"
+msgstr "Partita IVA"
 
 #. module: l10n_din5008_stock
 #: model:ir.model,name:l10n_din5008_stock.model_stock_picking

--- a/addons/l10n_din5008_stock/i18n/l10n_din5008_stock.pot
+++ b/addons/l10n_din5008_stock/i18n/l10n_din5008_stock.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server saas~16.2\n"
+"Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-20 12:12+0000\n"
-"PO-Revision-Date: 2024-02-20 12:12+0000\n"
+"POT-Creation-Date: 2024-10-15 12:11+0000\n"
+"PO-Revision-Date: 2024-10-15 12:11+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -19,19 +19,24 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_din5008_stock/models/stock.py:0
 #, python-format
-msgid "Customer Address:"
+msgid "Beneficiary:"
 msgstr ""
 
 #. module: l10n_din5008_stock
 #. odoo-python
 #: code:addons/l10n_din5008_stock/models/stock.py:0
 #, python-format
-msgid "Delivery Address:"
+msgid "Customer Address:"
 msgstr ""
 
 #. module: l10n_din5008_stock
 #: model:ir.model.fields,field_description:l10n_din5008_stock.field_stock_picking__l10n_din5008_addresses
 msgid "L10N Din5008 Addresses"
+msgstr ""
+
+#. module: l10n_din5008_stock
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_stock.report_deliveryslip
+msgid "Tax ID"
 msgstr ""
 
 #. module: l10n_din5008_stock

--- a/addons/l10n_din5008_stock/models/stock.py
+++ b/addons/l10n_din5008_stock/models/stock.py
@@ -10,16 +10,26 @@ class StockPicking(models.Model):
     def _compute_l10n_din5008_addresses(self):
         for record in self:
             record.l10n_din5008_addresses = data = []
-            if record.partner_id:
-                if record.picking_type_id.code == 'incoming':
-                    data.append((_('Vendor Address:'), record.partner_id))
-                if record.picking_type_id.code == 'internal':
-                    data.append((_('Warehouse Address:'), record.partner_id))
-                if record.picking_type_id.code == 'outgoing' and record.move_ids_without_package and record.move_ids_without_package[0].partner_id \
-                        and record.move_ids_without_package[0].partner_id.id != record.partner_id.id:
-                    data.append((_('Customer Address:'), record.partner_id))
-                if record.picking_type_id.code == 'outgoing' and record.partner_id.id != record.partner_id.commercial_partner_id.id:
-                    data.append((_('Delivery Address:'), record.move_ids_without_package[0].partner_id))
+            if not record.partner_id:
+                continue
+            if record.picking_type_id.code == 'incoming':
+                data.append((_("Vendor Address:"), record.partner_id))
+            elif record.picking_type_id.code == 'internal':
+                data.append((_("Warehouse Address:"), record.partner_id))
+            elif record.picking_type_id.code == 'outgoing':
+                main_address_box = record.move_ids[0].partner_id if record.should_print_delivery_address() else record.partner_id
+                if main_address_box.id != record.partner_id.commercial_partner_id.id:
+                    data.append((
+                        _("Beneficiary:"),
+                        record.partner_id.commercial_partner_id,
+                        # If the main delivery address is not the company address,
+                        # the company address will have a separate beneficiary address block.
+                        # The VAT number will not be displayed in the main address block,
+                        # but in the beneficiary address block
+                        {'show_tax_id': True},
+                    ))
+                if main_address_box.id != record.partner_id.id:
+                    data.append((_("Customer Address:"), record.partner_id))
 
     def check_field_access_rights(self, operation, field_names):
         field_names = super().check_field_access_rights(operation, field_names)

--- a/addons/l10n_din5008_stock/report/din5008_stock_picking_layout.xml
+++ b/addons/l10n_din5008_stock/report/din5008_stock_picking_layout.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <data>
+        <template id="external_layout_din5008_deliveryslip" inherit_id="l10n_din5008.external_layout_din5008">
+            <xpath expr="//t[@t-set='address']" position="before">
+                <t t-if="o and o._name == 'stock.picking' and (o.should_print_delivery_address() or o.partner_id)">
+                    <t t-set="address">
+                        <t t-set="main_address" t-value="o.move_ids[0].partner_id if o.should_print_delivery_address() else o.partner_id"/>
+                        <t t-if="o.should_print_delivery_address()">
+                            <address class="mb-0" t-field="o.move_ids[0].partner_id" t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True}'/>
+                        </t>
+                        <t t-else="">
+                            <address class="mb-0" t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True}'/>
+                        </t>
+                        <div t-if="not (o.picking_type_id.code == 'outgoing' and main_address.id != o.partner_id.commercial_partner_id.id)" id="partner_vat_address_same_as_shipping">
+                            <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-out="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
+                            <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/>
+                        </div>
+                    </t>
+                </t>
+            </xpath>
+        </template>
+    </data>
+</odoo>


### PR DESCRIPTION
The DIN 5008 layout was not properly addressing reports on invoices and delivery slips. On invoices/pro-forma, the reports were not addressed to the correct partners (commercial partner instead of invoice partner). In the delivery slips the reports were not addressed to the delivery partner. This led to functionally and legally incorrect reports.

task-4089521