### PR TITLE
[FIX] website: fix table of content destroy

### DIFF
--- a/addons/website/static/src/snippets/s_table_of_content/000.js
+++ b/addons/website/static/src/snippets/s_table_of_content/000.js
@@ -76,7 +76,7 @@ const TableOfContent = publicWidget.Widget.extend({
      * @override
      */
     destroy() {
-        this._scrollTarget.removeEventListener("scroll", this._onScrollBound);
+        this._scrollTarget?.removeEventListener("scroll", this._onScrollBound);
         const indexCallback = extraMenuUpdateCallbacks.indexOf(this._updateTableOfContentNavbarPositionBound);
         if (indexCallback >= 0) {
             extraMenuUpdateCallbacks.splice(indexCallback, 1);


### PR DESCRIPTION
A previous commit [1] fixed a bug where multiple "table of content" snippets were hidden in "mobile" view on a page (see commit message).

However, this did not fix all cases. It is likely that with even more hidden elements on the page, the problem remains unresolved.

We thought that await the start would solve the issue, but in some cases, the start wasn't even triggered by the time we reached the destroy.

This commit fixes the issue by checking that the "this._scrollTarget" variable is initialized before removing its listener in the destroy.

This bug requires more investigation, but this fix solves the issue for now.

[1]: https://github.com/odoo/odoo/commit/ac5e9fe93c2158be1e8555de3da1419c69f543e5

task-4160033
opw-4228666
opw-4220959
opw-4226783