### PR TITLE
[IMP] website: introduce `s_reviews_wall` snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -179,6 +179,7 @@
         'views/snippets/s_cta_card.xml',
         'views/snippets/s_image_frame.xml',
         'views/snippets/s_cta_mobile.xml',
+        'views/snippets/s_reviews_wall.xml',
         'views/snippets/s_website_form_cover.xml',
         'views/snippets/s_form_aside.xml',
         'views/snippets/s_banner_connected.xml',

--- a/addons/website/views/snippets/s_blockquote.xml
+++ b/addons/website/views/snippets/s_blockquote.xml
@@ -20,56 +20,83 @@
     </blockquote>
 </template>
 
-<template id="s_blockquote_options" inherit_id="website.snippet_options">
+<template id="s_blockquote_options">
+    <div t-if="not disable_blockquote_width" t-att-data-selector="selector" t-att-data-target="target" t-att-data-exclude="exclude">
+        <we-select string="Width">
+            <we-button data-select-class="w-25">25%</we-button>
+            <we-button data-select-class="w-50">50%</we-button>
+            <we-button data-select-class="w-75">75%</we-button>
+            <we-button data-select-class="w-100" data-name="so_width_100">100%</we-button>
+        </we-select>
+        <we-button-group string="Alignment" class="o_we_sublevel_1" data-dependencies="!so_width_100">
+            <we-button class="fa fa-fw fa-align-left" title="Left" data-select-class="me-auto"/>
+            <we-button class="fa fa-fw fa-align-center" title="Center" data-select-class="mx-auto"/>
+            <we-button class="fa fa-fw fa-align-right" title="Right" data-select-class="ms-auto"/>
+        </we-button-group>
+    </div>
+
+    <!-- Color and images -->
+    <t t-call="website.snippet_options_background_options">
+        <t t-set="selector" t-value="selector"/>
+        <t t-set="exclude" t-value="exclude"/>
+        <t t-set="target" t-value="target"/>
+        <t t-set="with_colors" t-value="True"/>
+        <t t-set="with_images" t-value="True"/>
+        <t t-set="with_shapes" t-value="True"/>
+        <t t-set="with_gradients" t-value="True"/>
+        <t t-set="with_color_combinations" t-value="True"/>
+    </t>
+
+    <!-- Layout -->
+    <div t-att-data-selector="selector" t-att-data-target="target" t-att-data-exclude="exclude">
+        <we-range string="Edge Spacing" data-select-class="p-1|p-2|p-3|p-4|p-5"/>
+        <we-select string="Decoration">
+            <we-button data-select-class="s_blockquote_default">None</we-button>
+            <we-button data-select-class="s_blockquote_with_line" data-name="blockquote_with_line_opt">Left line</we-button>
+            <we-button data-select-class="s_blockquote_with_icon">Icon</we-button>
+        </we-select>
+        <we-row string="Style" class="o_we_sublevel_1">
+            <we-input data-apply-to=".s_blockquote_line_elt" data-css-property="width" data-select-style="" data-unit="px" data-dependencies="blockquote_with_line_opt"/>
+            <we-colorpicker title="Color"
+            data-apply-to=".s_blockquote_line_elt"
+                data-name="bg_color_opt"
+                data-select-style=""
+                data-css-property="background-color"
+                data-color-prefix="bg-"
+                t-att-data-with-gradients="True"
+                data-dependencies="blockquote_with_line_opt"
+            />
+        </we-row>
+        <we-checkbox string="Author" data-name="toggle_blockquote_author_opt" data-select-class="d-flex" data-apply-to=".s_blockquote_infos"/>
+        <we-select string="Alignment" class="o_we_sublevel_1" data-dependencies="toggle_blockquote_author_opt" data-apply-to=".s_blockquote_infos">
+            <we-button data-select-class="flex-row align-items-start justify-content-start text-start">Left</we-button>
+            <we-button data-select-class="flex-column align-items-center text-center">Center</we-button>
+            <we-button data-select-class="flex-row-reverse align-items-start justify-content-start text-end">Right</we-button>
+        </we-select>
+        <we-range string="Content spacing" data-select-class="gap-1|gap-2|gap-3|gap-4|gap-5"/>
+    </div>
+
+    <!-- Border and Shadow -->
+    <div data-js="Box" t-att-data-selector="selector" t-att-data-target="target" t-att-data-exclude="exclude">
+        <t t-call="website.snippet_options_border_widgets"/>
+        <t t-call="website.snippet_options_shadow_widgets"/>
+    </div>
+</template>
+
+<template id="s_blockquote_options_apply" inherit_id="website.snippet_options">
     <xpath expr="." position="inside">
