### PR TITLE
[FIX] base: remove mogrify for _read_group_orderby

### DIFF
--- a/odoo/addons/test_read_group/models.py
+++ b/odoo/addons/test_read_group/models.py
@@ -68,6 +68,14 @@ class Order(models.Model):
 
     line_ids = fields.One2many('test_read_group.order.line', 'order_id')
     date = fields.Date()
+    company_dependent_name = fields.Char(company_dependent=True)
+    many2one_id = fields.Many2one('test_read_group.order')
+
+    @property
+    def _order(self):
+        if self.env.context.get('test_read_group_order_company_dependent'):
+            return 'company_dependent_name'
+        return super()._order
 
 
 class OrderLine(models.Model):

--- a/odoo/addons/test_read_group/tests/__init__.py
+++ b/odoo/addons/test_read_group/tests/__init__.py
@@ -7,6 +7,7 @@ from . import test_auto_join
 from . import test_m2m_grouping
 from . import test_date_range
 from . import test_groupby_week
+from . import test_override
 from . import test_private_read_group
 from . import test_inherits
 from . import test_read_progress_bar

--- a/odoo/addons/test_read_group/tests/test_override.py
+++ b/odoo/addons/test_read_group/tests/test_override.py
@@ -1,0 +1,32 @@
+from psycopg2.errors import GroupingError
+
+from odoo import models
+from odoo.tests.common import tagged, TransactionCase
+
+
+@tagged('-at_install', 'post_install')
+class TestReadGroupOverride(TransactionCase):
+    def test_order_for_groupby(self):
+        Order = self.env['test_read_group.order']
+        many2one_field = Order._fields['many2one_id']
+        self.addCleanup(setattr, many2one_field, 'comodel_name', many2one_field.comodel_name)
+        BaseModel = models.BaseModel
+        for Model in self.env.registry.values():
+            if not Model._abstract and Model._auto and (
+                Model._order_field_to_sql is not BaseModel._order_field_to_sql
+                or Model._order_to_sql is not BaseModel._order_to_sql
+                or Model._read_group_orderby is not BaseModel._read_group_orderby
+            ):
+                # methods for customized order are overridden by Model
+                # change comodel_name of a many2one field as a hack for the test
+                many2one_field.comodel_name = Model._name
+                try:
+                    Order.read_group([], ['many2one_id'], ['many2one_id'])
+                except GroupingError as e:
+                    self.assertEqual(
+                        e, None,
+                        f'Bad method override for model {Model._name}. '
+                        'Fields used by both customized order and Model._order '
+                        'must be added to the query.groupby when query.groupby '
+                        'is not empty to avoid GroupingError.'
+                    )

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1948,41 +1948,26 @@ class BaseModel(metaclass=MetaModel):
             return []
 
         query = self._search(domain)
+        query.limit = limit
+        query.offset = offset
 
         groupby_terms: dict[str, SQL] = {
             spec: self._read_group_groupby(spec, query)
             for spec in groupby
         }
+        if groupby_terms:
+            query.groupby = SQL(", ").join(groupby_terms.values())
+            query.having = self._read_group_having(having, query)
+            # _read_group_orderby may possibly extend query.groupby for orderby
+            query.order = self._read_group_orderby(order, groupby_terms, query)
+
         select_terms: list[SQL] = [
             self._read_group_select(spec, query)
             for spec in aggregates
         ]
-        sql_having = self._read_group_having(having, query)
-        sql_order, sql_extra_groupby = self._read_group_orderby(order, groupby_terms, query)
-
-        groupby_terms = list(groupby_terms.values())
-
-        query_parts = [
-            SQL("SELECT %s", SQL(", ").join(groupby_terms + select_terms)),
-            SQL("FROM %s", query.from_clause),
-        ]
-        if query.where_clause:
-            query_parts.append(SQL("WHERE %s", query.where_clause))
-        if groupby_terms:
-            if sql_extra_groupby:
-                groupby_terms.append(sql_extra_groupby)
-            query_parts.append(SQL("GROUP BY %s", SQL(", ").join(groupby_terms)))
-        if sql_having:
-            query_parts.append(SQL("HAVING %s", sql_having))
-        if sql_order:
-            query_parts.append(SQL("ORDER BY %s", sql_order))
-        if limit:
-            query_parts.append(SQL("LIMIT %s", limit))
-        if offset:
-            query_parts.append(SQL("OFFSET %s", offset))
 
         # row_values: [(a1, b1, c1), (a2, b2, c2), ...]
-        row_values = self.env.execute_query(SQL("\n").join(query_parts))
+        row_values = self.env.execute_query(query.select(*groupby_terms.values(), *select_terms))
 
         if not row_values:
             return row_values
