### PR TITLE
[IMP] discuss: show a volume preview when testing the microphone

### DIFF
--- a/addons/mail/controllers/discuss/rtc.py
+++ b/addons/mail/controllers/discuss/rtc.py
@@ -101,7 +101,7 @@ class RtcController(http.Controller):
         # sudo: discuss.channel.rtc.session - can cancel invitations in accessible channel
         channel.sudo()._rtc_cancel_invitations(member_ids=member_ids)
 
-    @http.route("/mail/rtc/audio_worklet_processor", methods=["GET"], type="http", auth="public", readonly=True)
+    @http.route("/mail/rtc/audio_worklet_processor_v2", methods=["GET"], type="http", auth="public", readonly=True)
     def audio_worklet_processor(self):
         """Returns a JS file that declares a WorkletProcessor class in
         a WorkletGlobalScope, which means that it cannot be added to the

--- a/addons/mail/static/src/discuss/call/common/call_settings.js
+++ b/addons/mail/static/src/discuss/call/common/call_settings.js
@@ -5,6 +5,7 @@ import { browser } from "@web/core/browser/browser";
 import { debounce } from "@web/core/utils/timing";
 import { isMobileOS } from "@web/core/browser/feature_detection";
 import { useService } from "@web/core/utils/hooks";
+import { useMicrophoneVolume } from "@mail/utils/common/hooks";
 import { ActionPanel } from "@mail/discuss/core/common/action_panel";
 
 export class CallSettings extends Component {
@@ -20,6 +21,7 @@ export class CallSettings extends Component {
         this.notification = useService("notification");
         this.store = useState(useService("mail.store"));
         this.rtc = useState(useService("discuss.rtc"));
+        this.microphoneVolume = useMicrophoneVolume();
         this.state = useState({
             userDevices: [],
         });
@@ -50,6 +52,14 @@ export class CallSettings extends Component {
             }
             this.state.userDevices = await browser.navigator.mediaDevices.enumerateDevices();
         });
+    }
+
+    get stopText() {
+        return _t("Stop");
+    }
+
+    get testText() {
+        return _t("Test");
     }
 
     get pushToTalkKeyText() {
@@ -111,10 +121,6 @@ export class CallSettings extends Component {
 
     onChangeDelay(ev) {
         this.store.settings.setDelayValue(ev.target.value);
-    }
-
-    onChangeThreshold(ev) {
-        this.store.settings.setThresholdValue(parseFloat(ev.target.value));
     }
 
     onChangeBlur(ev) {

--- a/addons/mail/static/src/discuss/call/common/call_settings.scss
+++ b/addons/mail/static/src/discuss/call/common/call_settings.scss
@@ -1,0 +1,20 @@
+.o-Discuss-CallSettings-thresholdInput {
+    &::-moz-range-track {
+        background: linear-gradient(
+            to right,
+            $o-success 0%,
+            $o-success var(--volume),
+            $form-range-track-bg var(--volume),
+            $form-range-track-bg 100%
+        );
+    }
+    &::-webkit-slider-runnable-track {
+        background: linear-gradient(
+            to right,
+            $o-success 0%,
+            $o-success var(--volume),
+            $form-range-track-bg var(--volume),
+            $form-range-track-bg 100%
+        );
+    }
+}

--- a/addons/mail/static/src/discuss/call/common/call_settings.xml
+++ b/addons/mail/static/src/discuss/call/common/call_settings.xml
@@ -36,13 +36,25 @@
                 <span t-if="store.settings.use_push_to_talk and !isMobileOS and !pttExtService.isEnabled" class="small text-muted fst-italic mb-3" t-out="pttExtService.downloadText"/>
             </div>
             <div class="d-flex flex-column">
-                <label t-if="!store.settings.use_push_to_talk" class="d-flex flex-column flex-wrap flex-grow-1 align-items-start" title="Voice detection threshold" aria-label="Voice detection threshold">
-                    <span class="me-2 my-1 text-truncate text-wrap">Voice detection threshold</span>
-                    <div class="d-flex w-100 align-items-center">
-                        <input class="flex-grow-1 form-range" type="range" min="0.001" max="1" step="0.001" t-att-value="store.settings.voiceActivationThreshold" t-on-change="onChangeThreshold"/>
-                        <span class="p-1 text-end"><t t-out="Math.floor(store.settings.voiceActivationThreshold * 100)"/>%</span>
+                <t t-if="!store.settings.use_push_to_talk">
+                    <span class="me-2 my-1 text-truncate text-wrap">Voice detection sensitivity</span>
+                    <div class="d-flex align-items-center w-100 h-100">
+                        <button class="btn btn-primary" t-on-click="microphoneVolume.toggle" t-att-disabled="!microphoneVolume.isReady">
+                            <div class="position-relative">
+                                <span class="d-flex invisible text-nowrap">
+                                    <t t-out="testText.length > stopText.length ? testText : stopText"/>
+                                </span>
+                                <span class="position-absolute end-0 top-0">
+                                    <t t-if="microphoneVolume.isActive" t-out="stopText"/>
+                                    <t t-else="" t-out="testText"/>
+                                </span>
+                            </div>
+                        </button>
+                        <label class="w-100 d-flex ms-2" title="Voice detection sensitivity" aria-label="Voice detection sensitivity">
+                            <input class="o-Discuss-CallSettings-thresholdInput form-range rounded" t-attf-style="--volume: {{microphoneVolume.value * 100}}%;" type="range" min="0.001" max="1" step="0.001" t-model="store.settings.voiceActivationThreshold"/>
+                        </label>
                     </div>
-                </label>
+                </t>
                 <div t-if="store.settings.use_push_to_talk" class="d-flex" t-att-class="{'flex-column': props.isCompact}">
                     <div t-if="!isMobileOS" class="d-flex flex-column align-items-center" t-att-class="{'me-1 w-50': !props.isCompact}">
                         <label class="d-flex flex-column align-items-start flex-wrap w-100" title="Push-to-talk key" aria-label="Push-to-talk key">

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -1,6 +1,6 @@
 import { Record } from "@mail/core/common/record";
 import { BlurManager } from "@mail/discuss/call/common/blur_manager";
-import { monitorAudio } from "@mail/discuss/call/common/media_monitoring";
+import { monitorAudio } from "@mail/utils/common/media_monitoring";
 import { rpc } from "@web/core/network/rpc";
 import { closeStream, onChange } from "@mail/utils/common/misc";
 

--- a/addons/mail/static/src/utils/common/media_monitoring.js
+++ b/addons/mail/static/src/utils/common/media_monitoring.js
@@ -148,16 +148,18 @@ async function _loadAudioWorkletProcessor(
         onThreshold,
         onTic,
         volumeThreshold = 0.3,
+        normalizationParameters = { boost: 1, shift: 0.6 },
     } = {}
 ) {
     await audioContext.resume();
     // Safari does not support Worklet.addModule
-    await audioContext.audioWorklet.addModule("/mail/rtc/audio_worklet_processor");
+    await audioContext.audioWorklet.addModule("/mail/rtc/audio_worklet_processor_v2");
     const thresholdProcessor = new window.AudioWorkletNode(audioContext, "audio-processor", {
         processorOptions: {
             minimumActiveCycles,
             volumeThreshold,
             frequencyRange,
+            normalizationParameters,
             postAllTics: !!onTic,
         },
     });

--- a/addons/mail/static/src/worklets/audio_processor.js
+++ b/addons/mail/static/src/worklets/audio_processor.js
@@ -1,3 +1,40 @@
+class BiquadBandpassFilter {
+    constructor(sampleRate, frequency, Q) {
+        this.x1 = 0;
+        this.x2 = 0;
+        this.y1 = 0;
+        this.y2 = 0;
+
+        const w0 = 2 * Math.PI * (frequency / sampleRate);
+        const cosW0 = Math.cos(w0);
+        const sinW0 = Math.sin(w0);
+        const alpha = sinW0 / (2 * Q);
+        const a0 = 1 + alpha;
+
+        this.b0 = alpha / a0;
+        this.b1 = 0;
+        this.b2 = -alpha / a0;
+        this.a1 = (-2 * cosW0) / a0;
+        this.a2 = (1 - alpha) / a0;
+    }
+
+    processSample(input) {
+        const output =
+            this.b0 * input +
+            this.b1 * this.x1 +
+            this.b2 * this.x2 -
+            this.a1 * this.y1 -
+            this.a2 * this.y2;
+
+        this.x2 = this.x1;
+        this.x1 = input;
+        this.y2 = this.y1;
+        this.y1 = output;
+
+        return output;
+    }
+}
+
 // This processor allows access to audio channels directly on the audio rendering thread.
 // This can be useful for running possibly expensive audio monitoring or processing operations
 // off the main thread.
@@ -13,6 +50,7 @@ class ThresholdProcessor extends globalThis.AudioWorkletProcessor {
      * @param {boolean} [param0.processorOptions.postAllTics] true if we need to postMessage at each tics, this prevents
             sending events to the main thread on all tics when not necessary.
      * @param {number} [param0.processorOptions.volumeThreshold] the minimum value for audio detection
+     * @param {{ boost, shift }} [param0.processorOptions.normalizationParameters]
      */
     constructor({
         processorOptions: {
@@ -20,17 +58,21 @@ class ThresholdProcessor extends globalThis.AudioWorkletProcessor {
             minimumActiveCycles = 30,
             postAllTics,
             volumeThreshold = 0.3,
+            processInterval = 50,
+            normalizationParameters = { boost: 1, shift: 0.6 },
         },
     }) {
         super();
 
         // timing variables
-        this.processInterval = 50; // how many ms between each computation
+        this.processInterval = processInterval; // how many ms between each computation
         this.minimumActiveCycles = minimumActiveCycles;
         this.intervalInFrames = (this.processInterval / 1000) * globalThis.sampleRate;
         this.nextUpdateFrame = this.processInterval;
 
         // process variables
+        this.boost = normalizationParameters.boost;
+        this.shift = normalizationParameters.shift;
         this.activityBuffer = 0;
         this.volumeThreshold = volumeThreshold;
         this.frequencyRange = frequencyRange || [80, 400];
@@ -38,6 +80,13 @@ class ThresholdProcessor extends globalThis.AudioWorkletProcessor {
         this.postAllTics = postAllTics;
         this.volume = 0;
         this.wasAboveThreshold = undefined;
+        const centerFrequency = (frequencyRange[0] + frequencyRange[1]) / 2;
+        const bandwidth = frequencyRange[1] - frequencyRange[0];
+        this.bandpassFilter = new BiquadBandpassFilter(
+            globalThis.sampleRate,
+            centerFrequency,
+            centerFrequency / bandwidth
+        );
     }
 
     process(inputs, outputs, parameters) {
@@ -46,37 +95,27 @@ class ThresholdProcessor extends globalThis.AudioWorkletProcessor {
             return;
         }
         const samples = input[0];
-
+        // filter frequencies
+        const filteredSamples = new Float32Array(samples.length);
+        for (let i = 0; i < samples.length; i++) {
+            filteredSamples[i] = this.bandpassFilter.processSample(samples[i]);
+        }
         // throttles down the processing tic rate
         this.nextUpdateFrame -= samples.length;
         if (this.nextUpdateFrame >= 0) {
             return true;
         }
         this.nextUpdateFrame += this.intervalInFrames;
-
-        // computes volume and threshold
-        const startIndex = _getFrequencyIndex(
-            this.frequencyRange[0],
-            globalThis.sampleRate,
-            samples.length
-        );
-        const endIndex = _getFrequencyIndex(
-            this.frequencyRange[1],
-            globalThis.sampleRate,
-            samples.length
-        );
-        let sum = 0;
-        for (let i = startIndex; i < endIndex; ++i) {
-            sum += samples[i];
+        // root mean square (too get a normalized volume)
+        let sumOfSquares = 0;
+        for (const sample of filteredSamples) {
+            sumOfSquares += sample * sample;
         }
-        // Normalizing the volume so that volume mostly fits in the [0,1] range.
-        const preNormalizationVolume = sum / (endIndex - startIndex);
-        const preLogarithmVolume = preNormalizationVolume * 50 + 1;
-        if (preLogarithmVolume <= 0) {
-            this.volume = 0;
-        } else {
-            this.volume = Math.log10(preLogarithmVolume);
-        }
+        const rms = Math.sqrt(sumOfSquares / filteredSamples.length);
+        // bias the volume for a better spread on the [0,1] range
+        const k = 1 + this.boost;
+        const v = Math.pow(rms, this.shift);
+        this.volume = (k * v) / ((k - 1) * v + 1);
 
         if (this.volume >= this.volumeThreshold) {
             this.activityBuffer = this.minimumActiveCycles;
@@ -94,17 +133,6 @@ class ThresholdProcessor extends globalThis.AudioWorkletProcessor {
             this.port.postMessage({ volume: this.volume, isAboveThreshold: this.isAboveThreshold });
         return true;
     }
-}
-
-/**
- * @param {number} targetFrequency in Hz
- * @param {number} sampleRate the sample rate of the audio
- * @param {number} samplesSize amount of samples in the audio input
- * @returns {number} the index of the targetFrequency within samplesSize
- */
-function _getFrequencyIndex(targetFrequency, sampleRate, samplesSize) {
-    const index = Math.round((targetFrequency / (sampleRate / 2)) * samplesSize);
-    return Math.min(Math.max(0, index), samplesSize);
 }
 
 globalThis.registerProcessor("audio-processor", ThresholdProcessor);

--- a/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
+++ b/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
@@ -49,7 +49,8 @@ test("Renders the call settings", async () => {
     await contains("option[value=mockVideoDeviceId]", { count: 0 });
     await contains("button", { text: "Voice Detection" });
     await contains("button", { text: "Push to Talk" });
-    await contains("label", { text: "Voice detection threshold" });
+    await contains("span", { text: "Voice detection sensitivity" });
+    await contains("button", { text: "Test" });
     await contains("label", { text: "Show video participants only" });
     await contains("label", { text: "Blur video background" });
 });
@@ -65,7 +66,7 @@ test("activate push to talk", async () => {
     await click("button", { text: "Push to Talk" });
     await contains("i[aria-label='Register new key']");
     await contains("label", { text: "Delay after releasing push-to-talk" });
-    await contains("label", { text: "Voice detection threshold", count: 0 });
+    await contains("label", { text: "Voice detection sensitivity", count: 0 });
 });
 
 test("activate blur", async () => {

--- a/addons/mail/static/tests/tours/discuss_configuration_tour.js
+++ b/addons/mail/static/tests/tours/discuss_configuration_tour.js
@@ -53,7 +53,7 @@ registry.category("web_tour.tours").add("discuss_configuration_tour", {
             run: "click",
         },
         {
-            trigger: "label:contains('Voice detection threshold')",
+            trigger: "span:contains('Voice detection sensitivity')",
         },
         {
             trigger: "button:contains('Push to Talk')",


### PR DESCRIPTION
This commit adds a new visual indicator (dynamic volume bar) to the
call settings so that users can see and adapt their voice detection
threshold based on that feedback.

This commit also improves the normalization of volume in the audio
worklet:

* Replacing inaccurate frequency-domain analysis with a time-domain
analysis ([bandpass filter](https://en.wikipedia.org/wiki/Digital_biquad_filter#Direct_form_1)).
* Replacing basic sample averaging with a [root mean square](https://en.wikipedia.org/wiki/Root_mean_square) to better
represent the power of the signal (= the perception of sound) and
normalize the value of volume.
* Added additional processing to bias the output value to the lower ends
to give more precision when the volume is low.

task-4264575

![image](https://github.com/user-attachments/assets/66c6f295-dc4d-465a-8782-d27d54c1baf1)

