### PR TITLE
[FIX] mrp: don't override parameter name in loop

### DIFF
--- a/addons/mrp/report/mrp_report_bom_structure.py
+++ b/addons/mrp/report/mrp_report_bom_structure.py
@@ -840,12 +840,12 @@ class ReportBomStructure(models.AbstractModel):
             simulated_leaves_per_workcenter = defaultdict(list)
         # Plan operation after its predecessors
         date_start = max(start_date, datetime.now())
-        for operation in operation.blocked_by_operation_ids:
-            if operation._skip_operation_line(product):
+        for op in operation.blocked_by_operation_ids:
+            if op._skip_operation_line(product):
                 continue
-            if operation not in planning_per_operation:
-                self._simulate_operation_planning(operation, product, start_date, quantity, planning_per_operation, simulated_leaves_per_workcenter)
-            date_start = max(date_start, planning_per_operation[operation]['date_finished'])
+            if op not in planning_per_operation:
+                self._simulate_operation_planning(op, product, start_date, quantity, planning_per_operation, simulated_leaves_per_workcenter)
+            date_start = max(date_start, planning_per_operation[op]['date_finished'])
         # Consider workcenter and alternatives
         workcenters = operation.workcenter_id | operation.workcenter_id.alternative_workcenter_ids
         best_date_finished = datetime.max


### PR DESCRIPTION
This commit makes sure `operation` parameter is not reused in the `for` loop.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
