### PR TITLE
[FIX] calendar: use default when res_id is 0

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -435,10 +435,11 @@ class Meeting(models.Model):
         # Prevent sending update notification when _inverse_dates is called
         self = self.with_context(is_calendar_event_new=True)
 
-        vals_list = [  # Else bug with quick_create when we are filter on an other user
-            dict(vals, user_id=self.env.user.id) if not 'user_id' in vals else vals
-            for vals in vals_list
-        ]
+        for vals in vals_list:
+            if 'user_id' not in vals:  # Else bug with quick_create when we are filter on an other user
+                vals.setdefault('user_id', self.env.user.id)
+            if vals.get('res_id') == 0:
+                vals.pop('res_id')
 
         defaults = self.default_get(['activity_ids', 'res_model_id', 'res_id', 'user_id', 'res_model', 'partner_ids'])
         meeting_activity_type = self.env['mail.activity.type'].search([('category', '=', 'meeting')], limit=1)

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -435,13 +435,15 @@ class Meeting(models.Model):
         # Prevent sending update notification when _inverse_dates is called
         self = self.with_context(is_calendar_event_new=True)
 
-        for vals in vals_list:
-            if 'user_id' not in vals:  # Else bug with quick_create when we are filter on an other user
-                vals.setdefault('user_id', self.env.user.id)
-            if vals.get('res_id') == 0:
-                vals.pop('res_id')
+        vals_list = [  # Else bug with quick_create when we are filter on an other user
+            dict(vals, user_id=self.env.user.id) if not 'user_id' in vals else vals
+            for vals in vals_list
+        ]
 
         defaults = self.default_get(['activity_ids', 'res_model_id', 'res_id', 'user_id', 'res_model', 'partner_ids'])
+        for vals in vals_list:
+            if defaults.get('res_id') and not vals.get('res_id'):
+                vals.update({'res_id': defaults['res_id']})
         meeting_activity_type = self.env['mail.activity.type'].search([('category', '=', 'meeting')], limit=1)
         # get list of models ids and filter out None values directly
         model_ids = list(filter(None, {values.get('res_model_id', defaults.get('res_model_id')) for values in vals_list}))

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -435,15 +435,17 @@ class Meeting(models.Model):
         # Prevent sending update notification when _inverse_dates is called
         self = self.with_context(is_calendar_event_new=True)
 
-        vals_list = [  # Else bug with quick_create when we are filter on an other user
-            dict(vals, user_id=self.env.user.id) if not 'user_id' in vals else vals
-            for vals in vals_list
-        ]
+        updated_vals_list = []
+        for vals in vals_list:
+            # Ensure 'user_id' is added if missing (else bug with quick_create when we are filter on)
+            updated_vals = dict(vals, user_id=self.env.user.id) if 'user_id' not in vals else vals.copy()
+            # Remove res_id if it's falsy (forces to use default value, when res_id points to nothingness)
+            if not updated_vals.get('res_id'):
+                updated_vals.pop('res_id', None)
+            updated_vals_list.append(updated_vals)
+        vals_list = updated_vals_list
 
         defaults = self.default_get(['activity_ids', 'res_model_id', 'res_id', 'user_id', 'res_model', 'partner_ids'])
-        for vals in vals_list:
-            if defaults.get('res_id') and not vals.get('res_id'):
-                vals.update({'res_id': defaults['res_id']})
         meeting_activity_type = self.env['mail.activity.type'].search([('category', '=', 'meeting')], limit=1)
         # get list of models ids and filter out None values directly
         model_ids = list(filter(None, {values.get('res_model_id', defaults.get('res_model_id')) for values in vals_list}))

--- a/addons/crm/tests/test_res_partner.py
+++ b/addons/crm/tests/test_res_partner.py
@@ -69,3 +69,30 @@ class TestPartner(TestCrmCommon):
         partner_form.name = 'Mom Corp'
         self.assertFalse(partner_form.team_id)
         self.assertFalse(partner_form.user_id)
