### PR TITLE
[FIX] mail: handling of deleted messages for unread message banner

### DIFF
--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -109,6 +109,7 @@ class ChannelMember(models.Model):
                       WHERE mail_message.model = 'discuss.channel'
                         AND mail_message.message_type NOT IN ('notification', 'user_notification')
                         AND mail_message.id >= discuss_channel_member.new_message_separator
+                        AND mail_message.body != ''
                         AND discuss_channel_member.id IN %(ids)s
                    GROUP BY discuss_channel_member.id
             """, {'ids': tuple(self.ids)})

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -737,7 +737,7 @@ class Message(models.Model):
         # Notify front-end of messages deletion for partners having a user
         if messages_by_partner:
             self.env['bus.bus']._sendmany([
-                (partner, 'mail.message/delete', {'message_ids': messages.ids})
+                (partner, 'mail.message/delete', {'message_ids': messages.ids, 'delete_from_store': True})
                 for partner, messages in messages_by_partner.items()
             ])
 

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4533,6 +4533,12 @@ class MailThread(models.AbstractModel):
         empty_messages = message.sudo()._filter_empty()
         empty_messages._cleanup_side_records()
         empty_messages.write({'pinned_at': None})
+        if empty_messages:
+            self.env['bus.bus']._sendone(
+                empty_messages._bus_notification_target(),
+                'mail.message/delete',
+                {'message_ids': empty_messages.ids}
+            )
         attachments = message.attachment_ids.sorted("id")
         broadcast_store = Store(attachments)
         res = {

--- a/addons/mail/static/src/core/common/mail_core_common_service.js
+++ b/addons/mail/static/src/core/common/mail_core_common_service.js
@@ -29,7 +29,9 @@ export class MailCoreCommon {
                     continue;
                 }
                 this.env.bus.trigger("mail.message/delete", { message, notifId });
-                message.delete();
+                if (payload.delete_from_store) {
+                    message.delete();
+                }
             }
         });
         this.busService.subscribe("mail.message/toggle_star", (payload, metadata) =>

--- a/addons/mail/static/src/core/web/mail_core_web_service.js
+++ b/addons/mail/static/src/core/web/mail_core_web_service.js
@@ -26,9 +26,6 @@ export class MailCoreWeb {
             if (message.needaction && notifId > this.store.inbox.counter_bus_id) {
                 this.store.inbox.counter--;
             }
-            if (message.starred && notifId > this.store.starred.counter_bus_id) {
-                this.store.starred.counter--;
-            }
         });
         this.busService.subscribe("mail.message/inbox", (payload, { id: notifId }) => {
             const { Message: messages = [] } = this.store.insert(payload, { html: true });

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -88,8 +88,8 @@ export class DiscussCoreCommon {
             if (message.thread) {
                 const { selfMember } = message.thread;
                 if (
-                    message.id > selfMember?.seen_message_id.id &&
-                    notifId > selfMember.message_unread_counter_bus_id
+                    message.id > (selfMember?.seen_message_id?.id ?? 0) &&
+                    notifId > selfMember?.message_unread_counter_bus_id
                 ) {
                     selfMember.message_unread_counter--;
                 }

--- a/addons/mail/static/tests/crosstab/crosstab.test.js
+++ b/addons/mail/static/tests/crosstab/crosstab.test.js
@@ -192,9 +192,11 @@ test("Message delete notification", async () => {
     await click("[title='Mark as Todo']");
     await contains("button", { text: "Inbox", contains: [".badge", { text: "1" }] });
     await contains("button", { text: "Starred", contains: [".badge", { text: "1" }] });
-    const [partner] = pyEnv["res.partner"].read(serverState.partnerId);
-    pyEnv["bus.bus"]._sendone(partner, "mail.message/delete", {
-        message_ids: [messageId],
+    // simulate deleted message
+    rpc("/mail/message/update_content", {
+        message_id: messageId,
+        body: "",
+        attachment_ids: [],
     });
     await contains(".o-mail-Message", { count: 0 });
     await contains("button", { text: "Inbox", contains: [".badge", { count: 0 }] });

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -2190,3 +2190,67 @@ test("Read of unread chat where new message is deleted should mark as read [REQU
         contains: [".badge", { count: 0 }],
     });
 });
+
+test("Counter of unread messages of a channel member is updated after an unread message is deleted", async () => {
+    const pyEnv = await startServer();
+    const bobUserId = pyEnv["res.users"].create({ name: "bob" });
+    const bobPartnerId = pyEnv["res.partner"].create({ name: "bob", user_ids: [bobUserId] });
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: bobPartnerId }),
+        ],
+        channel_type: "chat",
+    });
+    const [memberId] = pyEnv["discuss.channel.member"].search([
+        ["channel_id", "=", channelId],
+        ["partner_id", "=", serverState.partnerId],
+    ]);
+    const messageId = pyEnv["mail.message"].create({
+        author_id: bobPartnerId,
+        body: "Hey!",
+        model: "discuss.channel",
+        res_id: channelId,
+        needaction: true,
+        message_type: "comment",
+    });
+    pyEnv["discuss.channel.member"].write([memberId], {
+        seen_message_id: messageId,
+        message_unread_counter: 0,
+    });
+    pyEnv["mail.notification"].create({
+        mail_message_id: messageId,
+        notification_status: "sent",
+        notification_type: "inbox",
+        res_partner_id: serverState.partnerId,
+    });
+    await start();
+    await openDiscuss();
+    // wait for Discuss rendering with messages to prevent race conditions problem
+    await contains(".o-mail-Message");
+    await withUser(bobUserId, () =>
+        rpc("/mail/message/post", {
+            post_data: { body: "Regrettable message", message_type: "comment" },
+            thread_id: channelId,
+            thread_model: "discuss.channel",
+        })
+    );
+    await contains(".o-mail-DiscussSidebar-item", {
+        text: "bob",
+        contains: [".badge", { text: "2" }],
+    });
+    // simulate bob deleting message
+    await withUser(bobUserId, () =>
+        rpc("/mail/message/update_content", {
+            message_id: 2,
+            body: "",
+            attachment_ids: [],
+        })
+    );
+    await contains(".o-mail-DiscussSidebar-item", {
+        text: "bob",
+        contains: [".badge", { text: "1" }],
+    });
+    await click("button", { text: "bob" });
+    await contains("span", { text: "1 new messageMark as Read" });
+});

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -648,6 +648,9 @@ async function mail_message_update_content(request) {
     if (body === "" && attachment_ids.length === 0) {
         MailMessage.write([message_id], { pinned_at: false });
         MailMessage._cleanup_side_records([message_id]);
+        BusBus._sendone(MailMessage._bus_notification_target(message_id), "mail.message/delete", {
+            message_ids: [message_id],
+        });
     }
     const [message] = MailMessage.search_read([["id", "=", message_id]]);
     const broadcast_store = new mailDataHelpers.Store(IrAttachment.browse(attachment_ids));


### PR DESCRIPTION
Before this commit, if a user deletes a message before the recipient sees it, the notification stays in the recipient's discuss and when the recipient tries to click on "1 new message", they get a traceback.

Steps to reproduce:
1. Send message as Mitchell Admin to Marc Demo
2. Delete said message
3. Open the conversation as Marc Demo
4. Click on the new message banner

The traceback happens because the highlighMessage hook tries to access a non-existing message.
This commit fixes the issue by:
- Adding a guard when accessing the message on the highlightMessage hook
- Sending a bus message to notify the front-end of a message deletion
- Changing the compute of the message unread counter as not to count deleted messages

task-4240887