### PR TITLE
[FIX] web: add an empty value to the minute selection in DateTimePicker

### DIFF
--- a/addons/web/static/src/core/datetime/datetime_picker.xml
+++ b/addons/web/static/src/core/datetime/datetime_picker.xml
@@ -129,6 +129,12 @@
             t-model="timeValue[unitIndex]"
             t-on-change="() => this.selectTime(timeValue_index)"
         >
+            <option
+                t-if="unitIndex === 1 and !!(timeValue[unitIndex] % props.rounding)"
+                class="text-center"
+                value=""
+                selected="true"
+            />
             <t t-foreach="unitList" t-as="unit" t-key="unit[0]">
                 <option
                     class="text-center"

--- a/addons/web/static/tests/core/datetime/datetime_picker_tests.js
+++ b/addons/web/static/tests/core/datetime/datetime_picker_tests.js
@@ -761,9 +761,11 @@ QUnit.module("Components", ({ beforeEach }) => {
 
         const [firstTimePicker, secondTimePicker] = getTimePickers();
         assert.deepEqual(getTexts(firstTimePicker[0], "option"), range(24, String));
+        const expectedMinutes = range(12, (i) => pad2(i * 5));
+        expectedMinutes.unshift("");
         assert.deepEqual(
             getTexts(firstTimePicker[1], "option"),
-            range(12, (i) => pad2(i * 5))
+            expectedMinutes
         );
         assert.deepEqual(getTexts(secondTimePicker[0], "option"), range(24, String));
         assert.deepEqual(
@@ -813,9 +815,11 @@ QUnit.module("Components", ({ beforeEach }) => {
 
         const [firstTimePicker, secondTimePicker] = getTimePickers();
         assert.deepEqual(getTexts(firstTimePicker[0], "option"), range(24, String));
+        const expectedMinutes = range(12, (i) => pad2(i * 5));
+        expectedMinutes.unshift("");
         assert.deepEqual(
             getTexts(firstTimePicker[1], "option"),
-            range(12, (i) => pad2(i * 5))
+            expectedMinutes
         );
         assert.deepEqual(getTexts(secondTimePicker[0], "option"), range(24, String));
         assert.deepEqual(


### PR DESCRIPTION
Steps to reproduce
==================

- Open any list/kanban view
- Add a custom filter
- Select a datetime field, for example Created on

=> The default value is the current datetime
   If you click on the datetime field, the datetimepicker is opened but
   the minutes are set to 00.
   If you click on apply, 00 is not set.

Cause of the issue
==================

The DateTimeInput has a rounding props (by default 5). If we open it with a value that has the minutes not rounded by that amount, 00 will be displayed instead because a <select/> is used, and only the rounded values are present.

Solution
========

Round the default value to the nearest 5 minutes

opw-4170906