-        <!-- Color and images -->
-        <t t-call="website.snippet_options_background_options">
+        <!-- Binding the blockquote options on blockquotes without a handler parent -->
+        <t t-call="website.s_blockquote_options">
             <t t-set="selector" t-value="'.s_blockquote'"/>
-            <t t-set="with_colors" t-value="True"/>
-            <t t-set="with_images" t-value="True"/>
-            <t t-set="with_shapes" t-value="True"/>
-            <t t-set="with_gradients" t-value="True"/>
-            <t t-set="with_color_combinations" t-value="True"/>
+            <t t-set="exclude" t-valuef="div:is(#{blockquote_parent_handlers}) > .s_blockquote"/>
         </t>
 
-        <!-- Layout -->
-        <div data-selector=".s_blockquote">
-            <we-range string="Edge Spacing" data-select-class="p-1|p-2|p-3|p-4|p-5"/>
-            <we-select string="Decoration">
-                <we-button data-select-class="s_blockquote_default">None</we-button>
-                <we-button data-select-class="s_blockquote_with_line" data-name="blockquote_with_line_opt">Left line</we-button>
-                <we-button data-select-class="s_blockquote_with_icon">Icon</we-button>
-            </we-select>
-        </div>
-
-        <div data-selector=".s_blockquote" data-target=".s_blockquote_line_elt">
-            <we-row string="Style" class="o_we_sublevel_1">
-                <we-input data-css-property="width" data-select-style="" data-unit="px" data-dependencies="blockquote_with_line_opt"/>
-                <we-colorpicker title="Color"
-                    data-name="bg_color_opt"
-                    data-select-style=""
-                    data-css-property="background-color"
-                    data-color-prefix="bg-"
-                    t-att-data-with-gradients="True"
-                    data-dependencies="blockquote_with_line_opt"
-                />
-            </we-row>
-        </div>
-
-        <div data-selector=".s_blockquote" data-target=".s_blockquote_infos">
-            <we-checkbox string="Author" data-name="toggle_blockquote_author_opt" data-select-class="d-flex"/>
-            <we-select string="Alignment" class="o_we_sublevel_1" data-dependencies="toggle_blockquote_author_opt">
-                <we-button data-select-class="flex-row align-items-start justify-content-start text-start">Left</we-button>
-                <we-button data-select-class="flex-column align-items-center text-center">Center</we-button>
-                <we-button data-select-class="flex-row-reverse align-items-start justify-content-start text-end">Right</we-button>
-            </we-select>
-        </div>
-
-        <!-- Border and Shadow -->
-        <div data-js="Box" data-selector=".s_blockquote">
-            <t t-call="website.snippet_options_border_widgets"/>
-            <t t-call="website.snippet_options_shadow_widgets"/>
-        </div>
+        <!-- Binding the blockquote options on the blockquote handler parents -->
+        <t t-call="website.s_blockquote_options">
+            <t t-set="selector" t-valuef="#{blockquote_parent_handlers}"/>
+            <t t-set="target" t-value="'> .s_blockquote'"/>
+            <t t-set="disable_blockquote_width" t-value="true"/>
+        </t>
     </xpath>
 </template>
 

