### PR TITLE
[IMP] mail: improve chatter composer style

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -88,8 +88,12 @@ export class Composer extends Component {
         super.setup();
         this.isMobileOS = isMobileOS();
         this.isIosPwa = isIOS() && isDisplayStandalone();
-        this.SEND_KEYBIND_TO_SEND = markup(
-            _t("<samp>%(send_keybind)s</samp><i> to send</i>", { send_keybind: this.sendKeybind })
+        this.OR_PRESS_SEND_KEYBIND = markup(
+            _t("or press %(send_keybind)s", {
+                send_keybind: this.sendKeybinds
+                    .map((key) => `<samp>${escape(key)}</samp>`)
+                    .join(" + "),
+            })
         );
         this.store = useState(useService("mail.store"));
         this.attachmentUploader = useAttachmentUploader(
@@ -291,8 +295,8 @@ export class Composer extends Component {
         return this.props.type === "note" ? _t("Log") : _t("Send");
     }
 
-    get sendKeybind() {
-        return this.props.mode === "extended" ? _t("CTRL-Enter") : _t("Enter");
+    get sendKeybinds() {
+        return this.props.mode === "extended" ? [_t("CTRL"), _t("Enter")] : [_t("Enter")];
     }
 
     get showComposerAvatar() {

--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -37,10 +37,6 @@
 }
 
 .o-mail-Composer-actions {
-    &.o-extended {
-        margin-left: map-get($spacers, 2) + map-get($spacers, 1);
-        margin-right: map-get($spacers, 2) + map-get($spacers, 1);
-    }
 
     button {
         opacity: 75%;
@@ -48,6 +44,10 @@
             &:hover {
                 background-color: $gray-200;
                 opacity: 100%;
+
+                .o-mail-Message.o-editing & {
+                    background-color: rgba(0, 0, 0, 0.05);
+                }
             }
         }
         &:disabled {
@@ -56,6 +56,10 @@
             opacity: var(--btn-disabled-opacity);
         }
     }
+}
+
+.o-mail-Composer-quickActions .o-mail-Composer-mainActions {
+    margin-top: map-get($spacers, 2) - map-get($spacers, 1) / 2;
 }
 
 .o-mail-Composer-bg {

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -38,7 +38,6 @@
                         'o-iosPwa': isIosPwa,
                         'rounded-3' : normal or isMobileOS or extended,
                         'align-self-stretch' : extended,
-                        'flex-column': extended or props.composer.message,
                     }"
                     t-ref="input-container"
                 >
@@ -69,33 +68,14 @@
                             disabled="1"
                         />
                     </div>
-                    <div class="o-mail-Composer-actions d-flex o-mail-Composer-bg"
-                        t-att-class="{
-                            'ms-1': compact and ui.isSmall,
-                            'mx-1': compact and !ui.isSmall,
-                            'ms-3': normal,
-                            'border-top px-0 py-1 o-extended': extended,
-                            'border-top': extended or props.composer.message,
-                            'rounded': !props.composer.message,
-                        }"
-                    >
-                        <div class="o-mail-Composer-mainActions d-flex flex-grow-1 align-items-baseline" t-att-class="{ 'mt-1': !props.composer.message and !env.inChatWindow }" t-ref="main-actions">
-                            <button class="btn border-0 p-1 rounded-pill" t-att-class="{'bg-300': this.picker.state.picker === this.picker.PICKERS.EMOJI}" aria-label="Emojis" t-on-click="onClickAddEmoji" t-ref="emoji-button"><i class="fa fa-fw fa-smile-o"/></button>
-                            <FileUploader t-if="allowUpload" multiUpload="true" onUploaded.bind="(data) => { attachmentUploader.uploadData(data) }">
-                                <t t-set-slot="toggler">
-                                    <button t-att-disabled="!state.active" class="o-mail-Composer-attachFiles btn border-0 rounded-pill p-1" title="Attach files" aria-label="Attach files" type="button" t-on-click="onClickAddAttachment"><i class="fa fa-fw fa-paperclip"/></button>
-                                </t>
-                            </FileUploader>
-                            <t t-if="extended and ui.isSmall and props.composer.message" t-call="mail.Composer.sendButton"/>
-                            <t t-if="!extended" t-call="mail.Composer.fullComposer"/>
-                            <t t-if="hasSendButtonNonEditing" t-call="mail.Composer.sendButton"/>
-                        </div>
-                        <t t-if="extended" t-call="mail.Composer.fullComposer"/>
-                    </div>
+                    <t t-if="!extended and !props.composer.message" t-call="mail.Composer.actions"/>
+                    <t t-else="" t-call="mail.Composer.quickActions"/>
                 </div>
-                <div t-if="extended and !props.composer.message" class="d-flex align-items-center mt-2 gap-2">
+                <div t-if="extended and !props.composer.message" class="d-flex align-items-center mt-2 gap-1 w-100 px-2">
                     <t t-call="mail.Composer.sendButton"/>
-                    <span t-if="!isSendButtonDisabled and !props.composer.message" t-out="SEND_KEYBIND_TO_SEND"/>
+                    <span t-if="!isSendButtonDisabled and !props.composer.message" class="text-muted small ms-1" t-out="OR_PRESS_SEND_KEYBIND"/>
+                    <span class="flex-grow-1"/>
+                    <t t-call="mail.Composer.extraActions"/>
                 </div>
             </div>
             <div class="o-mail-Composer-footer overflow-auto">
@@ -107,14 +87,24 @@
                 <Picker t-props="picker"/>
             </div>
         </div>
-        <span t-if="props.composer.message" class="text-muted px-1" t-out="CANCEL_OR_SAVE_EDIT_TEXT" t-on-click="onClickCancelOrSaveEditText"/>
+        <div t-if="props.composer.message" class="d-flex align-items-center gap-1 w-100">
+            <span t-if="props.composer.message" class="text-muted px-1 small" t-out="CANCEL_OR_SAVE_EDIT_TEXT" t-on-click="onClickCancelOrSaveEditText"/>
+            <span class="flex-grow-1"/>
+            <t t-call="mail.Composer.extraActions"/>
+        </div>
     </div>
     <NavigableList t-if="suggestion" class="'o-mail-Composer-suggestionList'" t-props="navigableListProps"/>
 </t>
 
 <t t-name="mail.Composer.sendButton">
     <button class="o-mail-Composer-send btn"
-        t-att-class="{'btn-primary': extended, 'p-1 rounded-pill': !extended, 'btn-link': !extended, 'border-start-0 me-2': env.inDiscussApp}"
+        t-att-class="{
+            'btn-primary btn-sm': extended,
+            'btn-link p-1 rounded-pill': !extended,
+            'me-2': env.inDiscussApp,
+            'border-start-0': env.inDiscussApp and !props.composer.message,
+            'border-0': props.composer.message,
+        }"
         t-on-click="sendMessage"
         t-att-disabled="isSendButtonDisabled"
         t-att-aria-label="SEND_TEXT"
@@ -128,6 +118,60 @@
     <button t-if="props.showFullComposer and thread and thread.model !== 'discuss.channel'" class="o-mail-Composer-fullComposer btn p-1 border-0 rounded-pill" title="Full composer" aria-label="Full composer" type="button" t-on-click="onClickFullComposer" data-hotkey="shift+c">
         <i class="fa fa-fw fa-expand"/>
     </button>
+</t>
+
+<t t-name="mail.Composer.actions">
+    <div class="o-mail-Composer-actions d-flex" name="root"
+        t-att-class="{
+            'ms-1': compact and ui.isSmall,
+            'mx-1': compact and !ui.isSmall,
+            'mx-2': extended,
+            'ms-3': normal,
+            'rounded': !props.composer.message,
+            'o-mail-Composer-bg': !extended and !props.composer.message,
+        }"
+    >
+        <div class="o-mail-Composer-mainActions d-flex flex-grow-1 align-items-baseline" t-att-class="{ 'mt-1': !props.composer.message and !env.inChatWindow and !extended }" t-ref="main-actions">
+            <t t-call="mail.Composer.emojiPicker"/>
+            <t t-call="mail.Composer.attachFiles"/>
+            <t t-if="extended and ui.isSmall and props.composer.message" t-call="mail.Composer.sendButton"/>
+            <t t-if="!extended" t-call="mail.Composer.fullComposer"/>
+            <t t-if="hasSendButtonNonEditing" t-call="mail.Composer.sendButton"/>
+        </div>
+        <t t-if="extended" t-call="mail.Composer.fullComposer"/>
+    </div>
+</t>
+
+<t t-name="mail.Composer.quickActions">
+    <div class="o-mail-Composer-actions o-mail-Composer-quickActions d-flex rounded o-mail-Composer-bg" name="root" t-att-class="{ 'me-1': props.composer.message, 'me-2': extended }">
+        <div class="o-mail-Composer-mainActions d-flex flex-grow-1 align-items-baseline" t-ref="main-actions">
+            <t t-call="mail.Composer.emojiPicker"/>
+        </div>
+    </div>
+</t>
+
+<t t-name="mail.Composer.extraActions">
+    <div class="o-mail-Composer-actions d-flex" name="root" t-att-class="{ 'mx-1': props.composer.message }">
+        <div class="o-mail-Composer-mainActions d-flex flex-grow-1 align-items-baseline">
+            <t t-call="mail.Composer.attachFiles"/>
+            <t t-if="extended and ui.isSmall and props.composer.message" t-call="mail.Composer.sendButton"/>
+            <t t-if="!extended" t-call="mail.Composer.fullComposer"/>
+            <t t-if="hasSendButtonNonEditing" t-call="mail.Composer.sendButton"/>
+        </div>
+        <t t-if="extended" t-call="mail.Composer.fullComposer"/>
+    </div>
+</t>
+
+<t t-name="mail.Composer.emojiPicker">
+    <button class="btn border-0 p-1 rounded-pill" t-att-class="{'bg-300': this.picker.state.picker === this.picker.PICKERS.EMOJI}" aria-label="Emojis" t-on-click="onClickAddEmoji" t-ref="emoji-button"><i class="fa fa-fw fa-smile-o"/></button>
+</t>
+
+<t t-name="mail.Composer.attachFiles">
+    <FileUploader t-if="allowUpload" multiUpload="true" onUploaded.bind="(data) => { attachmentUploader.uploadData(data) }">
+        <t t-set-slot="toggler">
+            <button t-att-disabled="!state.active" class="o-mail-Composer-attachFiles btn border-0 rounded-pill p-1" title="Attach files" aria-label="Attach files" type="button" t-on-click="onClickAddAttachment"><i class="fa fa-fw fa-paperclip"/></button>
+        </t>
+    </FileUploader>
 </t>
 
     <t t-name="mail.Composer.suggestionSpecial">

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -79,7 +79,9 @@
                                                 <div class="position-relative text-break o-mail-Message-body" t-att-class="{
                                                             'p-1': message.is_note,
                                                             'fs-1': !state.isEditing and !env.inChatter and message.onlyEmojis,
