### PR TITLE
[FIX] point_of_sale: synchronize cashier info on order and receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -109,7 +109,7 @@ export class PosOrder extends Base {
             change: this.amount_return,
             name: this.pos_reference,
             invoice_id: null, //TODO
-            cashier: this.employee_id?.name || this.user_id?.name,
+            cashier: this.getCashierName(),
             date: formatDateTime(parseUTCString(this.date_order)),
             pos_qr_code:
                 this.company.point_of_sale_use_ticket_qr_code &&
@@ -126,6 +126,9 @@ export class PosOrder extends Base {
                 trackingNumber: this.tracking_number,
             },
         };
+    }
+    getCashierName() {
+        return this.user_id?.name;
     }
     canPay() {
         return this.lines.length;

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1637,7 +1637,7 @@ export class PosStore extends Reactive {
     getReceiptHeaderData(order) {
         return {
             company: this.company,
-            cashier: _t("Served by %s", this.get_cashier()?.name),
+            cashier: _t("Served by %s", order.getCashierName() || this.get_cashier()?.name),
             header: this.config.receipt_header,
         };
     }

--- a/addons/pos_hr/static/src/overrides/models/pos_order.js
+++ b/addons/pos_hr/static/src/overrides/models/pos_order.js
@@ -1,0 +1,9 @@
+import { PosOrder } from "@point_of_sale/app/models/pos_order";
+import { patch } from "@web/core/utils/patch";
+
+patch(PosOrder.prototype, {
+    // @Override
+    getCashierName() {
+        return this.employee_id?.name || super.getCashierName(...arguments);
+    },
+});


### PR DESCRIPTION
Before this commit, adding a product to an order and then changing the cashier would not update the cashier information on the captured order, resulting in the previous cashier being recorded. However, the printed receipt would display the current cashier, leading to inconsistency.

opw-4257705

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
