### PR TITLE
[FIX] hw_drivers: remove reference to chromium_additional_args

### DIFF
--- a/addons/hw_drivers/browser.py
+++ b/addons/hw_drivers/browser.py
@@ -42,9 +42,9 @@ class Browser:
         # helpers.get_version returns a string formatted as: <L|W><version> (L: Linux, W: Windows)
         self.browser = 'chromium-browser' if float(helpers.get_version()[1:]) >= MIN_IMAGE_VERSION else 'firefox'
         self.browser_process_name = 'chromium' if self.browser == 'chromium-browser' else self.browser
+        self.state = BrowserState.NORMAL
         self._x_screen = _x_screen
         self._set_environment(env)
-        self._state = BrowserState.NORMAL
 
     def _set_environment(self, env):
         """
@@ -64,7 +64,7 @@ class Browser:
         :param state: State of the browser (normal, kiosk, fullscreen)
         """
         self.url = url or self.url
-        self._state = state
+        self.state = state
 
         # Reopen to take new url or additional args into account
         self.close_browser()
@@ -139,5 +139,5 @@ class Browser:
 
     def disable_kiosk_mode(self):
         """Removes arguments to chromium-browser cli to open it without kiosk mode"""
-        if self._state == BrowserState.KIOSK:
+        if self.state == BrowserState.KIOSK:
             self.open_browser(state=BrowserState.FULLSCREEN)

--- a/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
@@ -71,7 +71,7 @@ class DisplayDriver(Driver):
     def run(self):
         while self.device_identifier != 'distant_display' and not self._stopped.is_set() and "pos_customer_display" not in self.url:
             time.sleep(60)
-            if self.url != 'http://localhost:8069/point_of_sale/display/' + self.device_identifier and self.browser.chromium_additional_args != self.browser.kiosk_args:
+            if self.url != 'http://localhost:8069/point_of_sale/display/' + self.device_identifier and self.browser.state != BrowserState.KIOSK:
                 # Refresh the page every minute
                 self.browser.refresh()
 


### PR DESCRIPTION
In #183565 the `chromium_additional_args` variable was removed, however a reference to it was missed in `DisplayDriver_L`. This PR fixes this reference by replacing it with `browser.state`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
