### PR TITLE
[FIX] base: Fix attachment generation for multi-page reports

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -860,7 +860,7 @@ class IrActionsReport(models.Model):
 
             # if res_id is false
             # we are unable to fetch the record, it won't be saved as we can't split the documents unambiguously
-            if not res_id:
+            if not res_id or not stream_data['stream']:
                 _logger.warning(
                     "These documents were not saved as an attachment because the template of %s doesn't "
                     "have any headers seperating different instances of it. If you want it saved,"


### PR DESCRIPTION
When we try to print multiple invoice who have multiple pages and have H2 title in the comments, the system treats the document as separate files, resulting in error: `AttributeError: 'NoneType' object has no attribute 'getValue'`.

Steps to reproduce:
- Create an invoice without any attachment.
- Create another invoice, ensuring that its printout spans multiple pages, and add an H2 title in the comments (narration).
- In the list view, attempt to print both invoices.
  - Ensure that the report being printed contains a value in the "Save as attachment prefix" field.

The issue arises because the presence of multiple H2 headings causes the system to treat the document as separate files. Consequently, the condition `if has_same_number_of_outlines and has_top_level_heading:` is not satisfied, which results in a stream to be None.

opw-4247013
