### PR TITLE
[FIX] calendar: avoid creating res.users.settings when not needed

### DIFF
--- a/addons/calendar/models/res_users.py
+++ b/addons/calendar/models/res_users.py
@@ -47,15 +47,17 @@ class Users(models.Model):
             partner_ids += [self.env.user.partner_id.id]
         return partner_ids
 
+    @api.model
+    def _default_user_calendar_default_privacy(self):
+        """ Get the calendar default privacy from the Default User Template, set public as default. """
+        if default_user := self.env.ref('base.default_user', raise_if_not_found=False):
+            return default_user.sudo().calendar_default_privacy or 'public'
+        return 'public'
+
     @api.model_create_multi
     def create(self, vals_list):
         """ Set the calendar default privacy as the same as Default User Template when defined. """
-        # Get the calendar default privacy from the Default User Template, set public as default.
-        default_privacy = 'public'
-        default_user = self.env.ref('base.default_user', raise_if_not_found=False)
-        if default_user and default_user.calendar_default_privacy:
-            default_privacy = default_user.calendar_default_privacy
-
+        default_privacy = self._default_user_calendar_default_privacy()
         # Update the dictionaries in vals_list with the calendar default privacy.
         for vals_dict in vals_list:
             if not vals_dict.get('calendar_default_privacy'):
@@ -75,15 +77,23 @@ class Users(models.Model):
 
     @api.depends("res_users_settings_id.calendar_default_privacy")
     def _compute_calendar_default_privacy(self):
+        """
+        Compute the calendar default privacy of the users, pointing to its ResUsersSettings.
+        When any user doesn't have its setting from ResUsersSettings defined, fallback to Default User Template's.
+        """
+        fallback_default_privacy = 'public'
+        if any(not user.res_users_settings_id.calendar_default_privacy for user in self):
+            fallback_default_privacy = self._default_user_calendar_default_privacy()
+
         for user in self:
-            user.calendar_default_privacy = user.res_users_settings_id.calendar_default_privacy
+            user.calendar_default_privacy = user.res_users_settings_id.calendar_default_privacy or fallback_default_privacy
 
     def _inverse_calendar_res_users_settings(self):
         """
         Updates the values of the calendar fields in 'res_users_settings_ids' to have the same values as their related
         fields in 'res.users'. If there is no 'res.users.settings' record for the user, then the record is created.
         """
-        for user in self:
+        for user in self.filtered(lambda user: user._is_internal()):
             settings = self.env["res.users.settings"].sudo()._find_or_create_for_user(user)
             configuration = {field: user[field] for field in self._get_user_calendar_configuration_fields()}
             settings.sudo().update(configuration)


### PR DESCRIPTION
Before this commit, res.users.settings entries were being created for portal and public users in the inverse method of the 'calendar_default_privacy' computed field. From now on, we will not create these entries for these type of users anymore since we don't make use of the fields inside it when the user is not internal.

After this commit, we no longer create res.users.settings entries for portal and public users since this creation is skipped using the '_is_internal()' check during the inverse method execution. Additionally, we added the 'public' value fallback for the calendar_default_privacy' field when the 'res_users_settings_id' field is not created.

task-4260834