### PR TITLE
[FIX] account: Prevent misalignment of terms and conditions in invoice PDF

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -282,7 +282,7 @@
                                     </div>
                                 </div>
                                 <!--terms and conditions-->
-                                <div class="text-muted mb-3" t-attf-style="#{'text-align:justify;text-justify:inter-word;' if o.company_id.terms_type != 'html' else ''}" t-if="not is_html_empty(o.narration)" name="comment">
+                                <div class="text-muted mb-3" t-attf-style="clear: right; #{'text-align:justify;text-justify:inter-word;' if o.company_id.terms_type != 'html' else ''}" t-if="not is_html_empty(o.narration)" name="comment">
                                     <span t-field="o.narration"/>
                                 </div>
                             </div>


### PR DESCRIPTION
**Issue:**

When printing an invoice with 'Untaxed Amount' and 'Total'  but without a payment reference, the terms and conditions text is incorrectly displayed on the same line as 'Untaxed Amount' and 'Total' sections.

**Steps to reproduce:**

1- Go to the Accounting module.
2- Create a new invoice with taxed products and no payment reference. 
3- Print the invoice.

The terms and conditions text will appear misaligned (see attached screenshot for reference)

**Before the fix**

![bug_screenshot](https://github.com/user-attachments/assets/46a1ffc7-26b3-4bc6-9a0c-46c15abcc22b)

**After the fix:**

![fix_screenshot](https://github.com/user-attachments/assets/3988ca64-17fb-438b-a581-e39125173e3b)

OPW-4189931

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
