### PR TITLE
[IMP] point_of_sale: automatically trigger invoice for refund orders

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -65,6 +65,14 @@ export class PaymentScreen extends Component {
         if (this.payment_methods_from_config.length == 1 && this.paymentLines.length == 0) {
             this.addNewPaymentLine(this.payment_methods_from_config[0]);
         }
+
+        //Activate the invoice option for refund orders if the original order was invoiced.
+        if (
+            this.currentOrder._isRefundOrder() &&
+            this.currentOrder.lines[0].refunded_orderline_id?.order_id?.is_to_invoice()
+        ) {
+            this.currentOrder.set_to_invoice(true);
+        }
     }
 
     getNumpadButtons() {

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
@@ -112,7 +112,7 @@
                     </span>
                 </button>
                 <button class="button js_invoice btn btn-light btn-lg d-flex justify-content-between align-items-baseline w-100 w-md-50 lh-lg" t-att-class="{ 'highlight active': currentOrder.is_to_invoice() }"
-                    t-on-click="toggleIsToInvoice">
+                    t-on-click="toggleIsToInvoice" t-att-disabled="currentOrder.lines[0]?.refunded_orderline_id?.order_id?.is_to_invoice()">
                     <span><i class="fa fa-file-text-o me-2" />Invoice</span>
                     <i class="fa me-2" t-attf-class="{{ currentOrder.is_to_invoice() ? 'fa-check-square text-action' : 'fa-square-o' }}" /> 
                 </button>


### PR DESCRIPTION
Before this commit:
====================
Users had to manually activate the invoice option for refund orders, even when the original order was invoiced.

After this commit:
===================
The system now automatically activates the invoice option on the payment page for refund orders if the original order was invoiced.

Task- 4256770

