### PR TITLE
17.0 stock backport replenish perf avd

### DIFF
--- a/addons/mrp/models/stock_orderpoint.py
+++ b/addons/mrp/models/stock_orderpoint.py
@@ -64,7 +64,12 @@ class StockWarehouseOrderpoint(models.Model):
 
     def _compute_days_to_order(self):
         res = super()._compute_days_to_order()
-        for orderpoint in self:
+        # Avoid computing rule_ids in case no manufacture rules.
+        if not self.env['stock.rule'].search([('action', '=', 'manufacture')]):
+            return res
+        # Compute rule_ids only for orderpoint with boms
+        orderpoints_with_bom = self.filtered(lambda orderpoint: orderpoint.product_id.variant_bom_ids or orderpoint.product_id.bom_ids)
+        for orderpoint in orderpoints_with_bom:
             if 'manufacture' in orderpoint.rule_ids.mapped('action'):
                 boms = (orderpoint.product_id.variant_bom_ids or orderpoint.product_id.bom_ids)
                 orderpoint.days_to_order = boms and boms[0].days_to_prepare_mo or 0

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -126,7 +126,12 @@ class Orderpoint(models.Model):
 
     def _compute_days_to_order(self):
         res = super()._compute_days_to_order()
-        for orderpoint in self:
+        # Avoid computing rule_ids if no stock.rules with the buy action
+        if not self.env['stock.rule'].search([('action', '=', 'buy')]):
+            return res
+        # Compute rule_ids only for orderpoint whose compnay_id.days_to_purchase != orderpoint.days_to_order
+        orderpoints_to_compute = self.filtered(lambda orderpoint: orderpoint.days_to_order != orderpoint.company_id.days_to_purchase)
+        for orderpoint in orderpoints_to_compute:
             if 'buy' in orderpoint.rule_ids.mapped('action'):
                 orderpoint.days_to_order = orderpoint.company_id.days_to_purchase
         return res

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -636,6 +636,17 @@ class Product(models.Model):
     def _count_returned_sn_products(self, sn_lot):
         return 0
 
+    def filter_has_routes(self):
+        """ Return products with route_ids
+            or whose categ_id has total_route_ids.
+        """
+        products_with_routes = self.env['product.product']
+        # retrieve products with route_ids
+        products_with_routes += self.search([('id', 'in', self.ids), ('route_ids', '!=', False)])
+        # retrive products with categ_ids having routes
+        products_with_routes += self.search([('id', 'in', (self - products_with_routes).ids), ('categ_id.total_route_ids', '!=', False)])
+        return products_with_routes
+
 
 class ProductTemplate(models.Model):
     _inherit = 'product.template'
