### PR TITLE
[CLN] calendar: clean up code and split test files

### DIFF
--- a/addons/calendar/__init__.py
+++ b/addons/calendar/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import controllers

--- a/addons/calendar/__manifest__.py
+++ b/addons/calendar/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 {

--- a/addons/calendar/controllers/__init__.py
+++ b/addons/calendar/controllers/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import main

--- a/addons/calendar/controllers/main.py
+++ b/addons/calendar/controllers/main.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import odoo.http as http

--- a/addons/calendar/models/__init__.py
+++ b/addons/calendar/models/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import ir_http

--- a/addons/calendar/models/calendar_alarm.py
+++ b/addons/calendar/models/calendar_alarm.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models

--- a/addons/calendar/models/calendar_attendee.py
+++ b/addons/calendar/models/calendar_attendee.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import uuid
 import base64

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging

--- a/addons/calendar/models/calendar_event_type.py
+++ b/addons/calendar/models/calendar_event_type.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from random import randint

--- a/addons/calendar/models/calendar_filter.py
+++ b/addons/calendar/models/calendar_filter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models

--- a/addons/calendar/models/calendar_recurrence.py
+++ b/addons/calendar/models/calendar_recurrence.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import datetime, time

--- a/addons/calendar/models/ir_http.py
+++ b/addons/calendar/models/ir_http.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from werkzeug.exceptions import BadRequest

--- a/addons/calendar/models/mail_activity.py
+++ b/addons/calendar/models/mail_activity.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, fields, tools, _

--- a/addons/calendar/models/mail_activity_mixin.py
+++ b/addons/calendar/models/mail_activity_mixin.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models

--- a/addons/calendar/models/mail_activity_type.py
+++ b/addons/calendar/models/mail_activity_type.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, fields

--- a/addons/calendar/models/res_partner.py
+++ b/addons/calendar/models/res_partner.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import datetime

--- a/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_model.js
+++ b/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_model.js
@@ -6,9 +6,11 @@ import { askRecurrenceUpdatePolicy } from "@calendar/views/ask_recurrence_update
 import { deleteConfirmationMessage, ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 
 export class AttendeeCalendarModel extends CalendarModel {
-    setup(params, { dialog }) {
+    static services = [...CalendarModel.services, "dialog", "orm"];
+
+    setup(params, services) {
         super.setup(...arguments);
-        this.dialog = dialog;
+        this.dialog = services.dialog;
         this.rpc = rpc;
     }
 
@@ -206,4 +208,3 @@ export class AttendeeCalendarModel extends CalendarModel {
         await this.load();
     }
 }
-AttendeeCalendarModel.services = [...CalendarModel.services, "dialog", "orm"];

--- a/addons/calendar/tests/__init__.py
+++ b/addons/calendar/tests/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_access_rights
@@ -6,6 +5,7 @@ from . import test_attendees
 from . import test_calendar
 from . import test_calendar_controller
 from . import test_calendar_recurrent_event_case2
+from . import test_calendar_tour
 from . import test_event_recurrence
 from . import test_event_notifications
 from . import test_mail_activity_mixin

--- a/addons/calendar/tests/test_access_rights.py
+++ b/addons/calendar/tests/test_access_rights.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import datetime, timedelta

--- a/addons/calendar/tests/test_attendees.py
+++ b/addons/calendar/tests/test_attendees.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import datetime

--- a/addons/calendar/tests/test_calendar.py
+++ b/addons/calendar/tests/test_calendar.py
@@ -1,12 +1,9 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-import datetime
 
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 
 from odoo import fields, Command
-from odoo.addons.base.tests.common import HttpCaseWithUserDemo
-from odoo.tests import Form, tagged, new_test_user
+from odoo.tests import Form, new_test_user
 from odoo.addons.base.tests.common import SavepointCaseWithUserDemo
 
 import freezegun
@@ -482,92 +479,6 @@ class TestCalendar(SavepointCaseWithUserDemo):
             'partner_ids': [Command.link(new_partner) for new_partner in new_partners]
         })
         self.assertTrue(set(new_partners) == set(self.event_tech_presentation.videocall_channel_id.channel_partner_ids.ids), 'new partners must be invited to the channel')
-
-@tagged('post_install', '-at_install')
-class TestCalendarTours(HttpCaseWithUserDemo):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.env.ref('base.user_admin').write({
-            'email': 'mitchell.admin@example.com',
-        })
-
-    def test_calendar_month_view_start_hour_displayed(self):
-        """ Test that the time is displayed in the month view. """
-        self.start_tour("/odoo", 'calendar_appointments_hour_tour', login="demo")
-
-    def test_calendar_delete_tour(self):
-        """
-            Check that we can delete events with the "Everybody's calendars" filter.
-        """
-        user_admin = self.env.ref('base.user_admin')
-        start = datetime.combine(date.today(), datetime.min.time()).replace(hour=9)
-        stop = datetime.combine(date.today(), datetime.min.time()).replace(hour=12)
-        event = self.env['calendar.event'].with_user(user_admin).create({
-            'name': 'Test Event',
-            'description': 'Test Description',
-            'start': start.strftime("%Y-%m-%d %H:%M:%S"),
-            'stop': stop.strftime("%Y-%m-%d %H:%M:%S"),
-            'duration': 3,
-            'location': 'Odoo S.A.',
-            'privacy': 'public',
-            'show_as': 'busy',
-        })
-        action_id = self.env.ref('calendar.action_calendar_event')
-        url = "/odoo/action-" + str(action_id.id)
-        self.start_tour(url, 'test_calendar_delete_tour', login='admin')
-        event = self.env['calendar.event'].search([('name', '=', 'Test Event')])
-        self.assertFalse(event) # Check if the event has been correctly deleted
-
-    def test_calendar_decline_tour(self):
-        """
-            Check that we can decline events.
-        """
-        user_admin = self.env.ref('base.user_admin')
-        user_demo = self.user_demo
-        start = datetime.combine(date.today(), datetime.min.time()).replace(hour=9)
-        stop = datetime.combine(date.today(), datetime.min.time()).replace(hour=12)
-        event = self.env['calendar.event'].with_user(user_admin).create({
-            'name': 'Test Event',
-            'description': 'Test Description',
-            'start': start.strftime("%Y-%m-%d %H:%M:%S"),
-            'stop': stop.strftime("%Y-%m-%d %H:%M:%S"),
-            'duration': 3,
-            'location': 'Odoo S.A.',
-            'privacy': 'public',
-            'show_as': 'busy',
-        })
-        event.partner_ids = [Command.link(user_demo.partner_id.id)]
-        action_id = self.env.ref('calendar.action_calendar_event')
-        url = "/odoo/action-" + str(action_id.id)
-        self.start_tour(url, 'test_calendar_decline_tour', login='demo')
-        attendee = self.env['calendar.attendee'].search([('event_id', '=', event.id), ('partner_id', '=', user_demo.partner_id.id)])
-        self.assertEqual(attendee.state, 'declined') # Check if the event has been correctly declined
-
-    def test_calendar_decline_with_everybody_filter_tour(self):
-        """
-            Check that we can decline events with the "Everybody's calendars" filter.
-        """
-        user_admin = self.env.ref('base.user_admin')
-        user_demo = self.user_demo
-        start = datetime.combine(date.today(), datetime.min.time()).replace(hour=9)
-        stop = datetime.combine(date.today(), datetime.min.time()).replace(hour=12)
-        event = self.env['calendar.event'].with_user(user_admin).create({
-            'name': 'Test Event',
-            'description': 'Test Description',
-            'start': start.strftime("%Y-%m-%d %H:%M:%S"),
-            'stop': stop.strftime("%Y-%m-%d %H:%M:%S"),
-            'duration': 3,
-            'location': 'Odoo S.A.',
-            'privacy': 'public',
-            'show_as': 'busy',
-        })
-        event.partner_ids = [Command.link(user_demo.partner_id.id)]
-        action_id = self.env.ref('calendar.action_calendar_event')
-        url = "/odoo/action-" + str(action_id.id)
-        self.start_tour(url, 'test_calendar_decline_with_everybody_filter_tour', login='demo')
-        attendee = self.env['calendar.attendee'].search([('event_id', '=', event.id), ('partner_id', '=', user_demo.partner_id.id)])
-        self.assertEqual(attendee.state, 'declined') # Check if the event has been correctly declined
 
     def test_default_duration(self):
         # Check the default duration depending on various parameters

--- a/addons/calendar/tests/test_calendar_controller.py
+++ b/addons/calendar/tests/test_calendar_controller.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from datetime import datetime
 

--- a/addons/calendar/tests/test_calendar_recurrent_event_case2.py
+++ b/addons/calendar/tests/test_calendar_recurrent_event_case2.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests import common

--- a/addons/calendar/tests/test_calendar_tour.py
+++ b/addons/calendar/tests/test_calendar_tour.py
@@ -1,0 +1,94 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import date, datetime
+
+from odoo import Command
+from odoo.addons.base.tests.common import HttpCaseWithUserDemo
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install')
+class TestCalendarTours(HttpCaseWithUserDemo):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.ref('base.user_admin').write({
+            'email': 'mitchell.admin@example.com',
+        })
+
+    def test_calendar_month_view_start_hour_displayed(self):
+        """ Test that the time is displayed in the month view. """
+        self.start_tour("/odoo", 'calendar_appointments_hour_tour', login="demo")
+
+    def test_calendar_delete_tour(self):
+        """
+            Check that we can delete events with the "Everybody's calendars" filter.
+        """
+        user_admin = self.env.ref('base.user_admin')
+        start = datetime.combine(date.today(), datetime.min.time()).replace(hour=9)
+        stop = datetime.combine(date.today(), datetime.min.time()).replace(hour=12)
+        event = self.env['calendar.event'].with_user(user_admin).create({
+            'name': 'Test Event',
+            'description': 'Test Description',
+            'start': start.strftime("%Y-%m-%d %H:%M:%S"),
+            'stop': stop.strftime("%Y-%m-%d %H:%M:%S"),
+            'duration': 3,
+            'location': 'Odoo S.A.',
+            'privacy': 'public',
+            'show_as': 'busy',
+        })
+        action_id = self.env.ref('calendar.action_calendar_event')
+        url = "/odoo/action-" + str(action_id.id)
+        self.start_tour(url, 'test_calendar_delete_tour', login='admin')
+        event = self.env['calendar.event'].search([('name', '=', 'Test Event')])
+        self.assertFalse(event)  # Check if the event has been correctly deleted
+
+    def test_calendar_decline_tour(self):
+        """
+            Check that we can decline events.
+        """
+        user_admin = self.env.ref('base.user_admin')
+        user_demo = self.user_demo
+        start = datetime.combine(date.today(), datetime.min.time()).replace(hour=9)
+        stop = datetime.combine(date.today(), datetime.min.time()).replace(hour=12)
+        event = self.env['calendar.event'].with_user(user_admin).create({
+            'name': 'Test Event',
+            'description': 'Test Description',
+            'start': start.strftime("%Y-%m-%d %H:%M:%S"),
+            'stop': stop.strftime("%Y-%m-%d %H:%M:%S"),
+            'duration': 3,
+            'location': 'Odoo S.A.',
+            'privacy': 'public',
+            'show_as': 'busy',
+        })
+        event.partner_ids = [Command.link(user_demo.partner_id.id)]
+        action_id = self.env.ref('calendar.action_calendar_event')
+        url = "/odoo/action-" + str(action_id.id)
+        self.start_tour(url, 'test_calendar_decline_tour', login='demo')
+        attendee = self.env['calendar.attendee'].search([('event_id', '=', event.id), ('partner_id', '=', user_demo.partner_id.id)])
+        self.assertEqual(attendee.state, 'declined')  # Check if the event has been correctly declined
+
+    def test_calendar_decline_with_everybody_filter_tour(self):
+        """
+            Check that we can decline events with the "Everybody's calendars" filter.
+        """
+        user_admin = self.env.ref('base.user_admin')
+        user_demo = self.user_demo
+        start = datetime.combine(date.today(), datetime.min.time()).replace(hour=9)
+        stop = datetime.combine(date.today(), datetime.min.time()).replace(hour=12)
+        event = self.env['calendar.event'].with_user(user_admin).create({
+            'name': 'Test Event',
+            'description': 'Test Description',
+            'start': start.strftime("%Y-%m-%d %H:%M:%S"),
+            'stop': stop.strftime("%Y-%m-%d %H:%M:%S"),
+            'duration': 3,
+            'location': 'Odoo S.A.',
+            'privacy': 'public',
+            'show_as': 'busy',
+        })
+        event.partner_ids = [Command.link(user_demo.partner_id.id)]
+        action_id = self.env.ref('calendar.action_calendar_event')
+        url = "/odoo/action-" + str(action_id.id)
+        self.start_tour(url, 'test_calendar_decline_with_everybody_filter_tour', login='demo')
+        attendee = self.env['calendar.attendee'].search([('event_id', '=', event.id), ('partner_id', '=', user_demo.partner_id.id)])
+        self.assertEqual(attendee.state, 'declined')  # Check if the event has been correctly declined

--- a/addons/calendar/tests/test_event_recurrence.py
+++ b/addons/calendar/tests/test_event_recurrence.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import pytz

--- a/addons/calendar/tests/test_mail_activity_mixin.py
+++ b/addons/calendar/tests/test_mail_activity_mixin.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import datetime, time

--- a/addons/calendar/tests/test_recurrence_rule.py
+++ b/addons/calendar/tests/test_recurrence_rule.py
@@ -1,3 +1,5 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from datetime import datetime
 
 from odoo.tests.common import TransactionCase

--- a/addons/calendar/tests/test_res_partner.py
+++ b/addons/calendar/tests/test_res_partner.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests.common import TransactionCase

--- a/addons/calendar/tests/test_res_users.py
+++ b/addons/calendar/tests/test_res_users.py
@@ -1,3 +1,5 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from odoo.tests.common import TransactionCase
 
 

--- a/addons/calendar/wizard/__init__.py
+++ b/addons/calendar/wizard/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 

--- a/addons/calendar/wizard/calendar_popover_delete_wizard.py
+++ b/addons/calendar/wizard/calendar_popover_delete_wizard.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models

--- a/addons/calendar/wizard/calendar_provider_config.py
+++ b/addons/calendar/wizard/calendar_provider_config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models

--- a/addons/calendar/wizard/mail_activity_schedule.py
+++ b/addons/calendar/wizard/mail_activity_schedule.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models

--- a/addons/google_calendar/__init__.py
+++ b/addons/google_calendar/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import controllers

--- a/addons/google_calendar/__manifest__.py
+++ b/addons/google_calendar/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 {

--- a/addons/google_calendar/controllers/__init__.py
+++ b/addons/google_calendar/controllers/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import main

--- a/addons/google_calendar/controllers/main.py
+++ b/addons/google_calendar/controllers/main.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import http

--- a/addons/google_calendar/models/__init__.py
+++ b/addons/google_calendar/models/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import res_config_settings

--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import pytz

--- a/addons/google_calendar/models/calendar_attendee.py
+++ b/addons/google_calendar/models/calendar_attendee.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models

--- a/addons/google_calendar/models/calendar_recurrence_rule.py
+++ b/addons/google_calendar/models/calendar_recurrence_rule.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import re

--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging

--- a/addons/google_calendar/models/res_config_settings.py
+++ b/addons/google_calendar/models/res_config_settings.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models

--- a/addons/google_calendar/models/res_users.py
+++ b/addons/google_calendar/models/res_users.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging

--- a/addons/google_calendar/tests/__init__.py
+++ b/addons/google_calendar/tests/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_google_event

--- a/addons/google_calendar/tests/__init__.py
+++ b/addons/google_calendar/tests/__init__.py
@@ -4,4 +4,5 @@ from . import test_google_event
 from . import test_sync_common
 from . import test_sync_google2odoo
 from . import test_sync_odoo2google
+from . import test_sync_odoo2google_mail
 from . import test_token_access

--- a/addons/google_calendar/tests/test_google_event.py
+++ b/addons/google_calendar/tests/test_google_event.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo.tests.common import BaseCase
 from odoo.addons.google_calendar.utils.google_calendar import GoogleEvent

--- a/addons/google_calendar/tests/test_sync_common.py
+++ b/addons/google_calendar/tests/test_sync_common.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import defaultdict

--- a/addons/google_calendar/tests/test_sync_google2odoo.py
+++ b/addons/google_calendar/tests/test_sync_google2odoo.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import pytz

--- a/addons/google_calendar/tests/test_sync_odoo2google.py
+++ b/addons/google_calendar/tests/test_sync_odoo2google.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
-from freezegun import freeze_time
 from unittest.mock import patch
 
 from odoo.addons.google_calendar.utils.google_event import GoogleEvent
@@ -15,7 +13,6 @@ from odoo.tests.common import users, warmup
 from odoo.tests import tagged
 from odoo import tools
 
-from .test_token_access import TestTokenAccess
 
 @tagged('odoo2google')
 @patch.object(ResUsers, '_get_google_calendar_token', lambda user: 'dummy-token')
@@ -922,47 +919,3 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'extendedProperties': {'shared': {'%s_odoo_id' % self.env.cr.dbname: recurrence.id}},
             'transparency': 'opaque',
         }, timeout=3)
