### PR TITLE
[IMP] html_editor: rename Image command to Media

### DIFF
--- a/addons/html_editor/i18n/html_editor.pot
+++ b/addons/html_editor/i18n/html_editor.pot
@@ -251,6 +251,7 @@ msgstr ""
 #. module: html_editor
 #. odoo-javascript
 #: code:addons/html_editor/static/src/main/font/color_plugin.js:0
+#: code:addons/html_editor/static/src/main/media/icon_plugin.js:0
 msgid "Background Color"
 msgstr ""
 
@@ -387,6 +388,12 @@ msgstr ""
 
 #. module: html_editor
 #. odoo-javascript
+#: code:addons/html_editor/static/src/main/column_plugin.js:0
+msgid "Columnize"
+msgstr ""
+
+#. module: html_editor
+#. odoo-javascript
 #: code:addons/html_editor/static/src/components/history_dialog/history_dialog.js:0
 msgid "Comparison"
 msgstr ""
@@ -419,6 +426,12 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/html_editor/static/src/main/column_plugin.js:0
 msgid "Convert into 4 columns"
+msgstr ""
+
+#. module: html_editor
+#. odoo-javascript
+#: code:addons/html_editor/static/src/main/column_plugin.js:0
+msgid "Convert into columns"
 msgstr ""
 
 #. module: html_editor
@@ -551,7 +564,7 @@ msgstr ""
 
 #. module: html_editor
 #. odoo-javascript
-#: code:addons/html_editor/static/src/others/dynamic_placeholder/dynamic_placeholder.js:0
+#: code:addons/html_editor/static/src/others/dynamic_placeholder_plugin.js:0
 msgid "Dynamic Placeholder"
 msgstr ""
 
@@ -708,6 +721,7 @@ msgstr ""
 #. module: html_editor
 #. odoo-javascript
 #: code:addons/html_editor/static/src/main/font/color_plugin.js:0
+#: code:addons/html_editor/static/src/main/media/icon_plugin.js:0
 msgid "Font Color"
 msgstr ""
 
@@ -887,6 +901,12 @@ msgstr ""
 
 #. module: html_editor
 #. odoo-javascript
+#: code:addons/html_editor/static/src/main/media/media_plugin.js:0
+msgid "Icon"
+msgstr ""
+
+#. module: html_editor
+#. odoo-javascript
 #: code:addons/html_editor/static/src/main/media/icon_plugin.js:0
 msgid "Icon size 1x"
 msgstr ""
@@ -988,13 +1008,19 @@ msgstr ""
 
 #. module: html_editor
 #. odoo-javascript
+#: code:addons/html_editor/static/src/main/banner_plugin.js:0
+msgid "Insert a danger banner"
+msgstr ""
+
+#. module: html_editor
+#. odoo-javascript
 #: code:addons/html_editor/static/src/others/embedded_components/plugins/excalidraw_plugin/excalidraw_dialog/excalidraw_dialog.xml:0
 msgid "Insert a drawing board"
 msgstr ""
 
 #. module: html_editor
 #. odoo-javascript
-#: code:addons/html_editor/static/src/others/dynamic_placeholder/dynamic_placeholder.js:0
+#: code:addons/html_editor/static/src/others/dynamic_placeholder_plugin.js:0
 msgid "Insert a field"
 msgstr ""
 
@@ -1002,6 +1028,12 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/html_editor/static/src/core/dom_plugin.js:0
 msgid "Insert a horizontal rule separator"
+msgstr ""
+
+#. module: html_editor
+#. odoo-javascript
+#: code:addons/html_editor/static/src/main/star_plugin.js:0
+msgid "Insert a rating"
 msgstr ""
 
 #. module: html_editor
@@ -1018,14 +1050,20 @@ msgstr ""
 
 #. module: html_editor
 #. odoo-javascript
+#: code:addons/html_editor/static/src/main/banner_plugin.js:0
+msgid "Insert a success banner"
+msgstr ""
+
+#. module: html_editor
+#. odoo-javascript
 #: code:addons/html_editor/static/src/main/table/table_ui_plugin.js:0
 msgid "Insert a table"
 msgstr ""
 
 #. module: html_editor
 #. odoo-javascript
-#: code:addons/html_editor/static/src/main/media/media_plugin.js:0
-msgid "Insert a video"
+#: code:addons/html_editor/static/src/main/banner_plugin.js:0
+msgid "Insert a warning banner"
 msgstr ""
 
 #. module: html_editor
