### PR TITLE
[FIX] website_sale: display zero-priced products with price extras

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -197,6 +197,7 @@
                             </del>
                         </t>
                         <span class="h6 mb-0" t-if="template_price_vals['price_reduce'] or not website.prevent_zero_price_sale" t-esc="template_price_vals['price_reduce']" t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
+                        <span class="h6 mb-0" t-elif="any(ptav.price_extra for ptav in product.attribute_line_ids.product_template_value_ids)">&amp;nbsp;</span>
                         <span class="h6 mb-0" t-else="" t-field="website.prevent_zero_price_sale_text"/>
                         <span itemprop="price" style="display:none;" t-esc="template_price_vals['price_reduce']" />
                         <span itemprop="priceCurrency" style="display:none;" t-esc="website.currency_id.name" />


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Create a zero-priced product template;
2. add some attribute values;
3. configure price extras for the attributes;
4. configure eCommerce to prevent sale of zero-priced products;
5. go to eCommerce products page.

Issue
-----
Product is displayed as "Not Available For Sale," even though you can click on it, select a price-extra attribute, add it to cart, and purchase it.

Cause
-----
The template doesn't consider potential `price_extra` attributes when displaying the not available message.

Solution
--------
Add a `t-elif` element to the template, checking if the product has any non-zero price-extra attribute values, if so, don't display the not available message, but also don't display the zero price.

opw-4225183