### PR TITLE
[IMP] account: add company name to kanban view while drag and drop

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -395,6 +395,7 @@ class AccountJournal(models.Model):
             dashboard_data[journal.id] = {
                 'currency_id': journal.currency_id.id or journal.company_id.sudo().currency_id.id,
                 'show_company': len(self.env.companies) > 1 or journal.company_id.id != self.env.company.id,
+                'company_name': journal.company_id.name,
             }
         self._fill_bank_cash_dashboard_data(dashboard_data)
         self._fill_sale_purchase_dashboard_data(dashboard_data)

--- a/addons/account/static/src/components/upload_drop_zone/upload_drop_zone.js
+++ b/addons/account/static/src/components/upload_drop_zone/upload_drop_zone.js
@@ -11,6 +11,8 @@ export class UploadDropZone extends Component {
         dragIcon: { type: String, optional: true },
         dragText: { type: String, optional: true },
         dragTitle: { type: String, optional: true },
+        dragCompany: { type: String, optional: true },
+        dragShowCompany: { type: Boolean, optional: true },
     };
     static defaultProps = {
         hideZone: () => {},

--- a/addons/account/static/src/components/upload_drop_zone/upload_drop_zone.xml
+++ b/addons/account/static/src/components/upload_drop_zone/upload_drop_zone.xml
@@ -25,6 +25,11 @@
                     <div class="h3 pe-none" t-att-class="{'text-primary': props.visible}">
                         <t t-out="props.dragTitle"/>
                     </div>
+                    <t t-if="props.dragShowCompany">
+                        <div t-att-class="{'text-primary': props.visible}">
+                            <span class="small fw-bold">(<t t-out="props.dragCompany"/>)</span>
+                        </div>
+                    </t>
                   <div class="pe-none">
                       <span t-att-class="{'invisible': !props.visible, 'text-primary': props.visible}">
                           <t t-out="props.dragText"/>

--- a/addons/account/static/src/views/account_dashboard_kanban/account_dashboard_kanban_record.js
+++ b/addons/account/static/src/views/account_dashboard_kanban/account_dashboard_kanban_record.js
@@ -36,15 +36,23 @@ export class DashboardKanbanRecord extends KanbanRecord {
     }
 
     get recordDropSettings() {
-        return JSON.parse(this.props.record.data.kanban_dashboard).drag_drop_settings;
+        const kanbanDashboard = JSON.parse(this.props.record.data.kanban_dashboard);
+        return {
+            image: kanbanDashboard.drag_drop_settings.image,
+            text: kanbanDashboard.drag_drop_settings.text,
+            company_name: kanbanDashboard.company_name,
+            show_company: kanbanDashboard.show_company
+        };
     }
 
     get dropzoneProps() {
-        const {image, text} = this.recordDropSettings;
+        const recordDropSettings = this.recordDropSettings;
         return {
             visible: this.dropzoneState.visible,
-            dragIcon: image,
-            dragText: text,
+            dragIcon: recordDropSettings.image,
+            dragText: recordDropSettings.text,
+            dragCompany: recordDropSettings.company_name,
+            dragShowCompany: recordDropSettings.show_company,
             dragTitle: this.props.record.data.name,
             hideZone: () => { this.dropzoneState.visible = false; },
         }


### PR DESCRIPTION
When multiple companies are selected and a file is uploaded via drag-and-drop on accounting dashboard, the company name does not appear on the journal, leading to confusion about which journal the file should be dropped into.

> task-4246889