### PR TITLE
[FIX] pos_viva_wallet: ensure amount is an integer

### DIFF
--- a/addons/pos_viva_wallet/__manifest__.py
+++ b/addons/pos_viva_wallet/__manifest__.py
@@ -12,7 +12,10 @@
     'installable': True,
     'assets': {
         'point_of_sale._assets_pos': [
-            'pos_viva_wallet/static/**/*',
+            'pos_viva_wallet/static/src/**/*',
+        ],
+        'web.assets_tests': [
+            'pos_viva_wallet/static/tests/tours/**/*',
         ],
     },
     'license': 'LGPL-3',

--- a/addons/pos_viva_wallet/static/src/app/payment_viva_wallet.js
+++ b/addons/pos_viva_wallet/static/src/app/payment_viva_wallet.js
@@ -4,6 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import { PaymentInterface } from "@point_of_sale/app/payment/payment_interface";
 import { ErrorPopup } from "@point_of_sale/app/errors/popups/error_popup";
 import { sprintf } from "@web/core/utils/strings";
+import { roundPrecision } from "@web/core/utils/numbers";
 import { uuidv4 } from "@point_of_sale/utils";
 
 export class PaymentVivaWallet extends PaymentInterface {
@@ -86,7 +87,7 @@ export class PaymentVivaWallet extends PaymentInterface {
             "sessionId": line.sessionId,
             "terminalId": line.payment_method.viva_wallet_terminal_id,
             "cashRegisterId": this.pos.get_cashier().name,
-            "amount": line.amount * 100,
+            "amount": roundPrecision(line.amount * 100, 1),
             "currencyCode": '978', // Viva wallet only uses EUR 978 need add a new field numeric_code in res.currency
             "merchantReference": line.sessionId + '/' + this.pos.pos_session.id,
             "customerTrns": customerTrns,

--- a/addons/pos_viva_wallet/static/tests/tours/helpers/PaymentScreenVivaTourMethods.js
+++ b/addons/pos_viva_wallet/static/tests/tours/helpers/PaymentScreenVivaTourMethods.js
@@ -1,0 +1,18 @@
+/** @odoo-module */
+
+export function send_payment_request() {
+    return [
+        {
+            content: "click send button",
+            trigger: ".button.send_payment_request",
+        },
+    ]
+}
+export function send_payment_cancel() {
+    return [
+        {
+            content: "click send button",
+            trigger: ".button.send_payment_cancel",
+        },
+    ]
+}

--- a/addons/pos_viva_wallet/static/tests/tours/viva_wallet_tour.js
+++ b/addons/pos_viva_wallet/static/tests/tours/viva_wallet_tour.js
@@ -1,0 +1,22 @@
+/** @odoo-module */
+
+import * as ProductScreen from "@point_of_sale/../tests/tours/helpers/ProductScreenTourMethods";
+import * as PaymentScreenPos from "@point_of_sale/../tests/tours/helpers/PaymentScreenTourMethods";
+import * as PaymentScreenViva from "@pos_viva_wallet/../tests/tours/helpers/PaymentScreenVivaTourMethods";
+const PaymentScreen = { ...PaymentScreenPos, ...PaymentScreenViva };
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("VivaWalletTour", {
+    test: true,
+    url: "/pos/ui",
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.addOrderline("Desk Pad", "1", "5.1", "5.1"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.isShown(),
+            PaymentScreen.clickPaymentMethod("Viva"),
+            PaymentScreen.send_payment_request(),
+            PaymentScreen.isShown(),
+        ].flat(),
+});

--- a/addons/pos_viva_wallet/tests/__init__.py
+++ b/addons/pos_viva_wallet/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_frontend

--- a/addons/pos_viva_wallet/tests/test_frontend.py
+++ b/addons/pos_viva_wallet/tests/test_frontend.py
@@ -1,0 +1,41 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
+from odoo.addons.pos_viva_wallet.models.pos_payment_method import PosPaymentMethod
+from unittest.mock import patch
+from odoo import Command
+import odoo.tests
+
+
+@odoo.tests.tagged('post_install', '-at_install')
+class TestVivaWalletHttpCommon(TestPointOfSaleHttpCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        # Create viva wallet payment method
+        viva_payment_method = cls.env['pos.payment.method'].create({
+            'name': 'Viva',
+            'journal_id': cls.bank_journal.id,
+            'use_payment_terminal': 'viva_wallet',
+            'viva_wallet_merchant_id': 'test-merchant-id',
+            'viva_wallet_api_key': 'test-api-key',
+            'viva_wallet_client_id': 'test-client-id',
+            'viva_wallet_client_secret': 'test-client-secret',
+            'viva_wallet_terminal_id': '01234543210',
+        })
+        payment_methods = cls.main_pos_config.payment_method_ids | viva_payment_method
+        cls.main_pos_config.write({'payment_method_ids': [Command.set(payment_methods.ids)]})
+
+    def test_vw_request_data(self):
+        def mocked_call_viva_wallet_check_post_data(self, endpoint, action, data=None):
+            if not isinstance(data['amount'], int):
+                raise TypeError(f"Expected 'amount' to be an integer, but got {data['amount']}.")
+            if not data['terminalId'] == '01234543210':
+                raise Exception(f"Expected 'terminalId' to be 01234543210, but got {data['terminalId']}")
+            return {}
+
+        with patch.object(PosPaymentMethod, '_call_viva_wallet', mocked_call_viva_wallet_check_post_data):
+            self.main_pos_config.open_ui()
+            self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'VivaWalletTour', login="accountman")


### PR DESCRIPTION
Some payment request are failing when sent to viva wallet.

Steps to reproduce:
-------------------
* Configure viva wallet payment for shop session
* Configure one product to have a price unit of 5.1 and na taxes
* Open shop session
* Add that product to order (only once)
* Select **Payment**
* Select viva wallet payment method that you configured
* Select **Send**
> Observation: Error. There are some issues betwees us and Viva Wallet, try again later. [{'type': 'int_from_float', 'loc': ['body', 'amount'], 'msg': 'Input should be a valid integer, got a number with fractional part', 'input': 510.00000000000006, 'url': '...'}]

Why the fix:
------------
Just a floating point precision issue. `3.1 * 100 = 310` but `5.1 * 100 = 510.00000000000006`, explaining why the issue does not always happen.

opw-4076168