### PR TITLE
[IMP] web: add base64 pdf o_image mimetype

### DIFF
--- a/addons/web/static/src/scss/mimetypes.scss
+++ b/addons/web/static/src/scss/mimetypes.scss
@@ -25,7 +25,7 @@
     &[data-mimetype$='archive'], &[data-mimetype$='compressed'], &[data-mimetype*='zip'], &[data-mimetype$='tar'], &[data-mimetype*='package'] {
         background-image: url('/web/static/img/mimetypes/archive.svg');
     }
-    &[data-mimetype='application/pdf'] {
+    &[data-mimetype^='application/pdf'] {
         background-image: url('/web/static/img/mimetypes/pdf.svg');
     }
     &[data-mimetype^='text-master'], &[data-mimetype*='document'], &[data-mimetype*='msword'], &[data-mimetype*='wordprocessing'] {


### PR DESCRIPTION
In the o_image scss, add support for the 'application/pdf;base64' mimetype
so that these files are also represented with the pdf background image.

Task-4263142

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