-                                                            'mb-0 py-2': !message.is_note,
+                                                            'mb-0': !message.is_note,
+                                                            'py-2': !message.is_note and !state.isEditing,
+                                                            'pt-2 pb-1': !message.is_note and state.isEditing,
                                                             'o-note': message.is_note,
                                                             'align-self-start rounded-end-3 rounded-bottom-3': !state.isEditing and !message.is_note,
                                                             'flex-grow-1': state.isEditing,

--- a/addons/mail/static/src/discuss/gif_picker/common/composer_patch.xml
+++ b/addons/mail/static/src/discuss/gif_picker/common/composer_patch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-inherit="mail.Composer" t-inherit-mode="extension">
+    <t t-inherit="mail.Composer.emojiPicker" t-inherit-mode="extension">
         <xpath expr="//*[@t-ref='emoji-button']" position="attributes">
             <attribute name="t-att-class">
                 {'bg-300': this.picker.state.picker === this.picker.PICKERS.EMOJI or (this.picker.state.picker === this.picker.PICKERS.GIF and this.ui.isSmall)}

--- a/addons/mail/static/tests/tours/discuss_channel_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_public_tour.js
@@ -150,12 +150,10 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
         },
         {
             content: "Add one more file in composer",
-            trigger: ".o-mail-Message .o-mail-Composer button[aria-label='Attach files']",
+            trigger: ".o-mail-Message button[aria-label='Attach files']",
             async run() {
                 const extratxt = new File(["hello 2"], "extra.txt", { type: "text/plain" });
-                await inputFiles(".o-mail-Message .o-mail-Composer-coreMain .o_input_file", [
-                    extratxt,
-                ]);
+                await inputFiles(".o-mail-Message .o_input_file", [extratxt]);
             },
         },
         {


### PR DESCRIPTION
- Reword "Ctrl-Enter to send" to "or press Ctrl + Enter"
- Show emoji action inline with 1st line of composer textarea
- Other actions have been moved in same row as "Send message"/ "Log note", at the very end.

Similar change has been made to editing message.

Part of task-4260440

https://github.com/odoo/enterprise/pull/72074

<img width="795" alt="Screenshot 2024-10-18 at 12 48 11" src="https://github.com/user-attachments/assets/38d74a0b-3671-49dd-b7c0-cdc5d38b719f">
<img width="354" alt="Screenshot 2024-10-18 at 12 48 42" src="https://github.com/user-attachments/assets/acde081f-805f-4c18-8cc4-a838f4c2646e">
