### PR TITLE
[PERF] spreadsheet_dashboard: handcraft serialized json response

### DIFF
--- a/addons/spreadsheet/static/src/helpers/model.js
+++ b/addons/spreadsheet/static/src/helpers/model.js
@@ -19,9 +19,9 @@ import {
  */
 
 export async function fetchSpreadsheetModel(env, resModel, resId) {
-    const { data, revisions } = await env.services.orm.call(resModel, "join_spreadsheet_session", [
-        resId,
-    ]);
+    const { data, revisions } = await env.services.http.get(
+        `/spreadsheet/data/${resModel}/${resId}`
+    );
     return createSpreadsheetModel({ env, data, revisions });
 }
 
@@ -116,13 +116,20 @@ export async function freezeOdooData(model) {
                     for (let row = top; row <= bottom; row++) {
                         for (let col = left; col <= right; col++) {
                             const xc = toXC(col, row);
-                            const evaluatedCell = model.getters.getEvaluatedCell({ sheetId, col, row });
+                            const evaluatedCell = model.getters.getEvaluatedCell({
+                                sheetId,
+                                col,
+                                row,
+                            });
                             sheet.cells[xc] = {
                                 ...sheet.cells[xc],
                                 content: evaluatedCell.value.toString(),
                             };
                             if (evaluatedCell.format) {
-                                sheet.cells[xc].format = getItemId(evaluatedCell.format, data.formats);
+                                sheet.cells[xc].format = getItemId(
+                                    evaluatedCell.format,
+                                    data.formats
+                                );
                             }
                         }
                     }

--- a/addons/spreadsheet/utils/__init__.py
+++ b/addons/spreadsheet/utils/__init__.py
@@ -1,2 +1,3 @@
 from . import formatting
 from . import validate_data
+from . import json

--- a/addons/spreadsheet/utils/json.py
+++ b/addons/spreadsheet/utils/json.py
@@ -1,0 +1,17 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+def extend_serialized_json(json: str, key_value_pairs: list) -> str:
+    """
+    Add key-value pairs to a serialized JSON object string.
+    value should be already serialized.
+    """
+    # avoid copying strings as much as possible for performance reasons
+    parts = [json.rstrip('}')]
+    if json != '{}':
+        parts.append(',')
+    for i, (key, value) in enumerate(key_value_pairs):
+        parts.extend([f'"{key}":', value])
+        if i != len(key_value_pairs) - 1:
+            parts.append(',')
+    parts.append('}')
+    return ''.join(parts)

--- a/addons/spreadsheet_dashboard/controllers/__init__.py
+++ b/addons/spreadsheet_dashboard/controllers/__init__.py
@@ -1,1 +1,2 @@
 from . import share
+from . import dashboards_controllers

--- a/addons/spreadsheet_dashboard/controllers/dashboards_controllers.py
+++ b/addons/spreadsheet_dashboard/controllers/dashboards_controllers.py
@@ -1,0 +1,28 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import http
+from odoo.http import request
+
+
+class DashboardDataRoute(http.Controller):
+    @http.route(['/spreadsheet/dashboard/data/<model("spreadsheet.dashboard"):dashboard>'], type='http', auth='user')
+    def get_dashboard_data(self, dashboard):
+        dashboard = dashboard.exists()
+        if not dashboard:
+            raise request.not_found()
+        cids_str = request.cookies.get('cids', str(request.env.user.company_id.id))
+        cids = [int(cid) for cid in cids_str.split('-')]
+        dashboard = dashboard.with_context(allowed_company_ids=cids)
+        if dashboard._dashboard_is_empty() and dashboard.sample_dashboard_file_path:
+            sample_data = dashboard._get_sample_dashboard()
+            if sample_data:
+                return request.make_json_response({
+                    'snapshot': sample_data,
+                    'is_sample': True,
+                })
+        body = dashboard._get_serialized_readonly_dashboard()
+        headers = [
+            ('Content-Length', len(body)),
+            ('Content-Type', 'application/json; charset=utf-8'),
+        ]
+        return request.make_response(body, headers)

--- a/addons/spreadsheet_dashboard/models/spreadsheet_dashboard.py
+++ b/addons/spreadsheet_dashboard/models/spreadsheet_dashboard.py
@@ -43,24 +43,16 @@ class SpreadsheetDashboard(models.Model):
         else:
             self.sudo().favorite_user_ids = [Command.link(current_user_id)]
 
-    def get_readonly_dashboard(self):
-        self.ensure_one()
+    def _get_serialized_readonly_dashboard(self):
         snapshot = json.loads(self.spreadsheet_data)
-        if self._dashboard_is_empty() and self.sample_dashboard_file_path:
-            sample_data = self._get_sample_dashboard()
-            if sample_data:
-                return {
-                    "snapshot": sample_data,
-                    "is_sample": True,
-                }
         user_locale = self.env['res.lang']._get_user_spreadsheet_locale()
         snapshot.setdefault('settings', {})['locale'] = user_locale
         default_currency = self.env['res.currency'].get_company_currency_for_spreadsheet()
-        return {
+        return json.dumps({
             'snapshot': snapshot,
             'revisions': [],
             'default_currency': default_currency,
-        }
+        })
 
     def _get_sample_dashboard(self):
         try:

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_loader.js
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_loader.js
@@ -193,11 +193,10 @@ export class DashboardLoader {
         const dashboard = this._getDashboard(dashboardId);
         dashboard.status = Status.Loading;
         try {
-            const { snapshot, revisions, default_currency, is_sample } = await this.orm.call(
-                "spreadsheet.dashboard",
-                "get_readonly_dashboard",
-                [dashboardId]
+            const result = await this.env.services.http.get(
+                `/spreadsheet/dashboard/data/${dashboardId}`
             );
+            const { snapshot, revisions, default_currency, is_sample } = result;
             dashboard.model = this._createSpreadsheetModel(snapshot, revisions, default_currency);
             dashboard.status = Status.Loaded;
             dashboard.isSample = is_sample;

--- a/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action.test.js
+++ b/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action.test.js
@@ -7,7 +7,7 @@ import {
     defineSpreadsheetDashboardModels,
     getDashboardServerData,
 } from "@spreadsheet_dashboard/../tests/helpers/data";
-import { contains, patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { contains, onRpc, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { browser } from "@web/core/browser/browser";
 import { RPCError } from "@web/core/network/rpc";
 import { Deferred } from "@web/core/utils/concurrency";
@@ -145,19 +145,16 @@ test("display no dashboard message", async () => {
 
 test("display error message", async () => {
     onErrorHoot((ev) => ev.preventDefault());
-    await createSpreadsheetDashboard({
-        mockRPC: function (route, args) {
-            if (
-                args.model === "spreadsheet.dashboard" &&
-                args.method === "get_readonly_dashboard" &&
-                args.args[0] === 2
-            ) {
-                const error = new RPCError();
-                error.data = {};
-                throw error;
-            }
+    onRpc(
+        "/spreadsheet/dashboard/data/2",
+        () => {
+            const error = new RPCError();
+            error.data = {};
+            throw error;
         },
-    });
+        { pure: true }
+    );
+    await createSpreadsheetDashboard();
     const fixture = getFixture();
     const spreadsheets = fixture.querySelectorAll(".o_search_panel li");
     expect(".o-spreadsheet").toHaveCount(1, { message: "It should display the spreadsheet" });

--- a/addons/spreadsheet_dashboard/static/tests/helpers/data.js
+++ b/addons/spreadsheet_dashboard/static/tests/helpers/data.js
@@ -1,5 +1,5 @@
 import { SpreadsheetModels, defineSpreadsheetModels } from "@spreadsheet/../tests/helpers/data";
-import { fields, models } from "@web/../tests/web_test_helpers";
+import { fields, models, onRpc } from "@web/../tests/web_test_helpers";
 import { RPCError } from "@web/core/network/rpc";
 
 export function getDashboardServerData() {
@@ -27,19 +27,6 @@ export class SpreadsheetDashboard extends models.Model {
         for (const record of this) {
             record.is_favorite = record.favorite_user_ids.includes(this.env.uid);
         }
-    }
-
-    get_readonly_dashboard(id) {
-        const dashboard = this.env["spreadsheet.dashboard"].search_read([["id", "=", id]])[0];
-        if (!dashboard) {
-            const error = new RPCError();
-            error.data = {};
-            throw error;
-        }
-        return {
-            snapshot: JSON.parse(dashboard.spreadsheet_data),
-            revisions: [],
-        };
     }
 
     _records = [
@@ -81,6 +68,23 @@ export class SpreadsheetDashboardGroup extends models.Model {
         { id: 2, name: "Container 2", published_dashboard_ids: [3] },
     ];
 }
+
+function mockDashboardDataController(request) {
+    const parts = request.url.split("/");
+    const resId = parseInt(parts.at(-1));
+    const record = this.env["spreadsheet.dashboard"].search_read([["id", "=", resId]])[0];
+    if (!record) {
+        const error = new RPCError(`Dashboard ${resId} does not exist`);
+        error.data = {};
+        throw error;
+    }
+    return {
+        snapshot: JSON.parse(record.spreadsheet_data),
+        revisions: [],
+    };
+}
+
+onRpc("/spreadsheet/dashboard/data/*", mockDashboardDataController, { pure: true });
 
 export function defineSpreadsheetDashboardModels() {
     const SpreadsheetDashboardModels = [SpreadsheetDashboard, SpreadsheetDashboardGroup];

--- a/addons/spreadsheet_dashboard/tests/__init__.py
+++ b/addons/spreadsheet_dashboard/tests/__init__.py
@@ -1,4 +1,5 @@
 from . import test_spreadsheet_dashboard
 from . import test_dashboard_share
+from . import test_dashboard_controllers
 from . import test_share_dashboard_tour
 from . import test_share_controllers

--- a/addons/spreadsheet_dashboard/tests/test_dashboard_controllers.py
+++ b/addons/spreadsheet_dashboard/tests/test_dashboard_controllers.py
@@ -1,0 +1,49 @@
+
+from odoo.tests.common import HttpCase
+
+from .common import DashboardTestCommon
+
+
+class TestDashboardController(DashboardTestCommon, HttpCase):
+
+    def test_load_with_user_locale(self):
+        self.authenticate(self.user.login, self.user.password)
+        dashboard = self.create_dashboard().with_user(self.user)
+        self.user.lang = 'en_US'
+
+        response = self.url_open(f'/spreadsheet/dashboard/data/{dashboard.id}')
+        data = response.json()
+        locale = data['snapshot']['settings']['locale']
+        self.assertEqual(locale['code'], 'en_US')
+        self.assertEqual(len(data['revisions']), 0)
+
+        self.env.ref('base.lang_fr').active = True
+        self.user.lang = 'fr_FR'
+        response = self.url_open(f'/spreadsheet/dashboard/data/{dashboard.id}')
+        data = response.json()
+        locale = data['snapshot']['settings']['locale']
+        self.assertEqual(locale['code'], 'fr_FR')
+        self.assertEqual(len(data['revisions']), 0)
+
+    def test_load_with_company_currency(self):
+        self.authenticate(self.user.login, self.user.password)
+        dashboard = self.create_dashboard().with_user(self.user)
+        response = self.url_open(f'/spreadsheet/dashboard/data/{dashboard.id}')
+        data = response.json()
+        self.assertEqual(
+            data['default_currency'],
+            self.env['res.currency'].get_company_currency_for_spreadsheet()
+        )
+
+    def test_get_sample_dashboard(self):
+        self.authenticate(self.user.login, self.user.password)
+        sample_dashboard_path = 'spreadsheet_dashboard/tests/data/sample_dashboard.json'
+        dashboard = self.create_dashboard()
+        dashboard.sample_dashboard_file_path = sample_dashboard_path
+        dashboard.main_data_model_ids = [(4, self.env.ref('base.model_res_bank').id)]
+        self.env['res.bank'].search([]).action_archive()
+        response = self.url_open(f'/spreadsheet/dashboard/data/{dashboard.id}')
+        self.assertEqual(response.json(), {
+            'is_sample': True,
+            'snapshot': {'sheets': []},
+        })

--- a/addons/spreadsheet_dashboard/tests/test_spreadsheet_dashboard.py
+++ b/addons/spreadsheet_dashboard/tests/test_spreadsheet_dashboard.py
@@ -51,29 +51,6 @@ class TestSpreadsheetDashboard(DashboardTestCommon):
         with self.assertRaises(UserError, msg="You cannot delete a_group as it is used in another module"):
             group.unlink()
 
-    def test_load_with_user_locale(self):
-        dashboard = self.create_dashboard().with_user(self.user)
-        self.user.lang = "en_US"
-        data = dashboard.get_readonly_dashboard()
-        locale = data["snapshot"]["settings"]["locale"]
-        self.assertEqual(locale["code"], "en_US")
-        self.assertEqual(len(data["revisions"]), 0)
-
-        self.env.ref("base.lang_fr").active = True
-        self.user.lang = "fr_FR"
-        data = dashboard.get_readonly_dashboard()
-        locale = data["snapshot"]["settings"]["locale"]
-        self.assertEqual(locale["code"], "fr_FR")
-        self.assertEqual(len(data["revisions"]), 0)
-
-    def test_load_with_company_currency(self):
-        dashboard = self.create_dashboard().with_user(self.user)
-        data = dashboard.get_readonly_dashboard()
-        self.assertEqual(
-            data["default_currency"],
-            self.env["res.currency"].get_company_currency_for_spreadsheet()
-        )
-
     def test_unpublish_dashboard(self):
         group = self.env["spreadsheet.dashboard.group"].create({
             "name": "Dashboard group"
@@ -92,18 +69,6 @@ class TestSpreadsheetDashboard(DashboardTestCommon):
         self.assertFalse(group.published_dashboard_ids)
         dashboard.is_published = True
         self.assertEqual(group.published_dashboard_ids, dashboard)
-
-    def test_get_sample_dashboard(self):
-        sample_dashboard_path = "spreadsheet_dashboard/tests/data/sample_dashboard.json"
-        dashboard = self.create_dashboard()
-        dashboard.sample_dashboard_file_path = sample_dashboard_path
-        dashboard.main_data_model_ids = [(4, self.env.ref("base.model_res_users").id)]
-        self.env["res.users"].search([]).action_archive()
-
-        self.assertEqual(dashboard.with_user(self.user).get_readonly_dashboard(), {
-            "is_sample": True,
-            "snapshot": {"sheets": []},
-        })
 
     def test_toggle_favorite(self):
         dashboard = self.create_dashboard().with_user(self.user)

--- a/addons/web/static/tests/_framework/mock_server/mock_server.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_server.js
@@ -653,6 +653,9 @@ export class MockServer {
             }
             if (!isNil(result) || (options.alwaysReturns ?? routeOptions.alwaysReturns)) {
                 if (options.pure ?? routeOptions.pure) {
+                    if (result instanceof Error) {
+                        throw result;
+                    }
                     return result;
                 }
                 if (result instanceof RPCError) {


### PR DESCRIPTION
Server-side load time for a 16.7Mb spreadsheet:

**before: 606ms**  (`join_spreadsheet_session`)
**after: 83ms** (-86%!) (new `/spreadsheet/data/<...>` controller)

Previously, `join_spreadsheet_session` returned a combination of:

- The full spreadsheet snapshot (JSON file on the filestore)
- Pending revision data (also serialized JSON, stored in a Char field)
- Additional metadata

These were combined into a Python dict and re-serialized into JSON for the response. This process is inefficient as it involved unnecessary parsing and re-serialization of already serialized JSON data.

With this commit, we handcraft the json response body, avoiding the need for parsing and re-serializing large json objects, resulting in significant performance improvements in both CPU and memory.

To have control of the response body, we now have to use an http controller instead of an RPC method.

We could also have sent the raw/serialized data from `join_spreadsheet_session` but then it would be serialized json over json which has several drawbacks:
- reduces client-side debuggability
- introduce a lot of additional escape characters (e.g. `\"`)
- the client would need to explicitly parse the nested json

With this solution, the client receives a clean, valid json content type

Alternative idea: we could stream the snapshot file directly from the file store to be even more efficient. But then we would need to load the additional metadata and revisions with another http request. As those two requests would not be executed as part of the same transaction, it would come with its own share of issues.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
