### PR TITLE
[FIX] l10n_br_sales: correctly override a t-call

### DIFF
--- a/addons/l10n_br_sales/views/sale_portal_templates.xml
+++ b/addons/l10n_br_sales/views/sale_portal_templates.xml
@@ -13,8 +13,10 @@
         </span>
         <xpath expr="//t[@t-call='sale.sale_order_portal_content_totals_table']" position="replace">
             <table class="table table-sm">
-                <t t-set="tax_totals" t-value="sale_order.tax_totals"/>
-                <t t-call="l10n_br_sales.document_tax_totals_brazil"/>
+                <t t-call="l10n_br_sales.document_tax_totals_brazil">
+                    <t t-set="tax_totals" t-value="sale_order.tax_totals"/>
+                    <t t-set="currency" t-value="sale_order.currency_id"/>
+                </t>
             </table>
         </xpath>
     </template>


### PR DESCRIPTION
Currently, you view quotations in the portal with a Brazilian company.

### Steps to reproduce

* install `l10n_br_sales`
* switch to a Brazilian company
* attempt to "Preview" a quotation

You should be met with the following traceback:
```
AttributeError: 'NoneType' object has no attribute 'decimal_places'
Template: l10n_br_sales.document_tax_totals_brazil
Path: /t/tr[2]/td[2]/strong
Node: <strong t-out="tax_totals[\'total_amount_currency\']" t-options="{&quot;widget&quot;: &quot;monetary&quot;, &quot;display_currency&quot;: currency}"/>
```

opw-4247492