--- a/addons/website/views/snippets/s_reviews_wall.xml
+++ b/addons/website/views/snippets/s_reviews_wall.xml
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_reviews_wall" name="Reviews Wall">
+    <section class="s_reviews_wall o_colored_level o_cc o_cc2 pt80 pb80">
+        <div class="container">
+            <h2>Customers testimonials</h2>
+            <p class="lead">What our customers are saying about us.</p>
+            <div class="row align-items-stretch">
+                <div class="col-12 col-lg-4 pt16 pb16" data-name="Review">
+                    <blockquote class="s_blockquote s_blockquote_default o_cc o_cc1 o_animable position-relative d-flex flex-column gap-4 w-100 h-100 mx-auto p-4 rounded fst-normal" data-vcss="001" data-snippet="s_blockquote" data-name="Review" style="border-radius: 6.4px !important;">
+                        <div class="s_blockquote_line_elt position-absolute top-0 start-0 bottom-0 bg-o-color-1"/>
+                        <div class="s_blockquote_wrap_icon position-absolute top-0 start-50 translate-middle w-100">
+                            <i class="s_blockquote_icon fa fa-quote-right d-block mx-auto rounded bg-o-color-1" role="img"/>
+                        </div>
+                        <div class="s_rating s_rating_no_title" data-snippet="s_rating" data-name="Rating" data-vcss="001" data-icon="fa-star" aria-label="4 out of 5 stars">
+                            <h4 class="s_rating_title">Rating</h4>
+                            <div class="s_rating_icons o_not_editable">
+                                <span class="s_rating_active_icons" style="color: #f3cc00;">
+                                    <i class="fa fa-star" role="presentation"/>
+                                    <i class="fa fa-star" role="presentation"/>
+                                    <i class="fa fa-star" role="presentation"/>
+                                    <i class="fa fa-star" role="presentation"/>
+                                </span>
+                                <span class="s_rating_inactive_icons" style="color: var(--border-color);">
+                                    <i class="fa fa-star" role="presentation"/>
+                                </span>
+                            </div>
+                        </div>
+                        <p class="s_blockquote_quote mb-auto">"Engaging with this team was effortless from start to end. Their proficiency and meticulous approach greatly enhanced our project. I couldn’t be happier with the final product!"</p>
+                        <div class="s_blockquote_infos d-flex gap-2 flex-row align-items-start justify-content-start w-100 text-start">
+                            <img src="/web/image/website.s_company_team_image_1" class="s_blockquote_avatar img rounded-circle" alt=""/>
+                            <div class="s_blockquote_author">
+                                <strong>Sullivan Mitchell</strong><br/>
+                                <span class="text-muted">Marketing Director</span>
+                            </div>
+                        </div>
+                    </blockquote>
+                </div>
+                <div class="col-12 col-lg-4 pt16 pb16" data-name="Review">
+                    <blockquote class="s_blockquote s_blockquote_default o_cc o_cc1 o_animable position-relative d-flex flex-column gap-4 w-100 h-100 mx-auto p-4 rounded fst-normal" data-vcss="001" data-snippet="s_blockquote" data-name="Review" style="border-radius: 6.4px !important;">
+                        <div class="s_blockquote_line_elt position-absolute top-0 start-0 bottom-0 bg-o-color-1"/>
+                        <div class="s_blockquote_wrap_icon position-absolute top-0 start-50 translate-middle w-100">
+                            <i class="s_blockquote_icon fa fa-quote-right d-block mx-auto rounded bg-o-color-1" role="img"/>
+                        </div>
+                        <div class="s_rating s_rating_no_title" data-snippet="s_rating" data-name="Rating" data-vcss="001" data-icon="fa-star" aria-label="4 out of 5 stars">
+                            <h4 class="s_rating_title">Rating</h4>
+                            <div class="s_rating_icons o_not_editable">
+                                <span class="s_rating_active_icons" style="color: #f3cc00;">
+                                    <i class="fa fa-star" role="presentation"/>
+                                    <i class="fa fa-star" role="presentation"/>
+                                    <i class="fa fa-star" role="presentation"/>
+                                    <i class="fa fa-star" role="presentation"/>
+                                </span>
+                                <span class="s_rating_inactive_icons" style="color: var(--border-color);">
+                                    <i class="fa fa-star" role="presentation"/>
+                                </span>
+                            </div>
+                        </div>
+                        <p class="s_blockquote_quote mb-auto">"Working with this team was smooth and efficient at every stage. Their skills and commitment to quality had a major impact on our project. I am thrilled with the final results!"</p>
+                        <div class="s_blockquote_infos d-flex gap-2 flex-row align-items-start justify-content-start w-100 text-start">
+                            <img src="/web/image/website.s_company_team_image_2" class="s_blockquote_avatar img rounded-circle" alt=""/>
+                            <div class="s_blockquote_author">
+                                <strong>James Carter</strong><br/>
+                                <span class="text-muted">Chief Technical Officer</span>
+                            </div>
+                        </div>
+                    </blockquote>
+                </div>
+                <div class="col-12 col-lg-4 pt16 pb16" data-name="Review">
+                    <blockquote class="s_blockquote s_blockquote_default o_cc o_cc1 o_animable position-relative d-flex flex-column gap-4 w-100 h-100 mx-auto p-4 rounded fst-normal" data-vcss="001" data-snippet="s_blockquote" data-name="Review" style="border-radius: 6.4px !important;">
+                        <div class="s_blockquote_line_elt position-absolute top-0 start-0 bottom-0 bg-o-color-1"/>
+                        <div class="s_blockquote_wrap_icon position-absolute top-0 start-50 translate-middle w-100">
+                            <i class="s_blockquote_icon fa fa-quote-right d-block mx-auto rounded bg-o-color-1" role="img"/>
+                        </div>
+                        <div class="s_rating s_rating_no_title" data-snippet="s_rating" data-name="Rating" data-vcss="001" data-icon="fa-star" aria-label="4 out of 5 stars">
+                            <h4 class="s_rating_title">Rating</h4>
+                            <div class="s_rating_icons o_not_editable">
+                                <span class="s_rating_active_icons" style="color: #f3cc00;">
+                                    <i class="fa fa-star" role="presentation"/>
+                                    <i class="fa fa-star" role="presentation"/>
+                                    <i class="fa fa-star" role="presentation"/>
+                                    <i class="fa fa-star" role="presentation"/>
+                                </span>
+                                <span class="s_rating_inactive_icons" style="color: var(--border-color);">
+                                    <i class="fa fa-star" role="presentation"/>
+                                </span>
+                            </div>
+                        </div>
+                        <p class="s_blockquote_quote mb-auto">"Partnering with this team was a breeze from beginning to end. Their knowledge and focus on detail significantly benefited our project. I am extremely happy with the outcome!"</p>
+                        <div class="s_blockquote_infos d-flex gap-2 flex-row align-items-start justify-content-start w-100 text-start">
+                            <img src="/web/image/website.s_company_team_image_3" class="s_blockquote_avatar img rounded-circle" alt=""/>
+                            <div class="s_blockquote_author">
+                                <strong>Laura Evans</strong><br/>
+                                <span class="text-muted">Head of Operations</span>
+                            </div>
+                        </div>
+                    </blockquote>
+                </div>
+                <div class="col-12 col-lg-4 pt16 pb16" data-name="Review">
+                    <blockquote class="s_blockquote s_blockquote_default o_cc o_cc1 o_animable position-relative d-flex flex-column gap-4 w-100 h-100 mx-auto p-4 rounded fst-normal" data-vcss="001" data-snippet="s_blockquote" data-name="Review" style="border-radius: 6.4px !important;">
+                        <div class="s_blockquote_line_elt position-absolute top-0 start-0 bottom-0 bg-o-color-1"/>
+                        <div class="s_blockquote_wrap_icon position-absolute top-0 start-50 translate-middle w-100">
+                            <i class="s_blockquote_icon fa fa-quote-right d-block mx-auto rounded bg-o-color-1" role="img"/>
+                        </div>
+                        <div class="s_rating s_rating_no_title" data-snippet="s_rating" data-name="Rating" data-vcss="001" data-icon="fa-star" aria-label="4 out of 5 stars">
+                            <h4 class="s_rating_title">Rating</h4>
+                            <div class="s_rating_icons o_not_editable">
+                                <span class="s_rating_active_icons" style="color: #f3cc00;">
+                                    <i class="fa fa-star" role="presentation"/>
+                                    <i class="fa fa-star" role="presentation"/>
+                                    <i class="fa fa-star" role="presentation"/>
+                                    <i class="fa fa-star" role="presentation"/>
+                                </span>
+                                <span class="s_rating_inactive_icons" style="color: var(--border-color);">
+                                    <i class="fa fa-star" role="presentation"/>
+                                </span>
+                            </div>
+                        </div>
+                        <p class="s_blockquote_quote mb-auto">"From the first meeting, it was clear we were in good hands. They took our vision and turned it into something even better than we had imagined. Highly recommend!"</p>
+                        <div class="s_blockquote_infos d-flex gap-2 flex-row align-items-start justify-content-start w-100 text-start">
+                            <img src="/web/image/website.s_company_team_image_4" class="s_blockquote_avatar img rounded-circle" alt=""/>
+                            <div class="s_blockquote_author">
+                                <strong>Jody Roberts</strong><br/>
+                                <span class="text-muted">Chief Financial Officer</span>
+                            </div>
+                        </div>
+                    </blockquote>
+                </div>
+                <div class="col-12 col-lg-4 pt16 pb16" data-name="Review">
+                    <blockquote class="s_blockquote s_blockquote_default o_cc o_cc1 o_animable position-relative d-flex flex-column gap-4 w-100 h-100 mx-auto p-4 rounded fst-normal" data-vcss="001" data-snippet="s_blockquote" data-name="Review" style="border-radius: 6.4px !important;">
+                        <div class="s_blockquote_line_elt position-absolute top-0 start-0 bottom-0 bg-o-color-1"/>
+                        <div class="s_blockquote_wrap_icon position-absolute top-0 start-50 translate-middle w-100">
+                            <i class="s_blockquote_icon fa fa-quote-right d-block mx-auto rounded bg-o-color-1" role="img"/>
+                        </div>
+                        <div class="s_rating s_rating_no_title" data-snippet="s_rating" data-name="Rating" data-vcss="001" data-icon="fa-star" aria-label="4 out of 5 stars">
+                            <h4 class="s_rating_title">Rating</h4>
+                            <div class="s_rating_icons o_not_editable">
+                                <span class="s_rating_active_icons" style="color: #f3cc00;">
+                                    <i class="fa fa-star" role="presentation"/>
+                                    <i class="fa fa-star" role="presentation"/>
+                                    <i class="fa fa-star" role="presentation"/>
+                                    <i class="fa fa-star" role="presentation"/>
+                                </span>
+                                <span class="s_rating_inactive_icons" style="color: var(--border-color);">
+                                    <i class="fa fa-star" role="presentation"/>
+                                </span>
+                            </div>
+                        </div>
+                        <p class="s_blockquote_quote mb-auto">"Exceptional service and great communication throughout the entire process. They went above and beyond to ensure our project was a complete success."</p>
+                        <div class="s_blockquote_infos d-flex gap-2 flex-row align-items-start justify-content-start w-100 text-start">
+                            <img src="/web/image/website.s_company_team_image_5" class="s_blockquote_avatar img rounded-circle" alt=""/>
+                            <div class="s_blockquote_author">
+                                <strong>Emil Foster</strong><br/>
+                                <span class="text-muted">Creative Director</span>
+                            </div>
+                        </div>
+                    </blockquote>
+                </div>
+                <div class="col-12 col-lg-4 pt16 pb16" data-name="Review">
+                    <blockquote class="s_blockquote s_blockquote_default o_cc o_cc1 o_animable position-relative d-flex flex-column gap-4 w-100 h-100 mx-auto p-4 rounded fst-normal" data-vcss="001" data-snippet="s_blockquote" data-name="Review" style="border-radius: 6.4px !important;">
+                        <div class="s_blockquote_line_elt position-absolute top-0 start-0 bottom-0 bg-o-color-1"/>
+                        <div class="s_blockquote_wrap_icon position-absolute top-0 start-50 translate-middle w-100">
+                            <i class="s_blockquote_icon fa fa-quote-right d-block mx-auto rounded bg-o-color-1" role="img"/>
+                        </div>
+                        <div class="s_rating s_rating_no_title" data-snippet="s_rating" data-name="Rating" data-vcss="001" data-icon="fa-star" aria-label="4 out of 5 stars">
+                            <h4 class="s_rating_title">Rating</h4>
+                            <div class="s_rating_icons o_not_editable">
+                                <span class="s_rating_active_icons" style="color: #f3cc00;">
+                                    <i class="fa fa-star" role="presentation"/>
+                                    <i class="fa fa-star" role="presentation"/>
+                                    <i class="fa fa-star" role="presentation"/>
+                                    <i class="fa fa-star" role="presentation"/>
+                                </span>
+                                <span class="s_rating_inactive_icons" style="color: var(--border-color);">
+                                    <i class="fa fa-star" role="presentation"/>
+                                </span>
+                            </div>
+                        </div>
+                        <p class="s_blockquote_quote mb-auto">"This team truly understands the meaning of partnership. They brought fresh ideas to the table and delivered a final product that exceeded expectations."</p>
+                        <div class="s_blockquote_infos d-flex gap-2 flex-row align-items-start justify-content-start w-100 text-start">
+                            <img src="/web/image/website.s_company_team_image_6" class="s_blockquote_avatar img rounded-circle" alt=""/>
+                            <div class="s_blockquote_author">
+                                <strong>Daniella Clarke</strong><br/>
+                                <span class="text-muted">Senior Manager</span>
+                            </div>
+                        </div>
+                    </blockquote>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -343,6 +343,9 @@
                 <t t-snippet="website.s_quotes_carousel_minimal" string="Quotes Minimal" group="people" label="Carousel">
                     <keywords>cite, testimonials, endorsements, reviews, feedback, statements, references, sayings, comments, appreciations, citations, carousel</keywords>
                 </t>
