### PR TITLE
[FIX] account_*: process payments with early discount from portal

### DIFF
--- a/addons/account/controllers/portal.py
+++ b/addons/account/controllers/portal.py
@@ -32,7 +32,7 @@ class PortalAccount(CustomerPortal):
     def _invoice_get_page_view_values(self, invoice, access_token, **kwargs):
         values = {
             'page_name': 'invoice',
-            'invoice': invoice,
+            **invoice._get_invoice_portal_extra_values(),
         }
         return self._get_page_view_values(invoice, access_token, values, 'my_invoices_history', False, **kwargs)
 

--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -5465,6 +5465,13 @@ msgid "Discount amount in Currency"
 msgstr ""
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_move.py:0
+#, python-format
+msgid "Discount of %(amount)s if paid %(when)s"
+msgstr ""
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_account_analytic_applicability__display_account_prefix
 msgid "Display Account Prefix"
 msgstr ""
@@ -16991,6 +16998,13 @@ msgstr ""
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_tour_upload_bill_email_confirm
 msgid "with a pdf of an invoice as attachment."
+msgstr ""
+
+#. module: account
+#. odoo-python
+#: code:addons/account/models/account_move.py:0
+#, python-format
+msgid "within %(days)s days"
 msgstr ""
 
 #. module: account

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4411,6 +4411,72 @@ class AccountMove(models.Model):
     def is_outbound(self, include_receipts=True):
         return self.move_type in self.get_outbound_types(include_receipts)
 
