### PR TITLE
[FIX] website_sale: ensure delivery method is set during checkout

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1797,6 +1797,9 @@ class WebsiteSale(payment_portal.PaymentPortal):
         if redirection := self._check_cart_and_addresses(order_sudo):
             return redirection
 
+        if redirection := self._check_shipping_method(order_sudo):
+            return redirection
+
         render_values = self._get_shop_payment_values(order_sudo, **post)
         render_values['only_services'] = order_sudo and order_sudo.only_services
 
@@ -1979,6 +1982,10 @@ class WebsiteSale(payment_portal.PaymentPortal):
             partner_sudo.country_id
         )
         return all(partner_sudo.read(mandatory_billing_fields)[0].values())
+
+    def _check_shipping_method(self, order_sudo):
+        if not order_sudo._is_delivery_ready():
+            return request.redirect('/shop/checkout')
 
     def _get_mandatory_billing_address_fields(self, country_sudo):
         """ Return the set of mandatory billing field names.

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -707,3 +707,6 @@ class SaleOrder(models.Model):
 
         if not self.only_services and not self.carrier_id:
             raise ValidationError(_("No shipping method is selected."))
+
+    def _is_delivery_ready(self):
+        return not self._has_deliverable_products() or self.carrier_id


### PR DESCRIPTION
In Mexican (or Colombian) e-commerce websites, a customer may face an issue where they are unable to confirm an order because no delivery method is selected.

### Steps to reproduce

- Install `l10n_mx_edi_website_sale`
- Ensure the website is configured with a Mexican company
- Enable 'Automatic Invoice' in website settings
- As a public user, proceed through checkout and try to confirm the order

The issue occurs if the user is prompted to fill in delivery information and hasn't previously provided an address. This can be consistently reproduced using a new incognito session.

Upon attempting to confirm the order, the following error is shown: "No shipping method is selected."

### Cause

The delivery information form (`/shop/address/submit`) normally redirects to `/shop/checkout`, where the user selects a delivery method. However, the `_get_extra_billing_info_route` hook can alter the redirect, bypassing the checkout step and causing the delivery method to remain unset.

opw-4205135
opw-4222398