### PR TITLE
18.0 ubl first cleanup clbr

### DIFF
--- a/addons/account_edi_ubl_cii/views/res_partner_views.xml
+++ b/addons/account_edi_ubl_cii/views/res_partner_views.xml
@@ -5,8 +5,8 @@
         <field name="inherit_id" ref="account.view_partner_property_form"/>
         <field name="arch" type="xml">
             <xpath expr="//group[@id='invoice_send_settings']" position="inside">
-                <field name="peppol_eas" invisible="invoice_edi_format in ('facturx', False)"/>
-                <field name="peppol_endpoint" invisible="invoice_edi_format in ('facturx', False)"/>
+                <field name="peppol_eas" invisible="not is_peppol_edi_format"/>
+                <field name="peppol_endpoint" invisible="not is_peppol_edi_format"/>
             </xpath>
         </field>
     </record>

--- a/addons/account_peppol/models/res_partner.py
+++ b/addons/account_peppol/models/res_partner.py
@@ -12,7 +12,6 @@ from odoo.addons.account_peppol.tools.demo_utils import handle_demo
 from odoo.addons.account.models.company import PEPPOL_LIST
 
 TIMEOUT = 10
-NON_PEPPOL_FORMAT = (False, 'facturx', 'oioubl_201', 'ciusro')
 
 
 class ResPartner(models.Model):
@@ -32,7 +31,6 @@ class ResPartner(models.Model):
         string='Peppol endpoint verification',
         company_dependent=True,
     )
-    is_peppol_edi_format = fields.Boolean(compute='_compute_is_peppol_edi_format')
 
     # -------------------------------------------------------------------------
     # HELPERS
@@ -143,16 +141,6 @@ class ResPartner(models.Model):
                 partner.button_account_peppol_check_partner_endpoint(company=company)
 
     # -------------------------------------------------------------------------
-    # COMPUTE METHODS
-    # -------------------------------------------------------------------------
-
-    @api.depends_context('company')
-    @api.depends('invoice_edi_format')
-    def _compute_is_peppol_edi_format(self):
-        for partner in self:
-            partner.is_peppol_edi_format = partner.invoice_edi_format not in NON_PEPPOL_FORMAT
-
-    # -------------------------------------------------------------------------
     # LOW-LEVEL METHODS
     # -------------------------------------------------------------------------
 
@@ -201,7 +189,7 @@ class ResPartner(models.Model):
     @api.model
     @handle_demo
     def _get_peppol_verification_state(self, peppol_endpoint, peppol_eas, invoice_edi_format):
-        if (not (peppol_eas and peppol_endpoint) or invoice_edi_format in NON_PEPPOL_FORMAT):
+        if not (peppol_eas and peppol_endpoint) or invoice_edi_format not in self._get_peppol_formats():
             return False
 
         edi_identification = f"{peppol_eas}:{peppol_endpoint}".lower()

--- a/addons/account_peppol/tests/test_peppol_messages.py
+++ b/addons/account_peppol/tests/test_peppol_messages.py
@@ -392,3 +392,14 @@ class TestPeppolMessage(TestAccountMoveSendCommon):
         self.env.ref('account.ir_cron_account_move_send').with_company(company_2).method_direct_trigger()
         # only move 1 & 2 should be processed, move_3 is related to an invalid partner (with regard to company_2) thus should fail to send
         self.assertEqual((move_1 + move_2 + move_3).mapped('peppol_move_state'), ['processing', 'processing', 'to_send'])
+
+    def test_available_peppol_sending_methods(self):
+        company_us = self.setup_other_company()['company']  # not a valid Peppol country
+        self.assertTrue('peppol' in self.valid_partner.with_company(self.env.company).available_peppol_sending_methods)
+        self.assertFalse('peppol' in self.valid_partner.with_company(company_us).available_peppol_sending_methods)
+
+    def test_available_peppol_edi_formats(self):
+        self.valid_partner.invoice_sending_method = 'peppol'
+        self.assertFalse('facturx' in self.valid_partner.available_peppol_edi_formats)
+        self.valid_partner.invoice_sending_method = 'email'
+        self.assertTrue('facturx' in self.valid_partner.available_peppol_edi_formats)

--- a/addons/account_peppol/views/res_partner_views.xml
+++ b/addons/account_peppol/views/res_partner_views.xml
@@ -15,7 +15,7 @@
                     <div class="alert alert-warning mb-0"
                          colspan="2"
                          role="alert"
-                         invisible="country_code != 'BE' or invoice_edi_format in (False, 'facturx') or peppol_eas in (False, '0208')">
+                         invisible="country_code != 'BE' or not is_peppol_edi_format or peppol_eas in (False, '0208')">
                          The recommended EAS code for Belgium is 0208. The Endpoint should be the Company Registry number.
                     </div>
                     <div class="alert alert-warning"