+                <t t-snippet="website.s_reviews_wall" string="Reviews Wall" group="people">
+                    <keywords>cite, testimonials, endorsements, reviews, feedback, statements, references, sayings, comments, appreciations, citations</keywords>
+                </t>
                 <t t-snippet="website.s_quotes_carousel_compact" string="Quotes Compact" group="people" label="Carousel">
                     <keywords>cite, testimonials, endorsements, reviews, feedback, statements, references, sayings, comments, appreciations, citations, carousel</keywords>
                 </t>
@@ -903,7 +906,7 @@
              Note: defined here to be set above all the other options that might
              need it. -->
         <t t-set="card_parent_handlers" t-value="'.s_three_columns .row > div, .s_comparisons .row > div, .s_cards_grid .row > div, .s_cards_soft .row > div, .s_product_list .row > div, .s_newsletter_centered .row > div, .s_company_team_spotlight .row > div, .s_comparisons_horizontal .row > div, .s_company_team_grid .row > div, .s_company_team_card .row > div, .s_carousel_cards_item'"/>
-        <t t-set="blockquote_parent_handlers" t-value=""/>
+        <t t-set="blockquote_parent_handlers" t-value="'.s_reviews_wall .row > div'"/>
 
         <!-- Binding the option on the snippet if it is not a s_card or a s_blockquote with a
              handler parent -->
