### PR TITLE
[FIX] web_editor: switch record doesn't transfer content

### DIFF
--- a/addons/web_editor/static/tests/html_field_tests.js
+++ b/addons/web_editor/static/tests/html_field_tests.js
@@ -744,7 +744,6 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
 
         // Paste image.
         const img = await pasteImage(editor, "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII");
-
         // Test environment replaces 'src' by 'data-src'.
         assert.ok(/^data:image\/png;base64,/.test(img.dataset['src']));
         assert.ok(img.classList.contains('o_b64_image_to_save'));
@@ -755,6 +754,72 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
         await htmlField.commitChanges();
         assert.equal(img.dataset['src'], '/test_image_url.png?access_token=1234');
         assert.ok(!img.classList.contains('o_b64_image_to_save'));
+    });
+
+    QUnit.test("Pasted/dropped images are saved and content not transfered to next record", async (assert) => {
+        serverData.models.partner.records = [
+            { id: 1, txt: "<p class='image_target'>first</p>" },
+            { id: 2, txt: "<p>second</p>" },
+        ];
+
+        // Patch to get a promise to get the htmlField component instance when
+        // the wysiwyg is instancied.
+        const htmlFieldPromise = makeDeferred();
+        patchWithCleanup(HtmlField.prototype, {
+            async startWysiwyg() {
+                await super.startWysiwyg(...arguments);
+                await nextTick();
+                htmlFieldPromise.resolve(this);
+            }
+        });
+
+        const mockRPC = async function (route, args) {
+            if (route === '/web_editor/attachment/add_data') {
+                return {
+                    image_src: '/test_image_url.png',
+                    access_token: '1234',
+                    public: false,
+                }
+            }
+            if (route.includes("web_save")){
+                // reading next record
+                return [{ id: 2, txt: "<p>second</p>" }];
+            }
+        };
+
+        await makeView({
+            type: "form",
+            resId: 1,
+            resIds: [1, 2],
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <field name="txt" widget="html"/>
+                </form>`,
+            mockRPC: mockRPC,
+        });
+        // Let the htmlField be mounted and recover the Component instance.
+        const htmlField = await htmlFieldPromise;
+        const editor = htmlField.wysiwyg.odooEditor;
+
+        const paragraph = editor.editable.querySelector(".image_target");
+        Wysiwyg.setRange(paragraph);
+
+        // Paste image.
+        const img = await pasteImage(editor, "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII");
+        // Restore 'src' attribute so that SavePendingImages can do its job.
+        img.src = img.dataset['src'];
+
+        const blurEvent = new Event('blur', {
+            bubbles: true,
+            cancelable: true
+        });
+        target.querySelector(".odoo-editor-editable").dispatchEvent(blurEvent);
+
+        await click(target.querySelector(".o_pager_next"));
+        await nextTick();
+        assert.containsOnce(target, ".odoo-editor-editable p:contains('second')");
     });
 
     QUnit.module('Odoo fields synchronisation');


### PR DESCRIPTION
Issue:
======
Going to next record in to do overrides the next record content with the older one.

Steps to reproduce the issue:
==============================
- Go to do and create 2 to-dos
- Add an image using copy paste
- Go to next record using the pager
- The record has the same content as the first one

Origin of the issue:
====================
The main reason behind the issue is a race condition. Basically there are 2 flows being executed in parallel:
- First flow is from `onWysiygBlur` which calls commit changes and save image changes. Since we have an image in the content, it will take longer to finish. the commit that was called now is fron emty content to the base64 image.
- The scond flow comes from the pager update which finds the content dirty because its old content is the base64 image ans its new content is the image with the url so it will call commit changes itself and it will load the next id.
- Currently we have the `_update` of the `commitChanges` from the `blur` event isn't done yet but we already changed the id of the record to the id of the new recod (comes fron pager).
- Now when the `_update` of the old `blur` event is executed, it will update the body of the new record and not the old record.

Solution:
=========
If the html field is already saving sonething we wait for it first. so In our case, the commit changes of the paged will do nothing since it will wait for the one of the `blur` event and the editable after it will be not dirty.

task-4082860