### PR TITLE
[IMP] portal: enable editing of portal entry cards in Website Editor

### DIFF
--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -12,30 +12,24 @@
         </xpath>
     </template>
 
-    <template id="portal_my_home_invoice" name="Invoices / Bills" inherit_id="portal.portal_my_home" customize_show="True" priority="30">
-        <xpath expr="//div[hasclass('o_portal_docs')]" position="before">
-            <t t-set="portal_client_category_enable" t-value="True"/>
-            <t t-set="portal_vendor_category_enable" t-value="True"/>
-        </xpath>
-        <div id="portal_client_category" position="inside">
-            <t t-call="portal.portal_docs_entry">
-                <t t-set="icon" t-value="'/account/static/src/img/Bill.svg'"/>
-                <t t-set="title">Your Invoices</t>
-                <t t-set="url" t-value="'/my/invoices?filterby=invoices'"/>
-                <t t-set="text">Follow, download or pay your invoices</t>
-                <t t-set="placeholder_count" t-value="'invoice_count'"/>
-            </t>
-        </div>
-        <div id="portal_vendor_category" position="inside">
-            <t t-call="portal.portal_docs_entry">
-                <t t-set="icon" t-value="'/account/static/src/img/Bill.svg'"/>
-                <t t-set="title">Our Invoices</t>
-                <t t-set="url" t-value="'/my/invoices?filterby=bills'"/>
-                <t t-set="text">Follow, download or pay our invoices</t>
-                <t t-set="placeholder_count" t-value="'bill_count'"/>
-            </t>
-        </div>
-    </template>
+    <data noupdate="1">
+        <record id="portal_invoice_client" model="portal.entry">
+            <field name="title">Your Invoices</field>
+            <field name="text">Follow, download or pay your invoices</field>
+            <field name="url">/my/invoices?filterby=invoices</field>
+            <field name="icon">/account/static/src/img/Bill.svg</field>
+            <field name="placeholder_count">invoice_count</field>
+            <field name="bg_color">bg-light</field>
+        </record>
+        <record id="portal_invoice_vendor" model="portal.entry">
+            <field name="title">Our Invoices</field>
+            <field name="text">Follow, download or pay our invoices</field>
+            <field name="url">/my/invoices?filterby=bills</field>
+            <field name="icon">/account/static/src/img/Bill.svg</field>
+            <field name="placeholder_count">bill_count</field>
+            <field name="bg_color">bg-light</field>
+        </record>
+    </data>
 
     <template id="portal_my_invoices" name="My Invoices and Payments">
       <t t-call="portal.portal_layout">

--- a/addons/account_payment/views/account_portal_templates.xml
+++ b/addons/account_payment/views/account_portal_templates.xml
@@ -20,6 +20,7 @@
         </xpath>
     </template>
 
+   <!-- TODO: manage this case
     <template id="account_payment.portal_docs_entry" inherit_id="portal.portal_docs_entry">
         <xpath expr="//a" position="inside">
             <button
@@ -29,23 +30,18 @@
                 Pay Now
             </button>
         </xpath>
-    </template>
+    </template>-->
 
-    <template id="portal_my_home_account_payment" name="Overdue invoices" customize_show="True" inherit_id="portal.portal_my_home" priority="20">
-        <xpath expr="//div[hasclass('o_portal_docs')]" position="before">
-            <t t-set="portal_alert_category_enable" t-value="True"/>
-        </xpath>
-        <div id="portal_alert_category" position="inside">
-            <t t-call="portal.portal_docs_entry">
-                <t t-set="bg_color" t-value="'alert alert-primary align-items-center'"/>
-                <t t-set="placeholder_count" t-value="'overdue_invoice_count'"/>
-                <t t-set="title">Invoices to pay</t>
-                <t t-set="url" t-value="'/my/invoices?filterby=overdue_invoices'"/>
-                <t t-set="show_count" t-value="True"/>
-                <t t-set="show_pay_overdue_invoices_button" t-value="True"/>
-            </t>
-        </div>
-    </template>
+    <data noupdate="1">
+        <record id="portal_entry_overdue_invoices" model="portal.entry">
+            <field name="title">Invoices to pay</field>
+            <field name="url">/my/invoices?filterby=overdue_invoices</field>
+            <field name="bg_color">alert alert-primary align-items-center</field>
+            <field name="placeholder_count">overdue_invoice_count</field>
+            <field name="is_alert">True</field>
+        </record>
+    </data>
+
 
     <template id="portal_overdue_invoices_page" name="Overdue payments">
         <t t-call="portal.portal_layout">

