### PR TITLE
[IMP] mail: can manually unpin a sub-thread

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -384,6 +384,45 @@ msgstr ""
 
 #. module: mail
 #. odoo-javascript
+#: code:addons/mail/static/src/js/tours/discuss_channel_tour.js:0
+msgid ""
+"<p><b>Chat with coworkers</b> in real-time using direct "
+"messages.</p><p><i>You might need to invite users from the Settings app "
+"first.</i></p>"
+msgstr ""
+
+#. module: mail
+#. odoo-javascript
+#: code:addons/mail/static/src/js/tours/discuss_channel_tour.js:0
+msgid ""
+"<p><b>Write a message</b> to the members of the channel here.</p> <p>You can"
+" notify someone with <i>'@'</i> or link another channel with <i>'#'</i>. "
+"Start your message with <i>'/'</i> to get the list of possible commands.</p>"
+msgstr ""
+
+#. module: mail
+#. odoo-javascript
+#: code:addons/mail/static/src/js/tours/discuss_channel_tour.js:0
+msgid ""
+"<p>Channels make it easy to organize information across different topics and"
+" groups.</p> <p>Try to <b>create your first channel</b> (e.g. sales, "
+"marketing, product XYZ, after work party, etc).</p>"
+msgstr ""
+
+#. module: mail
+#. odoo-javascript
+#: code:addons/mail/static/src/js/tours/discuss_channel_tour.js:0
+msgid "<p>Create a channel here.</p>"
+msgstr ""
+
+#. module: mail
+#. odoo-javascript
+#: code:addons/mail/static/src/js/tours/discuss_channel_tour.js:0
+msgid "<p>Create a public or private channel.</p>"
+msgstr ""
+
+#. module: mail
+#. odoo-javascript
 #: code:addons/mail/static/src/core/common/composer.js:0
 msgid "<samp>%(send_keybind)s</samp><i> to send</i>"
 msgstr ""
@@ -435,6 +474,11 @@ msgid ""
 "                                The message will be posted as a message on the record,\n"
 "                                notifying all followers. It will appear in the messaging history.\n"
 "                            </span>"
+msgstr ""
+
+#. module: mail
+#: model_terms:web_tour.tour,rainbow_man_message:mail.discuss_channel_tour
+msgid "<span><b>Good job!</b> You went through all steps of this tour.</span>"
 msgstr ""
 
 #. module: mail
@@ -2003,6 +2047,12 @@ msgstr ""
 
 #. module: mail
 #. odoo-javascript
+#: code:addons/mail/static/src/js/tours/discuss_channel_tour.js:0
+msgid "Click on your message"
+msgstr ""
+
+#. module: mail
+#. odoo-javascript
 #: code:addons/mail/static/src/core/common/message_in_reply.xml:0
 msgid "Click to see the attachments"
 msgstr ""
@@ -3540,6 +3590,12 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/mail/static/src/core/common/message.js:0
 msgid "Expand"
+msgstr ""
+
+#. module: mail
+#. odoo-javascript
+#: code:addons/mail/static/src/js/tours/discuss_channel_tour.js:0
+msgid "Expand options"
 msgstr ""
 
 #. module: mail
@@ -5840,6 +5896,12 @@ msgid "Messages Search"
 msgstr ""
 
 #. module: mail
+#. odoo-javascript
+#: code:addons/mail/static/src/js/tours/discuss_channel_tour.js:0
+msgid "Messages can be <b>starred</b> to remind you to check back later."
+msgstr ""
+
+#. module: mail
 #: model:ir.model.constraint,message:mail.constraint_discuss_channel_from_message_id_unique
 msgid "Messages can only be linked to one sub-channel"
 msgstr ""
@@ -6591,6 +6653,14 @@ msgstr ""
 
 #. module: mail
 #. odoo-javascript
+#: code:addons/mail/static/src/js/tours/discuss_channel_tour.js:0
+msgid ""
+"Once a message has been starred, you can come back and review it at any time"
+" here."
+msgstr ""
+
+#. module: mail
+#. odoo-javascript
 #: code:addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.xml:0
 msgid "Ongoing call"
 msgstr ""
@@ -7158,6 +7228,12 @@ msgstr ""
 #. module: mail
 #: model:ir.model.fields.selection,name:mail.selection__mail_compose_message__composition_mode__comment
 msgid "Post on a document"
+msgstr ""
+
+#. module: mail
+#. odoo-javascript
+#: code:addons/mail/static/src/js/tours/discuss_channel_tour.js:0
+msgid "Post your message on the thread"
 msgstr ""
 
 #. module: mail
@@ -9701,6 +9777,12 @@ msgid "Unpin Message"
 msgstr ""
 
 #. module: mail
+#. odoo-javascript
+#: code:addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js:0
+msgid "Unpin Thread"
+msgstr ""
+
+#. module: mail
 #: model:ir.model.fields,field_description:mail.field_discuss_channel_member__unpin_dt
 msgid "Unpin date"
 msgstr ""
