### PR TITLE
[IMP] base: allow import of ir_attachment

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -402,10 +402,9 @@ class IrAttachment(models.Model):
     name = fields.Char('Name', required=True)
     description = fields.Text('Description')
     res_name = fields.Char('Resource Name', compute='_compute_res_name')
-    res_model = fields.Char('Resource Model', readonly=True)
-    res_field = fields.Char('Resource Field', readonly=True)
-    res_id = fields.Many2oneReference('Resource ID', model_field='res_model',
-                                      readonly=True)
+    res_model = fields.Char('Resource Model')
+    res_field = fields.Char('Resource Field')
+    res_id = fields.Many2oneReference('Resource ID', model_field='res_model')
     company_id = fields.Many2one('res.company', string='Company', change_default=True,
                                  default=lambda self: self.env.company)
     type = fields.Selection([('url', 'URL'), ('binary', 'File')],


### PR DESCRIPTION
readonly=True on `res_model`/`res_field`/`res_id` of ir_attachment making these fields not importable. Attachment menu is only accessible in debug mode in the technical menu anyway. Then we suppose that user in attachment views understand what he does (hopefully).

task-4252555