--- a/addons/hr_timesheet/views/hr_timesheet_portal_templates.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_portal_templates.xml
@@ -8,20 +8,16 @@
         </xpath>
     </template>
 
-    <template id="portal_my_home_timesheet" name="Timesheets" customize_show="True"  inherit_id="portal.portal_my_home" priority="45">
-        <xpath expr="//div[hasclass('o_portal_docs')]" position="before">
-            <t t-set="portal_service_category_enable" t-value="True"/>
-        </xpath>
-        <div id="portal_service_category" position="inside">
-            <t t-call="portal.portal_docs_entry">
-                <t t-set="icon" t-value="'/hr_timesheet/static/img/timesheet.svg'"/>
-                <t t-set="title">Timesheets</t>
-                <t t-set="url" t-value="'/my/timesheets'"/>
-                <t t-set="text">Review all timesheets related to your projects</t>
-                <t t-set="placeholder_count" t-value="'timesheet_count'"/>
-            </t>
-        </div>
-    </template>
+    <data noupdate="1">
+        <record id="portal_timesheets" model="portal.entry">
+            <field name="title">Timesheets</field>
+            <field name="text">Review all timesheets related to your projects</field>
+            <field name="url">/my/timesheets</field>
+            <field name="icon">/hr_timesheet/static/img/timesheet.svg</field>
+            <field name="placeholder_count">timesheet_count</field>
+        </record>
+    </data>
+
 
     <template id="portal_my_timesheets" name="My Timesheets">
         <t t-call="portal.portal_layout">

--- a/addons/mrp_subcontracting/views/subcontracting_portal_templates.xml
+++ b/addons/mrp_subcontracting/views/subcontracting_portal_templates.xml
@@ -1,20 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <template id="portal_my_home_productions" name="Productions" customize_show="True" inherit_id="portal.portal_my_home" priority="20">
-        <xpath expr="//div[hasclass('o_portal_docs')]" position="before">
-            <t t-set="portal_vendor_category_enable" t-value="True"/>
-        </xpath>
-        <div id="portal_vendor_category" position="inside">
-            <t t-call="portal.portal_docs_entry">
-                <t t-set="icon" t-value="'/mrp_subcontracting/static/src/img/manufacturing.svg'"/>
-                <t t-set="title">Manufacturing Orders</t>
-                <t t-set="text">Follow manufacturing orders you have to fulfill</t>
-                <t t-set="url" t-value="'/my/productions'"/>
-                <t t-set="placeholder_count" t-value="'production_count'"/>
-            </t>
-        </div>
-    </template>
+    <data noupdate="1">
+        <record id="portal_manufacturing_orders" model="portal.entry">
+            <field name="title">Manufacturing Orders</field>
+            <field name="text">Follow manufacturing orders you have to fulfill</field>
+            <field name="url">/my/productions</field>
+            <field name="icon">/mrp_subcontracting/static/src/img/manufacturing.svg</field>
+            <field name="placeholder_count">production_count</field>
+        </record>
+    </data>
 
     <template id="portal_my_home_menu_production" name="Portal layout : production menu entries" inherit_id="portal.portal_breadcrumbs" priority="25">
         <xpath expr="//ol[hasclass('o_portal_submenu')]" position="inside">

--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -174,6 +174,10 @@ class CustomerPortal(Controller):
     def home(self, **kw):
         values = self._prepare_portal_layout_values()
         values.update(self._prepare_home_portal_values([]))
+        portal_entries = request.env['portal.entry'].search([])
+        values.update({
+            'portal_entries': portal_entries,
+        })
         return request.render("portal.portal_my_home", values)
 
     @route(['/my/account'], type='http', auth='user', website=True)

--- a/addons/portal/models/__init__.py
+++ b/addons/portal/models/__init__.py
@@ -10,3 +10,4 @@ from . import portal_mixin
 from . import res_config_settings
 from . import res_partner
 from . import res_users_apikeys_description
