### PR TITLE
[FIX] l10n_sa_invoice: Fixed Labels and Translations

### DIFF
--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -66,10 +66,10 @@
                                 فاتورة ملغاة
                             </span>
                             <span t-if="o.move_type == 'out_refund'">
-                                إشعار خصم
+                                إشعار دائن
                             </span>
                             <span t-if="o.move_type == 'in_refund'">
-                                إشعار خصم المورد
+                                إشعار مدين
                             </span>
                             <span t-if="o.move_type == 'in_invoice'">
                                 فاتورة المورد
@@ -138,12 +138,12 @@
                             </strong>
                         </div>
                     </div>
-                    <div class="col-auto mw-100 mb-2" t-if="o.ref" name="reference">
+                    <div class="row" t-if="o.ref" name="reference">
                         <div class="col-2">
                             <strong style="white-space:nowrap">Reference:
                             </strong>
                         </div>
-                        <div class="col-2">
+                        <div class="col-8">
                             <span t-field="o.ref"/>
                         </div>
                         <div class="col-2 text-right">

--- a/addons/l10n_sa/i18n_extra/ar.po
+++ b/addons/l10n_sa/i18n_extra/ar.po
@@ -1242,3 +1242,8 @@ msgstr "ريال"
 #: model:res.currency,currency_subunit_label:base.SAR
 msgid "Halala"
 msgstr "هللة"
+
+#. module: l10n_sa
+#: model:account.tax.group,name:l10n_sa.sa_tax_group_taxes_15
+msgid "VAT Taxes"
+msgstr "ضريبة القيمة المضافة"

--- a/addons/l10n_sa/i18n_extra/l10n_sa.pot
+++ b/addons/l10n_sa/i18n_extra/l10n_sa.pot
@@ -1242,3 +1242,8 @@ msgstr ""
 #: model:res.currency,currency_subunit_label:base.SAR
 msgid "Halala"
 msgstr ""
+
+#. module: l10n_sa
+#: model:account.tax.group,name:l10n_sa.sa_tax_group_taxes_15
+msgid "VAT Taxes"
+msgstr ""

--- a/addons/l10n_sa_edi/i18n/ar.po
+++ b/addons/l10n_sa_edi/i18n/ar.po
@@ -121,17 +121,17 @@ msgstr "<strong>سعر الصرف</strong>"
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
 msgid "<strong>Subtotal (SAR)</strong>"
-msgstr "<strong>الإجمالي الفرعي (بالريال السعودي)</strong>"
+msgstr "<strong>الإجمالي الفرعي بالريال السعودي</strong>"
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
 msgid "<strong>Total (SAR)</strong>"
-msgstr "<strong>الإجمالي (بالريال السعودي)</strong>"
+msgstr "<strong>الإجمالي بالريال السعودي</strong>"
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
 msgid "<strong>VAT Amount (SAR)</strong>"
-msgstr "<strong>مبلغ ضريبة القيمة المضافة (بالريال السعودي)</strong>"
+msgstr "<strong>مبلغ ضريبة القيمة المضافة بالريال السعودي</strong>"
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form

--- a/addons/l10n_sa_edi/views/report_invoice.xml
+++ b/addons/l10n_sa_edi/views/report_invoice.xml
@@ -6,31 +6,27 @@
 
             <!--    Add Currency Exchange rate if different currency than SAR    -->
             <xpath expr="//div[hasclass('clearfix')]" position="after">
-                <div t-if="o.company_id.country_id.code == 'SA' and o.currency_id != o.company_id.currency_id"
-                     id="sar_amounts" class="row clearfix ml-auto my-3 text-nowrap table">
+                <table t-if="o.company_id.country_id.code == 'SA' and o.currency_id != o.company_id.currency_id"
+                     id="sar_amounts" t-att-style="'ltr' if lang != 'ar_001' else 'rtl'" class="row clearfix ml-auto my-3 table table-sm table-borderless">
                     <t t-set="sar_rate"
                        t-value="o.env['res.currency']._get_conversion_rate(o.currency_id, o.company_id.currency_id, o.company_id, o.invoice_date)"/>
