### PR TITLE
[IMP] discuss: public user joins the channel on more reload

### DIFF
--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -160,7 +160,8 @@ class ChannelController(http.Controller):
     @http.route("/discuss/channel/join", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
     def discuss_channel_join(self, channel_id):
-        channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
+        # sudo(): add a guest as a channel member.
+        channel = request.env["discuss.channel"].sudo().search([("id", "=", channel_id)])
         if not channel:
             raise NotFound()
         channel._find_or_create_member_for_self()

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -861,7 +861,7 @@ class DiscussChannel(models.Model):
             return self.add_members(guest_ids=guest.ids)
         return self.env["discuss.channel.member"]
 
-    def _find_or_create_persona_for_channel(self, guest_name, timezone, country_code, post_joined_message=True):
+    def _find_or_create_persona_for_channel(self, guest_name, timezone, country_code, post_joined_message=True, join_channel=True):
         """
         :param channel: channel to add the persona to
         :param guest_name: name of the persona
@@ -889,7 +889,8 @@ class DiscussChannel(models.Model):
                 ).sudo(False)
                 guest._set_auth_cookie()
                 self = self.with_context(guest=guest)
-            self.add_members(guest_ids=guest.ids, post_joined_message=post_joined_message)
+            if join_channel:
+                self.add_members(guest_ids=guest.ids, post_joined_message=post_joined_message)
         return self.env.user.partner_id if not guest else self.env["res.partner"], guest
 
     @api.model

--- a/addons/mail/static/src/discuss/call/public/discuss_client_action_patch.js
+++ b/addons/mail/static/src/discuss/call/public/discuss_client_action_patch.js
@@ -12,7 +12,7 @@ patch(DiscussClientAction.prototype, {
         this.rtc = useState(useService("discuss.rtc"));
     },
     async joinCallWithWelcomeSettings() {
-        if (this.store.discuss_public_thread.default_display_mode !== "video_full_screen") {
+        if (this.store.discuss_public_thread_data.default_display_mode !== "video_full_screen") {
             return;
         }
         const mute = browser.localStorage.getItem("discuss_call_preview_join_mute") === "true";

--- a/addons/mail/static/src/discuss/core/public/discuss_client_action_patch.js
+++ b/addons/mail/static/src/discuss/core/public/discuss_client_action_patch.js
@@ -18,7 +18,7 @@ patch(DiscussClientAction.prototype, {
             browser.history.replaceState(
                 browser.history.state,
                 null,
-                `/discuss/channel/${this.store.discuss_public_thread.id}${browser.location.search}`
+                `/discuss/channel/${this.store.discuss_public_thread_data.id}${browser.location.search}`
             );
         }
         browser.addEventListener("popstate", () => this.restoreDiscussThread(this.props));

--- a/addons/mail/static/src/discuss/core/public/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/public/store_service_patch.js
@@ -10,6 +10,7 @@ const storeServicePatch = {
         this.companyName;
         this.inPublicPage;
         this.isChannelTokenSecret;
+        this.discuss_public_thread_data;
         this.discuss_public_thread = Record.one("Thread");
         this.shouldDisplayWelcomeViewInitially;
     },

--- a/addons/mail/static/src/discuss/core/public/welcome_page.xml
+++ b/addons/mail/static/src/discuss/core/public/welcome_page.xml
@@ -4,12 +4,12 @@
 <t t-name="mail.WelcomePage">
     <div class="o-mail-WelcomePage h-100 w-100 d-flex flex-column justify-content-center align-items-center bg-light">
         <h1 class="fw-light">
-            <span t-if="this.store.discuss_public_thread.default_display_mode === 'video_full_screen'">You've been invited to a meeting!</span>
+            <span t-if="this.store.discuss_public_thread_data.default_display_mode === 'video_full_screen'">You've been invited to a meeting!</span>
             <span t-else="">You've been invited to a chat!</span>
         </h1>
         <h2 class="m-5" t-esc="store.companyName"/>
         <div class="d-flex justify-content-center gap-5" t-att-class="{'flex-column': ui.isSmall}">
-            <div t-if="this.store.discuss_public_thread.default_display_mode === 'video_full_screen'" class="position-relative d-flex justify-content-center" t-ref="root">
+            <div t-if="this.store.discuss_public_thread_data.default_display_mode === 'video_full_screen'" class="position-relative d-flex justify-content-center" t-ref="root">
                 <video class="shadow rounded bg-dark" t-attf-height="{{ui.isSmall ? 240 : 480}}" t-attf-width="{{ui.isSmall ? 320 : 640}}" autoplay="" t-ref="video"/>
                 <p t-if="hasRtcSupport and !state.videoStream" class="position-absolute bottom-50 text-light">
                     Camera is off

--- a/addons/mail/static/tests/tours/discuss_channel_as_guest_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_as_guest_tour.js
@@ -12,6 +12,13 @@ registry.category("web_tour.tours").add("discuss_channel_as_guest_tour.js", {
             },
         },
         {
+            content: "Guest shouldn't join channel until click on 'Join Channel'",
+            trigger: "body",
+            run() {
+                window.location.reload();
+            },
+        },
+        {
             content: "Click join",
             trigger: "button[title='Join Channel']",
             run: "click",


### PR DESCRIPTION
**Current behavior before PR:**

When a public user joins a channel using an invitation link, they are automatically added to the channel without clicking the 'Join Channel' button. Due to this, the user is able to see the channel upon refreshing the page.

**Desired behavior after PR is merged:**

This PR ensures that the user is not added to the channel and cannot see the channel until they explicitly click the 'Join Channel' button.

**Task**-4241725


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
