### PR TITLE
[FIX] account: allow invoicing admin to create a branch

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -394,7 +394,7 @@ class ResCompany(models.Model):
         for company in companies:
             if root_template := company.parent_ids[0].chart_template:
                 def try_loading(company=company):
-                    self.env['account.chart.template']._load(
+                    self.env['account.chart.template'].sudo()._load(
                         root_template,
                         company,
                         install_demo=False,


### PR DESCRIPTION
**Steps to reproduce:**
- Install Invoicing
- Make sure that current user has "Invoicing: Administrator" rights
- Go to the configuration of a company
- Create a branch
- Save

**Issue:**
An Access Error is raised because a write is performed on an "account. reconcile.model.line" record while loading the chart template during the creation of the branch, but the user has not the appropriate group (i.e. Technical/Show Full Accounting Features).
The creation of a branch should be possible for a user with the "Invoicing: Admnistrator" rights, even if he has no edition right on "account.reconcile. model.line" model.

opw-4247717



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
