### PR TITLE
[FIX] project_stock_account: compute delivery aal into the materials costs section

### DIFF
--- a/addons/project_stock_account/i18n/project_stock_account.pot
+++ b/addons/project_stock_account/i18n/project_stock_account.pot
@@ -29,8 +29,18 @@ msgid "Analytic Costs"
 msgstr ""
 
 #. module: project_stock_account
+#: model:ir.model,name:project_stock_account.model_account_analytic_line
+msgid "Analytic Line"
+msgstr ""
+
+#. module: project_stock_account
 #: model:ir.model,name:project_stock_account.model_account_analytic_applicability
 msgid "Analytic Plan's Applicabilities"
+msgstr ""
+
+#. module: project_stock_account
+#: model:ir.model.fields,field_description:project_stock_account.field_account_analytic_line__category
+msgid "Category"
 msgstr ""
 
 #. module: project_stock_account
@@ -39,8 +49,24 @@ msgid "Domain"
 msgstr ""
 
 #. module: project_stock_account
+#: model:ir.model.fields.selection,name:project_stock_account.selection__account_analytic_line__category__picking_entry
+msgid "Inventory Transfer"
+msgstr ""
+
+#. module: project_stock_account
+#. odoo-python
+#: code:addons/project_stock_account/models/project_project.py:0
+msgid "Materials"
+msgstr ""
+
+#. module: project_stock_account
 #: model:ir.model,name:project_stock_account.model_stock_picking_type
 msgid "Picking Type"
+msgstr ""
+
+#. module: project_stock_account
+#: model:ir.model,name:project_stock_account.model_project_project
+msgid "Project"
 msgstr ""
 
 #. module: project_stock_account

--- a/addons/project_stock_account/models/__init__.py
+++ b/addons/project_stock_account/models/__init__.py
@@ -3,3 +3,5 @@
 from . import analytic_applicability
 from . import stock_move
 from . import stock_picking_type
+from . import project_project
+from . import account_analytic_line

--- a/addons/project_stock_account/models/account_analytic_line.py
+++ b/addons/project_stock_account/models/account_analytic_line.py
@@ -1,0 +1,9 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class AccountAnalyticLine(models.Model):
+    _inherit = 'account.analytic.line'
+
+    category = fields.Selection(selection_add=[('picking_entry', 'Inventory Transfer')])

--- a/addons/project_stock_account/models/project_project.py
+++ b/addons/project_stock_account/models/project_project.py
@@ -1,0 +1,64 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.osv import expression
+
+from odoo import models, _lt
+
+
+class Project(models.Model):
+    _inherit = 'project.project'
+
+    def _get_profitability_labels(self):
+        return {
+            **super()._get_profitability_labels(),
+            'other_costs': _lt('Materials'),
+        }
+
+    def _get_profitability_sequence_per_invoice_type(self):
+        return {
+            **super()._get_profitability_sequence_per_invoice_type(),
+            'other_costs': 12,
+        }
+
+    def _get_profitability_items(self, with_action=True):
+        profitability_items = super()._get_profitability_items(with_action)
+        aal_from_picking = self._get_items_from_aal_picking(with_action)
+        if aal_from_picking:
+            profitability_items['costs']['data'] += aal_from_picking
+            profitability_items['costs']['total']['billed'] += aal_from_picking[0]['billed']
+        return profitability_items
+
+    def _get_items_from_aal_picking(self, with_action=True):
+        domain = self._get_domain_aal_with_no_move_line()
+        domain = expression.AND([
+            domain,
+            [('category', '=', 'picking_entry')]
+        ])
+        aal_other_search = self.env['account.analytic.line'].sudo().search_read(domain, ['id', 'amount', 'currency_id'])
+        if not aal_other_search:
+            return False
+
+        dict_amount_per_currency_id = {}
+        set_currency_ids = {self.currency_id.id}
+        cost_ids = []
+        for aal in aal_other_search:
+            set_currency_ids.add(aal['currency_id'][0])
+            aal_amount = aal['amount']
+            if not dict_amount_per_currency_id.get(aal['currency_id'][0]):
+                dict_amount_per_currency_id[aal['currency_id'][0]] = aal_amount
+            else:
+                dict_amount_per_currency_id[aal['currency_id'][0]] += aal_amount
+            cost_ids.append(aal['id'])
+
+        total_costs = 0.0
+        for currency_id, amounts in dict_amount_per_currency_id.items():
+            currency = self.env['res.currency'].browse(currency_id).with_prefetch(dict_amount_per_currency_id)
+            total_costs += currency._convert(amounts, self.currency_id, self.company_id)
+
+        profitability_sequence_per_invoice_type = self._get_profitability_sequence_per_invoice_type()
+        costs = [{'id': 'other_costs', 'sequence': profitability_sequence_per_invoice_type['other_costs_aal'], 'billed': total_costs, 'to_bill': 0.0}]
+
+        if with_action and self.env.user.has_group('account.group_account_readonly'):
+            costs[0]['action'] = self._get_action_for_profitability_section(cost_ids, 'other_costs_aal')
+
+        return costs

--- a/addons/project_stock_account/models/stock_move.py
+++ b/addons/project_stock_account/models/stock_move.py
@@ -19,6 +19,7 @@ class StockMove(models.Model):
         res = super()._prepare_analytic_line_values(account_field_values, amount, unit_amount)
         if self.picking_id:
             res['name'] = self.picking_id.name
+            res['category'] = 'picking_entry'
         return res
 
     def _get_valid_moves_domain(self):

--- a/addons/project_stock_account/tests/test_analytics.py
+++ b/addons/project_stock_account/tests/test_analytics.py
@@ -84,6 +84,12 @@ class TestAnalytics(TestStockCommon):
         self.assertEqual(analytic_line2[self.plan2_name], self.analytic_account2)
 
     def test_analytic_lines_generation_receipt(self):
+        """
+            In this module, the project profitability should be computed while checking the AAL data from the pickings.
+            When the 'analytic costs' option from delivery order is enabled, it is expected for picking to generate
+            an aal for the move line created. These aals should be taken into account when computing the 'project
+            profitability' right side panel and displayed under the 'costs -> materials' section.
+        """
         picking_in = self.PickingObj.create({
             'picking_type_id': self.picking_type_in,
             'location_id': self.supplier_location,
@@ -125,6 +131,17 @@ class TestAnalytics(TestStockCommon):
         self.assertEqual(analytic_line2.amount, 1000.0)
         self.assertEqual(analytic_line2[self.plan1_name], self.analytic_account1)
         self.assertEqual(analytic_line2[self.plan2_name], self.analytic_account2)
+
+        self.assertDictEqual(
+            self.project._get_profitability_items(False),
+            {
+                'revenues': {'data': [], 'total': {'invoiced': 0.0, 'to_invoice': 0.0}},
+                'costs': {
+                    'data': [{'id': 'other_costs', 'sequence': 15, 'billed': 1300.0, 'to_bill': 0.0}],
+                    'total': {'billed': 1300.0, 'to_bill': 0.0}
+                }
+            }
+        )
 
     def test_mandatory_analytic_plan_picking(self):
         self.env['account.analytic.applicability'].create({


### PR DESCRIPTION
This commit's purpose is to put the aal generated from deliveries into the 'materials' section under the costs section in the project profitability panel. Currently, those aal are considered as random aal and put under the 'other costs' section. This does not sees very appropirate.

In order to be able to differentiate aal created on the fly and the aal generated from picking, a new option is added on the already existing selection field 'category' in order to avoid a heavy search and computation on the move.line model.

version 18.0 - master
task - 4180276
