### PR TITLE
[FIX] l10n_din5008_purchase: fix din5008 rfq layout regression

### DIFF
--- a/addons/l10n_din5008_purchase/i18n/de.po
+++ b/addons/l10n_din5008_purchase/i18n/de.po
@@ -6,10 +6,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.3alpha1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-24 13:04+0000\n"
+"POT-Creation-Date: 2024-11-18 08:13+0000\n"
 "PO-Revision-Date: 2024-04-24 13:04+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -17,60 +18,72 @@ msgstr ""
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "<span class=\"fw-bold\">Shipping Address:</span>"
 msgstr "<span class=\"fw-bold\">Lieferadresse:</span>"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Cancelled Purchase Order"
 msgstr "Stornierte Bestellung"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Cancelled Purchase Order No.:"
 msgstr "Stornierte Bestellnummer:"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Incoterm:"
 msgstr "Incoterm"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Order Date:"
 msgstr "Bestelldatum:"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Order Deadline:"
 msgstr "Bestellfrist:"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Order Reference:"
 msgstr "Bestellreferenz:"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Purchase Order"
 msgstr "Bestellung"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Purchase Order No.:"
 msgstr "Bestellnummer:"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Purchase Representative:"
 msgstr "Einkaufsbeauftragter:"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Request for Quotation"
 msgstr "Angebotsanfrage"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Request for Quotation No.:"
 msgstr "Angebotsanfrage Nr.:"

--- a/addons/l10n_din5008_purchase/i18n/fr.po
+++ b/addons/l10n_din5008_purchase/i18n/fr.po
@@ -6,10 +6,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.3alpha1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-24 13:02+0000\n"
+"POT-Creation-Date: 2024-11-18 08:13+0000\n"
 "PO-Revision-Date: 2024-04-24 13:02+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -17,60 +18,72 @@ msgstr ""
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "<span class=\"fw-bold\">Shipping Address:</span>"
 msgstr "<span class=\"fw-bold\">Adresse d'expédition :</span>"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Cancelled Purchase Order"
 msgstr "Bon de commande annulé"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Cancelled Purchase Order No.:"
 msgstr "Numéro du bon de commande annulé :"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Incoterm:"
 msgstr "Incoterm :"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Order Date:"
 msgstr "Date de commande :"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Order Deadline:"
 msgstr "Échéance de commande :"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Order Reference:"
 msgstr "Référence de la commande :"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Purchase Order"
 msgstr "Bon de commande"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Purchase Order No.:"
 msgstr "Numéro du bon de commande :"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Purchase Representative:"
 msgstr "Responsable des achats :"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Request for Quotation"
 msgstr "Demande de prix"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Request for Quotation No.:"
 msgstr "N° de demande de prix :"

--- a/addons/l10n_din5008_purchase/i18n/it.po
+++ b/addons/l10n_din5008_purchase/i18n/it.po
@@ -6,10 +6,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.3alpha1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-24 13:04+0000\n"
+"POT-Creation-Date: 2024-11-18 08:13+0000\n"
 "PO-Revision-Date: 2024-04-24 13:04+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -17,60 +18,72 @@ msgstr ""
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "<span class=\"fw-bold\">Shipping Address:</span>"
 msgstr "<span class=\"fw-bold\">Indirizzo di spedizione:</span>"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Cancelled Purchase Order"
 msgstr "Ordine di acquisto annullato"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Cancelled Purchase Order No.:"
 msgstr "Ordine di acquisto annullato n:"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Incoterm:"
 msgstr "Incoterm:"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Order Date:"
 msgstr "Data dell'ordine:"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Order Deadline:"
 msgstr "Scadenza dell'ordine:"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Order Reference:"
 msgstr "Riferimento ordine:"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Purchase Order"
 msgstr "Ordine di acquisto"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Purchase Order No.:"
 msgstr "Ordine di acquisto n:"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Purchase Representative:"
 msgstr "Referente acquisti:"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Request for Quotation"
 msgstr "Richiesta di preventivo"
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Request for Quotation No.:"
 msgstr "Richiesta di preventivo n.:"