-
-
-@tagged('odoo2google')
-class TestSyncOdoo2GoogleMail(TestTokenAccess, TestSyncGoogle, MailCommon):
-
-    @patch.object(ResUsers, '_get_google_calendar_token', lambda user: user.google_calendar_token)
-    @freeze_time("2020-01-01")
-    def test_event_creation_for_user(self):
-        organizer1 = self.users[0]
-        organizer2 = self.users[1]
-        user_root = self.env.ref('base.user_root')
-        organizer1.google_calendar_token = 'abc'
-        organizer2.google_calendar_token = False
-        event_values = {
-            'name': "Event",
-            'start': datetime(2020, 1, 15, 8, 0),
-            'stop': datetime(2020, 1, 15, 18, 0),
-        }
-        partner = self.env['res.partner'].create({'name': 'Jean-Luc', 'email': 'jean-luc@opoo.com'})
-        for create_user, organizer, responsible, expect_mail, is_public in [
-            (user_root, organizer1, organizer1, False, True), (user_root, None, user_root, True, True),
-                (organizer1, None, organizer1, False, False), (organizer1, organizer2, organizer1, False, True)]:
-            with self.subTest(create_uid=create_user.name if create_user else None, user_id=organizer.name if organizer else None):
-                with self.mock_mail_gateway(), self.mock_google_sync(user_id=responsible):
-                    self.env['calendar.event'].with_user(create_user).create({
-                        **event_values,
-                        'partner_ids': [(4, partner.id)],
-                        'user_id': organizer.id if organizer else False,
-                    })
-                if not expect_mail:
-                    self.assertNotSentEmail()
-                    self.assertGoogleEventInserted({
-                        'attendees': [{'email': 'jean-luc@opoo.com', 'responseStatus': 'needsAction'}],
-                        'id': False,
-                        'start': {'dateTime': '2020-01-15T08:00:00+00:00', 'date': None},
-                        'end': {'dateTime': '2020-01-15T18:00:00+00:00', 'date': None},
-                        'guestsCanModify': is_public,
-                        'organizer': {'email': organizer.email, 'self': False} if organizer else False,
-                        'summary': 'Event',
-                        'reminders': {'useDefault': False, 'overrides': []},
-                    }, timeout=3)
-                else:
-                    self.assertGoogleEventNotInserted()
-                    self.assertMailMail(partner, 'sent', author=user_root.partner_id)

