### PR TITLE
[FIX] pos_restaurant: update qty on existing order lines

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -90,6 +90,23 @@ patch(PosStore.prototype, {
             tableByIds[table.id].uiState.orderCount = table.orders;
             tableByIds[table.id].uiState.skipCount = table.skip_changes;
         }
+        if (
+            this.selectedTable &&
+            data["table_ids"].includes(this.selectedTable.id) &&
+            this.selectedOrderUuid
+        ) {
+            const changes = this.getOrderChanges();
+            if (changes.nbrOfChanges > 0) {
+                // at this stage we are sure to be on a concurrent pos session
+                // that needs to update its data from the server
+                try {
+                    this.tableSyncing = true;
+                    await this.syncAllOrders({ cancel_table_notification: true });
+                } finally {
+                    this.tableSyncing = false;
+                }
+            }
+        }
     },
     get categoryCount() {
         const orderChange = this.getOrderChanges().orderlines;


### PR DESCRIPTION
Steps to reproduce:
1. open a first restaurant session on one tab => S1
2. open the same restaurant session on a second device (e.g. incognito tab) => S2
3. select a table on S2, create an order and add a product
4. open that order on S1
5. add more of the same product from S2
6. you will see negative quantities on the order button on S1

Before this commit, the callback for websocket notification "TABLE_ORDER_COUNT" was assuming we were on the floor screen and thus not updating the (potential) opened order.
The result was an inconsistency when using multiple devices, with one of the POS session detecting "negative" additions to the order.

Typical use case where this causes problems:
A restaurant where waiters use mobile devices to take the orders at tables and a fixed PC as the checkout to settle orders and payments. In such instances, if the waiter forgot to return to floor screen after taking an order or if someone went to check the table order from the PC and kept that view open, inconsistencies arise.

After this commit, changes made to the order from another device are taken into account even when the order is already opened on this device.

opw-4208794