### PR TITLE
[IMP] website:Ensure carousel starts at first slide

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -9872,6 +9872,21 @@ registry.CarouselHandler = registry.GalleryHandler.extend({
      * @param {integer} position - the position of the indicator to activate on
      * the carousel.
      */
+    _updateIndicator(position) {
+        debugger
+        const carouselEl = this.$target[0].classList.contains("carousel") ? this.$target[0]
+        : this.$target[0].querySelector(".carousel");
+        carouselEl.classList.remove("slide");
+        $(carouselEl).carousel(position);
+        this.$target[0].querySelector(`.carousel-indicators button[data-bs-slide-to="${position}"]`);
+        carouselEl.classList.add("slide");
+    },
+    /**
+     * Update the carousel indicator and activate the snippet.
+     *
+     * @private
+     * @param {integer} position - The position of the indicator to activate on the carousel.
+     */
     _updateIndicatorAndActivateSnippet(position) {
         const carouselEl = this.$target[0].classList.contains("carousel") ? this.$target[0]
             : this.$target[0].querySelector(".carousel");

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -9866,22 +9866,6 @@ registry.CarouselHandler = registry.GalleryHandler.extend({
     //--------------------------------------------------------------------------
 
     /**
-     * Update the carousel indicator.
-     *
-     * @private
-     * @param {integer} position - the position of the indicator to activate on
-     * the carousel.
-     */
-    _updateIndicator(position) {
-        debugger
-        const carouselEl = this.$target[0].classList.contains("carousel") ? this.$target[0]
-        : this.$target[0].querySelector(".carousel");
-        carouselEl.classList.remove("slide");
-        $(carouselEl).carousel(position);
-        this.$target[0].querySelector(`.carousel-indicators button[data-bs-slide-to="${position}"]`);
-        carouselEl.classList.add("slide");
-    },
-    /**
      * Update the carousel indicator and activate the snippet.
      *
      * @private

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -9866,10 +9866,11 @@ registry.CarouselHandler = registry.GalleryHandler.extend({
     //--------------------------------------------------------------------------
 
     /**
-     * Update the carousel indicator and activate the snippet.
+     * Update the carousel indicator.
      *
      * @private
-     * @param {integer} position - The position of the indicator to activate on the carousel.
+     * @param {integer} position - the position of the indicator to activate on
+     * the carousel.
      */
     _updateIndicatorAndActivateSnippet(position) {
         const carouselEl = this.$target[0].classList.contains("carousel") ? this.$target[0]

--- a/addons/website/static/src/snippets/s_carousel_intro/options.js
+++ b/addons/website/static/src/snippets/s_carousel_intro/options.js
@@ -23,11 +23,4 @@ options.registry.CarouselIntro = options.registry.Carousel.extend({
         }
         return this._super(...arguments);
     },
-    /**
-     * @override
-     */
-    cleanForSave() {
-        // Set Indicator to the first image on save
-        this._updateIndicator(0);
-    },
 });

--- a/addons/website/static/src/snippets/s_carousel_intro/options.js
+++ b/addons/website/static/src/snippets/s_carousel_intro/options.js
@@ -23,4 +23,11 @@ options.registry.CarouselIntro = options.registry.Carousel.extend({
         }
         return this._super(...arguments);
     },
+    /**
+     * @override
+     */
+    cleanForSave() {
+        // Set Indicator to the first image on save
+        this._updateIndicator(0);
+    },
 });

--- a/addons/website/static/src/snippets/s_image_gallery/options.js
+++ b/addons/website/static/src/snippets/s_image_gallery/options.js
@@ -318,6 +318,13 @@ options.registry.GalleryLayout = options.registry.CarouselHandler.extend({
             }, 0.2 * _slideDuration);
         });
     },
+    /**
+     * @override
+     */
+    cleanForSave() {
+        // Set Indicator to the first image on save
+        this._updateIndicator(0);
+    },
 });
 
 options.registry.gallery = options.registry.GalleryLayout.extend({

--- a/addons/website/static/src/snippets/s_image_gallery/options.js
+++ b/addons/website/static/src/snippets/s_image_gallery/options.js
@@ -323,7 +323,14 @@ options.registry.GalleryLayout = options.registry.CarouselHandler.extend({
      */
     cleanForSave() {
         // Set Indicator to the first image on save
-        this._updateIndicator(0);
+        const targetEL = this.$target[0];
+        const carouselEl = targetEL.classList.contains("carousel")
+            ? targetEL
+            : targetEL.querySelector(".carousel");
+        carouselEl.classList.remove("slide");
+        $(carouselEl).carousel(0);
+        targetEL.querySelector(".carousel-indicators button[data-bs-slide-to='0']");
+        carouselEl.classList.add("slide");
     },
 });
 

--- a/addons/website/static/tests/tours/carousel_slide.js
+++ b/addons/website/static/tests/tours/carousel_slide.js
@@ -1,0 +1,34 @@
+/** @odoo-module */
+import { insertSnippet, registerWebsitePreviewTour, clickOnSave } from '@website/js/tours/tour_utils';
+
+registerWebsitePreviewTour("carousel_slide", {
+    url: '/',
+    edition: true,
+    test:true,
+}, () => [
+    ...insertSnippet({
+        id: 's_carousel',
+        name: 'Carousel',
+        groupName: "Intro",
+    }),
+    {
+        content: "Select the active carousel item.",
+        trigger: ":iframe .carousel-indicators button:nth-child(3)",
+        run: "click",
+    },
+    {
+        content: "Check that the carousel has moved to the third slide",
+        trigger: ":iframe .carousel-indicators button:nth-child(3).active",
+    },
+    ...clickOnSave(),
+    {
+        content: "Ensure that the carousel has moved to the first slide after saving",
+        trigger: ":iframe .carousel-indicators",
+        run: () => {
+            const $carouselIndicators = document.querySelector(':iframe .carousel-indicators');
+            if ($carouselIndicators.querySelector('.active').getAttribute('data-slide-to') !== '0') {
+                throw new Error('The carousel did not move to the first slide after saving');
+            }
+        }
+    },
+]);

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -71,7 +71,7 @@ class TestSnippets(HttpCase):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_popup_add_remove', login='admin')
 
     def test_07_image_gallery(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_image_gallery', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_image_gallery', login='admin', watch=True)
 
     def test_08_table_of_content(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_table_of_content', login='admin')
@@ -115,3 +115,6 @@ class TestSnippets(HttpCase):
 
     def test_rating_snippet(self):
         self.start_tour(self.env["website"].get_client_action_url("/"), "snippet_rating", login="admin")
+
+    def test_carousel_slide(self):
+        self.start_tour("/", 'carousel_slide', login='admin')


### PR DESCRIPTION
Specification:

Currently the carousel is stuck at the image that is selected by the user while
editing the snippet, once the editing is done the carousel should start
from the first slide.

task-4251065
