### PR TITLE
[IMP] account_edi_ubl_cii: separate by space for xml line description

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -224,7 +224,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         if self._context.get('convert_fixed_taxes'):
             taxes = taxes.filtered(lambda t: t.amount_type != 'fixed')
         tax_category_vals_list = self._get_tax_category_list(line.move_id, taxes)
-        description = line.name and line.name.replace('\n', ', ')
+        description = line.name and line.name.replace('\n', ' ')
         return {
             'description': description,
             'name': product.name or description,


### PR DESCRIPTION
Item description node in UBL is merged to one line in the XML by replacing the new line with ', '. This commit improves on it by using single spacebar without the comma.

opw-4213014