@@ -1043,37 +1081,19 @@ msgstr ""
 #. module: html_editor
 #. odoo-javascript
 #: code:addons/html_editor/static/src/main/banner_plugin.js:0
-msgid "Insert an danger banner"
-msgstr ""
-
-#. module: html_editor
-#. odoo-javascript
-#: code:addons/html_editor/static/src/main/media/media_plugin.js:0
-msgid "Insert an image"
-msgstr ""
-
-#. module: html_editor
-#. odoo-javascript
-#: code:addons/html_editor/static/src/main/banner_plugin.js:0
 msgid "Insert an info banner"
-msgstr ""
-
-#. module: html_editor
-#. odoo-javascript
-#: code:addons/html_editor/static/src/main/banner_plugin.js:0
-msgid "Insert an success banner"
-msgstr ""
-
-#. module: html_editor
-#. odoo-javascript
-#: code:addons/html_editor/static/src/main/banner_plugin.js:0
-msgid "Insert an warning banner"
 msgstr ""
 
 #. module: html_editor
 #. odoo-javascript
 #: code:addons/html_editor/static/src/main/table/table_menu.js:0
 msgid "Insert below"
+msgstr ""
+
+#. module: html_editor
+#. odoo-javascript
+#: code:addons/html_editor/static/src/main/media/media_plugin.js:0
+msgid "Insert image or icon"
 msgstr ""
 
 #. module: html_editor
@@ -1168,7 +1188,7 @@ msgstr ""
 
 #. module: html_editor
 #. odoo-javascript
-#: code:addons/html_editor/static/src/others/dynamic_placeholder/dynamic_placeholder.js:0
+#: code:addons/html_editor/static/src/others/dynamic_placeholder_plugin.js:0
 msgid "Marketing Tools"
 msgstr ""
 
@@ -1198,7 +1218,7 @@ msgstr ""
 
 #. module: html_editor
 #. odoo-javascript
-#: code:addons/html_editor/static/src/main/power_buttons_plugin.js:0
+#: code:addons/html_editor/static/src/main/powerbox/powerbox_plugin.js:0
 msgid "More options"
 msgstr ""
 
@@ -1634,6 +1654,12 @@ msgstr ""
 
 #. module: html_editor
 #. odoo-javascript
+#: code:addons/html_editor/static/src/main/star_plugin.js:0
+msgid "Stars"
+msgstr ""
+
+#. module: html_editor
+#. odoo-javascript
 #: code:addons/html_editor/static/src/main/powerbox/powerbox_plugin.js:0
 msgid "Structure"
 msgstr ""
@@ -1883,12 +1909,6 @@ msgstr ""
 
 #. module: html_editor
 #. odoo-javascript
-#: code:addons/html_editor/static/src/main/media/media_plugin.js:0
-msgid "Video"
-msgstr ""
-
-#. module: html_editor
-#. odoo-javascript
 #: code:addons/html_editor/static/src/others/embedded_components/plugins/video_plugin/video_plugin.js:0
 msgid "Video Link"
 msgstr ""
@@ -1961,7 +1981,7 @@ msgstr ""
 
 #. module: html_editor
 #. odoo-javascript
-#: code:addons/html_editor/static/src/others/dynamic_placeholder/dynamic_placeholder.js:0
+#: code:addons/html_editor/static/src/others/dynamic_placeholder_plugin.js:0
 msgid ""
 "You need to select a model before opening the dynamic placeholder selector."
 msgstr ""

--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -15,26 +15,6 @@ import { withSequence } from "@html_editor/utils/resource";
 const MEDIA_SELECTOR = `${ICON_SELECTOR} , .o_image, .media_iframe_video`;
 
 /**
- * @param {MediaPlugin} plugin
- */
-const getPowerboxItems = (plugin) => {
-    const powerboxItems = [];
-    if (!plugin.config.disableImage) {
-        powerboxItems.push({
-            categoryId: "media",
-            commandId: "insertImage",
-        });
-    }
-    if (!plugin.config.disableVideo) {
-        powerboxItems.push({
-            categoryId: "media",
-            commandId: "insertVideo",
-        });
-    }
-    return powerboxItems;
-};
-
-/**
  * @typedef { Object } MediaShared
  * @property { MediaPlugin['savePendingImages'] } savePendingImages
  */
