### PR TITLE
[IMP] portal: Add country and state validation

### DIFF
--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -257,7 +257,7 @@
                     You can choose how you want us to send your invoices, and with which electronic format.
                 </small>
             </div>
-            <div class="row m-0 p-0" t-if="len(invoice_sending_methods) > 1">
+            <div class="row m-0 p-0" t-if="invoice_sending_methods and len(invoice_sending_methods) > 1">
                 <div class="col-xl-6">
                     <label class="col-form-label" for="invoice_sending_method">Receive invoices</label>
                     <select name="invoice_sending_method" class="form-select">

--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -330,6 +330,29 @@ class CustomerPortal(Controller):
             error["email"] = 'error'
             error_message.append(_('Invalid Email! Please enter a valid email address.'))
 
+        # country and state validation
+        country_id = data.get("country_id")
+
+        if country_id and country_id.isdigit():
+            country_id = request.env['res.country'].browse(int(country_id))
+
+            if not country_id:
+                error["country_id"] = 'error'
+                error_message.append(_('Invalid Country! Please select a valid country.'))
+        else:
+            error["country_id"] = 'error'
+            error_message.append(_('Country ID is missing or invalid.'))
+
+        state_id = data.get("state_id")
+
+        if state_id and state_id.isdigit():
+            if int(state_id) not in country_id.state_ids.ids:
+                error["state_id"] = 'error'
+                error_message.append(_('Invalid State / Province. Please select a valid State or Province.'))
+        elif country_id and country_id.state_required:
+            error["state_id"] = 'error'
+            error_message.append(_('Some required fields are empty.'))
+
         # vat validation
         partner = request.env.user.partner_id
         if data.get("vat") and partner and partner.vat != data.get("vat"):

--- a/doc/cla/individual/elierayalabernal.md
+++ b/doc/cla/individual/elierayalabernal.md
@@ -1,0 +1,12 @@
+Canada, 2024-10-15
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Elier Ayala Bernal elierayalawii@gmail.com https://github.com/elierayalabernal
+


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Currently, there is no validation ensuring the selected state corresponds to the chosen country, nor checks that enforce a state selection when required by the country. 

Current behavior before PR:
Users can select a state that doesn't belong to the selected country. No validation exists to require a state selection when the country mandates it. 

Desired behavior after PR is merged:
The selected state will be validated to ensure it belongs to the selected country. A state will be mandatory when the country requires it, and appropriate error messages will be shown when these conditions are not met.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
