### PR TITLE
[FIX] account: no l10n module install when loading chart template

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -189,6 +189,7 @@ class AccountChartTemplate(models.AbstractModel):
             tracking_disable=True,
             delay_account_group_sync=True,
             lang='en_US',
+            chart_template_load=True,
         )
         company = self.env['res.company'].browse(company.id)  # also update company.pool
 

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -610,6 +610,9 @@ class ResCompany(models.Model):
         return account
 
     def install_l10n_modules(self):
+        if self.env.context.get('chart_template_load'):
+            # No automatic install during the loading of a chart_template
+            return False
         if res := super().install_l10n_modules():
             self.env.flush_all()
             self.env.reset()     # clear the set of environments


### PR DESCRIPTION
Currently there is the following problem when loading a chart template on a company.
In case the company has no country set the loading of the template may set it.
This can i.e. happen when the template specifies a `account_fiscal_country_id`.
Setting a country on a company (`write`) may trigger the installation of additional
localization modules related to the country (`install_l10n_modules`).
The problematic `write` happens in `_pre_load_data` but the actual
template data is not loaded yet (happens later in `_load_data`).

This can cause the following 2 issues.

Issue (1)
The new modules may add new data to the current template (modifies the
result of `_get_chart_template_data`).
But this new data is not considered during the current loading
since the template data is fetched before the automatic installation happens.
The module may not work as intended for companies w/o the new data though.
So we would have to reload the chart template manually.

Issue (2)
The auto-installation happens after the chart template info (field `chart_template`)
is set on the company but before the data is actually loaded.
The module installation may trigger a post init hook to set up new
data on companies with the current template (field `chart_template`).
This new setup may rely on the chart template data (from before the
module was installed) being laoded already though.

Issue (2) i.e. causes runbut build error-60149.
During the populate test a company with chart_template 'generic_coa'
is created which causes the installation of module `l10n_us_reports`
during the 'generic_coa' chart template loading.
There the deferred expense and revenue accounts are loaded in a post init hook
via `_load_data` for every company where the `chart_template` field has value 'generic_coa'.
```python
ChartTemplate._load_data({
    'res.company': , {
        company.id: {
            'deferred_expense_account_id': 'prepaid_expenses',
            'deferred_revenue_account_id': 'deferred_revenue',
        }
    }
})
```
Here 'prepaid_expenses' and 'deferred_revenue' are xmlids of accounts of the
'generic_coa' chart template from module 'account'.
Since the template data has not been loaded yet we cannot derefence
these 2 xmlids. In the log we get the following warning:
> Failed when trying to recover prepaid_expenses for field=res.company.deferred_expense_account_id

To avoid this problem we just skip the automatic installing in case we are in the process
of loading a chart template.

runbot build error-60149