### PR TITLE
[IMP] account, l10n_*, *: enhance tax name visibility.

### DIFF
--- a/addons/account/static/src/components/autosave_many2many_tax_tags/autosave_many2many_tax_tags.js
+++ b/addons/account/static/src/components/autosave_many2many_tax_tags/autosave_many2many_tax_tags.js
@@ -1,8 +1,11 @@
 import { registry } from "@web/core/registry";
 import { useRecordObserver } from "@web/model/relational_model/utils";
-import { Many2ManyTagsField, many2ManyTagsField } from "@web/views/fields/many2many_tags/many2many_tags_field";
+import {
+    Many2ManyTaxTagsField,
+    many2ManyTaxTagsField
+} from "@account/components/many2x_tax_tags/many2x_tax_tags";
 
-export class AutosaveMany2ManyTagsField extends Many2ManyTagsField {
+export class AutosaveMany2ManyTaxTagsField extends Many2ManyTaxTagsField {
     setup() {
         super.setup();
 
@@ -42,9 +45,9 @@ export class AutosaveMany2ManyTagsField extends Many2ManyTagsField {
     }
 }
 
-export const autosaveMany2ManyTagsField = {
-    ...many2ManyTagsField,
-    component: AutosaveMany2ManyTagsField,
+export const autosaveMany2ManyTaxTagsField = {
+    ...many2ManyTaxTagsField,
+    component: AutosaveMany2ManyTaxTagsField,
 };
 
-registry.category("fields").add("autosave_many2many_tags", autosaveMany2ManyTagsField);
+registry.category("fields").add("autosave_many2many_tax_tags", autosaveMany2ManyTaxTagsField);

--- a/addons/account/static/src/components/many2x_tax_tags/many2x_tax_tags.js
+++ b/addons/account/static/src/components/many2x_tax_tags/many2x_tax_tags.js
@@ -1,15 +1,17 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
-
 import { Many2XAutocomplete } from "@web/views/fields/relational_utils";
 import {
     Many2ManyTagsField,
     many2ManyTagsField,
 } from "@web/views/fields/many2many_tags/many2many_tags_field";
-
+import {
+    Many2OneField,
+    many2OneField,
+} from "@web/views/fields/many2one/many2one_field";
 import { TaxAutoComplete } from "@account/components/tax_autocomplete/tax_autocomplete";
 
-export class Many2ManyTaxTagsAutocomplete extends Many2XAutocomplete {
+export class Many2XTaxTagsAutocomplete extends Many2XAutocomplete {
     static components = {
         ...Many2XAutocomplete.components,
         AutoComplete: TaxAutoComplete,
@@ -56,7 +58,14 @@ export class Many2ManyTaxTagsAutocomplete extends Many2XAutocomplete {
 export class Many2ManyTaxTagsField extends Many2ManyTagsField {
     static components = {
         ...Many2ManyTagsField.components,
-        Many2XAutocomplete: Many2ManyTaxTagsAutocomplete,
+        Many2XAutocomplete: Many2XTaxTagsAutocomplete,
+    };
+}
+
+export class Many2OneTaxTagsField extends Many2OneField {
+    static components = {
+        ...Many2OneField.components,
+        Many2XAutocomplete: Many2XTaxTagsAutocomplete,
     };
 }
 
@@ -66,4 +75,11 @@ export const many2ManyTaxTagsField = {
     additionalClasses: ['o_field_many2many_tags']
 };
 
+export const many2OneTaxTagsField = {
+    ...many2OneField,
+    component: Many2OneTaxTagsField,
+    additionalClasses: ['o_field_many2one'],
+};
+
 registry.category("fields").add("many2many_tax_tags", many2ManyTaxTagsField);
+registry.category("fields").add("many2one_tax_tags", many2OneTaxTagsField);

--- a/addons/account/views/account_account_views.xml
+++ b/addons/account/views/account_account_views.xml
@@ -61,7 +61,7 @@
                                 <group>
                                     <group>
                                         <field name="account_type" widget="account_type_selection"/>
-                                        <field name="tax_ids" widget="many2many_tags" invisible="account_type == 'off_balance'" options="{'no_quick_create': True}"/>
+                                        <field name="tax_ids" widget="many2many_tax_tags" invisible="account_type == 'off_balance'" options="{'no_quick_create': True}"/>
                                         <field name="tag_ids" widget="many2many_tags" domain="[('applicability', '=', 'accounts')]" context="{'default_applicability': 'accounts'}" options="{'no_create_edit': True}"/>
                                         <field name="allowed_journal_ids" widget="many2many_tags" options="{'no_create_edit': True}"/>
                                     </group>
@@ -103,7 +103,7 @@
                     <field name="internal_group" column_invisible="True"/>
                     <field name="reconcile" widget="boolean_toggle" invisible="account_type in ('asset_cash', 'liability_credit_card', 'off_balance')"/>
                     <field name="non_trade" widget="boolean_toggle" invisible="account_type not in ('liability_payable', 'asset_receivable')" optional="hide"/>
-                    <field name="tax_ids" optional="hide" widget="many2many_tags"/>
+                    <field name="tax_ids" optional="hide" widget="many2many_tax_tags"/>
                     <field name="tag_ids" domain="[('applicability', '=', 'accounts')]" optional="hide" widget="many2many_tags"/>
                     <field name="allowed_journal_ids" optional="hide" widget="many2many_tags"/>
                     <field name="currency_id" options="{'no_create': True}" groups="base.group_multi_currency"/>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -37,7 +37,7 @@
 
                                     <group string="Taxes" invisible="not tax_line_id and not tax_ids">
                                         <field name="tax_line_id" readonly="1" invisible="not tax_line_id"/>
-                                        <field name="tax_ids" widget="many2many_tags" readonly="1" invisible="not tax_ids"/>
+                                        <field name="tax_ids" widget="many2many_tax_tags" readonly="1" invisible="not tax_ids"/>
                                         <field name="tax_tag_invert" readonly="1" groups="base.group_no_one"/>
                                     </group>
                                     <group string="Matching" invisible="not matched_debit_ids and not matched_credit_ids">
@@ -111,7 +111,7 @@
                             </div>
                             <div class="row">
                                 <div class="col-6">
-                                    <field name="tax_ids" widget="many2many_tags"/>
+                                    <field name="tax_ids" widget="many2many_tax_tags"/>
                                 </div>
                                 <div class="col-6 text-end">
                                     <t t-if="record.debit.raw_value > 0">
@@ -176,7 +176,7 @@
                            optional="hide"
                            options="{'product_field': 'product_id', 'account_field': 'account_id', 'force_applicability': 'optional'}"
                     />
-                    <field name="tax_ids" widget="many2many_tags" optional="hide" readonly="1"/>
+                    <field name="tax_ids" widget="many2many_tax_tags" optional="hide" readonly="1"/>
                     <field name="amount_currency" string="In Currency" groups="base.group_multi_currency" optional="hide" readonly="1" invisible="is_same_currency"/>
                     <field name="currency_id" groups="base.group_multi_currency" optional="hide" string="Currency" readonly="1" invisible="is_same_currency"/>
                     <field name="debit" sum="Total Debit" readonly="1"/>
@@ -1226,7 +1226,7 @@
                                             </group>
                                             <group>
                                                 <field name="account_id" domain="[('deprecated', '=', False)]" options="{'no_create': True}" context="{'partner_id': partner_id, 'move_type': parent.move_type}"/>
-                                                <field name="tax_ids" widget="many2many_tags"/>
+                                                <field name="tax_ids" widget="many2many_tax_tags"/>
                                                 <field name="analytic_distribution" widget="analytic_distribution" groups="analytic.group_analytic_accounting"/>
                                             </group>
                                             <group>
@@ -1301,7 +1301,7 @@
                                         <field name="currency_id" options="{'no_create': True}"
                                                optional="hide" groups="base.group_multi_currency"
                                                column_invisible="parent.move_type != 'entry'"/>
-                                        <field name="tax_ids" widget="autosave_many2many_tags"
+                                        <field name="tax_ids" widget="autosave_many2many_tax_tags"
                                                optional="hide"
                                                domain="[('type_tax_use', '=?', parent.invoice_filter_type_domain)]"
                                                context="{'append_type_to_tax_name': not parent.invoice_filter_type_domain, 'active_test': True}"
@@ -1374,7 +1374,7 @@
                                         <field name="debit" sum="Total Debit"/>
                                         <field name="credit" sum="Total Credit"/>
                                         <field name="balance" invisible="1"/>
-                                        <field name="tax_ids" string="Taxes Applied" widget="autosave_many2many_tags" options="{'no_create': True}"/>
+                                        <field name="tax_ids" string="Taxes Applied" widget="autosave_many2many_tax_tags" options="{'no_create': True}"/>
                                         <field name="date_maturity" required="0" invisible="context.get('view_no_maturity', False)"/>
                                       </group>
                                     </form>

--- a/addons/account/views/account_reconcile_model_views.xml
+++ b/addons/account/views/account_reconcile_model_views.xml
@@ -20,7 +20,7 @@
                                    domain="[('company_id', '=', company_id)]"
                                    options="{'no_create': True}"
                                    context="{'append_type_to_tax_name': True}"
-                                   widget="many2many_tags"/>
+                                   widget="many2many_tax_tags"/>
                             <field name="show_force_tax_included" invisible="1"/>
                             <field name="force_tax_included"
                                    invisible="not show_force_tax_included" force_save="1"/>
@@ -198,7 +198,7 @@
                                                    domain="[('type', '=', parent.counterpart_type)]"/>
                                             <field name="amount_string"/>
                                             <field name="tax_ids"
-                                                   widget="many2many_tags"
+                                                   widget="many2many_tax_tags"
                                                    optional="hide"
                                                    domain="[('type_tax_use', '=?', parent.counterpart_type if parent.counterpart_type in ('sale', 'purchase') and rule_type == 'writeoff_button' else None)]"/>
                                             <field name="analytic_distribution" widget="analytic_distribution"

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -62,7 +62,7 @@
                             <field name="tax_ids" widget="one2many" nolabel="1" context="{'append_type_to_tax_name': True}">
                                 <list name="tax_map_tree" string="Tax Mapping" editable="bottom" no_open="1" decoration-muted="tax_dest_id and not tax_dest_active">
                                     <field name="tax_dest_active" column_invisible="1"/>
-                                    <field name="tax_src_id"
+                                    <field name="tax_src_id" widget="many2one_tax_tags"
                                         domain="[
                                             ('type_tax_use', '!=', 'none'),
                                             ('country_id', '=', parent.company_country_id),
@@ -71,7 +71,7 @@
                                         context="{'append_type_to_tax_name': True}"
                                     />
 
-                                    <field name="tax_dest_id"
+                                    <field name="tax_dest_id" widget="many2one_tax_tags"
                                         domain="[
                                             ('type_tax_use', '!=', 'none'),
                                             ('country_id', '=', parent.country_id if parent.foreign_vat else parent.company_country_id),

--- a/addons/account/views/product_view.xml
+++ b/addons/account/views/product_view.xml
@@ -10,8 +10,8 @@
                     <field name="default_code"/>
                     <field name="name"/>
                     <field name="list_price"/>
-                    <field name="taxes_id" widget="many2many_tags"/>
-                    <field name="supplier_taxes_id" widget="many2many_tags"/>
+                    <field name="taxes_id" widget="many2many_tax_tags"/>
+                    <field name="supplier_taxes_id" widget="many2many_tax_tags"/>
                     <field name="activity_exception_decoration" widget="activity_exception"/>
                 </list>
             </field>
@@ -75,7 +75,7 @@
                     <div name="taxes_div" class="o_row" invisible="type == 'combo'">
                         <field
                             name="taxes_id"
-                            widget="many2many_tags"
+                            widget="many2many_tax_tags"
                             class="oe_inline"
                             context="{
                                 'default_type_tax_use': 'sale',
@@ -90,7 +90,7 @@
                 <div name="standard_price_uom" position="after">
                     <field name="supplier_taxes_id"
                         invisible="not purchase_ok or type == 'combo'"
-                        widget="many2many_tags"
+                        widget="many2many_tax_tags"
                         context="{
                             'default_type_tax_use':'purchase',
                             'search_default_purchase': 1,

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -47,11 +47,11 @@
                                 <div class="content-group">
                                     <div class="row mt16">
                                         <label string="Sales Tax" for="sale_tax_id" class="col-lg-3 o_light_label"/>
-                                        <field name="sale_tax_id" domain="[('type_tax_use', 'in', ('sale', 'all'))]"/>
+                                        <field name="sale_tax_id" widget="many2one_tax_tags" domain="[('type_tax_use', 'in', ('sale', 'all'))]"/>
                                     </div>
                                     <div class="row">
                                         <label string="Purchase Tax" for="purchase_tax_id" class="col-lg-3 o_light_label"/>
-                                        <field name="purchase_tax_id" domain="[('type_tax_use', 'in', ('purchase', 'all'))]"/>
+                                        <field name="purchase_tax_id" widget="many2one_tax_tags" domain="[('type_tax_use', 'in', ('purchase', 'all'))]"/>
                                     </div>
                                     <div class="row">
                                         <div class="col-lg-3">

--- a/addons/account/wizard/setup_wizards_view.xml
+++ b/addons/account/wizard/setup_wizards_view.xml
@@ -69,7 +69,7 @@
                     <field name="opening_debit" options="{'no_symbol': True}"/>
                     <field name="opening_credit" options="{'no_symbol': True}"/>
                     <field name="opening_balance" optional="hide" options="{'no_symbol': True}"/>
-                    <field name="tax_ids" optional="hide" widget="many2many_tags"/>
+                    <field name="tax_ids" optional="hide" widget="many2many_tax_tags"/>
                     <field name="tag_ids" optional="hide" widget="many2many_tags"/>
                     <field name="allowed_journal_ids" optional="hide" widget="many2many_tags"/>
                 </list>

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -71,7 +71,7 @@
                     <field name="price_unit" string="Unit Price" optional="hide" widget="monetary"
                            options="{'currency_field': 'company_currency_id', 'field_digits': True}" readonly="True"/>
                     <field name="quantity" optional="hide" readonly="not is_editable or not product_has_cost"/>
-                    <field name="tax_ids" optional="hide" widget="many2many_tags"
+                    <field name="tax_ids" optional="hide" widget="many2many_tax_tags"
                            groups="account.group_account_invoice,account.group_account_readonly"
                            readonly="not is_editable or not product_has_cost"/>
                     <field name="tax_amount" sum="Total Taxes" readonly="True"
@@ -222,7 +222,7 @@
                             <div class="o_row">
                                 <field name="tax_ids"
                                        force_save="1"
-                                       widget="many2many_tags"
+                                       widget="many2many_tax_tags"
                                        readonly="not is_editable"
                                        options="{'no_create': True}"/>
                                 <field name="tax_amount_currency"/>
@@ -593,7 +593,7 @@
                             </group>
                             <group>
                                 <field name="property_account_expense_id" class="w-50" groups="account.group_account_readonly"/>
-                                <field name="supplier_taxes_id" class="w-50" widget="many2many_tags"
+                                <field name="supplier_taxes_id" class="w-50" widget="many2many_tax_tags"
                                        context="{'default_type_tax_use':'purchase', 'default_price_include': 1}"
                                        options="{'no_quick_create': True}" placeholder="no taxes"/>
                             </group>
@@ -645,7 +645,7 @@
                     <field name="description" string="Note" optional="show" readonly="1"/>
                     <field name="lst_price" widget='monetary' options="{'currency_field': 'currency_id', 'field_digits': True}" optional="show" string="Sales Price"/>
                     <field name="standard_price" widget='monetary' options="{'currency_field': 'currency_id', 'field_digits': True}" optional="show"/>
-                    <field name="supplier_taxes_id" widget="many2many_tags" optional="show"/>
+                    <field name="supplier_taxes_id" widget="many2many_tax_tags" optional="show"/>
                 </list>
             </field>
         </record>
@@ -903,7 +903,7 @@
                                     <field name="price_unit" optional="hide" widget="monetary" options="{'currency_field': 'company_currency_id', 'field_digits': True}" readonly="True"/>
                                     <field name="currency_id" optional="hide" readonly="True" groups="base.group_multi_currency"/>
                                     <field name="quantity" optional="hide" readonly="True"/>
-                                    <field name="tax_ids" string="Taxes" optional="show" widget="many2many_tags"
+                                    <field name="tax_ids" string="Taxes" optional="show" widget="many2many_tax_tags"
                                            context="{'default_company_id': company_id}" readonly="True"/>
                                     <field name="tax_amount_currency" optional="hide"  options="{'currency_field': 'currency_id'}"
                                            context="{'default_company_id': company_id}" readonly="True" groups="base.group_multi_currency"/>

--- a/addons/hr_expense/wizard/hr_expense_split_wizard_views.xml
+++ b/addons/hr_expense/wizard/hr_expense_split_wizard_views.xml
@@ -22,7 +22,7 @@
                             <field name="name"/>
                             <field name="product_id"/>
                             <field name="employee_id" widget="many2one_avatar_user"/>
-                            <field name="tax_ids" widget="many2many_tags" readonly="not product_has_tax"/>
+                            <field name="tax_ids" widget="many2many_tax_tags" readonly="not product_has_tax"/>
                             <field name="tax_amount_currency"/>
                             <field name="analytic_distribution" widget="analytic_distribution"
                                 optional="show"

--- a/addons/l10n_ar_withholding/views/res_partner_view.xml
+++ b/addons/l10n_ar_withholding/views/res_partner_view.xml
@@ -10,7 +10,7 @@
                 <group string="Purchase Withholding" invisible="'AR' not in fiscal_country_codes or not is_company">
                     <field name="l10n_ar_partner_tax_ids" nolabel="1" colspan="2" widget="auto_save_res_partner">
                         <list editable="top">
-                            <field name="tax_id" options="{'no_create': True, 'no_open': True}" domain="[('l10n_ar_withholding_payment_type', '=', 'supplier')]"/>
+                            <field name="tax_id" widget="many2one_tax_tags" options="{'no_create': True, 'no_open': True}" domain="[('l10n_ar_withholding_payment_type', '=', 'supplier')]"/>
                             <field name="from_date" optional="hide"/>
                             <field name="to_date" optional="hide"/>
                             <field name="ref" optional="hide"/>

--- a/addons/l10n_ar_withholding/wizards/account_payment_register_views.xml
+++ b/addons/l10n_ar_withholding/wizards/account_payment_register_views.xml
@@ -12,7 +12,7 @@
                             <field name="withholding_sequence_id" column_invisible="True"/>
                             <field name="company_id" column_invisible="True"/>
                             <field name="currency_id" column_invisible="True"/>
-                            <field name="tax_id" options="{'no_open': True, 'no_create': True}"/>
+                            <field name="tax_id" widget="many2one_tax_tags" options="{'no_open': True, 'no_create': True}"/>
                             <field name="name" readonly="withholding_sequence_id"/>
                             <field name="base_amount"/>
                             <field name="amount"/>

--- a/addons/l10n_in_ewaybill_stock/views/l10n_in_ewaybill_views.xml
+++ b/addons/l10n_in_ewaybill_stock/views/l10n_in_ewaybill_views.xml
@@ -124,7 +124,7 @@
                                     <field name="product_id" readonly="1"/>
                                     <field name="quantity" string="Quantity" readonly="1"/>
                                     <field name="ewaybill_price_unit" string="Unit Price"/>
-                                    <field name="ewaybill_tax_ids" widget="many2many_tags"/>
+                                    <field name="ewaybill_tax_ids" widget="many2many_tax_tags"/>
                                 </list>
                             </field>
                         </page>

--- a/addons/l10n_in_withholding/views/account_move_line_views.xml
+++ b/addons/l10n_in_withholding/views/account_move_line_views.xml
@@ -7,7 +7,7 @@
         <field name="mode">primary</field>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='l10n_in_hsn_code']" position="after">
-                <field name="tax_ids" widget="many2many_tags" domain="[('type_tax_use', '=', 'sale')]"/>
+                <field name="tax_ids" widget="many2many_tax_tags" domain="[('type_tax_use', '=', 'sale')]"/>
             </xpath>
         </field>
     </record>

--- a/addons/l10n_in_withholding/views/account_move_views.xml
+++ b/addons/l10n_in_withholding/views/account_move_views.xml
@@ -26,7 +26,7 @@
                 <page name="withholding_tab" string="TDS Information" invisible="not l10n_in_withholding_line_ids">
                     <field name="l10n_in_withholding_line_ids" nolabel="1" colspan="4">
                         <list editable="bottom" string="TDS Information">
-                            <field name="tax_ids" string="Tax" widget="many2many_tags"/>
+                            <field name="tax_ids" string="Tax" widget="many2many_tax_tags"/>
                             <field name="price_subtotal" string="Base Amount" sum="Total"/>
                             <field name="l10n_in_withhold_tax_amount" string="TDS Amount" sum="Total"/>
                         </list>
@@ -45,7 +45,7 @@
                 <field name="name" widget="section_and_note_text"/>
                 <field name="account_id"/>
                 <field name="tax_ids"
-                       widget="many2many_tags"
+                       widget="many2many_tax_tags"
                        domain="[('type_tax_use', '=', context.get('default_tax_type_use'))]"
                        column_invisible="context.get('move_type')"/>
                 <field name="l10n_in_tds_tcs_section_id" string="Suggested Section"/>

--- a/addons/l10n_in_withholding/wizard/l10n_in_withhold_wizard.xml
+++ b/addons/l10n_in_withholding/wizard/l10n_in_withhold_wizard.xml
@@ -23,7 +23,7 @@
                         <group id="header_left_group">
                             <field name="date" string="Entry Date"/>
                             <field name="base" widget="monetary" options="{'currency_field': 'currency_id'}" required="True"/>
-                            <field name="tax_id" domain="[('l10n_in_tds_tax_type', '=', l10n_in_tds_tax_type)]" required="True"/>
+                            <field name="tax_id" widget="many2one_tax_tags" domain="[('l10n_in_tds_tax_type', '=', l10n_in_tds_tax_type)]" required="True"/>
                             <field name="amount" widget="monetary" options="{'currency_field': 'currency_id'}"/>
                             <field name="currency_id" invisible="1"/>
                             <field name="related_move_id" invisible="1"/> <!-- used to compute the l10n_in_tds_tax_type -->

--- a/addons/loyalty/views/loyalty_reward_views.xml
+++ b/addons/loyalty/views/loyalty_reward_views.xml
@@ -40,7 +40,7 @@
                             <field
                                 name="tax_ids"
                                 placeholder="Untaxed discount"
-                                widget="many2many_tags"
+                                widget="many2many_tax_tags"
                                 options="{'no_create': True}"
                                 invisible="discount_applicability != 'order' or
                                     discount_mode not in ('per_order','per_point')"

--- a/addons/membership/views/product_views.xml
+++ b/addons/membership/views/product_views.xml
@@ -89,7 +89,7 @@
                                 <field name="list_price" string="Membership Fee"/>
                                 <field
                                     name="property_account_income_id"/>
-                                <field name="taxes_id" widget="many2many_tags" string="Taxes"/>
+                                <field name="taxes_id" widget="many2many_tax_tags" string="Taxes"/>
                             </group>
                         </group>
                         <label for="description"/>

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -95,8 +95,8 @@
                                 <field name="margin" invisible="not is_total_cost_computed" optional="hide" widget="monetary"/>
                                 <field name="margin_percent" invisible="not is_total_cost_computed" optional="hide" widget="percentage"/>
                                 <field name="discount" width="50px" string="Disc.%"/>
-                                <field name="tax_ids_after_fiscal_position" widget="many2many_tags" string="Taxes"/>
-                                <field name="tax_ids" widget="many2many_tags" column_invisible="True"/>
+                                <field name="tax_ids_after_fiscal_position" widget="many2many_tax_tags" string="Taxes"/>
+                                <field name="tax_ids" widget="many2many_tax_tags" column_invisible="True"/>
                                 <field name="price_subtotal" widget="monetary" force_save="1"/>
                                 <field name="price_subtotal_incl" widget="monetary" force_save="1"/>
                                 <field name="currency_id" column_invisible="True"/>
@@ -110,8 +110,8 @@
                                     <field name="price_unit" widget="monetary"/>
                                     <field name="price_subtotal" invisible="1" widget="monetary" force_save="1"/>
                                     <field name="price_subtotal_incl" invisible="1" widget="monetary" force_save="1"/>
-                                    <field name="tax_ids_after_fiscal_position" widget="many2many_tags" string="Taxes"/>
-                                    <field name="tax_ids" widget="many2many_tags" invisible="1"/>
+                                    <field name="tax_ids_after_fiscal_position" widget="many2many_tax_tags" string="Taxes"/>
+                                    <field name="tax_ids" widget="many2many_tax_tags" invisible="1"/>
                                     <field name="pack_lot_ids" widget="many2many_tags" groups="stock.group_production_lot"/>
                                     <field name="notice"/>
                                     <field name="currency_id" invisible="1"/>

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -163,7 +163,7 @@
                                     Default sales tax for products
                                 </div>
                                 <div class="content-group mt16">
-                                    <field name="sale_tax_id" colspan="4" nolabel="1" domain="[('type_tax_use', 'in', ('sale', 'all'))]"/>
+                                    <field name="sale_tax_id" widget="many2one_tax_tags" colspan="4" nolabel="1" domain="[('type_tax_use', 'in', ('sale', 'all'))]"/>
                                 </div>
                                 <div class="mt8">
                                     <button name="%(account.action_tax_form)d" icon="oi-arrow-right" type="action" string="Taxes" class="btn-link"/>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -265,7 +265,7 @@
                                     <field name="product_packaging_id" invisible="not product_id" context="{'default_product_id': product_id, 'list_view_ref':'product.product_packaging_tree_view', 'form_view_ref':'product.product_packaging_form_view'}" groups="product.group_stock_packaging" optional="show"/>
                                     <field name="price_unit" readonly="qty_invoiced != 0"/>
                                     <button name="action_purchase_history" type="object" icon="fa-history" title="Purchase History" invisible="not id"/>
-                                    <field name="taxes_id" widget="many2many_tags" domain="[('type_tax_use', '=', 'purchase'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id), ('active', '=', True)]" context="{'default_type_tax_use': 'purchase', 'search_view_ref': 'account.account_tax_view_search'}" options="{'no_create': True}" optional="show" readonly="is_downpayment"/>
+                                    <field name="taxes_id" widget="many2many_tax_tags" domain="[('type_tax_use', '=', 'purchase'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id), ('active', '=', True)]" context="{'default_type_tax_use': 'purchase', 'search_view_ref': 'account.account_tax_view_search'}" options="{'no_create': True}" optional="show" readonly="is_downpayment"/>
                                     <field name="discount" string="Disc.%" width="50px" readonly="qty_invoiced != 0" optional="hide"/>
                                     <field name="price_subtotal" string="Amount"/>
                                 </list>
@@ -295,7 +295,7 @@
                                                 <field name="product_packaging_id" invisible="not product_id" context="{'default_product_id': product_id, 'list_view_ref':'product.product_packaging_tree_view', 'form_view_ref':'product.product_packaging_form_view'}" groups="product.group_stock_packaging" />
                                                 <field name="price_unit"/>
                                                 <field name="discount"/>
-                                                <field name="taxes_id" widget="many2many_tags" domain="[('type_tax_use', '=', 'purchase'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id)]" options="{'no_create': True}"/>
+                                                <field name="taxes_id" widget="many2many_tax_tags" domain="[('type_tax_use', '=', 'purchase'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id)]" options="{'no_create': True}"/>
                                             </group>
                                             <group>
                                                 <field name="date_planned" required="not display_type and not is_downpayment"/>
@@ -737,7 +737,7 @@
                                 <field name="price_unit"/>
                             </group>
                             <group>
-                                <field name="taxes_id" widget="many2many_tags"
+                                <field name="taxes_id" widget="many2many_tax_tags"
                                     domain="[('type_tax_use', '=', 'purchase')]"/>
                                 <field name="date_planned" readonly="1"/>
                                 <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>

--- a/addons/sale/views/sale_order_line_views.xml
+++ b/addons/sale/views/sale_order_line_views.xml
@@ -79,7 +79,7 @@
                                    invisible="company_price_include == 'tax_excluded'"
                                 />
                             <field name="tax_ids"
-                                widget="many2many_tags"
+                                widget="many2many_tax_tags"
                                 options="{'no_create': True}"
                                 context="{'search_view_ref': 'account.account_tax_view_search'}"
                                 domain="[('type_tax_use', '=', 'sale'), ('company_id', '=', company_id), ('country_id', '=', tax_country_id)]"

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -470,7 +470,7 @@
                                         <field name="product_packaging_qty" invisible="not product_id or not product_packaging_id" groups="product.group_stock_packaging"/>
                                         <field name="product_packaging_id" invisible="not product_id" context="{'default_product_id': product_id, 'list_view_ref':'product.product_packaging_tree_view', 'form_view_ref':'product.product_packaging_form_view'}" groups="product.group_stock_packaging" />
                                         <field name="price_unit"/>
-                                        <field name="tax_ids" widget="many2many_tags" options="{'no_create': True}" context="{'search_view_ref': 'account.account_tax_view_search'}" domain="[('type_tax_use', '=', 'sale'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id)]"
+                                        <field name="tax_ids" widget="many2many_tax_tags" options="{'no_create': True}" context="{'search_view_ref': 'account.account_tax_view_search'}" domain="[('type_tax_use', '=', 'sale'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id)]"
                                             readonly="qty_invoiced &gt; 0"/>
                                         <t groups="sale.group_discount_per_so_line">
                                             <label for="discount"/>
@@ -641,7 +641,7 @@
                                 <field name="technical_price_unit" column_invisible="1"/>
                                 <field
                                     name="tax_ids"
-                                    widget="many2many_tags"
+                                    widget="many2many_tax_tags"
                                     options="{'no_create': True}"
                                     domain="[('type_tax_use', '=', 'sale'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id)]"
                                     context="{'active_test': True}"

--- a/addons/sale/wizard/sale_order_discount_views.xml
+++ b/addons/sale/wizard/sale_order_discount_views.xml
@@ -24,7 +24,7 @@
                                 <field
                                     name="tax_ids"
                                     placeholder="Untaxed discount"
-                                    widget="many2many_tags"
+                                    widget="many2many_tax_tags"
                                     options="{'no_create': True}"
                                     invisible="discount_type != 'amount'"
                                 />

--- a/addons/sale_expense/views/product_view.xml
+++ b/addons/sale_expense/views/product_view.xml
@@ -19,7 +19,7 @@
                 <field name="list_price" invisible="expense_policy != 'sales_price'"/>
             </xpath>
             <xpath expr="//field[@name='supplier_taxes_id']" position="after">
-                <field name="taxes_id" widget="many2many_tags" invisible="expense_policy == 'no'"
+                <field name="taxes_id" widget="many2many_tax_tags" invisible="expense_policy == 'no'"
                        options="{'no_quick_create': True}" class="w-50"/>
             </xpath>
         </field>


### PR DESCRIPTION
where * = hr_expense, loyalty, membership, point_of_sale, purchase, sale, sale_expense.

Before this **PR**:
Tax fields in some modules were not showing tax scope during the tax selection.

After this **PR**:
1) Tax fields are now consistent and displays tax scope
   during tax selection.
2) 'many2one_tax_tags' widget, similar to 'many2many_tax_tags' widget, has been
   augmented for many2one fields.
3) The 'autosave_many2many_tags' widget has been renamed to
   'autosave_many2many_tax_tags' to use the 'many2many_tax_tags' widget instead of
   the 'many2many_tags' widget, enabling support for the additional features
   provided by 'many2many_tax_tags'.

**task**-4184119

**Enterprise PR** - https://github.com/odoo/enterprise/pull/72179