### PR TITLE
[FIX] spreadsheet_dashboard: admin is internal user

### DIFF
--- a/addons/spreadsheet_dashboard/security/security.xml
+++ b/addons/spreadsheet_dashboard/security/security.xml
@@ -24,6 +24,7 @@
         <field name="name">Admin</field>
         <field name="category_id" ref="base.module_category_productivity_dashboard" />
         <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]" />
+        <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
     </record>
 
     <record id="spreadsheet_dashboard_share_create_uid_rule" model="ir.rule">


### PR DESCRIPTION
With this commit, all Dashboard Admins are also automatically internal users.

Steps to reproduce:

- install module spreadsheet_dashboard_edition
- run test `.test_session_info_with_right`

=> the test fails because of a combinaision of two factors:

- the user is granted the group `group_dashboard_manager` but he is not an internal user (which means he is a portal user)
- `_inverse_calendar_res_users_settings` creates `res.users.settings` for portal users (will be fixed independently) and it crashes in the readonly transaction



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
