### PR TITLE
[IMP] auth_oauth: add support for Okta OAuth2 provider

### DIFF
--- a/addons/auth_oauth/controllers/main.py
+++ b/addons/auth_oauth/controllers/main.py
@@ -66,8 +66,12 @@ class OAuthLogin(Home):
                 redirect_uri=return_url,
                 scope=provider['scope'],
                 state=json.dumps(state),
-                # nonce=base64.urlsafe_b64encode(os.urandom(16)),
             )
+            # Okta is the only provider that requires nonce. We cannot add it
+            # for all providers because some throw an error if nonce is present.
+            if '.okta.com/' in provider['auth_endpoint']:
+                params['nonce'] = base64.urlsafe_b64encode(os.urandom(16))
+
             provider['auth_link'] = "%s?%s" % (provider['auth_endpoint'], werkzeug.urls.url_encode(params))
         return providers
 


### PR DESCRIPTION
This commit adds support for the Okta OAuth2 provider.

Initially, support for Okta was added with [this commit], and subsequently, the nonce parameter was removed by [this other commit] due to compatibility issues with other OAuth providers.

Some Odoo customers require Okta integration. This commit ensures that the nonce parameter is included when the provider is Okta.

Examples of Odoo tasks related to Okta integration (Help & Custom dev):
- 4065710
- 2479700
- 4177359
- 3302655
- 4220350
- 3506931
- 3291275
- ...

[this commit]: https://github.com/odoo/odoo/commit/56fe16bd5b3f2167541a335c97e193b9686902a8
[this other commit]: https://github.com/odoo/odoo/commit/e0345512d9fe8b255334d4260eda4454248d82dd