### PR TITLE
[FIX] mail: handling of deleted messages for unread message banner

### DIFF
--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -109,6 +109,7 @@ class ChannelMember(models.Model):
                       WHERE mail_message.model = 'discuss.channel'
                         AND mail_message.message_type NOT IN ('notification', 'user_notification')
                         AND mail_message.id >= discuss_channel_member.new_message_separator
+                        AND mail_message.body != ''
                         AND discuss_channel_member.id IN %(ids)s
                    GROUP BY discuss_channel_member.id
             """, {'ids': tuple(self.ids)})

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4533,6 +4533,13 @@ class MailThread(models.AbstractModel):
         empty_messages = message.sudo()._filter_empty()
         empty_messages._cleanup_side_records()
         empty_messages.write({'pinned_at': None})
+        # Notify front-end of messages deletion for accurate counters
+        if empty_messages:
+            self.env['bus.bus']._sendone(
+                empty_messages._bus_notification_target(),
+                'mail.message/delete',
+                {'message_ids': empty_messages.ids}
+            )
         attachments = message.attachment_ids.sorted("id")
         broadcast_store = Store(attachments)
         res = {

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -88,8 +88,8 @@ export class DiscussCoreCommon {
             if (message.thread) {
                 const { selfMember } = message.thread;
                 if (
-                    message.id > selfMember?.seen_message_id.id &&
-                    notifId > selfMember.message_unread_counter_bus_id
+                    message.id > (selfMember?.seen_message_id?.id ?? 0) &&
+                    notifId > selfMember?.message_unread_counter_bus_id
                 ) {
                     selfMember.message_unread_counter--;
                 }

--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -238,7 +238,7 @@ export function useMessageHighlight(duration = 2000) {
          * @param {import("models").Thread} thread
          */
         async highlightMessage(message, thread) {
-            if (thread.notEq(message.thread)) {
+            if (thread.notEq(message?.thread)) {
                 return;
             }
             await thread.loadAround(message.id);

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -648,6 +648,9 @@ async function mail_message_update_content(request) {
     if (body === "" && attachment_ids.length === 0) {
         MailMessage.write([message_id], { pinned_at: false });
         MailMessage._cleanup_side_records([message_id]);
+        BusBus._sendone(MailMessage._bus_notification_target(message_id), "mail.message/delete", {
+            message_ids: [message_id],
+        });
     }
     const [message] = MailMessage.search_read([["id", "=", message_id]]);
     const broadcast_store = new mailDataHelpers.Store(IrAttachment.browse(attachment_ids));


### PR DESCRIPTION
Before this commit, if a user deletes a message before the recipient sees it, the notification stays in the recipient's discuss and when the recipient tries to click on "1 new message", they get a traceback.

Steps to reproduce:
1. Send message as Mitchell Admin to Marc Demo
2. Delete said message
3. Open the conversation as Marc Demo
4. Click on the new message banner

The traceback happens because the highlighMessage hook tries to access a non-existing message.
This commit fixes the issue by:
- Adding a guard when accessing the message on the highlightMessage hook
- Sending a bus message to notify the front-end of a message deletion
- Changing the compute of the message unread counter as not to count deleted messages