### PR TITLE
[FIX] web_editor: display columns correctly in pdf

### DIFF
--- a/addons/web/static/src/webclient/actions/reports/report.scss
+++ b/addons/web/static/src/webclient/actions/reports/report.scss
@@ -211,31 +211,6 @@ blockquote {
     -webkit-box-flex: 1 !important;
 }
 
-// Report footer need to support bootstrap columns (2, 3 and 4 columns)
-// Even if the width is smaller than the media querry limit from bootstrap.
-// This need come from the footer being editable via the Odoo editor.
-
-.footer {
-    .row {
-        -webkit-box-flex: 1 !important;
-    }
-    .col-lg-3 {
-        flex: 0 0 auto;
-        -webkit-box-flex: 1 !important;
-        width: 25%;
-    }
-    .col-lg-4 {
-        flex: 0 0 auto;
-        -webkit-box-flex: 1 !important;
-        width: 33.33333333%;
-    }
-    .col-lg-6 {
-        flex: 0 0 auto;
-        -webkit-box-flex: 1 !important;
-        width: 50%;
-    }
-}
-
 // Boostrap 5 introduces variable paddings for container which wkhtmltopdf doesn't seem to process, so we restore Boostrap 4's paddings for PDFs
 .container {
     padding-right: $container-padding-x;

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/base_style.scss
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/base_style.scss
@@ -8,7 +8,7 @@ li.oe-nested {
         padding: 0.5rem;
     }
 }
-$sizes: 'xs', 'sm', 'md', 'lg', 'xl', 'xxl';
+$sizes: '', 'xs-', 'sm-', 'md-', 'lg-', 'xl-', 'xxl-';
 .o_text_columns {
     max-width: 100% !important;
     padding: 0 !important;
@@ -32,10 +32,10 @@ $--enable-no-overflow-of-text-columns: true !default;
         margin: 0 !important;
         @each $size in $sizes {
             @for $i from 1 through 12 {
-                & > .col-#{$size}-#{$i}:first-of-type {
+                & > .col-#{$size}#{$i}:first-of-type {
                     padding-left: 0;
                 }
-                & > .col-#{$size}-#{$i}:last-of-type {
+                & > .col-#{$size}#{$i}:last-of-type {
                     padding-right: 0;
                 }
             }

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -983,7 +983,7 @@ export const editorCommands = {
             const columns = [];
             for (let i = 0; i < numberOfColumns; i++) {
                 const column = document.createElement('div');
-                column.classList.add(`col-lg-${columnSize}`);
+                column.classList.add(`col-${columnSize}`);
                 row.append(column);
                 columns.push(column);
             }
@@ -1016,7 +1016,7 @@ export const editorCommands = {
                 let lastColumn = columns[columns.length - 1];
                 for (let i = 0; i < diff; i++) {
                     const column = document.createElement('div');
-                    column.classList.add(`col-lg-${columnSize}`);
+                    column.classList.add(`col-${columnSize}`);
                     const p = document.createElement('p');
                     p.append(document.createElement('br'));
                     p.classList.add('oe-hint');
@@ -1030,7 +1030,7 @@ export const editorCommands = {
                 // Remove superfluous columns.
                 const restore = preserveCursor(editor.document);
                 for (const column of columns) {
-                    column.className = column.className.replace(REGEX_BOOTSTRAP_COLUMN, `col$1-${columnSize}`);
+                    column.className = column.className.replace(REGEX_BOOTSTRAP_COLUMN, `col-${columnSize}`);
                 }
                 const contents = [];
                 for (let i = diff; i < 0; i++) {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -4932,7 +4932,7 @@ X[]
 
     describe('columnize', () => {
         const columnsContainer = contents => `<div class="container o_text_columns"><div class="row">${contents}</div></div>`;
-        const column = (size, contents) => `<div class="col-lg-${size}">${contents}</div>`;
+        const column = (size, contents) => `<div class="col-${size}">${contents}</div>`;
         describe('2 columns', () => {
             it('should do nothing', async () => {
                 await testEditor(BasicEditor, {
@@ -5174,10 +5174,10 @@ X[]
                     stepFunction: editor => editor.execCommand('columnize', 2),
                     contentAfter: '<div class="container"><div class="row"><div class="col">' +
                                       '<div class="o_text_columns"><div class="row">' + // no "container" class
-                                          '<div class="col-lg-6">' +
+                                          '<div class="col-6">' +
                                               '<p>ab[]cd</p>' +
                                           '</div>' +
-                                          '<div class="col-lg-6"><p><br></p></div>' +
+                                          '<div class="col-6"><p><br></p></div>' +
                                       '</div></div>' +
                                       '<p><br></p>' +
                                   '</div></div></div>',


### PR DESCRIPTION
Steps to reproduce the issue:
=============================
- Go to any sale order
- Add 2 columns in terms and conditions
- Make sure the 2 columns have a long text in them
- Print it
- The 2 columns aren't displayed correctly in the pdf

Origin of the issue:
====================
The style of `col-lg-sz` wasn't applied because the media query consider
the report as mobile view.

Solution:
=========
We use `col-sz` instead for colums as used in.

opw-4224039