+from . import portal_entry

--- a/addons/portal/models/portal_entry.py
+++ b/addons/portal/models/portal_entry.py
@@ -1,0 +1,16 @@
+from odoo import fields, models
+
+
+class PortalEntry(models.Model):
+    _name = 'portal.entry'
+    _description = 'Portal Entry'
+
+    title = fields.Char(string="Title", required=True)
+    text = fields.Char(string="Text")
+    url = fields.Char(string="URL", required=True)
+    icon = fields.Char(string="Icon Path")  # TODO: Remove, replaced by img
+    placeholder_count = fields.Char(string="Placeholder Count")
+    bg_color = fields.Char(string="Background Color")
+    is_alert = fields.Boolean(string="Is Alert", default=False)
+    img = fields.Binary(
+        readonly=False)

--- a/addons/portal/security/ir.model.access.csv
+++ b/addons/portal/security/ir.model.access.csv
@@ -2,3 +2,4 @@
 "access_portal_share","access.portal.share","model_portal_share","base.group_partner_manager",1,1,1,0
 "access_portal_wizard","access.portal.wizard","model_portal_wizard","base.group_partner_manager",1,1,1,0
 "access_portal_wizard_user","access.portal.wizard.user","model_portal_wizard_user","base.group_partner_manager",1,1,1,0
+"access_portal_entry","access.portal.entry","model_portal_entry","base.group_user",1,1,1,1

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <data noupdate="1">
+        <record id="portal_entry_base" model="portal.entry">
+            <field name="title">Connection &amp; Security</field>
+            <field name="text">Configure your connection parameters</field>
+            <field name="url">/my/security</field>
+            <field name="icon">/portal/static/src/img/portal-connection.svg</field>
+        </record>
+    </data>
+
     <template id="frontend_layout" name="Main Frontend Layout" inherit_id="web.frontend_layout">
         <xpath expr="//div[@id='wrapwrap']" position="attributes">
             <attribute name="t-attf-class" add="#{request.env['res.lang']._get_data(code=request.env.lang).direction == 'rtl' and 'o_rtl' or ''}" separator=" "/>
@@ -225,42 +234,55 @@
             <div class="o_portal_my_home">
                 <div class="oe_structure" id="oe_structure_portal_my_home_1"/>
                 <div class="o_portal_docs row g-2">
-                    <div t-if="portal_alert_category_enable" class="o_portal_category row g-2 mt-3" id="portal_alert_category"/>
                     <div t-if="portal_client_category_enable" class="o_portal_category row g-2 mt-3" id="portal_client_category"/>
-                    <div t-if="portal_service_category_enable" class="o_portal_category row g-2 mt-3" id="portal_service_category"/>
-                    <div t-if="portal_vendor_category_enable" class="o_portal_category row g-2 mt-3" id="portal_vendor_category"/>
-                    <div class="o_portal_category row g-2 mt-3" id="portal_common_category">
-                        <t t-call="portal.portal_docs_entry" t-if="False"/>
+
+                    <!-- Section for Alerts -->
+
+                    <div t-foreach="portal_entries" t-as="entry" t-if="entry.is_alert">
                         <t t-call="portal.portal_docs_entry">
-                            <t t-set="icon" t-value="'/portal/static/src/img/portal-connection.svg'"/>
-                            <t t-set="title">Connection &amp; Security</t>
-                            <t t-set="text">Configure your connection parameters</t>
-                            <t t-set="url" t-value="'/my/security'"/>
-                            <t t-set="config_card" t-value="True"/>
+                            <t t-set="show_count" t-value="True"/>
                         </t>
+
                     </div>
-                    <div class="o_portal_doc_spinner spinner-border text-o-color-2 align-self-center mt-5"/>
+
+                    <!-- General Section modificato per le due colonne -->
+                    <div class="row row-cols-1 row-cols-md-2 g-2">
+                        <div t-foreach="portal_entries" t-as="entry" t-if="not entry.is_alert" class="col">
+                            <t t-call="portal.portal_docs_entry">
+                                <t t-set="show_count" t-value="True"/>
+                            </t>
+                        </div>
+                    </div>
                 </div>
