### PR TITLE
[FIX] website: restore "Layout" and "Content Width" options in carousels

### DIFF
--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -242,6 +242,18 @@ export class WebsiteSnippetsMenu extends weSnippetEditor.SnippetsMenu {
         const toFind = $html.find("we-fontfamilypicker[data-variable]").toArray();
         const fontVariables = toFind.map((el) => el.dataset.variable);
         FontFamilyPickerUserValueWidget.prototype.fontVariables = fontVariables;
+
+        // TODO remove in master: adds back the "Layout" and "Content Width"
+        // options on some carousels.
+        const layoutOptionEl = html.querySelector('[data-js="layout_column"][data-selector="section"]');
+        const containerWidthOptionEl = html.querySelector('[data-js="ContainerWidth"][data-selector="section"]');
+        if (layoutOptionEl) {
+            layoutOptionEl.dataset.selector += ", section.s_carousel_wrapper .carousel-item";
+        }
+        if (containerWidthOptionEl) {
+            containerWidthOptionEl.dataset.selector += ", .s_carousel .carousel-item";
+        }
+
         return super._computeSnippetTemplates(html);
     }
     /**

--- a/addons/website/static/src/snippets/s_carousel/001.scss
+++ b/addons/website/static/src/snippets/s_carousel/001.scss
@@ -1,5 +1,13 @@
 .s_carousel_wrapper[data-vcss='001'] {
     .s_carousel {
         @extend %s_carousel_variants;
+
+        &.s_carousel_arrows_hidden .carousel-item {
+            @include media-breakpoint-up(md) {
+                // Removing the padding so the container can be full when the
+                // arrows are hidden.
+                padding: 0;
+            }
+        }
     }
 }


### PR DESCRIPTION
In commit [1], the carousels have been redesigned. However, with it, the "Layout" and the "Content Width" options have been removed from some of them. They can therefore not be toggled to grid mode anymore and their container width cannot be changed, which could have been useful now that the arrows can be hidden.

This commit restores these options for the `s_carousel` snippet. Note that the `s_carousel_intro` one redefined these options, which is why it has them. The other ones (i.e. `s_image_gallery`, `s_quotes_carousel` and `s_quotes_carousel_minimal`) do not need them.

[1]: https://github.com/odoo/odoo/commit/3deb8050831c69ca1e32039622b322ffa38cc497#diff-934f432382bbc5c89d776f677d71ef50392d8652b2e9fa7bba3ff39475b842ae

task-4263725