### PR TITLE
[FIX] mail: rename 'Copy Message Link' to 'Copy Link'

### DIFF
--- a/addons/im_livechat/static/tests/embed/message_actions.test.js
+++ b/addons/im_livechat/static/tests/embed/message_actions.test.js
@@ -41,7 +41,7 @@ test("Only two quick actions are shown", async () => {
     await contains("[title='Expand']");
     await click("[title='Expand']");
     await contains(".o-mail-Message-actions i, .o-mail-Message-moreMenu i", { count: 7 });
-    await contains("[title='Copy Message Link']");
+    await contains("[title='Copy Link']");
     await contains("[title='Edit']");
     await contains("[title='Delete']");
     await contains("[title='View Reactions']");

--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -2339,7 +2339,7 @@ msgstr ""
 #. module: mail
 #. odoo-javascript
 #: code:addons/mail/static/src/core/common/message_actions.js:0
-msgid "Copy Message Link"
+msgid "Copy Link"
 msgstr ""
 
 #. module: mail

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -202,7 +202,7 @@ messageActionsRegistry
             component.message.message_type &&
             component.message.message_type !== "user_notification",
         icon: "fa-link",
-        title: _t("Copy Message Link"),
+        title: _t("Copy Link"),
         onClick: (component) => component.message.copyLink(),
         sequence: 110,
     });

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -1949,9 +1949,9 @@ test("Copy Message Link", async () => {
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-Message:eq(0) [title='Expand']");
-    await contains("[title='Copy Message Link']", { count: 0 });
+    await contains("[title='Copy Link']", { count: 0 });
     await click(".o-mail-Message:eq(1) [title='Expand']");
-    await click("[title='Copy Message Link']");
+    await click("[title='Copy Link']");
     await assertSteps([url(`/mail/message/${messageId_2}`)]);
     await press(["ctrl", "v"]);
     await click(".o-mail-Composer-send:enabled");


### PR DESCRIPTION
Shorter is better.

Part of Task-4260440

![Screenshot 2024-10-15 at 17 46 13](https://github.com/user-attachments/assets/148d09e3-db63-4cbc-9804-7a217a7da0ac)
