### PR TITLE
[FIX] web: traceback when getting file name of binary field

### DIFF
--- a/addons/web/static/src/views/fields/binary/binary_field.js
+++ b/addons/web/static/src/views/fields/binary/binary_field.js
@@ -31,11 +31,11 @@ export class BinaryField extends Component {
     }
 
     get fileName() {
-        return (
-            this.props.record.data[this.props.fileNameField] ||
-            this.props.record.data[this.props.name] ||
-            ""
-        ).slice(0, toBase64Length(MAX_FILENAME_SIZE_BYTES));
+        const fileName = this.props.record.data[this.props.fileNameField] || this.props.record.data[this.props.name] || "";
+        if (typeof fileName === "string") {
+            return fileName.slice(0, toBase64Length(MAX_FILENAME_SIZE_BYTES));
+        }
+        return "";
     }
 
     update({ data, name }) {


### PR DESCRIPTION
* STEP TO REPRODUCE: install account -> journals -> Bank journal -> View Journal Items -> Click on any bank journal item -> traceback
* REASON: When click on Bank journal item, system take use to account.bank.statement.line form view , there we have some field for example needed_terms is binary so the system try to retreive filename for it but it fails because when using this.props.record.data[this.props.name] it will return a proxy object which is not a string
* SOLUTION: check the return value if a string we do a slice for it else return empty string

Video reproduce on runbot (17/10/2024): 
https://github.com/user-attachments/assets/b520e27a-09db-4f55-9b6d-4a2ef202047e




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