+
+    def test_contact_calendar(self):
+
+        context = {
+            "active_model": "res.partner",
+            "active_id": self.contact_1.id,
+        }
+
+        event = self.env["calendar.event"].with_context(context).create([
+            {
+                "name": "Simulates flow: partner's calendar -> open quickcreate -> Save",
+                "allday": False,
+                "start": "2024-10-24 13:45:00",
+                "stop": "2024-10-24 15:45:00",
+            }
+        ])
+        self.assertEqual(event.res_id, self.contact_1.id, "Partner not linked to the event with res_id")
+
+        event2 = self.env["calendar.event"].with_context(context).create([
+            {
+                "res_id": 0,
+                "name": "Simulates flow: partner's calendar -> open quickcreate -> Edit -> Save",
+                "start": "2024-10-24 16:45:00",
+                "stop": "2024-10-24 18:45:00",
+            }
+        ])
+        self.assertEqual(event2.res_id, self.contact_1.id, "Partner not linked to the event with res_id (default res_id not used)")

--- a/addons/crm/tests/test_res_partner.py
+++ b/addons/crm/tests/test_res_partner.py
@@ -69,30 +69,3 @@ class TestPartner(TestCrmCommon):
         partner_form.name = 'Mom Corp'
         self.assertFalse(partner_form.team_id)
         self.assertFalse(partner_form.user_id)
-
-    def test_contact_calendar(self):
-
-        context = {
-            "active_model": "res.partner",
-            "active_id": self.contact_1.id,
-        }
-
-        event = self.env["calendar.event"].with_context(context).create([
-            {
-                "name": "Simulates flow: partner's calendar -> open quickcreate -> Save",
-                "allday": False,
-                "start": "2024-10-24 13:45:00",
-                "stop": "2024-10-24 15:45:00",
-            }
-        ])
-        self.assertEqual(event.res_id, self.contact_1.id, "Partner not linked to the event with res_id")
-
-        event2 = self.env["calendar.event"].with_context(context).create([
-            {
-                "res_id": 0,
-                "name": "Simulates flow: partner's calendar -> open quickcreate -> Edit -> Save",
-                "start": "2024-10-24 16:45:00",
-                "stop": "2024-10-24 18:45:00",
-            }
-        ])
-        self.assertEqual(event2.res_id, self.contact_1.id, "Partner not linked to the event with res_id (default res_id not used)")

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -3118,21 +3118,7 @@ class Many2oneReference(Integer):
         # cache format: id or None
         if isinstance(value, BaseModel):
             value = value._ids[0] if value._ids else None
-        value = super().convert_to_cache(value, record, validate)
-        if value in [0, None]:
-            return None
-        else:
-            return value
-
-    def convert_to_column(self, value, record, values=None, validate=True):
-        return None if value in [0, None] else int(value)
-
-    def convert_to_record(self, value, record):
-        value = super().convert_to_cache(value, record)
-        if value in [0, None]:
-            return None
-        else:
-            return value
+        return super().convert_to_cache(value, record, validate)
 
     def _remove_inverses(self, records, value):
         # TODO: unused

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -3118,7 +3118,21 @@ class Many2oneReference(Integer):
         # cache format: id or None
         if isinstance(value, BaseModel):
             value = value._ids[0] if value._ids else None
-        return super().convert_to_cache(value, record, validate)
+        value = super().convert_to_cache(value, record, validate)
+        if value in [0, None]:
+            return None
+        else:
+            return value
+
+    def convert_to_column(self, value, record, values=None, validate=True):
+        return None if value in [0, None] else int(value)
+
+    def convert_to_record(self, value, record):
+        value = super().convert_to_cache(value, record)
+        if value in [0, None]:
+            return None
+        else:
+            return value
 
     def _remove_inverses(self, records, value):
         # TODO: unused


### PR DESCRIPTION
[FIX] calendar: use default when res_id is 0


Reproduce
---
-  -contacts
- Open a contact, click on Meetings smart button
- Add a meeting -> Edit -> Save   (if you din'g click Edit, but save, no bug)
- Open created meeting, click on Document smart button -> BUG: no effect

opw-[4176381](https://www.odoo.com/web#id=4176381&view_type=form&model=project.task)