### PR TITLE
[FIX] l10n_ch: replace remaining occurence of ref of account.payment

### DIFF
--- a/addons/l10n_ch/models/account_payment.py
+++ b/addons/l10n_ch/models/account_payment.py
@@ -16,7 +16,7 @@ class AccountPayment(models.Model):
             if payment.payment_type == 'outbound' and\
                     payment.partner_id.country_code in ['CH', 'LI'] and\
                     payment.partner_bank_id.l10n_ch_qr_iban and\
-                    not payment._l10n_ch_reference_is_valid(payment.ref):
+                    not payment._l10n_ch_reference_is_valid(payment.memo):
                 payment.l10n_ch_reference_warning_msg = _("Please fill in a correct QRR reference in the payment reference. The banks will refuse your payment file otherwise.")
             else:
                 payment.l10n_ch_reference_warning_msg = False


### PR DESCRIPTION
**Steps to reproduce:**
- Install l10n_ch
- Switch to a Swiss company (e.g. CH Company)
- Go to "Invoicing / Vendors / Payments"
- Select a Swiss contact as vendor

**Issue:**
A traceback is raised while trying to access "ref" field of "account.payment" model.

**Cause:**
"ref" field has been replaced by "memo" field in "account.payment" model.

opw-4244999




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
