### PR TITLE
[FIX] mrp_{subcontracting_dropshipping,account}: use comp qty in price unit calc

### DIFF
--- a/addons/mrp_account/models/product.py
+++ b/addons/mrp_account/models/product.py
@@ -58,7 +58,11 @@ class ProductProduct(models.Model):
         for bom_line, moves_list in groupby(stock_moves.filtered(lambda sm: sm.state != 'cancel'), lambda sm: sm.bom_line_id):
             if bom_line not in bom_lines:
                 for move in moves_list:
-                    value += move.product_id._compute_average_price(qty_invoiced * move.product_qty, qty_to_invoice * move.product_qty, move, is_returned=is_returned)
+                    component_quantity = next(
+                        (bml.product_qty for bml in move.product_id.bom_line_ids if bml in bom_lines),
+                        1
+                    )
+                    value += component_quantity * move.product_id._compute_average_price(qty_invoiced * move.product_qty, qty_to_invoice * move.product_qty, move, is_returned=is_returned)
                 continue
             line_qty = bom_line.product_uom_id._compute_quantity(bom_lines[bom_line]['qty'], bom_line.product_id.uom_id)
             moves = self.env['stock.move'].concat(*moves_list)

--- a/addons/mrp_subcontracting_dropshipping/tests/test_anglo_saxon_valuation.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_anglo_saxon_valuation.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_common import ValuationReconciliationTestCommon
+from odoo import Command
 from odoo.tests import tagged, Form
 
 
@@ -212,6 +213,17 @@ class TestSubcontractingDropshippingValuation(ValuationReconciliationTestCommon)
         purchase order line has been manually edited.
         """
         kit_final_prod = self.product_a
+        product_c = self.env['product.product'].create({
+            'name': 'product_c',
+            'uom_id': self.env.ref('uom.product_uom_dozen').id,
+            'uom_po_id': self.env.ref('uom.product_uom_dozen').id,
+            'lst_price': 120.0,
+            'standard_price': 100.0,
+            'property_account_income_id': self.copy_account(self.company_data['default_account_revenue']).id,
+            'property_account_expense_id': self.copy_account(self.company_data['default_account_expense']).id,
+            'taxes_id': [Command.set((self.tax_sale_a + self.tax_sale_b).ids)],
+            'supplier_taxes_id': [Command.set((self.tax_purchase_a + self.tax_purchase_b).ids)],
+        })
         kit_bom = self.env['mrp.bom'].create({
             'product_tmpl_id': kit_final_prod.product_tmpl_id.id,
             'product_uom_id': kit_final_prod.uom_id.id,
@@ -220,13 +232,21 @@ class TestSubcontractingDropshippingValuation(ValuationReconciliationTestCommon)
         })
         kit_bom.bom_line_ids = [(0, 0, {
             'product_id': self.product_b.id,
-            'product_qty': 1,
+            'product_qty': 4,
+        }), (0, 0, {
+            'product_id': product_c.id,
+            'product_qty': 2,
         })]
 
         self.env['product.supplierinfo'].create({
             'product_id': self.product_b.id,
             'partner_id': self.partner_a.id,
-            'price': 2000,
+            'price': 160,
+        })
+        self.env['product.supplierinfo'].create({
+            'product_id': product_c.id,
+            'partner_id': self.partner_a.id,
+            'price': 100,
         })
 
         (kit_final_prod + self.product_b).categ_id.write({
@@ -253,6 +273,10 @@ class TestSubcontractingDropshippingValuation(ValuationReconciliationTestCommon)
         account_move = sale_order._create_invoices()
         account_move.action_post()
 
+        # Each product_a should cost:
+        # 4x product_b = 160 * 4 = 640 +
+        # 2x product_c = 100 * 2 = 200
+        #                        = 840
         self.assertRecordValues(
             account_move.line_ids,
             [
@@ -260,7 +284,7 @@ class TestSubcontractingDropshippingValuation(ValuationReconciliationTestCommon)
                 {'name': 'Tax 15% (Copy)',      'debit': 0.0,       'credit': 270.0},
                 {'name': 'INV/2024/00001',      'debit': 621.0,     'credit': 0.0},
                 {'name': 'INV/2024/00001',      'debit': 1449.0,    'credit': 0.0},
-                {'name': 'product_a',           'debit': 0.0,       'credit': 4000.0},
-                {'name': 'product_a',           'debit': 4000.0,    'credit': 0.0},
+                {'name': 'product_a',           'debit': 0.0,       'credit': 840 * 2},
+                {'name': 'product_a',           'debit': 840 * 2,   'credit': 0.0},
             ]
         )


### PR DESCRIPTION
**Current behavior:**
Selling a kit bom product will result in inaccurate journal entries in the stock output and expense accounts, the amount_currency field will only reflect the price unit of the kit's components.

**Expected behavior:**
The price unit should reflect the total cost of the components on the BoM: e.g., if a kit product needs 4 of some component1, the price unit should be 4 * component1.standard_price.

**Steps to reproduce:**
1. Create a kit product with 2 components, both with qty > 1

2. Assign dropshipping to the kit

3. Create a sale order and confirm -> confirm the purchase order

4. Validate the dropship transfer, invoice the sale order and post it

5. See the 2 inaccurate journal entries, where the debit/credit respectively only total to one instance of each component's cost added together

**Cause of the issue:**
The price unit calculation didn't look at the bom line product qty, only using the price unit 1 time per component.

**Fix:**
Multiply the value by the quantity of it required on its line in the BoM.

opw-4253827