-                    <div name="exchange_rate" class="col-auto">
-                        <strong>Exchange Rate</strong>
-                        <p class="m-0" t-esc="sar_rate" t-options='{"widget": "float", "precision": 5}'/>
-                    </div>
-                    <div name="sar_subtotal" class="col-auto">
-                        <strong>Subtotal (SAR)</strong>
-                        <p class="m-0" t-esc="o.amount_untaxed_signed"
-                           t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'/>
-                    </div>
-                    <div name="sar_vat_amount" class="col-auto">
-                        <strong>VAT Amount (SAR)</strong>
-                        <p class="m-0"
-                           t-esc="o.currency_id._convert(o.amount_tax, o.company_id.currency_id, o.company_id, o.invoice_date)"
-                           t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'/>
-                    </div>
-                    <div name="sar_total" class="col-auto">
-                        <strong>Total (SAR)</strong>
-                        <p class="m-0" t-esc="o.amount_total_signed"
-                           t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'/>
-                    </div>
-                </div>
+                    <tr>
+                        <td style="width: 25%"><strong>Exchange Rate</strong></td>
+                        <td style="width: 25%"><strong>Subtotal (SAR)</strong></td>
+                        <td style="width: 25%"><strong>VAT Amount (SAR)</strong></td>
+                        <td style="width: 25%"><strong>Total (SAR)</strong></td>
+                    </tr>
+                    <tr>
+                        <td><p class="m-0" t-esc="sar_rate" t-options='{"widget": "float", "precision": 5}'/></td>
+                        <td><p class="m-0" t-esc="o.amount_untaxed_signed"
+                            t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'/></td>
+                        <td><p class="m-0"
+                            t-esc="o.currency_id._convert(o.amount_tax, o.company_id.currency_id, o.company_id, o.invoice_date)"
+                            t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'/></td>
+                        <td><p class="m-0" t-esc="o.amount_total_signed"
+                            t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'/></td>
+                    </tr>
+                </table>
             </xpath>
 
             <xpath expr="//t[@t-set='address']" position="inside">

--- a/addons/l10n_sa_invoice/views/report_invoice.xml
+++ b/addons/l10n_sa_invoice/views/report_invoice.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <template id="arabic_english_invoice" inherit_id="l10n_gcc_invoice.arabic_english_invoice">
         <xpath expr="//div[@name='due_date']" position="after">
             <div class="row" t-if="o.l10n_sa_delivery_date" name="delivery_date">
@@ -28,6 +27,121 @@
                 </p>
             </t>
         </xpath>