+                <div class="o_portal_doc_spinner spinner-border text-o-color-2 align-self-center mt-5"/>
             </div>
             <div class="oe_structure" id="oe_structure_portal_my_home_2"/>
         </t>
     </template>
 
     <template id="portal_docs_entry" name="My Portal Docs Entry">
+<!-- TODO: implement show_count
+
         <t t-set="force_show" t-value="placeholder_count and request.session.get('portal_counters', {}).get(placeholder_count) and not show_count"/>
+-->
+        <t t-set="force_show" t-value="True"/>
         <div t-att-class="'o_portal_index_card ' +  ('' if force_show or config_card else 'd-none ') + ('col-12 order-0' if show_count else 'col-md-6 order-2')">
-            <a t-att-href="url" t-att-title="title" t-attf-class="d-flex gap-2 gap-md-3 py-3 pe-2 px-md-3 h-100 rounded text-decoration-none #{bg_color if bg_color else 'bg-100'}">
-                <div t-if="icon" class="o_portal_icon d-none">
-                    <img t-attf-src="#{icon}"/>
+            <a t-att-href="url" t-att-title="title" t-attf-class="d-flex gap-2 gap-md-3 py-3 pe-2 px-md-3 h-100 rounded text-decoration-none #{entry.bg_color if entry.bg_color else 'bg-100'}">
+                <div class="o_portal_icon">
+                    <span t-field="entry.img"
+                          t-options="{'widget': 'image', 'width': 40, 'height': 40}"
+                          role="img"
+                          style="display: block; width: 40px; height: auto;"
+                          t-attf-aria-label="'Icon for %s' % entry.title"
+                          t-attf-title="entry.title"/>
                 </div>
-                <div t-att-class="'alert-link' if bg_color else ''">
-                    <div t-attf-class="mt-0 mb-1 fs-5 fw-normal lh-1 #{'d-flex gap-2' if placeholder_count or count else ''}">
-                        <t t-out="count"/>
-                        <span t-if="placeholder_count and not force_show" t-att-class="'fw-bold' if show_count else 'd-none'" t-att-data-placeholder_count="placeholder_count"/>
-                        <span t-out="title"/>
+                <div t-att-class="'alert-link' if entry.bg_color else ''">
+                    <div t-attf-class="mt-0 mb-1 fs-5 fw-normal lh-1 #{'d-flex gap-2' if entry.placeholder_count or count else ''}">
+                        <span t-if="entry.placeholder_count" t-att-class="'fw-bold' if show_count else 'd-none'" t-field="entry.placeholder_count" t-att-data-placeholder_count="entry.placeholder_count"/>
+                        <span t-field="entry.title"/>
                     </div>
                     <div class="opacity-75">
-                        <t t-out="text"/>
+                        <p t-field="entry.text"></p>
                     </div>
                 </div>
             </a>

--- a/addons/project/views/project_portal_project_project_templates.xml
+++ b/addons/project/views/project_portal_project_project_templates.xml
@@ -38,27 +38,22 @@
         </xpath>
     </template>
 
-    <template id="portal_my_home" name="Projects / Tasks" customize_show="True" inherit_id="portal.portal_my_home" priority="40">
-        <xpath expr="//div[hasclass('o_portal_docs')]" position="before">
-            <t t-set="portal_service_category_enable" t-value="True"/>
-        </xpath>
-        <div id="portal_service_category" position="inside">
-            <t t-call="portal.portal_docs_entry">
-                <t t-set="icon" t-value="'/web/static/img/folder.svg'"/>
-                <t t-set="title">Projects</t>
-                <t t-set="url" t-value="'/my/projects'"/>
-                <t t-set="text">Follow the evolution of your projects</t>
-                <t t-set="placeholder_count" t-value="'project_count'"/>
-            </t>
-            <t t-call="portal.portal_docs_entry">
-                <t t-set="icon" t-value="'/project/static/src/img/tasks.svg'"/>
-                <t t-set="title">Tasks</t>
-                <t t-set="url" t-value="'/my/tasks'"/>
-                <t t-set="text">Follow and comments tasks of your projects</t>
-                <t t-set="placeholder_count" t-value="'task_count'"/>
-            </t>
-        </div>
-    </template>
+    <data noupdate="1">
+        <record id="portal_projects" model="portal.entry">
+            <field name="title">Projects</field>
+            <field name="text">Follow the evolution of your projects</field>
+            <field name="url">/my/projects</field>
+            <field name="icon">/web/static/img/folder.svg</field>
+            <field name="placeholder_count">project_count</field>
+        </record>
+        <record id="portal_tasks" model="portal.entry">
+            <field name="title">Tasks</field>
+            <field name="text">Follow and comments tasks of your projects</field>
+            <field name="url">/my/tasks</field>
+            <field name="icon">/project/static/src/img/tasks.svg</field>
+            <field name="placeholder_count">task_count</field>
+        </record>
+    </data>
 
     <template id="portal_my_projects" name="My Projects">
         <t t-call="portal.portal_layout">