--- a/addons/google_calendar/tests/test_sync_odoo2google_mail.py
+++ b/addons/google_calendar/tests/test_sync_odoo2google_mail.py
@@ -1,0 +1,56 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import datetime
+from freezegun import freeze_time
+from unittest.mock import patch
+
+from odoo.addons.google_calendar.models.res_users import ResUsers
+from odoo.addons.google_calendar.tests.test_sync_common import TestSyncGoogle
+from odoo.addons.mail.tests.common import MailCommon
+from odoo.tests import tagged
+
+from .test_token_access import TestTokenAccess
+
+
+@tagged('odoo2google')
+class TestSyncOdoo2GoogleMail(TestTokenAccess, TestSyncGoogle, MailCommon):
+
+    @patch.object(ResUsers, '_get_google_calendar_token', lambda user: user.google_calendar_token)
+    @freeze_time("2020-01-01")
+    def test_event_creation_for_user(self):
+        organizer1 = self.users[0]
+        organizer2 = self.users[1]
+        user_root = self.env.ref('base.user_root')
+        organizer1.google_calendar_token = 'abc'
+        organizer2.google_calendar_token = False
+        event_values = {
+            'name': "Event",
+            'start': datetime(2020, 1, 15, 8, 0),
+            'stop': datetime(2020, 1, 15, 18, 0),
+        }
+        partner = self.env['res.partner'].create({'name': 'Jean-Luc', 'email': 'jean-luc@opoo.com'})
+        for create_user, organizer, responsible, expect_mail, is_public in [
+            (user_root, organizer1, organizer1, False, True), (user_root, None, user_root, True, True),
+                (organizer1, None, organizer1, False, False), (organizer1, organizer2, organizer1, False, True)]:
+            with self.subTest(create_uid=create_user.name if create_user else None, user_id=organizer.name if organizer else None):
+                with self.mock_mail_gateway(), self.mock_google_sync(user_id=responsible):
+                    self.env['calendar.event'].with_user(create_user).create({
+                        **event_values,
+                        'partner_ids': [(4, partner.id)],
+                        'user_id': organizer.id if organizer else False,
+                    })
+                if not expect_mail:
+                    self.assertNotSentEmail()
+                    self.assertGoogleEventInserted({
+                        'attendees': [{'email': 'jean-luc@opoo.com', 'responseStatus': 'needsAction'}],
+                        'id': False,
+                        'start': {'dateTime': '2020-01-15T08:00:00+00:00', 'date': None},
+                        'end': {'dateTime': '2020-01-15T18:00:00+00:00', 'date': None},
+                        'guestsCanModify': is_public,
+                        'organizer': {'email': organizer.email, 'self': False} if organizer else False,
+                        'summary': 'Event',
+                        'reminders': {'useDefault': False, 'overrides': []},
+                    }, timeout=3)
+                else:
+                    self.assertGoogleEventNotInserted()
+                    self.assertMailMail(partner, 'sent', author=user_root.partner_id)

