### PR TITLE
[REF] point_of_sale: update links when setting object value

### DIFF
--- a/addons/l10n_ar_pos/static/src/overrides/components/product_screen/product_screen.js
+++ b/addons/l10n_ar_pos/static/src/overrides/components/product_screen/product_screen.js
@@ -8,9 +8,7 @@ patch(ProductScreen.prototype, {
 
         onMounted(() => {
             if (this.pos.isArgentineanCompany() && !this.pos.get_order().partner_id) {
-                this.pos.get_order().update({
-                    partner_id: this.pos.session._consumidor_final_anonimo_id,
-                });
+                this.pos.get_order().partner_id = this.pos.session._consumidor_final_anonimo_id;
             }
         });
     },

--- a/addons/l10n_ar_pos/static/src/overrides/models/pos_order.js
+++ b/addons/l10n_ar_pos/static/src/overrides/models/pos_order.js
@@ -6,7 +6,7 @@ patch(PosOrder.prototype, {
         super.setup(...arguments);
         if (this.isArgentineanCompany()) {
             if (!this.partner_id) {
-                this.update({ partner_id: this.session._consumidor_final_anonimo_id });
+                this.partner_id = this.session._consumidor_final_anonimo_id;
             }
         }
     },

--- a/addons/l10n_pe_pos/static/src/overrides/models/pos_store.js
+++ b/addons/l10n_pe_pos/static/src/overrides/models/pos_store.js
@@ -18,7 +18,7 @@ patch(PosStore.prototype, {
         const order = super.createNewOrder(...arguments);
 
         if (this.isPeruvianCompany() && !order.partner_id) {
-            order.update({ partner_id: this.session._consumidor_final_anonimo_id });
+            order.partner_id = this.session._consumidor_final_anonimo_id;
         }
 
         return order;

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -19,7 +19,7 @@ export class PosOrder extends Base {
         super.setup(vals);
 
         if (!this.session_id && typeof this.id === "string") {
-            this.update({ session_id: this.session });
+            this.session_id = this.session;
         }
 
         // Data present in python model
@@ -355,11 +355,7 @@ export class PosOrder extends Base {
     }
 
     set_pricelist(pricelist) {
-        if (pricelist) {
-            this.update({ pricelist_id: pricelist });
-        } else {
-            this.update({ pricelist_id: false });
-        }
+        this.pricelist_id = pricelist ? pricelist : false;
 
         const lines_to_recompute = this.lines.filter(
             (line) =>
@@ -901,7 +897,7 @@ export class PosOrder extends Base {
     // the partner related to the current order.
     set_partner(partner) {
         this.assert_editable();
-        this.update({ partner_id: partner });
+        this.partner_id = partner;
         this.updatePricelistAndFiscalPosition(partner);
     }
 
@@ -976,7 +972,7 @@ export class PosOrder extends Base {
         }
 
         this.set_pricelist(newPartnerPricelist);
-        this.update({ fiscal_position_id: newPartnerFiscalPosition });
+        this.fiscal_position_id = newPartnerFiscalPosition;
     }
 
     /* ---- Ship later --- */

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -62,15 +62,13 @@ export class ControlButtons extends Component {
         }
 
         if (selectedFiscalPosition === "none") {
-            this.currentOrder.update({
-                fiscal_position_id: false,
-            });
+            this.currentOrder.fiscal_position_id = false;
             return;
         }
 
-        this.currentOrder.update({
-            fiscal_position_id: selectedFiscalPosition ? selectedFiscalPosition.id : false,
-        });
+        this.currentOrder.fiscal_position_id = selectedFiscalPosition
+            ? selectedFiscalPosition
+            : false;
     }
     async clickPricelist() {
         // Create the list to be passed to the SelectionPopup.

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -252,9 +252,7 @@ export class TicketScreen extends Component {
             const children = refundComboParent.refunded_orderline_id.combo_line_ids
                 .map((l) => l.refund_orderline_ids)
                 .flat();
-            refundComboParent.update({
-                combo_line_ids: [["link", ...children]],
-            });
+            refundComboParent.combo_line_ids = [["link", ...children]];
         }
 
         //Add a check too see if the fiscal position exist in the pos
@@ -269,7 +267,7 @@ export class TicketScreen extends Component {
         }
 
         if (order.fiscal_position_id) {
-            destinationOrder.update({ fiscal_position_id: order.fiscal_position_id });
+            destinationOrder.fiscal_position_id = order.fiscal_position_id;
         }
         // Set the partner to the destinationOrder.
         this.setPartnerToRefundOrder(partner, destinationOrder);

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1181,10 +1181,8 @@ export class PosStore extends Reactive {
     async loadServerOrders(domain) {
         const orders = await this.data.searchRead("pos.order", domain);
         for (const order of orders) {
-            order.update({
-                config_id: this.config,
-                session_id: this.session,
-            });
+            order.config_id = this.config;
+            order.session_id = this.session;
         }
         return orders;
     }

--- a/addons/pos_hr/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_hr/static/src/overrides/components/payment_screen/payment_screen.js
@@ -4,7 +4,7 @@ import { patch } from "@web/core/utils/patch";
 patch(PaymentScreen.prototype, {
     async validateOrder(isForceValidate) {
         if (this.pos.config.module_pos_hr && this.pos.get_cashier() === null) {
-            this.currentOrder.update({ employee_id: this.pos.get_cashier() });
+            this.currentOrder.employee_id = this.pos.get_cashier();
         }
 
         await super.validateOrder(...arguments);

--- a/addons/pos_hr/static/src/overrides/models/pos_store.js
+++ b/addons/pos_hr/static/src/overrides/models/pos_store.js
@@ -53,7 +53,7 @@ patch(PosStore.prototype, {
         const order = super.createNewOrder(...arguments);
 
         if (this.config.module_pos_hr) {
-            order.update({ employee_id: this.get_cashier() });
+            order.employee_id = this.get_cashier();
         }
 
         return order;
@@ -73,7 +73,7 @@ patch(PosStore.prototype, {
             if (o && !o.get_orderlines().length) {
                 // Order without lines can be considered to be un-owned by any employee.
                 // We set the cashier on that order to the currently set employee.
-                o.update({ employee_id: employee });
+                o.employee_id = employee;
             }
             if (!this.cashierHasPriceControlRights() && this.numpadMode === "price") {
                 this.numpadMode = "quantity";
@@ -88,7 +88,7 @@ patch(PosStore.prototype, {
 
             if (cashier && cashier.model.modelName === "hr.employee") {
                 const order = this.get_order();
-                order.update({ employee_id: this.get_cashier() });
+                order.employee_id = this.get_cashier();
             }
         }
 

--- a/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
@@ -145,7 +145,7 @@ patch(PaymentScreen.prototype, {
                         if (!coupon) {
                             await this.pos.data.read("loyalty.card", [couponUpdate.id]);
                         } else {
-                            coupon.update({ points: couponUpdate.points });
+                            coupon.points = couponUpdate.points;
                         }
                     } else {
                         // create a new coupon and delete the old one
@@ -162,7 +162,7 @@ patch(PaymentScreen.prototype, {
                         // Before deleting the old coupon, update the order lines that use it.
                         for (const line of order.lines) {
                             if (line.coupon_id?.id == couponUpdate.old_id) {
-                                line.update({ coupon_id: coupon });
+                                line.coupon_id = coupon;
                             }
                         }
 

--- a/addons/pos_loyalty/static/src/overrides/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_order.js
@@ -233,7 +233,7 @@ patch(PosOrder.prototype, {
         for (const rewardLine of this.lines.filter((line) => line.is_reward_line)) {
             rewardLine.delete();
         }
-        this.update({ _code_activated_coupon_ids: [["clear"]] });
+        this._code_activated_coupon_ids = [["clear"]];
     },
     /**
      * Refreshes the currently applied rewards, if they are not applicable anymore they are removed.

--- a/addons/pos_loyalty/static/src/overrides/models/pos_order_line.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_order_line.js
@@ -51,13 +51,13 @@ patch(PosOrderline.prototype, {
     },
     setOptions(options) {
         if (options.eWalletGiftCardProgram) {
-            this.update({ _e_wallet_program_id: options.eWalletGiftCardProgram });
+            this._e_wallet_program_id = options.eWalletGiftCardProgram;
         }
         if (options.giftBarcode) {
-            this.update({ _gift_barcode: options.giftBarcode });
+            this._gift_barcode = options.giftBarcode;
         }
         if (options.giftCardId) {
-            this.update({ _gift_card_id: this.models["loyalty.card"].get(options.giftCardId) });
+            this._gift_card_id = options.giftCardId;
         }
         return super.setOptions(...arguments);
     },

--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -237,7 +237,7 @@ patch(PosStore.prototype, {
                 return true;
             })
         );
-        order.update({ _code_activated_coupon_ids: [["unlink", ...toUnlink]] });
+        order._code_activated_coupon_ids = [["unlink", ...toUnlink]];
     },
     async activateCode(code) {
         const order = this.get_order();
@@ -307,7 +307,7 @@ patch(PosStore.prototype, {
                     // TODO JCB: make the expiration_date work.
                     // expiration_date: payload.expiration_date,
                 });
-                order.update({ _code_activated_coupon_ids: [["link", coupon]] });
+                order._code_activated_coupon_ids = [["link", coupon]];
                 await this.orderUpdateLoyaltyPrograms();
                 claimableRewards = order.getClaimableRewards(coupon.id);
             } else {
@@ -600,11 +600,9 @@ patch(PosStore.prototype, {
         const domain = new Domain(reward_product_domain);
 
         try {
-            reward.update({
-                all_discount_product_ids: [
-                    ["link", ...products.filter((p) => domain.contains(p.serialize()))],
-                ],
-            });
+            reward.all_discount_product_ids = [
+                ["link", ...products.filter((p) => domain.contains(p.serialize()))],
+            ];
         } catch (error) {
             if (!(error instanceof InvalidDomainError || error instanceof TypeError)) {
                 throw error;
@@ -720,20 +718,16 @@ patch(PosStore.prototype, {
         for (const order of orders) {
             for (const line of order.lines) {
                 if (line.uuid in this.couponByLineUuidCache) {
-                    line.update({
-                        coupon_id: this.models["loyalty.card"].get(
-                            this.couponByLineUuidCache[line.uuid]
-                        ),
-                    });
+                    line.coupon_id = this.models["loyalty.card"].get(
+                        this.couponByLineUuidCache[line.uuid]
+                    );
                 }
             }
             for (const line of order.lines) {
                 if (line.uuid in this.rewardProductByLineUuidCache) {
-                    line.update({
-                        _reward_product_id: this.models["product.product"].get(
-                            this.rewardProductByLineUuidCache[line.uuid]
-                        ),
-                    });
+                    line._reward_product_id = this.models["product.product"].get(
+                        this.rewardProductByLineUuidCache[line.uuid]
+                    );
                 }
             }
         }

--- a/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.js
+++ b/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.js
@@ -72,7 +72,7 @@ patch(ControlButtons.prototype, {
         const takeawayFp = this.pos.config.takeaway_fp_id;
 
         this.currentOrder.takeaway = isTakeAway;
-        this.currentOrder.update({ fiscal_position_id: isTakeAway ? takeawayFp : defaultFp });
+        this.currentOrder.fiscal_position_id = isTakeAway ? takeawayFp : defaultFp;
     },
     editFloatingOrderName(order) {
         this.dialog.add(TextInputPopup, {

--- a/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
+++ b/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
@@ -111,7 +111,7 @@ export class SplitBillScreen extends Component {
                 if (line.get_quantity() === this.qtyTracker[line.uuid]) {
                     lineToDel.push(line);
                 } else {
-                    line.update({ qty: line.get_quantity() - this.qtyTracker[line.uuid] });
+                    line.qty = line.get_quantity() - this.qtyTracker[line.uuid];
                 }
             }
         }

--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -88,7 +88,7 @@ patch(PosStore.prototype, {
         const order = super.createNewOrder(...arguments);
 
         if (this.config.module_pos_restaurant && this.selectedTable && !order.table_id) {
-            order.update({ table_id: this.selectedTable });
+            order.table_id = this.selectedTable;
         }
 
         return order;
@@ -256,7 +256,7 @@ patch(PosStore.prototype, {
 
                 if (potentialsOrders.length) {
                     currentOrder = potentialsOrders[0];
-                    currentOrder.update({ table_id: table });
+                    currentOrder.table_id = table;
                     this.selectedOrderUuid = currentOrder.uuid;
                 } else {
                     await this.add_new_order();
@@ -335,7 +335,7 @@ patch(PosStore.prototype, {
             return;
         }
         if (!this.tableHasOrders(destinationTable)) {
-            order.update({ table_id: destinationTable });
+            order.table_id = destinationTable;
             this.set_order(order);
             this.addPendingOrder([order.id]);
         } else {
@@ -352,7 +352,7 @@ patch(PosStore.prototype, {
                 }
             }
             linesToUpdate.forEach((orderline) => {
-                orderline.update({ order_id: destinationOrder.id });
+                orderline.order_id = destinationOrder;
             });
             this.set_order(destinationOrder);
             if (destinationOrder?.id) {

--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -55,9 +55,7 @@ patch(PosStore.prototype, {
                 (position) => position.id === sale_order.fiscal_position_id
             );
         if (orderFiscalPos) {
-            this.get_order().update({
-                fiscal_position_id: orderFiscalPos,
-            });
+            this.get_order().fiscal_position_id = orderFiscalPos;
         }
         if (sale_order.partner_id) {
             this.get_order().set_partner(sale_order.partner_id);

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
@@ -62,9 +62,7 @@ export class CartPage extends Component {
             this.state.selectTable = true;
             return;
         } else {
-            this.selfOrder.currentOrder.update({
-                table_id: this.selfOrder.currentTable,
-            });
+            this.selfOrder.currentOrder.table_id = this.selfOrder.currentTable;
         }
 
         this.selfOrder.rpcLoading = true;
@@ -74,9 +72,7 @@ export class CartPage extends Component {
 
     selectTable(table) {
         if (table) {
-            this.selfOrder.currentOrder.update({
-                table_id: table,
-            });
+            this.selfOrder.currentOrder.table_id = table;
             this.selfOrder.currentTable = table;
             this.router.addTableIdentifier(table);
             this.pay();

--- a/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.js
+++ b/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.js
@@ -20,9 +20,7 @@ export class EatingLocationPage extends Component {
         this.selfOrder.orderTakeAwayState[this.selfOrder.currentOrder.uuid] = true;
 
         if (loc === "out") {
-            this.selfOrder.currentOrder.update({
-                fiscal_position_id: this.selfOrder.config.takeaway_fp_id,
-            });
+            this.selfOrder.currentOrder.fiscal_position_id = this.selfOrder.config.takeaway_fp_id;
         }
         this.router.navigate("product_list");
     }


### PR DESCRIPTION
In this commit, we are now instantiating a record as a Proxy that traps the setter. When setting a value for a certain key on a record, we call the `update` internally to ensure that related records are linked. This means that developers are no longer required to use `record.update` to apply changes on a record, they can just set the value as if the record is a normal object.

Enterprise: https://github.com/odoo/enterprise/pull/72198
