### PR TITLE
[REV] website_sale: sort pricelist in cached method

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -186,7 +186,9 @@ class Website(models.Model):
             pricelists |= partner_pricelist
 
         # This method is cached, must not return records! See also #8795
-        return pricelists.ids
+        # sudo is needed to ensure no records rules are applied during the sorted call,
+        # we only want to reorder the records on hand, not filter them.
+        return pricelists.sudo().sorted().ids
 
     def get_pricelist_available(self, show_visible=False):
         """ Return the list of pricelists that can be used on website for the current user.
@@ -270,11 +272,11 @@ class Website(models.Model):
             if available_pricelists and pricelist not in available_pricelists:
                 # If there is at least one pricelist in the available pricelists
                 # and the chosen pricelist is not within them
-                # it then choose the first available pricelist based on _order of the model.
+                # it then choose the first available pricelist.
                 # This can only happen when the pricelist is the public user pricelist and this pricelist is not in the available pricelist for this localization
                 # If the user is signed in, and has a special pricelist (different than the public user pricelist),
                 # then this special pricelist is amongs these available pricelists, and therefore it won't fall in this case.
-                pricelist = available_pricelists.sorted()[0]
+                pricelist = available_pricelists[0]
 
             if not pricelist:
                 _logger.error(


### PR DESCRIPTION
revert commit 30c561b422d58d7622f7ee173fae2f8158a14657 because it broke existing optimization and users were unable to access the website instead the functionality was moved to `_get_pl_partner_order()` because it's a cached method and the extra search added by the `.sorted()` wouldn't be an issue.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
