### PR TITLE
[FIX] Account: Prevent to taking wrong EU FP for EU Customer

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -251,7 +251,7 @@ class AccountFiscalPosition(models.Model):
         eu_delivery = delivery.country_code in eu_country_codes
         domestic_delivery = delivery_country == company.country_id
 
-        vat_required = bool(partner.vat) or domestic_delivery
+        vat_required = bool(partner.vat) or (bool(partner.vat) and domestic_delivery)
 
         # If the delivery is within the EU, the partner does not have a valid EU VAT number and is not from the EU,
         # then assign the company's country as the delivery country and force vat_required to True


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Current behavior before PR:

**Steps to Reproduce:**

When the company and customer are both located in the same EU country, the system incorrectly applies the "VAT Required" fiscal position, even if the customer does not have a VAT number set.

For example:
- **Company Country:** IE (Ireland)
- **Customer Country:** IE (Ireland)
- **Customer VAT:** N/A (Empty)

**Issue:** The system is assigning the "VAT Required" fiscal position, which is incorrect in this case.


Desired behavior after PR is merged:
When both the company and customer are located in the same EU country, and the customer does not have a VAT number set, the system should apply the correct fiscal position (the one where "VAT Required" is not enabled).



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
