### PR TITLE
[FIX] web: avoid a traceback with gantt popovers

### DIFF
--- a/addons/web/static/src/core/position/position_hook.js
+++ b/addons/web/static/src/core/position/position_hook.js
@@ -55,7 +55,7 @@ export function usePosition(refName, getTarget, options = {}) {
     let lock = false;
     const update = () => {
         const targetEl = getTarget();
-        if (!ref.el || !targetEl || lock) {
+        if (!ref.el || !targetEl?.isConnected || lock) {
             // No compute needed
             return;
         }

--- a/addons/web/static/tests/core/position/position_hook.test.js
+++ b/addons/web/static/tests/core/position/position_hook.test.js
@@ -748,6 +748,37 @@ test("batch update call", async () => {
     expect.verifySteps(["positioned"]);
 });
 
+test("not positioned if target not connected", async () => {
+    const target = document.createElement("div");
+    class TestComponent extends Component {
+        static template = xml`
+            <div t-ref="container"><div t-ref="popper"/></div>
+        `;
+        static props = ["*"];
+        setup() {
+            this.container = useRef("container");
+            this.position = usePosition("popper", () => target, {
+                onPositioned: () => {
+                    expect.step("positioned");
+                },
+            });
+        }
+    }
+
+    const comp = await mountWithCleanup(TestComponent);
+    expect.verifySteps([]);
+
+    comp.container.el.appendChild(target);
+    comp.position.unlock();
+    await animationFrame();
+    expect.verifySteps(["positioned"]);
+
+    comp.container.el.removeChild(target);
+    comp.position.unlock();
+    await animationFrame();
+    expect.verifySteps([]);
+});
+
 function getPositionTest(position, positionToCheck) {
     return async () => {
         expect.assertions(2);


### PR DESCRIPTION
Since [1] have a gantt popover opened and then scroll the popover out: a traceback occur due to the onPositioned callback still called when the popover is being closed.

Now usePosition will check if needed elements are connected before the positioning computation.

[1]: https://github.com/odoo/enterprise/commit/ebeb633be737eb7bd614c2b474fafd65cd54f0ae