### PR TITLE
[FIX] *: remove use of non-public zipfile APIs

### DIFF
--- a/addons/account/tests/test_download_docs.py
+++ b/addons/account/tests/test_download_docs.py
@@ -52,9 +52,10 @@ class TestDownloadDocs(AccountTestInvoicingHttpCommon):
         res = self.url_open(url)
         self.assertEqual(res.status_code, 200)
         with ZipFile(BytesIO(res.content)) as zip_file:
-            self.assertEqual(len(zip_file.filelist), 2)
-            self.assertTrue(zip_file.NameToInfo.get(self.invoices[0].invoice_pdf_report_id.name))
-            self.assertTrue(zip_file.NameToInfo.get(self.invoices[1].invoice_pdf_report_id.name))
+            self.assertEqual(
+                zip_file.namelist(),
+                self.invoices.invoice_pdf_report_id.mapped('name'),
+            )
 
     def test_download_invoice_documents_filetype_one(self):
         url = f'/account/download_invoice_documents/{self.invoices[0].id}/pdf'
@@ -69,6 +70,7 @@ class TestDownloadDocs(AccountTestInvoicingHttpCommon):
         res = self.url_open(url)
         self.assertEqual(res.status_code, 200)
         with ZipFile(BytesIO(res.content)) as zip_file:
-            self.assertEqual(len(zip_file.filelist), 2)
-            self.assertTrue(zip_file.NameToInfo.get(self.invoices[0].invoice_pdf_report_id.name))
-            self.assertTrue(zip_file.NameToInfo.get(self.invoices[1].invoice_pdf_report_id.name))
+            self.assertEqual(
+                zip_file.namelist(),
+                self.invoices.invoice_pdf_report_id.mapped('name'),
+            )

--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -263,14 +263,14 @@ class IrModuleModule(models.Model):
 
         module_names = []
         with zipfile.ZipFile(module_file, "r") as z:
-            for zf in z.filelist:
+            for zf in z.infolist():
                 if zf.file_size > MAX_FILE_SIZE:
                     raise UserError(_("File '%s' exceed maximum allowed file size", zf.filename))
 
             with file_open_temporary_directory(self.env) as module_dir:
                 manifest_files = [
                     file
-                    for file in z.filelist
+                    for file in z.infolist()
                     if file.filename.count('/') == 1
                     and file.filename.split('/')[1] in MANIFEST_NAMES
                 ]
@@ -290,7 +290,7 @@ class IrModuleModule(models.Model):
                         if os.path.splitext(filename)[1].lower() not in ('.xml', '.csv', '.sql'):
                             continue
                         module_data_files[mod_name].append('%s/%s' % (mod_name, filename))
-                for file in z.filelist:
+                for file in z.infolist():
                     filename = file.filename
                     mod_name = filename.split('/')[0]
                     is_data_file = filename in module_data_files[mod_name]
@@ -497,7 +497,7 @@ class IrModuleModule(models.Model):
         with zipfile.ZipFile(BytesIO(zip_data), "r") as z:
             manifest_files = [
                 file
-                for file in z.filelist
+                for file in z.infolist()
                 if file.filename.count('/') == 1
                 and file.filename.split('/')[1] in MANIFEST_NAMES
             ]

--- a/addons/l10n_vn_edi_viettel/models/account_move.py
+++ b/addons/l10n_vn_edi_viettel/models/account_move.py
@@ -261,9 +261,9 @@ class AccountMove(models.Model):
         # The content of the inner zip is a xsl file as well as a xml file.
         # In our case the xsl file is not important, so we can simply ignore it.
         with zipfile.ZipFile(io.BytesIO(file_bytes)) as zip_file:
-            inner_zip_bytes = zip_file.read(zip_file.filelist[0])
+            inner_zip_bytes = zip_file.read(zip_file.infolist()[0])
             with zipfile.ZipFile(io.BytesIO(inner_zip_bytes)) as inner_zip:
-                for file in inner_zip.filelist:
+                for file in inner_zip.infolist():
                     if file.filename.endswith('.xml'):
                         return {
                             'name': file.filename,

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -990,7 +990,7 @@ class Website(Home):
         readable_data = BytesIO(binary_data)
         if zipfile.is_zipfile(readable_data):
             with zipfile.ZipFile(readable_data, "r") as zip_file:
-                for entry in zip_file.filelist:
+                for entry in zip_file.infolist():
                     if entry.file_size > MAX_FONT_FILE_SIZE:
                         raise UserError(_("File '%s' exceeds maximum allowed file size", entry.filename))
                     if entry.filename.rsplit('.', 1)[-1].lower() not in SUPPORTED_FONT_EXTENSIONS \


### PR DESCRIPTION
`NameToInfo` and `filelist` are implementation details, `infolist()` is the correct API for `namelist()`, and `getinfo` for `NameToInfo` but in reality the latter is useless: checking the filelist size before checking for existence based on `NamedToInfo` is unnecessarily convoluted, we can just compare the list of expected filenames to the `namelist()`.
