### PR TITLE
[FIX] l10n_din5008_purchase: fix din5008 rfq layout regression

### DIFF
--- a/addons/l10n_din5008_purchase/report/din5008_purchase_order_templates.xml
+++ b/addons/l10n_din5008_purchase/report/din5008_purchase_order_templates.xml
@@ -57,4 +57,61 @@
             </t>
         </xpath>
     </template>
+    <template id="report_purchasequotation_document" inherit_id="purchase.report_purchasequotation_document">
+        <xpath expr="//t[@t-set='address']" position="after">
+            <t t-set="din5008_document_information">
+                <div class="information_block" t-if="o and o._name=='purchase.order'">
+                    <table>
+                        <tr t-if="o.name">
+                            <td t-if="o.state == 'draft'">Request for Quotation No.:</td>
+                            <td t-elif="o.state in {'sent', 'to approve', 'purchase', 'done'}">Purchase Order No.:</td>
+                            <td t-elif="o.state == 'cancel'">Cancelled Purchase Order No.:</td>
+                            <td><t t-out="o.name"/></td>
+                        </tr>
+                        <tr t-if="o.user_id">
+                            <td>Purchase Representative:</td>
+                            <td><t t-out="o.user_id.name"/></td>
+                        </tr>
+                        <tr t-if="o.partner_ref">
+                            <td>Order Reference:</td>
+                            <td><t t-out="o.partner_ref"/></td>
+                        </tr>
+                        <tr t-if="o.date_approve">
+                            <td>Order Date:</td>
+                            <td><t t-out="o.date_approve"/></td>
+                        </tr>
+                        <tr t-if="o.date_order">
+                            <td>Order Deadline:</td>
+                            <td><t t-out="o.date_order"/></td>
+                        </tr>
+                        <tr t-if="o.incoterm_id">
+                            <td>Incoterm:</td>
+                            <td><t t-out="o.incoterm_id"/></td>
+                        </tr>
+                    </table>
+                </div>
+            </t>
+
+            <t t-set="din5008_address_block">
+                <tr t-if="o and o._name=='purchase.order'">
+                    <td class="shipping_address" t-if="o.dest_address_id">
+                        <span class="fw-bold">Shipping Address:</span>
+                        <address t-esc="o.dest_address_id" t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True}'/>
+                    </td>
+                    <td class="shipping_address" t-elif="'picking_type_id' in o._fields and o.picking_type_id.warehouse_id">
+                        <span class="fw-bold">Shipping Address:</span>
+                        <address t-esc="o.picking_type_id.warehouse_id.partner_id" t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True}'/>
+                    </td>
+                </tr>
+            </t>
+
+            <t t-set="din5008_document_title">
+                <span t-if="o and o._name == 'purchase.order'">
+                    <t t-if="o.state in {'draft', 'sent', 'to approve'}">Request for Quotation</t>
+                    <t t-elif="o.state in {'purchase', 'done'}">Purchase Order</t>
+                    <t t-elif="o.state == 'cancel'">Cancelled Purchase Order</t>
+                </span>
+            </t>
+        </xpath>
+    </template>
 </odoo>


### PR DESCRIPTION
Commit ab5b806ced3a72f04af9b92f1ec8c32e9a03f4d7 introduced a regression by moving the computation logic for the DIN 5008 layout from Python into the XML template report_purchaseorder_document. However, the same logic was not applied to report_purchasequotation_document, which is used for RFQs, causing discrepancies in the RFQ layout.

task-4089521