### PR TITLE
18.0 clean api delegate trigger nby

### DIFF
--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -4,7 +4,7 @@ import { closestBlock, isBlock } from "../utils/blocks";
 import { unwrapContents } from "../utils/dom";
 import { ancestors, childNodes, closestElement } from "../utils/dom_traversal";
 import { parseHTML } from "../utils/html";
-import { delegate } from "@html_editor/utils/resource";
+import { delegate, trigger } from "@html_editor/utils/resource";
 
 /**
  * @typedef { import("./selection_plugin").EditorSelection } EditorSelection
@@ -212,7 +212,7 @@ export class ClipboardPlugin extends Plugin {
 
         this.dispatch("HISTORY_STAGE_SELECTION");
 
-        this.getResource("before_paste").forEach((handler) => handler(selection));
+        trigger(this.getResource("before_paste"), selection);
         // refresh selection after potential changes from `before_paste` handlers
         selection = this.shared.getEditableSelection();
 

--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -4,6 +4,7 @@ import { closestBlock, isBlock } from "../utils/blocks";
 import { unwrapContents } from "../utils/dom";
 import { ancestors, childNodes, closestElement } from "../utils/dom_traversal";
 import { parseHTML } from "../utils/html";
+import { delegate } from "@html_editor/utils/resource";
 
 /**
  * @typedef { import("./selection_plugin").EditorSelection } EditorSelection
@@ -284,7 +285,7 @@ export class ClipboardPlugin extends Plugin {
      */
     handlePasteText(selection, clipboardData) {
         const text = clipboardData.getData("text/plain");
-        if (this.getResource("handle_paste_text").some((handler) => handler(selection, text))) {
+        if (delegate(this.getResource("handle_paste_text"), text)) {
             return;
         } else {
             this.pasteText(selection, text);

--- a/addons/html_editor/static/src/core/comment_plugin.js
+++ b/addons/html_editor/static/src/core/comment_plugin.js
@@ -4,14 +4,9 @@ import { descendants } from "../utils/dom_traversal";
 
 export class CommentPlugin extends Plugin {
     static name = "comment";
-
-    handleCommand(command, payload) {
-        switch (command) {
-            case "NORMALIZE":
-                this.removeComment(payload.node);
-                break;
-        }
-    }
+    resources = {
+        normalize_listeners: this.removeComment.bind(this),
+    };
 
     removeComment(node) {
         for (const el of [node, ...descendants(node)]) {

--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -38,7 +38,7 @@ import {
     startPos,
 } from "../utils/position";
 import { CTYPES } from "../utils/content_types";
-import { withSequence } from "@html_editor/utils/resource";
+import { delegate, withSequence } from "@html_editor/utils/resource";
 
 /**
  * @typedef {Object} RangeLike
@@ -139,10 +139,8 @@ export class DeletePlugin extends Plugin {
             this.fullyIncludeLinks,
         ]);
 
-        for (const callback of this.getResource("handle_delete_range")) {
-            if (callback(range)) {
-                return;
-            }
+        if (delegate(this.getResource("handle_delete_range"), range)) {
+            return;
         }
 
         range = this.deleteRange(range);
@@ -188,11 +186,8 @@ export class DeletePlugin extends Plugin {
             word: "handle_delete_backward_word",
             line: "handle_delete_backward_line",
         };
-        const handlers = this.getResource(resourceIds[granularity]);
-        for (const handler of handlers) {
-            if (handler(range)) {
-                return;
-            }
+        if (delegate(this.getResource(resourceIds[granularity]), range)) {
+            return;
         }
 
         range = this.adjustRange(range, [
@@ -219,11 +214,8 @@ export class DeletePlugin extends Plugin {
             word: "handle_delete_forward_word",
             line: "handle_delete_forward_line",
         };
-        const handlers = this.getResource(resourceIds[granularity]);
-        for (const handler of handlers) {
-            if (handler(range)) {
-                return;
-            }
+        if (delegate(this.getResource(resourceIds[granularity]), range)) {
+            return;
         }
 
         range = this.adjustRange(range, [

--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -16,7 +16,7 @@ import { boundariesIn, boundariesOut, DIRECTIONS, leftPos, rightPos } from "../u
 import { prepareUpdate } from "@html_editor/utils/dom_state";
 import { _t } from "@web/core/l10n/translation";
 import { callbacksForCursorUpdate } from "@html_editor/utils/selection";
-import { withSequence } from "@html_editor/utils/resource";
+import { trigger, withSequence } from "@html_editor/utils/resource";
 
 const allWhitespaceRegex = /^[\s\u200b]*$/;
 
@@ -153,9 +153,7 @@ export class FormatPlugin extends Plugin {
             }
             this._formatSelection(format, { applyStyle: false });
         }
-        for (const callback of this.getResource("removeFormat")) {
-            callback();
-        }
+        trigger(this.getResource("removeFormat"));
         this.dispatch("ADD_STEP");
     }
 

--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -1,4 +1,4 @@
-import { delegate } from "@html_editor/utils/resource";
+import { delegate, trigger } from "@html_editor/utils/resource";
 import { Plugin } from "../plugin";
 import { childNodes, descendants, getCommonAncestor } from "../utils/dom_traversal";
 
@@ -182,7 +182,7 @@ export class HistoryPlugin extends Plugin {
         }
         this.steps = steps;
         // todo: to test
-        this.getResource("historyResetFromSteps").forEach((cb) => cb());
+        trigger(this.getResource("historyResetFromSteps"));
 
         this.enableObserver();
         this.dispatch("HISTORY_RESET_FROM_STEPS");

--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -1,3 +1,4 @@
+import { delegate } from "@html_editor/utils/resource";
 import { Plugin } from "../plugin";
 import { childNodes, descendants, getCommonAncestor } from "../utils/dom_traversal";
 
@@ -651,13 +652,12 @@ export class HistoryPlugin extends Plugin {
      * @param { number } index
      */
     isReversibleStep(index) {
-        for (const cb of this.getResource("is_reversible_step")) {
-            const result = cb(index);
-            if (typeof result !== "undefined") {
-                return result;
-            }
+        const cbs = this.getResource("is_reversible_step");
+        if (cbs.length) {
+            return cbs.every((cb) => cb(index));
+        } else {
+            return Boolean(this.steps[index]);
         }
-        return Boolean(this.steps[index]);
     }
     /**
      * Get the step index in the history to redo.
@@ -1001,12 +1001,10 @@ export class HistoryPlugin extends Plugin {
      * @param { string } attributeValue
      */
     setAttribute(node, attributeName, attributeValue) {
-        for (const cb of this.getResource("set_attribute")) {
-            const result = cb(node, attributeName, attributeValue);
-            if (result) {
-                return;
-            }
+        if (delegate(this.getResource("set_attribute"), node, attributeName, attributeValue)) {
+            return;
         }
+
         // if attributeValue is falsy but not null, we still need to apply it
         if (attributeValue !== null) {
             node.setAttribute(attributeName, attributeValue);

--- a/addons/html_editor/static/src/core/input_plugin.js
+++ b/addons/html_editor/static/src/core/input_plugin.js
@@ -3,18 +3,19 @@ import { Plugin } from "../plugin";
 
 export class InputPlugin extends Plugin {
     static name = "input";
+    static dependencies = ["history"];
     setup() {
         this.addDomListener(this.editable, "beforeinput", this.onBeforeInput);
         this.addDomListener(this.editable, "input", this.onInput);
     }
 
     onBeforeInput(ev) {
-        this.dispatch("HISTORY_STAGE_SELECTION");
+        this.shared.stageSelection();
         trigger(this.getResource("onBeforeInput"), ev);
     }
 
     onInput(ev) {
-        this.dispatch("ADD_STEP");
+        this.shared.addStep();
         trigger(this.getResource("onInput"), ev);
     }
 }

--- a/addons/html_editor/static/src/core/input_plugin.js
+++ b/addons/html_editor/static/src/core/input_plugin.js
@@ -1,3 +1,4 @@
+import { trigger } from "@html_editor/utils/resource";
 import { Plugin } from "../plugin";
 
 export class InputPlugin extends Plugin {
@@ -9,15 +10,11 @@ export class InputPlugin extends Plugin {
 
     onBeforeInput(ev) {
         this.dispatch("HISTORY_STAGE_SELECTION");
-        for (const handler of this.getResource("onBeforeInput")) {
-            handler(ev);
-        }
+        trigger(this.getResource("onBeforeInput"), ev);
     }
 
     onInput(ev) {
         this.dispatch("ADD_STEP");
-        for (const handler of this.getResource("onInput")) {
-            handler(ev);
-        }
+        trigger(this.getResource("onInput"), ev);
     }
 }

--- a/addons/html_editor/static/src/core/line_break_plugin.js
+++ b/addons/html_editor/static/src/core/line_break_plugin.js
@@ -1,3 +1,4 @@
+import { delegate } from "@html_editor/utils/resource";
 import { Plugin } from "../plugin";
 import { CTYPES } from "../utils/content_types";
 import { getState, isFakeLineBreak, prepareUpdate } from "../utils/dom_state";
@@ -47,10 +48,13 @@ export class LineBreakPlugin extends Plugin {
             targetNode = targetNode.parentElement;
         }
 
-        for (const callback of this.getResource("handle_insert_line_break_element")) {
-            if (callback({ targetNode, targetOffset })) {
-                return;
-            }
+        if (
+            delegate(this.getResource("handle_insert_line_break_element"), {
+                targetNode,
+                targetOffset,
+            })
+        ) {
+            return;
         }
 
         this.insertLineBreakElement({ targetNode, targetOffset });

--- a/addons/html_editor/static/src/core/no_inline_root_plugin.js
+++ b/addons/html_editor/static/src/core/no_inline_root_plugin.js
@@ -1,0 +1,150 @@
+import { getDeepestPosition, paragraphRelatedElements } from "@html_editor/utils/dom_info";
+import { Plugin } from "../plugin";
+import { isNotAllowedContent } from "./selection_plugin";
+import { nodeSize } from "@html_editor/utils/position";
+
+export class NoInlineRootPlugin extends Plugin {
+    static name = "no_inline_root";
+    static dependencies = ["selection", "history"];
+
+    resources = {
+        ...(!this.config.allowInlineAtRoot && {
+            fix_selection_on_editable_root_listeners: this.fixSelectionOnEditableRoot.bind(this),
+        }),
+    };
+
+    setup() {
+        this.addDomListener(this.editable, "keydown", (ev) => {
+            this.currentKeyDown = ev.key;
+        });
+        this.addDomListener(this.editable, "pointerdown", () => {
+            this.isPointerDown = true;
+        });
+        this.addDomListener(this.editable, "pointerup", () => {
+            this.isPointerDown = false;
+            this.preventNextPointerdownFix = false;
+        });
+    }
+
+    /**
+     * Places the cursor in a safe place (not the editable root).
+     * Inserts an empty paragraph if selection results from mouse click and
+     * there's no other way to insert text before/after a block.
+     *
+     * @param {Selection} selection - Collapsed selection at the editable root.
+     */
+    fixSelectionOnEditableRoot(selection) {
+        if (
+            !selection.isCollapsed ||
+            selection.anchorNode !== this.editable ||
+            this.config.allowInlineAtRoot
+        ) {
+            return false;
+        }
+
+        const nodeAfterCursor = this.editable.childNodes[selection.anchorOffset];
+        const nodeBeforeCursor = nodeAfterCursor && nodeAfterCursor.previousElementSibling;
+
+        return (
+            this.fixSelectionOnEditableRootArrowKeys(nodeAfterCursor, nodeBeforeCursor) ||
+            this.fixSelectionOnEditableRootGeneric(nodeAfterCursor, nodeBeforeCursor) ||
+            this.fixSelectionOnEditableRootCreateP(nodeAfterCursor, nodeBeforeCursor)
+        );
+    }
+    /**
+     * @param {Node} nodeAfterCursor
+     * @param {Node} nodeBeforeCursor
+     * @returns {boolean}
+     */
+    fixSelectionOnEditableRootArrowKeys(nodeAfterCursor, nodeBeforeCursor) {
+        const currentKeyDown = this.currentKeyDown;
+        delete this.currentKeyDown;
+        if (currentKeyDown === "ArrowRight" || currentKeyDown === "ArrowDown") {
+            while (nodeAfterCursor && isNotAllowedContent(nodeAfterCursor)) {
+                nodeAfterCursor = nodeAfterCursor.nextElementSibling;
+            }
+            const [anchorNode] = getDeepestPosition(nodeAfterCursor, 0);
+            if (nodeAfterCursor) {
+                this.shared.setSelection({ anchorNode: anchorNode, anchorOffset: 0 });
+                return true;
+            } else {
+                this.shared.resetActiveSelection();
+            }
+        } else if (currentKeyDown === "ArrowLeft" || currentKeyDown === "ArrowUp") {
+            while (nodeBeforeCursor && isNotAllowedContent(nodeBeforeCursor)) {
+                nodeBeforeCursor = nodeBeforeCursor.previousElementSibling;
+            }
+            if (nodeBeforeCursor) {
+                const [anchorNode, anchorOffset] = getDeepestPosition(
+                    nodeBeforeCursor,
+                    nodeSize(nodeBeforeCursor)
+                );
+                this.shared.setSelection({
+                    anchorNode: anchorNode,
+                    anchorOffset: anchorOffset,
+                });
+                return true;
+            } else {
+                this.shared.resetActiveSelection();
+            }
+        }
+    }
+    /**
+     * @param {Node} nodeAfterCursor
+     * @param {Node} nodeBeforeCursor
+     * @returns {boolean}
+     */
+    fixSelectionOnEditableRootGeneric(nodeAfterCursor, nodeBeforeCursor) {
+        // Handle arrow key presses.
+        if (nodeAfterCursor && paragraphRelatedElements.includes(nodeAfterCursor.nodeName)) {
+            // Cursor is right before a 'P'.
+            this.shared.setCursorStart(nodeAfterCursor);
+            return true;
+        } else if (
+            nodeBeforeCursor &&
+            paragraphRelatedElements.includes(nodeBeforeCursor.nodeName)
+        ) {
+            // Cursor is right after a 'P'.
+            this.shared.setCursorEnd(nodeBeforeCursor);
+            return true;
+        }
+    }
+    /**
+     * Handle cursor not next to a 'P'.
+     * Insert a new 'P' if selection resulted from a mouse click.
+     *
+     * In some situations (notably around tables and horizontal
+     * separators), the cursor could be placed having its anchorNode at
+     * the editable root, allowing the user to insert inlined text at
+     * it.
+     *
+     * @param {Node} nodeAfterCursor
+     * @param {Node} nodeBeforeCursor
+     * @returns {boolean}
+     */
+    fixSelectionOnEditableRootCreateP(nodeAfterCursor, nodeBeforeCursor) {
+        if (this.isPointerDown && !this.preventNextPointerdownFix) {
+            // The setSelection at the end of this fix could trigger another
+            // setSelection (that would re-trigger this fix). So this flag is
+            // used to prevent to fix twice from the same mouse event.
+            this.preventNextPointerdownFix = true;
+
+            const p = this.document.createElement("p");
+            p.append(this.document.createElement("br"));
+            if (!nodeAfterCursor) {
+                // Cursor is at the end of the editable.
+                this.editable.append(p);
+            } else if (!nodeBeforeCursor) {
+                // Cursor is at the beginning of the editable.
+                this.editable.prepend(p);
+            } else {
+                // Cursor is between two non-p blocks
+                nodeAfterCursor.before(p);
+            }
+            this.shared.setCursorStart(p);
+            this.shared.addStep();
+            return true;
+        }
+        return false;
+    }
+}

--- a/addons/html_editor/static/src/core/overlay_plugin.js
+++ b/addons/html_editor/static/src/core/overlay_plugin.js
@@ -12,14 +12,9 @@ export class OverlayPlugin extends Plugin {
     static name = "overlay";
     static dependencies = ["history"];
     static shared = ["createOverlay"];
-
-    handleCommand(command) {
-        switch (command) {
-            case "STEP_ADDED":
-                this.container = this.getScrollContainer();
-                break;
-        }
-    }
+    resources = {
+        step_added_listeners: this.getScrollContainer.bind(this),
+    };
 
     overlays = [];
 

--- a/addons/html_editor/static/src/core/protected_node_plugin.js
+++ b/addons/html_editor/static/src/core/protected_node_plugin.js
@@ -12,27 +12,13 @@ export class ProtectedNodePlugin extends Plugin {
         is_mutation_record_savable: this.isMutationRecordSavable.bind(this),
         filter_descendants_to_remove: this.filterDescendantsToRemove.bind(this),
         isUnsplittable: isProtecting, // avoid merge
+        clean_for_save_listeners: ({ root }) => this.cleanForSave(root),
+        normalize_listeners: this.normalize.bind(this),
+        before_filter_mutation_record_listeners: this.beforeFilteringMutationRecords.bind(this),
     };
 
     setup() {
         this.protectedNodes = new WeakSet();
-    }
-
-    handleCommand(command, payload) {
-        switch (command) {
-            case "NORMALIZE": {
-                this.normalize(payload.node);
-                break;
-            }
-            case "CLEAN_FOR_SAVE": {
-                this.cleanForSave(payload.root);
-                break;
-            }
-            case "BEFORE_FILTERING_MUTATION_RECORDS": {
-                this.beforeFilteringMutationRecords(payload.records);
-                break;
-            }
-        }
     }
 
     filterDescendantsToRemove(elem) {

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -5,7 +5,6 @@ import {
     isProtected,
     isProtecting,
     isUnprotecting,
-    paragraphRelatedElements,
     previousLeaf,
 } from "@html_editor/utils/dom_info";
 import { childNodes, closestElement, descendants } from "@html_editor/utils/dom_traversal";
@@ -121,11 +120,14 @@ export class SelectionPlugin extends Plugin {
         "getTraversedBlocks",
         "modifySelection",
         "rectifySelection",
+        // todo: ideally, this should not be shared
+        "resetActiveSelection",
         "focusEditable",
         // "collapseIfZWS",
     ];
     resources = {
-        shortcuts: [{ hotkey: "control+a", command: "SELECT_ALL" }],
+        user_commands: { id: "selectAll", run: this.selectAll.bind(this) },
+        shortcuts: [{ hotkey: "control+a", commandId: "selectAll" }],
     };
 
     setup() {
@@ -143,29 +145,14 @@ export class SelectionPlugin extends Plugin {
                 this.onKeyDownArrows(ev);
             }
         });
-        this.addDomListener(this.editable, "pointerdown", () => {
-            this.isPointerDown = true;
-        });
-        this.addDomListener(this.editable, "pointerup", () => {
-            this.isPointerDown = false;
-            this.preventNextPointerdownFix = false;
-        });
     }
 
-    handleCommand(command, payload) {
-        switch (command) {
-            case "SELECT_ALL":
-                {
-                    const selection = this.getEditableSelection();
-                    const containerSelector = "#wrap > *, .oe_structure > *, [contenteditable]";
-                    const container =
-                        selection && closestElement(selection.anchorNode, containerSelector);
-                    const [anchorNode, anchorOffset, focusNode, focusOffset] =
-                        boundariesIn(container);
-                    this.setSelection({ anchorNode, anchorOffset, focusNode, focusOffset });
-                }
-                break;
-        }
+    selectAll() {
+        const selection = this.getEditableSelection();
+        const containerSelector = "#wrap > *, .oe_structure > *, [contenteditable]";
+        const container = selection && closestElement(selection.anchorNode, containerSelector);
+        const [anchorNode, anchorOffset, focusNode, focusOffset] = boundariesIn(container);
+        this.setSelection({ anchorNode, anchorOffset, focusNode, focusOffset });
     }
 
     resetSelection() {
@@ -641,120 +628,11 @@ export class SelectionPlugin extends Plugin {
      * @param {Selection} selection - Collapsed selection at the editable root.
      */
     fixSelectionOnEditableRoot(selection) {
-        if (
-            !(
-                selection.isCollapsed &&
-                selection.anchorNode === this.editable &&
-                !this.config.allowInlineAtRoot
-            )
-        ) {
+        if (!selection.isCollapsed || selection.anchorNode !== this.editable) {
             return false;
         }
 
-        const nodeAfterCursor = this.editable.childNodes[selection.anchorOffset];
-        const nodeBeforeCursor = nodeAfterCursor && nodeAfterCursor.previousElementSibling;
-
-        return (
-            this.fixSelectionOnEditableRootArrowKeys(nodeAfterCursor, nodeBeforeCursor) ||
-            this.fixSelectionOnEditableRootGeneric(nodeAfterCursor, nodeBeforeCursor) ||
-            this.fixSelectionOnEditableRootCreateP(nodeAfterCursor, nodeBeforeCursor)
-        );
-    }
-    /**
-     * @param {Node} nodeAfterCursor
-     * @param {Node} nodeBeforeCursor
-     * @returns {boolean}
-     */
-    fixSelectionOnEditableRootArrowKeys(nodeAfterCursor, nodeBeforeCursor) {
-        const currentKeyDown = this.currentKeyDown;
-        delete this.currentKeyDown;
-        if (currentKeyDown === "ArrowRight" || currentKeyDown === "ArrowDown") {
-            while (nodeAfterCursor && isNotAllowedContent(nodeAfterCursor)) {
-                nodeAfterCursor = nodeAfterCursor.nextElementSibling;
-            }
-            const [anchorNode] = getDeepestPosition(nodeAfterCursor, 0);
-            if (nodeAfterCursor) {
-                this.setSelection({ anchorNode: anchorNode, anchorOffset: 0 });
-                return true;
-            } else {
-                this.resetActiveSelection();
-            }
-        } else if (currentKeyDown === "ArrowLeft" || currentKeyDown === "ArrowUp") {
-            while (nodeBeforeCursor && isNotAllowedContent(nodeBeforeCursor)) {
-                nodeBeforeCursor = nodeBeforeCursor.previousElementSibling;
-            }
-            if (nodeBeforeCursor) {
-                const [anchorNode, anchorOffset] = getDeepestPosition(
-                    nodeBeforeCursor,
-                    nodeSize(nodeBeforeCursor)
-                );
-                this.setSelection({
-                    anchorNode: anchorNode,
-                    anchorOffset: anchorOffset,
-                });
-                return true;
-            } else {
-                this.resetActiveSelection();
-            }
-        }
-    }
-    /**
-     * @param {Node} nodeAfterCursor
-     * @param {Node} nodeBeforeCursor
-     * @returns {boolean}
-     */
-    fixSelectionOnEditableRootGeneric(nodeAfterCursor, nodeBeforeCursor) {
-        // Handle arrow key presses.
-        if (nodeAfterCursor && paragraphRelatedElements.includes(nodeAfterCursor.nodeName)) {
-            // Cursor is right before a 'P'.
-            this.setCursorStart(nodeAfterCursor);
-            return true;
-        } else if (
-            nodeBeforeCursor &&
-            paragraphRelatedElements.includes(nodeBeforeCursor.nodeName)
-        ) {
-            // Cursor is right after a 'P'.
-            this.setCursorEnd(nodeBeforeCursor);
-            return true;
-        }
-    }
-    /**
-     * Handle cursor not next to a 'P'.
-     * Insert a new 'P' if selection resulted from a mouse click.
-     *
-     * In some situations (notably around tables and horizontal
-     * separators), the cursor could be placed having its anchorNode at
-     * the editable root, allowing the user to insert inlined text at
-     * it.
-     *
-     * @param {Node} nodeAfterCursor
-     * @param {Node} nodeBeforeCursor
-     * @returns {boolean}
-     */
-    fixSelectionOnEditableRootCreateP(nodeAfterCursor, nodeBeforeCursor) {
-        if (this.isPointerDown && !this.preventNextPointerdownFix) {
-            // The setSelection at the end of this fix could trigger another
-            // setSelection (that would re-trigger this fix). So this flag is
-            // used to prevent to fix twice from the same mouse event.
-            this.preventNextPointerdownFix = true;
-
-            const p = this.document.createElement("p");
-            p.append(this.document.createElement("br"));
-            if (!nodeAfterCursor) {
-                // Cursor is at the end of the editable.
-                this.editable.append(p);
-            } else if (!nodeBeforeCursor) {
-                // Cursor is at the beginning of the editable.
-                this.editable.prepend(p);
-            } else {
-                // Cursor is between two non-p blocks
-                nodeAfterCursor.before(p);
-            }
-            this.setCursorStart(p);
-            this.dispatch("ADD_STEP");
-            return true;
-        }
-        return false;
+        trigger(this.getResource("fix_selection_on_editable_root_listeners"), selection);
     }
 
     /**

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -18,6 +18,7 @@ import {
     normalizeDeepCursorPosition,
     normalizeFakeBR,
 } from "../utils/selection";
+import { trigger } from "@html_editor/utils/resource";
 
 /**
  * @typedef { Object } EditorSelection
@@ -191,9 +192,7 @@ export class SelectionPlugin extends Plugin {
                 return;
             }
         }
-        for (const handler of this.getResource("onSelectionChange")) {
-            handler(selectionData);
-        }
+        trigger(this.getResource("onSelectionChange"), selectionData);
     }
 
     /**

--- a/addons/html_editor/static/src/core/shortcut_plugin.js
+++ b/addons/html_editor/static/src/core/shortcut_plugin.js
@@ -2,6 +2,7 @@ import { Plugin } from "../plugin";
 
 export class ShortCutPlugin extends Plugin {
     static name = "shortcut";
+    static dependencies = ["user_command"];
 
     setup() {
         const hotkeyService = this.services.hotkey;
@@ -13,7 +14,7 @@ export class ShortCutPlugin extends Plugin {
         }
         for (const shortcut of this.getResource("shortcuts")) {
             this.addShortcut(shortcut.hotkey, () => {
-                this.dispatch(shortcut.command);
+                this.shared.execCommand(shortcut.commandId, shortcut.commandParams);
             });
         }
     }

--- a/addons/html_editor/static/src/core/split_plugin.js
+++ b/addons/html_editor/static/src/core/split_plugin.js
@@ -1,3 +1,4 @@
+import { delegate } from "@html_editor/utils/resource";
 import { Plugin } from "../plugin";
 import { isBlock } from "../utils/blocks";
 import { fillEmpty } from "../utils/dom";
@@ -82,10 +83,14 @@ export class SplitPlugin extends Plugin {
         }
         const blockToSplit = closestElement(targetNode, isBlock);
 
-        for (const callback of this.getResource("split_element_block")) {
-            if (callback({ targetNode, targetOffset, blockToSplit })) {
-                return [undefined, undefined];
-            }
+        if (
+            delegate(this.getResource("split_element_block"), {
+                targetNode,
+                targetOffset,
+                blockToSplit,
+            })
+        ) {
+            return [undefined, undefined];
         }
 
         return this.splitElementBlock({ targetNode, targetOffset, blockToSplit });

--- a/addons/html_editor/static/src/core/user_command_plugin.js
+++ b/addons/html_editor/static/src/core/user_command_plugin.js
@@ -1,0 +1,28 @@
+import { Plugin } from "../plugin";
+
+export class UserCommandPlugin extends Plugin {
+    static name = "user_command";
+    static shared = ["execCommand", "getCommands"];
+
+    setup() {
+        this.commands = {};
+        for (const command of this.getResource("user_commands")) {
+            if (command.id in this.commands) {
+                throw new Error(`Duplicate user command id: ${command.id}`);
+            }
+            this.commands[command.id] = command;
+        }
+    }
+
+    execCommand(commandId, params) {
+        const command = this.commands[commandId];
+        if (!command) {
+            throw new Error(`Unknown user command id: ${commandId}`);
+        }
+        return command.run(params);
+    }
+
+    getCommands() {
+        return this.commands;
+    }
+}

--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -196,7 +196,7 @@ export class HtmlField extends Component {
         this.state.showCodeView = !this.state.showCodeView;
         if (!this.state.showCodeView && this.editor) {
             this.editor.editable.innerHTML = this.value;
-            this.editor.dispatch("ADD_STEP");
+            this.editor.shared.addStep();
         }
     }
 
@@ -248,17 +248,21 @@ export class HtmlField extends Component {
         }
         if (this.props.codeview) {
             config.resources = {
+                user_commands: [
+                    {
+                        id: "codeview",
+                        label: _t("Code view"),
+                        icon: "fa-code",
+                        run: this.toggleCodeView.bind(this),
+                    },
+                ],
                 toolbarCategory: withSequence(100, {
                     id: "codeview",
                 }),
                 toolbarItems: {
                     id: "codeview",
                     category: "codeview",
-                    title: _t("Code view"),
-                    icon: "fa-code",
-                    action: () => {
-                        this.toggleCodeView();
-                    },
+                    commandId: "codeview",
                 },
             };
         }

--- a/addons/html_editor/static/src/main/banner_plugin.js
+++ b/addons/html_editor/static/src/main/banner_plugin.js
@@ -9,52 +9,70 @@ function isAvailable(node) {
 }
 export class BannerPlugin extends Plugin {
     static name = "banner";
-    static dependencies = ["dom", "emoji", "selection"];
+    static dependencies = ["history", "dom", "emoji", "selection"];
     resources = {
-        powerboxCategory: withSequence(20, { id: "banner", name: _t("Banner") }),
-        powerboxItems: [
+        user_commands: [
             {
-                category: "banner",
-                name: _t("Banner Info"),
+                id: "banner_info",
+                label: _t("Banner Info"),
                 description: _t("Insert an info banner"),
-                fontawesome: "fa-info-circle",
+                icon: "fa-info-circle",
                 isAvailable,
-                action: () => {
+                run: () => {
                     this.insertBanner(_t("Banner Info"), "💡", "info");
                 },
             },
             {
-                category: "banner",
-                name: _t("Banner Success"),
-                description: _t("Insert an success banner"),
-                fontawesome: "fa-check-circle",
+                id: "banner_success",
+                label: _t("Banner Success"),
+                description: _t("Insert a success banner"),
+                icon: "fa-check-circle",
                 isAvailable,
-                action: () => {
+                run: () => {
                     this.insertBanner(_t("Banner Success"), "✅", "success");
                 },
             },
             {
-                category: "banner",
-                name: _t("Banner Warning"),
-                description: _t("Insert an warning banner"),
-                fontawesome: "fa-exclamation-triangle",
+                id: "banner_warning",
+                label: _t("Banner Warning"),
+                description: _t("Insert a warning banner"),
+                icon: "fa-exclamation-triangle",
                 isAvailable,
-                action: () => {
+                run: () => {
                     this.insertBanner(_t("Banner Warning"), "⚠️", "warning");
                 },
             },
             {
-                category: "banner",
-                name: _t("Banner Danger"),
-                description: _t("Insert an danger banner"),
-                fontawesome: "fa-exclamation-circle",
+                id: "banner_danger",
+                label: _t("Banner Danger"),
+                description: _t("Insert a danger banner"),
+                icon: "fa-exclamation-circle",
                 isAvailable,
-                action: () => {
+                run: () => {
                     this.insertBanner(_t("Banner Danger"), "❌", "danger");
                 },
             },
         ],
         showPowerButtons: (selection) => !closestElement(selection.anchorNode, ".o_editor_banner"),
+        powerboxCategory: withSequence(20, { id: "banner", name: _t("Banner") }),
+        powerboxItems: [
+            {
+                commandId: "banner_info",
+                category: "banner",
+            },
+            {
+                commandId: "banner_success",
+                category: "banner",
+            },
+            {
+                commandId: "banner_warning",
+                category: "banner",
+            },
+            {
+                commandId: "banner_danger",
+                category: "banner",
+            },
+        ],
     };
 
     setup() {
@@ -84,7 +102,7 @@ export class BannerPlugin extends Plugin {
             bannerElement.before(zws);
         }
         this.shared.setCursorStart(bannerElement.querySelector(".o_editor_banner > div > p"));
-        this.dispatch("ADD_STEP");
+        this.shared.addStep();
     }
 
     onBannerEmojiChange(iconElement) {
@@ -92,7 +110,7 @@ export class BannerPlugin extends Plugin {
             target: iconElement,
             onSelect: (emoji) => {
                 iconElement.textContent = emoji;
-                this.dispatch("ADD_STEP");
+                this.shared.addStep();
             },
         });
     }

--- a/addons/html_editor/static/src/main/chatgpt/language_selector.js
+++ b/addons/html_editor/static/src/main/chatgpt/language_selector.js
@@ -7,7 +7,10 @@ import { toolbarButtonProps } from "@html_editor/main/toolbar/toolbar";
 
 export class LanguageSelector extends Component {
     static template = "html_editor.LanguageSelector";
-    static props = toolbarButtonProps;
+    static props = {
+        ...toolbarButtonProps,
+        onSelected: { type: Function },
+    };
     static components = { Dropdown, DropdownItem };
 
     setup() {
@@ -22,6 +25,6 @@ export class LanguageSelector extends Component {
         });
     }
     onSelected(language) {
-        this.props.dispatch("OPEN_CHATGPT_DIALOG", { language });
+        this.props.onSelected(language);
     }
 }

--- a/addons/html_editor/static/src/main/chatgpt/language_selector.xml
+++ b/addons/html_editor/static/src/main/chatgpt/language_selector.xml
@@ -3,7 +3,7 @@
         <button t-if="state.languages.length === 1"
             class="btn btn-light px-1"
             name="translate"
-            t-att-title="props.title"
+            t-att-title="props.label"
             t-on-click="() => this.onSelected(state.languages[0][1])">
                 Translate
         </button>

--- a/addons/html_editor/static/src/main/column_plugin.js
+++ b/addons/html_editor/static/src/main/column_plugin.js
@@ -30,52 +30,53 @@ function columnisAvailable(numberOfColumns) {
 
 export class ColumnPlugin extends Plugin {
     static name = "column";
-    static dependencies = ["selection"];
+    static dependencies = ["selection", "history"];
     resources = {
+        user_commands: [
+            {
+                id: "columnize",
+                label: _t("Columnize"),
+                description: _t("Convert into columns"),
+                icon: "fa-columns",
+                run: this.columnize.bind(this),
+            },
+        ],
         isUnremovable: isUnremovableColumn,
         powerboxItems: [
             {
-                name: _t("2 columns"),
+                label: _t("2 columns"),
                 description: _t("Convert into 2 columns"),
                 category: "structure",
-                fontawesome: "fa-columns",
                 isAvailable: columnisAvailable(2),
-                action(dispatch) {
-                    dispatch("COLUMNIZE", { numberOfColumns: 2 });
-                },
+                commandId: "columnize",
+                commandParams: { numberOfColumns: 2 },
             },
             {
-                name: _t("3 columns"),
+                label: _t("3 columns"),
                 description: _t("Convert into 3 columns"),
                 category: "structure",
-                fontawesome: "fa-columns",
                 isAvailable: columnisAvailable(3),
-                action(dispatch) {
-                    dispatch("COLUMNIZE", { numberOfColumns: 3 });
-                },
+                commandId: "columnize",
+                commandParams: { numberOfColumns: 3 },
             },
             {
-                name: _t("4 columns"),
+                label: _t("4 columns"),
                 description: _t("Convert into 4 columns"),
                 category: "structure",
-                fontawesome: "fa-columns",
                 isAvailable: columnisAvailable(4),
-                action(dispatch) {
-                    dispatch("COLUMNIZE", { numberOfColumns: 4 });
-                },
+                commandId: "columnize",
+                commandParams: { numberOfColumns: 4 },
             },
             {
-                name: _t("Remove columns"),
+                label: _t("Remove columns"),
                 description: _t("Back to one column"),
                 category: "structure",
-                fontawesome: "fa-columns",
                 isAvailable(node) {
                     const row = closestElement(node, ".o_text_columns .row");
                     return !row;
                 },
-                action(dispatch) {
-                    dispatch("COLUMNIZE", { numberOfColumns: 0 });
-                },
+                commandId: "columnize",
+                commandParams: { numberOfColumns: 0 },
             },
         ],
         hints: [
@@ -88,17 +89,11 @@ export class ColumnPlugin extends Plugin {
         showPowerButtons: (selection) => !closestElement(selection.anchorNode, ".o_text_columns"),
     };
 
-    handleCommand(command, payload) {
-        switch (command) {
-            case "COLUMNIZE": {
-                const { numberOfColumns, addParagraphAfter } = payload;
-                this.columnize(numberOfColumns, addParagraphAfter);
-                this.dispatch("ADD_STEP");
-                break;
-            }
-        }
+    columnize({ numberOfColumns, addParagraphAfter } = {}) {
+        this._columnize(numberOfColumns, addParagraphAfter);
+        this.shared.addStep();
     }
-    columnize(numberOfColumns, addParagraphAfter = true) {
+    _columnize(numberOfColumns, addParagraphAfter = true) {
         const selectionToRestore = this.shared.getEditableSelection();
         const anchor = selectionToRestore.anchorNode;
         const hasColumns = !!closestElement(anchor, ".o_text_columns");

--- a/addons/html_editor/static/src/main/emoji_plugin.js
+++ b/addons/html_editor/static/src/main/emoji_plugin.js
@@ -4,18 +4,22 @@ import { _t } from "@web/core/l10n/translation";
 
 export class EmojiPlugin extends Plugin {
     static name = "emoji";
-    static dependencies = ["overlay", "dom", "selection"];
+    static dependencies = ["history", "overlay", "dom", "selection"];
     static shared = ["showEmojiPicker"];
     resources = {
+        user_commands: [
+            {
+                id: "addEmoji",
+                label: _t("Emoji"),
+                description: _t("Add an emoji"),
+                icon: "fa-smile-o",
+                run: this.showEmojiPicker.bind(this),
+            },
+        ],
         powerboxItems: [
             {
                 category: "widget",
-                name: _t("Emoji"),
-                description: _t("Add an emoji"),
-                fontawesome: "fa-smile-o",
-                action: () => {
-                    this.showEmojiPicker();
-                },
+                commandId: "addEmoji",
             },
         ],
     };
@@ -46,7 +50,7 @@ export class EmojiPlugin extends Plugin {
                         return;
                     }
                     this.shared.domInsert(str);
-                    this.dispatch("ADD_STEP");
+                    this.shared.addStep();
                 },
             },
             target,

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -20,7 +20,7 @@ import { isCSSColor } from "@web/core/utils/colors";
 import { ColorSelector } from "./color_selector";
 import { reactive } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
-import { withSequence } from "@html_editor/utils/resource";
+import { delegate, withSequence } from "@html_editor/utils/resource";
 
 export class ColorPlugin extends Plugin {
     static name = "color";
@@ -139,10 +139,8 @@ export class ColorPlugin extends Plugin {
      * @param {string} mode 'color' or 'backgroundColor'
      */
     applyColor(color, mode) {
-        for (const cb of this.getResource("colorApply") || []) {
-            if (cb(color, mode)) {
-                return;
-            }
+        if (delegate(this.getResource("colorApply", color, mode))) {
+            return;
         }
         let selection = this.shared.getEditableSelection();
         let selectionNodes;

--- a/addons/html_editor/static/src/main/font/color_selector.js
+++ b/addons/html_editor/static/src/main/font/color_selector.js
@@ -37,6 +37,9 @@ export class ColorSelector extends Component {
         type: String, // either foreground or background
         getUsedCustomColors: Function,
         getSelectedColors: Function,
+        applyColor: Function,
+        applyColorPreview: Function,
+        applyColorResetPreview: Function,
         focusEditable: Function,
         ...toolbarButtonProps,
     };
@@ -45,7 +48,7 @@ export class ColorSelector extends Component {
         this.DEFAULT_COLORS = DEFAULT_COLORS;
         this.DEFAULT_GRADIENT_COLORS = DEFAULT_GRADIENT_COLORS;
         this.dropdown = useDropdownState({
-            onClose: () => this.props.dispatch("COLOR_RESET_PREVIEW"),
+            onClose: () => this.props.applyColorResetPreview(),
         });
 
         this.mode = this.props.type === "foreground" ? "color" : "backgroundColor";
@@ -73,7 +76,7 @@ export class ColorSelector extends Component {
 
     applyColor(color) {
         this.currentCustomColor.color = color;
-        this.props.dispatch("APPLY_COLOR", { color: color || "", mode: this.mode });
+        this.props.applyColor({ color: color || "", mode: this.mode });
         this.props.focusEditable();
     }
 
@@ -88,7 +91,7 @@ export class ColorSelector extends Component {
 
     onColorPreview(ev) {
         const color = ev.hex ? ev.hex : this.processColorFromEvent(ev);
-        this.props.dispatch("COLOR_PREVIEW", { color: color || "", mode: this.mode });
+        this.props.applyColorPreview({ color: color || "", mode: this.mode });
     }
 
     onColorHover(ev) {
@@ -102,7 +105,7 @@ export class ColorSelector extends Component {
         if (ev.target.tagName !== "BUTTON") {
             return;
         }
-        this.props.dispatch("COLOR_RESET_PREVIEW");
+        this.props.applyColorResetPreview();
     }
 
     getCurrentGradientColor() {

--- a/addons/html_editor/static/src/main/font/color_selector.xml
+++ b/addons/html_editor/static/src/main/font/color_selector.xml
@@ -1,7 +1,7 @@
 <templates xml:space="preserve">
     <t t-name="html_editor.ColorSelector">
         <Dropdown state="dropdown">
-            <button class="btn btn-light" t-attf-class="o-select-color-{{props.type}} {{dropdown.isOpen ? 'active' : ''}}" t-att-title="props.title">
+            <button class="btn btn-light" t-attf-class="o-select-color-{{props.type}} {{dropdown.isOpen ? 'active' : ''}}" t-att-title="props.label">
                 <t t-if="mode === 'color'">
                     <i class="fa fa-fw fa-font py-1" t-att-style="this.getSelectedColorStyle()"/>
                 </t>

--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -97,8 +97,52 @@ const handledElemSelector = [...headingTags, "PRE", "BLOCKQUOTE"].join(", ");
 
 export class FontPlugin extends Plugin {
     static name = "font";
-    static dependencies = ["split", "selection"];
+    static dependencies = ["split", "selection", "user_command"];
     resources = {
+        user_commands: [
+            {
+                id: "setTagHeading1",
+                label: _t("Heading 1"),
+                description: _t("Big section heading"),
+                icon: "fa-header",
+                run: () => this.shared.execCommand("setTag", { tagName: "H1" }),
+            },
+            {
+                id: "setTagHeading2",
+                label: _t("Heading 2"),
+                description: _t("Medium section heading"),
+                icon: "fa-header",
+                run: () => this.shared.execCommand("setTag", { tagName: "H2" }),
+            },
+            {
+                id: "setTagHeading3",
+                label: _t("Heading 3"),
+                description: _t("Small section heading"),
+                icon: "fa-header",
+                run: () => this.shared.execCommand("setTag", { tagName: "H3" }),
+            },
+            {
+                id: "setTagParagraph",
+                label: _t("Text"),
+                description: _t("Paragraph block"),
+                icon: "fa-paragraph",
+                run: () => this.shared.execCommand("setTag", { tagName: "P" }),
+            },
+            {
+                id: "setTagQuote",
+                label: _t("Quote"),
+                description: _t("Add a blockquote section"),
+                icon: "fa-quote-right",
+                run: () => this.shared.execCommand("setTag", { tagName: "blockquote" }),
+            },
+            {
+                id: "setTagPre",
+                label: _t("Code"),
+                description: _t("Add a code section"),
+                icon: "fa-code",
+                run: () => this.shared.execCommand("setTag", { tagName: "pre" }),
+            },
+        ],
         split_element_block: [
             this.handleSplitBlockPRE.bind(this),
             this.handleSplitBlockHeading.bind(this),
@@ -118,22 +162,31 @@ export class FontPlugin extends Plugin {
             {
                 id: "font",
                 category: "font",
-                title: _t("Font style"),
+                label: _t("Font style"),
                 Component: FontSelector,
                 props: {
                     getItems: () => fontItems,
-                    command: "SET_TAG",
+                    onSelected: (item) => {
+                        this.shared.execCommand("setTag", {
+                            tagName: item.tagName,
+                            extraClass: item.extraClass,
+                        });
+                    },
                 },
             },
             {
                 id: "font-size",
                 category: "font-size",
-                title: _t("Font size"),
+                label: _t("Font size"),
                 Component: FontSelector,
                 props: {
                     getItems: () => this.fontSizeItems,
+                    onSelected: (item) => {
+                        this.shared.execCommand("formatFontSizeClassName", {
+                            className: item.className,
+                        });
+                    },
                     isFontSize: true,
-                    command: "FORMAT_FONT_SIZE_CLASSNAME",
                     document: this.document,
                 },
             },
@@ -141,58 +194,28 @@ export class FontPlugin extends Plugin {
         powerboxCategory: withSequence(30, { id: "format", name: _t("Format") }),
         powerboxItems: [
             {
-                name: _t("Heading 1"),
-                description: _t("Big section heading"),
                 category: "format",
-                fontawesome: "fa-header",
-                action(dispatch) {
-                    dispatch("SET_TAG", { tagName: "H1" });
-                },
-            },
-            {
-                name: _t("Heading 2"),
-                description: _t("Medium section heading"),
-                category: "format",
-                fontawesome: "fa-header",
-                action(dispatch) {
-                    dispatch("SET_TAG", { tagName: "H2" });
-                },
-            },
-            {
-                name: _t("Heading 3"),
-                description: _t("Small section heading"),
-                category: "format",
-                fontawesome: "fa-header",
-                action(dispatch) {
-                    dispatch("SET_TAG", { tagName: "H3" });
-                },
+                commandId: "setTagHeading1",
             },
             {
                 category: "format",
-                name: _t("Text"),
-                description: _t("Paragraph block"),
-                fontawesome: "fa-paragraph",
-                action(dispatch) {
-                    dispatch("SET_TAG", { tagName: "P" });
-                },
+                commandId: "setTagHeading2",
+            },
+            {
+                category: "format",
+                commandId: "setTagHeading3",
+            },
+            {
+                category: "format",
+                commandId: "setTagParagraph",
             },
             {
                 category: "structure",
-                name: _t("Quote"),
-                description: _t("Add a blockquote section"),
-                fontawesome: "fa-quote-right",
-                action(dispatch) {
-                    dispatch("SET_TAG", { tagName: "blockquote" });
-                },
+                commandId: "setTagQuote",
             },
             {
                 category: "structure",
-                name: _t("Code"),
-                description: _t("Add a code section"),
-                fontawesome: "fa-code",
-                action(dispatch) {
-                    dispatch("SET_TAG", { tagName: "pre" });
-                },
+                commandId: "setTagPre",
             },
         ],
         hints: [
@@ -341,7 +364,7 @@ export class FontPlugin extends Plugin {
             });
             this.shared.extractContent(this.shared.getEditableSelection());
             fillEmpty(blockEl);
-            this.dispatch("SET_TAG", { tagName: headingToBe });
+            this.shared.execCommand("setTag", { tagName: headingToBe });
         }
     }
 }

--- a/addons/html_editor/static/src/main/font/font_selector.js
+++ b/addons/html_editor/static/src/main/font/font_selector.js
@@ -10,8 +10,8 @@ export class FontSelector extends Component {
     static props = {
         document: { optional: true },
         getItems: Function,
-        command: String,
         isFontSize: { type: Boolean, optional: true },
+        onSelected: Function,
         ...toolbarButtonProps,
     };
     static components = { Dropdown, DropdownItem };
@@ -61,7 +61,7 @@ export class FontSelector extends Component {
     }
 
     onSelected(item) {
-        this.props.dispatch(this.props.command, item);
+        this.props.onSelected(item);
         this.state.displayName = this.getDisplay();
     }
 }

--- a/addons/html_editor/static/src/main/font/font_selector.xml
+++ b/addons/html_editor/static/src/main/font/font_selector.xml
@@ -1,7 +1,7 @@
 <templates xml:space="preserve">
     <t t-name="html_editor.FontSelector">
         <Dropdown menuClass="'o_font_selector_menu'">
-            <button class="btn btn-light" t-att-title="props.title">
+            <button class="btn btn-light" t-att-title="props.label">
                 <span class="px-1" t-esc="state.displayName"/>
             </button>
             <t t-set-slot="content">

--- a/addons/html_editor/static/src/main/hint_plugin.js
+++ b/addons/html_editor/static/src/main/hint_plugin.js
@@ -33,6 +33,9 @@ export class HintPlugin extends Plugin {
             this.clearHints();
             this.updateHints();
         },
+        clean_listeners: this.clearHints.bind(this),
+        clean_for_save_listeners: ({ root }) => this.clearHints(root),
+        content_updated_listeners: this.updateHints.bind(this),
         ...(this.config.placeholder && {
             hints: [
                 {
@@ -51,19 +54,6 @@ export class HintPlugin extends Plugin {
     destroy() {
         super.destroy();
         this.clearHints();
-    }
-
-    handleCommand(command, payload) {
-        switch (command) {
-            case "CONTENT_UPDATED": {
-                this.updateHints(payload.root);
-                break;
-            }
-            case "CLEAN":
-            case "CLEAN_FOR_SAVE":
-                this.clearHints(payload.root);
-                break;
-        }
     }
 
     /**

--- a/addons/html_editor/static/src/main/inline_code.js
+++ b/addons/html_editor/static/src/main/inline_code.js
@@ -4,7 +4,7 @@ import { DIRECTIONS } from "@html_editor/utils/position";
 
 export class InlineCodePlugin extends Plugin {
     static name = "inline_code";
-    static dependencies = ["selection", "split"];
+    static dependencies = ["selection", "history", "split"];
     resources = {
         onInput: this.onInput.bind(this),
     };
@@ -35,7 +35,7 @@ export class InlineCodePlugin extends Plugin {
         this.shared.setSelection({ anchorNode: textNode, anchorOffset: offset });
         const textHasTwoTicks = /`.*`/.test(textNode.textContent);
         if (textHasTwoTicks) {
-            this.dispatch("ADD_STEP");
+            this.shared.addStep();
             const insertedBacktickIndex = offset - 1;
             const textBeforeInsertedBacktick = textNode.textContent.substring(
                 0,
@@ -91,6 +91,6 @@ export class InlineCodePlugin extends Plugin {
                 });
             }
         }
-        this.dispatch("ADD_STEP");
+        this.shared.addStep();
     }
 }

--- a/addons/html_editor/static/src/main/justify_plugin.js
+++ b/addons/html_editor/static/src/main/justify_plugin.js
@@ -5,23 +5,14 @@ import { isVisibleTextNode } from "@html_editor/utils/dom_info";
 export class JustifyPlugin extends Plugin {
     static name = "justify";
     static dependencies = ["selection"];
-
-    handleCommand(command) {
-        switch (command) {
-            case "JUSTIFY_LEFT":
-                this.align("left");
-                break;
-            case "JUSTIFY_RIGHT":
-                this.align("right");
-                break;
-            case "JUSTIFY_CENTER":
-                this.align("center");
-                break;
-            case "JUSTIFY_FULL":
-                this.align("justify");
-                break;
-        }
-    }
+    resources = {
+        user_commands: [
+            { id: "justifyLeft", run: () => this.align("left") },
+            { id: "justifyRight", run: () => this.align("right") },
+            { id: "justifyCenter", run: () => this.align("center") },
+            { id: "justifyFull", run: () => this.align("justify") },
+        ],
+    };
 
     align(mode) {
         const visitedBlocks = new Set();

--- a/addons/html_editor/static/src/main/link/link_paste_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_paste_plugin.js
@@ -50,7 +50,7 @@ export class LinkPastePlugin extends Plugin {
             this.handlePasteTextUrlInsideLink(text, url);
             return;
         }
-        if (delegate(this.getResource("handle_paste_url", text, url))) {
+        if (delegate(this.getResource("handle_paste_url"), text, url)) {
             return;
         }
         this.shared.insertLink(url, text);

--- a/addons/html_editor/static/src/main/link/link_paste_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_paste_plugin.js
@@ -3,6 +3,7 @@ import { URL_REGEX, cleanZWChars } from "./utils";
 import { isImageUrl } from "@html_editor/utils/url";
 import { Plugin } from "@html_editor/plugin";
 import { leftPos } from "@html_editor/utils/position";
+import { delegate } from "@html_editor/utils/resource";
 
 export class LinkPastePlugin extends Plugin {
     static name = "link_paste";
@@ -49,10 +50,7 @@ export class LinkPastePlugin extends Plugin {
             this.handlePasteTextUrlInsideLink(text, url);
             return;
         }
-        const isHandled = this.getResource("handle_paste_url").some((handler) =>
-            handler(text, url)
-        );
-        if (isHandled) {
+        if (delegate(this.getResource("handle_paste_url", text, url))) {
             return;
         }
         this.shared.insertLink(url, text);

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -100,32 +100,28 @@ async function fetchInternalMetaData(url) {
     return result;
 }
 
-const linkItem = {
-    id: "link",
-    title: _t("Link"),
-    action(dispatch) {
-        dispatch("CREATE_LINK_ON_SELECTION");
-    },
-    icon: "fa-link",
-    isFormatApplied: isLinkActive,
-};
-const unlinkItem = {
-    id: "unlink",
-    title: _t("Remove Link"),
-
-    action(dispatch) {
-        dispatch("REMOVE_LINK_FROM_SELECTION");
-    },
-    icon: "fa-unlink",
-    isAvailable: isSelectionHasLink,
-};
-
 export class LinkPlugin extends Plugin {
     static name = "link";
-    static dependencies = ["dom", "selection", "split", "line_break", "overlay"];
+    static dependencies = ["dom", "history", "selection", "split", "line_break", "overlay"];
     // @phoenix @todo: do we want to have createLink and insertLink methods in link plugin?
     static shared = ["createLink", "insertLink", "getPathAsUrlCommand"];
     resources = {
+        user_commands: [
+            {
+                id: "toggleLinkTools",
+                label: _t("Link"),
+                description: _t("Add a link"),
+                icon: "fa-link",
+                run: this.toggleLinkTools.bind(this),
+            },
+            {
+                id: "removeLinkFromSelection",
+                label: _t("Remove Link"),
+                icon: "fa-unlink",
+                isAvailable: isSelectionHasLink,
+                run: this.removeLinkFromSelection.bind(this),
+            },
+        ],
         onBeforeInput: withSequence(5, this.onBeforeInput.bind(this)),
         toolbarCategory: [
             withSequence(40, {
@@ -138,49 +134,48 @@ export class LinkPlugin extends Plugin {
         ],
         toolbarItems: [
             {
-                ...linkItem,
+                id: "link",
                 category: "link",
+                commandId: "toggleLinkTools",
+                isFormatApplied: isLinkActive,
             },
             {
-                ...unlinkItem,
+                id: "unlink",
                 category: "link",
+                commandId: "removeLinkFromSelection",
             },
             {
-                ...linkItem,
+                id: "link",
                 category: "image_link",
+                commandId: "toggleLinkTools",
+                isFormatApplied: isLinkActive,
             },
             {
-                ...unlinkItem,
+                id: "unlink",
                 category: "image_link",
+                commandId: "removeLinkFromSelection",
             },
         ],
 
         powerboxCategory: withSequence(50, { id: "navigation", name: _t("Navigation") }),
         powerboxItems: [
             {
-                id: "link",
-                name: _t("Link"),
-                description: _t("Add a link"),
                 category: "navigation",
-                fontawesome: "fa-link",
-                action(dispatch) {
-                    dispatch("TOGGLE_LINK");
-                },
+                commandId: "toggleLinkTools",
             },
             {
-                name: _t("Button"),
+                label: _t("Button"),
                 description: _t("Add a button"),
                 category: "navigation",
-                fontawesome: "fa-link",
-                action(dispatch) {
-                    dispatch("TOGGLE_LINK");
-                },
+                commandId: "toggleLinkTools",
             },
         ],
         onSelectionChange: this.handleSelectionChange.bind(this),
         split_element_block: this.handleSplitBlock.bind(this),
         handle_insert_line_break_element: this.handleInsertLineBreak.bind(this),
-        powerButtons: ["link"],
+        powerButtons: ["toggleLinkTools"],
+        clean_for_save_listeners: ({ root }) => this.removeEmptyLinks(root),
+        normalize_listeners: this.normalizeLink.bind(this),
     };
     setup() {
         this.overlay = this.shared.createOverlay(LinkPopover, {}, { sequence: 40 });
@@ -214,26 +209,6 @@ export class LinkPlugin extends Plugin {
         this.removeLinkShortcut();
     }
 
-    handleCommand(command, payload) {
-        switch (command) {
-            case "CREATE_LINK_ON_SELECTION":
-                this.toggleLinkTools(payload.options);
-                break;
-            case "TOGGLE_LINK":
-                this.toggleLinkTools(payload.options);
-                break;
-            case "NORMALIZE":
-                this.normalizeLink();
-                break;
-            case "CLEAN_FOR_SAVE":
-                this.removeEmptyLinks(payload.root);
-                break;
-            case "REMOVE_LINK_FROM_SELECTION":
-                this.removeLinkFromSelection();
-                break;
-        }
-    }
-
     // -------------------------------------------------------------------------
     // Commands
     // -------------------------------------------------------------------------
@@ -265,7 +240,7 @@ export class LinkPlugin extends Plugin {
             link = this.createLink(url, label);
             this.shared.domInsert(link);
         }
-        this.dispatch("ADD_STEP");
+        this.shared.addStep();
         const linkParent = link.parentElement;
         const linkOffset = Array.from(linkParent.childNodes).indexOf(link);
         this.shared.setSelection(
@@ -279,12 +254,12 @@ export class LinkPlugin extends Plugin {
      */
     getPathAsUrlCommand(text, url) {
         const pasteAsURLCommand = {
-            name: _t("Paste as URL"),
+            label: _t("Paste as URL"),
             description: _t("Create an URL."),
-            fontawesome: "fa-link",
-            action: () => {
+            icon: "fa-link",
+            run: () => {
                 this.shared.domInsert(this.createLink(url, text));
-                this.dispatch("ADD_STEP");
+                this.shared.addStep();
             },
         };
         return pasteAsURLCommand;
@@ -320,7 +295,7 @@ export class LinkPlugin extends Plugin {
             onRemove: () => {
                 this.removeLink();
                 this.overlay.close();
-                this.dispatch("ADD_STEP");
+                this.shared.addStep();
             },
             onCopy: () => {
                 this.overlay.close();
@@ -358,7 +333,7 @@ export class LinkPlugin extends Plugin {
                         this.shared.setCursorEnd(this.linkElement);
                         this.shared.focusEditable();
                         this.removeCurrentLinkIfEmtpy();
-                        this.dispatch("ADD_STEP");
+                        this.shared.addStep();
                     },
                 };
 
@@ -413,7 +388,7 @@ export class LinkPlugin extends Plugin {
                     }
                     this.shared.focusEditable();
                     this.removeCurrentLinkIfEmtpy();
-                    this.dispatch("ADD_STEP");
+                    this.shared.addStep();
                 },
             };
 
@@ -450,7 +425,7 @@ export class LinkPlugin extends Plugin {
                     after = linkElement.nextSibling;
                 }
                 this.shared.setCursorEnd(linkElement);
-                this.dispatch("ADD_STEP");
+                this.shared.addStep();
             }
             return linkElement;
         } else {
@@ -494,7 +469,7 @@ export class LinkPlugin extends Plugin {
             !this.linkElement.hasAttribute("t-att-href")
         ) {
             this.removeLink();
-            this.dispatch("ADD_STEP");
+            this.shared.addStep();
         }
     }
 
@@ -550,7 +525,7 @@ export class LinkPlugin extends Plugin {
                 selectedImageNodes.length === 1 &&
                 selectedImageNodes.length === selectedNodes.length
             ) {
-                this.dispatch("ADD_STEP");
+                this.shared.addStep();
                 return;
             }
         }
@@ -584,7 +559,7 @@ export class LinkPlugin extends Plugin {
             }
             cursors.restore();
         }
-        this.dispatch("ADD_STEP");
+        this.shared.addStep();
     }
 
     removeEmptyLinks(root) {
@@ -646,7 +621,7 @@ export class LinkPlugin extends Plugin {
                 textNodeToReplace.splitText(match[0].length);
                 selection.anchorNode.parentElement.replaceChild(link, textNodeToReplace);
                 this.shared.setCursorStart(nodeForSelectionRestore);
-                this.dispatch("ADD_STEP");
+                this.shared.addStep();
             }
         }
     }

--- a/addons/html_editor/static/src/main/link/link_selection_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_selection_plugin.js
@@ -56,21 +56,12 @@ export class LinkSelectionPlugin extends Plugin {
         mutation_filtered_classes: ["o_link_in_selection"],
         link_ignore_classes: ["o_link_in_selection"],
         onSelectionChange: this.resetLinkInSelection.bind(this),
+        clean_for_save_listeners: this.cleanForSave.bind(this),
         arrows_should_skip: (ev, char, lastSkipped) =>
             // Skip first FEFF, but not the second one (unless shift is pressed).
             char === "\uFEFF" && (ev.shiftKey || lastSkipped !== "\uFEFF"),
+        normalize_listeners: (el) => this.normalize(el || this.editable),
     };
-
-    handleCommand(command, payload) {
-        switch (command) {
-            case "NORMALIZE":
-                this.normalize(payload.node || this.editable);
-                break;
-            case "CLEAN_FOR_SAVE":
-                this.cleanForSave(payload);
-                break;
-        }
-    }
 
     /**
      * @param {Element} root

--- a/addons/html_editor/static/src/main/media/icon_plugin.js
+++ b/addons/html_editor/static/src/main/media/icon_plugin.js
@@ -7,6 +7,39 @@ export class IconPlugin extends Plugin {
     static dependencies = ["history", "link", "selection", "color"];
     /** @type { (p: IconPlugin) => Record<string, any> } */
     resources = {
+        user_commands: [
+            {
+                id: "resizeIcon1",
+                label: _t("Icon size 1x"),
+                run: () => this.resizeIcon({ size: "1" }),
+            },
+            {
+                id: "resizeIcon2",
+                label: _t("Icon size 2x"),
+                run: () => this.resizeIcon({ size: "2" }),
+            },
+            {
+                id: "resizeIcon3",
+                label: _t("Icon size 3x"),
+                run: () => this.resizeIcon({ size: "3" }),
+            },
+            {
+                id: "resizeIcon4",
+                label: _t("Icon size 4x"),
+                run: () => this.resizeIcon({ size: "4" }),
+            },
+            {
+                id: "resizeIcon5",
+                label: _t("Icon size 5x"),
+                run: () => this.resizeIcon({ size: "5" }),
+            },
+            {
+                id: "toggleSpinIcon",
+                label: _t("Toggle icon spin"),
+                icon: "fa-play",
+                run: this.toggleSpinIcon.bind(this),
+            },
+        ],
         toolbarNamespace: [
             {
                 id: "icon",
@@ -45,65 +78,46 @@ export class IconPlugin extends Plugin {
             {
                 id: "icon_size_1",
                 category: "icon_size",
-                action(dispatch) {
-                    dispatch("RESIZE_ICON", "1");
-                },
+                commandId: "resizeIcon1",
                 text: "1x",
-                title: _t("Icon size 1x"),
                 isFormatApplied: () => this.hasIconSize("1"),
             },
             {
                 id: "icon_size_2",
                 category: "icon_size",
-                action(dispatch) {
-                    dispatch("RESIZE_ICON", "2");
-                },
+                commandId: "resizeIcon2",
                 text: "2x",
-                title: _t("Icon size 2x"),
                 isFormatApplied: () => this.hasIconSize("2"),
             },
             {
                 id: "icon_size_3",
                 category: "icon_size",
-                action(dispatch) {
-                    dispatch("RESIZE_ICON", "3");
-                },
+                commandId: "resizeIcon3",
                 text: "3x",
-                title: _t("Icon size 3x"),
                 isFormatApplied: () => this.hasIconSize("3"),
             },
             {
                 id: "icon_size_4",
                 category: "icon_size",
-                action(dispatch) {
-                    dispatch("RESIZE_ICON", "4");
-                },
+                commandId: "resizeIcon4",
                 text: "4x",
-                title: _t("Icon size 4x"),
                 isFormatApplied: () => this.hasIconSize("4"),
             },
             {
                 id: "icon_size_5",
                 category: "icon_size",
-                action(dispatch) {
-                    dispatch("RESIZE_ICON", "5");
-                },
+                commandId: "resizeIcon5",
                 text: "5x",
-                title: _t("Icon size 5x"),
                 isFormatApplied: () => this.hasIconSize("5"),
             },
             {
                 id: "icon_spin",
                 category: "icon_spin",
-                action(dispatch) {
-                    dispatch("TOGGLE_SPIN_ICON");
-                },
-                icon: "fa-play",
-                title: _t("Toggle icon spin"),
+                commandId: "toggleSpinIcon",
                 isFormatApplied: () => this.hasSpinIcon(),
             },
         ],
-        colorApply: this.applyIconColor.bind(this),
+        color_apply_handlers: this.applyIconColor.bind(this),
     };
 
     getSelectedIcon() {
@@ -111,33 +125,28 @@ export class IconPlugin extends Plugin {
         return selectedNodes.find((node) => node.classList?.contains?.("fa"));
     }
 
-    handleCommand(command, payload) {
-        switch (command) {
-            case "RESIZE_ICON": {
-                const selectedIcon = this.getSelectedIcon();
-                if (!selectedIcon) {
-                    return;
-                }
-                for (const classString of selectedIcon.classList) {
-                    if (classString.match(/^fa-[2-5]x$/)) {
-                        selectedIcon.classList.remove(classString);
-                    }
-                    this.dispatch("ADD_STEP");
-                }
-                if (payload !== "1") {
-                    selectedIcon.classList.add(`fa-${payload}x`);
-                }
-                break;
-            }
-            case "TOGGLE_SPIN_ICON": {
-                const selectedIcon = this.getSelectedIcon();
-                if (!selectedIcon) {
-                    return;
-                }
-                selectedIcon.classList.toggle("fa-spin");
-                break;
-            }
+    resizeIcon({ size }) {
+        const selectedIcon = this.getSelectedIcon();
+        if (!selectedIcon) {
+            return;
         }
+        for (const classString of selectedIcon.classList) {
+            if (classString.match(/^fa-[2-5]x$/)) {
+                selectedIcon.classList.remove(classString);
+            }
+            this.shared.addStep();
+        }
+        if (size !== "1") {
+            selectedIcon.classList.add(`fa-${size}x`);
+        }
+    }
+
+    toggleSpinIcon() {
+        const selectedIcon = this.getSelectedIcon();
+        if (!selectedIcon) {
+            return;
+        }
+        selectedIcon.classList.toggle("fa-spin");
     }
 
     hasIconSize(size) {

--- a/addons/html_editor/static/src/main/media/image_crop_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_crop_plugin.js
@@ -7,8 +7,16 @@ import { withSequence } from "@html_editor/utils/resource";
 
 export class ImageCropPlugin extends Plugin {
     static name = "image_crop";
-    static dependencies = ["image", "selection"];
+    static dependencies = ["image", "selection", "history"];
     resources = {
+        user_commands: [
+            {
+                id: "cropImage",
+                run: this.openCropImage.bind(this),
+                label: _t("Crop image"),
+                icon: "fa-crop",
+            },
+        ],
         toolbarCategory: withSequence(27, {
             id: "image_crop",
             namespace: "image",
@@ -16,12 +24,8 @@ export class ImageCropPlugin extends Plugin {
         toolbarItems: [
             {
                 id: "image_crop",
-                category: "image_crop",
-                title: _t("Crop image"),
-                icon: "fa-crop",
-                action(dispatch) {
-                    dispatch("CROP_IMAGE");
-                },
+                commandId: "cropImage",
+                categoryId: "image_crop",
             },
         ],
     };
@@ -33,32 +37,25 @@ export class ImageCropPlugin extends Plugin {
         };
     }
 
-    handleCommand(command, payload) {
-        switch (command) {
-            case "CROP_IMAGE": {
-                const selectedImg = this.getSelectedImage();
-                if (!selectedImg) {
-                    return;
-                }
-                this.imageCropProps.media = selectedImg;
-                this.openCropImage();
-                break;
-            }
-        }
-    }
-
     getSelectedImage() {
         const selectedNodes = this.shared.getSelectedNodes();
         return selectedNodes.find((node) => node.tagName === "IMG");
     }
 
     async openCropImage() {
+        const selectedImg = this.getSelectedImage();
+        if (!selectedImg) {
+            return;
+        }
+
+        this.imageCropProps.media = selectedImg;
+
         const onClose = () => {
             registry.category("main_components").remove("ImageCropping");
         };
 
         const onSave = () => {
-            this.dispatch("ADD_STEP");
+            this.shared.addStep();
         };
 
         await loadBundle("html_editor.assets_image_cropper");

--- a/addons/html_editor/static/src/main/media/image_description.js
+++ b/addons/html_editor/static/src/main/media/image_description.js
@@ -8,6 +8,7 @@ export class ImageDescription extends Component {
     static props = {
         getDescription: Function,
         getTooltip: Function,
+        updateImageDescription: Function,
         ...toolbarButtonProps,
     };
     static template = "html_editor.ImageDescription";
@@ -20,7 +21,7 @@ export class ImageDescription extends Component {
         this.dialog.add(ImageDescriptionDialog, {
             description: this.props.getDescription(),
             onConfirm: (description, tooltip) =>
-                this.props.dispatch("UPDATE_IMAGE_DESCRIPTION", { description, tooltip }),
+                this.props.updateImageDescription({ description, tooltip }),
             tooltip: this.props.getTooltip(),
         });
     }

--- a/addons/html_editor/static/src/main/media/image_padding.js
+++ b/addons/html_editor/static/src/main/media/image_padding.js
@@ -5,7 +5,10 @@ import { toolbarButtonProps } from "@html_editor/main/toolbar/toolbar";
 
 export class ImagePadding extends Component {
     static components = { Dropdown, DropdownItem };
-    static props = toolbarButtonProps;
+    static props = {
+        ...toolbarButtonProps,
+        onSelected: Function,
+    };
     static template = "html_editor.ImagePadding";
 
     setup() {
@@ -13,6 +16,6 @@ export class ImagePadding extends Component {
     }
 
     onSelected(padding) {
-        this.props.dispatch("SET_IMAGE_PADDING", { padding: this.paddings[padding] });
+        this.props.onSelected({ size: this.paddings[padding] });
     }
 }

--- a/addons/html_editor/static/src/main/movenode_plugin.js
+++ b/addons/html_editor/static/src/main/movenode_plugin.js
@@ -12,7 +12,7 @@ const ALLOWED_ELEMENTS =
 
 export class MoveNodePlugin extends Plugin {
     static name = "movenode";
-    static dependencies = ["selection", "position", "local-overlay"];
+    static dependencies = ["selection", "history", "position", "local-overlay"];
     resources = {
         layoutGeometryChange: () => {
             if (this.currentMovableElement) {
@@ -389,7 +389,7 @@ export class MoveNodePlugin extends Plugin {
                 anchorNode: selectionPosition[0],
                 anchorOffset: selectionPosition[1],
             });
-            this.dispatch("ADD_STEP");
+            this.shared.addStep();
         }
     }
     onMousemove(e) {

--- a/addons/html_editor/static/src/main/movenode_plugin.js
+++ b/addons/html_editor/static/src/main/movenode_plugin.js
@@ -2,6 +2,7 @@ import { useNativeDraggable } from "@html_editor/utils/drag_and_drop";
 import { endPos } from "@html_editor/utils/position";
 import { Plugin } from "../plugin";
 import { ancestors, closestElement } from "../utils/dom_traversal";
+import { trigger } from "@html_editor/utils/resource";
 
 const WIDGET_CONTAINER_WIDTH = 25;
 const WIDGET_MOVE_SIZE = 20;
@@ -208,7 +209,7 @@ export class MoveNodePlugin extends Plugin {
     setMovableElement(movableElement) {
         this.removeMoveWidget();
         this.currentMovableElement = movableElement;
-        this.getResource("setMovableElement").forEach((cb) => cb(movableElement));
+        trigger(this.getResource("setMovableElement"), movableElement);
 
         const containerRect = this.widgetContainer.getBoundingClientRect();
         const anchorBlockRect = this.currentMovableElement.getBoundingClientRect();
@@ -258,7 +259,7 @@ export class MoveNodePlugin extends Plugin {
         }
     }
     removeMoveWidget() {
-        this.getResource("unsetMovableElement").forEach((cb) => cb());
+        trigger(this.getResource("unsetMovableElement"));
         this.moveWidget?.remove();
         this.moveWidget = undefined;
         this.currentMovableElement = undefined;

--- a/addons/html_editor/static/src/main/position_plugin.js
+++ b/addons/html_editor/static/src/main/position_plugin.js
@@ -2,6 +2,7 @@ import { ancestors } from "@html_editor/utils/dom_traversal";
 import { Plugin } from "../plugin";
 import { throttleForAnimation } from "@web/core/utils/timing";
 import { couldBeScrollableX, couldBeScrollableY } from "@web/core/utils/scrolling";
+import { trigger } from "@html_editor/utils/resource";
 
 /**
  * This plugins provides a way to create a "local" overlays so that their
@@ -47,6 +48,6 @@ export class PositionPlugin extends Plugin {
         super.destroy();
     }
     layoutGeometryChange() {
-        this.getResource("layoutGeometryChange").forEach((cb) => cb());
+        trigger(this.getResource("layoutGeometryChange"));
     }
 }

--- a/addons/html_editor/static/src/main/position_plugin.js
+++ b/addons/html_editor/static/src/main/position_plugin.js
@@ -14,6 +14,7 @@ export class PositionPlugin extends Plugin {
         // todo: it is strange that the position plugin is aware of onExternalHistorySteps and historyResetFromSteps.
         onExternalHistorySteps: this.layoutGeometryChange.bind(this),
         historyResetFromSteps: this.layoutGeometryChange.bind(this),
+        step_added_listeners: this.layoutGeometryChange.bind(this),
     };
 
     setup() {
@@ -36,13 +37,6 @@ export class PositionPlugin extends Plugin {
         }
     }
 
-    handleCommand(commandName) {
-        switch (commandName) {
-            case "ADD_STEP":
-                this.layoutGeometryChange();
-                break;
-        }
-    }
     destroy() {
         this.resizeObserver.disconnect();
         super.destroy();

--- a/addons/html_editor/static/src/main/powerbox/powerbox.xml
+++ b/addons/html_editor/static/src/main/powerbox/powerbox.xml
@@ -11,10 +11,10 @@
                     t-on-mouseenter="() => this.onMouseEnter(command_index)"
                     t-on-click="() => this.props.applyCommand(command)">
                     <div class="border rounded">
-                        <i class="o-we-command-img d-flex align-items-center justify-content-center fa" t-att-class="command.fontawesome"/>
+                        <i class="o-we-command-img d-flex align-items-center justify-content-center fa" t-att-class="command.icon"/>
                     </div>
                     <div class="ms-3">
-                        <div class="o-we-command-name" t-esc="command.name"/>
+                        <div class="o-we-command-name" t-esc="command.label"/>
                         <div class="o-we-command-description" t-esc="command.description"/>
                     </div>
                 </div>

--- a/addons/html_editor/static/src/main/powerbox/search_powerbox_plugin.js
+++ b/addons/html_editor/static/src/main/powerbox/search_powerbox_plugin.js
@@ -8,10 +8,13 @@ import { Plugin } from "../../plugin";
 
 export class SearchPowerboxPlugin extends Plugin {
     static name = "search_powerbox";
-    static dependencies = ["powerbox", "selection", "history"];
+    static dependencies = ["powerbox", "selection", "history", "user_command"];
     resources = {
         onBeforeInput: this.onBeforeInput.bind(this),
         onInput: this.onInput.bind(this),
+        delete_listeners: this.update.bind(this),
+        post_undo_listeners: this.update.bind(this),
+        post_redo_listeners: this.update.bind(this),
     };
     setup() {
         const categoryIds = new Set();
@@ -22,22 +25,7 @@ export class SearchPowerboxPlugin extends Plugin {
             categoryIds.add(category.id);
         }
         this.categories = this.getResource("powerboxCategory");
-        this.commands = this.getResource("powerboxItems").map((command) => ({
-            ...command,
-            categoryName: this.categories.find((category) => category.id === command.category).name,
-        }));
-
         this.shouldUpdate = false;
-    }
-    handleCommand(command) {
-        switch (command) {
-            case "DELETE_BACKWARD":
-            case "DELETE_FORWARD":
-            case "HISTORY_UNDO":
-            case "HISTORY_REDO":
-                this.update();
-                break;
-        }
     }
     onBeforeInput(ev) {
         if (ev.data === "/") {
@@ -83,7 +71,7 @@ export class SearchPowerboxPlugin extends Plugin {
      */
     filterCommands(searchTerm) {
         return fuzzyLookup(searchTerm, this.enabledCommands, (cmd) => [
-            cmd.name,
+            cmd.label,
             cmd.categoryName,
             cmd.description,
             ...(cmd.searchKeywords || []),
@@ -103,9 +91,7 @@ export class SearchPowerboxPlugin extends Plugin {
     openPowerbox() {
         const selection = this.shared.getEditableSelection();
         this.offset = selection.startOffset - 1;
-        this.enabledCommands = this.commands.filter(
-            (cmd) => !cmd.isAvailable?.(selection.anchorNode)
-        );
+        this.enabledCommands = this.shared.getAvailablePowerboxItems();
         this.shared.openPowerbox({
             commands: this.enabledCommands,
             categories: this.categories,

--- a/addons/html_editor/static/src/main/signature_plugin.js
+++ b/addons/html_editor/static/src/main/signature_plugin.js
@@ -6,18 +6,22 @@ import { withSequence } from "@html_editor/utils/resource";
 
 export class SignaturePlugin extends Plugin {
     static name = "signature";
-    static dependencies = ["dom"];
+    static dependencies = ["dom", "history"];
     resources = {
+        user_commands: [
+            {
+                id: "insertSignature",
+                label: _t("Signature"),
+                description: _t("Insert your signature"),
+                icon: "fa-pencil-square-o",
+                run: this.insertSignature.bind(this),
+            },
+        ],
         powerboxCategory: withSequence(100, { id: "basic_block", name: _t("Basic Bloc") }),
         powerboxItems: [
             {
                 category: "basic_block",
-                name: _t("Signature"),
-                description: _t("Insert your signature"),
-                fontawesome: "fa-pencil-square-o",
-                action: () => {
-                    return this.insertSignature();
-                },
+                commandId: "insertSignature",
             },
         ],
     };
@@ -30,7 +34,7 @@ export class SignaturePlugin extends Plugin {
         );
         if (currentUser && currentUser.signature) {
             this.shared.domInsert(parseHTML(this.document, currentUser.signature));
-            this.dispatch("ADD_STEP");
+            this.shared.addStep();
         }
     }
 }

--- a/addons/html_editor/static/src/main/star_plugin.js
+++ b/addons/html_editor/static/src/main/star_plugin.js
@@ -8,26 +8,32 @@ import { _t } from "@web/core/l10n/translation";
 
 export class StarPlugin extends Plugin {
     static name = "star";
-    static dependencies = ["dom"];
+    static dependencies = ["dom", "history"];
     resources = {
+        user_commands: [
+            {
+                id: "addStars",
+                label: _t("Stars"),
+                description: _t("Insert a rating"),
+                icon: "fa-star",
+                run: this.addStars.bind(this),
+            },
+        ],
         powerboxItems: [
             {
-                name: _t("3 Stars"),
+                label: _t("3 Stars"),
                 description: _t("Insert a rating over 3 stars"),
                 category: "widget",
-                fontawesome: "fa-star-o",
-                action: () => {
-                    this.addStars(3);
-                },
+                icon: "fa-star-o",
+                commandId: "addStars",
+                commandParams: { length: 3 },
             },
             {
-                name: _t("5 Stars"),
+                label: _t("5 Stars"),
                 description: _t("Insert a rating over 5 stars"),
                 category: "widget",
-                fontawesome: "fa-star",
-                action: () => {
-                    this.addStars(5);
-                },
+                commandId: "addStars",
+                commandParams: { length: 5 },
             },
         ],
     };
@@ -60,17 +66,17 @@ export class StarPlugin extends Plugin {
                     star.classList.toggle("fa-star-o", true);
                     star.classList.toggle("fa-star", false);
                 }
-                this.dispatch("ADD_STEP");
+                this.shared.addStep();
             }
             ev.stopPropagation();
             ev.preventDefault();
         }
     }
 
-    addStars(length) {
+    addStars({ length }) {
         const stars = Array.from({ length }, () => '<i class="fa fa-star-o"></i>').join("");
         const html = `\u200B<span contenteditable="false" class="o_stars">${stars}</span>\u200B`;
         this.shared.domInsert(parseHTML(this.document, html));
-        this.dispatch("ADD_STEP");
+        this.shared.addStep();
     }
 }

--- a/addons/html_editor/static/src/main/table/table_menu.js
+++ b/addons/html_editor/static/src/main/table/table_menu.js
@@ -7,7 +7,13 @@ export class TableMenu extends Component {
     static template = "html_editor.TableMenu";
     static props = {
         type: String, // column or row
-        dispatch: Function,
+        moveColumn: Function,
+        addColumn: Function,
+        removeColumn: Function,
+        moveRow: Function,
+        addRow: Function,
+        removeRow: Function,
+        resetTableSize: Function,
         overlay: Object,
         dropdownState: Object,
         target: { validate: (el) => el.nodeType === Node.ELEMENT_NODE },
@@ -47,37 +53,37 @@ export class TableMenu extends Component {
                 name: "move_left",
                 icon: "fa-chevron-left disabled",
                 text: ltr ? _t("Move left") : _t("Move right"),
-                action: this.moveColumn.bind(this, "left"),
+                action: this.props.moveColumn.bind(this, "left"),
             },
             !this.isLast && {
                 name: "move_right",
                 icon: "fa-chevron-right",
                 text: ltr ? _t("Move right") : _t("Move left"),
-                action: this.moveColumn.bind(this, "right"),
+                action: this.props.moveColumn.bind(this, "right"),
             },
             {
                 name: "insert_left",
                 icon: "fa-plus",
                 text: ltr ? _t("Insert left") : _t("Insert right"),
-                action: this.insertColumn.bind(this, "before"),
+                action: this.props.addColumn.bind(this, "before"),
             },
             {
                 name: "insert_right",
                 icon: "fa-plus",
                 text: ltr ? _t("Insert right") : _t("Insert left"),
-                action: this.insertColumn.bind(this, "after"),
+                action: this.props.addColumn.bind(this, "after"),
             },
             {
                 name: "delete",
                 icon: "fa-trash",
                 text: _t("Delete"),
-                action: this.deleteColumn.bind(this),
+                action: this.props.removeColumn.bind(this),
             },
             this.hasCustomSize && {
                 name: "reset_size",
                 icon: "fa-table",
                 text: _t("Reset Size"),
-                action: this.resetSize.bind(this),
+                action: (target) => this.props.resetTableSize(target.closest("table")),
             },
         ].filter(Boolean);
     }
@@ -88,66 +94,38 @@ export class TableMenu extends Component {
                 name: "move_up",
                 icon: "fa-chevron-up",
                 text: _t("Move up"),
-                action: this.moveRow.bind(this, "up"),
+                action: (target) => this.props.moveRow("up", target.parentElement),
             },
             !this.isLast && {
                 name: "move_down",
                 icon: "fa-chevron-down",
                 text: _t("Move down"),
-                action: this.moveRow.bind(this, "down"),
+                action: (target) => this.props.moveRow("down", target.parentElement),
             },
             {
                 name: "insert_above",
                 icon: "fa-plus",
                 text: _t("Insert above"),
-                action: this.insertRow.bind(this, "before"),
+                action: (target) => this.props.addRow("before", target.parentElement),
             },
             {
                 name: "insert_below",
                 icon: "fa-plus",
                 text: _t("Insert below"),
-                action: this.insertRow.bind(this, "after"),
+                action: (target) => this.props.addRow("after", target.parentElement),
             },
             {
                 name: "delete",
                 icon: "fa-trash",
                 text: _t("Delete"),
-                action: this.deleteRow.bind(this),
+                action: (target) => this.props.removeRow(target.parentElement),
             },
             this.hasCustomSize && {
                 name: "reset_size",
                 icon: "fa-table",
                 text: _t("Reset Size"),
-                action: this.resetSize.bind(this),
+                action: (target) => this.props.resetTableSize(target.closest("table")),
             },
         ].filter(Boolean);
-    }
-
-    moveColumn(position, target) {
-        this.props.dispatch("MOVE_COLUMN", { position, cell: target });
-    }
-
-    insertColumn(position, target) {
-        this.props.dispatch("ADD_COLUMN", { position, reference: target });
-    }
-
-    deleteColumn(target) {
-        this.props.dispatch("REMOVE_COLUMN", { cell: target });
-    }
-
-    moveRow(position, target) {
-        this.props.dispatch("MOVE_ROW", { position, row: target.parentElement });
-    }
-
-    insertRow(position, target) {
-        this.props.dispatch("ADD_ROW", { position, reference: target.parentElement });
-    }
-
-    deleteRow(target) {
-        this.props.dispatch("REMOVE_ROW", { row: target.parentElement });
-    }
-
-    resetSize(target) {
-        this.props.dispatch("RESET_SIZE", { table: target.closest("table") });
     }
 }

--- a/addons/html_editor/static/src/main/table/table_picker.js
+++ b/addons/html_editor/static/src/main/table/table_picker.js
@@ -3,7 +3,7 @@ import { Component, useExternalListener, useState } from "@odoo/owl";
 export class TablePicker extends Component {
     static template = "html_editor.TablePicker";
     static props = {
-        dispatch: Function,
+        insertTable: Function,
         editable: {
             validate: (el) => el.nodeType === Node.ELEMENT_NODE,
         },
@@ -67,7 +67,7 @@ export class TablePicker extends Component {
     }
 
     insertTable() {
-        this.props.dispatch("INSERT_TABLE", { cols: this.state.cols, rows: this.state.rows });
+        this.props.insertTable({ cols: this.state.cols, rows: this.state.rows });
         this.props.overlay.close();
     }
 }

--- a/addons/html_editor/static/src/main/table/table_resize_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_resize_plugin.js
@@ -9,7 +9,7 @@ import { BORDER_SENSITIVITY } from "@html_editor/main/table/table_plugin";
 
 export class TableResizePlugin extends Plugin {
     static name = "table_resize";
-    static dependencies = ["table"];
+    static dependencies = ["table", "history"];
 
     setup() {
         this.addDomListener(this.editable, "mousedown", this.onMousedown);
@@ -294,7 +294,7 @@ export class TableResizePlugin extends Plugin {
                 ev.preventDefault();
                 this.isResizingTable = false;
                 this.setTableResizeCursor(false);
-                this.dispatch("ADD_STEP");
+                this.shared.addStep();
                 this.document.removeEventListener("mousemove", resizeTable);
                 this.document.removeEventListener("mouseup", stopResizing);
                 this.document.removeEventListener("mouseleave", stopResizing);

--- a/addons/html_editor/static/src/main/tabulation_plugin.js
+++ b/addons/html_editor/static/src/main/tabulation_plugin.js
@@ -4,6 +4,7 @@ import { isEditorTab, isTextNode, isZWS } from "@html_editor/utils/dom_info";
 import { descendants, getAdjacentPreviousSiblings } from "@html_editor/utils/dom_traversal";
 import { parseHTML } from "@html_editor/utils/html";
 import { DIRECTIONS, childNodeIndex } from "@html_editor/utils/position";
+import { delegate } from "@html_editor/utils/resource";
 
 const tabHtml = '<span class="oe-tabs" contenteditable="false">\u0009</span>\u200B';
 const GRID_COLUMN_WIDTH = 40; //@todo Configurable?
@@ -59,10 +60,8 @@ export class TabulationPlugin extends Plugin {
     }
 
     handleTab() {
-        for (const callback of this.getResource("handle_tab")) {
-            if (callback()) {
-                return;
-            }
+        if (delegate(this.getResource("handle_tab"))) {
+            return;
         }
 
         const selection = this.shared.getEditableSelection();
@@ -76,10 +75,8 @@ export class TabulationPlugin extends Plugin {
     }
 
     handleShiftTab() {
-        for (const callback of this.getResource("handle_shift_tab")) {
-            if (callback()) {
-                return;
-            }
+        if (delegate(this.getResource("handle_shift_tab"))) {
+            return;
         }
         const traversedBlocks = this.shared.getTraversedBlocks();
         this.outdentBlocks(traversedBlocks);

--- a/addons/html_editor/static/src/main/text_direction_plugin.js
+++ b/addons/html_editor/static/src/main/text_direction_plugin.js
@@ -6,17 +6,21 @@ import { isContentEditable, isTextNode } from "@html_editor/utils/dom_info";
 
 export class TextDirectionPlugin extends Plugin {
     static name = "text_direction";
-    static dependencies = ["selection", "split", "format"];
+    static dependencies = ["selection", "history", "split", "format"];
     resources = {
+        user_commands: [
+            {
+                id: "switchDirection",
+                label: _t("Switch direction"),
+                description: _t("Switch the text's direction"),
+                icon: "fa-exchange",
+                run: this.switchDirection.bind(this),
+            },
+        ],
         powerboxItems: [
             {
-                name: _t("Switch direction"),
-                description: _t("Switch the text's direction"),
                 category: "format",
-                fontawesome: "fa-exchange",
-                action(dispatch) {
-                    dispatch("SWITCH_DIRECTION");
-                },
+                commandId: "switchDirection",
             },
         ],
     };
@@ -26,14 +30,6 @@ export class TextDirectionPlugin extends Plugin {
             this.editable.setAttribute("dir", this.config.direction);
         }
         this.direction = this.config.direction || "ltr";
-    }
-
-    handleCommand(command) {
-        switch (command) {
-            case "SWITCH_DIRECTION":
-                this.switchDirection();
-                break;
-        }
     }
 
     switchDirection() {
@@ -70,6 +66,6 @@ export class TextDirectionPlugin extends Plugin {
                 element.style.setProperty("text-align", "right");
             }
         }
-        this.dispatch("ADD_STEP");
+        this.shared.addStep();
     }
 }

--- a/addons/html_editor/static/src/main/toolbar/toolbar.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar.js
@@ -7,7 +7,6 @@ export class Toolbar extends Component {
         toolbar: {
             type: Object,
             shape: {
-                dispatch: Function,
                 getSelection: Function,
                 focusEditable: Function,
                 buttonGroups: {
@@ -25,7 +24,7 @@ export class Toolbar extends Component {
                                         const base = {
                                             id: String,
                                             category: String,
-                                            title: String,
+                                            label: String,
                                             inherit: { type: String, optional: true },
                                         };
                                         if (button.Component) {
@@ -38,7 +37,7 @@ export class Toolbar extends Component {
                                         } else {
                                             validate(button, {
                                                 ...base,
-                                                action: Function,
+                                                run: Function,
                                                 icon: { type: String, optional: true },
                                                 text: { type: String, optional: true },
                                                 isFormatApplied: { type: Function, optional: true },
@@ -86,13 +85,12 @@ export class Toolbar extends Component {
     }
 
     onButtonClick(button) {
-        button.action(this.props.toolbar.dispatch);
+        button.run();
         this.props.toolbar.focusEditable();
     }
 }
 
 export const toolbarButtonProps = {
-    title: String,
-    dispatch: Function,
+    label: String,
     getSelection: Function,
 };

--- a/addons/html_editor/static/src/main/toolbar/toolbar.xml
+++ b/addons/html_editor/static/src/main/toolbar/toolbar.xml
@@ -9,8 +9,7 @@
                             <t t-if="button.Component">
                                 <t t-component="button.Component"
                                     t-props="button.props"
-                                    title="button.title"
-                                    dispatch.bind="props.toolbar.dispatch"
+                                    label="button.label"
                                     getSelection.bind="props.toolbar.getSelection"/>
                             </t>
                             <button t-else=""
@@ -19,7 +18,7 @@
                                     active: state.buttonsActiveState[button.id],
                                     disabled: state.buttonsDisabledState[button.id]
                                 }"
-                                t-att-title="button.title"
+                                t-att-title="button.label"
                                 t-att-name="button.id"
                                 t-on-click="() => this.onButtonClick(button)"
                             >

--- a/addons/html_editor/static/src/main/youtube_plugin.js
+++ b/addons/html_editor/static/src/main/youtube_plugin.js
@@ -8,7 +8,7 @@ export const YOUTUBE_URL_GET_VIDEO_ID =
 
 export class YoutubePlugin extends Plugin {
     static name = "youtube";
-    static dependencies = ["history", "powerbox", "link", "dom"];
+    static dependencies = ["history", "history", "powerbox", "link", "dom"];
     static shared = [];
     resources = {
         handle_paste_url: this.handlePasteUrl.bind(this),
@@ -26,16 +26,16 @@ export class YoutubePlugin extends Plugin {
             // Open powerbox with commands to embed media or paste as link.
             // Insert URL as text, revert it later if a command is triggered.
             this.shared.domInsert(text);
-            this.dispatch("ADD_STEP");
+            this.shared.addStep();
             // URL is a YouTube video.
             const embedVideoCommand = {
-                name: _t("Embed Youtube Video"),
+                label: _t("Embed Youtube Video"),
                 description: _t("Embed the youtube video in the document."),
-                fontawesome: "fa-youtube-play",
-                action: async () => {
+                icon: "fa-youtube-play",
+                run: async () => {
                     const videoElement = await this.getYoutubeVideoElement(youtubeUrl[0]);
                     this.shared.domInsert(videoElement);
-                    this.dispatch("ADD_STEP");
+                    this.shared.addStep();
                 },
             };
             const commands = [embedVideoCommand, this.shared.getPathAsUrlCommand(text, url)];

--- a/addons/html_editor/static/src/others/collaboration/collaboration_odoo_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_odoo_plugin.js
@@ -4,6 +4,7 @@ import { user } from "@web/core/user";
 import { Mutex } from "@web/core/utils/concurrency";
 import { debounce } from "@web/core/utils/timing";
 import { PeerToPeer, RequestError } from "./PeerToPeer";
+import { trigger } from "@html_editor/utils/resource";
 
 /**
  * @typedef {Object} CollaborationSelection
@@ -269,9 +270,7 @@ export class CollaborationOdooPlugin extends Plugin {
                 },
             },
             onNotification: async (notification) => {
-                for (const cb of this.getResource("handleCollaborationNotification")) {
-                    cb(notification);
-                }
+                trigger(this.getResource("handleCollaborationNotification"), notification);
                 let { fromPeerId, notificationName, notificationPayload } = notification;
                 switch (notificationName) {
                     case "ptp_remove":
@@ -361,7 +360,7 @@ export class CollaborationOdooPlugin extends Plugin {
      * @param {CollaborationSelection} selection
      */
     onExternalMultiselectionUpdate(selection) {
-        this.getResource("collaborativeSelectionUpdate").forEach((cb) => cb(selection));
+        trigger(this.getResource("collaborativeSelectionUpdate"), selection);
     }
 
     async requestPeer(peerId, requestName, requestPayload, params) {

--- a/addons/html_editor/static/src/others/collaboration/collaboration_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_plugin.js
@@ -1,4 +1,5 @@
 import { Plugin } from "@html_editor/plugin";
+import { trigger } from "@html_editor/utils/resource";
 
 // 60 seconds
 export const HISTORY_SNAPSHOT_INTERVAL = 1000 * 60;
@@ -160,7 +161,7 @@ export class CollaborationPlugin extends Plugin {
             this.shared.rectifySelection(selectionData.editableSelection);
         }
 
-        this.getResource("onExternalHistorySteps").forEach((cb) => cb());
+        trigger(this.getResource("onExternalHistorySteps"));
 
         // todo: ensure that if the selection was not in the editable before the
         // reset, it remains where it was after applying the snapshot.

--- a/addons/html_editor/static/src/others/dynamic_placeholder/dynamic_placeholder.js
+++ b/addons/html_editor/static/src/others/dynamic_placeholder/dynamic_placeholder.js
@@ -8,18 +8,23 @@ export class DynamicPlaceholderPlugin extends Plugin {
     static dependencies = ["overlay", "selection", "history", "dom", "qweb"];
     static shared = ["updateDphDefaultModel"];
     resources = {
+        user_commands: [
+            {
+                id: "openDynamicPlaceholder",
+                label: _t("Dynamic Placeholder"),
+                description: _t("Insert a field"),
+                icon: "fa-hashtag",
+                run: (params = {}) => {
+                    return this.open(params.resModel || this.defaultResModel);
+                },
+            },
+        ],
         powerboxCategory: withSequence(60, { id: "marketing_tools", name: _t("Marketing Tools") }),
         powerboxItems: {
-            id: "dynamic_placeholder",
-            name: _t("Dynamic Placeholder"),
-            description: _t("Insert a field"),
             category: "marketing_tools",
-            fontawesome: "fa-hashtag",
-            action(dispatch) {
-                dispatch("OPEN_DYNAMIC_PLACEHOLDER");
-            },
+            commandId: "openDynamicPlaceholder",
         },
-        powerButtons: ["dynamic_placeholder"],
+        powerButtons: ["openDynamicPlaceholder"],
     };
     setup() {
         this.defaultResModel = this.config.dynamicPlaceholderResModel;
@@ -29,15 +34,6 @@ export class DynamicPlaceholderPlugin extends Plugin {
             hasAutofocus: true,
             className: "popover",
         });
-    }
-
-    handleCommand(command, payload) {
-        switch (command) {
-            case "OPEN_DYNAMIC_PLACEHOLDER": {
-                this.open(payload.resModel || this.defaultResModel);
-                break;
-            }
-        }
     }
 
     /**
@@ -82,7 +78,7 @@ export class DynamicPlaceholderPlugin extends Plugin {
         }
 
         this.shared.domInsert(t);
-        this.dispatch("ADD_STEP");
+        this.shared.addStep();
     }
 
     onClose() {

--- a/addons/html_editor/static/src/others/embedded_component_utils.js
+++ b/addons/html_editor/static/src/others/embedded_component_utils.js
@@ -258,7 +258,8 @@ export class StateChangeManager {
     /**
      * @param {StateChangeManagerConfig} config
      * @param {HostElement} config.host
-     * @param {Function} config.dispatch plugin dispatch to send editor commands
+     * @param {Function} config.commitChanges notify the host that we can commit
+     *                                        changes
      */
     constructor(config) {
         this.config = config;
@@ -439,7 +440,7 @@ export class StateChangeManager {
             this.config.host.dataset.embeddedProps = JSON.stringify(
                 this.stateToEmbeddedProps(this.config.host, sortedState)
             );
-            this.config.dispatch("ADD_STEP");
+            this.config.commitStateChanges();
         }
         observeAllKeys(this.embeddedStateProxy);
     }

--- a/addons/html_editor/static/src/others/embedded_components/plugins/excalidraw_plugin/excalidraw_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/excalidraw_plugin/excalidraw_plugin.js
@@ -5,18 +5,20 @@ import { ExcalidrawDialog } from "@html_editor/others/embedded_components/plugin
 
 export class ExcalidrawPlugin extends Plugin {
     static name = "excalidraw";
-    static dependencies = ["embedded_components", "dom", "selection", "link"];
+    static dependencies = ["embedded_components", "dom", "selection", "link", "history"];
     resources = {
+        user_commands: [
+            {
+                id: "insertDrawingBoard",
+                label: _t("Drawing Board"),
+                description: _t("Insert an Excalidraw Board"),
+                icon: "fa-pencil-square-o",
+            },
+        ],
         powerboxItems: [
             {
                 category: "navigation",
-                name: _t("Drawing Board"),
-                priority: 70,
-                description: _t("Insert an Excalidraw Board"),
-                fontawesome: "fa-pencil-square-o",
-                action: () => {
-                    this.insertDrawingBoard();
-                },
+                commandId: "insertDrawingBoard",
             },
         ],
     };
@@ -37,8 +39,7 @@ export class ExcalidrawPlugin extends Plugin {
                         }
                     );
                     this.shared.domInsert(templateBlock);
-
-                    this.dispatch("ADD_STEP");
+                    this.shared.addStep();
 
                     restoreSelection = () => {};
                 },

--- a/addons/html_editor/static/src/others/embedded_components/plugins/file_plugin/file_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/file_plugin/file_plugin.js
@@ -7,22 +7,21 @@ import { isBlock } from "@html_editor/utils/blocks";
 
 export class FilePlugin extends Plugin {
     static name = "file";
-    static dependencies = ["embedded_components", "dom", "selection"];
+    static dependencies = ["embedded_components", "dom", "selection", "history"];
     resources = {
-        powerboxItems: [
+        user_commands: [
             {
-                category: "media",
-                name: _t("File"),
-                priority: 20,
+                id: "openMediaDialog",
+                label: _t("File"),
                 description: _t("Upload a file"),
-                fontawesome: "fa-file",
+                icon: "fa-file",
                 isAvailable: (node) => {
                     return (
                         !this.config.disableFile &&
                         !!closestElement(node, "[data-embedded='clipboard']")
                     );
                 },
-                action: () => {
+                run: () => {
                     this.openMediaDialog({
                         noVideos: true,
                         noImages: true,
@@ -32,16 +31,14 @@ export class FilePlugin extends Plugin {
                 },
             },
         ],
+        powerboxItems: [
+            {
+                category: "media",
+                commandId: "openMediaDialog",
+            },
+        ],
+        mount_component_listeners: this.setupNewFile.bind(this),
     };
-
-    handleCommand(command, payload) {
-        switch (command) {
-            case "SETUP_NEW_COMPONENT":
-                this.setupNewFile(payload);
-                break;
-        }
-        super.handleCommand(command);
-    }
 
     get recordInfo() {
         return this.config.getRecordInfo ? this.config.getRecordInfo() : {};
@@ -75,7 +72,7 @@ export class FilePlugin extends Plugin {
     onSaveMediaDialog(element, { restoreSelection }) {
         restoreSelection();
         this.shared.domInsert(element);
-        this.dispatch("ADD_STEP");
+        this.shared.addStep();
     }
 
     setupNewFile({ name, env }) {

--- a/addons/html_editor/static/src/others/embedded_components/plugins/video_plugin/video_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/video_plugin/video_plugin.js
@@ -5,20 +5,25 @@ import { renderToElement } from "@web/core/utils/render";
 
 export class VideoPlugin extends Plugin {
     static name = "video";
-    static dependencies = ["embedded_components", "dom", "selection", "link"];
+    static dependencies = ["embedded_components", "dom", "selection", "link", "history"];
     resources = {
-        powerboxItems: [
+        user_commands: [
             {
-                category: "navigation",
-                name: _t("Video Link"),
-                priority: 70,
+                id: "openVideoSelectorDialog",
+                label: _t("Video Link"),
                 description: _t("Insert a Video"),
-                fontawesome: "fa-play",
-                action: () => {
+                icon: "fa-play",
+                run: () => {
                     this.openVideoSelectorDialog((media) => {
                         this.insertVideo(media);
                     });
                 },
+            },
+        ],
+        powerboxItems: [
+            {
+                category: "navigation",
+                commandId: "openVideoSelectorDialog",
             },
         ],
     };
@@ -36,7 +41,7 @@ export class VideoPlugin extends Plugin {
             }),
         });
         this.shared.domInsert(videoBlock);
-        this.dispatch("ADD_STEP");
+        this.shared.addStep();
     }
 
     /**

--- a/addons/html_editor/static/src/others/qweb_plugin.js
+++ b/addons/html_editor/static/src/others/qweb_plugin.js
@@ -15,8 +15,16 @@ export class QWebPlugin extends Plugin {
     resources = {
         onSelectionChange: this.onSelectionChange.bind(this),
         is_mutation_record_savable: this.isMutationRecordSavable.bind(this),
+        clean_listeners: this.clearDataAttributes.bind(this),
         isUnremovable: (element) => element.getAttribute("t-set") || element.getAttribute("t-call"),
         isUnsplittable: isUnsplittableQWebElement,
+        clean_for_save_listeners: ({ root }) => {
+            this.clearDataAttributes(root);
+            for (const element of root.querySelectorAll("[t-esc], [t-raw], [t-out], [t-field]")) {
+                element.removeAttribute("contenteditable");
+            }
+        },
+        normalize_listeners: this.normalize.bind(this),
     };
 
     setup() {
@@ -41,25 +49,6 @@ export class QWebPlugin extends Plugin {
             }
         }
         return true;
-    }
-
-    handleCommand(command, payload) {
-        switch (command) {
-            case "NORMALIZE":
-                this.normalize(payload.node);
-                break;
-            case "CLEAN":
-                this.clearDataAttributes(payload.root);
-                break;
-            case "CLEAN_FOR_SAVE":
-                this.clearDataAttributes(payload.root);
-                for (const element of payload.root.querySelectorAll(
-                    "[t-esc], [t-raw], [t-out], [t-field]"
-                )) {
-                    element.removeAttribute("contenteditable");
-                }
-                break;
-        }
     }
 
     /**

--- a/addons/html_editor/static/src/plugin_sets.js
+++ b/addons/html_editor/static/src/plugin_sets.js
@@ -57,8 +57,11 @@ import { FilePlugin } from "@html_editor/others/embedded_components/plugins/file
 import { TableOfContentPlugin } from "@html_editor/others/embedded_components/plugins/table_of_content_plugin/table_of_content_plugin";
 import { VideoPlugin } from "@html_editor/others/embedded_components/plugins/video_plugin/video_plugin";
 import { QWebPlugin } from "./others/qweb_plugin";
+import { NoInlineRootPlugin } from "./core/no_inline_root_plugin";
+import { UserCommandPlugin } from "./core/user_command_plugin";
 
 export const CORE_PLUGINS = [
+    UserCommandPlugin,
     ClipboardPlugin,
     CommentPlugin,
     DeletePlugin,
@@ -72,6 +75,7 @@ export const CORE_PLUGINS = [
     ProtectedNodePlugin,
     SanitizePlugin,
     SelectionPlugin,
+    NoInlineRootPlugin,
     SplitPlugin,
 ];
 

--- a/addons/html_editor/static/src/utils/resource.js
+++ b/addons/html_editor/static/src/utils/resource.js
@@ -26,8 +26,24 @@ export function withSequence(sequenceNumber, object) {
  *
  * @param {Function[]} handlers A list of handlers to execute. The function
  * should return a truthy value to signal it has been handled.
- * @param  {...any} args
+ * @param  {...any} args The arguments to pass to the handlers.
  */
 export function delegate(handlers, ...args) {
     return handlers.some((fn) => fn(...args));
+}
+
+/**
+ * Execute a series of functions with the given arguments.
+ *
+ * This function is meant to enhances code readability by clearly expressing its
+ * intent.
+ *
+ * This function can be thought as an event dispatcher. It receives a list of
+ * callbacks and the arguments can be thought as the event payload.
+ *
+ * @param {Function[]} functions A list of functions to execute.
+ * @param  {...any} args The arguments to pass to the functions.
+ */
+export function trigger(functions, ...args) {
+    return functions.forEach((fn) => fn(...args));
 }

--- a/addons/html_editor/static/src/utils/resource.js
+++ b/addons/html_editor/static/src/utils/resource.js
@@ -6,3 +6,28 @@ export function withSequence(sequenceNumber, object) {
         object,
     };
 }
+
+/**
+ * Execute a series of handlers until one of them returns a truthy value.
+ *
+ * This function is meant to enhances code readability by clearly expressing its
+ * intent.
+ *
+ * A command "delegate" its execution to one of the handlers. It is the
+ * responsibility of the caller to stop the execution when a handler returns a
+ * truthy value.
+ *
+ * Example:
+ * ```js
+ * if (delegate(myHandlers, arg1, arg2)) {
+ *   return;
+ * }
+ * ```
+ *
+ * @param {Function[]} handlers A list of handlers to execute. The function
+ * should return a truthy value to signal it has been handled.
+ * @param  {...any} args
+ */
+export function delegate(handlers, ...args) {
+    return handlers.some((fn) => fn(...args));
+}

--- a/addons/html_editor/static/tests/_helpers/collaboration.js
+++ b/addons/html_editor/static/tests/_helpers/collaboration.js
@@ -1,6 +1,5 @@
 import { HistoryPlugin } from "@html_editor/core/history_plugin";
 import { CollaborationPlugin } from "@html_editor/others/collaboration/collaboration_plugin";
-import { Plugin } from "@html_editor/plugin";
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import { createDOMPathGenerator } from "@html_editor/utils/dom_traversal";
 import { DIRECTIONS } from "@html_editor/utils/position";
@@ -77,26 +76,17 @@ export const setupMultiEditor = async (spec) => {
                 selection = parseMultipleTextualSelection(editable, peerId);
             },
             config: {
-                Plugins: [
-                    ...defaultPlugins,
-                    CollaborationPlugin,
-                    class TestHistoryAdapterPlugin extends Plugin {
-                        static name = "test-history-adapter";
-                        handleCommand(commandId, payload) {
-                            switch (commandId) {
-                                case "COLLABORATION_STEP_ADDED":
-                                    peerInfo.steps.push(payload);
-                                    break;
-                                case "HISTORY_MISSING_PARENT_STEP":
-                                    historyMissingParentSteps(peerInfos, peerInfo, payload);
-                                    break;
-                            }
-                        }
-                    },
-                    ...(spec.Plugins || []),
-                ],
+                Plugins: [...defaultPlugins, CollaborationPlugin, ...(spec.Plugins || [])],
                 collaboration: { peerId },
-                resources: spec.resources,
+                resources: {
+                    ...spec.resources,
+                    collaboration_step_added_listeners: (step) => {
+                        peerInfo.steps.push(step);
+                    },
+                    history_missing_parent_step_listeners: (params) => {
+                        historyMissingParentSteps(peerInfos, peerInfo, params);
+                    },
+                },
             },
         });
         peerInfo.editor = base.editor;

--- a/addons/html_editor/static/tests/_helpers/editor.js
+++ b/addons/html_editor/static/tests/_helpers/editor.js
@@ -5,6 +5,7 @@ import { Component, xml } from "@odoo/owl";
 import { mountWithCleanup } from "@web/../tests/web_test_helpers";
 import { getContent, getSelection, setContent } from "./selection";
 import { animationFrame } from "@odoo/hoot-mock";
+import { trigger } from "@html_editor/utils/resource";
 
 export const Direction = {
     BACKWARD: "BACKWARD",
@@ -149,13 +150,14 @@ export async function testEditor(config) {
         };
     }
     const { el, editor } = await setupEditor(contentBefore, config);
-    // The HISTORY_STAGE_SELECTION should have been triggered by the click on
+    // The stageSelection should have been triggered by the click on
     // the editable. As we set the selection programmatically, we dispatch the
     // selection here for the commands that relies on it.
     // If the selection of the editor would be programatically set upon start
     // (like an autofocus feature), it would be the role of the autofocus
-    // feature to trigger the HISTORY_STAGE_SELECTION.
-    editor.dispatch("HISTORY_STAGE_SELECTION");
+    // feature to trigger the stageSelection.
+    editor.shared.stageSelection();
+
     if (config.props?.iframe) {
         expect("iframe").toHaveCount(1);
     }
@@ -174,7 +176,10 @@ export async function testEditor(config) {
     }
     if (contentAfter) {
         const content = editor.getContent();
-        editor.dispatch("CLEAN_FOR_SAVE", { root: el, preserveSelection: true });
+        trigger(editor.resources["clean_for_save_listeners"], {
+            root: el,
+            preserveSelection: true,
+        });
         compareFunction(getContent(el), contentAfter, "Editor content, after clean");
         compareFunction(content, el.innerHTML, "Value from editor.getContent()");
     }

--- a/addons/html_editor/static/tests/_helpers/user_actions.js
+++ b/addons/html_editor/static/tests/_helpers/user_actions.js
@@ -57,7 +57,7 @@ export async function insertText(editor, text) {
 
 /** @param {Editor} editor */
 export function deleteForward(editor) {
-    editor.dispatch("DELETE_FORWARD");
+    editor.shared.execCommand("deleteForward");
 }
 
 /**
@@ -67,34 +67,34 @@ export function deleteForward(editor) {
 export function deleteBackward(editor, isMobileTest = false) {
     // TODO phoenix: find a strategy for test mobile and desktop. (check legacy code)
 
-    editor.dispatch("DELETE_BACKWARD");
+    editor.shared.execCommand("deleteBackward");
 }
 
 // history
 /** @param {Editor} editor */
 export function addStep(editor) {
-    editor.dispatch("ADD_STEP");
+    editor.shared.addStep();
 }
 /** @param {Editor} editor */
 export function undo(editor) {
-    editor.dispatch("HISTORY_UNDO");
+    editor.shared.execCommand("historyUndo");
 }
 /** @param {Editor} editor */
 export function redo(editor) {
-    editor.dispatch("HISTORY_REDO");
+    editor.shared.execCommand("historyRedo");
 }
 
 // list
 export function toggleOrderedList(editor) {
-    editor.dispatch("TOGGLE_LIST", { mode: "OL" });
+    editor.shared.execCommand("toggleListOL");
 }
 /** @param {Editor} editor */
 export function toggleUnorderedList(editor) {
-    editor.dispatch("TOGGLE_LIST", { mode: "UL" });
+    editor.shared.execCommand("toggleListUL");
 }
 /** @param {Editor} editor */
 export function toggleCheckList(editor) {
-    editor.dispatch("TOGGLE_LIST", { mode: "CL" });
+    editor.shared.execCommand("toggleListCL");
 }
 
 /**
@@ -115,37 +115,38 @@ export async function clickCheckbox(li) {
 
 /** @param {Editor} editor */
 export function insertLineBreak(editor) {
-    editor.dispatch("INSERT_LINEBREAK");
+    editor.shared.insertLineBreak();
 }
 
 // Format commands
 
 /** @param {Editor} editor */
 export function bold(editor) {
-    editor.dispatch("FORMAT_BOLD");
+    editor.shared.execCommand("formatBold");
 }
 /** @param {Editor} editor */
 export function italic(editor) {
-    editor.dispatch("FORMAT_ITALIC");
+    editor.shared.execCommand("formatItalic");
 }
 /** @param {Editor} editor */
 export function underline(editor) {
-    editor.dispatch("FORMAT_UNDERLINE");
+    editor.shared.execCommand("formatUnderline");
 }
 /** @param {Editor} editor */
 export function strikeThrough(editor) {
-    editor.dispatch("FORMAT_STRIKETHROUGH");
+    editor.shared.execCommand("formatStrikethrough");
 }
 export function setFontSize(size) {
-    return (editor) => editor.dispatch("FORMAT_FONT_SIZE", { size });
+    return (editor) => editor.shared.execCommand("formatFontSize", { size });
 }
 /** @param {Editor} editor */
 export function switchDirection(editor) {
-    return editor.dispatch("SWITCH_DIRECTION");
+    return editor.shared.execCommand("switchDirection");
 }
 /** @param {Editor} editor */
 export function splitBlock(editor) {
-    editor.dispatch("SPLIT_BLOCK");
+    editor.shared.splitBlock();
+    editor.shared.addStep();
 }
 
 export async function simulateArrowKeyPress(editor, keys) {
@@ -161,7 +162,7 @@ export async function simulateArrowKeyPress(editor, keys) {
 }
 
 export function unlinkByCommand(editor) {
-    editor.dispatch("REMOVE_LINK_FROM_SELECTION");
+    editor.shared.execCommand("removeLinkFromSelection");
 }
 
 export async function unlinkFromToolbar() {
@@ -188,23 +189,23 @@ export async function keydownShiftTab(editor) {
 /** @param {Editor} editor */
 export function resetSize(editor) {
     const selection = editor.shared.getEditableSelection();
-    editor.dispatch("RESET_SIZE", { table: findInSelection(selection, "table") });
+    editor.shared.resetTableSize(findInSelection(selection, "table"));
 }
 /** @param {Editor} editor */
 export function justifyLeft(editor) {
-    editor.dispatch("JUSTIFY_LEFT");
+    editor.shared.execCommand("justifyLeft");
 }
 /** @param {Editor} editor */
 export function justifyCenter(editor) {
-    editor.dispatch("JUSTIFY_CENTER");
+    editor.shared.execCommand("justifyCenter");
 }
 /** @param {Editor} editor */
 export function justifyRight(editor) {
-    editor.dispatch("JUSTIFY_RIGHT");
+    editor.shared.execCommand("justifyRight");
 }
 /** @param {Editor} editor */
 export function justifyFull(editor) {
-    editor.dispatch("JUSTIFY_FULL");
+    editor.shared.execCommand("justifyFull");
 }
 
 /**
@@ -214,7 +215,7 @@ export function justifyFull(editor) {
 export function setColor(color, mode) {
     /** @param {Editor} editor */
     return (editor) => {
-        editor.dispatch("APPLY_COLOR", { color, mode });
+        editor.shared.execCommand("applyColor", { color, mode });
     };
 }
 

--- a/addons/html_editor/static/tests/banner.test.js
+++ b/addons/html_editor/static/tests/banner.test.js
@@ -135,9 +135,9 @@ test("Can change an emoji banner", async () => {
     await click(".o-EmojiPicker .o-Emoji");
     await animationFrame();
     expect("i.o_editor_banner_icon").toHaveText("😀");
-    editor.dispatch("HISTORY_UNDO");
+    editor.shared.execCommand("historyUndo");
     expect("i.o_editor_banner_icon").toHaveText("💡");
-    editor.dispatch("HISTORY_REDO");
+    editor.shared.execCommand("historyRedo");
     expect("i.o_editor_banner_icon").toHaveText("😀");
 });
 

--- a/addons/html_editor/static/tests/chatgpt.test.js
+++ b/addons/html_editor/static/tests/chatgpt.test.js
@@ -231,9 +231,9 @@ test("insert the response from ChatGPT translate dialog", async () => {
     loadLanguages.installedLanguages = false;
 
     // Expect to undo and redo the inserted text.
-    editor.dispatch("HISTORY_UNDO");
+    editor.shared.execCommand("historyUndo");
     expect(getContent(el)).toBe(`<p>[Hello]</p>`);
-    editor.dispatch("HISTORY_REDO");
+    editor.shared.execCommand("historyRedo");
     expect(getContent(el)).toBe(`<p>Bonjour[]</p>`);
 });
 

--- a/addons/html_editor/static/tests/collaboration.test.js
+++ b/addons/html_editor/static/tests/collaboration.test.js
@@ -32,6 +32,7 @@ import { click, manuallyDispatchProgrammaticEvent } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { onMounted, onWillDestroy } from "@odoo/owl";
+import { trigger } from "@html_editor/utils/resource";
 
 /**
  * @param {Editor} editor
@@ -39,7 +40,7 @@ import { onMounted, onWillDestroy } from "@odoo/owl";
  */
 function insert(editor, value) {
     editor.shared.domInsert(value);
-    editor.dispatch("ADD_STEP");
+    editor.shared.addStep();
 }
 
 describe("Conflict resolution", () => {
@@ -196,8 +197,8 @@ describe("collaborative makeSavePoint", () => {
         mergePeersSteps(peerInfos);
         savepoint();
         mergePeersSteps(peerInfos);
-        peerInfos.c1.editor.dispatch("CLEAN", { root: peerInfos.c1.editor.editable });
-        peerInfos.c2.editor.dispatch("CLEAN", { root: peerInfos.c2.editor.editable });
+        trigger(peerInfos.c1.editor.resources["clean_listeners"], peerInfos.c1.editor.editable);
+        trigger(peerInfos.c2.editor.resources["clean_listeners"], peerInfos.c1.editor.editable);
         renderTextualSelection(peerInfos);
         expect(peerInfos.c1.editor.editable.innerHTML).toBe(`<p>[c1}{c1]<br></p><p>ab[c2}{c2]</p>`);
         expect(peerInfos.c2.editor.editable.innerHTML).toBe(`<p>[c1}{c1]<br></p><p>ab[c2}{c2]</p>`);
@@ -210,7 +211,7 @@ describe("collaborative makeSavePoint", () => {
         const e1 = peerInfos.c1.editor;
         const e2 = peerInfos.c2.editor;
         const savepoint = e2.shared.makeSavePoint();
-        await   manuallyDispatchProgrammaticEvent(e1.editable, "beforeinput", {
+        await manuallyDispatchProgrammaticEvent(e1.editable, "beforeinput", {
             inputType: "insertParagraph",
         });
         mergePeersSteps(peerInfos);
@@ -231,10 +232,10 @@ describe("history addExternalStep", () => {
         peerInfos.c1.editor.shared.domInsert("b");
         insert(peerInfos.c2.editor, "a");
         mergePeersSteps(peerInfos);
-        peerInfos.c1.editor.dispatch("ADD_STEP");
+        peerInfos.c1.editor.shared.addStep();
         mergePeersSteps(peerInfos);
-        peerInfos.c1.editor.dispatch("CLEAN", { root: peerInfos.c1.editor.editable });
-        peerInfos.c2.editor.dispatch("CLEAN", { root: peerInfos.c2.editor.editable });
+        trigger(peerInfos.c1.editor.resources["clean_listeners"], peerInfos.c1.editor.editable);
+        trigger(peerInfos.c2.editor.resources["clean_listeners"], peerInfos.c2.editor.editable);
         // TODO @phoenix c1 editable should be `<p>iab[]</p>`, but its selection
         // was not adjusted properly when receiving the external step
         expect(getContent(peerInfos.c1.editor.editable)).toBe(`<p>ia[]b</p>`);
@@ -409,7 +410,7 @@ describe("sanitize", () => {
                 peerInfos.c2.collaborationPlugin.onExternalHistorySteps([
                     peerInfos.c1.historyPlugin.steps[2],
                 ]);
-                peerInfos.c2.editor.dispatch("HISTORY_UNDO");
+                peerInfos.c2.editor.shared.execCommand("historyUndo");
                 expect(peerInfos.c2.editor.editable.innerHTML).toBe("<p>a</p>");
             },
         });
@@ -433,7 +434,7 @@ describe("sanitize", () => {
                 peerInfos.c2.collaborationPlugin.onExternalHistorySteps([
                     peerInfos.c1.historyPlugin.steps[2],
                 ]);
-                peerInfos.c2.editor.dispatch("HISTORY_UNDO");
+                peerInfos.c2.editor.shared.execCommand("historyUndo");
                 expect(peerInfos.c2.editor.editable.innerHTML).toBe("<p>a</p><div><i>b</i></div>");
             },
         });
@@ -458,7 +459,7 @@ describe("sanitize", () => {
                 peerInfos.c2.collaborationPlugin.onExternalHistorySteps([
                     peerInfos.c1.historyPlugin.steps[2],
                 ]);
-                peerInfos.c2.editor.dispatch("HISTORY_UNDO");
+                peerInfos.c2.editor.shared.execCommand("historyUndo");
                 expect(peerInfos.c2.editor.editable.innerHTML).toBe('<p>a<img class="b"></p>');
             },
         });
@@ -472,8 +473,8 @@ describe("sanitize", () => {
                 const target = editor.editable.querySelector(".remove-me");
                 target.classList.remove("remove-me");
                 addStep(editor);
-                editor.dispatch("HISTORY_UNDO");
-                editor.dispatch("HISTORY_REDO");
+                editor.shared.execCommand("historyUndo");
+                editor.shared.execCommand("historyRedo");
             },
             contentAfter:
                 '<div contenteditable="true" placeholder="Type &quot;/&quot; for commands" class="o-we-hint">[c1}{c1]<br></div>',
@@ -547,7 +548,7 @@ describe("selection", () => {
         });
         const e1 = peerInfos.c1.editor;
         e1.shared.domInsert(parseHTML(e1.document, `<span contenteditable="false">a</span>`));
-        e1.dispatch("ADD_STEP");
+        e1.shared.addStep();
         mergePeersSteps(peerInfos);
         const e2 = peerInfos.c2.editor;
         expect(getContent(e1.editable)).toBe(`<p>a<span contenteditable="false">a</span>[]</p>`);
@@ -650,7 +651,7 @@ describe("data-oe-protected", () => {
                 `)
             )
         );
-        e1.dispatch("ADD_STEP");
+        e1.shared.addStep();
         mergePeersSteps(peerInfos);
         expect(getContent(e1.editable, { sortAttrs: true })).toBe(
             unformat(`
@@ -765,7 +766,7 @@ describe("serialize/unserialize", () => {
                 editor.editable.append(divA);
                 const p = editor.editable.querySelector("p");
                 divA.append(p);
-                editor.dispatch("ADD_STEP");
+                editor.shared.addStep();
             },
         });
         mergePeersSteps(peerInfos);
@@ -786,7 +787,7 @@ describe("serialize/unserialize", () => {
                 divB.textContent = "b";
                 editor.editable.append(divB);
                 divB.append(divA);
-                editor.dispatch("ADD_STEP");
+                editor.shared.addStep();
             },
         });
         mergePeersSteps(peerInfos);
@@ -819,13 +820,13 @@ describe("Collaboration with embedded components", () => {
         addStep(e1);
         peerInfos.c2.collaborationPlugin.onExternalHistorySteps(peerInfos.c1.historyPlugin.steps);
         validateSameHistory(peerInfos);
-        e2.dispatch("CLEAN", { root: e2.editable });
+        trigger(e2.resources["clean_listeners"], e2.editable);
         expect(getContent(e2.editable, { sortAttrs: true })).toBe(
             `<div contenteditable="false" data-embedded="counter" data-oe-protected="true"></div><p>[]<br></p>`
         );
         await animationFrame();
-        e1.dispatch("CLEAN", { root: e1.editable });
-        e2.dispatch("CLEAN", { root: e2.editable });
+        trigger(e1.resources["clean_listeners"], e1.editable);
+        trigger(e2.resources["clean_listeners"], e2.editable);
         expect(getContent(e1.editable, { sortAttrs: true })).toBe(
             unformat(`
                 <div contenteditable="false" data-embedded="counter" data-oe-protected="true">
@@ -869,7 +870,7 @@ describe("Collaboration with embedded components", () => {
         const e1 = peerInfos.c1.editor;
         const e2 = peerInfos.c2.editor;
         e1.shared.domInsert(parseHTML(e1.document, `<span data-embedded="counter"></span>`));
-        e1.dispatch("ADD_STEP");
+        e1.shared.addStep();
         mergePeersSteps(peerInfos);
         await animationFrame();
         expect.verifySteps(["1 mounted", "2 mounted"]);
@@ -926,13 +927,13 @@ describe("Collaboration with embedded components", () => {
         const e1 = peerInfos.c1.editor;
         const e2 = peerInfos.c2.editor;
         e1.shared.domInsert(parseHTML(e1.document, `<span data-embedded="counter"></span>`));
-        e1.dispatch("ADD_STEP");
+        e1.shared.addStep();
         await animationFrame();
         e2.shared.domInsert(parseHTML(e2.document, `<span data-embedded="counter"></span>`));
-        e2.dispatch("ADD_STEP");
+        e2.shared.addStep();
         await animationFrame();
         e2.shared.domInsert(parseHTML(e2.document, `<span data-embedded="counter"></span>`));
-        e2.dispatch("ADD_STEP");
+        e2.shared.addStep();
         await animationFrame();
         expect.verifySteps(["1 mounted", "2 mounted", "3 mounted"]);
         expect(getContent(e1.editable, { sortAttrs: true })).toBe(
@@ -988,14 +989,14 @@ describe("Collaboration with embedded components", () => {
                 `)
             )
         );
-        e1.dispatch("ADD_STEP");
+        e1.shared.addStep();
         const deep1 = e1.editable.querySelector("[data-embedded-editable='deep'] > p");
         deep1.append(e1.document.createTextNode("1"));
-        e1.dispatch("ADD_STEP");
+        e1.shared.addStep();
         mergePeersSteps(peerInfos);
         const deep2 = e2.editable.querySelector("[data-embedded-editable='deep'] > p");
         deep2.append(e2.document.createTextNode("2"));
-        e2.dispatch("ADD_STEP");
+        e2.shared.addStep();
         mergePeersSteps(peerInfos);
         // Before mount:
         let editable = unformat(`
@@ -1025,10 +1026,10 @@ describe("Collaboration with embedded components", () => {
         expect(getContent(e1.editable, { sortAttrs: true })).toBe(editable);
         expect(getContent(e2.editable, { sortAttrs: true })).toBe(editable);
         deep1.append(e1.document.createTextNode("3"));
-        e1.dispatch("ADD_STEP");
+        e1.shared.addStep();
         mergePeersSteps(peerInfos);
         deep2.append(e2.document.createTextNode("4"));
-        e2.dispatch("ADD_STEP");
+        e2.shared.addStep();
         mergePeersSteps(peerInfos);
         editable = unformat(`
             <div contenteditable="false" data-embedded="wrapper" data-oe-protected="true">
@@ -1080,7 +1081,7 @@ describe("Collaboration with embedded components", () => {
                 `)
             )
         );
-        e1.dispatch("ADD_STEP");
+        e1.shared.addStep();
         // ensure wrappers[0] is for c1
         await animationFrame();
         mergePeersSteps(peerInfos);
@@ -1091,12 +1092,12 @@ describe("Collaboration with embedded components", () => {
         // change state for c1
         wrappers[0].state.switch = true;
         deep1.append(e1.document.createTextNode("1"));
-        e1.dispatch("ADD_STEP");
+        e1.shared.addStep();
         // wait for patch for c1
         await animationFrame();
         mergePeersSteps(peerInfos);
         deep2.append(e2.document.createTextNode("2"));
-        e2.dispatch("ADD_STEP");
+        e2.shared.addStep();
         mergePeersSteps(peerInfos);
         expect(getContent(e1.editable, { sortAttrs: true })).toBe(
             unformat(`
@@ -1158,7 +1159,7 @@ describe("Collaboration with embedded components", () => {
                 `)
             )
         );
-        e1.dispatch("ADD_STEP");
+        e1.shared.addStep();
         mergePeersSteps(peerInfos);
         await animationFrame();
         deleteBackward(e1);
@@ -1168,12 +1169,12 @@ describe("Collaboration with embedded components", () => {
         undo(e1);
         const deep1 = e1.editable.querySelector("[data-embedded-editable='deep'] > p");
         deep1.append(e1.document.createTextNode("1"));
-        e1.dispatch("ADD_STEP");
+        e1.shared.addStep();
         mergePeersSteps(peerInfos);
         await animationFrame();
         const deep2 = e2.editable.querySelector("[data-embedded-editable='deep'] > p");
         deep2.append(e2.document.createTextNode("2"));
-        e2.dispatch("ADD_STEP");
+        e2.shared.addStep();
         mergePeersSteps(peerInfos);
         const editable = unformat(`
             <div contenteditable="false" data-embedded="wrapper" data-oe-protected="true">
@@ -1222,22 +1223,22 @@ describe("Collaboration with embedded components", () => {
                 `)
             )
         );
-        e1.dispatch("ADD_STEP");
+        e1.shared.addStep();
         mergePeersSteps(peerInfos);
         const shallow1 = e1.editable.querySelector("[data-embedded-editable='deep'] > p");
         shallow1.append(e1.document.createTextNode("1"));
-        e1.dispatch("ADD_STEP");
+        e1.shared.addStep();
         const deep1 = e1.editable.querySelectorAll("[data-embedded-editable='deep'] > p")[1];
         deep1.append(e1.document.createTextNode("9"));
-        e1.dispatch("ADD_STEP");
+        e1.shared.addStep();
         await animationFrame();
         mergePeersSteps(peerInfos);
         const shallow2 = e2.editable.querySelector("[data-embedded-editable='deep'] > p");
         shallow2.append(e2.document.createTextNode("2"));
-        e2.dispatch("ADD_STEP");
+        e2.shared.addStep();
         const deep2 = e2.editable.querySelectorAll("[data-embedded-editable='deep'] > p")[1];
         deep2.append(e2.document.createTextNode("8"));
-        e2.dispatch("ADD_STEP");
+        e2.shared.addStep();
         mergePeersSteps(peerInfos);
         const editable = unformat(`
             <div contenteditable="false" data-embedded="wrapper" data-oe-protected="true">
@@ -1496,7 +1497,7 @@ describe("Collaboration with embedded components", () => {
                     `<span data-embedded="counter" data-embedded-props='{"value":1}'></span>`
                 )
             );
-            e2.dispatch("ADD_STEP");
+            e2.shared.addStep();
             await animationFrame();
             const counter2 = [...peerInfos.c2.plugins.get("embedded_components").components][0].app
                 .root.component;

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -26,6 +26,7 @@ test("can set foreground color", async () => {
 
     await click(".o_color_button[data-color='#6BADDE']");
     await animationFrame();
+    await waitFor(".o-we-toolbar");
     expect(".o-we-toolbar").toHaveCount(1); // toolbar still open
     expect(".o_font_color_selector").toHaveCount(0); // selector closed
     expect(getContent(el)).toBe(`<p><font style="color: rgb(107, 173, 222);">[test]</font></p>`);
@@ -43,6 +44,7 @@ test("can set background color", async () => {
 
     await click(".o_color_button[data-color='#6BADDE']");
     await animationFrame();
+    await waitFor(".o-we-toolbar");
     expect(".o-we-toolbar").toHaveCount(1); // toolbar still open
     expect(".o_font_color_selector").toHaveCount(0); // selector closed
     expect(getContent(el)).toBe(
@@ -193,7 +195,7 @@ test("Can reset a color", async () => {
     await animationFrame();
     expect("font[style='color: rgb(255, 0, 0);']").toHaveCount(0);
     expect(".tested").toHaveInnerHTML("test");
-    editor.dispatch("HISTORY_UNDO");
+    editor.shared.execCommand("historyUndo");
     expect("font[style='color: rgb(255, 0, 0);']").toHaveCount(1);
     expect(".tested").not.toHaveInnerHTML("test");
 });
@@ -420,9 +422,9 @@ describe.tags("desktop")("color preview", () => {
         expect("font").toHaveCount(1);
         expect("font").toHaveClass("text-o-color-2");
         await animationFrame();
-        editor.dispatch("HISTORY_UNDO");
+        editor.shared.execCommand("historyUndo");
         expect("font").toHaveCount(0);
-        editor.dispatch("HISTORY_REDO");
+        editor.shared.execCommand("historyRedo");
         expect("font").toHaveCount(1);
         expect("font").toHaveClass("text-o-color-2");
     });
@@ -445,7 +447,7 @@ describe.tags("desktop")("color preview", () => {
         await press("escape");
         await animationFrame();
         expect("font").toHaveCount(0);
-        editor.dispatch("HISTORY_UNDO");
+        editor.shared.execCommand("historyUndo");
         expect("font").toHaveCount(0);
     });
 });

--- a/addons/html_editor/static/tests/columnize.test.js
+++ b/addons/html_editor/static/tests/columnize.test.js
@@ -15,7 +15,7 @@ function column(size, contents) {
 
 function columnize(numberOfColumns) {
     return (editor) => {
-        editor.dispatch("COLUMNIZE", { numberOfColumns });
+        editor.shared.execCommand("columnize", { numberOfColumns });
     };
 }
 

--- a/addons/html_editor/static/tests/data-oe/protected.test.js
+++ b/addons/html_editor/static/tests/data-oe/protected.test.js
@@ -7,6 +7,7 @@ import { waitFor, waitForNone } from "@odoo/hoot-dom";
 import { parseHTML } from "@html_editor/utils/html";
 import { Plugin } from "@html_editor/plugin";
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
+import { trigger } from "@html_editor/utils/resource";
 
 test("should ignore protected elements children mutations (true)", async () => {
     await testEditor({
@@ -20,8 +21,8 @@ test("should ignore protected elements children mutations (true)", async () => {
                 '[data-oe-protected="true"] > p'
             );
             protectedParagraph.append(document.createTextNode("b"));
-            editor.dispatch("ADD_STEP");
-            editor.dispatch("HISTORY_UNDO");
+            editor.shared.addStep();
+            editor.shared.execCommand("historyUndo");
         },
         contentAfterEdit: unformat(`
                 <div><p>ab[]</p></div>
@@ -43,7 +44,7 @@ test("should not ignore unprotected elements children mutations (false)", async 
             );
             setSelection({ anchorNode: unProtectedParagraph, anchorOffset: 1 });
             await insertText(editor, "bc");
-            editor.dispatch("HISTORY_UNDO");
+            editor.shared.execCommand("historyUndo");
         },
         contentAfterEdit: unformat(`
                 <div><p>abc</p></div>
@@ -64,7 +65,8 @@ test("should not normalize protected elements children (true)", async () => {
                     <ul><li>abc<p><br></p></li></ul>
                 </div>
                 `),
-        stepFunction: async (editor) => editor.dispatch("NORMALIZE", { node: editor.editable }),
+        stepFunction: async (editor) =>
+            trigger(editor.resources["normalize_listeners"], editor.editable),
         contentAfterEdit: unformat(`
                 <div>
                     <p><i class="fa" contenteditable="false">\u200B</i></p>
@@ -81,7 +83,7 @@ test("should not normalize protected elements children (true)", async () => {
 test("should not remove/merge empty (identical) protecting nodes", async () => {
     const { el, editor } = await setupEditor(`<p><span data-oe-protected="true"></span>[]</p>`);
     editor.shared.domInsert(parseHTML(editor.document, `<span data-oe-protected="true"></span>`));
-    editor.dispatch("ADD_STEP");
+    editor.shared.addStep();
     expect(getContent(el)).toBe(
         unformat(
             `<p>
@@ -104,7 +106,9 @@ test("should normalize unprotected elements children (false)", async () => {
                     </div>
                 </div>
                 `),
-        stepFunction: async (editor) => editor.dispatch("NORMALIZE", { node: editor.editable }),
+        stepFunction: async (editor) =>
+            trigger(editor.resources["normalize_listeners"], editor.editable),
+
         contentAfterEdit: unformat(`
                 <div data-oe-protected="true" contenteditable="false">
                     <p><i class="fa"></i></p>
@@ -241,7 +245,7 @@ test("should protect disconnected nodes", async () => {
     const protectedP = div.querySelector("p");
     protectedP.remove();
     div.remove();
-    editor.dispatch("ADD_STEP");
+    editor.shared.addStep();
     const lastStep = editor.shared.getHistorySteps().at(-1);
     expect(lastStep.mutations.length).toBe(1);
     expect(lastStep.mutations[0].type).toBe("remove");
@@ -257,7 +261,7 @@ test("should not crash when changing attributes and removing a protecting anchor
     const div = el.querySelector("div");
     div.dataset.attr = "other";
     div.remove();
-    editor.dispatch("ADD_STEP");
+    editor.shared.addStep();
     const lastStep = editor.shared.getHistorySteps().at(-1);
     expect(lastStep.mutations.length).toBe(2);
     expect(lastStep.mutations[0].type).toBe("attributes");
@@ -357,7 +361,7 @@ test("removing a protected node and then removing its protected parent should be
     const b = el.querySelector(".b");
     b.remove();
     a.remove();
-    editor.dispatch("ADD_STEP");
+    editor.shared.addStep();
     expect(editor.shared.getHistorySteps().length).toBe(1);
     expect(historyPlugin.currentStep.mutations).toEqual([]);
     expect(getContent(el)).toBe(`<div data-oe-protected="true" contenteditable="false"></div>`);
@@ -384,7 +388,7 @@ test("removing a protected ancestor, then a protected descendant, then its prote
     a.remove();
     c.remove();
     b.remove();
-    editor.dispatch("ADD_STEP");
+    editor.shared.addStep();
     expect(editor.shared.getHistorySteps().length).toBe(1);
     expect(historyPlugin.currentStep.mutations).toEqual([]);
     expect(getContent(el)).toBe(`<div data-oe-protected="true" contenteditable="false"></div>`);
@@ -407,7 +411,7 @@ test("moving a protected node at an unprotected location, only remove should be 
     const a = el.querySelector(".a");
     const b = el.querySelector(".b");
     b.append(a);
-    editor.dispatch("ADD_STEP");
+    editor.shared.addStep();
     const historySteps = editor.shared.getHistorySteps();
     expect(historySteps.length).toBe(2);
     const lastStep = historySteps.at(-1);
@@ -443,7 +447,7 @@ test("moving an unprotected node at a protected location, only add should be ign
     const a = el.querySelector(".a");
     const b = el.querySelector(".b");
     b.append(a);
-    editor.dispatch("ADD_STEP");
+    editor.shared.addStep();
     const historySteps = editor.shared.getHistorySteps();
     expect(historySteps.length).toBe(2);
     const lastStep = historySteps.at(-1);
@@ -477,7 +481,7 @@ test("sequentially added nodes under a protecting parent are correctly protected
     const node = editor.document.createTextNode("a");
     protecting.prepend(element);
     element.prepend(node);
-    editor.dispatch("ADD_STEP");
+    editor.shared.addStep();
     expect(protectedPlugin.protectedNodes.has(element)).toBe(true);
     expect(protectedPlugin.protectedNodes.has(node)).toBe(true);
     expect(getContent(el)).toBe(
@@ -489,7 +493,7 @@ test("sequentially added nodes under a protecting parent are correctly protected
         `)
     );
     node.remove();
-    editor.dispatch("ADD_STEP");
+    editor.shared.addStep();
     expect(getContent(el)).toBe(
         unformat(`
             <div data-oe-protected="true" contenteditable="false">
@@ -519,7 +523,7 @@ test("don't protect a node under data-oe-protected='false' through delete and un
     const node = editor.document.createTextNode("b");
     protecting.prepend(paragraph);
     paragraph.prepend(node);
-    editor.dispatch("ADD_STEP");
+    editor.shared.addStep();
     expect(editor.shared.getHistorySteps().length).toBe(2);
     expect(protectedPlugin.protectedNodes.has(paragraph)).toBe(false);
     expect(protectedPlugin.protectedNodes.has(node)).toBe(false);
@@ -587,7 +591,7 @@ test("protected plugin is robust against other plugins which can filter mutation
     const b = el.querySelector(".b");
     a.remove();
     b.remove();
-    editor.dispatch("ADD_STEP");
+    editor.shared.addStep();
     expect(editor.shared.getHistorySteps().length).toBe(1);
     expect(historyPlugin.currentStep.mutations).toEqual([]);
     expect(getContent(el)).toBe(`<div data-oe-protected="true" contenteditable="false"></div>`);

--- a/addons/html_editor/static/tests/delete/delete_range.test.js
+++ b/addons/html_editor/static/tests/delete/delete_range.test.js
@@ -23,7 +23,7 @@ async function deleteRange(editor) {
 
 // Tests the DELETE_SELECTION command.
 async function deleteSelection(editor) {
-    editor.dispatch("DELETE_SELECTION");
+    editor.shared.deleteSelection();
 }
 
 describe("deleteRange method", () => {
@@ -260,7 +260,7 @@ describe("deleteRange method", () => {
     });
 });
 
-describe("DELETE_SELECTION command", () => {
+describe("deleteSelection", () => {
     describe("Merge blocks", () => {
         test("should remove fully selected left block and keep second block", async () => {
             // As opposed to the deleteRange method.

--- a/addons/html_editor/static/tests/delete/history.test.js
+++ b/addons/html_editor/static/tests/delete/history.test.js
@@ -10,10 +10,10 @@ describe("delete backward", () => {
         await press("Backspace");
         expect(getContent(el)).toBe("<p>a[]cd</p>");
 
-        editor.dispatch("HISTORY_UNDO");
+        editor.shared.execCommand("historyUndo");
         expect(getContent(el)).toBe("<p>ab[]cd</p>");
 
-        editor.dispatch("HISTORY_REDO");
+        editor.shared.execCommand("historyRedo");
         expect(getContent(el)).toBe("<p>a[]cd</p>");
     });
 
@@ -23,10 +23,10 @@ describe("delete backward", () => {
         await press("Backspace");
         expect(getContent(el)).toBe("<p>ab[]ef</p>");
 
-        editor.dispatch("HISTORY_UNDO");
+        editor.shared.execCommand("historyUndo");
         expect(getContent(el)).toBe("<p>ab[cd]ef</p>");
 
-        editor.dispatch("HISTORY_REDO");
+        editor.shared.execCommand("historyRedo");
         expect(getContent(el)).toBe("<p>ab[]ef</p>");
     });
 });
@@ -38,10 +38,10 @@ describe("delete forward", () => {
         await press("Delete");
         expect(getContent(el)).toBe("<p>ab[]d</p>");
 
-        editor.dispatch("HISTORY_UNDO");
+        editor.shared.execCommand("historyUndo");
         expect(getContent(el)).toBe("<p>ab[]cd</p>");
 
-        editor.dispatch("HISTORY_REDO");
+        editor.shared.execCommand("historyRedo");
         expect(getContent(el)).toBe("<p>ab[]d</p>");
     });
 
@@ -51,10 +51,10 @@ describe("delete forward", () => {
         await press("Delete");
         expect(getContent(el)).toBe("<p>ab[]ef</p>");
 
-        editor.dispatch("HISTORY_UNDO");
+        editor.shared.execCommand("historyUndo");
         expect(getContent(el)).toBe("<p>ab[cd]ef</p>");
 
-        editor.dispatch("HISTORY_REDO");
+        editor.shared.execCommand("historyRedo");
         expect(getContent(el)).toBe("<p>ab[]ef</p>");
     });
 });

--- a/addons/html_editor/static/tests/editor.test.js
+++ b/addons/html_editor/static/tests/editor.test.js
@@ -69,21 +69,21 @@ test("Remove odoo-editor-editable class after every plugin is destroyed", async 
     expect.verifySteps(["operation"]);
 });
 
-test("CLEAN_FOR_SAVE is done last", async () => {
+test("clean_for_save_listeners is done last", async () => {
     // This test uses custom elements tag `c-div` to make sure they won't fall into
     // a case where they won't be merged anyway.
     // Without the proper fix, this test fails with sibling elements `c-div` merged together
     class TestPlugin extends Plugin {
+        resources = {
+            clean_for_save_listeners: ({ root }) => {
+                for (const el of root.querySelectorAll("c-div")) {
+                    el.removeAttribute("class");
+                }
+            },
+        };
         setup() {
             for (const el of this.editable.querySelectorAll("c-div")) {
                 el.classList.add("oe_unbreakable");
-            }
-        }
-        handleCommand(cmd, payload) {
-            if (cmd === "CLEAN_FOR_SAVE") {
-                for (const el of payload.root.querySelectorAll("c-div")) {
-                    el.removeAttribute("class");
-                }
             }
         }
     }

--- a/addons/html_editor/static/tests/embedded_components.test.js
+++ b/addons/html_editor/static/tests/embedded_components.test.js
@@ -39,6 +39,7 @@ import { deleteBackward, deleteForward, redo, undo } from "./_helpers/user_actio
 import { makeMockEnv } from "@web/../tests/_framework/env_test_helpers";
 import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { Deferred } from "@web/core/utils/concurrency";
+import { trigger } from "@html_editor/utils/resource";
 import { Plugin } from "@html_editor/plugin";
 
 function getConfig(components) {
@@ -73,7 +74,7 @@ describe("Mount and Destroy embedded components", () => {
         editor.shared.domInsert(
             parseHTML(editor.document, `<span data-embedded="counter"></span>`)
         );
-        editor.dispatch("ADD_STEP");
+        editor.shared.addStep();
         expect(getContent(el)).toBe(
             `<div>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"></span>[]b</div>`
         );
@@ -168,7 +169,7 @@ describe("Mount and Destroy embedded components", () => {
         editor.shared.domInsert(
             parseHTML(editor.document, `<span data-embedded="counter"></span>`)
         );
-        editor.dispatch("ADD_STEP");
+        editor.shared.addStep();
         await animationFrame();
         expect.verifySteps(["mounted"]);
         expect(getContent(el)).toBe(
@@ -207,7 +208,7 @@ describe("Mount and Destroy embedded components", () => {
             }
         );
 
-        editor.dispatch("HISTORY_STAGE_SELECTION");
+        editor.shared.stageSelection();
 
         expect(getContent(el)).toBe(
             `<div>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span>[]</div>`
@@ -255,7 +256,7 @@ describe("Mount and Destroy embedded components", () => {
                 config: getConfig([embedding("counter", Test)]),
             }
         );
-        editor.dispatch("HISTORY_STAGE_SELECTION");
+        editor.shared.stageSelection();
         expect(getContent(el)).toBe(
             `<div>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span>[]</div>`
         );
@@ -267,7 +268,7 @@ describe("Mount and Destroy embedded components", () => {
         editor.shared.domInsert(
             parseHTML(editor.document, `<span data-embedded="counter"></span>`)
         );
-        editor.dispatch("ADD_STEP");
+        editor.shared.addStep();
         await animationFrame();
         expect.verifySteps(["mounted"]);
         expect(getContent(el)).toBe(
@@ -385,7 +386,7 @@ describe("Mount and Destroy embedded components", () => {
             embeddedComponentPlugin.mountComponent(...orderedMountInfos[index]);
         }
         // Validate the step, but the mounting process already started.
-        editor.dispatch("ADD_STEP");
+        editor.shared.addStep();
         await animationFrame();
         expect.verifySteps(["mount 1", "mount 2", "mount 3"]);
         expect(getContent(el)).toBe(
@@ -476,7 +477,7 @@ describe("Mount and Destroy embedded components", () => {
         );
         const host = el.querySelector("[data-embedded='counter']");
         host.remove();
-        editor.dispatch("ADD_STEP");
+        editor.shared.addStep();
         expect.verifySteps(["destroyed counter"]);
         // Verify that there is no potential host outside of the editable,
         // because removed hosts are put back in the DOM and destroyed next to
@@ -507,7 +508,7 @@ describe("Mount and Destroy embedded components", () => {
         );
         const parent = el.querySelector(".parent");
         parent.remove();
-        editor.dispatch("ADD_STEP");
+        editor.shared.addStep();
         expect.verifySteps(["destroyed counter"]);
         // Verify that there is no potential host outside of the editable,
         // because removed hosts are put back in the DOM and destroyed next to
@@ -531,7 +532,7 @@ describe("Selection after embedded component insertion", () => {
         editor.shared.domInsert(
             parseHTML(editor.document, `<span data-embedded="counter">a</span>`)
         );
-        editor.dispatch("ADD_STEP");
+        editor.shared.addStep();
         await animationFrame();
         expect(getContent(el)).toBe(
             `<p><span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span>[]</p>`
@@ -544,7 +545,7 @@ describe("Selection after embedded component insertion", () => {
         editor.shared.domInsert(
             parseHTML(editor.document, `<span data-embedded="counter"></span>`)
         );
-        editor.dispatch("ADD_STEP");
+        editor.shared.addStep();
         await animationFrame();
         expect(getContent(el)).toBe(
             `<p>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span>[]</p>`
@@ -557,7 +558,7 @@ describe("Selection after embedded component insertion", () => {
         editor.shared.domInsert(
             parseHTML(editor.document, `<span data-embedded="counter"></span>`)
         );
-        editor.dispatch("ADD_STEP");
+        editor.shared.addStep();
         await animationFrame();
         expect(getContent(el)).toBe(
             `<p><span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span>[]a</p>`
@@ -570,7 +571,7 @@ describe("Selection after embedded component insertion", () => {
         editor.shared.domInsert(
             parseHTML(editor.document, `<span data-embedded="counter"></span>`)
         );
-        editor.dispatch("ADD_STEP");
+        editor.shared.addStep();
         await animationFrame();
         expect(getContent(el)).toBe(
             `<p>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span>[]b</p>`
@@ -581,9 +582,9 @@ describe("Selection after embedded component insertion", () => {
             config: getConfig([embedding("counter", Counter)]),
         });
         editor.shared.domInsert(parseHTML(editor.document, `<div data-embedded="counter"></div>`));
-        editor.dispatch("ADD_STEP");
+        editor.shared.addStep();
         await animationFrame();
-        editor.dispatch("CLEAN", { root: editor.editable });
+        trigger(editor.resources["clean_listeners"], editor.editable);
         expect(getContent(el)).toBe(
             unformat(`
                 <div data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></div>
@@ -595,9 +596,9 @@ describe("Selection after embedded component insertion", () => {
             config: getConfig([embedding("counter", Counter)]),
         });
         editor.shared.domInsert(parseHTML(editor.document, `<div data-embedded="counter"></div>`));
-        editor.dispatch("ADD_STEP");
+        editor.shared.addStep();
         await animationFrame();
-        editor.dispatch("CLEAN", { root: editor.editable });
+        trigger(editor.resources["clean_listeners"], editor.editable);
         expect(getContent(el)).toBe(
             unformat(`
                 <p>a</p>
@@ -610,9 +611,9 @@ describe("Selection after embedded component insertion", () => {
             config: getConfig([embedding("counter", Counter)]),
         });
         editor.shared.domInsert(parseHTML(editor.document, `<div data-embedded="counter"></div>`));
-        editor.dispatch("ADD_STEP");
+        editor.shared.addStep();
         await animationFrame();
-        editor.dispatch("CLEAN", { root: editor.editable });
+        trigger(editor.resources["clean_listeners"], editor.editable);
         expect(getContent(el)).toBe(
             unformat(`
                 <div data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></div>
@@ -624,9 +625,9 @@ describe("Selection after embedded component insertion", () => {
             config: getConfig([embedding("counter", Counter)]),
         });
         editor.shared.domInsert(parseHTML(editor.document, `<div data-embedded="counter"></div>`));
-        editor.dispatch("ADD_STEP");
+        editor.shared.addStep();
         await animationFrame();
-        editor.dispatch("CLEAN", { root: editor.editable });
+        trigger(editor.resources["clean_listeners"], editor.editable);
         expect(getContent(el)).toBe(
             unformat(`
                 <p>a</p>
@@ -843,15 +844,10 @@ describe("Mount processing", () => {
         let setSelection;
         class SimplePlugin extends Plugin {
             static name = "simple";
-            static dependencies = ["selection", "embedded_components", "dom"];
-
-            handleCommand(command, payload) {
-                switch (command) {
-                    case "SETUP_NEW_COMPONENT":
-                        this.setupNewComponent(payload);
-                        break;
-                }
-            }
+            static dependencies = ["selection", "embedded_components", "dom", "history"];
+            resources = {
+                mount_component_listeners: this.setupNewComponent.bind(this),
+            };
 
             setupNewComponent({ name, env }) {
                 if (name === "embeddedCounter") {
@@ -864,7 +860,7 @@ describe("Mount processing", () => {
             insertElement(element) {
                 const html = parseHTML(this.document, element);
                 this.shared.domInsert(html);
-                this.dispatch("ADD_STEP");
+                this.shared.addStep();
             }
         }
 
@@ -921,7 +917,7 @@ describe("In-editor manipulations", () => {
             }
         );
         const clone = el.cloneNode(true);
-        editor.dispatch("CLEAN_FOR_SAVE", { root: clone });
+        trigger(editor.resources["clean_for_save_listeners"], { root: clone });
         expect(getContent(clone)).toBe(`<div><p>a</p></div><div data-embedded="counter"></div>`);
     });
 
@@ -932,7 +928,7 @@ describe("In-editor manipulations", () => {
                 config: getConfig([embedding("counter", Counter)]),
             }
         );
-        editor.dispatch("CLEAN", { root: el });
+        trigger(editor.resources["clean_listeners"], el);
         expect(getContent(el)).toBe(
             `<div><p>a</p></div><div data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></div>`
         );
@@ -957,7 +953,7 @@ describe("In-editor manipulations", () => {
             `<div data-embedded="unknown"><p>UNKNOWN</p></div>`,
             { config: getConfig([]) }
         );
-        editor.dispatch("CLEAN_FOR_SAVE", { root: el });
+        trigger(editor.resources["clean_for_save_listeners"], { root: el });
         expect(getContent(el)).toBe(`<div data-embedded="unknown"><p>UNKNOWN</p></div>`);
     });
 
@@ -1067,7 +1063,7 @@ describe("editable descendants", () => {
             `)
         );
         // No mutation should be added to the next step
-        editor.dispatch("ADD_STEP");
+        editor.shared.addStep();
         const historyPlugin = plugins.get("history");
         const historySteps = editor.shared.getHistorySteps();
         expect(historySteps.length).toBe(1);
@@ -1095,7 +1091,7 @@ describe("editable descendants", () => {
             }
         );
         const clone = el.cloneNode(true);
-        editor.dispatch("CLEAN_FOR_SAVE", { root: clone });
+        trigger(editor.resources["clean_for_save_listeners"], { root: clone });
         expect(getContent(clone)).toBe(
             unformat(`
                 <div data-embedded="wrapper">
@@ -1330,7 +1326,7 @@ describe("Embedded state", () => {
                 baseValue: 5,
             },
         });
-        editor.dispatch("ADD_STEP");
+        editor.shared.addStep();
         await animationFrame();
         expect(getContent(el)).toBe(
             `<div><span data-embedded="counter" data-embedded-props='{"baseValue":4}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":-1,"previous":{"baseValue":1},"next":{"baseValue":5}}'><span class="counter">Counter:4</span></span></div>`

--- a/addons/html_editor/static/tests/font_awesome.test.js
+++ b/addons/html_editor/static/tests/font_awesome.test.js
@@ -5,7 +5,7 @@ import { getContent } from "./_helpers/selection";
 
 function insertFontAwesome(faClass) {
     return (editor) => {
-        editor.dispatch("INSERT_FONT_AWESOME", { faClass });
+        editor.shared.execCommand("insertFontAwesome", { faClass });
     };
 }
 
@@ -520,8 +520,8 @@ describe("FontAwesome insertion", () => {
         await testEditor({
             contentBefore: "<p>[]<br></p>",
             stepFunction: async (editor) => {
-                editor.dispatch("INSERT_FONT_AWESOME", { faClass: "fa fa-star" });
-                editor.dispatch("INSERT_FONT_AWESOME", { faClass: "fa fa-glass" });
+                editor.shared.execCommand("insertFontAwesome", { faClass: "fa fa-star" });
+                editor.shared.execCommand("insertFontAwesome", { faClass: "fa fa-glass" });
             },
             contentAfterEdit:
                 '<p><i class="fa fa-star" contenteditable="false">\u200b</i><i class="fa fa-glass" contenteditable="false">\u200b</i>[]</p>',

--- a/addons/html_editor/static/tests/format/font_size.test.js
+++ b/addons/html_editor/static/tests/format/font_size.test.js
@@ -33,7 +33,7 @@ test("should change the font size of a whole heading after a triple click", asyn
 
 test("should get ready to type with a different font size", async () => {
     const { editor } = await setupEditor('<p class="p">ab[]cd</p>');
-    editor.dispatch("FORMAT_FONT_SIZE", { size: "36px" });
+    editor.shared.execCommand("formatFontSize", { size: "36px" });
     await animationFrame();
     expect(".p span").toHaveStyle({ "font-size": "36px" });
     expect(".p span").toHaveAttribute("data-oe-zws-empty-inline", "");

--- a/addons/html_editor/static/tests/format/remove_format.test.js
+++ b/addons/html_editor/static/tests/format/remove_format.test.js
@@ -7,112 +7,112 @@ import { animationFrame } from "@odoo/hoot-mock";
 test("should do nothing if no format is set", async () => {
     await testEditor({
         contentBefore: "<div>ab[cd]ef</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test('should not remove "non formating" html class (1)', async () => {
     await testEditor({
         contentBefore: '<div>ab<span class="xyz">[cd]</span>ef</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: '<div>ab<span class="xyz">[cd]</span>ef</div>',
     });
 });
 test('should not remove "non formating" html class (2)', async () => {
     await testEditor({
         contentBefore: '<div>a[b<span class="xyz">cd</span>e]f</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: '<div>a[b<span class="xyz">cd</span>e]f</div>',
     });
 });
 test('should not remove "non formating" html class (3)', async () => {
     await testEditor({
         contentBefore: '<div>a<span class="xyz">b[cd]e</span>f</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: '<div>a<span class="xyz">b[cd]e</span>f</div>',
     });
 });
 test("should remove bold format (1)", async () => {
     await testEditor({
         contentBefore: "<div>ab<b>[cd]</b>ef</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove bold format (2)", async () => {
     await testEditor({
         contentBefore: "<div>ab[<b>cd]</b>ef</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove bold format (3)", async () => {
     await testEditor({
         contentBefore: "<div>ab<b>[cd</b>]ef</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove bold format (4)", async () => {
     await testEditor({
         contentBefore: "<div>ab[<b>cd</b>]ef</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove bold format (5)", async () => {
     await testEditor({
         contentBefore: "<div>ab[<b>cd</b>]ef</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove bold format (6)", async () => {
     await testEditor({
         contentBefore: "<div>a<b>b[cd]e</b>f</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>a<b>b</b>[cd]<b>e</b>f</div>",
     });
 });
 test("should remove bold format (7)", async () => {
     await testEditor({
         contentBefore: "<div>a<b>b[c</b>d]ef</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>a<b>b</b>[cd]ef</div>",
     });
 });
 test("should remove bold format (8)", async () => {
     await testEditor({
         contentBefore: '<div>ab<font style="font-weight: bold">[cd]</font>ef</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove bold format (9)", async () => {
     await testEditor({
         contentBefore: '<div>ab<font style="font-weight: bolder">[cd]</font>ef</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove bold format (10)", async () => {
     await testEditor({
         contentBefore: '<div>ab<font style="font-weight: 500">[cd]</font>ef</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove bold format (11)", async () => {
     await testEditor({
         contentBefore: '<div>ab<font style="font-weight: 600">[cd]</font>ef</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove bold format (12)", async () => {
     await testEditor({
         contentBefore: '<div>a<font style="font-weight: 600">b[cd]e</font>f</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter:
             '<div>a<font style="font-weight: 600">b</font>[cd]<font style="font-weight: 600">e</font>f</div>',
     });
@@ -120,77 +120,77 @@ test("should remove bold format (12)", async () => {
 test("should remove bold format (13)", async () => {
     await testEditor({
         contentBefore: "<div>ab<strong>[cd]</strong>ef</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove bold format (14)", async () => {
     await testEditor({
         contentBefore: "<div>a<strong>b[cd]e</strong>f</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>a<strong>b</strong>[cd]<strong>e</strong>f</div>",
     });
 });
 test("should remove italic format (1)", async () => {
     await testEditor({
         contentBefore: "<div>ab<i>[cd]</i>ef</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove italic format (2)", async () => {
     await testEditor({
         contentBefore: "<div>ab[<i>cd]</i>ef</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove italic format (3)", async () => {
     await testEditor({
         contentBefore: "<div>ab<i>[cd</i>]ef</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove italic format (4)", async () => {
     await testEditor({
         contentBefore: "<div>ab[<i>cd</i>]ef</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove italic format (5)", async () => {
     await testEditor({
         contentBefore: "<div>ab[<i>cd</i>]ef</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove italic format (6)", async () => {
     await testEditor({
         contentBefore: "<div>a<i>b[cd]e</i>f</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>a<i>b</i>[cd]<i>e</i>f</div>",
     });
 });
 test("should remove italic format (7)", async () => {
     await testEditor({
         contentBefore: "<div>a<i>b[c</i>d]ef</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>a<i>b</i>[cd]ef</div>",
     });
 });
 test("should remove italic format (8)", async () => {
     await testEditor({
         contentBefore: '<div>ab<font style="font-style: italic">[cd]</font>ef</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove italic format (9)", async () => {
     await testEditor({
         contentBefore: '<div>a<font style="font-style: italic">b[cd]e</font>f</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter:
             '<div>a<font style="font-style: italic">b</font>[cd]<font style="font-style: italic">e</font>f</div>',
     });
@@ -198,63 +198,63 @@ test("should remove italic format (9)", async () => {
 test("should remove underline format (1)", async () => {
     await testEditor({
         contentBefore: "<div>ab<u>[cd]</u>ef</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove underline format (2)", async () => {
     await testEditor({
         contentBefore: "<div>ab[<u>cd]</u>ef</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove underline format (3)", async () => {
     await testEditor({
         contentBefore: "<div>ab<u>[cd</u>]ef</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove underline format (4)", async () => {
     await testEditor({
         contentBefore: "<div>ab[<u>cd</u>]ef</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove underline format (5)", async () => {
     await testEditor({
         contentBefore: "<div>ab[<u>cd</u>]ef</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove underline format (6)", async () => {
     await testEditor({
         contentBefore: "<div>a<u>b[cd]e</u>f</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>a<u>b</u>[cd]<u>e</u>f</div>",
     });
 });
 test("should remove underline format (7)", async () => {
     await testEditor({
         contentBefore: "<div>a<u>b[c</u>d]ef</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>a<u>b</u>[cd]ef</div>",
     });
 });
 test("should remove underline format (8)", async () => {
     await testEditor({
         contentBefore: '<div>ab<font style="text-decoration: underline">[cd]</font>ef</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove underline format (9)", async () => {
     await testEditor({
         contentBefore: '<div>a<font style="text-decoration: underline">b[cd]e</font>f</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter:
             '<div>a<font style="text-decoration: underline">b</font>[cd]<font style="text-decoration: underline">e</font>f</div>',
     });
@@ -262,7 +262,7 @@ test("should remove underline format (9)", async () => {
 test("should remove underline format (10)", async () => {
     await testEditor({
         contentBefore: '<div>a<font style="text-decoration-line: underline">b[cd]e</font>f</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter:
             '<div>a<font style="text-decoration-line: underline">b</font>[cd]<font style="text-decoration-line: underline">e</font>f</div>',
     });
@@ -270,63 +270,63 @@ test("should remove underline format (10)", async () => {
 test("should remove striketrough format (1)", async () => {
     await testEditor({
         contentBefore: "<div>ab<s>[cd]</s>ef</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove striketrough format (2)", async () => {
     await testEditor({
         contentBefore: "<div>ab[<s>cd]</s>ef</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove striketrough format (3)", async () => {
     await testEditor({
         contentBefore: "<div>ab<s>[cd</s>]ef</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove striketrough format (4)", async () => {
     await testEditor({
         contentBefore: "<div>ab[<s>cd</s>]ef</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove striketrough format (5)", async () => {
     await testEditor({
         contentBefore: "<div>ab[<s>cd</s>]ef</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove striketrough format (6)", async () => {
     await testEditor({
         contentBefore: "<div>a<s>b[cd]e</s>f</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>a<s>b</s>[cd]<s>e</s>f</div>",
     });
 });
 test("should remove striketrough format (7)", async () => {
     await testEditor({
         contentBefore: "<div>a<s>b[c</s>d]ef</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>a<s>b</s>[cd]ef</div>",
     });
 });
 test("should remove striketrough format (8)", async () => {
     await testEditor({
         contentBefore: '<div>ab<font style="text-decoration: line-through">[cd]</font>ef</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove striketrough format (9)", async () => {
     await testEditor({
         contentBefore: '<div>a<font style="text-decoration: line-through">b[cd]e</font>f</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter:
             '<div>a<font style="text-decoration: line-through">b</font>[cd]<font style="text-decoration: line-through">e</font>f</div>',
     });
@@ -335,7 +335,7 @@ test("should remove striketrough format (10)", async () => {
     await testEditor({
         contentBefore:
             '<div>a<font style="text-decoration-line: line-through">b[cd]e</font>f</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter:
             '<div>a<font style="text-decoration-line: line-through">b</font>[cd]<font style="text-decoration-line: line-through">e</font>f</div>',
     });
@@ -343,35 +343,35 @@ test("should remove striketrough format (10)", async () => {
 test("should remove text color (1)", async () => {
     await testEditor({
         contentBefore: '<div>ab<font style="color: rgb(255, 0, 0);">[cd]</font>ef</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove text color (2)", async () => {
     await testEditor({
         contentBefore: '<div>ab<font style="color: red">[cd]</font>ef</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove text color (3)", async () => {
     await testEditor({
         contentBefore: '<div>ab<font style="color: #ff0000">[cd]</font>ef</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove text color (4)", async () => {
     await testEditor({
         contentBefore: '<div>ab<font class="text-o-color-1">[cd]</font>ef</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove text color (5)", async () => {
     await testEditor({
         contentBefore: '<div>a<font style="color: rgb(255, 0, 0);">b[cd]e</font>f</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter:
             '<div>a<font style="color: rgb(255, 0, 0);">b</font>[cd]<font style="color: rgb(255, 0, 0);">e</font>f</div>',
     });
@@ -379,7 +379,7 @@ test("should remove text color (5)", async () => {
 test("should remove text color (6)", async () => {
     await testEditor({
         contentBefore: '<div>a<font style="color: red">b[cd]e</font>f</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter:
             '<div>a<font style="color: red">b</font>[cd]<font style="color: red">e</font>f</div>',
     });
@@ -387,7 +387,7 @@ test("should remove text color (6)", async () => {
 test("should remove text color (7)", async () => {
     await testEditor({
         contentBefore: '<div>a<font style="color: #ff0000">b[cd]e</font>f</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter:
             '<div>a<font style="color: #ff0000">b</font>[cd]<font style="color: #ff0000">e</font>f</div>',
     });
@@ -395,7 +395,7 @@ test("should remove text color (7)", async () => {
 test("should remove text color (8)", async () => {
     await testEditor({
         contentBefore: '<div>a<font class="text-o-color-1">b[cd]e</font>f</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter:
             '<div>a<font class="text-o-color-1">b</font>[cd]<font class="text-o-color-1">e</font>f</div>',
     });
@@ -403,42 +403,42 @@ test("should remove text color (8)", async () => {
 test("should remove background color (1)", async () => {
     await testEditor({
         contentBefore: '<div>ab<font style="background: rgb(0, 0, 255);">[cd]</font>ef</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove background color (2)", async () => {
     await testEditor({
         contentBefore: '<div>ab<font style="background: blue">[cd]</font>ef</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove background color (3)", async () => {
     await testEditor({
         contentBefore: '<div>ab<font style="background: #00f">[cd]</font>ef</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove background color (4)", async () => {
     await testEditor({
         contentBefore: '<div>ab<font style="background-color: #00f">[cd]</font>ef</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove background color (5)", async () => {
     await testEditor({
         contentBefore: '<div>ab<font class="bg-o-color-1">[cd]</font>ef</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove background color (6)", async () => {
     await testEditor({
         contentBefore: '<div>a<font style="background: rgb(255, 0, 0);">b[cd]e</font>f</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter:
             '<div>a<font style="background: rgb(255, 0, 0);">b</font>[cd]<font style="background: rgb(255, 0, 0);">e</font>f</div>',
     });
@@ -446,7 +446,7 @@ test("should remove background color (6)", async () => {
 test("should remove background color (7)", async () => {
     await testEditor({
         contentBefore: '<div>a<font style="background: red">b[cd]e</font>f</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter:
             '<div>a<font style="background: red">b</font>[cd]<font style="background: red">e</font>f</div>',
     });
@@ -454,7 +454,7 @@ test("should remove background color (7)", async () => {
 test("should remove background color (8)", async () => {
     await testEditor({
         contentBefore: '<div>a<font style="background: #ff0000">b[cd]e</font>f</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter:
             '<div>a<font style="background: #ff0000">b</font>[cd]<font style="background: #ff0000">e</font>f</div>',
     });
@@ -462,7 +462,7 @@ test("should remove background color (8)", async () => {
 test("should remove background color (9)", async () => {
     await testEditor({
         contentBefore: '<div>a<font style="background-color: #ff0000">b[cd]e</font>f</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter:
             '<div>a<font style="background-color: #ff0000">b</font>[cd]<font style="background-color: #ff0000">e</font>f</div>',
     });
@@ -470,7 +470,7 @@ test("should remove background color (9)", async () => {
 test("should remove background color (10)", async () => {
     await testEditor({
         contentBefore: '<div>a<font class="bg-o-color-1">b[cd]e</font>f</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter:
             '<div>a<font class="bg-o-color-1">b</font>[cd]<font class="bg-o-color-1">e</font>f</div>',
     });
@@ -479,61 +479,61 @@ test("should remove the background image when clear the format", async () => {
     await testEditor({
         contentBefore:
             '<div><p><font class="text-gradient" style="background-image: linear-gradient(135deg, rgb(255, 204, 51) 0%, rgb(226, 51, 255) 100%);">[ab]</font></p></div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div><p>[ab]</p></div>",
     });
 });
 test("should remove all the colors for the text separated by Shift+Enter when using removeFormat button (1)", async () => {
     await testEditor({
         contentBefore: `<div><h1><font style="color: red">[ab</font><br><font style="color: red">cd</font><br><font style="color: red">ef]</font></h1></div>`,
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: `<div><h1>[ab<br>cd<br>ef]</h1></div>`,
     });
 });
 test("should remove all the colors for the text separated by Shift+Enter when using removeFormat button (2)", async () => {
     await testEditor({
         contentBefore: `<div><h1><font style="color: red">[ab</font><br><font style="color: red">cd</font><br><font style="color: red">]ef</font></h1></div>`,
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: `<div><h1>[ab<br>cd<br><font style="color: red">]ef</font></h1></div>`,
     });
 });
 test("should remove all the colors for the text separated by Enter when using removeFormat button", async () => {
     await testEditor({
         contentBefore: `<div><h1><font style="background-color: red">[ab</font></h1><h1><font style="background-color: red">cd</font></h1><h1><font style="background-color: red">ef]</font></h1></div>`,
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: `<div><h1>[ab</h1><h1>cd</h1><h1>ef]</h1></div>`,
     });
     await testEditor({
         contentBefore: `<div><h1><font style="color: red">[ab</font></h1><h1><font style="color: red">cd</font></h1><h1><font style="color: red">ef]</font></h1></div>`,
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: `<div><h1>[ab</h1><h1>cd</h1><h1>ef]</h1></div>`,
     });
 });
 test("should remove multiple format (1)", async () => {
     await testEditor({
         contentBefore: "<div>ab<b>[cd</b>ef<i>gh]</i>ij</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cdefgh]ij</div>",
     });
 });
 test("should remove multiple format (2)", async () => {
     await testEditor({
         contentBefore: "<div>ab<b>[c<u>d</u></b>ef<i>g</i>h]ij</div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cdefgh]ij</div>",
     });
 });
 test("should remove multiple format (3)", async () => {
     await testEditor({
         contentBefore: "<div><p><b>a[bc</b></p><p>de<br>fg<br></p><p><i>ij</i>sd]fsf</p></div>",
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div><p><b>a</b>[bc</p><p>de<br>fg<br></p><p>ijsd]fsf</p></div>",
     });
 });
 test("should remove format and keep attribute in a span", async () => {
     await testEditor({
         contentBefore: '<p><strong some-attr="1">[abc]</strong></p>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: '<p><span some-attr="1">[abc]</span></p>',
     });
 });
@@ -541,7 +541,7 @@ test("should remove multiple color (1)", async () => {
     await testEditor({
         contentBefore:
             '<div>ab<font style="background: rgb(0, 0, 255);color: rgb(0, 255, 255);">[cd]</font>ef</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
@@ -549,7 +549,7 @@ test("should remove multiple color (2)", async () => {
     await testEditor({
         contentBefore:
             '<div>ab<font style="background: red" class="bg-o-color-1">[cd]</font>ef</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
@@ -557,7 +557,7 @@ test("should remove multiple color (3)", async () => {
     await testEditor({
         contentBefore:
             '<div>ab<font style="background: rgb(0, 0, 255);"><font class="bg-o-color-1">[cd]</font></font>ef</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
@@ -565,7 +565,7 @@ test("should remove multiple color (4)", async () => {
     await testEditor({
         contentBefore:
             '<div>ab<font style="color: rgb(0, 0, 255);"><font class="bg-o-color-1">[cd]</font></font>ef</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: "<div>ab[cd]ef</div>",
     });
 });
@@ -573,7 +573,7 @@ test("should remove multiple color (5)", async () => {
     await testEditor({
         contentBefore:
             '<div>ab<font style="background: blue">c[d<font class="bg-o-color-1">ef]</font></font>gh</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter: '<div>ab<font style="background: blue">c</font>[def]gh</div>',
     });
 });
@@ -582,7 +582,7 @@ test.todo("should remove multiple color (6)", async () => {
     await testEditor({
         contentBefore:
             '<div>ab<font style="background: blue">c[d<font class="bg-o-color-1">e]f</font></font>gh</div>',
-        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        stepFunction: (editor) => editor.shared.execCommand("removeFormat"),
         contentAfter:
             '<div>ab<font style="background: blue">c</font>[de]<font class="bg-o-color-1">f</font>gh</div>',
     });
@@ -592,8 +592,8 @@ test("undo remove format should return the element to it's original state", asyn
         contentBefore:
             '<p><strong><em><u><s><font style="color: rgb(0, 255, 0); background: rgb(0, 0, 255);">[sdsdsdsds]</font></s></u></em></strong></p>',
         stepFunction: (editor) => {
-            editor.dispatch("FORMAT_REMOVE_FORMAT");
-            editor.dispatch("HISTORY_UNDO");
+            editor.shared.execCommand("removeFormat");
+            editor.shared.execCommand("historyUndo");
         },
         contentAfter:
             '<p><strong><em><u><s><font style="color: rgb(0, 255, 0); background: rgb(0, 0, 255);">[sdsdsdsds]</font></s></u></em></strong></p>',

--- a/addons/html_editor/static/tests/hint.test.js
+++ b/addons/html_editor/static/tests/hint.test.js
@@ -67,7 +67,8 @@ test("should not display hint in paragraph with media content", async () => {
 test("should not lose track of temporary hints on split block", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>", {});
     expect(getContent(el)).toBe(`<p placeholder='Type "/" for commands' class="o-we-hint">[]</p>`);
-    editor.dispatch("SPLIT_BLOCK");
+    editor.shared.splitBlock();
+    editor.shared.addStep();
     await animationFrame();
     expect(getContent(el)).toBe(
         unformat(`
@@ -99,11 +100,12 @@ test("hint should only Be display for focused empty block element", async () => 
     expect(getContent(el)).toBe(
         `<p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`
     );
-    editor.dispatch("SET_TAG", { tagName: "H1" });
+    editor.shared.execCommand("setTag", { tagName: "H1" });
     await animationFrame();
     // @todo @phoenix: getContent does not place the selection when anchor is BR
     expect(el.innerHTML).toBe(`<h1 placeholder="Heading 1" class="o-we-hint"><br></h1>`);
-    editor.dispatch("SPLIT_BLOCK");
+    editor.shared.splitBlock();
+    editor.shared.addStep();
     await animationFrame();
     expect(getContent(el)).toBe(
         unformat(`

--- a/addons/html_editor/static/tests/history.test.js
+++ b/addons/html_editor/static/tests/history.test.js
@@ -1,11 +1,9 @@
-import { Editor } from "@html_editor/editor";
 import { Plugin } from "@html_editor/plugin";
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import { parseHTML } from "@html_editor/utils/html";
 import { describe, expect, test } from "@odoo/hoot";
 import { click, pointerDown, pointerUp, press, queryOne } from "@odoo/hoot-dom";
 import { animationFrame, mockUserAgent, tick } from "@odoo/hoot-mock";
-import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { setupEditor, testEditor } from "./_helpers/editor";
 import { getContent, setSelection } from "./_helpers/selection";
 import { addStep, deleteBackward, insertText, redo, undo } from "./_helpers/user_actions";
@@ -14,13 +12,11 @@ describe("reset", () => {
     test("should not add mutations in the current step from the normalization when calling reset", async () => {
         const TestPlugin = class extends Plugin {
             static name = "test";
-            handleCommand(commandName) {
-                switch (commandName) {
-                    case "NORMALIZE":
-                        this.editable.firstChild.setAttribute("data-test-normalize", "1");
-                        break;
-                }
-            }
+            resources = {
+                normalize_listeners: () => {
+                    this.editable.firstChild.setAttribute("data-test-normalize", "1");
+                },
+            };
         };
         const { editor, el } = await setupEditor("<p>a</p>", {
             config: { Plugins: [...MAIN_PLUGINS, TestPlugin] },
@@ -79,7 +75,7 @@ describe("undo", () => {
         const { el, editor } = await setupEditor(`<p>[]c</p>`);
         const p = el.querySelector("p");
         editor.shared.domInsert("a");
-        editor.dispatch("ADD_STEP");
+        editor.shared.addStep();
         p.prepend(document.createTextNode("b"));
         undo(editor);
         expect(getContent(el)).toBe(`<p>[]c</p>`);
@@ -202,7 +198,7 @@ describe("redo", () => {
         const { el, editor } = await setupEditor(`<p>[]c</p>`);
         const p = el.querySelector("p");
         editor.shared.domInsert("a");
-        editor.dispatch("ADD_STEP");
+        editor.shared.addStep();
         undo(editor);
         expect(getContent(el)).toBe(`<p>[]c</p>`);
         p.prepend(document.createTextNode("b"));
@@ -246,7 +242,7 @@ describe("step", () => {
             stepFunction: async (editor) => {
                 const editable = '<div contenteditable="true">abc</div>';
                 editor.editable.querySelector("div").innerHTML = editable;
-                editor.dispatch("ADD_STEP");
+                editor.shared.addStep();
             },
             contentAfter: `<div contenteditable="false"><div contenteditable="true">abc</div></div>`,
         });
@@ -267,7 +263,7 @@ describe("prevent mutationFilteredClasses to be set from history", () => {
             stepFunction: async (editor) => {
                 const p = editor.editable.querySelector("p");
                 p.className = "x";
-                editor.dispatch("ADD_STEP");
+                editor.shared.addStep();
                 const history = editor.plugins.find((p) => p.constructor.name === "history");
                 expect(history.steps.length).toBe(1);
             },
@@ -329,15 +325,15 @@ describe("makeSavePoint", () => {
         const { el, editor } = await setupEditor(
             `<p>a[b<span style="color: tomato;">c</span>d]e</p>`
         );
-        // The HISTORY_STAGE_SELECTION should have been triggered by the click on
+        // The stageSelection should have been triggered by the click on
         // the editable. As we set the selection programmatically, we dispatch the
         // selection here for the commands that relies on it.
         // If the selection of the editor would be programatically set upon start
         // (like an autofocus feature), it would be the role of the autofocus
-        // feature to trigger the HISTORY_STAGE_SELECTION.
-        editor.dispatch("HISTORY_STAGE_SELECTION");
+        // feature to trigger the stageSelection.
+        editor.shared.stageSelection();
         const restore = editor.shared.makeSavePoint();
-        editor.dispatch("FORMAT_BOLD");
+        editor.shared.execCommand("formatBold");
         restore();
         expect(getContent(el)).toBe(`<p>a[b<span style="color: tomato;">c</span>d]e</p>`);
     });
@@ -367,7 +363,7 @@ describe("makeSavePoint", () => {
         const savepoint = editor.shared.makeSavePoint();
         // step to consume
         editor.shared.domInsert("z");
-        editor.dispatch("ADD_STEP");
+        editor.shared.addStep();
         let steps = editor.shared.getHistorySteps();
         expect(steps.length).toBe(2);
         const zStep = steps.at(-1);
@@ -514,11 +510,11 @@ describe("shortcut", () => {
         expect(state).toEqual({});
         await insertText(editor, "a");
         expect(state).toEqual({ canUndo: true, canRedo: false });
-        editor.dispatch("HISTORY_UNDO");
+        editor.shared.execCommand("historyUndo");
         expect(state).toEqual({ canUndo: false, canRedo: true });
-        editor.dispatch("HISTORY_REDO");
+        editor.shared.execCommand("historyRedo");
         expect(state).toEqual({ canUndo: true, canRedo: false });
-        editor.dispatch("HISTORY_UNDO");
+        editor.shared.execCommand("historyUndo");
         expect(state).toEqual({ canUndo: false, canRedo: true });
         await insertText(editor, "b");
         expect(state).toEqual({ canUndo: true, canRedo: false });
@@ -526,20 +522,15 @@ describe("shortcut", () => {
     });
 
     test("use handleNewRecords resource", async () => {
-        patchWithCleanup(Editor.prototype, {
-            dispatch(cmd, ...args) {
-                if (cmd === "CONTENT_UPDATED") {
-                    expect.step("CONTENT_UPDATED");
-                }
-                return super.dispatch(cmd, ...args);
-            },
-        });
         const onChange = () => {
             expect.step("onchange");
         };
         const resources = {
             handleNewRecords: () => {
                 expect.step("handleNewRecords");
+            },
+            content_updated_listeners: () => {
+                expect.step("contentUpdated");
             },
         };
         const { editor } = await setupEditor(`<p>[]</p>`, {
@@ -549,9 +540,9 @@ describe("shortcut", () => {
         await insertText(editor, "a");
         expect.verifySteps([
             "handleNewRecords",
-            "CONTENT_UPDATED",
+            "contentUpdated",
             "handleNewRecords",
-            "CONTENT_UPDATED",
+            "contentUpdated",
             "onchange",
         ]);
     });
@@ -575,7 +566,6 @@ describe("destroy", () => {
                     record.addedNodes.item(0).matches(".test")
                 ) {
                     expect.step("dispatch");
-                    this.dispatch("DISPATCH");
                     return false;
                 }
                 return true;

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -1865,7 +1865,7 @@ describe("save image", () => {
         sendBeaconDef = new Deferred();
         setSelectionInHtmlField(".test_target");
         await insertText(htmlEditor, "a");
-        htmlEditor.dispatch("ADD_STEP");
+        htmlEditor.shared.addStep();
         await formController.beforeUnload();
         await sendBeaconDef;
 
@@ -1874,7 +1874,7 @@ describe("save image", () => {
         const imageContainerElement = parseHTML(htmlEditor.document, imageContainerHTML).firstChild;
         const paragraph = htmlEditor.editable.querySelector(".test_target");
         htmlEditor.editable.replaceChild(imageContainerElement, paragraph);
-        htmlEditor.dispatch("ADD_STEP");
+        htmlEditor.shared.addStep();
 
         // Simulate an urgent save before the end of the RPC roundtrip for the
         // image.

--- a/addons/html_editor/static/tests/insert/html.test.js
+++ b/addons/html_editor/static/tests/insert/html.test.js
@@ -4,6 +4,7 @@ import { tick } from "@odoo/hoot-mock";
 import { setupEditor, testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { getContent } from "../_helpers/selection";
+import { trigger } from "@html_editor/utils/resource";
 
 function span(text) {
     const span = document.createElement("span");
@@ -20,7 +21,7 @@ describe("collapsed selection", () => {
                 editor.shared.domInsert(
                     parseHTML(editor.document, '<i class="fa fa-pastafarianism"></i>')
                 );
-                editor.dispatch("ADD_STEP");
+                editor.shared.addStep();
             },
             contentAfterEdit:
                 '<p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]</p>',
@@ -36,7 +37,7 @@ describe("collapsed selection", () => {
                 editor.shared.domInsert(
                     parseHTML(editor.document, '<i class="fa fa-pastafarianism"></i>')
                 );
-                editor.dispatch("ADD_STEP");
+                editor.shared.addStep();
             },
             contentAfterEdit:
                 '<p><br></p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]',
@@ -52,7 +53,7 @@ describe("collapsed selection", () => {
                 editor.shared.domInsert(
                     parseHTML(editor.document, '<i class="fa fa-pastafarianism"></i>')
                 );
-                editor.dispatch("ADD_STEP");
+                editor.shared.addStep();
             },
             contentAfterEdit:
                 '<p>a<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]b</p>',
@@ -67,7 +68,7 @@ describe("collapsed selection", () => {
                 editor.shared.domInsert(
                     parseHTML(editor.document, '<i class="fa fa-pastafarianism"></i>')
                 );
-                editor.dispatch("ADD_STEP");
+                editor.shared.addStep();
             },
             contentAfterEdit:
                 '<p>a<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]b</p>',
@@ -80,7 +81,7 @@ describe("collapsed selection", () => {
             contentBefore: "<p>a[]e<br></p>",
             stepFunction: async (editor) => {
                 editor.shared.domInsert(parseHTML(editor.document, "<p>b</p><p>c</p><p>d</p>"));
-                editor.dispatch("ADD_STEP");
+                editor.shared.addStep();
             },
             contentAfter: "<p>ab</p><p>c</p><p>d[]e</p>",
         });
@@ -91,7 +92,7 @@ describe("collapsed selection", () => {
             contentBefore: "<p>[]<br></p>",
             stepFunction: async (editor) => {
                 editor.shared.domInsert(parseHTML(editor.document, "<div><p>content</p></div>"));
-                editor.dispatch("ADD_STEP");
+                editor.shared.addStep();
             },
             contentAfter: "<div><p>content</p></div><p>[]<br></p>",
         });
@@ -102,7 +103,7 @@ describe("collapsed selection", () => {
             contentBefore: "<pre>abc[]<br>ghi</pre>",
             stepFunction: async (editor) => {
                 editor.shared.domInsert(parseHTML(editor.document, "<pre>def</pre>"));
-                editor.dispatch("ADD_STEP");
+                editor.shared.addStep();
             },
             contentAfter: "<pre>abcdef[]<br>ghi</pre>",
         });
@@ -118,7 +119,7 @@ describe("collapsed selection", () => {
                         '<p>unwrapped</p><div><i class="fa fa-circle-o-notch"></i></div><p>culprit</p><p>after</p>'
                     )
                 );
-                editor.dispatch("ADD_STEP");
+                editor.shared.addStep();
             },
             contentAfter:
                 '<p>contentunwrapped</p><div><i class="fa fa-circle-o-notch"></i></div><p>culprit</p><p>after[]</p>',
@@ -132,7 +133,7 @@ describe("collapsed selection", () => {
                 editor.shared.setCursorEnd(editor.editable, false);
                 editor.shared.focusEditable();
                 editor.shared.domInsert(parseHTML(editor.document, "<p>def</p>"));
-                editor.dispatch("ADD_STEP");
+                editor.shared.addStep();
             },
             contentAfter: "<p>content</p><p>def[]</p>",
         });
@@ -146,7 +147,7 @@ describe("collapsed selection", () => {
                 editor.shared.focusEditable();
                 await tick();
                 editor.shared.domInsert(parseHTML(editor.document, "<div>abc</div><p>def</p>"));
-                editor.dispatch("ADD_STEP");
+                editor.shared.addStep();
             },
             contentAfter: "<p>content</p><div>abc</div><p>def[]</p>",
         });
@@ -157,7 +158,7 @@ describe("collapsed selection", () => {
             contentBefore: "<p>abcd[]</p>",
             stepFunction: async (editor) => {
                 editor.shared.domInsert(parseHTML(editor.document, "<p>efgh</p><p></p>"));
-                editor.dispatch("ADD_STEP");
+                editor.shared.addStep();
             },
             contentAfter: "<p>abcdefgh</p><p>[]<br></p>",
         });
@@ -214,58 +215,58 @@ describe("collapsed selection", () => {
     test("insert inline in empty paragraph", async () => {
         const { el, editor } = await setupEditor(`<p>[]<br></p>`);
         editor.shared.domInsert(parseHTML(editor.document, `<span class="a">a</span>`));
-        editor.dispatch("ADD_STEP");
+        editor.shared.addStep();
         expect(getContent(el)).toBe(`<p><span class="a">a</span>[]</p>`);
     });
 
     test("insert inline at the end of a paragraph", async () => {
         const { el, editor } = await setupEditor(`<p>b[]</p>`);
         editor.shared.domInsert(parseHTML(editor.document, `<span class="a">a</span>`));
-        editor.dispatch("ADD_STEP");
+        editor.shared.addStep();
         expect(getContent(el)).toBe(`<p>b<span class="a">a</span>[]</p>`);
     });
 
     test("insert inline at the start of a paragraph", async () => {
         const { el, editor } = await setupEditor(`<p>[]b</p>`);
         editor.shared.domInsert(parseHTML(editor.document, `<span class="a">a</span>`));
-        editor.dispatch("ADD_STEP");
+        editor.shared.addStep();
         expect(getContent(el)).toBe(`<p><span class="a">a</span>[]b</p>`);
     });
 
     test("insert inline at the middle of a paragraph", async () => {
         const { el, editor } = await setupEditor(`<p>b[]c</p>`);
         editor.shared.domInsert(parseHTML(editor.document, `<span class="a">a</span>`));
-        editor.dispatch("ADD_STEP");
+        editor.shared.addStep();
         expect(getContent(el)).toBe(`<p>b<span class="a">a</span>[]c</p>`);
     });
 
     test("insert block in empty paragraph", async () => {
         const { el, editor } = await setupEditor(`<p>[]<br></p>`);
         editor.shared.domInsert(parseHTML(editor.document, `<div class="a">a</div>`));
-        editor.dispatch("ADD_STEP");
-        editor.dispatch("CLEAN", { root: editor.editable });
+        editor.shared.addStep();
+        trigger(editor.resources["clean_listeners"], editor.editable);
         expect(getContent(el)).toBe(`<div class="a">a</div><p>[]<br></p>`);
     });
 
     test("insert block at the end of a paragraph", async () => {
         const { el, editor } = await setupEditor(`<p>b[]</p>`);
         editor.shared.domInsert(parseHTML(editor.document, `<div class="a">a</div>`));
-        editor.dispatch("ADD_STEP");
-        editor.dispatch("CLEAN", { root: editor.editable });
+        editor.shared.addStep();
+        trigger(editor.resources["clean_listeners"], editor.editable);
         expect(getContent(el)).toBe(`<p>b</p><div class="a">a</div><p>[]<br></p>`);
     });
 
     test("insert block at the start of a paragraph", async () => {
         const { el, editor } = await setupEditor(`<p>[]b</p>`);
         editor.shared.domInsert(parseHTML(editor.document, `<div class="a">a</div>`));
-        editor.dispatch("ADD_STEP");
+        editor.shared.addStep();
         expect(getContent(el)).toBe(`<div class="a">a</div><p>[]b</p>`);
     });
 
     test("insert block at the middle of a paragraph", async () => {
         const { el, editor } = await setupEditor(`<p>b[]c</p>`);
         editor.shared.domInsert(parseHTML(editor.document, `<div class="a">a</div>`));
-        editor.dispatch("ADD_STEP");
+        editor.shared.addStep();
         expect(getContent(el)).toBe(`<p>b</p><div class="a">a</div><p>[]c</p>`);
     });
 });
@@ -292,7 +293,7 @@ describe("not collapsed selection", () => {
                 editor.shared.domInsert(
                     parseHTML(editor.document, '<i class="fa fa-pastafarianism"></i>')
                 );
-                editor.dispatch("ADD_STEP");
+                editor.shared.addStep();
             },
             contentAfterEdit:
                 '<p>a<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]c</p>',
@@ -312,7 +313,7 @@ describe("not collapsed selection", () => {
             ),
             stepFunction: (editor) => {
                 editor.shared.domInsert(span("TEST"));
-                editor.dispatch("ADD_STEP");
+                editor.shared.addStep();
             },
             contentAfter: '<p>a<span class="a">TEST</span>[]l</p>',
         });
@@ -329,7 +330,7 @@ describe("not collapsed selection", () => {
             ),
             stepFunction: (editor) => {
                 editor.shared.domInsert(span("TEST"));
-                editor.dispatch("ADD_STEP");
+                editor.shared.addStep();
             },
             contentAfter: unformat(
                 `<table><tbody>
@@ -353,7 +354,7 @@ describe("not collapsed selection", () => {
             ),
             stepFunction: (editor) => {
                 editor.shared.domInsert(span("TEST"));
-                editor.dispatch("ADD_STEP");
+                editor.shared.addStep();
             },
             contentAfter: unformat(
                 `<p>a<span class="a">TEST</span>[]</p>
@@ -374,7 +375,7 @@ describe("not collapsed selection", () => {
             ),
             stepFunction: (editor) => {
                 editor.shared.domInsert(span("TEST"));
-                editor.dispatch("ADD_STEP");
+                editor.shared.addStep();
             },
             contentAfter: unformat(
                 `<p>ab</p>
@@ -395,7 +396,7 @@ describe("not collapsed selection", () => {
             ),
             stepFunction: (editor) => {
                 editor.shared.domInsert(span("TEST"));
-                editor.dispatch("ADD_STEP");
+                editor.shared.addStep();
             },
             contentAfter: `<p>a<span class="a">TEST</span>[]l</p>`,
         });
@@ -419,7 +420,7 @@ describe("not collapsed selection", () => {
             ),
             stepFunction: (editor) => {
                 editor.shared.domInsert(span("TEST"));
-                editor.dispatch("ADD_STEP");
+                editor.shared.addStep();
             },
             contentAfter: `<p><span class="a">TEST</span>[]</p>`,
         });
@@ -447,7 +448,7 @@ describe("not collapsed selection", () => {
             ),
             stepFunction: (editor) => {
                 editor.shared.domInsert(span("TEST"));
-                editor.dispatch("ADD_STEP");
+                editor.shared.addStep();
             },
             contentAfter: `<p>0<span class="a">TEST</span>[]</p>`,
         });
@@ -475,7 +476,7 @@ describe("not collapsed selection", () => {
             ),
             stepFunction: (editor) => {
                 editor.shared.domInsert(span("TEST"));
-                editor.dispatch("ADD_STEP");
+                editor.shared.addStep();
             },
             contentAfter: `<p><span class="a">TEST</span>[]</p>`,
         });
@@ -490,7 +491,7 @@ describe("not collapsed selection", () => {
                         '<p>\uFEFF<a href="#">\uFEFFlink\uFEFF</a>\uFEFF</p><p>\uFEFF<a href="#">\uFEFFlink\uFEFF</a>\uFEFF</p>'
                     )
                 );
-                editor.dispatch("ADD_STEP");
+                editor.shared.addStep();
             },
             contentAfter: '<p><a href="#">link</a></p><p><a href="#">link</a>[]</p>',
         });

--- a/addons/html_editor/static/tests/insert/separator.test.js
+++ b/addons/html_editor/static/tests/insert/separator.test.js
@@ -3,7 +3,7 @@ import { setupEditor, testEditor } from "../_helpers/editor";
 import { getContent } from "../_helpers/selection";
 
 async function insertSeparator(editor) {
-    editor.dispatch("INSERT_SEPARATOR");
+    editor.shared.execCommand("insertSeparator");
 }
 
 describe("insert separator", () => {
@@ -63,7 +63,7 @@ describe("insert separator", () => {
         const separator = editor.document.createElement("hr");
         div.append(separator);
         el.append(div);
-        editor.dispatch("ADD_STEP");
+        editor.shared.addStep();
         expect(getContent(el)).toBe(
             `<p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p><div><hr contenteditable="false"></div>`
         );

--- a/addons/html_editor/static/tests/insert/text.test.js
+++ b/addons/html_editor/static/tests/insert/text.test.js
@@ -78,7 +78,7 @@ describe("not collapsed selection", () => {
         const { editor, el } = await setupEditor("<p>[abc]def</p>");
         await insertText(editor, "x");
         expect(getContent(el)).toBe("<p>x[]def</p>");
-        editor.dispatch("HISTORY_UNDO");
+        editor.shared.execCommand("historyUndo");
         expect(getContent(el)).toBe("<p>[abc]def</p>");
     });
 });

--- a/addons/html_editor/static/tests/keyboard/shortcut.test.js
+++ b/addons/html_editor/static/tests/keyboard/shortcut.test.js
@@ -9,13 +9,9 @@ test("shortcut plugin allow registering shortcuts", async () => {
     class TestPlugin extends Plugin {
         static name = "test";
         resources = {
-            shortcuts: [{ hotkey: "a", command: "TEST_CMD" }],
+            user_commands: [{ id: "TEST_CMD", run: () => count++ }],
+            shortcuts: [{ hotkey: "a", commandId: "TEST_CMD" }],
         };
-        handleCommand(command, payload) {
-            if (command === "TEST_CMD") {
-                count++;
-            }
-        }
     }
     await setupEditor(`<p>test[]</p>`, {
         config: { Plugins: [...MAIN_PLUGINS, TestPlugin] },
@@ -33,13 +29,9 @@ test.tags("iframe")("shortcut plugin allow registering shortcuts in iframe", asy
     class TestPlugin extends Plugin {
         static name = "test";
         resources = {
-            shortcuts: [{ hotkey: "a", command: "TEST_CMD" }],
+            user_commands: [{ id: "TEST_CMD", run: () => count++ }],
+            shortcuts: [{ hotkey: "a", commandId: "TEST_CMD" }],
         };
-        handleCommand(command, payload) {
-            if (command === "TEST_CMD") {
-                count++;
-            }
-        }
     }
     await setupEditor(`<p>test[]</p>`, {
         config: { Plugins: [...MAIN_PLUGINS, TestPlugin] },

--- a/addons/html_editor/static/tests/link/isolated.test.js
+++ b/addons/html_editor/static/tests/link/isolated.test.js
@@ -6,6 +6,7 @@ import { tick } from "@odoo/hoot-mock";
 import { getContent, setSelection } from "../_helpers/selection";
 import { cleanLinkArtifacts } from "../_helpers/format";
 import { waitFor } from "@odoo/hoot-dom";
+import { trigger } from "@html_editor/utils/resource";
 
 test("should pad a link with ZWNBSPs and add visual indication", async () => {
     await testEditor({
@@ -90,7 +91,7 @@ test("should zwnbsp-pad simple text link", async () => {
             // set the selection via the parent
             setSelection({ anchorNode: p, anchorOffset: 1 });
             // insert the zwnbsp again
-            editor.dispatch("NORMALIZE", { node: editor.editable });
+            trigger(editor.resources["normalize_listeners"], editor.editable);
         },
         contentAfterEdit: '<p>a\ufeff[]<a href="#/">\ufeffbc\ufeff</a>\ufeffd</p>',
     });
@@ -105,7 +106,7 @@ test("should zwnbsp-pad simple text link", async () => {
             setSelection({ anchorNode: a, anchorOffset: 0 });
             await tick();
             // insert the zwnbsp again
-            editor.dispatch("NORMALIZE", { node: editor.editable });
+            trigger(editor.resources["normalize_listeners"], editor.editable);
         },
         contentAfterEdit:
             '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeff[]bc\ufeff</a>\ufeffd</p>',
@@ -125,7 +126,7 @@ test("should zwnbsp-pad simple text link", async () => {
             setSelection({ anchorNode: a, anchorOffset: 1 });
             await tick();
             // insert the zwnbsp again
-            editor.dispatch("NORMALIZE", { node: editor.editable });
+            trigger(editor.resources["normalize_listeners"], editor.editable);
         },
         contentAfterEdit:
             '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeffb[]c\ufeff</a>\ufeffd</p>',
@@ -141,7 +142,7 @@ test("should zwnbsp-pad simple text link", async () => {
             setSelection({ anchorNode: a, anchorOffset: 1 });
             await tick();
             // insert the zwnbsp again
-            editor.dispatch("NORMALIZE", { node: editor.editable });
+            trigger(editor.resources["normalize_listeners"], editor.editable);
         },
         contentAfterEdit:
             '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeffbc[]\ufeff</a>\ufeffd</p>',
@@ -156,7 +157,7 @@ test("should zwnbsp-pad simple text link", async () => {
             setSelection({ anchorNode: p, anchorOffset: 2 });
             await tick();
             // insert the zwnbsp again
-            editor.dispatch("NORMALIZE", { node: editor.editable });
+            trigger(editor.resources["normalize_listeners"], editor.editable);
         },
         contentAfterEdit: '<p>a\ufeff<a href="#/">\ufeffbc\ufeff</a>\ufeff[]d</p>',
     });

--- a/addons/html_editor/static/tests/list/automatic_list_detection.test.js
+++ b/addons/html_editor/static/tests/list/automatic_list_detection.test.js
@@ -150,7 +150,7 @@ test("typing '[] ' should create checklist and restore the original text when un
         `<ul class="o_checklist"><li placeholder="List" class="o-we-hint">[]<br></li></ul>`
     );
 
-    editor.dispatch("HISTORY_UNDO");
+    editor.shared.execCommand("historyUndo");
     expect(getContent(el)).toBe(`<p>\[\] []</p>`);
 });
 
@@ -159,7 +159,7 @@ test("Typing '[] ' at the start of existing text should create a checklist and r
     await insertText(editor, "[] ");
     expect(getContent(el)).toBe(`<ul class="o_checklist"><li>[]abc</li></ul>`);
 
-    editor.dispatch("HISTORY_UNDO");
+    editor.shared.execCommand("historyUndo");
     expect(getContent(el)).toBe(`<p>\[\] []abc</p>`);
 });
 

--- a/addons/html_editor/static/tests/list/toggle_cl.test.js
+++ b/addons/html_editor/static/tests/list/toggle_cl.test.js
@@ -3,6 +3,7 @@ import { setupEditor, testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { getContent } from "../_helpers/selection";
 import { insertText, toggleCheckList } from "../_helpers/user_actions";
+import { trigger } from "@html_editor/utils/resource";
 
 describe("Range collapsed", () => {
     describe("Insert", () => {
@@ -56,7 +57,7 @@ describe("Range collapsed", () => {
             );
 
             await insertText(editor, "a");
-            editor.dispatch("NORMALIZE", { node: el });
+            trigger(editor.resources["normalize_listeners"], el);
             expect(getContent(el)).toBe(`<ul class="o_checklist"><li><h1>a[]</h1></li></ul>`);
         });
 

--- a/addons/html_editor/static/tests/misc.test.js
+++ b/addons/html_editor/static/tests/misc.test.js
@@ -11,7 +11,7 @@ test("can instantiate a Editor", async () => {
     expect(el.innerHTML).toBe(`<p>hello world</p>`);
     expect(getContent(el)).toBe(`<p>hel[lo] world</p>`);
     setContent(el, "<div>a[dddb]</div>");
-    editor.dispatch("FORMAT_BOLD");
+    editor.shared.execCommand("formatBold");
     expect(getContent(el)).toBe(`<div>a<strong>[dddb]</strong></div>`);
 });
 
@@ -35,7 +35,7 @@ test.tags("iframe")("can instantiate a Editor in an iframe", async () => {
     expect(el.innerHTML).toBe(`<p>hello world</p>`);
     expect(getContent(el)).toBe(`<p>hel[lo] world</p>`);
     setContent(el, "<div>a[dddb]</div>");
-    editor.dispatch("FORMAT_BOLD");
+    editor.shared.execCommand("formatBold");
     expect(getContent(el)).toBe(`<div>a<strong>[dddb]</strong></div>`);
 });
 

--- a/addons/html_editor/static/tests/odoo_collaboration.test.js
+++ b/addons/html_editor/static/tests/odoo_collaboration.test.js
@@ -307,7 +307,7 @@ async function createPeers(peerIds) {
 
 async function insertEditorText(editor, text) {
     await insertText(editor, text);
-    editor.dispatch("ADD_STEP");
+    editor.shared.addStep();
 }
 
 beforeEach(() => {
@@ -1014,7 +1014,7 @@ describe("Disconnect & reconnect", () => {
             const p = document.createElement("p");
             p.textContent = content;
             peer.editor.editable.append(p);
-            peer.editor.dispatch("ADD_STEP");
+            peer.editor.shared.addStep();
         };
 
         setSelection(peers.p1);
@@ -1139,11 +1139,13 @@ describe("History steps Ids", () => {
         const peers = pool.peers;
         const editor = peers.p1.editor;
         await peers.p1.focus();
-        editor.dispatch("SPLIT_BLOCK");
+        editor.shared.splitBlock();
+        editor.shared.addStep();
         expect(getContent(editor.editable)).toBe(
             `<p>a</p><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`
         );
-        editor.dispatch("SPLIT_BLOCK");
+        editor.shared.splitBlock();
+        editor.shared.addStep();
         expect(getContent(editor.editable)).toBe(
             `<p>a</p><p><br></p><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`
         );

--- a/addons/html_editor/static/tests/powerbox.test.js
+++ b/addons/html_editor/static/tests/powerbox.test.js
@@ -118,12 +118,12 @@ describe("search", () => {
                 powerboxCategory: { id: "test", name: "Test" },
                 powerboxItems: [
                     {
-                        name: "Test1",
+                        label: "Test1",
                         description: "Test1",
                         category: "test",
                     },
                     {
-                        name: "Test12",
+                        label: "Test12",
                         description: "Test12",
                         category: "test",
                     },
@@ -258,13 +258,13 @@ describe("search", () => {
                     powerboxCategory: { id: "test", name: "Test" },
                     powerboxItems: [
                         {
-                            name: "Test1",
+                            label: "Test1",
                             description: "Test1",
                             category: "test",
                             searchKeywords: ["apple", "orange"],
                         },
                         {
-                            name: "Test2",
+                            label: "Test2",
                             description: "Test2 has apples and oranges in its description",
                             category: "test",
                         },
@@ -305,17 +305,17 @@ describe("search", () => {
                     powerboxCategory: { id: "test", name: "Test" },
                     powerboxItems: [
                         {
-                            name: "Change direction", // "icon" fuzzy matches this
+                            label: "Change direction", // "icon" fuzzy matches this
                             description: "test",
                             category: "test",
                         },
                         {
-                            name: "Some command",
+                            label: "Some command",
                             description: "add a big section", // "icon" fuzzy matches this
                             category: "test",
                         },
                         {
-                            name: "Insert a pictogram",
+                            label: "Insert a pictogram",
                             description: "test",
                             category: "test",
                             searchKeywords: ["icon"],
@@ -498,16 +498,20 @@ test("should toggle list on empty paragraph", async () => {
 class NoOpPlugin extends Plugin {
     static name = "no_op";
     resources = {
+        user_commands: [
+            {
+                id: "noOp",
+                run: () => {},
+            },
+        ],
         powerboxCategory: { id: "no_op", name: "No-op" },
         powerboxItems: [
             {
-                name: "No-op",
+                label: "No-op",
                 description: "No-op",
                 category: "no_op",
-                fontawesome: "fa-header",
-                action(dispatch) {
-                    dispatch("NO_OP");
-                },
+                icon: "fa-header",
+                commandId: "noOp",
             },
         ],
     };
@@ -571,17 +575,17 @@ test("should discard /command insertion from history when command is executed", 
     expect(commandNames(el)).toEqual(["Heading 1"]);
     await press("Enter");
     expect(getContent(el)).toBe("<h1>abc[]</h1>");
-    editor.dispatch("HISTORY_UNDO");
+    editor.shared.execCommand("historyUndo");
     expect(getContent(el)).toBe("<p>abc[]</p>");
-    editor.dispatch("HISTORY_REDO");
+    editor.shared.execCommand("historyRedo");
     expect(getContent(el)).toBe("<h1>abc[]</h1>");
-    editor.dispatch("HISTORY_UNDO");
+    editor.shared.execCommand("historyUndo");
     expect(getContent(el)).toBe("<p>abc[]</p>");
-    editor.dispatch("HISTORY_UNDO");
+    editor.shared.execCommand("historyUndo");
     expect(getContent(el)).toBe("<p>ab[]</p>");
-    editor.dispatch("HISTORY_UNDO");
+    editor.shared.execCommand("historyUndo");
     expect(getContent(el)).toBe("<p>a[]</p>");
-    editor.dispatch("HISTORY_UNDO");
+    editor.shared.execCommand("historyUndo");
     expect(getContent(el)).toBe(
         `<p class="o-we-hint" placeholder='Type "/" for commands'>[]<br></p>`
     );

--- a/addons/html_editor/static/tests/qweb.test.js
+++ b/addons/html_editor/static/tests/qweb.test.js
@@ -5,6 +5,7 @@ import { setupEditor } from "./_helpers/editor";
 import { getContent, setSelection } from "./_helpers/selection";
 import { QWebPlugin } from "@html_editor/others/qweb_plugin";
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
+import { trigger } from "@html_editor/utils/resource";
 
 const config = { Plugins: [...MAIN_PLUGINS, QWebPlugin] };
 describe("qweb picker", () => {
@@ -31,7 +32,7 @@ describe("qweb picker", () => {
             `<div><t t-if="test" data-oe-t-inline="true" data-oe-t-group="0" data-oe-t-selectable="true">yes</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0" data-oe-t-group-active="true">no</t></div>`
         );
 
-        editor.dispatch("CLEAN", { root: el });
+        trigger(editor.resources["clean_listeners"], el);
         expect(getContent(el)).toBe(`<div><t t-if="test">yes</t><t t-else="">no</t></div>`);
     });
 

--- a/addons/html_editor/static/tests/selection.test.js
+++ b/addons/html_editor/static/tests/selection.test.js
@@ -175,14 +175,18 @@ test("restore a selection when you are not in the editable shouldn't move the fo
         static name = "test";
         static dependencies = ["overlay"];
         resources = {
+            user_commands: [
+                {
+                    id: "testShowOverlay",
+                    label: "Test",
+                    description: "Test",
+                    run: this.showOverlay.bind(this),
+                },
+            ],
             powerboxItems: [
                 {
                     category: "widget",
-                    name: "Test",
-                    description: "Test",
-                    action: () => {
-                        this.showOverlay();
-                    },
+                    commandId: "testShowOverlay",
                 },
             ],
         };

--- a/addons/html_editor/static/tests/table/children.test.js
+++ b/addons/html_editor/static/tests/table/children.test.js
@@ -9,14 +9,14 @@ import { getContent } from "../_helpers/selection";
 function addRow(position) {
     return (editor) => {
         const selection = editor.shared.getEditableSelection();
-        editor.dispatch("ADD_ROW", { position, reference: findInSelection(selection, "tr") });
+        editor.shared.addRow(position, findInSelection(selection, "tr"));
     };
 }
 
 function addColumn(position) {
     return (editor) => {
         const selection = editor.shared.getEditableSelection();
-        editor.dispatch("ADD_COLUMN", { position, reference: findInSelection(selection, "td") });
+        editor.shared.addColumn(position, findInSelection(selection, "td"));
     };
 }
 
@@ -26,7 +26,7 @@ function removeRow(row) {
             const selection = editor.shared.getEditableSelection();
             row = findInSelection(selection, "tr");
         }
-        editor.dispatch("REMOVE_ROW", { row });
+        editor.shared.removeRow(row);
     };
 }
 
@@ -36,7 +36,7 @@ function removeColumn(cell) {
             const selection = editor.shared.getEditableSelection();
             cell = findInSelection(selection, "td");
         }
-        editor.dispatch("REMOVE_COLUMN", { cell });
+        editor.shared.removeColumn(cell);
     };
 }
 

--- a/addons/html_editor/static/tests/table/misc.test.js
+++ b/addons/html_editor/static/tests/table/misc.test.js
@@ -5,7 +5,7 @@ import { animationFrame, tick } from "@odoo/hoot-mock";
 import { setSelection } from "../_helpers/selection";
 
 function insertTable(editor, cols, rows) {
-    editor.dispatch("INSERT_TABLE", { cols, rows });
+    editor.shared.execCommand("insertTable", { cols, rows });
 }
 
 test("can insert a table", async () => {

--- a/addons/html_editor/static/tests/tags.test.js
+++ b/addons/html_editor/static/tests/tags.test.js
@@ -6,7 +6,7 @@ import { insertText, tripleClick, undo } from "./_helpers/user_actions";
 import { animationFrame, tick } from "@odoo/hoot-mock";
 
 function setTag(tagName) {
-    return (editor) => editor.dispatch("SET_TAG", { tagName });
+    return (editor) => editor.shared.execCommand("setTag", { tagName });
 }
 
 describe("to paragraph", () => {

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -368,9 +368,9 @@ test("toolbar correctly show namespace button group and stop showing when namesp
                 {
                     id: "test_btn",
                     category: "test_group",
-                    title: "Test Button",
+                    label: "Test Button",
                     icon: "fa-square",
-                    action: () => null,
+                    run: () => null,
                 },
             ],
         };
@@ -394,15 +394,15 @@ test("toolbar correctly process inheritance buttons chain", async () => {
                 {
                     id: "test_btn",
                     category: "test_group",
-                    title: "Test Button",
+                    label: "Test Button",
                     icon: "fa-square",
-                    action: () => null,
+                    run: () => null,
                 },
                 {
                     id: "test_btn2",
                     category: "test_group",
                     inherit: "test_btn",
-                    title: "Test Button 2",
+                    label: "Test Button 2",
                 },
             ],
         };
@@ -430,10 +430,8 @@ test("toolbar does not evaluate isFormatApplied when namespace does not match", 
                 {
                     id: "test_btn",
                     category: "test_group",
-                    action(dispatch) {
-                        dispatch("test_cmd");
-                    },
-                    title: "Test Button",
+                    commandId: "test_cmd",
+                    label: "Test Button",
                     icon: "fa-square",
                     isFormatApplied: () => expect.step("image format evaluated"),
                 },
@@ -467,10 +465,8 @@ test("plugins can create buttons with text in toolbar", async () => {
                 {
                     id: "test_btn",
                     category: "test_group",
-                    action(dispatch) {
-                        dispatch("test_cmd");
-                    },
-                    title: "Test Button",
+                    commandId: "test_cmd",
+                    label: "Test Button",
                     text: "Text button",
                 },
             ],
@@ -525,24 +521,30 @@ test("toolbar buttons should have title attribute", async () => {
     }
 });
 
-test("toolbar buttons should have title attribute with translated text", async () => {
+test("toolbar buttons should have label attribute with translated text", async () => {
     // Retrieve toolbar buttons descriptions in English
-    const { editor } = await setupEditor("");
-    // item.title could be a LazyTranslatedString so we ensure it is a string with toString()
-    const titles = editor.resources.toolbarItems.map((item) => item.title.toString());
+    const { editor, plugins } = await setupEditor("");
+    // item.label could be a LazyTranslatedString so we ensure it is a string with toString()
+    const labels = plugins
+        .get("toolbar")
+        .getButtons()
+        .map((item) => item.label.toString());
     editor.destroy();
 
     // Patch translations to return "Translated" for these terms
-    patchTranslations(Object.fromEntries(titles.map((title) => [title, "Translated"])));
+    patchTranslations(Object.fromEntries(labels.map((label) => [label, "Translated"])));
 
     // Instantiate a new editor.
-    const { editor: postPatchEditor } = await setupEditor("<p>[abc]</p>");
+    const { plugins: postPatchPlugins } = await setupEditor("<p>[abc]</p>");
 
     // Check that every registered button has the result of the call to _t
-    postPatchEditor.resources.toolbarItems.forEach((item) => {
-        // item.title could be a LazyTranslatedString so we ensure it is a string with toString()
-        expect(item.title.toString()).toBe("Translated");
-    });
+    postPatchPlugins
+        .get("toolbar")
+        .getButtons()
+        .forEach((item) => {
+            // item.label could be a LazyTranslatedString so we ensure it is a string with toString()
+            expect(item.label.toString()).toBe("Translated");
+        });
 
     await waitFor(".o-we-toolbar");
 

--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/mention_plugin.js
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/mention_plugin.js
@@ -35,7 +35,7 @@ export class MentionPlugin extends Plugin {
         mentionBlock.appendChild(nameNode);
         this.historySavePointRestore();
         this.shared.domInsert(mentionBlock);
-        this.dispatch("ADD_STEP");
+        this.shared.addStep();
     }
 
     onBeforeInput(ev) {

--- a/addons/web_editor/static/src/js/backend/html_field.js
+++ b/addons/web_editor/static/src/js/backend/html_field.js
@@ -185,16 +185,13 @@ export class HtmlField extends Component {
         let dynamicPlaceholderOptions = {};
         if (this.props.dynamicPlaceholder) {
             dynamicPlaceholderOptions = {
-                // Add the powerbox option to open the Dynamic Placeholder
-                // generator.
-                powerboxItems: [
+                user_commands: [
                     {
-                        category: _t('Marketing Tools'),
-                        name: _t('Dynamic Placeholder'),
-                        priority: 10,
-                        description: _t('Insert a field'),
-                        fontawesome: 'fa-magic',
-                        callback: () => {
+                        id: "insertDynamicPlaceholder",
+                        label: _t("Dynamic Placeholder"),
+                        description: _t("Insert a field"),
+                        icon: "fa-magic",
+                        run: () => {
                             this.wysiwygRangePosition = getRangePosition(document.createElement('x'), this.wysiwyg.options.document || document);
                             this.dynamicPlaceholder.updateModel(this.props.dynamicPlaceholderModelReferenceField);
                             // The method openDynamicPlaceholder need to be triggered
@@ -208,7 +205,15 @@ export class HtmlField extends Component {
                                     }
                                 );
                             });
-                        },
+                        }
+                    },
+                ],
+                // Add the powerbox option to open the Dynamic Placeholder
+                // generator.
+                powerboxItems: [
+                    {
+                        category: _t('Marketing Tools'),
+                        commandId: "insertDynamicPlaceholder",
                     }
                 ],
                 powerboxFilters: [this._filterPowerBoxCommands.bind(this)],


### PR DESCRIPTION
# Use delegate

There is a common pattern in the editor plugins where we allow
other plugins to take over the handling of a command. In order to
make it explicit in the code, this commit introduces a new utility
function called delegate that will be used to call the handlers.


# Use trigger

In the editor, the pattern to dispatch events from one plugin to other
plugins is to use the resource mechanism that aggregates callbacks to
a specific resource. In order to make it clear when reading code that
we want to dispatch an event, this commit introduces the util function
trigger that communicates the intent to the reader.

# Remove dispatch

Reasons:

1) It is a redundant mechanism, we can achieve the same result though the use
of shared and resources.
2) Using the shared or the resources is more explicit. If we need to call a
command from a specific plugin, we should depend on the plugin and use the
shared. If we need multiple plugins to react to an "event", we should use the
resources.
3) We should distinguish between a "user command" and a "system command" or
"system event".
- A "user command" is anything that a user could configure as a shortcut,
toolbar item, powerbox item, or power button.
- A "system command" is a shared method.
- A "system event" is a resource.
4) When debugging, it was harder to "step into" a dispatched command as we would
step into the `handleCommand` of every plugins.

For `toolbarItems` and `powerboxItems` now inherit the properties of a user command
through the `commandId` property (if specified).

The power buttons now use the definition of the user commands instead of the
powerbox items.

The `toolbarItem` `Component` does not includes dispatch in the props by default
anymore, we need to specify the callbacks in the props of the `toolbarItem`
explicitly.