@@ -1071,7 +1074,7 @@
 
     <!--  Vertical Alignment -->
     <div data-js="vAlignment" id="row_valign_snippet_option"
-         data-selector=".s_text_image, .s_image_text, .s_three_columns, .s_showcase, .s_numbers, .s_faq_collapse, .s_references, .s_accordion_image, .s_shape_image"
+         data-selector=".s_text_image, .s_image_text, .s_three_columns, .s_showcase, .s_numbers, .s_faq_collapse, .s_references, .s_accordion_image, .s_shape_image, .s_reviews_wall"
          data-target=".row">
         <t t-call="website.vertical_alignment_option">
             <t t-set="indent" t-value="True"/>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -898,23 +898,24 @@
 
      <!-- Version control -->
     <xpath expr="//t[@t-call='web_editor.snippet_options_version_control']" position="replace">
-        <!-- General selector defining the parent elements of s_card snippets on
-             which the s_card options should be bound (instead of the s_card).
+        <!-- General selector defining the parent elements of s_card and s_blockquote snippets on
+             which the card or blockquote options should be bound (instead of the snippet itself).
              Note: defined here to be set above all the other options that might
              need it. -->
         <t t-set="card_parent_handlers" t-value="'.s_three_columns .row > div, .s_comparisons .row > div, .s_cards_grid .row > div, .s_cards_soft .row > div, .s_product_list .row > div, .s_newsletter_centered .row > div, .s_company_team_spotlight .row > div, .s_comparisons_horizontal .row > div, .s_company_team_grid .row > div, .s_company_team_card .row > div, .s_carousel_cards_item'"/>