--- a/addons/l10n_din5008_purchase/i18n/l10n_din5008_purchase.pot
+++ b/addons/l10n_din5008_purchase/i18n/l10n_din5008_purchase.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.3alpha1+e\n"
+"Project-Id-Version: Odoo Server saas~17.4+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-24 13:02+0000\n"
-"PO-Revision-Date: 2024-04-24 13:02+0000\n"
+"POT-Creation-Date: 2024-11-18 08:13+0000\n"
+"PO-Revision-Date: 2024-11-18 08:13+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -17,60 +17,72 @@ msgstr ""
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "<span class=\"fw-bold\">Shipping Address:</span>"
 msgstr ""
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Cancelled Purchase Order"
 msgstr ""
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Cancelled Purchase Order No.:"
 msgstr ""
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Incoterm:"
 msgstr ""
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Order Date:"
 msgstr ""
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Order Deadline:"
 msgstr ""
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Order Reference:"
 msgstr ""
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Purchase Order"
 msgstr ""
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Purchase Order No.:"
 msgstr ""
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Purchase Representative:"
 msgstr ""
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Request for Quotation"
 msgstr ""
 
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
 msgid "Request for Quotation No.:"
 msgstr ""

--- a/addons/l10n_din5008_purchase/report/din5008_purchase_order_templates.xml
+++ b/addons/l10n_din5008_purchase/report/din5008_purchase_order_templates.xml
@@ -1,60 +1,68 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <template id="report_common_purchase_din5008_template">
+        <t t-set="din5008_document_information">
+            <div class="information_block" t-if="o and o._name=='purchase.order'">
+                <table>
+                    <tr t-if="o.name">
+                        <td t-if="o.state == 'draft'">Request for Quotation No.:</td>
+                        <td t-elif="o.state in {'sent', 'to approve', 'purchase', 'done'}">Purchase Order No.:</td>
+                        <td t-elif="o.state == 'cancel'">Cancelled Purchase Order No.:</td>
+                        <td><t t-out="o.name"/></td>
+                    </tr>
+                    <tr t-if="o.user_id">
+                        <td>Purchase Representative:</td>
+                        <td><t t-out="o.user_id.name"/></td>
+                    </tr>
+                    <tr t-if="o.partner_ref">
+                        <td>Order Reference:</td>
+                        <td><t t-out="o.partner_ref"/></td>
+                    </tr>
+                    <tr t-if="o.date_approve">
+                        <td>Order Date:</td>
+                        <td><t t-out="o.date_approve" t-options="{'widget': 'date'}"/></td>
+                    </tr>
+                    <tr t-if="o.date_order">
+                        <td>Order Deadline:</td>
+                        <td><t t-out="o.date_order" t-options="{'widget': 'date'}"/></td>
+                    </tr>
+                    <tr t-if="o.incoterm_id">
+                        <td>Incoterm:</td>
+                        <td><t t-out="o.incoterm_id"/></td>
+                    </tr>
+                </table>
+            </div>
+        </t>
+
+        <t t-set="din5008_address_block">
+            <tr t-if="o and o._name=='purchase.order'">
+                <td class="shipping_address" t-if="o.dest_address_id">
+                    <span class="fw-bold">Shipping Address:</span>
+                    <address t-esc="o.dest_address_id" t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True}'/>
+                </td>
+                <td class="shipping_address" t-elif="'picking_type_id' in o._fields and o.picking_type_id.warehouse_id">
+                    <span class="fw-bold">Shipping Address:</span>
+                    <address t-esc="o.picking_type_id.warehouse_id.partner_id" t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True}'/>
+                </td>
+            </tr>
+        </t>
+
+        <t t-set="din5008_document_title">
+            <span t-if="o and o._name == 'purchase.order'">
+                <t t-if="o.state in {'draft', 'sent', 'to approve'}">Request for Quotation</t>
+                <t t-elif="o.state in {'purchase', 'done'}">Purchase Order</t>
+                <t t-elif="o.state == 'cancel'">Cancelled Purchase Order</t>
+            </span>
+        </t>
+    </template>
     <template id="report_purchaseorder_document" inherit_id="purchase.report_purchaseorder_document">
         <xpath expr="//t[@t-set='address']" position="after">