@@ -2170,7 +2155,7 @@ class BaseModel(metaclass=MetaModel):
         return stack[0]
 
     def _read_group_orderby(self, order: str, groupby_terms: dict[str, SQL],
-                            query: Query) -> tuple[SQL, SQL]:
+                            query: Query) -> SQL:
         """ Return (<SQL expression>, <SQL expression>)
         corresponding to the given order and groupby terms.
 
@@ -2185,10 +2170,9 @@ class BaseModel(metaclass=MetaModel):
             traverse_many2one = False
 
         if not order:
-            return SQL(), SQL()
+            return SQL()
 
         orderby_terms = []
-        extra_groupby_terms = []
 
         for order_part in order.split(','):
             order_match = regex_order.match(order_part)
@@ -2214,21 +2198,13 @@ class BaseModel(metaclass=MetaModel):
                 traverse_many2one and field and field.type == 'many2one'
                 and self.env[field.comodel_name]._order != 'id'
             ):
-                # this generates an extra clause to add in the group by
-                sql_order = self._order_to_sql(f'{term} {direction} {nulls}', query)
-                orderby_terms.append(sql_order)
-                sql_order_str = self.env.cr.mogrify(sql_order).decode()
-                extra_groupby_terms.extend(
-                    SQL(order.strip().split()[0])
-                    for order in sql_order_str.split(",")
-                    if order.strip()
-                )
-
+                if sql_order := self._order_to_sql(f'{term} {direction} {nulls}', query):
+                    orderby_terms.append(sql_order)
             else:
                 sql_expr = groupby_terms[term]
                 orderby_terms.append(SQL("%s %s %s", sql_expr, sql_direction, sql_nulls))
 
-        return SQL(", ").join(orderby_terms), SQL(", ").join(extra_groupby_terms)
+        return SQL(", ").join(orderby_terms)
 
     @api.model
     def _read_group_empty_value(self, spec):
@@ -2972,9 +2948,6 @@ class BaseModel(metaclass=MetaModel):
         if field.company_dependent:
             fallback = field.get_company_dependent_fallback(self)
             fallback = field.convert_to_column(field.convert_to_write(fallback, self), self)
-            # in _read_group_orderby the result of field to sql will be mogrified and split to
-            # e.g SQL('COALESCE(%s->%s') and SQL('to_jsonb(%s))::boolean') as 2 orderby values
-            # and concatenated by SQL(',') in the final result, which works in an unexpected way
             sql_field = SQL(
                 "COALESCE(%(column)s->%(company_id)s,to_jsonb(%(fallback)s::%(column_type)s))",
                 column=sql_field,
@@ -5545,7 +5518,7 @@ class BaseModel(metaclass=MetaModel):
         """
         order = order or self._order
         if not order:
-            return []
+            return SQL()
         self._check_qorder(order)
 
         alias = alias or self._table
@@ -5607,6 +5580,8 @@ class BaseModel(metaclass=MetaModel):
                 sql_field = self._field_to_sql(alias, field_name, query)
 
             if coorder == 'id':
+                if query.groupby:
+                    query.groupby = SQL('%s, %s', query.groupby, sql_field)
                 return SQL("%s %s %s", sql_field, direction, nulls)
 
             # instead of ordering by the field's raw value, use the comodel's
@@ -5635,6 +5610,8 @@ class BaseModel(metaclass=MetaModel):
         sql_field = self._field_to_sql(alias, field_name, query)
         if field.type == 'boolean':
             sql_field = SQL("COALESCE(%s, FALSE)", sql_field)
+        if query.groupby:
+            query.groupby = SQL('%s, %s', query.groupby, sql_field)
 
         return SQL("%s %s %s", sql_field, direction, nulls)
 

--- a/odoo/tools/query.py
+++ b/odoo/tools/query.py
@@ -67,7 +67,9 @@ class Query:
         # holds the list of WHERE conditions (to be joined with 'AND')
         self._where_clauses: list[SQL] = []
 
-        # order, limit, offset
+        # groupby, having, order, limit, offset
+        self.groupby: SQL | None = None
+        self.having: SQL | None = None
         self._order: SQL | None = None
         self.limit: int | None = None
         self.offset: int | None = None
@@ -178,10 +180,12 @@ class Query:
         """ Return the SELECT query as an ``SQL`` object. """
         sql_args = map(SQL, args) if args else [SQL.identifier(self.table, 'id')]
         return SQL(
-            "%s%s%s%s%s%s",
+            "%s%s%s%s%s%s%s%s",
             SQL("SELECT %s", SQL(", ").join(sql_args)),
             SQL(" FROM %s", self.from_clause),
             SQL(" WHERE %s", self.where_clause) if self._where_clauses else SQL(),
+            SQL(" GROUP BY %s", self.groupby) if self.groupby else SQL(),
+            SQL(" HAVING %s", self.having) if self.having else SQL(),
             SQL(" ORDER BY %s", self._order) if self._order else SQL(),
             SQL(" LIMIT %s", self.limit) if self.limit else SQL(),
             SQL(" OFFSET %s", self.offset) if self.offset else SQL(),


### PR DESCRIPTION
`_read_group_orderby` used `cr.mogrify`, `split(",")` and `split()[0]` for the
result coming from the `_order_to_sql` which may come from `_field_to_sql`
As a side effect, SQL code after a space/newline not adjacent to a comma will
be dropped after `split()[0]`. So the mogrified customized `_field_to_sql`
shoudn't have any space/newline not adjacent to a comma if the field is used
for `Model._order`.


Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
