### PR TITLE
[FIX] web: Missing list view header buttons on cog menu on mobile

### DIFF
--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -411,8 +411,8 @@ export class ListController extends Component {
             );
 
         return {
-            action: [...staticActionItems, ...(actionMenus.action || [])],
-            print: actionMenus.print,
+            action: [...staticActionItems, ...(actionMenus?.action || [])],
+            print: actionMenus?.print,
         };
     }
 

--- a/addons/web/static/src/views/list/list_controller.xml
+++ b/addons/web/static/src/views/list/list_controller.xml
@@ -41,7 +41,7 @@
 
                 <t t-set-slot="control-panel-additional-actions">
                     <CogMenu t-if="!hasSelectedRecords"/>
-                    <CogMenu t-elif="env.isSmall and props.info.actionMenus" t-props="this.actionMenuProps" hasSelectedRecords="hasSelectedRecords">
+                    <CogMenu t-elif="env.isSmall and (props.info.actionMenus or archInfo.headerButtons.length)" t-props="this.actionMenuProps" hasSelectedRecords="hasSelectedRecords">
                         <t t-foreach="archInfo.headerButtons" t-as="button" t-key="button.id" t-if="!evalViewModifier(button.invisible)">
                             <DropdownItem class="'o-dropdown-item-unstyled-button'">
                                 <MultiRecordViewButton

--- a/addons/web/static/tests/legacy/mobile/views/list_view_tests.js
+++ b/addons/web/static/tests/legacy/mobile/views/list_view_tests.js
@@ -221,4 +221,28 @@ QUnit.module("Mobile Views", ({ beforeEach }) => {
             assert.containsNone(fixture, "table .o_optional_columns_dropdown_toggle");
         }
     );
+
+    QUnit.test("list view header buttons are shift on the cog menus", async (assert) => {
+        await makeView({
+            type: "list",
+            resModel: "foo",
+            serverData,
+            arch: `
+                <list>
+                    <header>
+                        <button name="x" type="object" class="plaf" string="plaf"/>
+                    </header>
+                    <field name="foo"/>
+                </list>
+            `,
+        });
+
+        const getTextMenu = () => [...fixture.querySelectorAll(`.o_popover .o-dropdown-item`)].map((e) => e.innerText.trim());
+        assert.containsOnce(fixture, ".o_control_panel_breadcrumbs .o_cp_action_menus .fa-cog");
+        await click(fixture, ".o_control_panel_breadcrumbs .o_cp_action_menus .fa-cog");
+        assert.deepEqual(getTextMenu(), ["Export All"]);
+        await triggerEvents(fixture, ".o_data_row:nth-child(1)", ["touchstart", "touchend"]);
+        await click(fixture, ".o_control_panel_breadcrumbs .o_cp_action_menus .fa-cog");
+        assert.deepEqual(getTextMenu(), ["plaf", "Export", "Duplicate", "Delete"]);
+    });
 });


### PR DESCRIPTION
When we create a list view with a header buttons, the buttons didn't displayed in the DOM, but it should have been shift inside the cog menus.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
