### PR TITLE
[FIX] website_sale: ensure applied filters are preserved when sorting

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -315,6 +315,9 @@ class WebsiteSale(http.Controller):
         attributes_ids = {v[0] for v in attrib_values}
         attrib_set = {v[1] for v in attrib_values}
 
+        if attrib_list:
+            post['attrib'] = attrib_list
+
         keep = QueryURL('/shop', **self._shop_get_query_url_kwargs(category and int(category), search, min_price, max_price, **post))
 
         now = datetime.timestamp(datetime.now())
@@ -337,8 +340,6 @@ class WebsiteSale(http.Controller):
         url = "/shop"
         if search:
             post["search"] = search
-        if attrib_list:
-            post['attrib'] = attrib_list
 
         options = self._get_search_options(
             category=category,


### PR DESCRIPTION
## Problem:
When generating sorting URLs, the `post` dictionary only contains a single selected attribute. This is due to `request.params` only passing the first `attrib` parameter during dispatch, even though there can be multiple.

## Solution:
Modify the `post` dictionary to store attributes as a list before passing it to the `_shop_get_query_url_kwargs` method. This ensures that all selected attributes are preserved and properly passed to the `keep` query parameters.

## Steps to reproduce:
- Go to `/shop`.
- Apply multiple attribute filters (ensure more than one attribute is selected).
- Change the sorting option.
- Only the first selected attribute is applied in the filter.

opw-4244895

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
