### PR TITLE
[FIX] account: display plaintext for tax description

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -2,7 +2,7 @@
 from odoo import api, fields, models, _, Command
 from odoo.osv import expression
 from odoo.exceptions import UserError, ValidationError
-from odoo.tools import frozendict, groupby, split_every
+from odoo.tools import frozendict, groupby, html2plaintext, is_html_empty, split_every
 from odoo.tools.float_utils import float_round
 from odoo.tools.misc import clean_context, formatLang
 from odoo.tools.translate import html_translate
@@ -2318,6 +2318,12 @@ class AccountTax(models.Model):
             return -candidate['price_subtotal']
 
         return [same_product, same_price_subtotal, biggest_amount]
+
+    def _get_description_plaintext(self):
+        self.ensure_one()
+        if is_html_empty(self.description):
+            return ''
+        return html2plaintext(self.description)
 
 
 class AccountTaxRepartitionLine(models.Model):


### PR DESCRIPTION
Issue:
 - Tax descriptions in the field service report contain HTML tags, leading to undesirable formatting.
 - Tax descriptions that are empty result in `<p><br></p>` being printed.
 - Tax descriptions with content result in `<p>[description]</p>` being printed.

Steps To Reproduce:
- Create a field service task and add products on it.
- Add a Sales Order Item that has taxes.
- Print the field service report.
- Notice when the taxes has no description it print `<p><br><p>`.
- Notice when the taxes has has something in the [description] field it print `<p>[description]><p>`.

Solution:
- In the `account.tax` model, the description field was changed to an HTML field with this commit: https://github.com/odoo/odoo/commit/112c68a
- Added `_get_description_plaintext` method to convert HTML content to plaintext using `html2plaintext`. This will also ensure  compatibility for future changes to the description field.

- related enterprise fix: https://github.com/odoo/enterprise/pull/68454

opw-4104951

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