@@ -51,25 +31,12 @@ export class MediaPlugin extends Plugin {
                 run: this.replaceImage.bind(this),
             },
             {
-                id: "insertImage",
-                title: _t("Image"),
-                description: _t("Insert an image"),
+                id: "insertMedia",
+                title: _t("Media"),
+                description: _t("Insert image or icon"),
+                keywords: [_t("Image"), _t("Icon")],
                 icon: "fa-file-image-o",
                 run: this.openMediaDialog.bind(this),
-            },
-            {
-                id: "insertVideo",
-                title: _t("Video"),
-                description: _t("Insert a video"),
-                icon: "fa-file-video-o",
-                run: () => {
-                    this.openMediaDialog({
-                        noVideos: false,
-                        noImages: true,
-                        noIcons: true,
-                        noDocuments: true,
-                    });
-                },
             },
         ],
         toolbar_groups: withSequence(29, {
@@ -85,8 +52,12 @@ export class MediaPlugin extends Plugin {
             },
         ],
         powerbox_categories: withSequence(40, { id: "media", name: _t("Media") }),
-        powerbox_items: getPowerboxItems(this),
-        power_buttons: { commandId: "insertImage" },
+        powerbox_items: [
+            ...(this.config.disableImage
+                ? []
+                : [{ categoryId: "media", commandId: "insertMedia" }]),
+        ],
+        power_buttons: { commandId: "insertMedia" },
 
         /** Handlers */
         clean_handlers: this.clean.bind(this),

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -734,10 +734,10 @@ test("A new MediaDialog after switching record in a Form view should have the co
     expect(".odoo-editor-editable p:contains(second)").toHaveCount(1);
 
     setSelectionInHtmlField();
-    await insertText(htmlEditor, "/Image");
+    await insertText(htmlEditor, "/Media");
     await animationFrame();
     expect(".o-we-powerbox").toHaveCount(1);
-    expect(".active .o-we-command-name").toHaveText("Image");
+    expect(".active .o-we-command-name").toHaveText("Media");
 
     await press("Enter");
     await animationFrame();
@@ -916,7 +916,7 @@ test("html field with a placeholder", async () => {
     );
 });
 
-test("'Video' command is available by default", async () => {
+test("'Video Link' command is available", async () => {
     await mountView({
         type: "form",
         resId: 1,
@@ -929,52 +929,60 @@ test("'Video' command is available by default", async () => {
     setSelectionInHtmlField();
     await insertText(htmlEditor, "/video");
     await waitFor(".o-we-powerbox");
-    expect(queryAllTexts(".o-we-command-name")).toEqual(["Video", "Video Link"]);
+    expect(queryAllTexts(".o-we-command-name")).toEqual(["Video Link"]);
 });
 
-test("'Video' command is not available when 'disableVideo' = true", async () => {
+test("MediaDialog contains 'Videos' tab by default in html field", async () => {
     await mountView({
         type: "form",
         resId: 1,
         resModel: "partner",
         arch: `
             <form>
-                <field name="txt" widget="html" options="{'disableVideo': True}"/>
-            </form>`,
-    });
-    setSelectionInHtmlField();
-    await insertText(htmlEditor, "/video");
-    await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(1);
-    expect(queryAllTexts(".o-we-command-name")).toEqual(["Video Link"]);
-});
-
-test("'Video' command is not available by default when sanitize_tags = true", async () => {
-    class SanitizePartner extends models.Model {
-        _name = "sanitize.partner";
-
-        txt = fields.Html({ sanitize_tags: true });
-        _records = [{ id: 1, txt: "<p>first sanitize tags</p>" }];
-    }
-
-    defineModels([SanitizePartner]);
-    await mountView({
-        type: "form",
-        resId: 1,
-        resModel: "sanitize.partner",
-        arch: `
-            <form>
                 <field name="txt" widget="html"/>
             </form>`,
     });
     setSelectionInHtmlField();
-    await insertText(htmlEditor, "/video");
+    await insertText(htmlEditor, "/media");
+    await waitFor(".o-we-powerbox");
+    expect(queryAllTexts(".o-we-command-name")[0]).toEqual("Media");
+
+    await press("Enter");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(1);
-    expect(queryAllTexts(".o-we-command-name")).toEqual(["Video Link"]);
+    expect(queryAllTexts(".o_select_media_dialog .nav-tabs .nav-item")).toEqual([
+        "Images",
+        "Documents",
+        "Icons",
+        "Videos",
+    ]);
 });
 
-test("'Video' command is not available by default when sanitize = true", async () => {
+test("MediaDialog does not contain 'Videos' tab in html field when 'disableVideo' = true", async () => {
+    await mountView({
+        type: "form",
+        resId: 1,
+        resModel: "partner",
+        arch: `
+            <form>
+            <field name="txt" widget="html" options="{'disableVideo': True}"/>
+            </form>`,
+    });
+
+    setSelectionInHtmlField();
+    await insertText(htmlEditor, "/media");
+    await waitFor(".o-we-powerbox");
+    expect(queryAllTexts(".o-we-command-name")[0]).toEqual("Media");
+
+    await press("Enter");
+    await animationFrame();
+    expect(queryAllTexts(".o_select_media_dialog .nav-tabs .nav-item")).toEqual([
+        "Images",
+        "Documents",
+        "Icons",
+    ]);
+});
+
+test("MediaDialog does not contain 'Videos' tab when sanitize = true", async () => {
     class SanitizePartner extends models.Model {
         _name = "sanitize.partner";
 
@@ -993,13 +1001,20 @@ test("'Video' command is not available by default when sanitize = true", async (
             </form>`,
     });
     setSelectionInHtmlField();
-    await insertText(htmlEditor, "/video");
+    await insertText(htmlEditor, "/media");
+    await waitFor(".o-we-powerbox");
+    expect(queryAllTexts(".o-we-command-name")[0]).toEqual("Media");
+
+    await press("Enter");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(1);
-    expect(queryAllTexts(".o-we-command-name")).toEqual(["Video Link"]);
+    expect(queryAllTexts(".o_select_media_dialog .nav-tabs .nav-item")).toEqual([
+        "Images",
+        "Documents",
+        "Icons",
+    ]);
 });
 
-test("'Video' command is available when sanitize_tags = true and 'disableVideo' = false", async () => {
+test("MediaDialog contains 'Videos' tab when sanitize_tags = true and 'disableVideo' = false", async () => {
     class SanitizePartner extends models.Model {
         _name = "sanitize.partner";
 
@@ -1018,26 +1033,9 @@ test("'Video' command is available when sanitize_tags = true and 'disableVideo' 
             </form>`,
     });
     setSelectionInHtmlField();
-    await insertText(htmlEditor, "/video");
-    await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(1);
-    expect(queryAllTexts(".o-we-command-name")).toEqual(["Video", "Video Link"]);
-});
-
-test("MediaDialog contains 'Videos' tab by default in html field", async () => {
-    await mountView({
-        type: "form",
-        resId: 1,
-        resModel: "partner",
-        arch: `
-            <form>
-                <field name="txt" widget="html"/>
-            </form>`,
-    });
-    setSelectionInHtmlField();
-    await insertText(htmlEditor, "/image");
+    await insertText(htmlEditor, "/media");
     await waitFor(".o-we-powerbox");
-    expect(queryAllTexts(".o-we-command-name")).toEqual(["Image"]);
+    expect(queryAllTexts(".o-we-command-name")[0]).toEqual("Media");
 
     await press("Enter");
     await animationFrame();
@@ -1049,32 +1047,7 @@ test("MediaDialog contains 'Videos' tab by default in html field", async () => {
     ]);
 });
 
-test("MediaDialog don't contains 'Videos' tab in html field when 'disableVideo' = true", async () => {
-    await mountView({
-        type: "form",
-        resId: 1,
-        resModel: "partner",
-        arch: `
-            <form>
-            <field name="txt" widget="html" options="{'disableVideo': True}"/>
-            </form>`,
-    });
-
-    setSelectionInHtmlField();
-    await insertText(htmlEditor, "/image");
-    await waitFor(".o-we-powerbox");
-    expect(queryAllTexts(".o-we-command-name")).toEqual(["Image"]);
-
-    await press("Enter");
-    await animationFrame();
-    expect(queryAllTexts(".o_select_media_dialog .nav-tabs .nav-item")).toEqual([
-        "Images",
-        "Documents",
-        "Icons",
-    ]);
-});
-
-test("'Image' command is available by default", async () => {
+test("'Media' command is available by default", async () => {
     await mountView({
         type: "form",
         resId: 1,
@@ -1085,12 +1058,12 @@ test("'Image' command is available by default", async () => {
             </form>`,
     });
     setSelectionInHtmlField();
-    await insertText(htmlEditor, "/image");
+    await insertText(htmlEditor, "/media");
     await waitFor(".o-we-powerbox");
-    expect(queryAllTexts(".o-we-command-name")).toEqual(["Image"]);
+    expect(queryAllTexts(".o-we-command-name")[0]).toEqual("Media");
 });
 
-test("'Image' command is not available when 'disableImage' = true", async () => {
+test("'Media' command is not available when 'disableImage' = true", async () => {
     await mountView({
         type: "form",
         resId: 1,
@@ -1101,10 +1074,9 @@ test("'Image' command is not available when 'disableImage' = true", async () => 
             </form>`,
     });
     setSelectionInHtmlField();
-    await insertText(htmlEditor, "/image");
+    await insertText(htmlEditor, "/media");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(0);
-    expect(queryAllTexts(".o-we-command-name")).toEqual([]);
+    expect(queryAllTexts(".o-we-command-name")).not.toInclude("Media");
 });
 
 test("codeview is not available by default", async () => {

--- a/addons/html_editor/static/tests/media.test.js
+++ b/addons/html_editor/static/tests/media.test.js
@@ -1,4 +1,4 @@
-import { expect, test } from "@odoo/hoot";
+import { expect, test, describe } from "@odoo/hoot";
 import { click, getActiveElement, press, queryOne, waitFor } from "@odoo/hoot-dom";
 import { animationFrame, tick } from "@odoo/hoot-mock";
 import { setupEditor } from "./_helpers/editor";
@@ -104,4 +104,20 @@ test("press escape to close media dialog", async () => {
     await animationFrame();
     expect(".modal .o_select_media_dialog").toHaveCount(0);
     expect(getContent(el)).toBe("<p>a[]bc</p>");
+});
+
+describe("Powerbox search keywords", () => {
+    test("Image and Icon are keywords for the Media command", async () => {
+        const { editor } = await setupEditor("<p>[]<br></p>");
+        insertText(editor, "/");
+        for (const word of ["image", "icon"]) {
+            insertText(editor, word);
+            await animationFrame();
+            expect(".active .o-we-command-name").toHaveText("Media");
+            // delete the keyword to try the next one
+            for (let i = 0; i < word.length; i++) {
+                press("backspace");
+            }
+        }
+    });
 });

--- a/addons/html_editor/static/tests/powerbox.test.js
+++ b/addons/html_editor/static/tests/powerbox.test.js
@@ -73,7 +73,7 @@ describe("search", () => {
         const { el, editor } = await setupEditor("<p>ab[]</p>");
         await insertText(editor, "/");
         await animationFrame();
-        expect(commandNames(el).length).toBe(28);
+        expect(commandNames(el).length).toBe(27);
         await insertText(editor, "head");
         await animationFrame();
         expect(commandNames(el)).toEqual(["Heading 1", "Heading 2", "Heading 3"]);
@@ -83,7 +83,7 @@ describe("search", () => {
         const { el, editor } = await setupEditor("<p>ab[]</p>");
         await insertText(editor, "/");
         await animationFrame();
-        expect(commandNames(el).length).toBe(28);
+        expect(commandNames(el).length).toBe(27);
         expect(".o-we-category").toHaveCount(8);
         expect(queryAllTexts(".o-we-category")).toEqual([
             "STRUCTURE",
@@ -106,7 +106,7 @@ describe("search", () => {
         const { el, editor } = await setupEditor("<p>ab[]</p>", { props: { iframe: true } });
         await insertText(editor, "/");
         await animationFrame();
-        expect(commandNames(el).length).toBe(28);
+        expect(commandNames(el).length).toBe(27);
         await insertText(editor, "head");
         await animationFrame();
         expect(commandNames(el)).toEqual(["Heading 1", "Heading 2", "Heading 3"]);
@@ -158,7 +158,7 @@ describe("search", () => {
         await insertText(editor, "/");
         await animationFrame();
         expect(".o-we-powerbox").toHaveCount(1);
-        expect(commandNames(el).length).toBe(28);
+        expect(commandNames(el).length).toBe(27);
 
         await insertText(editor, "headx");
         await animationFrame();


### PR DESCRIPTION
This commit:
- renames the Image command to Media to better reflect its broader functionality and match the dialog's title ("Select a media").
- adds search keywords so that both "image" and "icon" are aliases to the Media command, improving discoverability.
- removed the Video command as it is currently not used in html_field (it is still available as a tab in the media dialog when the "disableVideo" option is set to false, effectively merging the Video command into the Media command).

task-4264248