-            <t t-set="din5008_document_information">
-                <div class="information_block" t-if="o and o._name=='purchase.order'">
-                    <table>
-                        <tr t-if="o.name">
-                            <td t-if="o.state == 'draft'">Request for Quotation No.:</td>
-                            <td t-elif="o.state in {'sent', 'to approve', 'purchase', 'done'}">Purchase Order No.:</td>
-                            <td t-elif="o.state == 'cancel'">Cancelled Purchase Order No.:</td>
-                            <td><t t-out="o.name"/></td>
-                        </tr>
-                        <tr t-if="o.user_id">
-                            <td>Purchase Representative:</td>
-                            <td><t t-out="o.user_id.name"/></td>
-                        </tr>
-                        <tr t-if="o.partner_ref">
-                            <td>Order Reference:</td>
-                            <td><t t-out="o.partner_ref"/></td>
-                        </tr>
-                        <tr t-if="o.date_approve">
-                            <td>Order Date:</td>
-                            <td><t t-out="o.date_approve" t-options="{'widget': 'date'}"/></td>
-                        </tr>
-                        <tr t-if="o.date_order">
-                            <td>Order Deadline:</td>
-                            <td><t t-out="o.date_order" t-options="{'widget': 'date'}"/></td>
-                        </tr>
-                        <tr t-if="o.incoterm_id">
-                            <td>Incoterm:</td>
-                            <td><t t-out="o.incoterm_id"/></td>
-                        </tr>
-                    </table>
-                </div>
-            </t>
-
-            <t t-set="din5008_address_block">
-                <tr t-if="o and o._name=='purchase.order'">
-                    <td class="shipping_address" t-if="o.dest_address_id">
-                        <span class="fw-bold">Shipping Address:</span>
-                        <address t-esc="o.dest_address_id" t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True}'/>
-                    </td>
-                    <td class="shipping_address" t-elif="'picking_type_id' in o._fields and o.picking_type_id.warehouse_id">
-                        <span class="fw-bold">Shipping Address:</span>
-                        <address t-esc="o.picking_type_id.warehouse_id.partner_id" t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True}'/>
-                    </td>
-                </tr>
-            </t>
-
-            <t t-set="din5008_document_title">
-                <span t-if="o and o._name == 'purchase.order'">
-                    <t t-if="o.state in {'draft', 'sent', 'to approve'}">Request for Quotation</t>
-                    <t t-elif="o.state in {'purchase', 'done'}">Purchase Order</t>
-                    <t t-elif="o.state == 'cancel'">Cancelled Purchase Order</t>
-                </span>
-            </t>
+            <t t-call="l10n_din5008_purchase.report_common_purchase_din5008_template"/>
+        </xpath>
+    </template>
+    <template id="report_purchasequotation_document" inherit_id="purchase.report_purchasequotation_document">
+        <xpath expr="//t[@t-set='address']" position="after">
+            <t t-call="l10n_din5008_purchase.report_common_purchase_din5008_template"/>
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
Commit ab5b806ced3a72f04af9b92f1ec8c32e9a03f4d7 introduced a regression by moving the computation logic for the DIN 5008 layout from Python into the XML template report_purchaseorder_document. However, the same logic was not applied to report_purchasequotation_document, which is used for RFQs, causing discrepancies in the RFQ layout.

task-4089521