### PR TITLE
[FIX] point_of_sale: use dedicated function for archived combinations

### DIFF
--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -180,10 +180,8 @@ class ProductProduct(models.Model):
 
     def _get_archived_combinations_per_product_tmpl_id(self, product_tmpl_ids):
         archived_combinations = {}
-        for product in self.env['product.product'].with_context(active_test=False).search([('product_tmpl_id', 'in', product_tmpl_ids), ('active', '=', False)]):
-            if not archived_combinations.get(product.product_tmpl_id.id):
-                archived_combinations[product.product_tmpl_id.id] = []
-            archived_combinations[product.product_tmpl_id.id].append(product.product_template_attribute_value_ids.ids)
+        for product_tmpl in self.env['product.template'].browse(product_tmpl_ids):
+            archived_combinations[product_tmpl.id] = product_tmpl._get_attribute_exclusions()['archived_combinations']
         return archived_combinations
 
     @api.ondelete(at_uninstall=False)


### PR DESCRIPTION
Before this commit, archived combinations were computed using a different method, despite the existence of a specific function designed for this purpose.

opw-4261061

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
