### PR TITLE
[FIX] website_project:  prevent KeyError: 'task' on click Preview URL

### DIFF
--- a/addons/website_project/views/project_portal_project_task_template.xml
+++ b/addons/website_project/views/project_portal_project_task_template.xml
@@ -24,7 +24,7 @@
                         <h2 class="text-center">Thank you for contacting us, our team will get right on it!</h2>
                         <div class="text-center">
                             <a class="btn btn-primary" t-attf-href="/my/task/#{task.id}"
-                                t-if="task.id and request.session.uid and task.project_id.id and task.project_privacy_visibility != 'followers'">
+                                t-if="task and task.id and request.session.uid and task.project_id.id and task.project_privacy_visibility != 'followers'">
                                 View Task
                             </a>
                             <a class="btn btn-primary" href='/'>Go to the Homepage</a>


### PR DESCRIPTION
Currently, an exception is generated when the user clicks on the preview URL of the "Create a Task" form by following the steps:

- Go to any website  page and open the website editor
- Add form to website page
- click on the added form and select Action as "Create a Task"
- Click on the Preview URL button of the added form >> errro generated

Error `KeyError: 'task'`

This is because when the user opens the direct URL, no task is available.

This commit will fix the above issue by accessing the key `task` when it is available in view.

sentry-5983056185