--- a/addons/account_peppol/views/res_partner_views.xml
+++ b/addons/account_peppol/views/res_partner_views.xml
@@ -7,8 +7,18 @@
             <field name="inherit_id" ref="base.view_partner_form"/>
             <field name="arch" type="xml">
             <data>
+                <xpath expr="//field[@name='invoice_sending_method']" position="before">
+                    <field name="available_peppol_sending_methods" invisible="1"/>
+                    <field name="available_peppol_edi_formats" invisible="1"/>
+                </xpath>
+                <xpath expr="//field[@name='invoice_sending_method']" position="attributes">
+                    <attribute name="widget">filterable_selection</attribute>
+                    <attribute name="options">{'whitelist_fname': 'available_peppol_sending_methods'}</attribute>
+                </xpath>
                 <xpath expr="//field[@name='invoice_edi_format']" position="attributes">
                     <attribute name="required">invoice_sending_method == 'peppol'</attribute>
+                    <attribute name="widget">filterable_selection</attribute>
+                    <attribute name="options">{'whitelist_fname': 'available_peppol_edi_formats'}</attribute>
                 </xpath>
                 <xpath expr="//field[@name='peppol_eas']" position="before">
                     <field name="bank_account_count" invisible="1"/>

--- a/addons/l10n_anz_ubl_pint/models/res_partner.py
+++ b/addons/l10n_anz_ubl_pint/models/res_partner.py
@@ -13,15 +13,8 @@ class ResPartner(models.Model):
             return self.env['account.edi.xml.pint_anz']
         return super()._get_edi_builder(invoice_edi_format)
 
-    def _get_ubl_cii_formats(self):
-        # EXTENDS 'account'
-        formats = super()._get_ubl_cii_formats()
-        formats.append('pint_anz')
-        return formats
-
-    def _get_ubl_cii_formats_by_country(self):
-        # EXTENDS 'account'
-        mapping = super()._get_ubl_cii_formats_by_country()
-        mapping['AU'] = 'pint_anz'
-        mapping['NZ'] = 'pint_anz'
-        return mapping
+    def _get_ubl_cii_formats_info(self):
+        # EXTENDS 'account_edi_ubl_cii'
+        formats_info = super()._get_ubl_cii_formats_info()
+        formats_info['pint_anz'] = {'countries': ['AU', 'NZ'], 'on_peppol': True, 'sequence': 90}  # has priority over UBL_ANZ from 'account_edi_ubl_cii'
+        return formats_info

--- a/addons/l10n_dk_oioubl/models/res_partner.py
+++ b/addons/l10n_dk_oioubl/models/res_partner.py
@@ -12,14 +12,8 @@ class ResPartner(models.Model):
             return self.env['account.edi.xml.oioubl_201']
         return super()._get_edi_builder(invoice_edi_format)
 
-    def _get_ubl_cii_formats(self):
-        # EXTENDS 'account'
-        formats = super()._get_ubl_cii_formats()
-        formats.append('oioubl_201')
-        return formats
-
-    def _get_ubl_cii_formats_by_country(self):
-        # EXTENDS 'account'
-        mapping = super()._get_ubl_cii_formats_by_country()
-        mapping['DK'] = 'oioubl_201'
-        return mapping
+    def _get_ubl_cii_formats_info(self):
+        # EXTENDS 'account_edi_ubl_cii'
+        formats_info = super()._get_ubl_cii_formats_info()
+        formats_info['oioubl_201'] = {'countries': ['DK']}
+        return formats_info

--- a/addons/l10n_jp_ubl_pint/models/res_partner.py
+++ b/addons/l10n_jp_ubl_pint/models/res_partner.py
@@ -12,14 +12,8 @@ class ResPartner(models.Model):
             return self.env['account.edi.xml.pint_jp']
         return super()._get_edi_builder(invoice_edi_format)
 
-    def _get_ubl_cii_formats(self):
-        # EXTENDS 'account'
-        formats = super()._get_ubl_cii_formats()
-        formats.append('pint_jp')
-        return formats
-
-    def _get_ubl_cii_formats_by_country(self):
-        # EXTENDS 'account'
-        mapping = super()._get_ubl_cii_formats_by_country()
-        mapping['JP'] = 'pint_jp'
-        return mapping
+    def _get_ubl_cii_formats_info(self):
+        # EXTENDS 'account_edi_ubl_cii'
+        formats_info = super()._get_ubl_cii_formats_info()
+        formats_info['pint_jp'] = {'countries': ['JP'], 'on_peppol': True}
+        return formats_info

