### PR TITLE
[FIX] hr_holidays: multi-company access to multi-employee allocations

### DIFF
--- a/addons/hr_holidays/security/hr_holidays_security.xml
+++ b/addons/hr_holidays/security/hr_holidays_security.xml
@@ -143,7 +143,11 @@
         <field name="model_id" ref="model_hr_leave_allocation"/>
         <field name="domain_force">[
             '|',
-                ('employee_id', '=', False),
+                '&amp;',
+                    ('employee_id', '=', False),
+                    '|',
+                        ('employee_ids', '=', False),
+                        ('employee_ids.company_id', 'in', company_ids),
                 ('employee_id.company_id', 'in', company_ids),
             ('holiday_status_id.company_id', 'in', company_ids + [False])
         ]</field>


### PR DESCRIPTION
Steps to reproduce:
1. Have multiple companies
2. Create a multiple employee allocation
3. Connect to the other company: you should be able to find the allocation

This commit further restricts multi-company access to allocations, so that it is accessible only when at least one of the employees on the allocation have the same company.

task-4241723


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
