### PR TITLE
[FIX] project: hide `Task Management` section in project if no options is active

### DIFF
--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -129,7 +129,7 @@
                                 </group>
                             </group>
                             <group>
-                                <group name="group_tasks_managment" string="Tasks Management" col="1" class="row mt16 o_settings_container" groups="project.group_project_task_dependencies,project.group_project_milestone,project.group_project_recurring_tasks">
+                                <group name="group_tasks_managment" string="Tasks Management" col="1" class="row mt16 o_settings_container" groups="project.group_project_task_dependencies,project.group_project_milestone">
                                     <div>
                                         <setting class="col-lg-12" id="task_dependencies_setting" help="Determine the order in which to perform tasks" groups="project.group_project_task_dependencies">
                                             <field name="allow_task_dependencies"/>


### PR DESCRIPTION
Fixed issue introduced in this PR: https://github.com/odoo/odoo/pull/119154.

  In the above PR, the recurring setting was removed, but the recurring groups
  were not removed from the group configuration, which caused the group's string
  to still appear. This issue has now been fixed.

  Steps to Reproduce and Verify the Fix:
      1) Install the Project App.
      2) Go to the Project App.
      3) Activate the Recurring Feature in the settings.
      4) Open any project and verify the settings.

  task-4260042



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
