### PR TITLE
[FIX] sale_stock,stock: fix traceback  if user click return picking for exchange

### DIFF
--- a/addons/sale_stock/wizard/__init__.py
+++ b/addons/sale_stock/wizard/__init__.py
@@ -3,3 +3,4 @@
 
 from . import stock_rules_report
 from . import sale_order_cancel
+from . import stock_return_picking

--- a/addons/sale_stock/wizard/stock_return_picking.py
+++ b/addons/sale_stock/wizard/stock_return_picking.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class ReturnPicking(models.TransientModel):
+    _inherit = 'stock.return.picking'
+
+    def _get_proc_values(self, line):
+        vals = super()._get_proc_values(line)
+        vals['sale_line_id'] = line.move_id.sale_line_id.id
+        return vals

--- a/addons/stock/wizard/stock_picking_return.py
+++ b/addons/stock/wizard/stock_picking_return.py
@@ -192,16 +192,7 @@ class ReturnPicking(models.TransientModel):
         for line in self.product_return_moves:
             if not line.move_id:
                 continue
-            proc_values = {
-                'group_id': self.picking_id.group_id,
-                'sale_line_id': line.move_id.sale_line_id.id,
-                'date_planned': line.move_id.date or fields.Datetime.now(),
-                'warehouse_id': self.picking_id.picking_type_id.warehouse_id,
-                'partner_id': self.picking_id.partner_id.id,
-                'location_final_id': line.move_id.location_final_id or self.picking_id.location_dest_id,
-                'company_id': self.picking_id.company_id,
-            }
-
+            proc_values = self._get_proc_values(line)
             proc_list.append(self.env["procurement.group"].Procurement(
                 line.product_id, line.quantity, line.uom_id,
                 line.move_id.location_dest_id or self.picking_id.location_dest_id,
@@ -211,3 +202,14 @@ class ReturnPicking(models.TransientModel):
         if proc_list:
             self.env['procurement.group'].run(proc_list)
         return action
+
+    def _get_proc_values(self, line):
+        self.ensure_one()
+        return {
+            'group_id': self.picking_id.group_id,
+            'date_planned': line.move_id.date or fields.Datetime.now(),
+            'warehouse_id': self.picking_id.picking_type_id.warehouse_id,
+            'partner_id': self.picking_id.partner_id.id,
+            'location_final_id': line.move_id.location_final_id or self.picking_id.location_dest_id,
+            'company_id': self.picking_id.company_id,
+        }


### PR DESCRIPTION
Currently, a traceback occurs when the user tries to click return for exchange button.

To reproduce this issue:

1) Install `stock`
2) Create a new receipt picking with stock moves and quantity 
3) Click on the `validate` button and then the `return` button
4) Update the return quantity and click `return for exchange`

Error:- 
```
AttributeError: 'stock.move' object has no attribute 'sale_line_id'
```

The `sale_line_id` is defined in `stock.move` from  `sale_stock` module. 
https://github.com/odoo/odoo/blob/2be7f413493a6ad43980eb031b8383deb3a706c0/addons/sale_stock/models/stock.py#L16-L17
If the sales module is not installed, then the move does not contain any sale_line_id.
which leads to the traceback mentioned above.

https://github.com/odoo/odoo/blob/2be7f413493a6ad43980eb031b8383deb3a706c0/addons/stock/wizard/stock_picking_return.py#L197

sentry-5993887458