--- a/addons/purchase/views/portal_templates.xml
+++ b/addons/purchase/views/portal_templates.xml
@@ -17,27 +17,24 @@
     </xpath>
   </template>
 
-  <template id="portal_my_home_purchase" name="Requests for Quotation / Purchase Orders" customize_show="True" inherit_id="portal.portal_my_home" priority="25">
-    <xpath expr="//div[hasclass('o_portal_docs')]" position="before">
-          <t t-set="portal_vendor_category_enable" t-value="True"/>
-      </xpath>
-      <div id="portal_vendor_category" position="inside">
-          <t t-call="portal.portal_docs_entry">
-              <t t-set="icon" t-value="'/web/static/img/rfq.svg'"/>
-              <t t-set="text">Follow your Requests for Quotation</t>
-              <t t-set="title">Requests for Quotation</t>
-              <t t-set="url" t-value="'/my/rfq'"/>
-              <t t-set="placeholder_count" t-value="'rfq_count'"/>
-          </t>
-          <t t-call="portal.portal_docs_entry">
-              <t t-set="icon" t-value="'/purchase/static/src/img/calculator.svg'"/>
-              <t t-set="text">Follow orders you have to fulfill</t>
-              <t t-set="title">Our Orders</t>
-              <t t-set="url" t-value="'/my/purchase'"/>
-              <t t-set="placeholder_count" t-value="'purchase_count'"/>
-          </t>
-      </div>
-  </template>
+    <data noupdate="1">
+        <record id="portal_rfq" model="portal.entry">
+            <field name="title">Requests for Quotation</field>
+            <field name="text">Follow your Requests for Quotation</field>
+            <field name="url">/my/rfq</field>
+            <field name="icon">/web/static/img/rfq.svg</field>
+            <field name="placeholder_count">rfq_count</field>
+            <field name="bg_color">bg-light</field>
+        </record>
+        <record id="portal_purchase_orders" model="portal.entry">
+            <field name="title">Our Orders</field>
+            <field name="text">Follow orders you have to fulfill</field>
+            <field name="url">/my/purchase</field>
+            <field name="icon">/purchase/static/src/img/calculator.svg</field>
+            <field name="placeholder_count">purchase_count</field>
+            <field name="bg_color">bg-light</field>
+        </record>
+    </data>
 
   <template id="portal_my_purchase_rfqs" name="My Requests For Quotation">
       <t t-call="portal.portal_layout">

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -18,30 +18,24 @@
         </xpath>
     </template>
 