+        <t t-set="blockquote_parent_handlers" t-value=""/>
 
-        <!-- Binding the option on the snippet if it is not a s_card with a
+        <!-- Binding the option on the snippet if it is not a s_card or a s_blockquote with a
              handler parent -->
         <t t-call="web_editor.snippet_options_version_control">
             <t t-set="selector" t-value="'[data-snippet]'"/>
-            <t t-set="exclude" t-valuef="div:is(#{card_parent_handlers}) > .s_card"/>
+            <t t-set="exclude" t-valuef="div:is(#{card_parent_handlers}) > .s_card, div:is(#{blockquote_parent_handlers}) > .s_blockquote"/>
         </t>
 
-        <!-- Binding the option on the s_card handler parent -->
+        <!-- Binding the option on the s_card or s_blockquote handler parent -->
         <t t-call="web_editor.snippet_options_version_control">
-            <t t-set="selector" t-valuef="#{card_parent_handlers}"/>
-            <t t-set="target" t-value="'> .s_card'"/>
+            <t t-set="selector" t-valuef="#{card_parent_handlers}, #{blockquote_parent_handlers}"/>
+            <t t-set="target" t-value="'> .s_card, > .s_blockquote'"/>
         </t>
     </xpath>
 
@@ -962,7 +963,7 @@
         <we-checkbox string="Color" data-select-class="no_icon_color|"/>
     </div>
 