@@ -10471,7 +10553,13 @@ msgstr ""
 #. module: mail
 #. odoo-javascript
 #: code:addons/mail/static/src/discuss/core/common/discuss_core_common_service.js:0
-msgid "You unpinned your conversation with %s"
+msgid "You unpinned %(conversation_name)s"
+msgstr ""
+
+#. module: mail
+#. odoo-javascript
+#: code:addons/mail/static/src/discuss/core/common/discuss_core_common_service.js:0
+msgid "You unpinned your conversation with %(user_name)s"
 msgstr ""
 
 #. module: mail

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -161,7 +161,9 @@ export class Thread extends Record {
         compute() {
             return (
                 this.is_pinned ||
-                (["channel", "group"].includes(this.channel_type) && this.hasSelfAsMember)
+                (["channel", "group"].includes(this.channel_type) &&
+                    this.hasSelfAsMember &&
+                    !this.parent_channel_id)
             );
         },
         onUpdate() {

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -68,7 +68,13 @@ export class DiscussCoreCommon {
             if (thread) {
                 thread.is_pinned = false;
                 this.notificationService.add(
-                    _t("You unpinned your conversation with %s", thread.displayName),
+                    thread.parent_channel_id
+                        ? _t(`You unpinned %(conversation_name)s`, {
+                              conversation_name: thread.displayName,
+                          })
+                        : _t(`You unpinned your conversation with %(user_name)s`, {
+                              user_name: thread.displayName,
+                          }),
                     { type: "info" }
                 );
             }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
@@ -38,6 +38,25 @@ export class DiscussSidebarSubchannel extends Component {
         return this.props.thread;
     }
 
+    get commands() {
+        const commands = [];
+        if (this.thread.canUnpin) {
+            commands.push({
+                onSelect: () => this.thread.unpin(),
+                label: _t("Unpin Thread"),
+                icon: "oi oi-close",
+                sequence: 20,
+            });
+        }
+        return commands;
+    }
+
+    get sortedCommands() {
+        const commands = [...this.commands];
+        commands.sort((c1, c2) => c1.sequence - c2.sequence);
+        return commands;
+    }
+
     /** @param {MouseEvent} ev */
     openThread(ev, thread) {
         markEventHandled(ev, "sidebar.openThread");

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -144,6 +144,7 @@
                     'text-muted': !(thread.selfMember?.message_unread_counter > 0 and !thread.isMuted),
                 }"/>
                 <span class="flex-grow-1"/>
+                <t t-if="!store.discuss.isSidebarCompact" t-call="mail.DiscussSidebarChannel.commands"/>
                 <span t-if="thread.importantCounter > 0" t-attf-class="o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge fw-bold top-0 {{thread.isMuted ? 'o-muted' : ''}}" t-att-class="{ 'mx-1': !store.discuss.isSidebarCompact, 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact }" t-esc="thread.importantCounter"/>
             </button>
             <t t-if="thread.selfMember?.message_unread_counter > 0 and !thread.isMuted and thread.importantCounter === 0" t-call="mail.DiscussSidebar.unreadIndicator"/>

--- a/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
@@ -66,6 +66,12 @@ patch(Thread.prototype, {
         this.loadSubChannelsDone = false;
         this.lastSubChannelLoaded = null;
     },
+    get canLeave() {
+        return !this.parent_channel_id && super.canLeave;
+    },
+    get canUnpin() {
+        return (this.parent_channel_id && this.importantCounter === 0) || super.canUnpin;
+    },
     get allowCalls() {
         return super.allowCalls && !this.parent_channel_id;
     },

--- a/addons/mail/static/tests/discuss/core/public_web/sub_channels.test.js
+++ b/addons/mail/static/tests/discuss/core/public_web/sub_channels.test.js
@@ -41,6 +41,22 @@ test("navigate to sub channel", async () => {
     await contains(".o-mail-Discuss-threadName", { value: "New Thread" });
 });
 
+test("can manually unpin a sub-thread", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    await start();
+    await openDiscuss(channelId);
+    // Open thread so this is pinned
+    await contains(".o-mail-Discuss-threadName", { value: "General" });
+    await click("button[title='Threads']");
+    await click("button[aria-label='Create Thread']");
+    await contains(".o-mail-Discuss-threadName", { value: "New Thread" });
+    await click("button[title='Unpin Thread']", {
+        parent: [".o-mail-DiscussSidebar-item", { text: "New Thread" }],
+    });
+    await contains(".o-mail-DiscussSidebar-item", { text: "New Thread", count: 0 });
+});
+
 test("open sub channel menu from notification", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });


### PR DESCRIPTION
Sub-thread is pinned by default and user couldn't unpin it. This commit lets user unpin the sub-thread manually.

Backport of https://github.com/odoo/odoo/pull/183758