### PR TITLE
[FIX] l10n_gcc_invoice: vat amount in invoice template

### DIFF
--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -339,7 +339,7 @@
                                         <tr class="o_taxes">
                                             <td class="text-end o_price_total">
                                                 <span class="text-nowrap"
-                                                      t-out="tax_group['display_base_amount_currency']"
+                                                      t-out="tax_group['tax_amount_currency']"
                                                       t-options='{"widget": "monetary", "display_currency": currency}'
                                                 >1.05</span>
                                             </td>


### PR DESCRIPTION
Create an Invoice with a standard tax
Send&Print
Issue: In totals section VAT amount will be wrong

opw-4256242
opw-4256566
