### PR TITLE
[FIX] stock_delivery: avoid external API calls in button visibility

### DIFF
--- a/addons/stock_delivery/views/delivery_view.xml
+++ b/addons/stock_delivery/views/delivery_view.xml
@@ -41,7 +41,7 @@
                 </xpath>
                 <div name="button_box" position="inside">
                     <button type="object" name="open_website_url" class="oe_stat_button" icon='fa-truck' string="Tracking"
-                         invisible="not carrier_tracking_url or delivery_type == 'grid'" />
+                         invisible="not carrier_tracking_ref or not carrier_id or delivery_type == 'grid'" />
                 </div>
                 <xpath expr="/form/header/button[last()]" position="after">
                     <button name="send_to_shipper" string="Send to Shipper" type="object" invisible="carrier_tracking_ref or delivery_type in ['fixed', 'base_on_rule'] or not delivery_type or state != 'done' or picking_type_code == 'incoming'" data-hotkey="shift+v"/>


### PR DESCRIPTION
Using a computed field that perform external API calls to decide about
when to hide UI elements is problematic. If the external API is
unreachable this will raise an exception each time users try to open
the form view. If the API is slow this will also cause general slow
downs for users. Finally during upgrades this causes unnecessary
failures because the upgrade process is run without external internet
access.

This is partial revert of odoo/odoo@edf1a7d

This issue blocks multiple upgrades to 17.4

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
