### PR TITLE
[REF] web: remove unused __processed_archs__ registry

### DIFF
--- a/addons/web/static/src/views/view_hook.js
+++ b/addons/web/static/src/views/view_hook.js
@@ -1,34 +1,8 @@
-import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { browser } from "@web/core/browser/browser";
 import { evaluateExpr } from "@web/core/py_js/py";
 
-import { useComponent, useEffect, xml } from "@odoo/owl";
-
-export function useViewArch(arch, params = {}) {
-    const CATEGORY = "__processed_archs__";
-
-    arch = arch.trim();
-    const processedRegistry = registry.category(CATEGORY);
-
-    let processedArch;
-    if (!processedRegistry.contains(arch)) {
-        processedArch = {};
-        processedRegistry.add(arch, processedArch);
-    } else {
-        processedArch = processedRegistry.get(arch);
-    }
-
-    const { compile, extract } = params;
-    if (!("template" in processedArch) && compile) {
-        processedArch.template = xml`${compile(arch)}`;
-    }
-    if (!("extracted" in processedArch) && extract) {
-        processedArch.extracted = extract(arch);
-    }
-
-    return processedArch;
-}
+import { useComponent, useEffect } from "@odoo/owl";
 
 /**
  * Allows for a component (usually a View component) to handle links with

--- a/addons/web/static/src/views/view_service.js
+++ b/addons/web/static/src/views/view_service.js
@@ -47,9 +47,6 @@ export const viewService = {
 
         function clearCache() {
             cache = {};
-            const processedArchs = registry.category("__processed_archs__");
-            processedArchs.content = {};
-            processedArchs.trigger("UPDATE");
         }
 
         env.bus.addEventListener("CLEAR-CACHES", clearCache);

--- a/addons/web/static/tests/legacy/helpers/mock_env.js
+++ b/addons/web/static/tests/legacy/helpers/mock_env.js
@@ -82,7 +82,6 @@ export const utils = {
         clearRegistryWithCleanup(registry.category("systray"));
         clearRegistryWithCleanup(registry.category("user_menuitems"));
         clearRegistryWithCleanup(registry.category("kanban_examples"));
-        clearRegistryWithCleanup(registry.category("__processed_archs__"));
         // fun fact: at least one registry is missing... this shows that we need a
         // better design for the way we clear these registries...
     },


### PR DESCRIPTION
Fun fact: this registry and the useViewArch hook have been introduced alongside the reporting views, which were the first views to be converted to owl, in v15 [1]. However, they have never been used. We probably introduced them during the development, and forgot to clean them before merging.

[1] 82588c57ea2f5ba5c039f44dae125344e9b851ba

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
