### PR TITLE
[FIX] html_editor: remove format not working on font-size

### DIFF
--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -81,6 +81,7 @@ export class FormatPlugin extends Plugin {
                 id: "formatFontSizeClassName",
                 run: ({ className }) => {
                     return this.formatSelection("setFontSizeClassName", {
+                        applyStyle: true,
                         formatProps: { className },
                     });
                 },

--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -177,6 +177,7 @@ export class FontPlugin extends Plugin {
                     onSelected: (item) =>
                         this.dependencies.format.formatSelection("setFontSizeClassName", {
                             formatProps: { className: item.className },
+                            applyStyle: true,
                         }),
                     isFontSize: true,
                     document: this.document,

--- a/addons/html_editor/static/src/main/font/font_selector.js
+++ b/addons/html_editor/static/src/main/font/font_selector.js
@@ -28,7 +28,7 @@ export class FontSelector extends Component {
     }
 
     get fontName() {
-        const sel = this.props.getSelection();
+        const sel = this.props.getSelection().deepEditableSelection;
         // if (!sel) {
         //     return "Normal";
         // }
@@ -53,7 +53,7 @@ export class FontSelector extends Component {
     }
 
     get fontSizeName() {
-        const sel = this.props.getSelection();
+        const sel = this.props.getSelection().deepEditableSelection;
         if (!sel) {
             return this.items[0].name;
         }

--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -251,7 +251,7 @@ export class ToolbarPlugin extends Plugin {
     getToolbarInfo() {
         return {
             buttonGroups: this.buttonGroups,
-            getSelection: () => this.dependencies.selection.getEditableSelection(),
+            getSelection: () => this.dependencies.selection.getSelectionData(),
             state: this.state,
             focusEditable: () => this.dependencies.selection.focusEditable(),
         };

--- a/addons/html_editor/static/src/utils/formatting.js
+++ b/addons/html_editor/static/src/utils/formatting.js
@@ -82,7 +82,7 @@ export const formatsSpecs = {
             ),
     },
     fontSize: {
-        isFormatted: (node) => node.style && node.style["font-size"],
+        isFormatted: (node) => closestElement(node)?.style["font-size"],
         hasStyle: (node) => node.style && node.style["font-size"],
         addStyle: (node, props) => {
             node.style["font-size"] = props.size;
@@ -91,7 +91,8 @@ export const formatsSpecs = {
         removeStyle: (node) => removeStyle(node, "font-size"),
     },
     setFontSizeClassName: {
-        isFormatted: (node) => FONT_SIZE_CLASSES.find((cls) => node?.classList?.contains(cls)),
+        isFormatted: (node) =>
+            FONT_SIZE_CLASSES.find((cls) => closestElement(node)?.classList?.contains(cls)),
         hasStyle: (node, props) => FONT_SIZE_CLASSES.find((cls) => node.classList.contains(cls)),
         addStyle: (node, props) => node.classList.add(props.className),
         removeStyle: (node) => removeClass(node, ...FONT_SIZE_CLASSES, ...TEXT_STYLE_CLASSES),

--- a/addons/html_editor/static/tests/format/remove_format.test.js
+++ b/addons/html_editor/static/tests/format/remove_format.test.js
@@ -600,6 +600,57 @@ test("undo remove format should return the element to it's original state", asyn
             '<p><strong><em><u><s><font style="color: rgb(0, 255, 0); background: rgb(0, 0, 255);">[sdsdsdsds]</font></s></u></em></strong></p>',
     });
 });
+
+test("should remove font size class from selected text", async () => {
+    await testEditor({
+        contentBefore: '<p>a<span class="h1-fs">[bcd]</span>e</p>',
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter: "<p>a[bcd]e</p>",
+    });
+});
+
+test("should remove font size classes from multiple sized selected text", async () => {
+    await testEditor({
+        contentBefore:
+            '<p>a<span class="h1-fs">[hello </span><span class="h2-fs">world]</span>b</p>',
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter: "<p>a[hello world]b</p>",
+    });
+});
+
+test("should remove font size class from multiple formatted selected text", async () => {
+    await testEditor({
+        contentBefore: '<p>a<strong>bc<span class="h2-fs">[de]</span>fg</strong>h</p>',
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter: "<p>a<strong>bc</strong>[de]<strong>fg</strong>h</p>",
+    });
+});
+
+test("should remove font-size style from selected text", async () => {
+    await testEditor({
+        contentBefore: `<p>ab<span style="font-size: 10px;">[cde]</span>fg</p>`,
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter: "<p>ab[cde]fg</p>",
+    });
+});
+
+test("should remove font-size style from multiple formatted selected text", async () => {
+    await testEditor({
+        contentBefore: '<p>a<strong>bc<span style="font-size: 10px;">[de]</span>fg</strong>h</p>',
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter: "<p>a<strong>bc</strong>[de]<strong>fg</strong>h</p>",
+    });
+});
+
+test("should remove font-size style from multiple sized selected text", async () => {
+    await testEditor({
+        contentBefore:
+            '<p>a<span style="font-size: 10px;">[hello </span><span style="font-size: 10px;">world]</span>b</p>',
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter: "<p>a[hello world]b</p>",
+    });
+});
+
 describe("Toolbar", () => {
     async function removeFormatClick() {
         await waitFor(".o-we-toolbar");
@@ -676,5 +727,12 @@ describe("Toolbar", () => {
         await waitFor(".o-we-toolbar");
         const formatButtons = queryAll(".o-we-toolbar .btn-group[name='decoration'] .btn");
         expect(formatButtons.at(-1)).toHaveAttribute("name", "remove_format");
+    });
+
+    test("Remove format button should be enabled when font-sized text is selected", async () => {
+        await setupEditor('<p><span class="h1-fs">[abc]</span></p>');
+        await waitFor(".o-we-toolbar");
+        expect(".btn[name='remove_format']").toHaveCount(1);
+        expect(".btn[name='remove_format'].disabled").toHaveCount(0);
     });
 });

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -273,6 +273,33 @@ test("toolbar works: can select font size", async () => {
     expect(".o-we-toolbar [name='font-size']").toHaveText(oSmallSize);
 });
 
+test.tags("desktop")("toolbar works: display correct font size on select all", async () => {
+    const { el } = await setupEditor("<p>test</p>");
+    expect(getContent(el)).toBe("<p>test</p>");
+
+    // set selection to open toolbar
+    expect(".o-we-toolbar").toHaveCount(0);
+    setContent(el, "<p>[test]</p>");
+    const style = getHtmlStyle(document);
+    const getFontSizeFromVar = (cssVar) => {
+        const strValue = getCSSVariableValue(cssVar, style);
+        const remValue = parseFloat(strValue);
+        const pxValue = convertNumericToUnit(remValue, "rem", "px", style);
+        return Math.round(pxValue);
+    };
+    await waitFor(".o-we-toolbar");
+    await contains(".o-we-toolbar [name='font-size'] .dropdown-toggle").click();
+    await animationFrame();
+    const h1Size = getFontSizeFromVar("h1-font-size").toString();
+    await contains(`.o_font_selector_menu .dropdown-item:contains('${h1Size}')`).click();
+    expect(getContent(el)).toBe(`<p><span class="h1-fs">[test]</span></p>`);
+    setContent(el, `<p><span class="h1-fs">te[]st</span></p>`);
+    await waitForNone(".o-we-toolbar");
+    await press(["ctrl", "a"]); // Select all
+    await waitFor(".o-we-toolbar");
+    expect(".o-we-toolbar [name='font-size']").toHaveText(`${h1Size}`);
+});
+
 test.tags("desktop")("toolbar should not open on keypress tab inside table", async () => {
     const contentBefore = unformat(`
         <table>


### PR DESCRIPTION
**Behaviour before PR:**

When a `font-size` is applied on a text, remove-format icon is disabled in toolbar when that text is selected and user is unable to reset `font-size`. This happens because in `formatSpecs` `isFormatted` method fails to get correct value in case of `setFontSizeClassName`. Same scenario is with `isFormatted` method of `fontSize`.

**Behaviour after PR:**

Now remove-format icon is enable when font-sized text is selected and user can remove and reset font-size of selected text.

task-4263625




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
