### PR TITLE
[FIX] analytic: prevent test crash due to hr.timesheet

### DIFF
--- a/addons/analytic/tests/test_analytic_account.py
+++ b/addons/analytic/tests/test_analytic_account.py
@@ -218,9 +218,10 @@ class TestAnalyticAccount(TransactionCase):
         Test that an analytic account defined in a parent company is accessible in its branches (children)
         """
         # timesheet adds a rule to forcer a project_id; account overrides it
-        timesheet_group = self.env.ref('hr_timesheet.group_hr_timesheet_user', raise_if_not_found=False)
-        if timesheet_group:
-            self.env.user.groups_id -= timesheet_group
+        timesheet_user = self.env.ref('hr_timesheet.group_hr_timesheet_user', raise_if_not_found=False)
+        account_user = self.env.ref('account.analytic.model_account_analytic_line', raise_if_not_found=False)
+        if timesheet_user and not account_user:
+            self.skipTest("`hr_timesheet` overrides analytic rights. Without `account` the test would crash")
 
         self.analytic_account_1.company_id = self.company_data
         self.env['account.analytic.line'].create({


### PR DESCRIPTION
Steps to reproduce:
- install new db with only industry_fsm or timesheet_grid
- Run the test

Cause:
https://github.com/odoo/odoo/blob/8029b467dacaf9e34b21db52b148a2963efb29e4/addons/hr_timesheet/security/hr_timesheet_security.xml#L33-L44 `hr.timesheet` overrides the acess rights for analytic line and adds an extra mandatory field; the analytic line should now have a project_id set.

Solution:
Instead of probably breaking the stable by changing the analytic_security.xml by adding a default rule, we skip the test if account is not present but hr.timesheet is.

runbot-100530
