### PR TITLE
[FIX] web: fix makeAsyncHandler and makeButtonHandler

### DIFF
--- a/addons/web/static/src/legacy/js/core/minimal_dom.js
+++ b/addons/web/static/src/legacy/js/core/minimal_dom.js
@@ -53,7 +53,7 @@ export function makeAsyncHandler(fct, preventDefault, stopPropagation) {
 
         _lock();
         const result = fct.apply(this, arguments);
-        Promise.resolve(result).then(_unlock, _unlock);
+        Promise.resolve(result).finally(_unlock);
         return result;
     };
 }

--- a/addons/web/static/tests/legacy/core/minimal_dom.js
+++ b/addons/web/static/tests/legacy/core/minimal_dom.js
@@ -1,0 +1,57 @@
+/** @odoo-module **/
+import { registerCleanup } from "@web/../tests/helpers/cleanup";
+import { getFixture, nextTick } from "@web/../tests/helpers/utils";
+import { DEBOUNCE, makeAsyncHandler, makeButtonHandler } from '@web/legacy/js/core/minimal_dom';
+
+QUnit.module('core', {}, function () {
+
+    QUnit.module('MinimalDom');
+
+    QUnit.test('MakeButtonHandler does not retrigger the same error', async function (assert) {
+        assert.expect(1);
+        assert.expectErrors();
+
+        // create a target for the button handler
+        const fixture = getFixture();
+        const button = document.createElement("button");
+        fixture.appendChild(button);
+        registerCleanup(() => { button.remove(); });
+
+        // get a way to reject the promise later
+        let rejectPromise;
+        const buttonHandler = makeButtonHandler(() => new Promise((resolve, reject) => {
+            rejectPromise = reject;
+        }));
+
+        // trigger the handler
+        buttonHandler({ target: button });
+
+        // wait for the button effect has been applied before rejecting the promise
+        await new Promise(res => setTimeout(res, DEBOUNCE + 1));
+        rejectPromise(new Error("reject"));
+
+        // check that there was only one unhandledrejection error
+        await nextTick();
+        assert.verifyErrors(["reject"]);
+    });
+
+    QUnit.test('MakeAsyncHandler does not retrigger the same error', async function (assert) {
+        assert.expect(1);
+        assert.expectErrors();
+
+        // get a way to reject the promise later
+        let rejectPromise;
+        const asyncHandler = makeAsyncHandler(() => new Promise((resolve, reject) => {
+            rejectPromise = reject;
+        }));
+
+        // trigger the handler
+        asyncHandler();
+
+        rejectPromise(new Error("reject"));
+
+        // check that there was only one unhandledrejection error
+        await nextTick();
+        assert.verifyErrors(["reject"]);
+    });
+});


### PR DESCRIPTION
In 865baf9ef154e2a36817e40a50e09d5e98cf95f9, makeAsyncHandler has been incorrectly modified so that the promise rejection is consumed by the catch, instead of letting it bubble up through a finally.

Indeed, contrarily to makeButtonHandler, makeAsyncHandler doesn't create a new Promise object. This means that the finally is applied on the result itself.
In makeButtonHandler, the then handler returns a new Promise that is different from result, but that will be rejected if result is rejected. This is why in this case we need to hide that extra rejection by swallowing it in the onRejected argument, instead of using a finally.

Task-Id: None