### PR TITLE
[FIX] auth_totp: update environment on successful login in web_totp

### DIFF
--- a/addons/auth_totp/controllers/home.py
+++ b/addons/auth_totp/controllers/home.py
@@ -34,6 +34,8 @@ class Home(web_home.Home):
                     scope="browser", key=key, uid=user.id)
                 if user_match:
                     request.session.finalize(request.env)
+                    request.update_env(user=request.session.uid)
+                    request.update_context(**request.session.context)
                     return request.redirect(self._login_redirect(request.session.uid, redirect=redirect))
 
         elif user and request.httprequest.method == 'POST' and kwargs.get('totp_token'):


### PR DESCRIPTION
There are two paths for a successful login via web_totp
 1. The user has a cookie saved which saves them from having to enter the TOTP
 2. The user is a new device / browser, enter the TOTP and a form is submitted

Both call self._login_redirect but only the latter updates the env and context.

This is a snippet to reproduce the bug:
```python
@http.route()
def web_totp():
    response = super().web_totp(*args, **kw)
    if not request.env.user or request.env.user.is_public:
        return response
    do_something()
    ...
```
This would call `do_something` only when a user successfully logs in by putting the TOTP explicitly but not when they log in thanks to a cookie  being set.

Description of the issue/feature this PR addresses:
Makes web_totp consistent for the 2 flows (submit totp or use cookie)

Current behavior before PR:
A code logic that works for web_login does not work for web_totp, or rather, it works only for one flow but not the other

Desired behavior after PR is merged:
A code logic that works for web_login also works for web_totp

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
