### PR TITLE
[FIX] hw_drivers: stop LED service during git checkout

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -172,7 +172,7 @@ def check_git_branch():
                     subprocess.run(
                         ['/home/pi/odoo/addons/point_of_sale/tools/posbox/configuration/posbox_update.sh'], check=True
                     )
-                    odoo_restart()
+                odoo_restart()
     except Exception:
         _logger.exception('An error occurred while connecting to server')
 

--- a/addons/point_of_sale/tools/posbox/configuration/posbox_update.sh
+++ b/addons/point_of_sale/tools/posbox/configuration/posbox_update.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+sudo service led-status stop
+
 cd /home/pi/odoo
 localbranch=$(git symbolic-ref -q --short HEAD)
 localremote=$(git config branch.$localbranch.remote)
@@ -34,5 +36,7 @@ fi
         done
     done
 } || {
-    exit 0
+    true
 }
+
+sudo service led-status start


### PR DESCRIPTION
Commands that stop and start the LED service
in `posbox_update.sh` were removed in commit
`bf96199`, however these were necessary to prevent the filesystem getting stuck in write-mode and
potentially getting corrupted (see #54339).

The fix is to restore these commands in
`posbox_update.sh`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
