### PR TITLE
[FIX] mail: fix non-deterministic unread banner test

### DIFF
--- a/addons/mail/static/tests/thread/thread.test.js
+++ b/addons/mail/static/tests/thread/thread.test.js
@@ -19,7 +19,6 @@ import {
 } from "@mail/../tests/mail_test_helpers";
 
 import { describe, expect, test } from "@odoo/hoot";
-import { queryFirst } from "@odoo/hoot-dom";
 import { Deferred, mockDate, tick } from "@odoo/hoot-mock";
 import { Command, makeKwArgs, onRpc, serverState, withUser } from "@web/../tests/web_test_helpers";
 
@@ -136,9 +135,7 @@ test("auto-scroll to last read message on thread load", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Thread-newMessage ~ .o-mail-Message", { text: "message 100" });
-    const thread = document.querySelector(".o-mail-Thread");
-    const message = queryFirst(".o-mail-Message:contains(message 100)");
-    expect(isInViewportOf(thread, message)).toBe(true);
+    await isInViewportOf(".o-mail-Message:contains(message 100)", ".o-mail-Thread");
 });
 
 test("display day separator before first message of the day", async () => {

--- a/addons/mail/static/tests/thread/unread_messages_banner.test.js
+++ b/addons/mail/static/tests/thread/unread_messages_banner.test.js
@@ -11,8 +11,7 @@ import {
     step,
 } from "@mail/../tests/mail_test_helpers";
 import { Thread } from "@mail/core/common/thread";
-import { describe, expect, test } from "@odoo/hoot";
-import { queryFirst } from "@odoo/hoot-dom";
+import { describe, test } from "@odoo/hoot";
 import { tick } from "@odoo/hoot-mock";
 import {
     Command,
@@ -107,12 +106,7 @@ test("scroll to the first unread message (slow ref registration)", async () => {
         text: "101 new messages",
         parent: ["span", { text: "101 new messagesMark as Read" }],
     });
-    document.addEventListener("scrollend", () => step("scrollend"), { capture: true });
-    // 1. scroll top, 2. scroll to the unread message 3. slight scroll when highlight ends.
-    await assertSteps(["scrollend", "scrollend", "scrollend"]);
-    const thread = document.querySelector(".o-mail-Thread");
-    const message = queryFirst(".o-mail-Message:contains(message 100)");
-    expect(isInViewportOf(thread, message)).toBe(true);
+    await isInViewportOf(".o-mail-Message:contains(message 100)", ".o-mail-Thread");
 });
 
 test("scroll to unread notification", async () => {
@@ -145,20 +139,16 @@ test("scroll to unread notification", async () => {
         text: "Bob joined the channel",
     });
     await tick(); // wait for the scroll to first unread to complete
-    document.addEventListener("scrollend", () => step("scrollend"), { capture: true });
     await contains(".o-mail-Thread", { scroll: "bottom" });
-    await assertSteps(["scrollend"]);
     await scroll(".o-mail-Thread", 0);
-    await assertSteps(["scrollend"]);
-    const thread = document.querySelector(".o-mail-Thread");
-    const message = queryFirst(".o-mail-NotificationMessage:contains(Bob joined the channel)");
-    expect(isInViewportOf(thread, message)).toBe(false);
     await click("span", {
         text: "1 new message",
         parent: ["span", { text: "1 new messageMark as Read" }],
     });
-    await assertSteps(["scrollend"]);
-    expect(isInViewportOf(thread, message)).toBe(true);
+    await isInViewportOf(
+        ".o-mail-NotificationMessage:contains(Bob joined the channel)",
+        ".o-mail-Thread"
+    );
 });
 
 test("remove banner when scrolling to bottom", async () => {


### PR DESCRIPTION
The `scroll to the first unread message (slow ref registration)` test
checks that clicking the unread message banner scrolls to the first
unread message, even with delayed message loading.

Previously, the test expected three `scrollend` events:
- Scroll to top
- Scroll to unread message
- Minor scroll from highlight effect

However, the highlight scroll sometimes fails to trigger if it starts
before the second scroll ends, causing a missing `scrollend`.

This PR resolves the issue by enhancing the `isInViewportOf` helper to
listen for scroll events and assert directly, without relying on
specific steps.

runbot-69429739