### PR TITLE
[FIX] hr_fleet: rearrange fleet attachment upload buttons

### DIFF
--- a/addons/hr_fleet/static/src/views/hr_fleet_kanban/hr_fleet_kanban_controller.js
+++ b/addons/hr_fleet/static/src/views/hr_fleet_kanban/hr_fleet_kanban_controller.js
@@ -18,6 +18,10 @@ export class HrFleetKanbanController extends KanbanController {
         );
     }
 
+    get canCreate() {
+        return false;
+    }
+
     async onInputChange(ev) {
         if (!ev.target.files) {
             return;

--- a/addons/hr_fleet/static/src/views/hr_fleet_kanban/hr_fleet_kanban_controller.xml
+++ b/addons/hr_fleet/static/src/views/hr_fleet_kanban/hr_fleet_kanban_controller.xml
@@ -3,7 +3,7 @@
     <t t-name="hr_fleet.HrFleetKanbanController.Buttons" t-inherit="web.KanbanView.Buttons" t-inherit-mode="primary">
         <xpath expr="//div[hasclass('o_cp_buttons')]" position="inside">
             <input type="file" multiple="true" t-ref="uploadFileInput" class="o_input_file o_hidden" t-on-change.stop="onInputChange"/>
-            <button type="button" t-att-class="'d-none d-md-block btn' + (!env.isSmall ? ' btn-primary' : 'btn-secondary')" t-on-click="() => this.uploadFileInput.el.click()">
+            <button type="button" t-att-class="'btn ' + (!env.isSmall ? 'btn-primary' : 'btn-secondary')" t-on-click="() => this.uploadFileInput.el.click()">
                 Upload
             </button>
         </xpath>


### PR DESCRIPTION
Steps to reproduce:
- Fleet app > Any vehicle > Drivers History > Attachments
- In mobile view > Primary button 'Upload' is not accessible
- Primary button 'New' does not do anything

This happens because the controller cannot find a form view for ir.attachment in fleet, which is the default view type for record creation (barring quickcreate stuff). Also d-none class hides the display of the 'Upload' button but the dropdown menu arrow is still there which is rather confusing.

Seeing how both buttons serve the same purpose, there is no need to keep 'New' which has no corresponding view.

opw-4229756

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
