### PR TITLE
[FIX] web: remove unnecessary call to startRouter

### DIFF
--- a/addons/web/static/tests/webclient/actions/load_state.test.js
+++ b/addons/web/static/tests/webclient/actions/load_state.test.js
@@ -21,7 +21,7 @@ import {
 import { browser } from "@web/core/browser/browser";
 import { registry } from "@web/core/registry";
 import { WebClient } from "@web/webclient/webclient";
-import { router, routerBus, startRouter } from "@web/core/browser/router";
+import { router, routerBus } from "@web/core/browser/router";
 import { redirect } from "@web/core/utils/urls";
 import { ControlPanel } from "@web/search/control_panel/control_panel";
 import { _t } from "@web/core/l10n/translation";
@@ -216,7 +216,6 @@ beforeEach(() => {
         origin: "http://example.com",
     });
     redirect("/odoo");
-    startRouter();
 });
 
 describe(`new urls`, () => {

--- a/addons/web/static/tests/webclient/actions/push_state.test.js
+++ b/addons/web/static/tests/webclient/actions/push_state.test.js
@@ -18,7 +18,7 @@ import {
 } from "@web/../tests/web_test_helpers";
 
 import { browser } from "@web/core/browser/browser";
-import { router, startRouter } from "@web/core/browser/router";
+import { router } from "@web/core/browser/router";
 import { registry } from "@web/core/registry";
 import { redirect } from "@web/core/utils/urls";
 import { WebClient } from "@web/webclient/webclient";
@@ -174,7 +174,6 @@ beforeEach(() => {
         origin: "http://example.com",
     });
     redirect("/odoo");
-    startRouter();
 });
 
 test(`basic action as App`, async () => {


### PR DESCRIPTION
Before each test on load_state.test.js and push_state.test.js, the startRouter function is called. This is not necessary, because is already called in : https://github.com/odoo/odoo/blob/3f142f332ef1eb168f91c6a83346c9c28a169aba/addons/web/static/tests/_framework/env_test_helpers.js#L109