--- a/addons/l10n_my_ubl_pint/models/res_partner.py
+++ b/addons/l10n_my_ubl_pint/models/res_partner.py
@@ -15,14 +15,8 @@ class ResPartner(models.Model):
             return self.env['account.edi.xml.pint_my']
         return super()._get_edi_builder(invoice_edi_format)
 
-    def _get_ubl_cii_formats(self):
-        # EXTENDS 'account'
-        formats = super()._get_ubl_cii_formats()
-        formats.append('pint_my')
-        return formats
-
-    def _get_ubl_cii_formats_by_country(self):
-        # EXTENDS 'account'
-        mapping = super()._get_ubl_cii_formats_by_country()
-        mapping['MY'] = 'pint_my'
-        return mapping
+    def _get_ubl_cii_formats_info(self):
+        # EXTENDS 'account_edi_ubl_cii'
+        formats_info = super()._get_ubl_cii_formats_info()
+        formats_info['pint_my'] = {'countries': ['MY'], 'on_peppol': True}
+        return formats_info

--- a/addons/l10n_ro_edi/models/res_partner.py
+++ b/addons/l10n_ro_edi/models/res_partner.py
@@ -12,14 +12,8 @@ class ResPartner(models.Model):
             return self.env['account.edi.xml.ubl_ro']
         return super()._get_edi_builder(invoice_edi_format)
 
-    def _get_ubl_cii_formats(self):
-        # EXTENDS 'account'
-        formats = super()._get_ubl_cii_formats()
-        formats.append('ciusro')
-        return formats
-
-    def _get_ubl_cii_formats_by_country(self):
-        # EXTENDS 'account'
-        mapping = super()._get_ubl_cii_formats_by_country()
-        mapping['RO'] = 'ciusro'
-        return mapping
+    def _get_ubl_cii_formats_info(self):
+        # EXTENDS 'account_edi_ubl_cii'
+        formats_info = super()._get_ubl_cii_formats_info()
+        formats_info['ciusro'] = {'countries': ['RO']}
+        return formats_info

--- a/addons/l10n_sg_ubl_pint/models/res_partner.py
+++ b/addons/l10n_sg_ubl_pint/models/res_partner.py
@@ -13,14 +13,8 @@ class ResPartner(models.Model):
             return self.env['account.edi.xml.pint_sg']
         return super()._get_edi_builder(invoice_edi_format)
 
-    def _get_ubl_cii_formats(self):
-        # EXTENDS 'account'
-        formats = super()._get_ubl_cii_formats()
-        formats.append('pint_sg')
-        return formats
-
-    def _get_ubl_cii_formats_by_country(self):
-        # EXTENDS 'account'
-        mapping = super()._get_ubl_cii_formats_by_country()
-        mapping['SG'] = 'pint_sg'
-        return mapping
+    def _get_ubl_cii_formats_info(self):
+        # EXTENDS 'account_edi_ubl_cii'
+        formats_info = super()._get_ubl_cii_formats_info()
+        formats_info['pint_sg'] = {'countries': ['SG'], 'on_peppol': True, 'sequence': 90}  # has priority over UBL_SG from 'account_edi_ubl_cii'
+        return formats_info


### PR DESCRIPTION
### Commit 1: [IMP] l10n_it_edi: add FatturaPA as the preferred edi format for IT partners
Add FatturaPA as the preferred EDI format set by default on Italian partners.

task-no

---
### Commit 2: [FIX] account_\*,l10n_\*: EDI formats computation fixes
1. Before this commit, there was multiple lists of UBL/CII formats
that needed to be maintained. This was error prone because each implementation
needed to overrive each of these lists. We now have one dict with all formats
informations that is parsed in different ways depending on the need.
(By Country, Peppol compatible, ...)

2. Before this commit, if a country had two possible UBL/CII formats, one
always override the other, we now have the possibility to have multiple formats
per country and set a priority on them (trough a sequence number).

3. Before this commit, we maintained a list of NON-PEPPOL formats, this had multiple
drawbacks: it's hard to maintain, error prone, unecessary negation that made condition
tricky to understand. We now set a value on the dictionnary of UBL/CII formats that marks
the format as compliant with Peppol Network.

task-4240924

---
### Commit 3: [IMP] account_peppol: refine displayed EDI formats and sending methods in partner form
Make the displayed information on partner form more relevant:
- the sending method "by Peppol" is no longer visible when the current company can't
enable Peppol (for example an US company).
- the EDI formats displayed when "by Peppol" is the preferred sending method are
now only EDI formats supported by the Peppol Network.

task-4240924