### PR TITLE
[FIX] certificate: prevent an error while add keys in certificate

### DIFF
--- a/addons/certificate/views/certificate_views.xml
+++ b/addons/certificate/views/certificate_views.xml
@@ -16,8 +16,8 @@
                         <field name="content" widget="binary"/>
                         <field name="pkcs12_password" password="True" />
                         <field name="subject_common_name" invisible="not pem_certificate"/>
-                        <field name="private_key_id" invisible="not pem_certificate"/>
-                        <field name="public_key_id" invisible="not pem_certificate"/>
+                        <field name="private_key_id" invisible="not pem_certificate" options="{'no_quick_create': True}"/>
+                        <field name="public_key_id" invisible="not pem_certificate" options="{'no_quick_create': True}"/>
                         <field name="scope" widget="radio" invisible="1"/> <!-- Should be overriden by modules adding options to this selection field -->
                     </group>
                     <group id="certificate_data">


### PR DESCRIPTION
Currently, an error occurs when while adding a private/public key in the certificate and key has no 'content' (Key file).

Step to produce:

- Install the ```certificate``` module.
- Go to Settings, Click on 'certificates' which is in the Certificates and Keys section
- Create a new certificate, add a name and valid certificate file.
- Create a ```Private Key``` or ```Public Key``` from the certificate form view and try to save the record.

```TypeError: argument should be a bytes-like object or ASCII string, not 'bool'```

An error occurs because a user can directly create a certificate's private/public key from the certificate form view without adding any content that is required true in ```certificate.key``` model, so an error occurs when the system tries to decode the content of private/public key at [1], but it is not available.

Link [1]: https://github.com/odoo/odoo/blob/2be7f413493a6ad43980eb031b8383deb3a706c0/addons/certificate/models/key.py#L157-L160

To resolve this issue, remove the 'create' option for private/public keys from certificate form view

Sentry-5993525387

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
