### PR TITLE
[FIX] html_editor: display the link popover correctly when linking an image

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -183,7 +183,7 @@ export class LinkPlugin extends Plugin {
         powerButtons: ["link"],
     };
     setup() {
-        this.overlay = this.shared.createOverlay(LinkPopover, {}, { sequence: 40 });
+        this.overlay = this.shared.createOverlay(LinkPopover, {}, { sequence: 50 });
         this.addDomListener(this.editable, "click", (ev) => {
             if (ev.target.tagName === "A" && ev.target.isContentEditable) {
                 ev.preventDefault();


### PR DESCRIPTION
Problem:
If a dialog is open and the link popover is triggered, it remains behind the dialog, creating further usability issues.

Probem:
The overlay items are displayed according to their `sequence` attribute, which determines their display order:
https://github.com/odoo/odoo/blob/bb20a6d0b3c3a70edbc1f68f560be1f333379ede/addons/web/static/src/core/overlay/overlay_container.js#L65-L67

Solution:
Increase the `sequence` value for the `LinkPopover` overlay, ensuring it appears on top of other overlays, including dialogs.

Steps to reproduce:
1. Insert an image in the editor in Settings/Configure your document layout/Footer.
2. Click on the image and try to add a link.
3. Observe that the link popover is not visible.

opw-4244308