### PR TITLE
[FIX] account: prevent error when removing the country from company

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -1011,7 +1011,7 @@ class ResCompany(models.Model):
             placeholder = _("/ if not applicable")
             if company.country_id or company.account_fiscal_country_id:
                 expected_vat = _ref_vat.get(
-                    company.country_id.code.lower() or company.account_fiscal_country_id.code.lower()
+                    (company.country_id.code or company.account_fiscal_country_id.code).lower()
                 )
                 if expected_vat:
                     placeholder = _("%s, or / if not applicable", expected_vat)


### PR DESCRIPTION
When the user removes the country from the company,
a traceback will appear.

Steps to reproduce the error:
- Create a new company > Select any country > Save
- Now, remove the country

Traceback:
```
AttributeError: 'bool' object has no attribute 'lower'
  File "odoo/http.py", line 2364, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1891, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1954, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 137, in retrying
    result = func()
  File "odoo/http.py", line 1921, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2168, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 330, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 728, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 35, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 517, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/web/models/models.py", line 1010, in onchange
    if field_name not in done and snapshot0.has_changed(field_name)
  File "addons/web/models/models.py", line 1123, in has_changed
    return self[field_name] != self.record[field_name]
  File "odoo/models.py", line 7000, in __getitem__
    return self._fields[key].__get__(self)
  File "odoo/fields.py", line 1287, in __get__
    self.compute_value(recs)
  File "odoo/fields.py", line 1469, in compute_value
    records._compute_field_value(self)
  File "addons/mail/models/mail_thread.py", line 427, in _compute_field_value
    return super()._compute_field_value(field)
  File "odoo/models.py", line 5243, in _compute_field_value
    fields.determine(field.compute, self)
  File "odoo/fields.py", line 109, in determine
    return needle(*args)
  File "addons/account/models/company.py", line 1014, in _compute_company_vat_placeholder
    company.country_id.code.lower() or company.account_fiscal_country_id.code.lower()
```

https://github.com/odoo/odoo/blob/bc2106bfb401d98678fd9c727281bf20c1a0231e/addons/account/models/company.py#L1014
When the user removes the country, ``company.country_id.code`` will be False,
So, it will lead to the above traceback.

sentry-5996003549

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
