### PR TITLE
[FIX] certificate: fix incorrect certificate attachments domain

### DIFF
--- a/addons/certificate/models/certificate.py
+++ b/addons/certificate/models/certificate.py
@@ -101,7 +101,7 @@ class Certificate(models.Model):
         attachments = self.env['ir.attachment'].search([
             ('res_model', '=', 'certificate.key'),
             ('res_field', '=', 'content'),
-            ('company_id', 'in', self.company_id.ids)
+            ('res_id', 'in', self.ids)
         ])
         content_to_key_id = {(att.datas, att.company_id.id): att.res_id for att in attachments}
 


### PR DESCRIPTION
This commit fixes the incorrect private key computation due to a incorrect domain search in `ir.attachment` model. The `company_id` field was used to search the private key and that is wrong because the `company_id` set on attachments is not same as the record set's company, ORM always sets active company on attachments created from  binary field.

