### PR TITLE
[FIX] core: correctly handle deferred constraints

### DIFF
--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -1105,7 +1105,7 @@ class Field(MetaField('DummyField', (object,), {}), typing.Generic[T]):
             def add_not_null():
                 # flush values before adding NOT NULL constraint
                 model.flush_model([self.name])
-                model.pool.post_constraint(apply_required, model, self.name)
+                model.pool.post_constraint(f"field_not_null:{model}.{self.name}", (apply_required, model, self.name))
 
         elif not self.required and has_notnull:
             sql.drop_not_null(model._cr, model._table, self.name)

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -564,17 +564,14 @@ class Registry(Mapping[str, type["BaseModel"]]):
         try:
             func_data[0](*func_data[1:])
         except sql.TableError as e:
-            if self._is_install:
-                _schema.error(e.args[0])
-            else:
-                _schema.info(e.args[0])
-                # Try to apply the constraint once the registry is fully loaded. We keep multiple
-                # constraints under same key because we still want to attempt to add a constraint
-                # even if some override failed. Do not add duplicated entries, if an entry is double
-                # move it to the end instead. Below is a poor-man move-to-end implementation using a
-                # standard dict.
-                self._table_stacks[key].pop(func_data, None)
-                self._table_stacks[key][func_data] = None
+            _schema.info(e.args[0])
+            # Try to apply the constraint once the registry is fully loaded. We keep multiple
+            # constraints under same key because we still want to attempt to add a constraint
+            # even if some override failed. Do not add duplicated entries, if an entry is double
+            # move it to the end instead. Below is a poor-man move-to-end implementation using a
+            # standard dict.
+            self._table_stacks[key].pop(func_data, None)
+            self._table_stacks[key][func_data] = None
         else:
             # If a module successfully applies a constraint, we remove all queued constraints with
             # same name ignoring the definition. In effect, if module A defines a constraint that is

--- a/odoo/orm/table_objects.py
+++ b/odoo/orm/table_objects.py
@@ -114,7 +114,7 @@ class Constraint(TableObject):
             # constraint exists but its definition may have changed
             sql.drop_constraint(cr, model._table, conname)
 
-        model.pool.post_constraint(sql.add_constraint, cr, model._table, conname, definition)
+        model.pool.post_constraint(f"constraint:{conname}", (sql.add_constraint, cr, model._table, conname, definition))
 
 
 class Index(TableObject):
@@ -155,13 +155,8 @@ class Index(TableObject):
 
         definition_clause = self._index_definition
         model.pool.post_constraint(
-            sql.add_index,
-            cr,
-            conname,
-            model._table,
-            comment=definition,
-            definition=definition_clause,
-            unique=self.unique,
+            f"index:{conname}",
+            (sql.add_index, cr, conname, model._table, definition_clause, self.unique, definition),
         )
 
 


### PR DESCRIPTION
When a module redefines a constraint the ORM fails to add it. It puts the operation in a deferred queue and tries to apply them after all modules are loaded. This causes issues with constraints redefinition. E.g. if module A defines a constraint that's overridden in module B and some data is added in the DB that violates the constraint in A. Then each time we reload the DB the ORM would try to re-add the constraint in A and it will fail each time.

Up to now we just output a warning in the logs when the constraint cannot be added in the post processing of the constraints. In this patch we propose to remove any pending operation for a constraint with the same name, ignoring the definition. This would essentially make an override properly work. Under the assumption that when a constraint is being applied, any previous one that failed (and are queued) with the same name can be ignored since it's being overridden.

Example in current modules: the redefinition of `unique_login` constraint in `res.users` in `website` module,
https://github.com/odoo/odoo/blob/09fa1db600c31d2d04f0504f0412cbbc85ff7e3d/addons/website/models/res_users.py#L18 overriding the definition in `base`.
https://github.com/odoo/odoo/blob/09fa1db600c31d2d04f0504f0412cbbc85ff7e3d/odoo/addons/base/models/res_users.py#L414

If we create two users with same login but different websites the original constraint in base cannot be applied and it fails in `finalize_constraints`
https://github.com/odoo/odoo/blob/09fa1db600c31d2d04f0504f0412cbbc85ff7e3d/odoo/modules/registry.py#L574-L577

```
odoo.schema:577 Table 'res_users': unable to add constraint 'res_users_login_key' as UNIQUE (login)
```

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
