### PR TITLE
[FIX] account: remove lone tax group 'on X' mention

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -360,9 +360,6 @@
                     <t t-else="">
                         <td>
                             <span t-out="amount_by_group['tax_group_name']">Tax 15%</span>
-                            <span t-if="not amount_by_group['hide_base_amount']" class="text-nowrap"> on
-                                <t t-esc="amount_by_group['formatted_tax_group_base_amount']"/>
-                            </span>
                         </td>
                         <td class="text-end o_price_total">
                             <span class="text-nowrap" t-out="amount_by_group['formatted_tax_group_amount']">4.05</span>


### PR DESCRIPTION
Steps to reproduce:
- Invoice any product(s) with only one percent based tax
- Print the invoice > Check subtotals

The mention 'n% on X' appears but other versions don't display this text if only one tax group is applied (Since there is no ambiguity).

opw-4110516

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
