### PR TITLE
[FIX] account: translate sending methods in Print & Send wizard

### DIFF
--- a/addons/account/wizard/account_move_send_wizard.py
+++ b/addons/account/wizard/account_move_send_wizard.py
@@ -127,7 +127,7 @@ class AccountMoveSendWizard(models.TransientModel):
         2. email,
         3. manual.
         """
-        methods = self.env['res.partner']._fields['invoice_sending_method'].selection
+        methods = self.env['ir.model.fields'].get_field_selection('res.partner', 'invoice_sending_method')
         for wizard in self:
             preferred_method = self._get_default_sending_method(wizard.move_id)
             need_fallback = not self._is_applicable_to_move(preferred_method, wizard.move_id)


### PR DESCRIPTION
The sending methods displayed in the Print & Send wizard were populated using the selection field's `selection` field. This only gave the English terms as defined in the code.

This commit fixes that by using another method that gets the values in the current user's language.