+        <xpath expr="//th[@name='th_total']//span[2]" position="attributes">
+            <span>
+                 <attribute name="class">d-none</attribute>
+            </span>
+        </xpath>
+        <xpath expr="//th[@name='th_total']//span[2]" position="after">
+            <span>
+                Subtotal<br/>(inclusive of VAT)
+            </span>
+        </xpath>
+        <xpath expr="//th[@name='th_total']//span" position="attributes">
+            <attribute name="class">d-none</attribute>
+        </xpath>
+        <xpath expr="//th[@name='th_total']//span" position="after">
+            <span>
+                المجموع شامل ضريبة القيمة المضافة
+            </span>
+        </xpath>
+        <xpath expr="//th[@name='th_subtotal']//span[2]" position="attributes">
+            <span>
+                <attribute name="class">d-none</attribute>
+            </span>
+        </xpath>
+        <xpath expr="//th[@name='th_subtotal']//span[2]" position="after">
+            <span>
+                Subtotal<br/>(exclusive of VAT)
+            </span>
+        </xpath>
+        <xpath expr="//th[@name='th_subtotal']//span" position="attributes">
+            <span>
+                <attribute name="class">d-none</attribute>
+            </span>
+        </xpath>
+        <xpath expr="//th[@name='th_subtotal']//span" position="after">
+            <span>
+                المجموع الفرعي بدون الضريبة
+            </span>
+        </xpath>
+        <xpath expr="//th[@name='th_taxes']//span" position="attributes">
+            <attribute name="class">d-none</attribute>
+        </xpath>
+        <xpath expr="//th[@name='th_taxes']//span" position="after">
+            <span>
+                نسبة الضريبة
+            </span>
+        </xpath>
+        <xpath expr="//tr" position="attributes">
+            <attribute name="style">font-size: 14px;</attribute>
+        </xpath>
+        <xpath expr="//span[@t-field='line.l10n_gcc_invoice_tax_amount']" position="attributes">
+            <attribute name="t-options">{"widget": "monetary", "display_currency": o.currency_id}</attribute>
+        </xpath>
+        <xpath expr="//span[@t-field='line.price_unit']" position="attributes">
+            <attribute name="t-options">{"widget": "monetary", "display_currency": o.currency_id}</attribute>
+        </xpath>
+        <xpath expr="//div[hasclass('clearfix')]//strong" position="attributes">
+            <attribute name="class">d-none</attribute>
+        </xpath>
+        <xpath expr="//div[hasclass('clearfix')]//strong" position="after">
+            <strong>
+                Invoice Taxable Amount
+                /<br/>
+                المبلغ الخاضع للضريبة غير شامل ضريبة القيمة المضافة
+            </strong>
+        </xpath>
+        <xpath expr="//t[@t-call='account.tax_groups_totals']" position="attributes">
+            <attribute name="t-if">0</attribute>
+        </xpath>
+        <xpath expr="//t[@t-call='account.tax_groups_totals']" position="after">
+            <t t-foreach="tax_totals['groups_by_subtotal'][subtotal_to_show]" t-as="amount_by_group">
+                <t t-set="arabic_tax_group_name" t-value="json.loads(o_sec.tax_totals_json)['groups_by_subtotal'][json.loads(o_sec.tax_totals_json)['subtotals'][subtotal_index]['name']][amount_by_group_index]['tax_group_name']"/>
+                <tr>
+                    <t t-if="len(tax_totals['groups_by_subtotal'][subtotal_to_show]) > 1 or (tax_totals['amount_untaxed'] != amount_by_group['tax_group_base_amount'])">
+                        <td>
+                            <span t-esc="amount_by_group['tax_group_name']"/>
+                            <span t-if="arabic_tax_group_name != amount_by_group['tax_group_name']" class="text-nowrap">/
+                                <t t-esc="arabic_tax_group_name"/>
+                            </span>
+                            <span class="text-nowrap"> on
+                                <t t-esc="amount_by_group['formatted_tax_group_base_amount']"/>
+                            </span>
+                        </td>
+                        <td class="text-right o_price_total">
+                            <span class="text-nowrap" t-esc="amount_by_group['formatted_tax_group_amount']"/>
+                        </td>
+                    </t>
+                    <t t-else="">
+                        <td>
+                            <span class="text-nowrap" t-esc="amount_by_group['tax_group_name']"/>
+                            <span t-if="arabic_tax_group_name != amount_by_group['tax_group_name']" class="text-nowrap">/
+                                <t t-esc="arabic_tax_group_name"/>
+                            </span>
+                        </td>
+                        <td class="text-right o_price_total">
+                            <span class="text-nowrap" t-esc="amount_by_group['formatted_tax_group_amount']" />
+                        </td>
+                    </t>
+                </tr>
+            </t>
+        </xpath>
+        <xpath expr="//tr[hasclass('o_total')]//strong" position="attributes">
+            <attribute name="class">d-none</attribute>
+        </xpath>
+        <xpath expr="//tr[hasclass('o_total')]//strong" position="after">
+            <strong>
+                Invoice Total (inclusive of VAT)
+                /
+                إجمالي قيمة الفاتورة شامل ضريبة القيمة المضافة
+            </strong>
+        </xpath>
+        <xpath expr="//div[@name='invoice_date']//span" position="before">
+            <span t-if="o.l10n_sa_confirmation_datetime" t-field="o.l10n_sa_confirmation_datetime"/>
+        </xpath>
+        <xpath expr="//div[@name='invoice_date']//span[@t-field='o.invoice_date']" position="attributes">
+            <attribute name="t-if">not o.l10n_sa_confirmation_datetime</attribute>
+        </xpath>
     </template>
-
 </odoo>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Link to task: [#4218972](https://www.odoo.com/web#model=project.task&id=4218972)
This change fixes english and arabic labels & translations in the l10n_sa_invoice module 

Current behavior before PR:
Some labels are inaccurate or do not match the saudi arabia ZATCA invoice template.

Desired behavior after PR is merged:
Labels are more accurate and match the saudi arabia ZATCA invoice template.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
