### PR TITLE
[IMP] mail,im_livechat: shorten access of channel settings

### DIFF
--- a/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
@@ -26,11 +26,8 @@ patch(Thread.prototype, {
     get hasMemberList() {
         return this.channel_type === "livechat" || super.hasMemberList;
     },
-    get canLeave() {
-        if (this.channel_type === "livechat") {
-            return !this.selfMember || this.selfMember.message_unread_counter === 0;
-        }
-        return super.canLeave;
+    get allowedToLeaveChannelTypes() {
+        return [...super.allowedToLeaveChannelTypes, "livechat"];
     },
     get correspondents() {
         return super.correspondents.filter((correspondent) => !correspondent.is_bot);

--- a/addons/im_livechat/static/src/embed/common/disabled_features.js
+++ b/addons/im_livechat/static/src/embed/common/disabled_features.js
@@ -12,7 +12,7 @@ patch(Thread.prototype, {
     },
 });
 
-const allowedThreadActions = new Set(["fold-chat-window", "close", "restart", "settings"]);
+const allowedThreadActions = new Set(["fold-chat-window", "close", "restart", "call-settings"]);
 for (const [actionName] of threadActionsRegistry.getEntries()) {
     if (!allowedThreadActions.has(actionName)) {
         threadActionsRegistry.remove(actionName);

--- a/addons/im_livechat/static/src/embed/common/thread_actions.js
+++ b/addons/im_livechat/static/src/embed/common/thread_actions.js
@@ -18,7 +18,7 @@ threadActionsRegistry.add("restart", {
     sequenceQuick: 15,
 });
 
-const callSettingsAction = threadActionsRegistry.get("settings");
+const callSettingsAction = threadActionsRegistry.get("call-settings");
 patch(callSettingsAction, {
     condition(component) {
         return component.thread?.channel_type === "livechat"

--- a/addons/im_livechat/static/tests/call.test.js
+++ b/addons/im_livechat/static/tests/call.test.js
@@ -38,6 +38,6 @@ test("should display started a call message with operator livechat username", as
     setupChatHub({ opened: [channelId] });
     await start();
     await contains(".o-mail-ChatWindow", { text: "Visitor" });
-    await click("[title='Start a Call']");
+    await click("[title='Start Call']");
     await contains(".o-mail-NotificationMessage", { text: "mitchell boss started a call.1:00 PM" });
 });

--- a/addons/im_livechat/static/tests/channel_join_leave.test.js
+++ b/addons/im_livechat/static/tests/channel_join_leave.test.js
@@ -46,9 +46,10 @@ test("from the discuss app", async () => {
     await click("[title='Join HR']", {
         parent: [".o-mail-DiscussSidebarCategory-livechat", { text: "HR" }],
     });
-    await click("[title='Leave Channel']", {
+    await click("[title='Chat Actions']", {
         parent: [".o-mail-DiscussSidebarChannel", { text: "Visitor" }],
     });
+    await click(".o-dropdown-item:contains('Leave Channel')");
     await click("button:contains(Leave Conversation)");
     await click("[title='Leave HR']", {
         parent: [".o-mail-DiscussSidebarCategory-livechat", { text: "HR" }],

--- a/addons/im_livechat/static/tests/sidebar_patch.test.js
+++ b/addons/im_livechat/static/tests/sidebar_patch.test.js
@@ -354,7 +354,8 @@ test("Clicking on leave button leaves the channel", async () => {
     await start();
     await openDiscuss();
     await contains(".o-mail-DiscussSidebarChannel", { text: "Visitor 11" });
-    await click(".o-mail-DiscussSidebarChannel [title='Leave Channel']");
+    await click("[title='Chat Actions']");
+    await click(".o-dropdown-item:contains('Leave Channel')");
     await click("button:contains(Leave Conversation)");
     await contains(".o-mail-DiscussSidebarChannel", { count: 0, text: "Visitor 11" });
 });
@@ -421,9 +422,8 @@ test("unknown livechat can be displayed and interacted with", async () => {
     await waitForSteps(["discuss.channel/new_message"]);
     await click("button", { text: "Inbox" });
     await contains(".o-mail-DiscussSidebarChannel:not(.o-active)", { text: "Jane" });
-    await click("[title='Leave Channel']", {
-        parent: [".o-mail-DiscussSidebarChannel", { text: "Jane" }],
-    });
+    await click("[title='Chat Actions']");
+    await click(".o-dropdown-item:contains('Leave Channel')");
     await click("button:contains('Leave Conversation')");
     await contains(".o-mail-DiscussSidebarCategory-livechat", { count: 0 });
     await contains(".o-mail-DiscussSidebarChannel", { count: 0 });

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -25,35 +25,10 @@
                         </button>
                         <t t-set-slot="content">
                             <t t-set="quickActionsInDropdown" t-value="partitionedActions.quick.slice(ui.isSmall ? 2 : 4)"/>
-                            <t t-if="quickActionsInDropdown.length > 0">
-                                <t t-set="groupBefore" t-value="true"/>
-                                <t t-foreach="quickActionsInDropdown" t-as="action" t-key="action.id">
-                                    <t t-call="mail.ChatWindow.dropdownAction">
-                                        <t t-set="action" t-value="action"/>
-                                    </t>
-                                </t>
-                            </t>
-                            <t t-else="" t-set="groupBefore" t-value="false"/>
-                            <t t-if="partitionedActions.group.length > 0">
-                                <hr t-if="groupBefore" class="mx-2 my-1"/>
-                                <t t-set="groupBefore" t-value="true"/>
-                                <t t-foreach="partitionedActions.group" t-as="group" t-key="group_index">
-                                    <t t-foreach="group" t-as="action" t-key="action.id">
-                                        <t t-call="mail.ChatWindow.dropdownAction">
-                                            <t t-set="action" t-value="action"/>
-                                        </t>
-                                    </t>
-                                    <hr t-if="!group_last" class="mx-2 my-1"/>
-                                </t>
-                            </t>
-                            <t t-else="" t-set="groupBefore" t-value="false"/>
-                            <t t-if="partitionedActions.other.length">
-                                <hr t-if="groupBefore" class="mx-2 my-1"/>
-                                <t t-foreach="partitionedActions.other" t-as="action" t-key="action.id">
-                                    <t t-call="mail.ChatWindow.dropdownAction">
-                                        <t t-set="action" t-value="action"/>
-                                    </t>
-                                </t>
+                            <t t-call="mail.ThreadActionsAsDropdownContent">
+                                <t t-set="quick" t-value="quickActionsInDropdown"/>
+                                <t t-set="group" t-value="partitionedActions.group"/>
+                                <t t-set="other" t-value="partitionedActions.other"/>
                             </t>
                         </t>
                     </Dropdown>
@@ -116,13 +91,6 @@
     <button class="o-mail-ChatWindow-command btn d-flex opacity-100-hover align-items-center p-0 o-quick rounded-3" style="aspect-ratio: 1;" t-att-class="{ 'o-small p-2 my-1': ui.isSmall }" t-attf-class="{{ itemClass }}" t-att-title="action.name" t-att-disabled="props.chatWindow.actionsDisabled" t-on-click.stop="() => action.onSelect()"><i class="fa-lg" t-attf-class="{{ action.icon }}"/></button>
 </t>
 
-<t t-name="mail.ChatWindow.dropdownAction">
-    <DropdownItem class="'o-mail-ChatWindow-command btn rounded-0 d-flex align-items-baseline p-2 m-0'" onSelected="() => action.onSelect()">
-        <i t-att-class="action.icon"/>
-        <span class="mx-2" t-att-class="action.nameClass" t-out="action.name"/>
-    </DropdownItem>
-</t>
-
 <t t-name="mail.ChatWindow.headerContent">
     <div class="o-mail-ChatWindow-threadAvatar position-relative bg-inherit my-0 me-1" t-att-class="{
         'py-1': !thread or threadActions.actions.length gt 3,
@@ -141,4 +109,45 @@
     <CountryFlag t-if="thread?.showCorrespondentCountry" country="thread.correspondentCountry" class="'o-mail-ChatWindow-country border shadow-sm'"/>
     <div t-if="!state.editingName" class="text-truncate fw-bold border border-transparent mx-1 my-0 py-1" t-att-title="props.chatWindow.displayName" t-esc="props.chatWindow.displayName" t-att-class="{ 'fs-4': ui.isSmall, 'fs-5': !ui.isSmall }"/>
 </t>
+
+<t t-name="mail.ThreadActionsAsDropdownContent">
+    <t t-if="quick?.length > 0">
+        <t t-set="groupBefore" t-value="true"/>
+        <t t-foreach="quick" t-as="action" t-key="action.id">
+            <t t-call="mail.ThreadActionsAsDropdownContent.action">
+                <t t-set="action" t-value="action"/>
+            </t>
+        </t>
+    </t>
+    <t t-else="" t-set="groupBefore" t-value="false"/>
+    <t t-if="group?.length > 0">
+        <hr t-if="groupBefore" class="mx-2 my-1"/>
+        <t t-set="groupBefore" t-value="true"/>
+        <t t-foreach="group" t-as="group" t-key="group_index">
+            <t t-foreach="group" t-as="action" t-key="action.id">
+                <t t-call="mail.ThreadActionsAsDropdownContent.action">
+                    <t t-set="action" t-value="action"/>
+                </t>
+            </t>
+            <hr t-if="!group_last" class="mx-2 my-1"/>
+        </t>
+    </t>
+    <t t-else="" t-set="groupBefore" t-value="false"/>
+    <t t-if="other?.length">
+        <hr t-if="groupBefore" class="mx-2 my-1"/>
+        <t t-foreach="other" t-as="action" t-key="action.id">
+            <t t-call="mail.ThreadActionsAsDropdownContent.action">
+                <t t-set="action" t-value="action"/>
+            </t>
+        </t>
+    </t>
+</t>
+
+<t t-name="mail.ThreadActionsAsDropdownContent.action">
+    <DropdownItem class="'btn d-flex align-items-baseline m-0 rounded-0 ' + (env.inChatWindow ? 'o-mail-ChatWindow-command p-2' : 'rounded-4 px-2 py-1 smaller')" onSelected="() => action.onSelect()">
+        <i t-att-class="action.icon"/>
+        <span t-att-class="{ 'mx-2': env.inChatWindow, 'mx-1': !env.inChatWindow }" t-attf-class="{{ action.nameClass }}" t-out="action.name"/>
+    </DropdownItem>
+</t>
+
 </templates>

--- a/addons/mail/static/src/core/common/composer_actions.js
+++ b/addons/mail/static/src/core/common/composer_actions.js
@@ -246,7 +246,7 @@ export function useComposerActions() {
             }
             const group = sortedGroups.map(([groupId, actions]) => actions);
             const other = actions
-                .filter((a) => !a.sequenceQuick & !a.sequenceGroup)
+                .filter((a) => !a.sequenceQuick && !a.sequenceGroup)
                 .sort((a1, a2) => a1.sequence - a2.sequence);
             return { quick, group, other, pickers };
         },

--- a/addons/mail/static/src/core/common/core.dark.scss
+++ b/addons/mail/static/src/core/common/core.dark.scss
@@ -1,5 +1,5 @@
 .o-mail-discussSidebarBgColor {
-    background-color: mix($white, $o-webclient-background-color, 15%);
+    background-color: mix($white, $o-webclient-background-color, 15%) !important;
 }
 
 a.o_mail_redirect, a.o_channel_redirect {

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -1,7 +1,7 @@
 $o-discuss-talkingColor: lighten($success, 10%);
 
 .o-mail-discussSidebarBgColor {
-    background-color: $white;
+    background-color: $white !important;
 }
 
 .o-mail-brighter {
@@ -85,6 +85,11 @@ $o-discuss-talkingColor: lighten($success, 10%);
 
 .o-mt-0_5 {
     margin-top: map-get($spacers, 1) / 2;
+}
+
+.o-px-0_5 {
+    padding-left: map-get($spacers, 1) / 2;
+    padding-right: map-get($spacers, 1) / 2;
 }
 
 .o-py-0_5 {

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -74,16 +74,23 @@ export class Thread extends Record {
          */
         sort: (a1, a2) => (a1.id < a2.id ? 1 : -1),
     });
+    get allowedToLeaveChannelTypes() {
+        return ["channel", "group"];
+    }
     get canLeave() {
         return (
-            ["channel", "group"].includes(this.channel_type) &&
-            !this.message_needaction_counter &&
+            this.allowedToLeaveChannelTypes.includes(this.channel_type) &&
             !this.group_based_subscription &&
             this.store.self?.type === "partner"
         );
     }
+    get allowedToUnpinChannelTypes() {
+        return ["chat"];
+    }
     get canUnpin() {
-        return this.channel_type === "chat" && this.importantCounter === 0;
+        return (
+            this.parent_channel_id || this.allowedToUnpinChannelTypes.includes(this.channel_type)
+        );
     }
     /** @type {boolean} */
     can_react = true;

--- a/addons/mail/static/src/core/public_web/discuss.js
+++ b/addons/mail/static/src/core/public_web/discuss.js
@@ -37,6 +37,7 @@ export class Discuss extends Component {
 
     setup() {
         super.setup();
+        window.aku = this;
         this.store = useService("mail.store");
         this.messageHighlight = useMessageHighlight();
         this.contentRef = useRef("content");

--- a/addons/mail/static/src/core/public_web/messaging_menu.js
+++ b/addons/mail/static/src/core/public_web/messaging_menu.js
@@ -163,6 +163,10 @@ export class MessagingMenu extends Component {
             this.store.discuss.thread = undefined;
         }
     }
+
+    canUnpinItem(thread) {
+        return thread.canUnpin && thread.message_unread_counter === 0;
+    }
 }
 
 registry

--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -19,7 +19,7 @@
                     muted="thread.mute_until_dt ? 2 : !thread.isUnread ? 1 : 0"
                     onClick="(isMarkAsRead) => this.onClickThread(isMarkAsRead, thread)"
                     onSwipeRight="hasTouch() and thread.isUnread ? { action: () => this.markAsRead(thread), icon: 'fa-check-circle', bgColor: 'bg-success' } : undefined"
-                    onSwipeLeft="hasTouch() and thread.canUnpin ? { action: () => thread.unpin(), icon: 'fa-times-circle', bgColor: 'bg-danger' } : undefined"
+                    onSwipeLeft="hasTouch() and canUnpinItem(thread) ? { action: () => thread.unpin(), icon: 'fa-times-circle', bgColor: 'bg-danger' } : undefined"
                     nameMaxLine="1"
                     textMaxLine="2"
                 >

--- a/addons/mail/static/src/core/public_web/thread_actions.js
+++ b/addons/mail/static/src/core/public_web/thread_actions.js
@@ -5,9 +5,11 @@ import { useService } from "@web/core/utils/hooks";
 
 threadActionsRegistry.add("leave", {
     condition: (component) =>
-        component.ui.isSmall && (component.thread?.canLeave || component.thread?.canUnpin),
+        !(component.env.inChatWindow && !component.ui.isSmall) &&
+        (component.thread?.canLeave || component.thread?.canUnpin),
     icon: "fa fa-fw fa-sign-out text-danger",
-    name: (component) => (component.thread.canLeave ? _t("Leave") : _t("Unpin")),
+    name: (component) =>
+        component.thread.canLeave ? _t("Leave Channel") : _t("Unpin Conversation"),
     nameClass: "text-danger",
     open: (component) =>
         component.thread.canLeave ? component.thread.leaveChannel() : component.thread.unpin(),
@@ -17,4 +19,6 @@ threadActionsRegistry.add("leave", {
         const component = useComponent();
         component.ui = useService("ui");
     },
+    sidebarSequence: 10,
+    sidebarSequenceGroup: 40,
 });

--- a/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.js
+++ b/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.js
@@ -18,8 +18,16 @@ export class Mailbox extends Component {
         super.setup();
         this.store = useService("mail.store");
         this.hover = useHover(["root", "floating*"], {
-            onHover: () => (this.floating.isOpen = true),
-            onAway: () => (this.floating.isOpen = false),
+            onHover: () => {
+                if (this.store.discuss.isSidebarCompact) {
+                    this.floating.isOpen = true;
+                }
+            },
+            onAway: () => {
+                if (this.store.discuss.isSidebarCompact) {
+                    this.floating.isOpen = false;
+                }
+            },
         });
         this.floating = useDropdownState();
         this.rootRef = useRef("root");

--- a/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
@@ -10,7 +10,7 @@
     </t>
 
     <t t-name="mail.Mailbox">
-        <Dropdown t-if="store.discuss.isSidebarCompact" state="floating" position="'right-middle'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary p-2 mx-2 my-2 min-w-0 shadow-sm'" manual="true">
+        <Dropdown t-if="store.discuss.isSidebarCompact" state="floating" position="'right-middle'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary p-2 mx-2 my-2 min-w-0 shadow-sm o-rounded-bubble'" manual="true">
             <t t-call="mail.Mailbox.main"/>
             <t t-set-slot="content">
                 <div class="overflow-hidden" t-ref="floating">

--- a/addons/mail/static/src/core/web/discuss_sidebar_patch.js
+++ b/addons/mail/static/src/core/web/discuss_sidebar_patch.js
@@ -10,8 +10,16 @@ patch(DiscussSidebar.prototype, {
         super.setup();
         this.ui = useService("ui");
         this.meetingHover = useHover(["meeting-btn", "meeting-floating*"], {
-            onHover: () => (this.meetingFloating.isOpen = true),
-            onAway: () => (this.meetingFloating.isOpen = false),
+            onHover: () => {
+                if (this.store.discuss.isSidebarCompact) {
+                    this.meetingFloating.isOpen = true;
+                }
+            },
+            onAway: () => {
+                if (this.store.discuss.isSidebarCompact) {
+                    this.meetingFloating.isOpen = false;
+                }
+            },
         });
         this.meetingFloating = useDropdownState();
     },

--- a/addons/mail/static/src/core/web/discuss_sidebar_patch.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.DiscussSidebar" t-inherit-mode="extension">
         <xpath expr="//*[@name='options-btn']" position="after">
-            <Dropdown t-if="store.discuss.isSidebarCompact" state="meetingFloating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary p-2 mx-2 my-0 min-w-0 shadow-sm'" manual="true">
+            <Dropdown t-if="store.discuss.isSidebarCompact" state="meetingFloating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary p-2 mx-2 my-0 min-w-0 shadow-sm o-rounded-bubble'" manual="true">
                 <t t-call="mail.DiscussSidebar.startMeetingButton"/>
                 <t t-set-slot="content">
                     <div t-ref="meeting-floating">

--- a/addons/mail/static/src/discuss/call/common/chat_window_patch.scss
+++ b/addons/mail/static/src/discuss/call/common/chat_window_patch.scss
@@ -1,16 +1,10 @@
-.o-mail-ChatWindow-command {
-    @media (hover: none) {
-        .fa-phone, .fa-video-camera {
-            color: $success !important;
-        }
-    }
-    @media (hover: hover) {
-        &:hover {
-            &:has(.fa-phone), &:has(.fa-video-camera) {
-                outline: 1px solid rgba($success, .35);
-                i {
-                    color: lighten($success, 5%) !important;
-                }
+
+@media (hover: hover) {
+    .o-mail-ChatWindow-command.o-quick:hover {
+        &:has(.fa-phone), &:has(.fa-video-camera) {
+            outline: 1px solid rgba($success, .35);
+            i {
+                color: lighten($success, 5%) !important;
             }
         }
     }

--- a/addons/mail/static/src/discuss/call/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/call/common/thread_actions.js
@@ -11,14 +11,15 @@ threadActionsRegistry
         condition(component) {
             return component.thread?.allowCalls && !component.thread?.eq(component.rtc.channel);
         },
-        icon: "fa fa-fw fa-phone",
-        iconLarge: "fa fa-fw fa-lg fa-phone",
+        icon: "fa fa-fw fa-phone text-success",
+        iconLarge: "fa fa-fw fa-lg fa-phone text-success",
         name(component) {
             if (component.thread.rtc_session_ids.length > 0) {
                 return _t("Join the Call");
             }
-            return _t("Start a Call");
+            return _t("Start Call");
         },
+        nameClass: "text-success",
         open(component) {
             component.rtc.toggleCall(component.thread);
         },
@@ -28,19 +29,22 @@ threadActionsRegistry
             const component = useComponent();
             component.rtc = useService("discuss.rtc");
         },
+        sidebarSequence: 10,
+        sidebarSequenceGroup: 10,
     })
     .add("camera-call", {
         condition(component) {
             return component.thread?.allowCalls && !component.thread?.eq(component.rtc.channel);
         },
-        icon: "fa fa-fw fa-video-camera",
-        iconLarge: "fa fa-fw fa-lg fa-video-camera",
+        icon: "fa fa-fw fa-video-camera text-success",
+        iconLarge: "fa fa-fw fa-lg fa-video-camera text-success",
         name(component) {
             if (component.thread.rtc_session_ids.length > 0) {
                 return _t("Join the Call with Camera");
             }
-            return _t("Start a Video Call");
+            return _t("Start Video Call");
         },
+        nameClass: "text-success",
         open(component) {
             component.rtc.toggleCall(component.thread, { camera: true });
         },
@@ -50,8 +54,10 @@ threadActionsRegistry
             const component = useComponent();
             component.rtc = useService("discuss.rtc");
         },
+        sidebarSequence: 20,
+        sidebarSequenceGroup: 10,
     })
-    .add("settings", {
+    .add("call-settings", {
         component: CallSettings,
         componentProps(action) {
             return { isCompact: true };
@@ -72,4 +78,19 @@ threadActionsRegistry
             component.rtc = useService("discuss.rtc");
         },
         toggle: true,
+    })
+    .add("disconnect", {
+        condition: (component) => component.rtc.selfSession?.in(component.thread?.rtc_session_ids),
+        open: (component) => component.rtc.toggleCall(component.thread),
+        icon: "fa fa-fw fa-phone text-danger",
+        iconLarge: "fa fa-fw fa-lg fa-phone text-danger",
+        name: _t("Disconnect"),
+        nameClass: "text-danger",
+        partition: false,
+        setup() {
+            const component = useComponent();
+            component.rtc = useService("discuss.rtc");
+        },
+        sidebarSequence: 30,
+        sidebarSequenceGroup: 10,
     });

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebarCallParticipants">
         <t t-if="sessions.length gt 0">
-            <Dropdown t-if="compact" state="floating" position="'right-start'" manual="true" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary py-0 shadow-sm'">
+            <Dropdown t-if="compact" state="floating" position="'right-start'" manual="true" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary py-0 shadow-sm o-rounded-bubble'">
                 <t t-call="mail.DiscussSidebarCallParticipants.main"/>
                 <t t-set-slot="content">
                     <div class="p-2" t-ref="floating">

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -178,7 +178,7 @@ export class ChannelInvitation extends Component {
             return "";
         }
         if (this.props.thread.channel_type === "channel") {
-            return _t("Invite to Channel");
+            return _t("Invite");
         } else if (this.props.thread.channel_type === "group") {
             return _t("Invite to Group Chat");
         } else if (this.props.thread.channel_type === "chat") {

--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -4,10 +4,22 @@ import { ChannelInvitation } from "@mail/discuss/core/common/channel_invitation"
 import { ChannelMemberList } from "@mail/discuss/core/common/channel_member_list";
 import { NotificationSettings } from "@mail/discuss/core/common/notification_settings";
 
-import { useComponent } from "@odoo/owl";
+import { Component, xml, useComponent } from "@odoo/owl";
 
+import { Dialog } from "@web/core/dialog/dialog";
 import { _t } from "@web/core/l10n/translation";
 import { usePopover } from "@web/core/popover/popover_hook";
+import { useService } from "@web/core/utils/hooks";
+
+class ChannelActionDialog extends Component {
+    static props = ["title", "contentComponent", "contentProps", "close?"];
+    static components = { Dialog };
+    static template = xml`
+        <Dialog size="'md'" title="props.title" footer="false" contentClass="'o-bg-body'" bodyClass="'p-1'">
+            <t t-component="props.contentComponent" t-props="props.contentProps"/>
+        </Dialog>
+    `;
+}
 
 threadActionsRegistry
     .add("notification-settings", {
@@ -28,12 +40,24 @@ threadActionsRegistry
                     popoverClass: action.panelOuterClass,
                 });
             }
+            action.dialogService = useService("dialog");
+            component.store = useService("mail.store");
         },
         open(component, action) {
-            action.popover?.open(component.root.el.querySelector(`[name="${action.id}"]`), {
-                hasSizeConstraints: true,
-                thread: component.thread,
-            });
+            if (action.sidebar) {
+                action.dialogService?.add(ChannelActionDialog, {
+                    title: component.thread.name,
+                    contentComponent: NotificationSettings,
+                    contentProps: {
+                        thread: component.thread,
+                    },
+                });
+            } else {
+                action.popover?.open(component.root.el.querySelector(`[name="${action.id}"]`), {
+                    hasSizeConstraints: true,
+                    thread: component.thread,
+                });
+            }
         },
         close(component, action) {
             action.popover?.close();
@@ -53,6 +77,8 @@ threadActionsRegistry
         panelOuterClass: "bg-100 border border-secondary",
         sequence: 10,
         sequenceGroup: 30,
+        sidebarSequence: 10,
+        sidebarSequenceGroup: 30,
         toggle: true,
     })
     .add("attachments", {
@@ -90,10 +116,24 @@ threadActionsRegistry
         iconLarge: "fa fa-fw fa-lg fa-user-plus",
         name: _t("Invite People"),
         open(component, action) {
-            action.popover?.open(component.root.el.querySelector(`[name="${action.id}"]`), {
-                hasSizeConstraints: true,
-                thread: component.thread,
-            });
+            if (action.sidebar) {
+                action.dialogService?.add(ChannelActionDialog, {
+                    title: component.thread.name,
+                    contentComponent: ChannelInvitation,
+                    contentProps: {
+                        autofocus: true,
+                        thread: component.thread,
+                        close: () => {
+                            action.dialogService.closeAll();
+                        },
+                    },
+                });
+            } else {
+                action.popover?.open(component.root.el.querySelector(`[name="${action.id}"]`), {
+                    hasSizeConstraints: true,
+                    thread: component.thread,
+                });
+            }
         },
         sequence: 10,
         sequenceGroup: 20,
@@ -105,7 +145,10 @@ threadActionsRegistry
                     popoverClass: action.panelOuterClass,
                 });
             }
+            action.dialogService = useService("dialog");
         },
+        sidebarSequence: 20,
+        sidebarSequenceGroup: 20,
         toggle: true,
     })
     .add("member-list", {
@@ -142,4 +185,15 @@ threadActionsRegistry
         sequence: 30,
         sequenceGroup: 10,
         toggle: true,
+    })
+    .add("mark-read", {
+        condition: (component) =>
+            component.thread?.selfMember?.message_unread_counter > 0 &&
+            !component.thread?.mute_until_dt,
+        open: (component) => component.thread.markAsRead(),
+        icon: "fa fa-fw fa-check",
+        name: _t("Mark Read"),
+        partition: false,
+        sidebarSequence: 10,
+        sidebarSequenceGroup: 20,
     });

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.dark.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.dark.scss
@@ -7,6 +7,10 @@
     ---mail-DiscussSidebarChannel-borderedBgColor: #{mix($gray-100, $gray-200, 75%)};
 }
 
+.o-mail-DiscussSidebarChannel-floatingName {
+    ---mail-DiscussSidebarChannel-floatingNameBgColor: #{mix($white, $gray-100, 25%)};
+}
+
 .o-mail-DiscussSidebarSubchannel {
     --mail-DiscussSidebarSubchannel-svgColor: #{mix($gray-300, $gray-400)};
 }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
@@ -27,12 +27,30 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .05;
     --border-opacity: 0.5;
 }
 
+.o-mail-DiscussSidebarChannel-floatingName {
+    --border-opacity: 0.5;
+    background-color: var(---mail-DiscussSidebarChannel-floatingNameBgColor, mix($gray-100, $gray-200));
+}
+
 .o-mail-DiscussSidebar-item {
     line-height: 2; // so that same height as actions
     background-color: inherit !important;
 
-    &:hover .o-mail-DiscussSidebarChannel-commands {
+    &:hover .o-mail-DiscussSidebarChannel-actions {
         display: flex !important;
+    }
+}
+
+.o-mail-DiscussSidebarChannel-actions button {
+    opacity: 35%;
+
+    &:hover {
+        opacity: 100%;
+    }
+
+    &.o-showingActions {
+        opacity: 100%;
+        --border-opacity: .25;
     }
 }
 

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebarCategories">
-        <Dropdown t-if="store.discuss.isSidebarCompact" state="searchFloating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary mx-2 my-0 min-w-0 p-0 shadow-sm'" manual="true">
+        <Dropdown t-if="store.discuss.isSidebarCompact" state="searchFloating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary mx-2 my-0 min-w-0 p-0 shadow-sm o-rounded-bubble'" manual="true">
             <button class="o-mail-DiscussSidebarCategories-searchBtn btn btn-light d-flex align-items-center justify-content-center border-0 px-1 mx-2 opacity-75 bg-transparent" t-on-click="onClickFindOrStartConversation" t-ref="search-btn"><i class="fa fa-lg fa-fw fa-search"/></button>
             <t t-set-slot="content">
                 <div class="p-2" t-ref="search-floating">
@@ -30,10 +30,10 @@
     </t>
 
     <t t-name="mail.DiscussSidebarCategory">
-        <Dropdown t-if="store.discuss.isSidebarCompact" state="floating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary p-2 mx-2 my-0 min-w-0 shadow-sm'" manual="true">
+        <Dropdown t-if="store.discuss.isSidebarCompact" state="floating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary p-2 mx-2 my-0 min-w-0 shadow-sm o-rounded-bubble'" manual="true">
             <t t-call="mail.DiscussSidebarCategory.main"/>
             <t t-set-slot="content">
-                <div class="overflow-hidden" t-ref="floating">
+                <div class="overflow-hidden d-flex flex-column" t-ref="floating">
                     <span class="fw-bold text-uppercase o-xsmaller user-select-none text-muted" t-esc="category.name"/>
                     <t t-call="mail.DiscussSidebarCategory.actions"/>
                 </div>
@@ -83,12 +83,12 @@
     <t t-name="mail.DiscussSidebarChannel">
         <div class="o-mail-DiscussSidebarChannel-container d-flex flex-column mx-2 bg-inherit" t-att-class="attClassContainer">
             <t name="root">
-                <Dropdown t-if="store.discuss.isSidebarCompact" state="floating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary p-2 mx-2 my-0 min-w-0 shadow-sm'" manual="true">
+                <Dropdown t-if="store.discuss.isSidebarCompact" state="floating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu rounded-3 bg-100 border border-secondary p-0 mx-2 my-0 min-w-0 shadow-sm o-rounded-bubble'" manual="true">
                     <t t-call="mail.DiscussSidebarChannel.main"/>
                     <t t-set-slot="content">
-                        <div class="overflow-hidden" t-ref="floating">
-                            <span class="fw-bolder user-select-none" t-esc="thread.displayName"/>
-                            <t t-call="mail.DiscussSidebarChannel.commands"/>
+                        <div class="overflow-hidden d-flex flex-column" t-ref="floating">
+                            <span class="o-mail-DiscussSidebarChannel-floatingName fw-bolder user-select-none text-truncate d-inline-block p-2 shadow-sm border-bottom border-secondary" t-esc="thread.displayName"/>
+                            <DiscussSidebarChannelActions thread="thread"/>
                         </div>
                     </t>
                 </Dropdown>
@@ -103,10 +103,13 @@
     </t>
 
     <t t-name="mail.DiscussSidebarSubchannel">
-        <Dropdown t-if="store.discuss.isSidebarCompact" state="floating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary p-2 mx-2 my-0 min-w-0 shadow-sm'" manual="true">
+        <Dropdown t-if="store.discuss.isSidebarCompact" state="floating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu rounded-3 bg-100 border border-secondary p-0 mx-2 my-0 min-w-0 shadow-sm o-rounded-bubble'" manual="true">
             <t t-call="mail.DiscussSidebarSubchannel.main"/>
             <t t-set-slot="content">
-                <div class="overflow-hidden user-select-none" t-ref="floating" t-esc="thread.displayName"/>
+                <div class="overflow-hidden d-flex flex-column" t-ref="floating">
+                    <span class="o-mail-DiscussSidebarChannel-floatingName fw-bolder user-select-none text-truncate d-inline-block p-2 shadow-sm border-bottom border-secondary" t-esc="thread.displayName"/>
+                    <DiscussSidebarChannelActions thread="thread"/>
+                </div>
             </t>
         </Dropdown>
         <t t-else="" t-call="mail.DiscussSidebarSubchannel.main"/>
@@ -136,7 +139,7 @@
                     'text-muted': !(thread.selfMember?.message_unread_counter > 0 and !thread.isMuted),
                 }" t-att-style="store.discuss.isSidebarCompact ? 'text-overflow: clip;' : ''"/>
                 <span class="flex-grow-1"/>
-                <t t-if="!store.discuss.isSidebarCompact" t-call="mail.DiscussSidebarChannel.commands"/>
+                <t t-if="!store.discuss.isSidebarCompact" t-call="mail.DiscussSidebarChannel.actions"/>
                 <span t-if="thread.importantCounter > 0" t-attf-class="o-mail-DiscussSidebar-badge shadow-sm badge rounded-pill o-discuss-badge fw-bold top-0 {{thread.isMuted ? 'o-muted' : ''}}" t-att-class="{ 'mx-1': !store.discuss.isSidebarCompact, 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact }" t-esc="thread.importantCounter"/>
             </button>
             <t t-if="thread.selfMember?.message_unread_counter > 0 and !thread.isMuted and thread.importantCounter === 0" t-call="mail.DiscussSidebar.unreadIndicator"/>
@@ -166,33 +169,32 @@
             <div t-if="indicators.length" class="position-absolute rounded-circle p-0 smaller o-mail-DiscussSidebarChannel-indicatorCompact lh-1 bg-inherit" name="indicator-compact">
                 <t t-component="indicators[0]" t-props="{ thread }"/>
             </div>
-            <t t-if="!store.discuss.isSidebarCompact">
-                <div class="flex-grow-1"/>
-                <t t-call="mail.DiscussSidebarChannel.commands"/>
-            </t>
+            <div t-if="!store.discuss.isSidebarCompact" class="flex-grow-1"/>
             <t t-if="thread.selfMember?.message_unread_counter > 0 and !thread.isMuted and thread.importantCounter === 0" t-call="mail.DiscussSidebar.unreadIndicator"/>
-            <t t-if="thread.importantCounter > 0" t-call="mail.discuss_badge">
+            <t t-if="thread.importantCounter > 0 and (showingActions.isOpen or store.discuss.isSidebarCompact or !hover.isHover)" t-call="mail.discuss_badge">
                 <t t-set="counter" t-value="thread.importantCounter"/>
-                <t t-set="badgeClass" t-value="'o-mail-DiscussSidebarChannel-badge o-mail-DiscussSidebar-badge shadow-sm flex-shrink-0 fw-bold ' + (thread.isMuted ? 'o-muted' : '') + ' ' + (store.discuss.isSidebarCompact ? 'position-absolute top-0 o-compact' : 'ms-1 me-2')"/>
+                <t t-set="badgeClass" t-value="'o-mail-DiscussSidebarChannel-badge o-mail-DiscussSidebar-badge shadow-sm flex-shrink-0 fw-bold ' + (thread.isMuted ? 'o-muted' : '') + ' ' + (store.discuss.isSidebarCompact ? 'position-absolute top-0 o-compact' : showingActions.isOpen ? 'ms-1 me-0' : 'ms-1 me-2')"/>
                 <t t-set="floating" t-value="store.discuss.isSidebarCompact"/>
             </t>
+            <t t-if="!store.discuss.isSidebarCompact" t-call="mail.DiscussSidebarChannel.actions"/>
         </button>
     </t>
 
-    <t t-name="mail.DiscussSidebarChannel.commands">
-        <div class="o-mail-DiscussSidebarChannel-commands" t-att-class="{
-            'd-none': !store.discuss.isSidebarCompact,
-            'mx-1': !store.discuss.isSidebarCompact and thread.importantCounter === 0,
-            'ms-1': !store.discuss.isSidebarCompact and thread.importantCounter > 0,
+    <t t-name="mail.DiscussSidebarChannel.actions">
+        <div class="o-mail-DiscussSidebarChannel-actions" t-att-class="{
+            'd-none': !showingActions.isOpen,
+            'd-flex': showingActions.isOpen,
+            'mx-1': thread.importantCounter === 0,
+            'ms-1': thread.importantCounter > 0,
         }">
-            <div t-att-class="{ 'd-flex flex-column align-items-start ps-1 pt-1': store.discuss.isSidebarCompact, 'btn-group btn-group-sm o-gap-0_5': !store.discuss.isSidebarCompact }">
-                <t t-foreach="sortedCommands" t-as="command" t-key="command_index">
-                    <button class="btn o-opacity-35 opacity-100-hover" t-att-class="{ 'd-flex align-items-center px-1 py-0 gap-1 text-start smaller btn-secondary shadow-sm': store.discuss.isSidebarCompact, 'btn-light bg-transparent rounded-3 p-0 border-transparent': !store.discuss.isSidebarCompact }" t-on-click.stop="() => command.onSelect()" t-att-title="store.discuss.isSidebarCompact ? '' : command.label">
-                        <i role="img" class="fa-fw fa-lg" t-att-class="command.icon"/>
-                        <span t-if="store.discuss.isSidebarCompact" t-esc="command.label"/>
-                    </button>
+            <Dropdown state="showingActions" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary my-0 min-w-0 p-0 o-rounded-bubble mx-1'">
+                <button class="btn me-1 btn-light rounded-circle d-flex o-px-0_5 py-1 align-items-center justify-content-center" t-att-class="{ 'o-showingActions border-dark o-mail-discussSidebarBgColor shadow-sm': showingActions.isOpen, 'bg-transparent border-transparent': !showingActions.isOpen }" t-att-title="actionsTitle">
+                    <i role="img" class="oi oi-fw oi-lg oi-ellipsis-h"/>
+                </button>
+                <t t-set-slot="content">
+                    <DiscussSidebarChannelActions thread="thread"/>
                 </t>
-            </div>
+            </Dropdown>
         </div>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel_actions.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel_actions.js
@@ -1,0 +1,29 @@
+import { useThreadActions } from "@mail/core/common/thread_actions";
+
+import { Component } from "@odoo/owl";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { useService } from "@web/core/utils/hooks";
+/**
+ * @typedef {Object} Props
+ * @property {import("@mail/core/common/thread_model").Thread} thread
+ * @property {function} [close]
+ * @extends {Component<Props, Env>}
+ */
+export class DiscussSidebarChannelActions extends Component {
+    static template = "mail.DiscussSidebarChannelActions";
+    static props = ["thread"];
+    static components = { DropdownItem };
+
+    setup() {
+        this.store = useService("mail.store");
+        this.threadActions = useThreadActions();
+    }
+
+    get thread() {
+        return this.props.thread;
+    }
+
+    open(action) {
+        action.open();
+    }
+}

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel_actions.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel_actions.scss
@@ -1,0 +1,11 @@
+.o-mail-DiscussSidebarChannelActions {
+    .o-dropdown-item {
+        opacity: 75%;
+        &.focus {
+            opacity: 100%;
+        }
+    }
+    hr {
+        opacity: 10%;
+    }
+}

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel_actions.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel_actions.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="mail.DiscussSidebarChannelActions">
+        <div class="o-mail-DiscussSidebarChannelActions d-flex flex-column o-gap-0_5" t-att-class="{ 'px-1 pt-1 pb-2': store.discuss.isSidebarCompact, 'p-1': !store.discuss.isSidebarCompact }">
+            <t t-call="mail.ThreadActionsAsDropdownContent">
+                <t t-set="group" t-value="threadActions.sidebarActions"/>
+            </t>
+        </div>
+    </t>
+</templates>

--- a/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
@@ -44,9 +44,6 @@ const threadPatch = {
     get canLeave() {
         return !this.parent_channel_id && super.canLeave;
     },
-    get canUnpin() {
-        return (this.parent_channel_id && this.importantCounter === 0) || super.canUnpin;
-    },
     _computeDiscussAppCategory() {
         if (this.parent_channel_id) {
             return;

--- a/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories_patch.js
+++ b/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories_patch.js
@@ -1,41 +1,7 @@
 import { patch } from "@web/core/utils/patch";
-import {
-    DiscussSidebarCategory,
-    DiscussSidebarChannel,
-} from "../public_web/discuss_sidebar_categories";
+import { DiscussSidebarCategory } from "../public_web/discuss_sidebar_categories";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
-
-/** @type {import("@mail/discuss/core/public_web/discuss_sidebar_categories").DiscussSidebarChannel} */
-const DiscussSidebarChannelPatch = {
-    setup() {
-        super.setup();
-        this.actionService = useService("action");
-    },
-    get commands() {
-        const commands = super.commands;
-        if (this.thread.channel_type === "channel") {
-            commands.push({
-                onSelect: () => this.openSettings(),
-                label: _t("Channel settings"),
-                icon: "fa fa-cog",
-                sequence: 10,
-            });
-        }
-        return commands;
-    },
-    openSettings() {
-        if (this.thread.channel_type === "channel") {
-            this.actionService.doAction({
-                type: "ir.actions.act_window",
-                res_model: "discuss.channel",
-                res_id: this.thread.id,
-                views: [[false, "form"]],
-                target: "current",
-            });
-        }
-    },
-};
 
 /** @type {import("@mail/discuss/core/public_web/discuss_sidebar_categories").DiscussSidebarCategory} */
 const DiscussSidebarCategoryPatch = {
@@ -74,5 +40,4 @@ const DiscussSidebarCategoryPatch = {
     },
 };
 
-patch(DiscussSidebarChannel.prototype, DiscussSidebarChannelPatch);
 patch(DiscussSidebarCategory.prototype, DiscussSidebarCategoryPatch);

--- a/addons/mail/static/src/discuss/core/web/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/web/thread_actions.js
@@ -4,36 +4,57 @@ import { useComponent } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 
-threadActionsRegistry.add("expand-discuss", {
-    condition(component) {
-        return (
-            component.thread &&
-            component.props.chatWindow?.isOpen &&
-            component.thread.model === "discuss.channel" &&
-            !component.ui.isSmall
-        );
-    },
-    setup() {
-        const component = useComponent();
-        component.actionService = useService("action");
-    },
-    icon: "fa fa-fw fa-expand",
-    name: _t("Open in Discuss"),
-    shouldClearBreadcrumbs(component) {
-        return false;
-    },
-    open(component) {
-        component.actionService.doAction(
-            {
-                type: "ir.actions.client",
-                tag: "mail.action_discuss",
-            },
-            {
-                clearBreadcrumbs: this.shouldClearBreadcrumbs(component),
-                additionalContext: { active_id: component.thread.id },
-            }
-        );
-    },
-    sequence: 10,
-    sequenceGroup: 5,
-});
+threadActionsRegistry
+    .add("expand-discuss", {
+        condition(component) {
+            return (
+                component.thread &&
+                component.props.chatWindow?.isOpen &&
+                component.thread.model === "discuss.channel" &&
+                !component.ui.isSmall
+            );
+        },
+        setup() {
+            const component = useComponent();
+            component.actionService = useService("action");
+        },
+        icon: "fa fa-fw fa-expand",
+        name: _t("Open in Discuss"),
+        shouldClearBreadcrumbs(component) {
+            return false;
+        },
+        open(component) {
+            component.actionService.doAction(
+                {
+                    type: "ir.actions.client",
+                    tag: "mail.action_discuss",
+                },
+                {
+                    clearBreadcrumbs: this.shouldClearBreadcrumbs(component),
+                    additionalContext: { active_id: component.thread.id },
+                }
+            );
+        },
+        sequence: 10,
+        sequenceGroup: 5,
+    })
+    .add("advanced-settings", {
+        condition: (component) => component.thread,
+        open(component, action) {
+            action.actionService.doAction({
+                type: "ir.actions.act_window",
+                res_model: "discuss.channel",
+                views: [[false, "form"]],
+                res_id: component.thread.id,
+                target: "current",
+            });
+        },
+        icon: "fa fa-fw fa-gear",
+        name: _t("Advanced Settings"),
+        partition: false,
+        setup(action) {
+            action.actionService = useService("action");
+        },
+        sidebarSequence: 20,
+        sidebarSequenceGroup: 30,
+    });

--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -195,8 +195,11 @@ export function useHover(refNames, { onHover, onAway, stateObserver, onHovering 
     }
 
     if (stateObserver) {
-        useEffect(() => {
-            if (lastHoveredTarget && !lastHoveredTarget.ref.el) {
+        useEffect((open) => {
+            // Note: stateObserver is essentially used with useDropdownState()?.isOpen.
+            // While isOpen can become false, the ref.el can still be there for a short period of time.
+            // Relying on isOpen becoming false forces good syncing of isHover state on dropdown close.
+            if ((lastHoveredTarget && !lastHoveredTarget.ref.el) || !open) {
                 setHover(false);
                 lastHoveredTarget = null;
             }

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -177,8 +177,8 @@ test("chat window: basic rendering", async () => {
     await contains(".o-mail-ChatWindow-header", { text: "General" });
     await contains(".o-mail-ChatWindow-header .o-mail-ChatWindow-threadAvatar");
     await contains(".o-mail-ChatWindow-command", { count: 5 });
-    await contains("[title='Start a Call']");
-    await contains("[title='Start a Video Call']");
+    await contains("[title='Start Call']");
+    await contains("[title='Start Video Call']");
     await contains("[title='Open Actions Menu']");
     await contains("[title='Fold']");
     await contains("[title*='Close Chat Window']");

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -41,7 +41,7 @@ test("basic rendering", async () => {
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     await start();
     await openDiscuss(channelId);
-    await click("[title='Start a Call']");
+    await click("[title='Start Call']");
     await contains(".o-discuss-Call");
     await contains(".o-discuss-CallParticipantCard[aria-label='Mitchell Admin']");
     await contains(".o-discuss-CallActionList");
@@ -68,7 +68,7 @@ test("keep the `more` popover active when hovering it", async () => {
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     await start();
     await openDiscuss(channelId);
-    await click("[title='Start a Call']");
+    await click("[title='Start Call']");
     await contains(".o-discuss-Call");
     await contains(".o-discuss-CallActionList");
     await click("[title='More']");
@@ -90,7 +90,7 @@ test("no call with odoobot", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Discuss-header");
-    await contains("[title='Start a Call']", { count: 0 });
+    await contains("[title='Start Call']", { count: 0 });
 });
 
 test("should not display call UI when no more members (self disconnect)", async () => {
@@ -99,7 +99,7 @@ test("should not display call UI when no more members (self disconnect)", async 
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     await start();
     await openDiscuss(channelId);
-    await click("[title='Start a Call']");
+    await click("[title='Start Call']");
     await contains(".o-discuss-Call");
     await click(".o-discuss-CallActionList button[aria-label='Disconnect']");
     await contains(".o-discuss-Call", { count: 0 });
@@ -114,9 +114,9 @@ test("show call UI in chat window when in call", async () => {
     await click(".o-mail-NotificationItem", { text: "General" });
     await contains(".o-mail-ChatWindow");
     await contains(".o-discuss-Call", { count: 0 });
-    await click(".o-mail-ChatWindow-command[title='Start a Call']");
+    await click(".o-mail-ChatWindow-command[title='Start Call']");
     await contains(".o-discuss-Call");
-    await contains(".o-mail-ChatWindow-command[title='Start a Call']", { count: 0 });
+    await contains(".o-mail-ChatWindow-command[title='Start Call']", { count: 0 });
 });
 
 test("should disconnect when closing page while in call", async () => {
@@ -133,7 +133,7 @@ test("should disconnect when closing page while in call", async () => {
         }
     });
 
-    await click("[title='Start a Call']");
+    await click("[title='Start Call']");
     await contains(".o-discuss-Call");
     // simulate page close
     await manuallyDispatchProgrammaticEvent(window, "pagehide");
@@ -201,7 +201,7 @@ test("can share screen", async () => {
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     await start();
     await openDiscuss(channelId);
-    await click("[title='Start a Call']");
+    await click("[title='Start Call']");
     await click("[title='More']");
     await click("[title='Share Screen']");
     await contains("video");
@@ -217,7 +217,7 @@ test("can share user camera", async () => {
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     await start();
     await openDiscuss(channelId);
-    await click("[title='Start a Call']");
+    await click("[title='Start Call']");
     await click("[title='Turn camera on']");
     await contains("video");
     await click("[title='Stop camera']");
@@ -230,7 +230,7 @@ test("Camera video stream stays in focus when on/off", async () => {
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     await start();
     await openDiscuss(channelId);
-    await click("[title='Start a Call']");
+    await click("[title='Start Call']");
     await click(".o-discuss-CallParticipantCard-avatar");
     await click("[title='Turn camera on']");
     await click("[title='Stop camera']");
@@ -260,7 +260,7 @@ test("Can share user camera and screen together", async () => {
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     await start();
     await openDiscuss(channelId);
-    await click("[title='Start a Call']");
+    await click("[title='Start Call']");
     await click("[title='More']");
     await click("[title='Share Screen']");
     await click("[title='Turn camera on']");
@@ -273,7 +273,7 @@ test("Click on inset card should replace the inset and active stream together", 
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     await start();
     await openDiscuss(channelId);
-    await click("[title='Start a Call']");
+    await click("[title='Start Call']");
     await click("[title='More']");
     await click("[title='Share Screen']");
     await click("[title='Turn camera on']");
@@ -301,7 +301,7 @@ test("join/leave sounds are only played on main tab", async () => {
     });
     await openDiscuss(channelId, { target: env1 });
     await openDiscuss(channelId, { target: env2 });
-    await click("[title='Start a Call']", { target: env1 });
+    await click("[title='Start Call']", { target: env1 });
     await contains(".o-discuss-Call", { target: env1 });
     await contains(".o-discuss-Call", { target: env2 });
     await waitForSteps(["tab1 - play - call-join"]);
@@ -339,7 +339,7 @@ test("Systray icon shows latest action", async () => {
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     await start();
     await openDiscuss(channelId);
-    await click("[title='Start a Call']");
+    await click("[title='Start Call']");
     await contains(".o-discuss-CallMenu-buttonContent .fa-microphone");
     await click("[title='Mute (shift+m)']");
     await contains(".o-discuss-CallMenu-buttonContent .fa-microphone-slash");
@@ -362,7 +362,7 @@ test("Systray icon keeps track of earlier actions", async () => {
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     await start();
     await openDiscuss(channelId);
-    await click("[title='Start a Call']");
+    await click("[title='Start Call']");
     await contains(".o-discuss-CallMenu-buttonContent .fa-microphone");
     await click("[title='More']");
     await click("[title='Share Screen']");
@@ -389,7 +389,7 @@ test("show call participants in discuss sidebar", async () => {
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     await start();
     await openDiscuss(channelId);
-    await click("[title='Start a Call']");
+    await click("[title='Start Call']");
     await contains(".o-mail-DiscussSidebar", {
         contains: [
             ".o-mail-DiscussSidebarChannel:contains('General') ~ .o-mail-DiscussSidebarCallParticipants:contains(Mitchell Admin)",
@@ -547,7 +547,7 @@ test("show call participants after stopping screen share", async () => {
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     await start();
     await openDiscuss(channelId);
-    await click("[title='Start a Call']");
+    await click("[title='Start Call']");
     await click("[title='Share Screen']");
     await contains("video");
     await triggerEvents(".o-discuss-Call-mainCards", ["mousemove"]); // show overlay
@@ -563,7 +563,7 @@ test("show call participants after stopping camera share", async () => {
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     await start();
     await openDiscuss(channelId);
-    await click("[title='Start a Call']");
+    await click("[title='Start Call']");
     await click("[title='Turn camera on']");
     await contains("video");
     await click("[title='Stop camera']");
@@ -643,11 +643,24 @@ test("should also invite to the call when inviting to the channel", async () => 
     });
     await start();
     await openDiscuss(channelId);
-    await click("[title='Start a Call']");
+    await click("[title='Start Call']");
     await contains(".o-discuss-Call");
     await click(".o-mail-Discuss-header button[title='Invite People']");
     await contains(".o-discuss-ChannelInvitation");
     await click(".o-discuss-ChannelInvitation-selectable", { text: "TestPartner" });
-    await click("[title='Invite to Channel']:enabled");
+    await click(".o-discuss-ChannelInvitation [title='Invite']:enabled");
     await contains(".o-discuss-CallParticipantCard.o-isInvitation");
+});
+
+test("can join / leave call from discuss sidebar actions", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    await start();
+    await openDiscuss(channelId);
+    await click("[title='Channel Actions']");
+    await click(".o-dropdown-item:contains('Start Call')");
+    await contains(".o-discuss-Call");
+    await click("[title='Channel Actions']");
+    await click(".o-dropdown-item:contains('Disconnect')");
+    await contains(".o-discuss-Call", { count: 0 });
 });

--- a/addons/mail/static/tests/discuss/call/web/call.test.js
+++ b/addons/mail/static/tests/discuss/call/web/call.test.js
@@ -63,7 +63,7 @@ test.skip("show Push-to-Talk button on mobile", async () => {
     patchUiSize({ size: SIZES.SM });
     await start();
     await openDiscuss(channelId);
-    await click("[title='Start a Call']");
+    await click("[title='Start Call']");
     // dropdown requires an extra delay before click (because handler is registered in useEffect)
     await contains("[title='Open Actions Menu']");
     await click("[title='Open Actions Menu']");

--- a/addons/mail/static/tests/discuss/core/channel_invitation.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_invitation.test.js
@@ -56,7 +56,7 @@ test("can invite users in channel from chat window", async () => {
     await click(".o-dropdown-item", { text: "Invite People" });
     await contains(".o-discuss-ChannelInvitation");
     await click(".o-discuss-ChannelInvitation-selectable", { text: "TestPartner" });
-    await click("[title='Invite to Channel']:enabled");
+    await click(".o-discuss-ChannelInvitation [title='Invite']:enabled");
     await contains(".o-discuss-ChannelInvitation", { count: 0 });
     await contains(".o-mail-Thread .o-mail-NotificationMessage", {
         text: "Mitchell Admin invited TestPartner to the channel1:00 PM",

--- a/addons/mail/static/tests/discuss/core/channel_member_list.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_member_list.test.js
@@ -160,7 +160,7 @@ test("Channel member count update after user joined", async () => {
     await contains(".o-discuss-ChannelMemberList h6", { text: "Offline - 1" });
     await click("[title='Invite People']");
     await click(".o-discuss-ChannelInvitation-selectable", { text: "Harry" });
-    await click("[title='Invite to Channel']:enabled");
+    await click(".o-discuss-ChannelInvitation [title='Invite']:enabled");
     await contains(".o-discuss-ChannelInvitation", { count: 0 });
     await click("[title='Members']");
     await contains(".o-discuss-ChannelMemberList h6", { text: "Offline - 2" });

--- a/addons/mail/static/tests/discuss/core/crosstab.test.js
+++ b/addons/mail/static/tests/discuss/core/crosstab.test.js
@@ -22,7 +22,7 @@ test("Add member to channel", async () => {
     await contains(".o-discuss-ChannelMember", { text: "Mitchell Admin" });
     await click("[title='Invite People']");
     await click(".o-discuss-ChannelInvitation-selectable", { text: "Harry" });
-    await click("[title='Invite to Channel']:enabled");
+    await click(".o-discuss-ChannelInvitation [title='Invite']:enabled");
     await contains(".o-discuss-ChannelInvitation", { count: 0 });
     await click("[title='Members']");
     await contains(".o-discuss-ChannelMember", { text: "Harry" });

--- a/addons/mail/static/tests/discuss/core/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/discuss.test.js
@@ -83,6 +83,7 @@ test("bus subscription is refreshed when channel is left", async () => {
     await waitForSteps(["subscribe"]);
     await openDiscuss();
     await waitForSteps([]);
-    await click("[title='Leave Channel']");
+    await click("[title='Channel Actions']");
+    await click(".o-dropdown-item:contains('Leave Channel')");
     await waitForSteps(["subscribe"]);
 });

--- a/addons/mail/static/tests/discuss/core/public_web/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/public_web/discuss.test.js
@@ -29,7 +29,8 @@ test("bus subscription updated when joining/leaving thread as non member", async
     await start();
     await openDiscuss(channelId);
     await waitForChannels([`discuss.channel_${channelId}`]);
-    await click("[title='Leave Channel']");
+    await click("[title='Channel Actions']");
+    await click(".o-dropdown-item:contains('Leave Channel')");
     await click("button", { text: "Leave Conversation" });
     await waitForChannels([`discuss.channel_${channelId}`], { operation: "delete" });
 });
@@ -47,7 +48,7 @@ test("bus subscription updated when joining locally pinned thread", async () => 
     await click(".o-discuss-ChannelInvitation-selectable", {
         text: "Mitchell Admin",
     });
-    await click("button", { text: "Invite to Channel" });
+    await click(".o-discuss-ChannelInvitation [title='Invite']:enabled");
     await waitForChannels([`discuss.channel_${channelId}`], { operation: "delete" });
 });
 

--- a/addons/mail/static/tests/discuss/core/public_web/sub_channels.test.js
+++ b/addons/mail/static/tests/discuss/core/public_web/sub_channels.test.js
@@ -53,9 +53,8 @@ test("can manually unpin a sub-thread", async () => {
     await click("button[title='Threads']");
     await click("button[aria-label='Create Thread']");
     await contains(".o-mail-Discuss-threadName", { value: "New Thread" });
-    await click("button[title='Unpin Thread']", {
-        parent: [".o-mail-DiscussSidebar-item", { text: "New Thread" }],
-    });
+    await click("[title='Threads Actions']");
+    await click(".o-dropdown-item:contains('Unpin Conversation')");
     await contains(".o-mail-DiscussSidebar-item", { text: "New Thread", count: 0 });
 });
 

--- a/addons/mail/static/tests/discuss/core/web/sidebar.test.js
+++ b/addons/mail/static/tests/discuss/core/web/sidebar.test.js
@@ -39,9 +39,8 @@ test("unknown channel can be displayed and interacted with", async () => {
     await waitForSteps(["discuss.channel/new_message"]);
     await click("button", { text: "Inbox" });
     await contains(".o-mail-DiscussSidebarChannel:not(.o-active)", { text: "Not So Secret" });
-    await click("[title='Leave Channel']", {
-        parent: [".o-mail-DiscussSidebarChannel", { text: "Not So Secret" }],
-    });
+    await click("[title='Channel Actions']");
+    await click(".o-dropdown-item:contains('Leave Channel')");
     await click("button", { text: "Leave Conversation" });
     await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
 });

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -567,13 +567,9 @@ test("sidebar: basic channel rendering", async () => {
     await openDiscuss();
     await contains(".o-mail-DiscussSidebarChannel", { text: "General" });
     await contains(".o-mail-DiscussSidebarChannel img[alt='Thread Image']");
-    await contains(".o-mail-DiscussSidebarChannel .o-mail-DiscussSidebarChannel-commands.d-none");
-    await contains(
-        ".o-mail-DiscussSidebarChannel .o-mail-DiscussSidebarChannel-commands [title='Channel settings']"
-    );
-    await contains(
-        ".o-mail-DiscussSidebarChannel .o-mail-DiscussSidebarChannel-commands [title='Leave Channel']"
-    );
+    await contains(".o-mail-DiscussSidebarChannel .o-mail-DiscussSidebarChannel-actions.d-none");
+    await click("[title='Channel Actions']");
+    await contains(".o-dropdown-item:contains('Leave Channel')");
 });
 
 test("channel become active", async () => {
@@ -616,28 +612,6 @@ test("sidebar: channel rendering with needaction counter", async () => {
         contains: [
             ["span", { text: "general" }],
             [".badge", { text: "1" }],
-        ],
-    });
-});
-
-test("sidebar: chat rendering with unread counter", async () => {
-    const pyEnv = await startServer();
-    const channelId = pyEnv["discuss.channel"].create({ channel_type: "chat" });
-    for (let i = 0; i < 100; ++i) {
-        pyEnv["mail.message"].create({
-            author_id: serverState.partnerId,
-            body: `message ${i}`,
-            message_type: "comment",
-            model: "discuss.channel",
-            res_id: channelId,
-        });
-    }
-    await start();
-    await openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel", {
-        contains: [
-            [".badge", { text: "100" }],
-            [".o-mail-DiscussSidebarChannel-commands", { text: "Unpin Conversation", count: 0 }], // weak test, no guarantee this selector is valid in the first place
         ],
     });
 });
@@ -1978,7 +1952,9 @@ test("composer state: attachments save and restore", async () => {
         ".o-mail-Composer:has(textarea[placeholder='Message #Special…']) input[type=file]",
         files
     );
-    await contains(".o-mail-Composer .o-mail-AttachmentContainer:not(.o-isUploading)", { count: 3 });
+    await contains(".o-mail-Composer .o-mail-AttachmentContainer:not(.o-isUploading)", {
+        count: 3,
+    });
     // Switch back to #general
     await click("button", { text: "General" });
     await contains(".o-mail-Composer .o-mail-AttachmentCard");
@@ -2100,9 +2076,10 @@ test("Correct breadcrumb when open discuss from chat window then see settings", 
     await contains("[title='Open Actions Menu']");
     await click("[title='Open Actions Menu']");
     await click(".o-dropdown-item", { text: "Open in Discuss" });
-    await click("[title='Channel settings']", {
+    await click("[title='Channel Actions']", {
         parent: [".o-mail-DiscussSidebarChannel", { text: "General" }],
     });
+    await click(".o-dropdown-item:contains('Advanced Settings')");
     await contains(".o_breadcrumb", { text: "GeneralGeneral" });
 });
 

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -247,9 +247,8 @@ test("sidebar: basic chat rendering", async () => {
     await contains(".o-mail-DiscussSidebarChannel");
     await contains(".o-mail-DiscussSidebarChannel", { text: "Demo" });
     await contains(".o-mail-DiscussSidebarChannel img[alt='Thread Image']");
-    await contains(
-        ".o-mail-DiscussSidebarChannel .o-mail-DiscussSidebarChannel-commands [title='Unpin Conversation']"
-    );
+    await click("[title='Chat Actions']");
+    await contains(".o-dropdown-item:contains('Unpin Conversation')");
     await contains(".o-mail-DiscussSidebarChannel .badge", { count: 0 });
 });
 
@@ -284,9 +283,8 @@ test("sidebar: open channel and leave it", async () => {
     await click(".o-mail-DiscussSidebarChannel", { text: "General" });
     await contains(".o-mail-Discuss-threadName", { value: "General" });
     await waitForSteps([]);
-    await click("[title='Leave Channel']", {
-        parent: [".o-mail-DiscussSidebarChannel.o-active", { text: "General" }],
-    });
+    await click("[title='Channel Actions']");
+    await click(".o-dropdown-item:contains('Leave Channel')");
     await click("button", { text: "Leave Conversation" });
     await contains(".o-mail-DiscussSidebarChannel", { count: 0, text: "General" });
     await contains(".o-mail-Discuss-threadName", { value: "Inbox" });
@@ -1065,7 +1063,8 @@ test("Can unpin chat channel", async () => {
     await start();
     await openDiscuss();
     await contains(".o-mail-DiscussSidebarChannel", { text: "Mitchell Admin" });
-    await click(".o-mail-DiscussSidebarChannel [title='Unpin Conversation']");
+    await click("[title='Chat Actions']");
+    await click(".o-dropdown-item:contains('Unpin Conversation')");
     await contains(".o-mail-DiscussSidebarChannel", { count: 0, text: "Mitchell Admin" });
 });
 
@@ -1085,7 +1084,8 @@ test("Can leave channel", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-DiscussSidebarChannel", { text: "General" });
-    await click("[title='Leave Channel']");
+    await click("[title='Channel Actions']");
+    await click(".o-dropdown-item:contains('Leave Channel')");
     await click("button", { text: "Leave Conversation" });
     await contains(".o-mail-DiscussSidebarChannel", { count: 0, text: "General" });
 });
@@ -1099,7 +1099,8 @@ test("Do no channel_info after unpin", async () => {
     // ensure onRpc is at least set up properly (because then it is asserted negatively)
     await waitStoreFetch("discuss.channel");
     await openDiscuss(channelId);
-    await click(".o-mail-DiscussSidebarChannel-commands [title='Unpin Conversation']");
+    await click("[title='Chat Actions']");
+    await click(".o-dropdown-item:contains('Advanced Settings')");
     rpc("/mail/message/post", {
         thread_id: channelId,
         thread_model: "discuss.channel",
@@ -1154,9 +1155,8 @@ test("Unpinning channel closes its chat window", async () => {
     await click(".o-mail-NotificationItem");
     await contains(".o-mail-ChatWindow", { text: "Sales" });
     await openDiscuss();
-    await click("[title='Leave Channel']", {
-        parent: [".o-mail-DiscussSidebarChannel", { text: "Sales" }],
-    });
+    await click("[title='Channel Actions']");
+    await click(".o-dropdown-item:contains('Leave Channel')");
     await openFormView("discuss.channel");
     await contains(".o-mail-ChatWindow", { count: 0, text: "Sales" });
 });

--- a/addons/mail/static/tests/mobile/mobile.test.js
+++ b/addons/mail/static/tests/mobile/mobile.test.js
@@ -65,7 +65,7 @@ test("can leave channel in mobile", async () => {
     // dropdown requires an extra delay before click (because handler is registered in useEffect)
     await contains(".o-mail-ChatWindow-command", { text: "General" });
     await click(".o-mail-ChatWindow-command", { text: "General" });
-    await contains(".o-dropdown-item", { text: "Leave" });
+    await contains(".o-dropdown-item", { text: "Leave Channel" });
 });
 
 test("enter key should create a newline in composer", async () => {

--- a/addons/mail/views/discuss_channel_views.xml
+++ b/addons/mail/views/discuss_channel_views.xml
@@ -133,6 +133,14 @@
             <field name="search_view_id" ref="discuss_channel_view_search"/>
         </record>
 
+        <record id="mail.discuss_channel_action" model="ir.actions.act_window">
+            <field name="name">Channels</field>
+            <field name="res_model">discuss.channel</field>
+            <field name="view_mode">kanban</field>
+            <field name="domain" eval="[(('channel_type', '=', 'channel'))]" />
+            <field name="search_view_id" ref="discuss_channel_view_search" />
+        </record>
+
     <record id="mail.action_discuss" model="ir.actions.client">
         <field name="name">Discuss</field>
         <field name="tag">mail.action_discuss</field>

--- a/addons/mail/views/mail_menus.xml
+++ b/addons/mail/views/mail_menus.xml
@@ -9,16 +9,23 @@
     />
     <menuitem
         id="mail.main_menu_discuss"
-        name="Conversations"
+        name="Discuss"
         parent="mail.menu_root_discuss"
         action="action_discuss"
         sequence="1"
     />
     <menuitem
+        id="mail.menu_channel"
+        name="Channel"
+        parent="mail.menu_root_discuss"
+        action="mail.discuss_channel_action"
+        sequence="2"
+    />
+    <menuitem
         id="mail.menu_configuration"
         name="Configuration"
         parent="mail.menu_root_discuss"
-        sequence="2"
+        sequence="3"
     />
     <menuitem name="Notifications"
         id="mail.menu_notification_settings"


### PR DESCRIPTION
Purpose of this PR:

1. Add a 'Channel' menu button that, when clicked, displays all the channels the current user is a member of.
2. Change the 'Conversation' menu item name to 'Discuss'
![image](https://github.com/user-attachments/assets/52a5ff21-ca27-4eb6-8c38-1e3be977a3d0)


3. Instead of opening the channel info when click on the channel settings button, open a popover containing setting options like,
 - Start a Call
 - Start a Video Call
 - Disconnect from Call
 - Mark all as read
 - Invite a User
 - Notification Settings
 - Channel Info
 - Leave/Unpin Channel
 
![image](https://github.com/user-attachments/assets/ec5984ea-dfde-4236-a619-d0c7539769fd)

task-4100138
