### PR TITLE
[IMP] account_payment: replace non-deterministic XPath in portal invoices view

### DIFF
--- a/addons/account_payment/views/account_portal_templates.xml
+++ b/addons/account_payment/views/account_portal_templates.xml
@@ -75,7 +75,7 @@
     </template>
 
     <template id="portal_my_invoices_payment" name="Payment on My Invoices" inherit_id="account.portal_my_invoices">
-        <xpath expr="//t[@t-call='portal.portal_table']/thead/tr/th[last()]" position="after">
+        <xpath expr="//t[@t-call='portal.portal_table']//th[@name='amount_due']" position="after">
             <th class="d-none d-lg-table-cell"/>
             <th/>
         </xpath>


### PR DESCRIPTION
Use a deterministic XPath expression for the empty header of the "Pay Now" button column, as the table headers now have names, following the approach outlined in [1].

[1] odoo/enterprise#63957

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