-    <template id="portal_my_home_sale" name="Quotations / Sales Orders" customize_show="True" inherit_id="portal.portal_my_home" priority="20">
-        <xpath expr="//div[hasclass('o_portal_docs')]" position="before">
-            <t t-set="portal_client_category_enable" t-value="True"/>
-            <t t-set="portal_alert_category_enable" t-value="True"/>
-        </xpath>
-        <div id="portal_alert_category" position="inside">
-            <t t-call="portal.portal_docs_entry">
-                <t t-set="bg_color" t-value="'alert alert-primary align-items-center'"/>
-                <t t-set="placeholder_count" t-value="'quotation_count'"/>
-                <t t-set="title">Quotations to review</t>
-                <t t-set="url" t-value="'/my/quotes'"/>
-                <t t-set="show_count" t-value="True"/>
-            </t>
-        </div>
-        <div id="portal_client_category" position="inside">
-            <t t-call="portal.portal_docs_entry">
-                <t t-set="icon" t-value="'/sale/static/src/img/bag.svg'"/>
-                <t t-set="title">Your Orders</t>
-                <t t-set="url" t-value="'/my/orders'"/>
-                <t t-set="text">Follow, view or pay your orders</t>
-                <t t-set="placeholder_count" t-value="'order_count'"/>
-            </t>
-        </div>
-    </template>
+    <data noupdate="1">
+        <record id="portal_quotations_to_review" model="portal.entry">
+            <field name="title">Quotations to review</field>
+            <field name="text">Review your quotations</field>
+            <field name="url">/my/quotes</field>
+            <field name="icon">/sale/static/src/img/bag.svg</field>
+            <field name="placeholder_count">quotation_count</field>
+            <field name="bg_color">alert alert-primary align-items-center</field>
+        </record>
+        <record id="portal_your_orders" model="portal.entry">
+            <field name="title">Your Orders</field>
+            <field name="text">Follow, view or pay your orders</field>
+            <field name="url">/my/orders</field>
+            <field name="icon">/sale/static/src/img/bag.svg</field>
+            <field name="placeholder_count">order_count</field>
+            <field name="bg_color">bg-light</field>
+        </record>
+    </data>
 
     <template id="portal_my_quotations" name="My Quotations">
         <t t-call="portal.portal_layout">

--- a/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
+++ b/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
@@ -297,28 +297,23 @@
         </xpath>
     </template>
 
-    <template id="portal_my_home_lead" name="Leads / Opps" inherit_id="portal.portal_my_home" priority="15">
-        <xpath expr="//div[hasclass('o_portal_docs')]" position="before">
-            <t t-set="portal_vendor_category_enable" t-value="True"/>
-        </xpath>
-        <div id="portal_vendor_category" position="inside">
-            <t t-call="portal.portal_docs_entry">
-                <t t-set="icon" t-value="'/website_crm_partner_assign/static/src/img/leads.svg'"/>
-                <t t-set="text">Follow and convert your leads</t>
-                <t t-set="title">Leads</t>
-                <t t-set="url" t-value="'/my/leads'"/>
-                <t t-set="placeholder_count" t-value="'lead_count'"/>
-            </t>
-            <t t-call="portal.portal_docs_entry">
-                <t t-set="icon" t-value="'/website_crm_partner_assign/static/src/img/quotation.svg'"/>
-                <t t-set="text">Follow and convert your opportunities</t>
-                <t t-set="title">Opportunities</t>
-                <t t-set="url" t-value="'/my/opportunities'"/>
-                <t t-set="placeholder_count" t-value="'opp_count'"/>
-                <t t-set="config_card" t-value="request.env.user.partner_id.grade_id or request.env.user.commercial_partner_id.grade_id"/>
-            </t>
-        </div>
-    </template>
+    <data noupdate="1">
+        <record id="portal_entry_leads" model="portal.entry">
+            <field name="title">Leads</field>
+            <field name="text">Follow and convert your leads</field>
+            <field name="url">/my/leads</field>
+            <field name="icon">/website_crm_partner_assign/static/src/img/leads.svg</field>
+            <field name="placeholder_count">lead_count</field>
+        </record>
+
+        <record id="portal_entry_opportunities" model="portal.entry">
+            <field name="title">Opportunities</field>
+            <field name="text">Follow and convert your opportunities</field>
+            <field name="url">/my/opportunities</field>
+            <field name="icon">/website_crm_partner_assign/static/src/img/quotation.svg</field>
+            <field name="placeholder_count">opp_count</field>
+        </record>
+    </data>
 
     <template id="portal_my_leads" name="My Leads">
         <t t-call="portal.portal_layout">


### PR DESCRIPTION
Introduced a new model `portal.entry` for customizable portal cards. Users can now edit text, images, and design attributes (bg color, border, rounded corners), enhancing usability. Future iterations may add more customization options for card layouts.

**Enterprise PR:** https://github.com/odoo/enterprise/pull/72470

**WIP for now**

task-3894113
