### PR TITLE
[PERF] mail: Disable prefetching of unneeded fields

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -505,7 +505,7 @@ class MailMail(models.Model):
         Return iterators over
             mail_server_id, email_from, Records<mail.mail>.ids
         """
-        mail_values = self.read(['id', 'email_from', 'mail_server_id', 'record_alias_domain_id'])
+        mail_values = self.with_context(prefetch_fields=False).read(['id', 'email_from', 'mail_server_id', 'record_alias_domain_id'])
 
         # First group the <mail.mail> per mail_server_id, per alias_domain (if no server) and per email_from
         group_per_email_from = defaultdict(list)
@@ -757,4 +757,5 @@ class MailMail(models.Model):
 
             if auto_commit is True:
                 self._cr.commit()
+            mail.invalidate_recordset(['body_html'])
         return True


### PR DESCRIPTION
Modifications are made around read, filtered, list comprehension.

The read function usually does not prefetech fields other than stated. But in this case, since the fields are related fields from another model, The fields of the other model are prefeteched. This includes the body which can be very big in size and cause an out of memory error.

Filtered does not need other fields and keeps them unnecessarily in cache.

List comprehension where it has a reference to specific field inside the model also triggers the prefetecher.

Benchmark:
|        |Number of queries| SQL time| Python time||
|-------|----------------------------|----------------|---------------|-|
|with prefetch| 82| 1.887 | 7.898| Out of memory|
|Without prefetch| 120| 0.385 | 5.973| |

The benchmark with the prefetch was done locally with increasing the memory limit.






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
