### PR TITLE
[FIX] stock: fix label_transfer_template report

### DIFF
--- a/addons/stock/report/picking_templates.xml
+++ b/addons/stock/report/picking_templates.xml
@@ -5,7 +5,7 @@
             <t t-set="uom_categ_unit" t-value="env.ref('uom.product_uom_categ_unit')"/>
             <t t-foreach="docs" t-as="picking">
 
-                <t t-set="picking_qty_done" t-value="any(picking.move_lines.move_line_ids.mapped('qty_done'))"/>
+                <t t-set="picking_qty_done" t-value="any(picking.move_ids.move_line_ids.mapped('qty_done'))"/>
                 <t t-foreach="picking.move_ids" t-as="move">
                     <t t-foreach="move.move_line_ids" t-as="move_line">
                         <t t-if="move_line.product_uom_id.category_id == uom_categ_unit">
@@ -13,7 +13,7 @@
                                 <t t-set="qty" t-value="int(move_line.qty_done)"/>
                             </t>
                             <t t-else="">
-                                <t t-set="qty" t-value="int(move_line.product_uom_qty)"/>
+                                <t t-set="qty" t-value="int(move_line.reserved_uom_qty)"/>
                             </t>
                         </t>
                         <t t-else="">
@@ -48,7 +48,7 @@
                 <div class="page">
                     <t t-set="uom_categ_unit" t-value="env.ref('uom.product_uom_categ_unit')"/>
                     <t t-foreach="docs" t-as="picking">
-                        <t t-set="picking_qty_done" t-value="any(picking.move_lines.move_line_ids.mapped('qty_done'))"/>
+                        <t t-set="picking_qty_done" t-value="any(picking.move_ids.move_line_ids.mapped('qty_done'))"/>
                         <t t-foreach="picking.move_ids" t-as="move">
                             <t t-foreach="move.move_line_ids" t-as="move_line">
                                 <t t-if="move_line.product_uom_id.category_id == uom_categ_unit">
@@ -56,7 +56,7 @@
                                         <t t-set="qty" t-value="int(move_line.qty_done)"/>
                                     </t>
                                     <t t-else="">
-                                        <t t-set="qty" t-value="int(move_line.product_uom_qty)"/>
+                                        <t t-set="qty" t-value="int(move_line.reserved_uom_qty)"/>
                                     </t>
                                 </t>
                                 <t t-else="">


### PR DESCRIPTION
**Steps to reproduce:**
- Create a PDF report for the stock.picking model
- Use the template stock.label_transfer_template_view_pdf.
- When saving the report, the mentioned error occurred.

```py
odoo.addons.base.models.ir_qweb.QWebException: Error while render the template
AttributeError: 'stock.picking' object has no attribute 'move_lines'
Template: stock.label_transfer_template_view_pdf
Path: /t/t/div/t[2]/t[2]
Node: <t t-foreach="picking.move_ids" t-as="move"/>
```
- [Ref](https://github.com/odoo/odoo/pull/78732) were move_lines has been renamed to move_ids.
- [Ref](https://github.com/odoo/odoo/pull/80434) were product_uom_qty has been renamed to reserved_uom_qty.


**Desired behavior after PR is merged:**

- Can create a report for stock.picking model

![Screenshot from 2024-10-17 11-47-54](https://github.com/user-attachments/assets/4a3377b3-520b-4190-8b03-1259e2049511)


OPW - [4239654](https://www.odoo.com/odoo/project/70/tasks/4239654)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