@@ -1026,7 +1037,7 @@ class ProductCategory(models.Model):
              "(the availability of this method depends on the \"Expiration Dates\" setting)."
     )
     total_route_ids = fields.Many2many(
-        'stock.route', string='Total routes', compute='_compute_total_route_ids',
+        'stock.route', string='Total routes', compute='_compute_total_route_ids', search='_search_total_route_ids',
         readonly=True)
     putaway_rule_ids = fields.One2many('stock.putaway.rule', 'category_id', 'Putaway Rules')
     packaging_reserve_method = fields.Selection([
@@ -1035,6 +1046,10 @@ class ProductCategory(models.Model):
         help="Reserve Only Full Packagings: will not reserve partial packagings. If customer orders 2 pallets of 1000 units each and you only have 1600 in stock, then only 1000 will be reserved\n"
              "Reserve Partial Packagings: allow reserving partial packagings. If customer orders 2 pallets of 1000 units each and you only have 1600 in stock, then 1600 will be reserved")
     filter_for_stock_putaway_rule = fields.Boolean('stock.putaway.rule', store=False, search='_search_filter_for_stock_putaway_rule')
+
+    def _search_total_route_ids(self, operator, value):
+        categ_ids = self.filtered_domain([('total_route_ids', operator, value)]).ids
+        return [('id', 'in', categ_ids)]
 
     def _compute_total_route_ids(self):
         for category in self:

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -2,8 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
-from collections import defaultdict, namedtuple
-
+from collections import defaultdict, namedtuple, OrderedDict
 from dateutil.relativedelta import relativedelta
 
 from odoo import SUPERUSER_ID, _, api, fields, models, registry
@@ -498,6 +497,31 @@ class ProcurementGroup(models.Model):
         return True
 
     @api.model
+    def _search_rule_for_warehouses(self, route_ids, packaging_id, product_id, warehouse_ids, domain):
+        if warehouse_ids:
+            domain = expression.AND([['|', ('warehouse_id', 'in', warehouse_ids.ids), ('warehouse_id', '=', False)], domain])
+        valid_route_ids = set()
+        if route_ids:
+            valid_route_ids |= set(route_ids.ids)
+        if packaging_id:
+            packaging_routes = packaging_id.route_ids
+            valid_route_ids |= set(packaging_routes.ids)
+        valid_route_ids |= set((product_id.route_ids | product_id.categ_id.total_route_ids).ids)
+        if warehouse_ids:
+            valid_route_ids |= set(warehouse_ids.route_ids.ids)
+        if valid_route_ids:
+            domain = expression.AND([[('route_id', 'in', list(valid_route_ids))], domain])
+        res = self.env["stock.rule"]._read_group(
+            domain,
+            groupby=["location_dest_id", "warehouse_id", "route_id"],
+            aggregates=["id:recordset"],
+            order="route_sequence:min, sequence:min",
+        )
+        rule_dict = defaultdict(OrderedDict)
+        for group in res:
+            rule_dict[group[0].id, group[2].id][group[1].id] = group[3].sorted(lambda rule: (rule.route_sequence, rule.sequence))[0]
+        return rule_dict
+
     def _search_rule(self, route_ids, packaging_id, product_id, warehouse_id, domain):
         """ First find a rule among the ones defined on the procurement
         group, then try on the routes defined for the product, finally fallback
@@ -529,16 +553,66 @@ class ProcurementGroup(models.Model):
         locations if it could not be found.
         """
         result = self.env['stock.rule']
+        locations = location_id
+        # Get the location hierarchy, starting from location_id up to its root location.
+        while locations[-1].location_id:
+            locations |= locations[-1].location_id
+        domain = self._get_rule_domain(locations, values)
+        # Get a mapping (location_id, route_id) -> warehouse_id -> rule_id
+        rule_dict = self._search_rule_for_warehouses(
+            values.get("route_ids", False),
+            values.get("product_packaging_id", False),
+            product_id,
+            values.get("warehouse_id", locations.warehouse_id),
+            domain,
+        )
+
+        def extract_rule(rule_dict, route_ids, warehouse_id, location_dest_id):
+            rule = self.env['stock.rule']
+            for route_id in route_ids:
+                sub_dict = rule_dict.get((location_dest_id.id, route_id.id))
+                if not sub_dict:
+                    continue
+                if not warehouse_id:
+                    rule = sub_dict[next(iter(sub_dict))]
+                else:
+                    rule = sub_dict.get(warehouse_id.id)
+                    rule = rule or sub_dict[False]
+                if rule:
+                    break
+            return rule
+
+        def get_rule_for_routes(rule_dict, route_ids, packaging_id, product_id, warehouse_id, location_dest_id):
+            res = self.env['stock.rule']
+            if route_ids:
+                res = extract_rule(rule_dict, route_ids, warehouse_id, location_dest_id)
+            if not res and packaging_id:
+                res = extract_rule(rule_dict, packaging_id.route_ids, warehouse_id, location_dest_id)
+            if not res:
+                res = extract_rule(rule_dict, product_id.route_ids | product_id.categ_id.total_route_ids, warehouse_id, location_dest_id)
+            if not res and warehouse_id:
+                res = extract_rule(rule_dict, warehouse_id.route_ids, warehouse_id, location_dest_id)
+            return res
+
         location = location_id
+        # Go through the location hierarchy again, this time breaking at the first valid stock.rule found
+        # in rules_by_location.
         while (not result) and location:
-            domain = self._get_rule_domain(location, values)
-            result = self._search_rule(values.get('route_ids', False), values.get('product_packaging_id', False), product_id, values.get('warehouse_id', location.warehouse_id), domain)
+            result = get_rule_for_routes(
+                rule_dict,
+                values.get("route_ids", self.env['stock.route']),
+                values.get("product_packaging_id", self.env['product.packaging']),
+                product_id,
+                values.get("warehouse_id", location.warehouse_id),
+                location,
+            )
             location = location.location_id
         return result
 
     @api.model
-    def _get_rule_domain(self, location, values):
-        domain = ['&', ('location_dest_id', '=', location.id), ('action', '!=', 'push')]
+    def _get_rule_domain(self, locations, values):
+        location_ids = locations.ids
+        domain = ['&', ('location_dest_id', 'in', location_ids), ('action', '!=', 'push')]
         # In case the method is called by the superuser, we need to restrict the rules to the
         # ones of the company. This is not useful as a regular user since there is a record
         # rule to filter out the rules based on the company.

--- a/addons/stock_dropshipping/models/stock.py
+++ b/addons/stock_dropshipping/models/stock.py
@@ -26,11 +26,11 @@ class ProcurementGroup(models.Model):
     _inherit = "procurement.group"
 
     @api.model
-    def _get_rule_domain(self, location, values):
+    def _get_rule_domain(self, locations, values):
         if 'sale_line_id' in values and values.get('company_id'):
-            return [('location_dest_id', '=', location.id), ('action', '!=', 'push'), ('company_id', '=', values['company_id'].id)]
+            return [('location_dest_id', 'in', locations.ids), ('action', '!=', 'push'), ('company_id', '=', values['company_id'].id)]
         else:
-            return super(ProcurementGroup, self)._get_rule_domain(location, values)
+            return super()._get_rule_domain(locations, values)
 
 class StockPicking(models.Model):
     _inherit = 'stock.picking'


### PR DESCRIPTION
Backport of PR odoo/odoo#182407 for 17.0. The major difference is the removal of the batching of
`orderpoint._qty_in_progress` and the removal of the check on the inter-company location as this was
only introduced in 17.4.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
