### PR TITLE
[FIX] account: use domestic fp when domestic vat in EU

### DIFF
--- a/addons/account/tests/test_fiscal_position.py
+++ b/addons/account/tests/test_fiscal_position.py
@@ -215,6 +215,11 @@ class TestFiscalPosition(common.TransactionCase):
             'name': 'US NO VAT',
             'country_id': self.us.id,
         })
+        partner_nl_be_vat = self.env['res.partner'].create({
+            'name': 'NL BE VAT',
+            'vat': 'BE0477472701',
+            'country_id': self.nl.id,
+        })
 
         # Case : 1
         # Billing (VAT/country) : BE/BE
@@ -268,6 +273,14 @@ class TestFiscalPosition(common.TransactionCase):
         self.assertEqual(
             self.env['account.fiscal.position']._get_fiscal_position(partner_us_no_vat, partner_us_no_vat),
             fp_eu_extra
+        )
+
+        # Case : 7
+        # Billing (VAT/country): BE/NL
+        # Delivery (VAT/country): BE/NL
+        self.assertEqual(
+            self.env['account.fiscal.position']._get_fiscal_position(partner_nl_be_vat, partner_nl_be_vat),
+            fp_be_nat
         )
 
     def test_fiscal_position_constraint(self):


### PR DESCRIPTION
Currently the fiscal position gets determined based on the country of the customer. However, in the EU we should take into account the country of the VAT number, since that determines the fiscal country.

Say you are a Belgian company and you have a customer with a Belgian VAT number, but the address in the Netherlands, the current logic would define that the fiscal position is "intra-community", since the countries differ.

This commit changes the check for the EU to take into account the fiscal country of the customer based on his VAT number (if there is one).

task-4185132
