### PR TITLE
[FIX] website_sale: Combo items not creating the correct amount of lines

### DIFF
--- a/addons/website_sale/controllers/combo_configurator.py
+++ b/addons/website_sale/controllers/combo_configurator.py
@@ -88,6 +88,7 @@ class WebsiteSaleComboConfiguratorController(SaleComboConfiguratorController, We
                     ],
                     linked_line_id=values['line_id'],
                     combo_item_id=combo_item['combo_item_id'],
+                    line_id=False
                     **kwargs,
                 )
                 line_ids.append(item_values['line_id'])

--- a/addons/website_sale/controllers/combo_configurator.py
+++ b/addons/website_sale/controllers/combo_configurator.py
@@ -81,6 +81,7 @@ class WebsiteSaleComboConfiguratorController(SaleComboConfiguratorController, We
             for combo_item in selected_combo_items:
                 item_values = order_sudo._cart_update(
                     product_id=combo_item['product_id'],
+                    line_id=False,
                     set_qty=quantity,
                     product_custom_attribute_values=combo_item['product_custom_attribute_values'],
                     no_variant_attribute_value_ids=[
@@ -88,7 +89,6 @@ class WebsiteSaleComboConfiguratorController(SaleComboConfiguratorController, We
                     ],
                     linked_line_id=values['line_id'],
                     combo_item_id=combo_item['combo_item_id'],
-                    line_id=False
                     **kwargs,
                 )
                 line_ids.append(item_values['line_id'])

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -287,7 +287,7 @@ class SaleOrder(models.Model):
         if add_qty and (not product or not product._is_add_to_cart_allowed()):
             raise UserError(_("The given product does not exist therefore it cannot be added to cart."))
 
-        if line_id:
+        if line_id is not False:
             order_line = self._cart_find_product_line(product_id, line_id, **kwargs)[:1]
         else:
             order_line = self.env['sale.order.line']

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -287,7 +287,7 @@ class SaleOrder(models.Model):
         if add_qty and (not product or not product._is_add_to_cart_allowed()):
             raise UserError(_("The given product does not exist therefore it cannot be added to cart."))
 
-        if line_id is not False:
+        if line_id:
             order_line = self._cart_find_product_line(product_id, line_id, **kwargs)[:1]
         else:
             order_line = self.env['sale.order.line']

--- a/doc/cla/individual/levi-bensley.md
+++ b/doc/cla/individual/levi-bensley.md
@@ -1,0 +1,11 @@
+United Kingdom, 2024-10-15
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Levi Bensley levi@leaneasy.co.uk https://github.com/Lean-Easy


### PR DESCRIPTION
When using combo products in ecommerce, if two of the combos contained the same product and they were selected, only one row with a quantity of 1 would be created.

e.g. if a you had a double burger combo product and the combos looked like:

- Burger 1: Cheeseburger, Double Cheeseburger, Chicken Burger
- Burger 2: Cheeseburger, Double Cheeseburger

Currently if you were to choose double cheeseburger in both options it would only add 1 burger with quantity of 1 to the basket.

Ideally it should be following the same practise as sale orders and create a line per each item.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
