### PR TITLE
[FIX] account: Ensure partner has country in fiscal position test

### DIFF
--- a/addons/account/tests/test_fiscal_position.py
+++ b/addons/account/tests/test_fiscal_position.py
@@ -335,6 +335,7 @@ class TestFiscalPosition(common.TransactionCase):
         fiscal_positions = self.fp.create([{
             'name': f'fiscal_position_{sequence}',
             'auto_apply': True,
+            'country_id': self.jc.country_id.id,
             'sequence': sequence
         } for sequence in range(1, 3)])
-        self.assertEqual(self.fp._get_fiscal_position(self.env.company.partner_id), fiscal_positions[0])
+        self.assertEqual(self.fp._get_fiscal_position(self.jc), fiscal_positions[0])


### PR DESCRIPTION
The test_get_first_fiscal_position() was failing on the runbot since its addition. The failure occurred because the company's partner in the environment either had no country set or a different country from the two fiscal positions defined in the test. This led to incorrect or missing fiscal positions being selected in _get_fiscal_position().

The issue arose because other test classes modified the company’s country. To resolve this, the test partner is now explicitly assigned a country, and the fiscal positions are defined with the same country to maintain consistent priority levels compared to existing fiscal positions. This ensures the test remains isolated from external factors, verifying that when two fiscal positions have identical attributes except for sequence, the one with the lowest sequence is prioritized.

Runbot issue: 98910


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