--- a/addons/google_calendar/tests/test_token_access.py
+++ b/addons/google_calendar/tests/test_token_access.py
@@ -1,3 +1,5 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from odoo import fields, Command
 from odoo.exceptions import AccessError
 from odoo.tests.common import TransactionCase

--- a/addons/google_calendar/utils/__init__.py
+++ b/addons/google_calendar/utils/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from . import google_calendar
 from . import google_event

--- a/addons/google_calendar/utils/google_calendar.py
+++ b/addons/google_calendar/utils/google_calendar.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from uuid import uuid4

--- a/addons/google_calendar/utils/google_event.py
+++ b/addons/google_calendar/utils/google_event.py
@@ -1,5 +1,5 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 import logging
 import re
 from collections import abc

--- a/addons/google_calendar/wizard/__init__.py
+++ b/addons/google_calendar/wizard/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import reset_account

--- a/addons/google_calendar/wizard/reset_account.py
+++ b/addons/google_calendar/wizard/reset_account.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models

--- a/addons/microsoft_calendar/__init__.py
+++ b/addons/microsoft_calendar/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import controllers

--- a/addons/microsoft_calendar/__manifest__.py
+++ b/addons/microsoft_calendar/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 {

--- a/addons/microsoft_calendar/controllers/__init__.py
+++ b/addons/microsoft_calendar/controllers/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import main

--- a/addons/microsoft_calendar/controllers/main.py
+++ b/addons/microsoft_calendar/controllers/main.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import http

--- a/addons/microsoft_calendar/models/__init__.py
+++ b/addons/microsoft_calendar/models/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import res_config_settings

--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging

--- a/addons/microsoft_calendar/models/calendar_attendee.py
+++ b/addons/microsoft_calendar/models/calendar_attendee.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 

--- a/addons/microsoft_calendar/models/calendar_recurrence_rule.py
+++ b/addons/microsoft_calendar/models/calendar_recurrence_rule.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models

--- a/addons/microsoft_calendar/models/microsoft_sync.py
+++ b/addons/microsoft_calendar/models/microsoft_sync.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging

--- a/addons/microsoft_calendar/models/res_config_settings.py
+++ b/addons/microsoft_calendar/models/res_config_settings.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models

--- a/addons/microsoft_calendar/models/res_users.py
+++ b/addons/microsoft_calendar/models/res_users.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging

--- a/addons/microsoft_calendar/tests/__init__.py
+++ b/addons/microsoft_calendar/tests/__init__.py
@@ -6,4 +6,5 @@ from . import test_microsoft_service
 from . import test_create_events
 from . import test_update_events
 from . import test_delete_events
+from . import test_sync_odoo2microsoft_mail
 from . import test_answer_events

--- a/addons/microsoft_calendar/tests/common.py
+++ b/addons/microsoft_calendar/tests/common.py
@@ -1,3 +1,5 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 import pytz
 from datetime import datetime, timedelta
 from markupsafe import Markup

--- a/addons/microsoft_calendar/tests/test_answer_events.py
+++ b/addons/microsoft_calendar/tests/test_answer_events.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from unittest.mock import patch, ANY
 from datetime import datetime, timedelta
 

--- a/addons/microsoft_calendar/tests/test_create_events.py
+++ b/addons/microsoft_calendar/tests/test_create_events.py
@@ -1,10 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from unittest.mock import patch
 from datetime import timedelta, datetime
 from freezegun import freeze_time
 
 from odoo import Command
 
-from odoo.addons.mail.tests.common import MailCommon, mail_new_test_user
+from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.microsoft_calendar.utils.microsoft_calendar import MicrosoftCalendarService
 from odoo.addons.microsoft_calendar.utils.microsoft_event import MicrosoftEvent
 from odoo.addons.microsoft_calendar.models.res_users import ResUsers
@@ -634,69 +636,11 @@ class TestCreateEvents(TestCommon):
         # Ensure that the calendar synchronization of user A is active. Deactivate user B synchronization.
         self.assertTrue(self.env['calendar.event'].with_user(self.organizer_user)._check_microsoft_sync_status())
         self.attendee_user.microsoft_synchronization_stopped = True
-
         # Create an event with user B (not synchronized) as organizer and invite user A.
         self.simple_event_values['user_id'] = self.attendee_user.id
         self.simple_event_values['partner_ids'] = [Command.set([self.organizer_user.partner_id.id, self.attendee_user.partner_id.id])]
         event = self.env['calendar.event'].with_user(self.attendee_user).create(self.simple_event_values)
         self.assertTrue(event, "The event for the not synchronized owner must be created in Odoo.")
-
         # Synchronize the calendar of user A, then make sure insert was not called.
         event.with_user(self.organizer_user).sudo()._sync_odoo2microsoft()
         mock_insert.assert_not_called()
-
-
-class TestSyncOdoo2MicrosoftMail(TestCommon, MailCommon):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.users = []
-        for n in range(1, 3):
-            user = cls.env['res.users'].create({
-                'name': f'user{n}',
-                'login': f'user{n}',
-                'email': f'user{n}@odoo.com',
-                'microsoft_calendar_rtoken': f'abc{n}',
-                'microsoft_calendar_token': f'abc{n}',
-                'microsoft_calendar_token_validity': datetime(9999, 12, 31),
-            })
-            user.res_users_settings_id.write({
-                'microsoft_synchronization_stopped': False,
-                'microsoft_calendar_sync_token': f'{n}_sync_token',
-            })
-            cls.users += [user]
-
-    @freeze_time("2020-01-01")
-    @patch.object(ResUsers, '_get_microsoft_calendar_token', lambda user: user.microsoft_calendar_token)
-    def test_event_creation_for_user(self):
-        """Check that either emails or synchronization happens correctly when creating an event for another user."""
-        user_root = self.env.ref('base.user_root')
-        self.assertFalse(user_root.microsoft_calendar_token)
-        partner = self.env['res.partner'].create({'name': 'Jean-Luc', 'email': 'jean-luc@opoo.com'})
-        event_values = {
-            'name': 'Event',
-            'need_sync_m': True,
-            'start': datetime(2020, 1, 15, 8, 0),
-            'stop': datetime(2020, 1, 15, 18, 0),
-        }
-        for create_user, organizer, expect_mail in [
-            (user_root, self.users[0], True), (user_root, None, True),
-                (self.users[0], None, False), (self.users[0], self.users[1], False)]:
-            with self.subTest(create_uid=create_user.name if create_user else None, user_id=organizer.name if organizer else None):
-                with self.mock_mail_gateway(), patch.object(MicrosoftCalendarService, 'insert') as mock_insert:
-                    mock_insert.return_value = ('1', '1')
-                    self.env['calendar.event'].with_user(create_user).create({
-                        **event_values,
-                        'partner_ids': [(4, organizer.partner_id.id), (4, partner.id)] if organizer else [(4, partner.id)],
-                        'user_id': organizer.id if organizer else False,
-                    })
-                    self.env.cr.postcommit.run()
-                if not expect_mail:
-                    self.assertNotSentEmail()
-                    mock_insert.assert_called_once()
-                    self.assert_dict_equal(mock_insert.call_args[0][0]['organizer'], {
-                        'emailAddress': {'address': organizer.email if organizer else '', 'name': organizer.name if organizer else ''}
-                    })
-                else:
-                    mock_insert.assert_not_called()
-                    self.assertMailMail(partner, 'sent', author=(organizer or create_user).partner_id)

--- a/addons/microsoft_calendar/tests/test_delete_events.py
+++ b/addons/microsoft_calendar/tests/test_delete_events.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from unittest.mock import patch, ANY, call
 from datetime import timedelta
 

--- a/addons/microsoft_calendar/tests/test_microsoft_event.py
+++ b/addons/microsoft_calendar/tests/test_microsoft_event.py
@@ -1,3 +1,5 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from pytz import UTC

--- a/addons/microsoft_calendar/tests/test_microsoft_service.py
+++ b/addons/microsoft_calendar/tests/test_microsoft_service.py
@@ -1,3 +1,5 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 import json
 import requests
 from unittest.mock import patch, call, MagicMock

--- a/addons/microsoft_calendar/tests/test_sync_odoo2microsoft_mail.py
+++ b/addons/microsoft_calendar/tests/test_sync_odoo2microsoft_mail.py
@@ -1,0 +1,66 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from unittest.mock import patch
+from datetime import datetime
+from freezegun import freeze_time
+
+from odoo.addons.mail.tests.common import MailCommon
+from odoo.addons.microsoft_calendar.utils.microsoft_calendar import MicrosoftCalendarService
+from odoo.addons.microsoft_calendar.models.res_users import ResUsers
+from odoo.addons.microsoft_calendar.tests.common import TestCommon
+
+
+class TestSyncOdoo2MicrosoftMail(TestCommon, MailCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.users = []
+        for n in range(1, 3):
+            user = cls.env['res.users'].create({
+                'name': f'user{n}',
+                'login': f'user{n}',
+                'email': f'user{n}@odoo.com',
+                'microsoft_calendar_rtoken': f'abc{n}',
+                'microsoft_calendar_token': f'abc{n}',
+                'microsoft_calendar_token_validity': datetime(9999, 12, 31),
+            })
+            user.res_users_settings_id.write({
+                'microsoft_synchronization_stopped': False,
+                'microsoft_calendar_sync_token': f'{n}_sync_token',
+            })
+            cls.users += [user]
+
+    @freeze_time("2020-01-01")
+    @patch.object(ResUsers, '_get_microsoft_calendar_token', lambda user: user.microsoft_calendar_token)
+    def test_event_creation_for_user(self):
+        """Check that either emails or synchronization happens correctly when creating an event for another user."""
+        user_root = self.env.ref('base.user_root')
+        self.assertFalse(user_root.microsoft_calendar_token)
+        partner = self.env['res.partner'].create({'name': 'Jean-Luc', 'email': 'jean-luc@opoo.com'})
+        event_values = {
+            'name': 'Event',
+            'need_sync_m': True,
+            'start': datetime(2020, 1, 15, 8, 0),
+            'stop': datetime(2020, 1, 15, 18, 0),
+        }
+        for create_user, organizer, expect_mail in [
+            (user_root, self.users[0], True), (user_root, None, True),
+                (self.users[0], None, False), (self.users[0], self.users[1], False)]:
+            with self.subTest(create_uid=create_user.name if create_user else None, user_id=organizer.name if organizer else None):
+                with self.mock_mail_gateway(), patch.object(MicrosoftCalendarService, 'insert') as mock_insert:
+                    mock_insert.return_value = ('1', '1')
+                    self.env['calendar.event'].with_user(create_user).create({
+                        **event_values,
+                        'partner_ids': [(4, organizer.partner_id.id), (4, partner.id)] if organizer else [(4, partner.id)],
+                        'user_id': organizer.id if organizer else False,
+                    })
+                    self.env.cr.postcommit.run()
+                if not expect_mail:
+                    self.assertNotSentEmail()
+                    mock_insert.assert_called_once()
+                    self.assert_dict_equal(mock_insert.call_args[0][0]['organizer'], {
+                        'emailAddress': {'address': organizer.email if organizer else '', 'name': organizer.name if organizer else ''}
+                    })
+                else:
+                    mock_insert.assert_not_called()
+                    self.assertMailMail(partner, 'sent', author=(organizer or create_user).partner_id)

--- a/addons/microsoft_calendar/tests/test_update_events.py
+++ b/addons/microsoft_calendar/tests/test_update_events.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from datetime import datetime, timedelta
 from dateutil.parser import parse
 import logging

--- a/addons/microsoft_calendar/utils/__init__.py
+++ b/addons/microsoft_calendar/utils/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from . import microsoft_calendar
 from . import microsoft_event

--- a/addons/microsoft_calendar/utils/microsoft_calendar.py
+++ b/addons/microsoft_calendar/utils/microsoft_calendar.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import requests

--- a/addons/microsoft_calendar/utils/microsoft_event.py
+++ b/addons/microsoft_calendar/utils/microsoft_event.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from collections import abc
 from typing import Iterator, Mapping

--- a/addons/microsoft_calendar/wizard/__init__.py
+++ b/addons/microsoft_calendar/wizard/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import reset_account

--- a/addons/microsoft_calendar/wizard/reset_account.py
+++ b/addons/microsoft_calendar/wizard/reset_account.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models


### PR DESCRIPTION
In this commit, I replaced the old service definition convention with the updated one. Additionally, I split the test files, moving the tour-related tests into a separate file for better organization.

