### PR TITLE
[IMP] html_editor: add reset image transformation button

### DIFF
--- a/addons/html_editor/static/src/main/media/image_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_plugin.js
@@ -5,9 +5,8 @@ import { ImageDescription } from "./image_description";
 import { ImagePadding } from "./image_padding";
 import { createFileViewer } from "@web/core/file_viewer/file_viewer_hook";
 import { boundariesOut } from "@html_editor/utils/position";
-import { ImageTransformation } from "./image_transformation";
-import { registry } from "@web/core/registry";
 import { withSequence } from "@html_editor/utils/resource";
+import { ImageTransformButton } from "./image_transform_button";
 
 function hasShape(imagePlugin, shapeName) {
     return () => imagePlugin.isSelectionShaped(shapeName);
@@ -55,12 +54,6 @@ export class ImagePlugin extends Plugin {
                 run: () => this.setImageShape("img-thumbnail"),
             },
             { id: "resizeImage", run: this.resizeImage.bind(this) },
-            {
-                id: "transformImage",
-                title: _t("Transform the picture (click twice to reset transformation)"),
-                icon: "fa-object-ungroup",
-                run: this.transformImage.bind(this),
-            },
         ],
         toolbar_namespaces: [
             {
@@ -169,8 +162,9 @@ export class ImagePlugin extends Plugin {
             {
                 id: "image_transform",
                 groupId: "image_transform",
-                commandId: "transformImage",
-                isActive: () => this.isImageTransformationOpen(),
+                title: _t("Transform the picture (click twice to reset transformation)"),
+                Component: ImageTransformButton,
+                props: this.getImageTransformProps(),
             },
             {
                 id: "image_delete",
@@ -178,7 +172,6 @@ export class ImagePlugin extends Plugin {
                 commandId: "deleteImage",
             },
         ],
-        selectionchange_handlers: this.onSelectionChange.bind(this),
         paste_url_overrides: this.handlePasteUrl.bind(this),
     };
 
@@ -205,7 +198,6 @@ export class ImagePlugin extends Plugin {
 
     destroy() {
         super.destroy();
-        this.closeImageTransformation();
     }
 
     setImagePadding({ size } = {}) {
@@ -228,14 +220,6 @@ export class ImagePlugin extends Plugin {
         }
         selectedImg.style.width = size || "";
         this.dependencies.history.addStep();
-    }
-
-    transformImage() {
-        const selectedImg = this.getSelectedImage();
-        if (!selectedImg) {
-            return;
-        }
-        this.openImageTransformation(selectedImg);
     }
 
     setImageShape(className, { excludeClasses = [] } = {}) {
@@ -272,17 +256,8 @@ export class ImagePlugin extends Plugin {
         const selectedImg = this.getSelectedImage();
         if (selectedImg) {
             selectedImg.remove();
-            this.closeImageTransformation();
             this.dependencies.history.addStep();
         }
-    }
-
-    onSelectionChange(selectionData) {
-        const { anchorNode, focusNode } = selectionData.documentSelection;
-        if (!anchorNode && !focusNode) {
-            return;
-        }
-        this.closeImageTransformation();
     }
 
     getSelectedImage() {
@@ -339,33 +314,6 @@ export class ImagePlugin extends Plugin {
         }
     }
 
-    openImageTransformation(image) {
-        if (registry.category("main_components").contains("ImageTransformation")) {
-            return;
-        }
-        Promise.resolve().then(() => {
-            this.document.getSelection()?.removeAllRanges();
-        });
-        registry.category("main_components").add("ImageTransformation", {
-            Component: ImageTransformation,
-            props: {
-                image,
-                document: this.document,
-                destroy: () => this.closeImageTransformation(),
-                onChange: () => this.dependencies.history.addStep(),
-            },
-        });
-    }
-
-    isImageTransformationOpen() {
-        return registry.category("main_components").contains("ImageTransformation");
-    }
-
-    closeImageTransformation() {
-        if (this.isImageTransformationOpen()) {
-            registry.category("main_components").remove("ImageTransformation");
-        }
-    }
     updateImageDescription({ description, tooltip } = {}) {
         const selectedImg = this.getSelectedImage();
         if (!selectedImg) {
@@ -374,5 +322,24 @@ export class ImagePlugin extends Plugin {
         selectedImg.setAttribute("alt", description);
         selectedImg.setAttribute("title", tooltip);
         this.dependencies.history.addStep();
+    }
+
+    resetImageTransformation(image) {
+        image.setAttribute(
+            "style",
+            (image.getAttribute("style") || "").replace(/[^;]*transform[\w:]*;?/g, "")
+        );
+        this.dependencies.history.addStep();
+    }
+
+    getImageTransformProps() {
+        return {
+            icon: "fa-object-ungroup",
+            getSelectedImage: this.getSelectedImage.bind(this),
+            resetImageTransformation: this.resetImageTransformation.bind(this),
+            addStep: this.dependencies.history.addStep.bind(this),
+            document: this.document,
+            editable: this.editable,
+        };
     }
 }

--- a/addons/html_editor/static/src/main/media/image_transform_button.js
+++ b/addons/html_editor/static/src/main/media/image_transform_button.js
@@ -1,0 +1,105 @@
+import { Component, useExternalListener, useState } from "@odoo/owl";
+import { toolbarButtonProps } from "@html_editor/main/toolbar/toolbar";
+import { registry } from "@web/core/registry";
+import { ImageTransformation } from "./image_transformation";
+
+export class ImageTransformButton extends Component {
+    static template = "html_editor.ImageTransformButton";
+    static props = {
+        icon: String,
+        getSelectedImage: Function,
+        resetImageTransformation: Function,
+        addStep: Function,
+        document: { validate: (p) => p.nodeType === Node.DOCUMENT_NODE },
+        editable: { validate: (p) => p.nodeType === Node.ELEMENT_NODE },
+        ...toolbarButtonProps,
+    };
+
+    setup() {
+        this.state = useState({ active: false });
+        this.mouseDownInsideTransform = false;
+        // We close the image transform when we click outside any element not related to it
+        // When the mousedown of the click is inside the image transform and mouseup is outside
+        // while resizing or rotating the image it will consider the click as being done outside
+        // image transform. So we need to keep track if the mousedown is inside or outside to
+        // know if we want to close the image transform component or not.
+        useExternalListener(this.props.document, "mousedown", (ev) => {
+            if (this.isNodeInsideTransform(ev.target)) {
+                this.mouseDownInsisdeTransform = true;
+            } else {
+                this.closeImageTransformation();
+                this.mouseDownInsideTransform = false;
+            }
+        });
+        useExternalListener(this.props.document, "click", (ev) => {
+            if (!this.isNodeInsideTransform(ev.target) && !this.mouseDownInsideTransform) {
+                this.closeImageTransformation();
+            }
+            this.mouseDownInsideTransform = false;
+        });
+        // When we click on any character the image is deleted and we need to close the image transform
+        // We handle this by selectionchange
+        useExternalListener(this.props.document, "selectionchange", (ev) => {
+            this.closeImageTransformation();
+        });
+    }
+
+    isNodeInsideTransform(node) {
+        if (!node) {
+            return false;
+        }
+        if (node.nodeType === Node.TEXT_NODE) {
+            node = node.parentElement;
+        }
+        if (node.matches('[name="image_transform"], [name="image_transform"] *')) {
+            return true;
+        }
+        if (
+            this.isImageTransformationOpen() &&
+            node.matches(
+                ".transfo-container, .transfo-container div, .transfo-container i, .transfo-container span"
+            )
+        ) {
+            return true;
+        }
+        return false;
+    }
+
+    onButtonClick() {
+        this.handleImageTransformation(this.props.getSelectedImage());
+    }
+
+    handleImageTransformation(image) {
+        if (this.isImageTransformationOpen()) {
+            this.props.resetImageTransformation(image);
+            this.closeImageTransformation();
+        } else {
+            this.openImageTransformation(image);
+        }
+    }
+
+    openImageTransformation(image) {
+        this.state.active = true;
+        registry.category("main_components").add("ImageTransformation", {
+            Component: ImageTransformation,
+            props: {
+                image,
+                document: this.props.document,
+                editable: this.props.editable,
+                destroy: () => this.closeImageTransformation(),
+                onChange: () => this.props.addStep(),
+            },
+        });
+    }
+
+    isImageTransformationOpen() {
+        return registry.category("main_components").contains("ImageTransformation");
+    }
+
+    closeImageTransformation() {
+        this.state.active = false;
+        if (this.isImageTransformationOpen()) {
+            registry.category("main_components").remove("ImageTransformation");
+        }
+    }
+}

--- a/addons/html_editor/static/src/main/media/image_transform_button.xml
+++ b/addons/html_editor/static/src/main/media/image_transform_button.xml
@@ -1,0 +1,7 @@
+<templates xml:space="preserve">
+    <t t-name="html_editor.ImageTransformButton">
+        <button class="btn btn-light" t-att-class="{active: state.active}" t-att-title="props.title" t-on-click="onButtonClick">
+            <span class="fa fa-fw" t-att-class="props.icon"/>
+        </button>
+    </t>
+</templates>

--- a/addons/html_editor/static/src/main/media/image_transformation.js
+++ b/addons/html_editor/static/src/main/media/image_transformation.js
@@ -25,6 +25,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 import { Component, onMounted, useExternalListener, useRef } from "@odoo/owl";
 import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
+import { usePositionHook } from "@html_editor/position_hook";
 
 const rad = Math.PI / 180;
 
@@ -32,6 +33,7 @@ export class ImageTransformation extends Component {
     static template = "html_editor.ImageTransformation";
     static props = {
         document: { validate: (p) => p.nodeType === Node.DOCUMENT_NODE },
+        editable: { validate: (p) => p.nodeType === Node.ELEMENT_NODE },
         image: { validate: (p) => p.tagName === "IMG" },
         destroy: { type: Function },
         onChange: { type: Function },
@@ -50,6 +52,7 @@ export class ImageTransformation extends Component {
         useExternalListener(window, "mousemove", this.mouseMove);
         useExternalListener(window, "mouseup", this.mouseUp);
         useHotkey("escape", () => this.props.destroy());
+        usePositionHook({ el: this.props.editable }, this.document, this.resetHandlers);
     }
 
     mouseMove(ev) {
@@ -224,7 +227,6 @@ export class ImageTransformation extends Component {
                 : 1;
 
         this.image.style.transform = "";
-        this.transfo.settings.style = this.image.style;
 
         this.transfo.settings.pos = this.getOffset(this.image);
 
@@ -261,7 +263,6 @@ export class ImageTransformation extends Component {
         settings.translatexp = Math.round((settings.translatex / width) * 1000) / 10;
         settings.translateyp = Math.round((settings.translatey / height) * 1000) / 10;
 
-        this.image.style = settings.style;
         this.setImageTransformation(this.image);
 
         this.transfoContainer.el.style.position = "absolute";
@@ -331,5 +332,10 @@ export class ImageTransformation extends Component {
                 left: rect.left + win.pageXOffset + offset.left,
             };
         }
+    }
+
+    resetHandlers() {
+        this.computeImageTransformations();
+        this.positionTransfoContainer();
     }
 }

--- a/addons/html_editor/static/src/main/media/image_transformation.scss
+++ b/addons/html_editor/static/src/main/media/image_transformation.scss
@@ -7,3 +7,7 @@
     margin-left: -4px;
     margin-top: -4px;
 }
+
+.transfo-container {
+    z-index: $zindex-modal + 1;
+}

--- a/addons/html_editor/static/src/main/media/image_transformation.xml
+++ b/addons/html_editor/static/src/main/media/image_transformation.xml
@@ -11,7 +11,7 @@
                 <div style="top: 0%; left: 0%; cursor: nw-resize;" class="transfo-scaler transfo-scaler-tl"></div>
                 <div style="top: 0%; left: 100%; cursor: ne-resize;" class="transfo-scaler transfo-scaler-tr"></div>
                 <div style="top: 100%; left: 100%; cursor: se-resize;" class="transfo-scaler transfo-scaler-br"></div>
-                <div style="top: 100%; left: 0%; cursor: sw-resize;" class=" transfo-sclaer transfo-scaler-bl"></div>
+                <div style="top: 100%; left: 0%; cursor: sw-resize;" class=" transfo-scaler transfo-scaler-bl"></div>
                 <div style="top: 0%; left: 50%; cursor: n-resize;" class="transfo-scaler transfo-scaler-tc"></div>
                 <div style="top: 100%; left: 50%; cursor: s-resize;" class="transfo-scaler transfo-scaler-bc"></div>
                 <div style="top: 50%; left: 0%; cursor: w-resize;" class="transfo-scaler transfo-scaler-ml"></div>

--- a/addons/html_editor/static/tests/image.test.js
+++ b/addons/html_editor/static/tests/image.test.js
@@ -272,7 +272,7 @@ test("Can transform an image", async () => {
     `);
     await click("img.test-image");
     await waitFor(".o-we-toolbar");
-    await click(".o-we-toolbar button[name='image_transform']");
+    await click(".o-we-toolbar div[name='image_transform'] button");
     await animationFrame();
     const transfoContainers = document.querySelectorAll(".transfo-container");
     expect(transfoContainers).toHaveCount(1);
@@ -289,7 +289,7 @@ test("Image transformation dissapear when selection change", async () => {
     `);
     await click("img.test-image");
     await waitFor(".o-we-toolbar");
-    await click(".o-we-toolbar button[name='image_transform']");
+    await click(".o-we-toolbar div[name='image_transform'] button");
     await animationFrame();
     let transfoContainers = document.querySelectorAll(".transfo-container");
     expect(transfoContainers).toHaveCount(1);
@@ -316,16 +316,83 @@ test("Image transformation disappear on escape", async () => {
     await waitFor(".o-we-toolbar");
     let toolbar = document.querySelectorAll(".o-we-toolbar");
     expect(toolbar.length).toBe(1);
-    click(".o-we-toolbar button[name='image_transform']");
+    click(".o-we-toolbar div[name='image_transform'] button");
     await animationFrame();
     toolbar = document.querySelectorAll(".o-we-toolbar");
-    expect(toolbar.length).toBe(0);
+    expect(toolbar.length).toBe(1);
     let transfoContainers = document.querySelectorAll(".transfo-container");
     expect(transfoContainers.length).toBe(1);
     press("escape");
     await animationFrame();
     transfoContainers = document.querySelectorAll(".transfo-container");
     expect(transfoContainers.length).toBe(0);
+});
+
+test("Image transformation scalers position", async () => {
+    await setupEditor(`
+        <p><img class="img-fluid test-image" src="${base64Img}"></p>
+    `);
+
+    const checkScalersPositions = (image) => {
+        const rect = image.getBoundingClientRect();
+        const topValues = [rect.top, rect.top + rect.height / 2, rect.top + rect.height];
+        const leftValues = [rect.left, rect.left + rect.width / 2, rect.left + rect.width];
+        const vertical = "tmb";
+        const horizontal = "lcr";
+        for (let i = 0; i < 3; i++) {
+            for (let j = 0; j < 3; j++) {
+                if (i == 1 && j == 1) {
+                    // no middle-center handler
+                    continue;
+                }
+                const scaler = queryOne(`.transfo-scaler-${vertical[i]}${horizontal[j]}`);
+                const scalerRect = scaler.getBoundingClientRect();
+                expect(scalerRect.top + scalerRect.height / 2).toBe(topValues[i], { digits: 3 });
+                expect(scalerRect.left + scalerRect.width / 2).toBe(leftValues[j], {
+                    digits: 3,
+                });
+            }
+        }
+    };
+    click("img.test-image");
+    await waitFor(".o-we-toolbar");
+    expect(".o-we-toolbar").toHaveCount(1);
+    click(".o-we-toolbar div[name='image_transform'] button");
+    await animationFrame();
+    expect(".o-we-toolbar").toHaveCount(1);
+    expect(".transfo-container").toHaveCount(1);
+    checkScalersPositions(queryOne("img"));
+    // resize by 25% update the position of the scalers
+    click('.o-we-toolbar [name="resize_25"]');
+    await animationFrame();
+    expect(".transfo-container").toHaveCount(0);
+});
+
+test("Image transformation reset", async () => {
+    const { el } = await setupEditor(`
+        <img class="img-fluid test-image" src="${base64Img}">
+    `);
+    el.querySelector("img").style.setProperty(
+        "transform",
+        "rotate(25deg) translateX(-0.2%) translateY(0.4%)"
+    );
+    const transformButtonSelector = ".o-we-toolbar div[name='image_transform'] button";
+    const resetTransformButtonSelector = ".o-we-toolbar div[name='image_transform'] button.active";
+    await click("img.test-image");
+    await waitFor(".o-we-toolbar");
+
+    expect(transformButtonSelector).toHaveCount(1);
+    expect(resetTransformButtonSelector).toHaveCount(0);
+
+    await click(transformButtonSelector);
+    await animationFrame();
+    expect(resetTransformButtonSelector).toHaveCount(1);
+
+    await click(resetTransformButtonSelector);
+    await animationFrame();
+    expect(el.querySelector("img").style.getPropertyValue("transform")).toBe("");
+    expect(transformButtonSelector).toHaveCount(1);
+    expect(resetTransformButtonSelector).toHaveCount(0);
 });
 
 test("Can delete an image", async () => {


### PR DESCRIPTION
Before this commit:
- Cliking twice wasn't resetting the transformation
- Click on image transformation closes the toolbar because of [1]
- Updating the size using the percentage does not update the position of
  the scalers
- Bottom left handler doesn't show
- The handlers doesn't position right when scrolling and resize
- The rotator handler is under the toolbar

After this commit:
- Clicking again on the button will reset the transformation
- Keep the toolbar open after click image transformation
- close the image_transform after any click outside
- Bottom left handler is visible
- The handlers now stay fixed on the image when scroll and resize of the
  browser
- The rotator handler is over the toolbar

[1]: https://github.com/odoo/odoo/commit/7f81aa4e54709383ac3c73ae3faa421330ba126d

task-4235140