### PR TITLE
[FIX] auth_totp_portal: allow revoking single devices

### DIFF
--- a/addons/auth_totp_portal/static/src/js/totp_frontend.js
+++ b/addons/auth_totp_portal/static/src/js/totp_frontend.js
@@ -228,6 +228,12 @@ publicWidget.registry.RevokeTrustedDeviceButton = publicWidget.Widget.extend({
         click: '_onClick'
     },
 
+    init() {
+        this._super(...arguments);
+        this.orm = this.bindService("orm");
+        this.dialog = this.bindService("dialog");
+    },
+
     async _onClick(e){
         e.preventDefault();
         await handleCheckIdentity(


### PR DESCRIPTION
Before this commit you could revoke all devices but attempting to revoke a single one will have resulted in an error that this.orm was undefined.