### PR TITLE
[FIX] web, hr_fleet: enable fleet attachment buttons

### DIFF
--- a/addons/hr_fleet/static/src/views/hr_fleet_kanban/hr_fleet_kanban_controller.xml
+++ b/addons/hr_fleet/static/src/views/hr_fleet_kanban/hr_fleet_kanban_controller.xml
@@ -3,7 +3,7 @@
     <t t-name="hr_fleet.HrFleetKanbanController.Buttons" t-inherit="web.KanbanView.Buttons" t-inherit-mode="primary">
         <xpath expr="//div[hasclass('o_cp_buttons')]" position="inside">
             <input type="file" multiple="true" t-ref="uploadFileInput" class="o_input_file o_hidden" t-on-change.stop="onInputChange"/>
-            <button type="button" t-att-class="'d-none d-md-block btn' + (!env.isSmall ? ' btn-primary' : 'btn-secondary')" t-on-click="() => this.uploadFileInput.el.click()">
+            <button type="button" t-att-class="'d-md-block btn' + (!env.isSmall ? ' btn-primary' : 'btn-secondary')" t-on-click="() => this.uploadFileInput.el.click()">
                 Upload
             </button>
         </xpath>

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -613,6 +613,22 @@ export function makeActionManager(env, router = _router) {
         if (typeof groupBy === "string") {
             groupBy = [groupBy];
         }
+        const openFormView = (resId, { activeIds, mode } = {}) => {
+            if (target !== "new") {
+                if (_getView("form")) {
+                    return switchView("form", { mode, resId, resIds: activeIds });
+                } else {
+                    return doAction(
+                        {
+                            type: "ir.actions.act_window",
+                            res_model: action.res_model,
+                            views: [[false, "form"]],
+                        },
+                        { props: { mode, resId, resIds: activeIds } }
+                    );
+                }
+            }
+        };
         const viewProps = Object.assign({}, props, {
             context,
             display: { mode: target === "new" ? "inDialog" : target },
@@ -622,16 +638,8 @@ export function makeActionManager(env, router = _router) {
             loadIrFilters: action.views.some((v) => v[1] === "search"),
             resModel: action.res_model,
             type: view.type,
-            selectRecord: async (resId, { activeIds, mode }) => {
-                if (target !== "new" && _getView("form")) {
-                    await switchView("form", { mode, resId, resIds: activeIds });
-                }
-            },
-            createRecord: async () => {
-                if (target !== "new" && _getView("form")) {
-                    await switchView("form", { resId: false });
-                }
-            },
+            selectRecord: openFormView,
+            createRecord: () => openFormView(false),
         });
         const currentState = {
             resId: viewProps.resId,

--- a/addons/web/static/tests/webclient/actions/effect.test.js
+++ b/addons/web/static/tests/webclient/actions/effect.test.js
@@ -97,7 +97,7 @@ test.tags("desktop")("rainbowman integrated to webClient", async () => {
     await animationFrame();
     expect(".o_reward").toHaveCount(1);
     expect(".o_kanban_view").toHaveCount(1);
-    await contains(".o_kanban_record").click();
+    await contains(".o_reward").click();
     expect(".o_reward").toHaveCount(0);
     expect(".o_kanban_view").toHaveCount(1);
     getService("effect").add({ type: "rainbow_man", message: "", fadeout: "no" });

--- a/addons/web/static/tests/webclient/actions/window_action.test.js
+++ b/addons/web/static/tests/webclient/actions/window_action.test.js
@@ -190,6 +190,14 @@ defineActions([
             [false, "form"],
         ],
     },
+    {
+        id: 9,
+        xml_id: "action_9",
+        name: "Ponies",
+        res_model: "pony",
+        type: "ir.actions.act_window",
+        views: [[false, "list"]],
+    },
 ]);
 
 test("can execute act_window actions from db ID", async () => {
@@ -205,6 +213,40 @@ test("can execute act_window actions from db ID", async () => {
         "get_views",
         "web_search_read",
     ]);
+});
+
+test("can open default form view with selectRecord when there is none in the action", async () => {
+    stepAllNetworkCalls();
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction(9);
+    expect.verifySteps([
+        "/web/webclient/translations",
+        "/web/webclient/load_menus",
+        "/web/action/load",
+        "get_views",
+        "web_search_read",
+        "has_group",
+    ]);
+    await contains(".o_data_row:eq(0) .o_data_cell").click();
+    expect(".o_form_view").toHaveCount(1, { message: "should display the form view" });
+    expect.verifySteps(["get_views", "web_read"]);
+});
+
+test("can open default form view with createRecord when there is none in the action", async () => {
+    stepAllNetworkCalls();
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction(9);
+    expect.verifySteps([
+        "/web/webclient/translations",
+        "/web/webclient/load_menus",
+        "/web/action/load",
+        "get_views",
+        "web_search_read",
+        "has_group",
+    ]);
+    await contains(".o_list_button_add").click();
+    expect(".o_form_view").toHaveCount(1, { message: "should display the form view" });
+    expect.verifySteps(["get_views", "onchange"]);
 });
 
 test.tags("desktop")("sidebar is present in list view", async () => {


### PR DESCRIPTION
Steps to reproduce:
- Fleet app > Any vehicle > Drivers History > Attachments
- In mobile view > Primary button 'Upload' is not accessible
- Primary button 'New' does not do anything

This happens because the controller cannot find a form view for ir.attachment in fleet, which is the default view type for record creation (barring quickcreate stuff). Also d-none class hides the display of the 'Upload' button but the dropdown menu arrow is still there which is rather confusing.

Backport of 5c7cc1d04d7bd4febc9fc0e17e5c1b2f43d71b9d This commit changes the behavior of the selectRecord and createRecord view props so that these will open the default form view when called without any form view found in the action.

opw-4229756

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