+    def _get_epd_data(self):
+        self.ensure_one()
+        term_lines = self.line_ids.filtered(lambda l: l.display_type == 'payment_term')
+        return term_lines._get_epd_data()
+
+    def _get_invoice_next_payment_values(self):
+        self.ensure_one()
+        if self.currency_id.is_zero(self.amount_residual):
+            payment_state = 'fully_paid'
+        elif self.currency_id.is_zero(self.amount_total - self.amount_residual):
+            payment_state = 'not_paid'
+        else:
+            payment_state = 'partially_paid'
+
+        term_lines = self.line_ids.filtered(lambda line: line.display_type == 'payment_term')
+        epd_installment = term_lines._get_epd_data()
+        epd_info = {}
+        if epd_installment:
+            installment_state = 'epd'
+            amount_due = epd_installment['amount_residual_currency_unsigned']
+            discount_date = epd_installment['line'].discount_date
+            discount_amount_currency = epd_installment['discount_amount_currency']
+            days_left = (discount_date - fields.Date.context_today(self)).days  # should never be lower than 0 since epd is valid
+            if days_left > 0:
+                discount_msg = _(
+                    "Discount of %(amount)s if paid within %(days)s days",
+                    amount=self.currency_id.format(discount_amount_currency),
+                    days=days_left,
+                )
+            else:
+                discount_msg = _(
+                    "Discount of %(amount)s if paid today",
+                    amount=self.currency_id.format(discount_amount_currency),
+                )
+
+            epd_info.update({
+                'epd_discount_amount_currency': discount_amount_currency,
+                'epd_discount_amount': epd_installment['discount_amount'],
+                'discount_date': fields.Date.to_string(discount_date),
+                'epd_days_left': days_left,
+                'epd_line': epd_installment['line'],
+                'epd_discount_msg': discount_msg,
+            })
+        else:
+            installment_state = None
+            amount_due = self.amount_residual
+            next_amount_to_pay = self.amount_residual
+
+        return {
+            'payment_state': payment_state,
+            'installment_state': installment_state,
+            'next_amount_to_pay': self.amount_residual,
+            'amount_paid': self.amount_total - self.amount_residual,
+            'amount_due': amount_due,
+            'due_date': self.invoice_date_due,
+            **epd_info,
+        }
+
+    def _get_invoice_portal_extra_values(self):
+        self.ensure_one()
+        return {
+            'invoice': self,
+            'currency': self.currency_id,
+            **self._get_invoice_next_payment_values(),
+        }
+
     def _get_accounting_date(self, invoice_date, has_tax):
         """Get correct accounting date for previous periods, taking tax lock date into account.
         When registering an invoice in the past, we still want the sequence to be increasing.

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -3139,6 +3139,28 @@ class AccountMoveLine(models.Model):
         }
 
     # -------------------------------------------------------------------------
+    # INSTALLMENTS
+    # -------------------------------------------------------------------------
+    def _get_epd_data(self, payment_currency=None, payment_date=None):
+        move = self.move_id
+        move.ensure_one()
+        payment_date = payment_date or fields.Date.context_today(self)
+        sign = move.direction_sign
+        for line in self:
+            if line.reconciled:
+                continue
+            if move._is_eligible_for_early_payment_discount(payment_currency or line.currency_id, payment_date):
+                return{
+                    'line': line,
+                    'amount_residual_currency': line.discount_amount_currency,
+                    'amount_residual': line.discount_balance,
+                    'amount_residual_currency_unsigned': -sign * line.discount_amount_currency,
+                    'amount_residual_unsigned': -sign * line.discount_balance,
+                    'discount_amount_currency': line.amount_currency - line.discount_amount_currency,
+                    'discount_amount': line.balance - line.discount_balance,
+                }
+
+    # -------------------------------------------------------------------------
     # MISC
     # -------------------------------------------------------------------------
 

--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -113,9 +113,26 @@
                 <t t-call="portal.portal_record_sidebar">
                     <t t-set="classes" t-value="'col-lg-3 col-xl-4 d-print-none me-lg-auto'"/>
                     <t t-set="title">
-                        <h2>
+                        <h2 t-if="0">
                             <span t-if="invoice.amount_residual > 0" t-field="invoice.amount_residual"/>
                             <span t-else="1" t-field="invoice.amount_total"/>
+                        </h2>
+                        <t t-set="early_payment" t-value="installment_state == 'epd'"/>
+                        <div t-if="early_payment" class="alert alert-info w-100 text-center" role="alert">
+                            <span t-esc="epd_discount_msg"/>
+                        </div>
+                        <h2 t-if="amount">
+                            <t t-if="early_payment">
+                                <span t-esc="next_amount_to_pay" t-attf-class="ms-1 h5" style="text-decoration: line-through; color: grey;" t-options='{"widget": "monetary", "display_currency": invoice.currency_id}'/>
+                                <span t-esc="amount_due"
+                                      t-options='{"widget": "monetary", "display_currency": invoice.currency_id}'/>
+                            </t>
+                            <t t-else="1">
+                                <span t-esc="amount" t-options='{"widget": "monetary", "display_currency": invoice.currency_id}'/>
+                            </t>
+                        </h2>
+                        <h2 t-else="1">
+                            <span t-esc="invoice.amount_total" t-options='{"widget": "monetary", "display_currency": invoice.currency_id}'/>
                         </h2>
                         <div class="small" t-if="invoice.payment_state not in ('paid', 'in_payment', 'reversed') and invoice.move_type == 'out_invoice'"><i class="fa fa-clock-o"/><span class="o_portal_sidebar_timeago ml4" t-att-datetime="invoice.invoice_date_due"/></div>
                     </t>

--- a/addons/account_payment/controllers/portal.py
+++ b/addons/account_payment/controllers/portal.py
@@ -15,6 +15,9 @@ class PortalAccount(portal.PortalAccount, PaymentPortal):
             # Do not compute payment-related stuff if given invoice doesn't have to be paid.
             return values
 
+        epd = values.get('epd_discount_amount_currency', 0.0)
+        discounted_amount = invoice.amount_residual - epd
+
         logged_in = not request.env.user._is_public()
         # We set partner_id to the partner id of the current user if logged in, otherwise we set it
         # to the invoice partner id. We do this to ensure that payment tokens are assigned to the
@@ -53,7 +56,7 @@ class PortalAccount(portal.PortalAccount, PaymentPortal):
             ),
         }
         payment_context = {
-            'amount': invoice.amount_residual,
+            'amount': discounted_amount,
             'currency': invoice.currency_id,
             'partner_id': partner_sudo.id,
             'providers_sudo': providers_sudo,

--- a/addons/account_payment/models/payment_transaction.py
+++ b/addons/account_payment/models/payment_transaction.py
@@ -159,8 +159,27 @@ class PaymentTransaction(models.Model):
             'payment_token_id': self.token_id.id,
             'payment_transaction_id': self.id,
             'ref': reference,
+            'write_off_line_vals': [],
             **extra_create_values,
         }
+
+        if self.invoice_ids:
+            next_payment_values = self.invoice_ids._get_invoice_next_payment_values()
+            if next_payment_values['installment_state'] == 'epd' and self.amount == next_payment_values['amount_due']:
+                aml = next_payment_values['epd_line']
+                epd_aml_values_list = [({
+                    'aml': aml,
+                    'amount_currency': -aml.amount_residual_currency,
+                    'balance': -aml.balance,
+                })]
+                open_balance = next_payment_values['epd_discount_amount']
+                early_payment_values = self.env['account.move']._get_invoice_counterpart_amls_for_early_payment_discount(epd_aml_values_list, open_balance)
+                for aml_values_list in early_payment_values.values():
+                    if aml_values_list:
+                        aml_vl = aml_values_list[0]
+                        aml_vl['partner_id'] = self.partner_id.id
+                        payment_values['write_off_line_vals'] += [aml_vl]
+
         payment = self.env['account.payment'].create(payment_values)
         payment.action_post()
 

--- a/addons/account_payment/tests/test_account_payment.py
+++ b/addons/account_payment/tests/test_account_payment.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import datetime, timedelta
 from unittest.mock import patch
 
 from odoo import Command
@@ -227,3 +228,262 @@ class TestAccountPayment(AccountPaymentCommon):
             copy_provider_pml = get_payment_method_line(copy_provider)
             with self.assertRaises(ValidationError):
                 journal.inbound_payment_method_line_ids = [Command.update(copy_provider_pml.id, {'payment_provider_id': provider.id})]
+
+    #   ////////////////////////////////////////////////////////
+    #   Tests for payments with early payments discount
+    #   ///////////////////////////////////////////////////////
+    def _create_payment_term_with_early_discount(self, **kwargs):
+        return self.env['account.payment.term'].create({
+            'name': "early_payment_term",
+            'company_id': self.company_data['company'].id,
+            'discount_percentage': 10,
+            'discount_days': 10,
+            'early_discount': True,
+            **kwargs,
+        })
+
+    def _create_invoice_with_early_discount(self, payment_term_id=None, **kwargs):
+        invoice_with_early_discount = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner.id,
+            'invoice_date': datetime.now().date(),
+            'currency_id': self.currency.id,
+            'invoice_payment_term_id': payment_term_id or self._create_payment_term_with_early_discount().id,
+            'invoice_line_ids': [Command.create({
+                'name': 'test line',
+                'price_unit': 100.0,
+                'tax_ids': [],
+            })],
+            **kwargs
+        })
+        invoice_with_early_discount.action_post()
+        return invoice_with_early_discount
+
+    def assert_invoice_payment(self, payment, invoice, expected_values):
+        self.assertEqual(payment.amount, expected_values['payment_amount'])
+        self.assertEqual(payment.amount_total, expected_values['payment_amount_total'])
+        self.assertEqual(invoice.payment_state, expected_values['invoice_payment_state'])
+        self.assertEqual(invoice.amount_paid, expected_values['invoice_amount_paid'])
+        self.assertRecordValues(payment.line_ids, expected_values['payment_line_ids'])
+
+    def test_eligible_invoice_no_tax(self):
+        """
+        This test verifies the correct application of early payment discount on an eligible invoice without taxes.
+        """
+        invoice_eligible = self._create_invoice_with_early_discount()
+        payment = self._create_transaction(
+            reference='payment_1',
+            flow='direct',
+            state='done',
+            amount=invoice_eligible.invoice_payment_term_id._get_amount_due_after_discount(
+                total_amount=invoice_eligible.amount_residual,      # 100.0
+                untaxed_amount=invoice_eligible.amount_tax,         # 0.0
+            ),                                                      # 90.0
+            invoice_ids=[invoice_eligible.id],
+        )._create_payment()
+
+        self.assert_invoice_payment(
+            payment=payment,
+            invoice=invoice_eligible,
+            expected_values={
+                'payment_amount': 90.0,
+                'payment_amount_total': 100.0,
+                'invoice_payment_state': 'in_payment',
+                'invoice_amount_paid': 90.0,
+                'payment_line_ids': [
+                    {'credit': 0.0, 'debit': 90.0, 'account_type': 'asset_current'},
+                    {'credit': 100, 'debit': 0.0, 'account_type': 'asset_receivable'},
+                    {'credit': 0, 'debit': 10.0, 'account_type': 'expense'},
+                ],
+            }
+        )
+
+    def test_ineligible_invoice_past_discount_date(self):
+        """
+        This test ensures no discount is applied to an invoice past the early payment discount date.
+        """
+        invoice_ineligible = self._create_invoice_with_early_discount(invoice_date=(datetime.now() - timedelta(days=30)).date())
+        payment = self._create_transaction(
+            reference='payment_2',
+            flow='direct',
+            state='done',
+            amount=invoice_ineligible.amount_residual,  # 100.0
+            invoice_ids=[invoice_ineligible.id],
+        )._create_payment()
+
+        self.assert_invoice_payment(
+            payment=payment,
+            invoice=invoice_ineligible,
+            expected_values={
+                'payment_amount': 100.0,
+                'payment_amount_total': 100.0,
+                'invoice_payment_state': 'in_payment',
+                'invoice_amount_paid': 100.0,
+                'payment_line_ids': [
+                    {'credit': 0.0, 'debit': 100.0, 'account_type': 'asset_current'},
+                    {'credit': 100, 'debit': 0.0, 'account_type': 'asset_receivable'},
+                ],
+            }
+        )
+
+    def test_eligible_invoice_with_tax(self):
+        """
+        This test checks the correct calculation of early payment discount on an eligible invoice with taxes.
+        """
+        invoice_eligible_with_tax = self._create_invoice_with_early_discount(
+            invoice_line_ids=[Command.create({
+                'name': 'test line',
+                'price_unit': 100.0,
+                'tax_ids': [(6, 0, self.company_data['default_tax_sale'].ids)],  # 15%
+            })],
+        )
+        payment = self._create_transaction(
+            reference='payment_3',
+            flow='direct',
+            state='done',
+            amount=invoice_eligible_with_tax.invoice_payment_term_id._get_amount_due_after_discount(
+                total_amount=invoice_eligible_with_tax.amount_residual,     # 100.0
+                untaxed_amount=invoice_eligible_with_tax.amount_tax,        # 15.0
+            ),                                                              # 115.0 - 10% -> 115 * (1 - 0.1) = 103.5
+            invoice_ids=[invoice_eligible_with_tax.id],
+        )._create_payment()
+
+        self.assert_invoice_payment(
+            payment=payment,
+            invoice=invoice_eligible_with_tax,
+            expected_values={
+                'payment_amount': 103.5,
+                'payment_amount_total': 115.0,
+                'invoice_payment_state': 'in_payment',
+                'invoice_amount_paid': 103.5,
+                'payment_line_ids': [
+                    {'credit': 0.0, 'debit': 103.5, 'account_type': 'asset_current'},
+                    {'credit': 115, 'debit': 0.0, 'account_type': 'asset_receivable'},
+                    {'credit': 0, 'debit': 10.0, 'account_type': 'expense'},
+                    {'credit': 0, 'debit': 1.5, 'account_type': 'liability_current'},
+                ],
+            }
+        )
+
+    def test_ineligible_invoice_mixed_discount_computation_and_tax(self):
+        """
+        This test validates the behavior of mixed discount computation on an ineligible invoice with taxes.
+        The early discount should be applied on the untaxed amount past the early payment discount date.
+        "The tax is always reduced. The base amount used to compute the tax is the discounted amount,
+        whether the customer benefits from the discount or not." (cf Cash discounts and tax reduction documentation)
+        """
+        payment_term_with_mixed_discount_computation = self._create_payment_term_with_early_discount(
+            early_pay_discount_computation='mixed',
+        )
+        invoice_ineligible_with_mixed_and_tax = self._create_invoice_with_early_discount(
+            payment_term_id=payment_term_with_mixed_discount_computation.id,
+            invoice_date=(datetime.now() - timedelta(days=30)).date(),
+            invoice_line_ids=[Command.create({
+                'name': 'test line',
+                'price_unit': 100.0,
+                'tax_ids': [(6, 0, self.company_data['default_tax_sale'].ids)],  # 15%
+            })],
+        )
+        payment = self._create_transaction(
+            reference='payment_4',
+            flow='direct',
+            state='done',
+            amount=invoice_ineligible_with_mixed_and_tax.amount_residual,  # 100 + (15 * (1 - 0.1)) = 113.5
+            invoice_ids=[invoice_ineligible_with_mixed_and_tax.id],
+        )._create_payment()
+
+        self.assert_invoice_payment(
+            payment=payment,
+            invoice=invoice_ineligible_with_mixed_and_tax,
+            expected_values={
+                'payment_amount': 113.5,
+                'payment_amount_total': 113.5,
+                'invoice_payment_state': 'in_payment',
+                'invoice_amount_paid': 113.5,
+                'payment_line_ids': [
+                    {'credit': 0.0, 'debit': 113.5, 'account_type': 'asset_current'},
+                    {'credit': 113.5, 'debit': 0.0, 'account_type': 'asset_receivable'},
+                ],
+            }
+        )
+
+    def test_eligible_invoice_excluded_discount_computation_and_tax(self):
+        """
+        This test validates the behavior of excluded discount computation method on an eligible invoice with taxes.
+        "The tax is never reduced. The base amount used to compute the tax is the full amount,
+        whether the customer benefits from the discount or not." (cf Cash discounts and tax reduction documentation)
+        """
+        payment_term_with_excluded_discount_computation = self._create_payment_term_with_early_discount(
+            early_pay_discount_computation='excluded',
+        )
+        invoice_eligible_with_excluded_and_tax = self._create_invoice_with_early_discount(
+            payment_term_id=payment_term_with_excluded_discount_computation.id,
+            invoice_line_ids=[Command.create({
+                'name': 'test line',
+                'price_unit': 100.0,
+                'tax_ids': [(6, 0, self.company_data['default_tax_sale'].ids)],  # 15%
+            })],
+        )
+        payment = self._create_transaction(
+            reference='payment_5',
+            flow='direct',
+            state='done',
+            amount=invoice_eligible_with_excluded_and_tax.invoice_payment_term_id._get_amount_due_after_discount(
+                total_amount=invoice_eligible_with_excluded_and_tax.amount_residual,    # 100.0
+                untaxed_amount=invoice_eligible_with_excluded_and_tax.amount_tax,       # 15.0
+            ),                                                                          # (100 - 10%), 90 + 15 = 105
+            invoice_ids=[invoice_eligible_with_excluded_and_tax.id],
+        )._create_payment()
+
+        self.assert_invoice_payment(
+            payment=payment,
+            invoice=invoice_eligible_with_excluded_and_tax,
+            expected_values={
+                'payment_amount': 105.0,
+                'payment_amount_total': 115.0,
+                'invoice_payment_state': 'in_payment',
+                'invoice_amount_paid': 105.0,
+                'payment_line_ids': [
+                    {'credit': 0.0, 'debit': 105.0, 'account_type': 'asset_current'},
+                    {'credit': 115, 'debit': 0.0, 'account_type': 'asset_receivable'},
+                    {'credit': 0, 'debit': 10.0, 'account_type': 'expense'},
+                ],
+            }
+        )
+
+    def test_eligible_invoice_foreign_currency(self):
+        """
+        This test checks the correct calculation of early payment discount on an eligible invoice in a foreign currency.
+        """
+        foreign_currency = self.currency_data['currency']  # Gold Coin currency
+        invoice_eligible_with_foreign_currency = self._create_invoice_with_early_discount(
+            currency_id=foreign_currency.id,
+            company_currency_id=self.currency.id,
+        )
+        payment = self._create_transaction(
+            reference='payment_6',
+            flow='direct',
+            state='done',
+            amount=invoice_eligible_with_foreign_currency.invoice_payment_term_id._get_amount_due_after_discount(
+                total_amount=invoice_eligible_with_foreign_currency.amount_residual,    # 100.0 gold    / 50.0$
+                untaxed_amount=invoice_eligible_with_foreign_currency.amount_tax,       # 0.0 gold      / 0.0$
+            ),                                                                          # 90.0 gold     / 45.0$
+            currency_id=foreign_currency.id,
+            invoice_ids=[invoice_eligible_with_foreign_currency.id],
+        )._create_payment()
+
+        self.assert_invoice_payment(
+            payment=payment,
+            invoice=invoice_eligible_with_foreign_currency,
+            expected_values={
+                'payment_amount': 90,
+                'payment_amount_total': 100,
+                'invoice_payment_state': 'in_payment',
+                'invoice_amount_paid': 90,
+                'payment_line_ids': [
+                    {'credit': 0.0, 'debit': 45.0, 'account_type': 'asset_current'},
+                    {'credit': 50.0, 'debit': 0.0, 'account_type': 'asset_receivable'},
+                    {'credit': 0, 'debit': 5.0, 'account_type': 'expense'},
+                ],
+            }
+        )


### PR DESCRIPTION
Steps to reproduce:
- Go to accounting > configuration > payment terms > NEW
- Create a new payment terms with Early Discount checked > confirm
- Go to customer > invoices > NEW
- Create a new invoice with the payment terms selected > confirm.
- When clicking "Restiger Payment" to manually pay, the modal will display the early discount informations if the invoice is eligible.
- Click on Preview (short cut to access to the invoice through the portal)
- Assuming the invoice is eligible for early payment discount, the informations are not displayed in the side bar.
- Click on pay > select a payment provider > confirm
- Notice how the full payment was registered in accounting chart of account.

Cause:
the early discount feature is not properly handled in the portal view.

Analysis:
When previewing the transaction, the context sent `amount` is not well computed (controller portal). This `amount` context is the one used when creating the transaction https://github.com/odoo/odoo/blob/3ef9310ec36f1d5abd3f55e92eedb2ac7133d97a/addons/account_payment/controllers/payment.py#L40-L42 Therefore, we need to make sure that the `amount` defined in the view is the discounted amount if early_payment and the full amount if not.

Solution:
Mainly backport from https://github.com/odoo/odoo/pull/177905/

XML:
- we keep the the `t-if="0"` to not break Xpath in stable
- `t-if="amount"` just to make sure it does not break for a credit note https://github.com/odoo/odoo/blob/17.0/addons/account_payment/controllers/portal.py#L14-L16

opw-3632594