### PR TITLE
[IMP] project_purchase: ensure to open PO form view instead of POL form view

### DIFF
--- a/addons/project_purchase/models/project_project.py
+++ b/addons/project_purchase/models/project_project.py
@@ -77,9 +77,9 @@ class ProjectProject(models.Model):
     def action_profitability_items(self, section_name, domain=None, res_id=False):
         if section_name == 'purchase_order':
             action = {
-                'name': self.env._('Purchase Order Items'),
+                'name': self.env._('Purchase Orders'),
                 'type': 'ir.actions.act_window',
-                'res_model': 'purchase.order.line',
+                'res_model': 'purchase.order',
                 'views': [[False, 'list'], [False, 'form']],
                 'domain': domain,
                 'context': {
@@ -169,9 +169,10 @@ class ProjectProject(models.Model):
                 section_id = 'purchase_order'
                 purchase_order_costs = {'id': section_id, 'sequence': self._get_profitability_sequence_per_invoice_type()[section_id], 'billed': amount_invoiced, 'to_bill': amount_to_invoice}
                 if with_action:
-                    args = [section_id, [('id', 'in', invoice_lines.purchase_line_id.ids)]]
-                    if len(invoice_lines.purchase_line_id) == 1:
-                        args.append(invoice_lines.purchase_line_id.id)
+                    purchase_order = invoice_lines.purchase_line_id.order_id
+                    args = [section_id, [('id', 'in', purchase_order.ids)]]
+                    if len(purchase_order) == 1:
+                        args.append(purchase_order.id)
                     action = {'name': 'action_profitability_items', 'type': 'object', 'args': json.dumps(args)}
                     purchase_order_costs['action'] = action
                 costs['data'].append(purchase_order_costs)

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -255,7 +255,6 @@
                                     <field name="name" widget="section_and_note_text" optional="show"/>
                                     <field name="date_planned" optional="hide" required="not display_type and not is_downpayment" force_save="1" readonly="is_downpayment"/>
                                     <field name="analytic_distribution" widget="analytic_distribution"
-                                           optional="hide"
                                            groups="analytic.group_analytic_accounting"
                                            options="{'product_field': 'product_id', 'business_domain': 'purchase_order', 'amount_field': 'price_subtotal'}"/>
                                     <field name="product_qty" readonly="is_downpayment"/>


### PR DESCRIPTION
### Before this commit:
When there is only one Purchase Order record, the form view for the Purchase Order Line opens instead of the Purchase Order form view.
    
### After this Commit:
The form view of the Purchase Order opens when there’s only one record.

task-4242410






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
