### PR TITLE
[FIX] account: correct inner function in compute_name of move line

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -464,6 +464,8 @@ class AccountMoveLine(models.Model):
                 product = line.product_id.with_context(lang=line.partner_id.lang)
             else:
                 product = line.product_id
+            if not product:
+                return False
 
             if product.partner_ref:
                 values.append(product.partner_ref)


### PR DESCRIPTION
* line._origin can be empty recordset so when line._origin.name it will return False then we compare it to result of inner function get_name which will be wrong because '\n'.join(values) will return empty string '' because line is empty so values is empty also . This commit correctly set the correct
return value for inner function which introduce in [1]. This will allow custom module can recompute the label by different api.depends

[1]: https://github.com/odoo/odoo/pull/182136/commits/2dee061cb022e15c60539b987a87f8225cdc4881

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
