### PR TITLE
[IMP] web: notification: custom autoclose delay

### DIFF
--- a/addons/web/static/src/core/notifications/notification_service.js
+++ b/addons/web/static/src/core/notifications/notification_service.js
@@ -15,6 +15,7 @@ const AUTOCLOSE_DELAY = 4000;
  *
  * @typedef {Object} NotificationOptions
  * @property {string} [title]
+ * @property {number} [autocloseDelay=4000]
  * @property {"warning" | "danger" | "success" | "info"} [type]
  * @property {boolean} [sticky=false]
  * @property {string} [className]
@@ -46,14 +47,16 @@ export const notificationService = {
             const id = ++notifId;
             const closeFn = () => close(id);
             const props = Object.assign({}, options, { message, close: closeFn });
+            const autocloseDelay = options.autocloseDelay ?? AUTOCLOSE_DELAY;
             const sticky = props.sticky;
             delete props.sticky;
             delete props.onClose;
+            delete props.autocloseDelay;
             let closeTimeout;
             const refresh = sticky
                 ? () => {}
                 : () => {
-                      closeTimeout = browser.setTimeout(closeFn, AUTOCLOSE_DELAY);
+                      closeTimeout = browser.setTimeout(closeFn, autocloseDelay);
                   };
             const freeze = sticky
                 ? () => {}
@@ -71,7 +74,7 @@ export const notificationService = {
             };
             notifications[id] = notification;
             if (!sticky) {
-                closeTimeout = browser.setTimeout(closeFn, AUTOCLOSE_DELAY);
+                closeTimeout = browser.setTimeout(closeFn, autocloseDelay);
             }
             return closeFn;
         }

--- a/addons/web/static/tests/core/notifications/notifications.test.js
+++ b/addons/web/static/tests/core/notifications/notifications.test.js
@@ -292,3 +292,23 @@ test("notification coming when NotificationManager not mounted yet", async () =>
     await animationFrame();
     expect(".o_notification").toHaveCount(1);
 });
+
+test("notification autocloses after a specified delay", async () => {
+    await makeMockEnv();
+    const { Component: NotificationContainer, props } = registry
+        .category("main_components")
+        .get("NotificationContainer");
+
+    await mountWithCleanup(NotificationContainer, { props, noMainContainer: true });
+    getService("notification").add("custom autoclose delay notification", {
+        autocloseDelay: 1000,
+    });
+
+    await advanceTime(500);
+    await animationFrame();
+    expect(".o_notification").toHaveCount(1);
+
+    await advanceTime(500);
+    await animationFrame();
+    expect(".o_notification").toHaveCount(0);
+});


### PR DESCRIPTION
In this commit, we introduce a way to customize the duration it takes for a notification to automatically disappear which is achieved by specifying `autocloseDelay` option in ms.

Documentation: https://github.com/odoo/documentation/pull/11219