### PR TITLE
[FIX] pos_restaurant: keep rewards when leaving table

### DIFF
--- a/addons/pos_restaurant_loyalty/__init__.py
+++ b/addons/pos_restaurant_loyalty/__init__.py
@@ -1,0 +1,1 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.

--- a/addons/pos_restaurant_loyalty/__manifest__.py
+++ b/addons/pos_restaurant_loyalty/__manifest__.py
@@ -1,0 +1,25 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+
+{
+    'name': 'POS - Restaurant Loyality',
+    'version': '1.0',
+    'category': 'Hidden',
+    'sequence': 6,
+    'summary': 'Link module between pos_restaurant and pos_loyalty',
+    'description': """
+This module correct some behaviors when both module are installed.
+""",
+    'depends': ['pos_restaurant', 'pos_loyalty'],
+    'installable': True,
+    'auto_install': True,
+    'assets': {
+        'point_of_sale._assets_pos': [
+            'pos_restaurant_loyalty/static/src/**/*',
+        ],
+        'web.assets_tests': [
+            'pos_restaurant_loyalty/static/tests/tours/**/*',
+        ],
+    },
+    'license': 'LGPL-3',
+}

--- a/addons/pos_restaurant_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant_loyalty/static/src/overrides/models/pos_store.js
@@ -1,0 +1,11 @@
+/** @odoo-module */
+
+import { patch } from "@web/core/utils/patch";
+import { PosStore } from "@point_of_sale/app/store/pos_store";
+
+patch(PosStore.prototype, {
+    async setTable(table, orderUid = null) {
+        await super.setTable(...arguments)
+        this.selectedOrder._updateRewards()
+    }
+})

--- a/addons/pos_restaurant_loyalty/static/tests/tours/PosRestaurantLoyaltyTour.js
+++ b/addons/pos_restaurant_loyalty/static/tests/tours/PosRestaurantLoyaltyTour.js
@@ -1,0 +1,21 @@
+/** @odoo-module **/
+
+import * as ProductScreen from "@point_of_sale/../tests/tours/helpers/ProductScreenTourMethods";
+import * as FloorScreen from "@pos_restaurant/../tests/tours/helpers/FloorScreenTourMethods";
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("PosRestaurantRewardStay", {
+    test: true,
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            FloorScreen.clickTable("5"),
+
+            ProductScreen.clickHomeCategory(),
+            ProductScreen.clickDisplayedProduct("Water"),
+            ProductScreen.totalAmountIs("1.98"),
+            FloorScreen.backToFloor(),
+            FloorScreen.clickTable("5"),
+            ProductScreen.totalAmountIs("1.98"),
+        ].flat()
+})

--- a/addons/pos_restaurant_loyalty/tests/__init__.py
+++ b/addons/pos_restaurant_loyalty/tests/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_pos_restaurant_loyalty

--- a/addons/pos_restaurant_loyalty/tests/test_pos_restaurant_loyalty.py
+++ b/addons/pos_restaurant_loyalty/tests/test_pos_restaurant_loyalty.py
@@ -1,0 +1,36 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.pos_restaurant.tests.test_frontend import TestFrontend
+from odoo.tests import tagged
+from odoo import Command
+
+
+@tagged("post_install", "-at_install")
+class TestPoSRestaurantLoyalty(TestFrontend):
+    def test_change_table_rewards_stay(self):
+        """
+        Test that make sure that rewards stay on the order when leaving the table
+        """
+        self.env['loyalty.program'].search([]).write({'active': False})
+        self.env['loyalty.program'].create({
+            'name': 'My super program',
+            'program_type': 'promotion',
+            'trigger': 'auto',
+            'applies_on': 'current',
+            'rule_ids': [Command.create({
+                'minimum_qty': 1,
+            })],
+            'reward_ids': [Command.create({
+                'reward_type': 'discount',
+                'discount': 10,
+                'discount_mode': 'percent',
+                'discount_applicability': 'order',
+            })],
+            'pos_config_ids': [Command.link(self.pos_config.id)],
+        })
+        self.pos_config.with_user(self.pos_admin).open_ui()
+        self.start_tour(
+            "/pos/web?config_id=%d" % self.pos_config.id,
+            "PosRestaurantRewardStay",
+            login="pos_admin",
+        )


### PR DESCRIPTION
When adding a reward to an order on a table, if you leave the table and come back to it the reward would be gone

Steps to reproduce:
-------------------
* Setup a promotion program that give 10% discount
* Open a PoS restaurant open a table and add some products
* The 10% discount should be applied
* Leave the table and come back to it
> Observation: The reward is gone

Why the fix:
------------
We make sure to update the rewards when selecting the table, because when opening the table we use the one saved on the server.

opw-4161408
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
