### PR TITLE
[FIX] calendar: default privacy not working for internal users

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -749,9 +749,10 @@ class Meeting(models.Model):
     def _check_private_event_conditions(self):
         """ Checks if the event is private, returning True if the conditions match and False otherwise. """
         self.ensure_one()
-        event_is_private = (self.privacy == 'private' or (not self.privacy and self.user_id and self.user_id.calendar_default_privacy == 'private'))
+        event_is_private = self.privacy == 'private'
+        calendar_is_private = not self.privacy and self.sudo().user_id.calendar_default_privacy == 'private'
         user_is_not_partner = self.user_id.id != self.env.uid and self.env.user.partner_id not in self.partner_ids
-        return event_is_private and user_is_not_partner
+        return (event_is_private or calendar_is_private) and user_is_not_partner
 
     @api.depends('privacy', 'user_id')
     def _compute_display_name(self):

--- a/addons/calendar/models/res_users.py
+++ b/addons/calendar/models/res_users.py
@@ -17,6 +17,7 @@ class Users(models.Model):
          ('confidential', 'Only internal users')],
         compute="_compute_calendar_default_privacy",
         inverse="_inverse_calendar_res_users_settings",
+        compute_sudo=True,
     )
 
     @property
@@ -83,9 +84,9 @@ class Users(models.Model):
         fields in 'res.users'. If there is no 'res.users.settings' record for the user, then the record is created.
         """
         for user in self:
-            settings = self.env["res.users.settings"]._find_or_create_for_user(user)
+            settings = self.env["res.users.settings"].sudo()._find_or_create_for_user(user)
             configuration = {field: user[field] for field in self._get_user_calendar_configuration_fields()}
-            settings.update(configuration)
+            settings.sudo().update(configuration)
 
     @api.model
     def _get_user_calendar_configuration_fields(self) -> list[str]:

--- a/addons/calendar/tests/test_access_rights.py
+++ b/addons/calendar/tests/test_access_rights.py
@@ -311,3 +311,15 @@ class TestAccessRights(TransactionCase):
                 self.john.with_user(self.admin_system_user).write({'calendar_default_privacy': privacy})
             with self.assertRaises(AccessError):
                 self.admin_system_user.with_user(self.john).write({'calendar_default_privacy': privacy})
+
+    def test_check_private_event_conditions_by_internal_user(self):
+        """ Ensure that internal user (non-admin) will see that admin's event is private. """
+        # Update admin calendar_default_privacy with 'private' option. Create private event for admin.
+        self.admin_user.with_user(self.admin_user).write({'calendar_default_privacy': 'private'})
+        admin_user_private_evt = self.create_event(self.admin_user, name='My Event', privacy=False, partner_ids=[self.admin_user.partner_id.id])
+
+        # Ensure that intrnal user will see the admin's event as private.
+        self.assertTrue(
+            admin_user_private_evt.with_user(self.raoul)._check_private_event_conditions(),
+            "Privacy check must be True since the new event is private (following John's calendar default privacy)."
+        )


### PR DESCRIPTION
Before this commit, the calendar default privacy setting was not working for internal users beacause they couldn't see the setting value of other users if they weren't administrators.

This commit fixes the issue by making a sudo update on the `res.users.settings` object when computing the calendar default privacy setting of it (and in the inverse method as well). Sudo was needed to allow the business customization and bypass the security that the record rule dictates on users not being able to see the other user's settings (unless they're administrators).

task-4260794