### PR TITLE
[FIX] point_of_sale: edit product dialog empty

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.js
@@ -22,7 +22,7 @@ export class ProductInfoPopup extends Component {
         return isAccessibleToEveryUser || isCashierManager;
     }
     editProduct() {
-        this.pos.editProduct(this.props.product);
+        this.pos.editProduct(this.props.productTemplate);
         this.props.close();
     }
     get allowProductEdition() {

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1579,13 +1579,13 @@ export class PosStore extends WithLazyGetterTrap {
     async editProduct(product) {
         this.action.doAction(
             product
-                ? "point_of_sale.product_product_action_edit_pos"
-                : "point_of_sale.product_product_action_add_pos",
+                ? "point_of_sale.product_template_action_edit_pos"
+                : "point_of_sale.product_template_action_add_pos",
             {
                 props: {
                     resId: product?.id,
                     onSave: (record) => {
-                        this.data.read("product.product", [record.evalContext.id]);
+                        this.data.read("product.template", [record.evalContext.id]);
                         this.action.doAction({
                             type: "ir.actions.act_window_close",
                         });

--- a/addons/point_of_sale/views/product_view.xml
+++ b/addons/point_of_sale/views/product_view.xml
@@ -174,38 +174,51 @@
         </field>
     </record>
 
-    <record id="product_product_view_form_normalized_pos" model="ir.ui.view">
-        <field name="name">product.product.view.form.normalized.inherit</field>
-        <field name="model">product.product</field>
-        <field name="inherit_id" ref="product.product_product_view_form_normalized"/>
+    <record id="product_template_view_form_normalized_pos" model="ir.ui.view">
+        <field name="name">product.template.view.form.normalized</field>
+        <field name="model">product.template</field>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='barcode']" position="after">
-                <label for="is_storable" class="oe_inline" invisible="type != 'consu'"/>
-                <div class="o_row w-100" invisible="type != 'consu'">
-                    <field name="is_storable"/>
-                    <field name="tracking" invisible="not is_storable" groups="stock.group_production_lot"/>
-                </div>
-            </xpath>
-            <div name="tax_info" position="after">
-                <field name="pos_categ_ids" string="POS Category" class="oe_inline" widget="many2many_tags" placeholder="Unsaleable"/>
-            </div>
+            <form>
+                <sheet>
+                    <field name="image_1920" widget="image" class="oe_avatar" nolabel="1" options="{'convert_to_webp': True,'preview_image': 'image_128'}"/>
+                    <group name="name">
+                            <field name="name" class="oe_inline" placeholder="e.g. Cheese Burger" string="Product Name"/>
+                            <field name="barcode" class="oe_inline" placeholder="e.g. 1234567890" widget="productScanner"/>
+                            <label for="is_storable" class="oe_inline" invisible="type != 'consu'"/>
+                            <div class="o_row w-100" invisible="type != 'consu'">
+                                <field name="is_storable"/>
+                                <field name="tracking" invisible="not is_storable" groups="stock.group_production_lot"/>
+                            </div>
+                            <field name="list_price" class="oe_inline" widget="monetary"
+                                    options="{'currency_field': 'currency_id', 'field_digits': True}"/>
+                            <label for="taxes_id"/>
+                            <div name="tax_info" class="o_row">
+                                <field name="taxes_id" widget="many2many_tags"
+                                    context="{'search_default_sale': 1}"
+                                    options="{'create': false, 'create_edit': false}"/>
+                                <field name="tax_string"/>
+                            </div>
+                            <field name="pos_categ_ids" string="POS Category" class="oe_inline" widget="many2many_tags" placeholder="Unsaleable"/>
+                    </group>
+                </sheet>
+            </form>
         </field>
     </record>
 
-    <record id="product_product_action_add_pos" model="ir.actions.act_window">
+    <record id="product_template_action_add_pos" model="ir.actions.act_window">
         <field name="name">New Product</field>
-        <field name="res_model">product.product</field>
+        <field name="res_model">product.template</field>
         <field name="view_mode">form</field>
         <field name="target">new</field>
         <field name="context" eval="{'default_available_in_pos': True, 'create_variant_never': 'no_variant', 'dialog_size': 'medium', 'can_be_sold': True, 'default_is_storable': True}"/>
-        <field name="view_id" ref="product_product_view_form_normalized_pos"/>
+        <field name="view_id" ref="point_of_sale.product_template_view_form_normalized_pos"/>
     </record>
-    <record id="product_product_action_edit_pos" model="ir.actions.act_window">
+    <record id="product_template_action_edit_pos" model="ir.actions.act_window">
         <field name="name">Edit Product</field>
-        <field name="res_model">product.product</field>
+        <field name="res_model">product.template</field>
         <field name="view_mode">form</field>
         <field name="target">new</field>
         <field name="context" eval="{'dialog_size': 'medium'}"/>
-        <field name="view_id" ref="point_of_sale.product_product_view_form_normalized_pos"/>
+        <field name="view_id" ref="point_of_sale.product_template_view_form_normalized_pos"/>
     </record>
 </odoo>


### PR DESCRIPTION
Before this commit:
===
- The product edition dialog was empty.

After this commit:
===
- The product edition dialog is no longer empty.

task-4264198

Related: https://github.com/odoo/upgrade/pull/6653
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
