### PR TITLE
[FIX] website: prevent duplicate field IDs when adding multiple forms

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -808,9 +808,15 @@ options.registry.WebsiteFormEditor = FormEditor.extend({
         if (formInfo) {
             const formatInfo = this._getDefaultFormat();
             await formInfo.formFields.forEach(async field => {
-                field.formatInfo = formatInfo;
-                await this._fetchFieldRecords(field);
-                this.$target.find('.s_website_form_submit, .s_website_form_recaptcha').first().before(this._renderField(field));
+                // Create a shallow copy of field to prevent unintended
+                // mutations to the original field stored in FormEditorRegistry
+                const _field = { ...field };
+                _field.formatInfo = formatInfo;
+                await this._fetchFieldRecords(_field);
+                const targetEl = this.$target[0].querySelector(".s_website_form_submit, .s_website_form_recaptcha");
+                if (targetEl) {
+                    targetEl.parentNode.insertBefore(this._renderField(_field), targetEl);
+                }
             });
         }
     },

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -141,6 +141,38 @@ odoo.define('website.tour.form_editor', function (require) {
             trigger: '#oe_snippets .oe_snippet:has(.s_website_form) .oe_snippet_thumbnail',
             run: 'drag_and_drop iframe #wrap',
         }, {
+            content: "Check if the form snippet is dropped",
+            trigger: "iframe .s_website_form_field",
+            run: () => null,
+        },
+        // Check if fields in two form snippet have unique IDs
+        {
+            content: "Drop another form snippet",
+            trigger: '#oe_snippets .oe_snippet:has(.s_website_form) .oe_snippet_thumbnail',
+            run: 'drag_and_drop iframe #wrap',
+        }, {
+            content: "Check if there are two form snippets on the page",
+            trigger: "iframe .s_website_form:nth-of-type(2) .s_website_form_field",
+            run: () => null,
+        }, {
+            content: "Check that the first field of both the form snippets have different IDs",
+            trigger: "iframe .s_website_form:nth-of-type(1) input[name='name']",
+            run: function() {
+                const firstFieldForm1El = this.$anchor[0];
+                const firstFieldForm2El = firstFieldForm1El.ownerDocument.querySelector(
+                    ".s_website_form:nth-of-type(2) input[name='name']"
+                );
+                if (firstFieldForm1El.id === firstFieldForm2El.id) {
+                    console.error("The first fields of two different form snippet have the same ID");
+                }
+            },
+        }, {
+            content: "Click on the second form",
+            trigger: "iframe .s_website_form:nth-of-type(2)",
+        }, {
+            content: "Remove the second snippet",
+            trigger: "iframe .oe_overlay.oe_active .oe_snippet_remove"
+        }, {
             content: "Select form by clicking on an input field",
             extra_trigger: 'iframe .s_website_form_field',
             trigger: 'iframe section.s_website_form input',


### PR DESCRIPTION
Previously, when multiple form snippets were added to the same page,
corresponding fields (e.g., the "Name" field) in each form were assigned
the same ID.

This happened because we retrieved the form fields from the
`FormEditorRegistry`.
For the first form snippet, field IDs are generated and assigned
correctly. However, assigning IDs to the fields also updated the fields
stored in the `FormEditorRegistry`.
So when a second form snippet is added, the fields it receives from the
registry already have an ID.
The ID generation logic skips fields that already have an ID, so the
fields in subsequent forms never got new IDs.

With this fix, we now create a shallow copy of each field before using
it. This prevents the original field definitions in the
`FormEditorRegistry` from being modified.

As a result, fields in different forms now receive unique IDs without
needing to explicitly delete the field ID to force a new one to be
generated.

[task-4251881](https://www.odoo.com/web#id=4251881&cids=1&menu_id=4720&action=333&active_id=1695&model=project.task&view_type=form)