### PR TITLE
[FIX] product: remove jQuery selector from pricelist report

### DIFF
--- a/addons/product/static/src/js/pricelist_report/product_pricelist_report.js
+++ b/addons/product/static/src/js/pricelist_report/product_pricelist_report.js
@@ -153,8 +153,8 @@ export class ProductPricelistReport extends Component {
             return;
         }
 
-        const qty = parseInt($("input.add-quantity-input")[0].value);
-        if (qty && qty > 0) {
+        const qty = parseInt(ev.target.previousSibling.value);
+        if (qty > 0) {
             // Check qty already exist.
             if (this.quantities.indexOf(qty) === -1) {
                 this.quantities.push(qty);


### PR DESCRIPTION
Versions
--------
- 18.0
- master

Steps
-----
1. Go to product view;
2. using the actions button, go to Pricelist Report;
3. click on the "+" button of the Quantities selector.

Issue
-----
ReferenceError: Can't find variable: $

Cause
-----
jQuery's `$` selector has been disabled there at some point between 17.4 & 18.0.

This wasn't caught by the pricelist report's unit tests, as jQuery is made available in that context.

Solution
--------
Replace the jQuery selector with `ev.target.previousSibling`, which points to the same `input` element.

opw-4230836