### PR TITLE
[FIX] l10n_din5008: add colons to invoice template fields

### DIFF
--- a/addons/l10n_din5008/i18n/de.po
+++ b/addons/l10n_din5008/i18n/de.po
@@ -157,10 +157,6 @@ msgstr "Gutschrift"
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
-msgid "Delivery Date"
-msgstr "Lieferdatum"
-
-#. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_wizard_preview
 msgid "Delivery Date:"
 msgstr "Lieferdatum:"
@@ -213,25 +209,17 @@ msgstr "Rechnung"
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
-msgid "Invoice Date"
-msgstr "Rechnungsdatum"
+msgid "Invoice Date Due:"
+msgstr "Fälligkeit der Rechnung:"
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
-msgid "Invoice Date Due"
-msgstr "Fälligkeit der Rechnung"
-
-#. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_wizard_preview
 msgid "Invoice Date:"
 msgstr "Rechnungsdatum:"
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
-msgid "Invoice No."
-msgstr "Rechnungsnr"
-
-#. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_wizard_preview
 msgid "Invoice No.:"
 msgstr "Rechnungsnr:"
@@ -258,10 +246,6 @@ msgstr "Seite: <span class=\"page\"/> von <span class=\"topage\"/>"
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
-msgid "Reference"
-msgstr "Referenz"
-
-#. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_wizard_preview
 msgid "Reference:"
 msgstr "Referenz:"
@@ -278,8 +262,8 @@ msgstr "SO/2021/45678"
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
-msgid "Source"
-msgstr "Verweis"
+msgid "Source:"
+msgstr "Verweis:"
 
 #. module: l10n_din5008
 #: model:ir.model.fields,field_description:l10n_din5008.field_base_document_layout__street

--- a/addons/l10n_din5008/i18n/fr.po
+++ b/addons/l10n_din5008/i18n/fr.po
@@ -131,10 +131,6 @@ msgstr "Note de crédit"
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
-msgid "Delivery Date"
-msgstr "Date de livraison"
-
-#. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_wizard_preview
 msgid "Delivery Date:"
 msgstr "Date de livraison:"
@@ -187,25 +183,17 @@ msgstr "Facture"
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
-msgid "Invoice Date"
-msgstr "Date de facturation"
+msgid "Invoice Date Due:"
+msgstr "Date d'échéance de la facture:"
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
-msgid "Invoice Date Due"
-msgstr "Date d'échéance de la facture"
-
-#. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_wizard_preview
 msgid "Invoice Date:"
 msgstr "Date de facturation:"
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
-msgid "Invoice No."
-msgstr "Numéro de facture"
-
-#. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_wizard_preview
 msgid "Invoice No.:"
 msgstr "Numéro de facture:"
@@ -232,10 +220,6 @@ msgstr "Page: <span class=\"page\"/> sur <span class=\"topage\"/>"
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
-msgid "Reference"
-msgstr "Référence"
-
-#. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_wizard_preview
 msgid "Reference:"
 msgstr "Référence:"
@@ -252,8 +236,8 @@ msgstr "SO/2021/45678"
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
-msgid "Source"
-msgstr "Source"
+msgid "Source:"
+msgstr "Source:"
 
 #. module: l10n_din5008
 #: model:ir.model.fields,field_description:l10n_din5008.field_base_document_layout__street

--- a/addons/l10n_din5008/i18n/it.po
+++ b/addons/l10n_din5008/i18n/it.po
@@ -130,10 +130,6 @@ msgstr "Nota di credito"
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
-msgid "Delivery Date"
-msgstr "Data di consegna"
-
-#. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_wizard_preview
 msgid "Delivery Date:"
 msgstr "Data di consegna:"
@@ -186,25 +182,17 @@ msgstr "Fattura"
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
-msgid "Invoice Date"
-msgstr "Data della fattura"
+msgid "Invoice Date Due:"
+msgstr "Data di scadenza della fattura:"
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
-msgid "Invoice Date Due"
-msgstr "Data di scadenza della fattura"
-
-#. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_wizard_preview
 msgid "Invoice Date:"
 msgstr "Data della fattura:"
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
-msgid "Invoice No."
-msgstr "Numero di fattura"
-
-#. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_wizard_preview
 msgid "Invoice No.:"
 msgstr "Numero di fattura:"
@@ -231,10 +219,6 @@ msgstr "Pagina: <span class=\"page\"/> di <span class=\"topage\"/>"
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
-msgid "Reference"
-msgstr "Riferimento"
-
-#. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_wizard_preview
 msgid "Reference:"
 msgstr "Riferimento:"
@@ -251,8 +235,8 @@ msgstr ""
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.report_invoice_document
-msgid "Source"
-msgstr "Fonte"
+msgid "Source:"
+msgstr "Fonte:"
 
 #. module: l10n_din5008
 #: model:ir.model.fields,field_description:l10n_din5008.field_base_document_layout__street

--- a/addons/l10n_din5008/report/din5008_report.xml
+++ b/addons/l10n_din5008/report/din5008_report.xml
@@ -192,27 +192,27 @@
                     <div class="information_block" t-if="o and o._name=='account.move'">
                         <table>
                             <tr t-if="o.name">
-                                <td>Invoice No.</td>
+                                <td>Invoice No:</td>
                                 <td><t t-out="o.name"/></td>
                             </tr>
                             <tr t-if="o.invoice_date">
-                                <td>Invoice Date</td>
+                                <td>Invoice Date:</td>
                                 <td><t t-out="o.invoice_date" t-options="{'widget': 'date'}"/></td>
                             </tr>
                             <tr t-if="o.invoice_date_due">
-                                <td>Invoice Date Due</td>
+                                <td>Invoice Date Due:</td>
                                 <td><t t-out="o.invoice_date_due" t-options="{'widget': 'date'}"/></td>
                             </tr>
                             <tr t-if="o.delivery_date">
-                                <td>Delivery Date</td>
+                                <td>Delivery Date:</td>
                                 <td><t t-out="o.delivery_date" t-options="{'widget': 'date'}"/></td>
                             </tr>
                             <tr t-if="o.invoice_origin">
-                                <td>Source</td>
+                                <td>Source:</td>
                                 <td><t t-out="o.invoice_origin"/></td>
                             </tr>
                             <tr t-if="o.ref">
-                                <td>Reference</td>
+                                <td>Reference:</td>
                                 <td><t t-out="o.ref"/></td>
                             </tr>
                         </table>


### PR DESCRIPTION
Added colons (:) after field labels in the invoice template for better consistency and improved readability.  
Steps to reproduce:

-> Have the Austria localization modules installed

-> Set the invoice document to DIN 5008

-> Notice in the preview on the top right corner the Colon ':' is next to the invoice number and others below

-> When creating an invoice from an SO and viewing the invoice the Colons ':' are not there

 
opw-4245658
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
