### PR TITLE
[FIX] account: portal use a custom template

### DIFF
--- a/addons/account/controllers/portal.py
+++ b/addons/account/controllers/portal.py
@@ -172,7 +172,10 @@ class PortalAccount(CustomerPortal):
         elif report_type in ('html', 'pdf', 'text'):
             has_generated_invoice = bool(invoice_sudo.invoice_pdf_report_id)
             request.update_context(proforma_invoice=not has_generated_invoice)
-            return self._show_report(model=invoice_sudo, report_type=report_type, report_ref='account.account_invoices', download=download)
+            # Use the template set on the related partner if there is.
+            # This is not perfect as the invoice can still have been computed with another template, but it's a slight fix/imp for stable.
+            pdf_report_name = invoice_sudo.partner_id.invoice_template_pdf_report_id.report_name or 'account.account_invoices'
+            return self._show_report(model=invoice_sudo, report_type=report_type, report_ref=pdf_report_name, download=download)
 
         values = self._invoice_get_page_view_values(invoice_sudo, access_token, **kw)
         return request.render("account.portal_invoice_page", values)


### PR DESCRIPTION
In the Print & Send, it is possible to use a different report template than the Odoo default one ('account.account_invoices'). This is not reflected in the portal preview.

Solution:
Which template has been used for an invoice is not an information that is saved in Odoo so we can't do something 100% accurate. When an invoice is generated with a different report than Odoo's one we save that as a setting on the partner.

We will render the portal preview with that template if it is set, to try to be closer to what should be shown.

task-no (approved by CHKL)
