### PR TITLE
[FIX] point_of_sale: product in pos category of same ancestry

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -373,9 +373,11 @@ export class ProductScreen extends Component {
 
     getProductsByCategory(category) {
         const allCategoryIds = category.getAllChildren().map((cat) => cat.id);
-        return allCategoryIds.flatMap(
+        const products = allCategoryIds.flatMap(
             (catId) => this.pos.models["product.product"].getBy("pos_categ_ids", catId) || []
         );
+        // Remove duplicates since owl doesn't like it.
+        return Array.from(new Set(products));
     }
 
     async onPressEnterKey() {

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -372,6 +372,7 @@ registry.category("web_tour.tours").add("PosCategoriesOrder", {
                 trigger: '.category-button:eq(1) > span:contains("AAB")',
                 run: "click",
             },
+            ProductScreen.productIsDisplayed("Product in AAB and AAX", 0),
             {
                 trigger: '.category-button:eq(2) > span:contains("AAX")',
             },

--- a/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
@@ -368,11 +368,17 @@ export function selectedOrderlineHas(productName, quantity, price) {
 export function orderIsEmpty() {
     return inLeftSide(Order.doesNotHaveLine());
 }
-export function productIsDisplayed(name) {
+
+/**
+ * @param {number} position The position of the product in the list. If -1 (default), the product can be anywhere in the list.
+ */
+export function productIsDisplayed(name, position = -1) {
     return [
         {
             content: `'${name}' should be displayed`,
-            trigger: `.product-list .product-name:contains("${name}")`,
+            trigger: `.product-list ${
+                position > -1 ? `article:eq(${position})` : ""
+            } .product-name:contains("${name}")`,
         },
     ];
 }

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1545,6 +1545,13 @@ class TestUi(TestPointOfSaleHttpCommon):
             'name': 'AAY',
             'parent_id': parentB.id,
         })
+        # Add a product that belongs to both parent and child categories.
+        # It's presence is checked during the tour to make sure app doesn't crash.
+        self.env['product.product'].create({
+            'name': 'Product in AAB and AAX',
+            'pos_categ_ids': [(6, 0, [parentA.id, parentB.id])],
+            'available_in_pos': True,
+        })
         self.main_pos_config.with_user(self.pos_admin).open_ui()
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PosCategoriesOrder', login="pos_admin")
 


### PR DESCRIPTION
Steps to reproduce:

1. Assign a product to category A and category B.
2. Make category A the parent of category B.
3. Put category A as restricted category of the pos.config.
4. Open the pos.config.
5. [ISSUE] click category A. The app crashes because of duplicate key.

This is because we are rendering 2 product cards with the same product coming from category A (the parent) and category B (the child).

To rectify, this commit proposes to remove the duplicates in the return value of `getProductsByCategory`.