-    <div id="so_width" data-selector=".s_alert, .s_blockquote, .s_text_highlight">
+    <div id="so_width" data-selector=".s_alert, .s_text_highlight">
         <we-select string="Width">
             <we-button data-select-class="w-25">25%</we-button>
             <we-button data-select-class="w-50">50%</we-button>
@@ -971,7 +972,7 @@
         </we-select>
     </div>
 
-    <div id="so_block_align" data-selector=".s_alert, .s_blockquote, .s_text_highlight">
+    <div id="so_block_align" data-selector=".s_alert, .s_text_highlight">
         <we-button-group string="Alignment" data-dependencies="!so_width_100">
             <we-button class="fa fa-fw fa-align-left" title="Left" data-select-class="me-auto"/>
             <we-button class="fa fa-fw fa-align-center" title="Center" data-select-class="mx-auto"/>
@@ -1092,7 +1093,7 @@
 
     <!-- Background -->
     <t t-set="only_bg_color_selector" t-value="'section .row > div, .s_text_highlight, .s_mega_menu_thumbnails_footer, .s_hr, .s_cta_badge'"/>
-    <t t-set="only_bg_color_exclude" t-valuef=".s_col_no_bgcolor, .s_col_no_bgcolor.row > div, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .s_image_gallery .row > div, .s_text_cover .row > .o_not_editable, [data-snippet] :not(.oe_structure) > .s_hr, #{card_parent_handlers}, .s_website_form_cover .row > .o_not_editable"/>
+    <t t-set="only_bg_color_exclude" t-valuef=".s_col_no_bgcolor, .s_col_no_bgcolor.row > div, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .s_image_gallery .row > div, .s_text_cover .row > .o_not_editable, [data-snippet] :not(.oe_structure) > .s_hr, #{card_parent_handlers}, .s_website_form_cover .row > .o_not_editable, #{blockquote_parent_handlers}"/>
 
     <t t-set="base_only_bg_image_selector" t-value="'.s_tabs_common .oe_structure > *, footer .oe_structure > *'"/>
     <t t-set="only_bg_image_selector" t-value="base_only_bg_image_selector"/>
