### PR TITLE
[FIX] microsoft_calendar: new events lose owner

### DIFF
--- a/addons/microsoft_calendar/models/microsoft_sync.py
+++ b/addons/microsoft_calendar/models/microsoft_sync.py
@@ -192,6 +192,11 @@ class MicrosoftSync(models.AbstractModel):
             record._microsoft_delete(record._get_organizer(), record.ms_organizer_event_id)
         for record in new_records:
             values = record._microsoft_values(self._get_microsoft_synced_fields())
+            sender_user = record._get_event_user_m()
+            # Prevent current user to synchronize new events of non-synchronized users, otherwise the event
+            # ownership will be lost in Outlook and it will block the future event sync for the original owner.
+            if record.user_id and record.user_id != self.env.user and sender_user == self.env.user:
+                continue
             if isinstance(values, dict):
                 record._microsoft_insert(values)
             else:

--- a/addons/microsoft_calendar/tests/test_create_events.py
+++ b/addons/microsoft_calendar/tests/test_create_events.py
@@ -497,3 +497,24 @@ class TestCreateEvents(TestCommon):
         new_records = (records - existing_records)
         self.assertEqual(len(new_records), 1)
         self.assert_odoo_event(new_records, expected_event)
+
+    @patch.object(MicrosoftCalendarService, 'insert')
+    def test_skip_sync_for_non_synchronized_users_new_events(self, mock_insert):
+        """
+        Skip the synchro of new events by attendees when the organizer is not synchronized with Outlook.
+        Otherwise, the event ownership will be lost to the attendee and it could generate duplicates in
+        Odoo, as well cause problems in the future the synchronization of that event for the original owner.
+        """
+        # Ensure that the calendar synchronization of user A is active. Deactivate user B synchronization.
+        self.assertTrue(self.env['calendar.event'].with_user(self.organizer_user)._check_microsoft_sync_status())
+        self.attendee_user.microsoft_synchronization_stopped = True
+
+        # Create an event with user B (not synchronized) as organizer and invite user A.
+        self.simple_event_values['user_id'] = self.attendee_user.id
+        self.simple_event_values['partner_ids'] = [Command.set([self.organizer_user.partner_id.id, self.attendee_user.partner_id.id])]
+        event = self.env['calendar.event'].with_user(self.attendee_user).create(self.simple_event_values)
+        self.assertTrue(event, "The event for the not synchronized owner must be created in Odoo.")
+
+        # Synchronize the calendar of user A, then make sure insert was not called.
+        event.with_user(self.organizer_user).sudo()._sync_odoo2microsoft()
+        mock_insert.assert_not_called()


### PR DESCRIPTION
Before this commit, when an user A is invited by an event of user B and none of these users are synchronized with Outlook, when the synchronization of user A starts or resumes, the event will be synchronized without any organizer in user A's Outlook calendar due to a limitation of Microsoft of not accepting creating events for other users (user B) directly. In the meanwhile, in Odoo, the event ownership will be transferred from user B to user A, which is also wrong.

After this commit, when user A starts or resumes its synchronization with Outlook, previous Odoo events which user A is attendee but not organizer won't be synchronized until the organizer synchronizes its calendar. This will keep the ownership of the event intact in Odoo, and when the organizer synchronizes its calendar with Outlook, it will be correctly synchronized in Outlook as well. This approach will also reduce the possibility of duplicated events in Odoo side (and by transitivity, in Outlook side).

task-4261237