### PR TITLE
[FIX] product_expiry: prevent setting expiration date no-tracked product

### DIFF
--- a/addons/product_expiry/views/stock_move_views.xml
+++ b/addons/product_expiry/views/stock_move_views.xml
@@ -33,7 +33,8 @@
             <xpath expr="//field[@name='lot_name']" position="after">
                 <field name="is_expired" column_invisible="True"/>
                 <field name="picking_type_use_existing_lots" column_invisible="True"/>
-                <field name="expiration_date" force_save="1" column_invisible="context.get('picking_code') != 'incoming'" readonly="picking_type_use_existing_lots" decoration-danger="is_expired"/>
+                <field name="tracking" column_invisible="True"/>
+                <field name="expiration_date" force_save="1" column_invisible="context.get('picking_code') != 'incoming'" invisible="tracking == 'none'" readonly="picking_type_use_existing_lots" decoration-danger="is_expired"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Enable the "Expiration Date" feature in inventory settings.
- Create a non-tracked product "P1".
- Create a receipt with one unit of P1.
- Mark it as "To Do".
- Go to the detailed operation.

**Problem:**
You are able to set an expiration date even though the product is not tracked.

opw-4256125