@@ -1142,7 +1143,7 @@
     <!-- Border | Columns -->
     <div data-js="Box"
          data-selector="section .row > div"
-         t-attf-data-exclude=".s_col_no_bgcolor, .s_col_no_bgcolor.row > div, .s_image_gallery .row > div, .s_masonry_block .s_col_no_resize, .s_text_cover .row > .o_not_editable, #{card_parent_handlers}">
+         t-attf-data-exclude=".s_col_no_bgcolor, .s_col_no_bgcolor.row > div, .s_image_gallery .row > div, .s_masonry_block .s_col_no_resize, .s_text_cover .row > .o_not_editable, #{card_parent_handlers}, #{blockquote_parent_handlers}">
         <t t-call="website.snippet_options_border_widgets"/>
         <t t-call="website.snippet_options_shadow_widgets"/>
     </div>
@@ -1169,17 +1170,18 @@
         <!-- TODO should be improved -->
 
     <t t-set="so_content_addition_selector" t-translation="off">
-        blockquote, .s_alert, .o_facebook_page, .s_share, .s_social_media, .s_rating,
+        .s_alert, .o_facebook_page, .s_share, .s_social_media, .s_rating,
         .s_hr, .s_google_map, .s_map, .s_countdown, .s_chart, .s_text_highlight, .s_progress_bar, .s_badge,
         .s_embed_code, .s_donation, .s_add_to_cart, .s_online_appointment, .o_snippet_drop_in_only, .s_image, .s_cta_badge, .s_accordion
     </t>
 
     <t t-set="special_cards_selector" t-valuef=".s_card.s_timeline_card, div:is(#{card_parent_handlers}) > .s_card"/>
+    <t t-set="special_blockquote_selector" t-valuef="div:is(#{blockquote_parent_handlers}) > .s_blockquote"/>
 
     <div id="so_content_addition"
-        t-attf-data-selector="#{so_content_addition_selector}, .s_card"
-        t-attf-data-drop-near="p, h1, h2, h3, ul, ol, div:not(.o_grid_item_image) > img, div:not(.o_grid_item_image) > a, .btn, #{so_content_addition_selector}, .s_card:not(#{special_cards_selector})"
-        t-attf-data-exclude="#{special_cards_selector}"
+        t-attf-data-selector="#{so_content_addition_selector}, .s_card, .s_blockquote"
+        t-attf-data-drop-near="p, h1, h2, h3, ul, ol, div:not(.o_grid_item_image) > img, div:not(.o_grid_item_image) > a, .btn, #{so_content_addition_selector}, .s_card:not(#{special_cards_selector}), .s_blockquote:not(#{special_blockquote_selector})"
+        t-attf-data-exclude="#{special_cards_selector}, #{special_blockquote_selector}"
         data-drop-in="nav"/>
 
     <div data-js="SnippetSave"
@@ -2041,7 +2043,7 @@
     <!-- Website Animate -->
     <div data-js="WebsiteAnimate"
          data-selector=".o_animable, section .row > div, img, .fa, .btn, .o_animated_text"
-         data-exclude="[data-oe-xpath], .o_not-animable, .s_col_no_resize.row > div, .s_col_no_resize"
+         t-attf-data-exclude="[data-oe-xpath], .o_not-animable, .s_col_no_resize.row > div, .s_col_no_resize, div:is(#{blockquote_parent_handlers}) > .s_blockquote"
          data-text-selector=".o_animated_text">
         <!-- Animation mode -->
         <we-row string="Animation">


### PR DESCRIPTION
This PR introduces the `s_reviews_wall` snippet and reviews the `s_blockquote` options management to achieve something similar to `s_card` allowing to bind options on the parent container rather than the snippet itself

| Snippet in use |
|--------|
| <img width="1712" alt="image" src="https://github.com/user-attachments/assets/d7a56d79-e72d-415a-aae4-733f6fe511a1"> | 

task-4264114
part of task-4077427

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
