### PR TITLE
[IMP] web_editor: autoscroll latest response message in chatgpt

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_prompt_dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_prompt_dialog.js
@@ -2,9 +2,10 @@
 
 import { ChatGPTDialog } from '@web_editor/js/wysiwyg/widgets/chatgpt_dialog';
 import { useState, useEffect, useRef } from "@odoo/owl";
-import { useAutofocus } from "@web/core/utils/hooks";
+import { useAutofocus, useChildRef } from "@web/core/utils/hooks";
 import { session } from "@web/session";
 import { browser } from "@web/core/browser/browser";
+import { scrollTo } from "@web/core/utils/scrolling";
 
 export class ChatGPTPromptDialog extends ChatGPTDialog {
     static template = 'web_edior.ChatGPTPromptDialog';
@@ -34,12 +35,23 @@ export class ChatGPTPromptDialog extends ChatGPTDialog {
             messages: [],
         });
         this.promptInputRef = useRef('promptInput');
+        this.modalRef = useChildRef();
         useAutofocus({ refName: 'promptInput' });
         useEffect(() => {
             // Resize the textarea to fit its content.
             this.promptInputRef.el.style.height = 0;
             this.promptInputRef.el.style.height = this.promptInputRef.el.scrollHeight + 'px';
         }, () => [this.state.prompt]);
+        useEffect(() => {
+            // Scroll to the latest message whenever new message
+            // is inserted.
+            const modalEl = this.modalRef.el.querySelector("main.modal-body");
+            const lastMessageEl = modalEl.lastElementChild;
+            scrollTo(lastMessageEl, {
+                behavior: "smooth",
+                isAnchor: true,
+            })
+        }, () => [this.state.conversationHistory.length]);
     }
 
     //--------------------------------------------------------------------------

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_prompt_dialog.xml
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_prompt_dialog.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
 
 <t t-name="web_edior.ChatGPTPromptDialog">
-    <Dialog size="'lg'" title="'Generate Text with AI'">
+    <Dialog size="'lg'" title="'Generate Text with AI'" modalRef="modalRef">
         <div t-foreach="state.messages" t-as="message" t-key="message_index"
             class="position-relative py-1 px-3"
             t-att-class="message_index ? 'mt-2' : 'mt-0'">


### PR DESCRIPTION
**Behaviour before PR:**

In chatGPT prompt dialog, scroll position is not set to the latest message automatically after hitting 3-4 prompts. User has to scroll to bottom manually.

**After this PR:**

This commit aims to make sure that the scroll postion is set to the latest message after submitting prompt.

task-4256085




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
