### PR TITLE
[IMP] tools: support nested translations extraction

### DIFF
--- a/odoo/addons/test_translation_import/i18n/fr.po
+++ b/odoo/addons/test_translation_import/i18n/fr.po
@@ -19,7 +19,20 @@ msgstr ""
 #. module: test_translation_import
 #. odoo-javascript
 #: code:addons/test_translation_import/data/files/test_spreadsheet_dashboard.json:0
+#: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
 msgid "Bar chart title"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
+msgid "Chart horizontal axis title"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
+msgid "Chart vertical axis title"
 msgstr ""
 
 #. module: test_translation_import
@@ -48,16 +61,19 @@ msgstr "Code, Français"
 
 #. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__create_uid
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__create_uid
 msgid "Created by"
 msgstr ""
 
 #. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__create_date
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__create_date
 msgid "Created on"
 msgstr ""
 
 #. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__display_name
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__display_name
 msgid "Display Name"
 msgstr ""
 
@@ -68,12 +84,170 @@ msgstr "Fourchette"
 
 #. module: test_translation_import
 #: model:ir.model.fields,help:test_translation_import.field_test_translation_import_model1__name
+#: model:ir.model.fields,help:test_translation_import.field_test_translation_import_model2__name
 msgid "Help, English"
 msgstr "Aider, Français"
 
 #. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__id
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__id
 msgid "ID"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 01 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 02 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 03 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 04 (Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 05 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 06 (Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 07 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 08 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 09 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 10 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 11 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 12 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 13 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 14 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 15 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 16 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 17 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 18 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 19 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 20 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 21 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 22 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 23"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 24 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 25"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 26"
 msgstr ""
 
 #. module: test_translation_import
@@ -82,29 +256,213 @@ msgid "Knife"
 msgstr "Couteau"
 
 #. module: test_translation_import
-#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1____last_update
-msgid "Last Modified on"
-msgstr ""
-
-#. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__write_uid
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__write_uid
 msgid "Last Updated by"
 msgstr ""
 
 #. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__write_date
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__write_date
 msgid "Last Updated on"
 msgstr ""
 
 #. module: test_translation_import
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__model1_id
+msgid "Model1"
+msgstr ""
+
+#. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__name
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__name
 msgid "Name"
 msgstr ""
 
 #. module: test_translation_import
 #. odoo-javascript
+#: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
+msgid "Odoo Chart horizontal axis title"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
+msgid "Odoo Chart vertical axis title"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
 #: code:addons/test_translation_import/data/files/test_spreadsheet_dashboard.json:0
+#: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
 msgid "Opportunities"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 01 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 02 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 03 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 04 (Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 05 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 06 (Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 07 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 08 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 09 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 10 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 11 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 12 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 13 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 14 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 15 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 16 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 17 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 18 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 19 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 20 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 21 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 22 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 23"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 24 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 25"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 26 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 27 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 28"
 msgstr ""
 
 #. module: test_translation_import
@@ -132,8 +490,9 @@ msgid "Scorecard description"
 msgstr ""
 
 #. module: test_translation_import
-#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__selection
-msgid "Selection"
+#. odoo-javascript
+#: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
+msgid "Scorecard title"
 msgstr ""
 
 #. module: test_translation_import
@@ -173,7 +532,13 @@ msgid "Translation Test 1"
 msgstr ""
 
 #. module: test_translation_import
+#: model:ir.model,name:test_translation_import.model_test_translation_import_model2
+msgid "Translation Test 2"
+msgstr ""
+
+#. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__xml
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__xml
 msgid "XML"
 msgstr ""
 

--- a/odoo/addons/test_translation_import/i18n/fr_BE.po
+++ b/odoo/addons/test_translation_import/i18n/fr_BE.po
@@ -17,7 +17,20 @@ msgstr ""
 #. module: test_translation_import
 #. odoo-javascript
 #: code:addons/test_translation_import/data/files/test_spreadsheet_dashboard.json:0
+#: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
 msgid "Bar chart title"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
+msgid "Chart horizontal axis title"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
+msgid "Chart vertical axis title"
 msgstr ""
 
 #. module: test_translation_import
@@ -46,16 +59,19 @@ msgstr "Code, Français, Belgium"
 
 #. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__create_uid
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__create_uid
 msgid "Created by"
 msgstr ""
 
 #. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__create_date
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__create_date
 msgid "Created on"
 msgstr ""
 
 #. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__display_name
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__display_name
 msgid "Display Name"
 msgstr ""
 
@@ -66,12 +82,170 @@ msgstr "Fourchette, Belgium"
 
 #. module: test_translation_import
 #: model:ir.model.fields,help:test_translation_import.field_test_translation_import_model1__name
+#: model:ir.model.fields,help:test_translation_import.field_test_translation_import_model2__name
 msgid "Help, English"
 msgstr "Aider, Français, Belgium"
 
 #. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__id
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__id
 msgid "ID"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 01 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 02 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 03 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 04 (Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 05 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 06 (Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 07 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 08 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 09 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 10 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 11 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 12 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 13 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 14 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 15 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 16 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 17 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 18 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 19 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 20 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 21 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 22 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 23"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 24 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 25"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 26"
 msgstr ""
 
 #. module: test_translation_import
@@ -80,29 +254,213 @@ msgid "Knife"
 msgstr "Couteau, Belgium"
 
 #. module: test_translation_import
-#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1____last_update
-msgid "Last Modified on"
-msgstr ""
-
-#. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__write_uid
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__write_uid
 msgid "Last Updated by"
 msgstr ""
 
 #. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__write_date
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__write_date
 msgid "Last Updated on"
 msgstr ""
 
 #. module: test_translation_import
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__model1_id
+msgid "Model1"
+msgstr ""
+
+#. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__name
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__name
 msgid "Name"
 msgstr ""
 
 #. module: test_translation_import
 #. odoo-javascript
+#: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
+msgid "Odoo Chart horizontal axis title"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
+msgid "Odoo Chart vertical axis title"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
 #: code:addons/test_translation_import/data/files/test_spreadsheet_dashboard.json:0
+#: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
 msgid "Opportunities"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 01 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 02 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 03 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 04 (Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 05 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 06 (Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 07 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 08 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 09 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 10 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 11 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 12 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 13 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 14 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 15 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 16 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 17 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 18 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 19 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 20 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 21 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 22 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 23"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 24 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 25"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 26 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 27 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 28"
 msgstr ""
 
 #. module: test_translation_import
@@ -130,8 +488,9 @@ msgid "Scorecard description"
 msgstr ""
 
 #. module: test_translation_import
-#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__selection
-msgid "Selection"
+#. odoo-javascript
+#: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
+msgid "Scorecard title"
 msgstr ""
 
 #. module: test_translation_import
@@ -171,7 +530,13 @@ msgid "Translation Test 1"
 msgstr ""
 
 #. module: test_translation_import
+#: model:ir.model,name:test_translation_import.model_test_translation_import_model2
+msgid "Translation Test 2"
+msgstr ""
+
+#. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__xml
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__xml
 msgid "XML"
 msgstr ""
 

--- a/odoo/addons/test_translation_import/i18n/fr_CA.po
+++ b/odoo/addons/test_translation_import/i18n/fr_CA.po
@@ -17,7 +17,20 @@ msgstr ""
 #. module: test_translation_import
 #. odoo-javascript
 #: code:addons/test_translation_import/data/files/test_spreadsheet_dashboard.json:0
+#: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
 msgid "Bar chart title"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
+msgid "Chart horizontal axis title"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
+msgid "Chart vertical axis title"
 msgstr ""
 
 #. module: test_translation_import
@@ -46,16 +59,19 @@ msgstr ""
 
 #. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__create_uid
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__create_uid
 msgid "Created by"
 msgstr ""
 
 #. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__create_date
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__create_date
 msgid "Created on"
 msgstr ""
 
 #. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__display_name
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__display_name
 msgid "Display Name"
 msgstr ""
 
@@ -66,12 +82,170 @@ msgstr ""
 
 #. module: test_translation_import
 #: model:ir.model.fields,help:test_translation_import.field_test_translation_import_model1__name
+#: model:ir.model.fields,help:test_translation_import.field_test_translation_import_model2__name
 msgid "Help, English"
 msgstr ""
 
 #. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__id
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__id
 msgid "ID"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 01 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 02 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 03 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 04 (Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 05 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 06 (Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 07 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 08 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 09 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 10 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 11 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 12 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 13 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 14 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 15 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 16 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 17 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 18 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 19 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 20 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 21 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 22 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 23"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 24 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 25"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 26"
 msgstr ""
 
 #. module: test_translation_import
@@ -80,29 +254,213 @@ msgid "Knife"
 msgstr "Couteau, Canada"
 
 #. module: test_translation_import
-#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1____last_update
-msgid "Last Modified on"
-msgstr ""
-
-#. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__write_uid
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__write_uid
 msgid "Last Updated by"
 msgstr ""
 
 #. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__write_date
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__write_date
 msgid "Last Updated on"
 msgstr ""
 
 #. module: test_translation_import
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__model1_id
+msgid "Model1"
+msgstr ""
+
+#. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__name
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__name
 msgid "Name"
 msgstr ""
 
 #. module: test_translation_import
 #. odoo-javascript
+#: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
+msgid "Odoo Chart horizontal axis title"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
+msgid "Odoo Chart vertical axis title"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
 #: code:addons/test_translation_import/data/files/test_spreadsheet_dashboard.json:0
+#: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
 msgid "Opportunities"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 01 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 02 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 03 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 04 (Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 05 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 06 (Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 07 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 08 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 09 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 10 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 11 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 12 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 13 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 14 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 15 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 16 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 17 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 18 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 19 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 20 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 21 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 22 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 23"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 24 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 25"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 26 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 27 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 28"
 msgstr ""
 
 #. module: test_translation_import
@@ -130,8 +488,9 @@ msgid "Scorecard description"
 msgstr ""
 
 #. module: test_translation_import
-#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__selection
-msgid "Selection"
+#. odoo-javascript
+#: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
+msgid "Scorecard title"
 msgstr ""
 
 #. module: test_translation_import
@@ -171,7 +530,13 @@ msgid "Translation Test 1"
 msgstr ""
 
 #. module: test_translation_import
+#: model:ir.model,name:test_translation_import.model_test_translation_import_model2
+msgid "Translation Test 2"
+msgstr ""
+
+#. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__xml
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__xml
 msgid "XML"
 msgstr ""
 

--- a/odoo/addons/test_translation_import/i18n/test_translation_import.pot
+++ b/odoo/addons/test_translation_import/i18n/test_translation_import.pot
@@ -93,6 +93,162 @@ msgid "ID"
 msgstr ""
 
 #. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 01 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 02 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 03 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 04 (Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 05 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 06 (Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 07 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 08 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 09 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 10 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 11 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 12 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 13 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 14 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 15 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 16 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 17 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 18 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 19 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 20 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 21 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 22 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 23"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 24 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 25"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 26"
+msgstr ""
+
+#. module: test_translation_import
 #: model_terms:test.translation.import.model1,xml:test_translation_import.test_translation_import_model1_record1
 msgid "Knife"
 msgstr ""
@@ -137,6 +293,174 @@ msgstr ""
 #: code:addons/test_translation_import/data/files/test_spreadsheet_dashboard.json:0
 #: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
 msgid "Opportunities"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 01 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 02 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 03 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 04 (Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 05 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 06 (Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 07 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 08 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 09 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 10 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 11 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 12 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 13 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 14 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 15 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 16 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 17 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 18 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 19 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 20 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 21 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 22 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 23"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 24 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 25"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 26 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 27 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 28"
 msgstr ""
 
 #. module: test_translation_import

--- a/odoo/addons/test_translation_import/i18n/tlh.po
+++ b/odoo/addons/test_translation_import/i18n/tlh.po
@@ -17,7 +17,20 @@ msgstr ""
 #. module: test_translation_import
 #. odoo-javascript
 #: code:addons/test_translation_import/data/files/test_spreadsheet_dashboard.json:0
+#: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
 msgid "Bar chart title"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
+msgid "Chart horizontal axis title"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
+msgid "Chart vertical axis title"
 msgstr ""
 
 #. module: test_translation_import
@@ -46,16 +59,19 @@ msgstr "Code, Klingon"
 
 #. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__create_uid
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__create_uid
 msgid "Created by"
 msgstr ""
 
 #. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__create_date
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__create_date
 msgid "Created on"
 msgstr ""
 
 #. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__display_name
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__display_name
 msgid "Display Name"
 msgstr ""
 
@@ -66,12 +82,170 @@ msgstr ""
 
 #. module: test_translation_import
 #: model:ir.model.fields,help:test_translation_import.field_test_translation_import_model1__name
+#: model:ir.model.fields,help:test_translation_import.field_test_translation_import_model2__name
 msgid "Help, English"
 msgstr ""
 
 #. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__id
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__id
 msgid "ID"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 01 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 02 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 03 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 04 (Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 05 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 06 (Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 07 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 08 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 09 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 10 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 11 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 12 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 13 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 14 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 15 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 16 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 17 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 18 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 19 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 20 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 21 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 22 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 23"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 24 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 25"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/static/src/js/js_codefile.js:0
+msgid "JS Export 26"
 msgstr ""
 
 #. module: test_translation_import
@@ -80,29 +254,213 @@ msgid "Knife"
 msgstr ""
 
 #. module: test_translation_import
-#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1____last_update
-msgid "Last Modified on"
-msgstr ""
-
-#. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__write_uid
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__write_uid
 msgid "Last Updated by"
 msgstr ""
 
 #. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__write_date
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__write_date
 msgid "Last Updated on"
 msgstr ""
 
 #. module: test_translation_import
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__model1_id
+msgid "Model1"
+msgstr ""
+
+#. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__name
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__name
 msgid "Name"
 msgstr ""
 
 #. module: test_translation_import
 #. odoo-javascript
+#: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
+msgid "Odoo Chart horizontal axis title"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
+#: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
+msgid "Odoo Chart vertical axis title"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-javascript
 #: code:addons/test_translation_import/data/files/test_spreadsheet_dashboard.json:0
+#: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
 msgid "Opportunities"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 01 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 02 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 03 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 04 (Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 05 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 06 (Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 07 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 08 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 09 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 10 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 11 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 12 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 13 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 14 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 15 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 16 (Double Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 17 %(named)s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 18 (Double Nested Named)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 19 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 20 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 21 (Base Nested)"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 22 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 23"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 24 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 25"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 26 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 27 %s"
+msgstr ""
+
+#. module: test_translation_import
+#. odoo-python
+#: code:addons/test_translation_import/models/models.py:0
+msgid "PY Export 28"
 msgstr ""
 
 #. module: test_translation_import
@@ -130,8 +488,9 @@ msgid "Scorecard description"
 msgstr ""
 
 #. module: test_translation_import
-#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__selection
-msgid "Selection"
+#. odoo-javascript
+#: code:addons/test_translation_import/data/files/test_spreadsheet_v16_dashboard.json:0
+msgid "Scorecard title"
 msgstr ""
 
 #. module: test_translation_import
@@ -171,7 +530,13 @@ msgid "Translation Test 1"
 msgstr ""
 
 #. module: test_translation_import
+#: model:ir.model,name:test_translation_import.model_test_translation_import_model2
+msgid "Translation Test 2"
+msgstr ""
+
+#. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__xml
+#: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model2__xml
 msgid "XML"
 msgstr ""
 

--- a/odoo/addons/test_translation_import/models/models.py
+++ b/odoo/addons/test_translation_import/models/models.py
@@ -5,6 +5,11 @@ from odoo.tools.translate import _, xml_translate, LazyTranslate
 _lt = LazyTranslate(__name__)
 
 
+class DummyClass:
+    def dummy_function(self, term):
+        return term
+
+
 class TestTranslationImportModel1(models.Model):
     _name = 'test.translation.import.model1'
     _description = 'Translation Test 1'
@@ -28,6 +33,51 @@ class TestTranslationImportModel1(models.Model):
 
     def get_code_named_placeholder_translation(self, *args, **kwargs):
         return _('Code, %(num)s, %(symbol)s, English', *args, **kwargs)
+
+    def test_deeply_nested_translations(self):
+        def dummy_function(term):
+            return term
+
+        dummy = DummyClass()
+        dummy_dict = {
+            "dummy_function": dummy_function,
+        }
+
+        terms = ["a", "b", "c"]
+        term = "term"
+
+        _("PY Export 01 %s", "NO - PY Export 01")
+        _("PY Export 02 %(named)s", named="NO - PY Export 02")
+
+        _("PY Export 03 %s", _("PY Export 04 (Nested)"))
+        _("PY Export 05 %(named)s", named=_("PY Export 06 (Nested Named)"))
+
+        _("PY Export 07 %s", dummy_function(_("PY Export 08 (Double Nested)")))
+        _("PY Export 09 %(named)s", named=dummy_function(_("PY Export 10 (Double Nested Named)")))
+
+        _("PY Export 11 %s", dummy.dummy_function(_("PY Export 12 (Double Nested)")))
+        _("PY Export 13 %(named)s", named=dummy.dummy_function(_("PY Export 14 (Double Nested Named)")))
+
+        _("PY Export 15 %s", dummy_dict["a_function"](_("PY Export 16 (Double Nested)")))
+        _("PY Export 17 %(named)s", named=dummy_dict["a_function"](_("PY Export 18 (Double Nested Named)")))
+
+        dummy_function(_("PY Export 19 (Base Nested)"))
+        dummy.dummy_function(_("PY Export 20 (Base Nested)"))
+        dummy_dict["a_function"](_("PY Export 21 (Base Nested)"))
+
+        _("PY Export 22 %s", "NO - PY Export 03" + _("PY Export 23"))
+        _("PY Export 24 %s", _("PY Export 25") + "NO - PY Export 04")
+
+        _("PY Export 26 %s", "NO - PY Export 05" + "".join(terms))
+        _("PY Export 27 %s", "".join(terms) + "NO - PY Export 06")
+
+        # pylint: disable=E8502
+        _(f"PY Export 28")  # noqa: F541, INT001
+        # pylint: disable=E8502
+        _(f"NO - PY Export 07 {term}")  # noqa: INT001
+
+        # pylint: disable=E8502
+        _(dummy_function("NO - PY Export 08"))
 
 
 class TestTranslationImportModel2(models.Model):

--- a/odoo/addons/test_translation_import/static/src/js/js_codefile.js
+++ b/odoo/addons/test_translation_import/static/src/js/js_codefile.js
@@ -1,0 +1,50 @@
+import { _t } from "@web/core/l10n/translation";
+
+export class TestTranslationExportModel {
+    testFunction() {
+        function dummyFunction(term) {
+            return term;
+        }
+
+        const dummy = {
+            dummyFunction,
+        };
+
+        const term = "term";
+
+        _t("JS Export 01 %s", "NO - JS Export 01");
+        _t("JS Export 02 %(named)s", { named: "NO - JS Export 02" });
+
+        _t("JS Export 03 %s", _t("JS Export 04 (Nested)"));
+        _t("JS Export 05 %(named)s", { named: _t("JS Export 06 (Nested Named)") });
+
+        _t("JS Export 07 %s", dummyFunction(_t("JS Export 08 (Double Nested)")));
+        _t("JS Export 09 %(named)s", {
+            named: dummyFunction(_t("JS Export 10 (Double Nested Named)")),
+        });
+
+        _t("JS Export 11 %s", dummy.dummyFunction(_t("JS Export 12 (Double Nested)")));
+        _t("JS Export 13 %(named)s", {
+            named: dummy.dummyFunction(_t("JS Export 14 (Double Nested Named)")),
+        });
+
+        _t("JS Export 15 %s", dummy["dummyFunction"](_t("JS Export 16 (Double Nested)")));
+        _t("JS Export 17 %(named)s", {
+            named: dummy["dummyFunction"](_t("JS Export 18 (Double Nested Named)")),
+        });
+
+        dummyFunction(_t("JS Export 19 (Base Nested)"));
+        dummy.dummyFunction(_t("JS Export 20 (Base Nested)"));
+        dummy["dummyFunction"](_t("JS Export 21 (Base Nested)"));
+
+        _t("JS Export 22 %s", "NO - JS Export 03" + _t("JS Export 23"));
+        _t("JS Export 24 %s", _t("JS Export 25") + "NO - JS Export 04");
+
+        _t(`JS Export 26`);
+
+        _t(dummyFunction`NO - JS Export 05`);
+        _t(dummyFunction`NO - JS Export 06 ${term}`);
+
+        _t(dummyFunction("NO - JS Export 07"));
+    }
+}

--- a/odoo/tools/babel/__init__.py
+++ b/odoo/tools/babel/__init__.py
@@ -1,0 +1,2 @@
+from .python_extractor import extract_python
+from .javascript_extractor import extract_javascript

--- a/odoo/tools/babel/javascript_extractor.py
+++ b/odoo/tools/babel/javascript_extractor.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import io
+from textwrap import dedent
+from typing import TYPE_CHECKING
+
+from babel.messages.jslexer import Token, line_re, tokenize, unquote_string
+
+if TYPE_CHECKING:
+    from collections.abc import Collection, Generator, Mapping
+    from typing import Protocol, TypeAlias, TypedDict
+
+    from _typeshed import SupportsRead, SupportsReadline
+
+    """
+    Types used by the extractor
+    """
+    # Tuple specifying which of the translation function's arguments contains localizable strings.
+    #   e.g. (1, 2)
+    #   -> Indicates the first and second argument are translatable terms, like in `ngettext`
+    #   e.g. ((1, 'c'), 2)
+    #   -> Indicates the first argument is a context key and the second is the translatable term, like in `pgettext`
+    #   e.g. None
+    #   -> Indicates there is only one argument translatable, like in `gettext`
+    _SimpleKeyword: TypeAlias = tuple[int | tuple[int, int] | tuple[int, str], ...] | None
+    # A `_SimpleKeyword` or a `dict` mapping the expected number of function arguments against the `_SimpleKeyword`
+    _Keyword: TypeAlias = dict[int | None, _SimpleKeyword] | _SimpleKeyword
+    # The result of extracting terms, a 4-tuple containing:
+    # (lineno: int, messages: str | tuple[str, ...], comments: list[str], context: str | None)
+    #   - `lineno`: The line number of the extracted term(s)
+    #   - `messages`: The extracted term(s). A single one or multiple in case of e.g. `ngettext`
+    #   - `comments`: The extracted translator comments for the term(s)
+    #   - `context`: The (optional) context key associated with the term(s)
+    _ExtractionResult: TypeAlias = tuple[int, str | tuple[str, ...], list[str], str | None]
+
+    # The file object to pass to the extraction function
+    class _FileObj(SupportsRead[bytes], SupportsReadline[bytes], Protocol):
+        def seek(self, offset: int, whence: int = ..., /) -> int: ...
+        def tell(self) -> int: ...
+
+    # The possible options to pass to the extraction function
+    class _JSOptions(TypedDict, total=False):
+        encoding: str
+        jsx: bool
+        template_string: bool
+        parse_template_string: bool
+
+
+def parse_template_string(
+    template_string: str,
+    keywords: Mapping[str, _Keyword],
+    comment_tags: Collection[str],
+    options: _JSOptions,
+    lineno: int = 1,
+) -> Generator[_ExtractionResult, None, None]:
+    prev_character = None
+    level = 0
+    inside_str = False
+    expression_contents = ''
+    for character in template_string[1:-1]:
+        if not inside_str and character in ('"', "'", '`'):
+            inside_str = character
+        elif inside_str == character and prev_character != r'\\':
+            inside_str = False
+        if level:
+            expression_contents += character
+        if not inside_str:
+            if character == '{' and prev_character == '$':
+                level += 1
+            elif level and character == '}':
+                level -= 1
+                if level == 0 and expression_contents:
+                    expression_contents = expression_contents[0:-1]
+                    fake_file_obj = io.BytesIO(expression_contents.encode())
+                    yield from extract_javascript(fake_file_obj, keywords, comment_tags, options, lineno)
+                    lineno += len(line_re.findall(expression_contents))
+                    expression_contents = ''
+        prev_character = character
+
+
+def extract_javascript(
+    fileobj: _FileObj,
+    keywords: Mapping[str, _Keyword],
+    comment_tags: Collection[str],
+    options: _JSOptions,
+) -> Generator[_ExtractionResult, None, None]:
+    """
+    Extract all translatable terms from a Javascript source file.
+
+    This function is modified from the official Babel extractor to support arbitrarily nested function calls.
+
+    :param fileobj: The Javascript source file
+    :param keywords: The translation keywords mapping
+    :param comment_tags: The keywords to extract translator comments
+    :param options: Extractor options for parsing the Javascript file
+    :yield: Tuples in the following form: `(lineno, funcname, message, comments)`
+    """
+    encoding = options.get('encoding', 'utf-8')
+    dotted = any('.' in kw for kw in keywords)
+
+    # Keep track of the last token we saw.
+    last_token = None
+    # Keep the stack of all function calls and its related contextual variables, so we can handle nested gettext calls.
+    function_stack = []
+    # Keep track of whether we're in a class or function definition.
+    in_def = False
+    # Keep track of whether we're in a block of translator comments.
+    in_translator_comments = False
+    # Keep track of the last encountered translator comments.
+    translator_comments = []
+    # Keep track of the (split) strings encountered.
+    message_buffer = []
+
+    for token in tokenize(
+        fileobj.read().decode(encoding),
+        jsx=options.get('jsx', True),
+        dotted=dotted,
+        template_string=options.get('template_string', True),
+    ):
+        if token.type == 'name' and token.value in ('class', 'function'):
+            # We're entering a class or function definition.
+            in_def = True
+            continue
+
+        elif in_def and token.type == 'operator' and token.value in ('(', '{'):
+            # We're in a class or function definition and should not do anything.
+            in_def = False
+            continue
+
+        elif (
+            last_token
+            and last_token.type == 'name'
+            and last_token.value in keywords
+            and token.type == 'template_string'
+        ):
+            # Turn keyword`foo` expressions into keyword("foo") function calls.
+            string_value = unquote_string(token.value)
+            cur_translator_comments = translator_comments
+            if function_stack and function_stack[-1]['function_lineno'] == last_token.lineno:
+                # If our current function call is on the same line as the previous one,
+                # copy their translator comments, since they also apply to us.
+                cur_translator_comments = function_stack[-1]['translator_comments']
+
+            # We add all information needed later for the current function call.
+            function_stack.append({
+                'function_lineno': last_token.lineno,
+                'function_name': last_token.value,
+                'message_lineno': token.lineno,
+                'messages': [string_value],
+                'translator_comments': cur_translator_comments,
+            })
+            translator_comments = []
+            message_buffer.clear()
+
+            # We act as if we are closing the function call now
+            last_token = token
+            token = Token('operator', ')', token.lineno)
+
+        if (
+            options.get('parse_template_string')
+            and (not last_token or last_token.type != 'name' or last_token.value not in keywords)
+            and token.type == 'template_string'
+        ):
+            yield from parse_template_string(token.value, keywords, comment_tags, options, token.lineno)
+
+        elif token.type == 'operator' and token.value == '(':
+            if last_token and last_token.type == 'name':
+                # We're entering a function call.
+                cur_translator_comments = translator_comments
+                if function_stack and function_stack[-1]['function_lineno'] == last_token.lineno:
+                    # If our current function call is on the same line as the previous one,
+                    # copy their translator comments, since they also apply to us.
+                    cur_translator_comments = function_stack[-1]['translator_comments']
+
+                # We add all information needed later for the current function call.
+                function_stack.append({
+                    'function_lineno': token.lineno,
+                    'function_name': last_token.value,
+                    'message_lineno': None,
+                    'messages': [],
+                    'translator_comments': cur_translator_comments,
+                })
+                translator_comments = []
+                message_buffer.clear()
+
+        elif token.type == 'linecomment':
+            # Strip the comment character from the line.
+            value = token.value[2:].strip()
+            if in_translator_comments and translator_comments[-1][0] == token.lineno - 1:
+                # We're already in a translator comment. Continue appending.
+                translator_comments.append((token.lineno, value))
+                continue
+
+            for comment_tag in comment_tags:
+                if value.startswith(comment_tag):
+                    # The comment starts with one of the translator comment keywords, so let's start capturing it.
+                    in_translator_comments = True
+                    translator_comments.append((token.lineno, value))
+                    break
+
+        elif token.type == 'multilinecomment':
+            # Only one multi-line comment may precede a translation.
+            translator_comments = []
+            value = token.value[2:-2].strip()
+            for comment_tag in comment_tags:
+                if value.startswith(comment_tag):
+                    lines = value.splitlines()
+                    if lines:
+                        lines[0] = lines[0].strip()
+                        lines[1:] = dedent('\n'.join(lines[1:])).splitlines()
+                        for offset, line in enumerate(lines):
+                            translator_comments.append((token.lineno + offset, line))
+                    break
+
+        elif function_stack and function_stack[-1]['function_name'] in keywords:
+            # We're inside a translation function call.
+            if token.type == 'operator' and token.value == ')':
+                # The call has ended, so we yield the translatable term(s).
+                messages = function_stack[-1]['messages']
+                lineno = function_stack[-1]['message_lineno'] or function_stack[-1]['function_lineno']
+                cur_translator_comments = function_stack[-1]['translator_comments']
+
+                if message_buffer:
+                    messages.append(''.join(message_buffer))
+                    message_buffer.clear()
+                else:
+                    messages.append(None)
+
+                messages = tuple(messages) if len(messages) > 1 else messages[0]
+                if cur_translator_comments and cur_translator_comments[-1][0] < lineno - 1:
+                    # The translator comments are not immediately preceding the current term, so we skip them.
+                    cur_translator_comments = []
+
+                yield (
+                    lineno,
+                    function_stack[-1]['function_name'],
+                    messages,
+                    [comment[1] for comment in cur_translator_comments],
+                )
+
+                function_stack.pop()
+
+            elif token.type in ('string', 'template_string'):
+                # We've encountered a string inside a translation function call.
+                if last_token.type == 'name':
+                    message_buffer.clear()
+                else:
+                    string_value = unquote_string(token.value)
+                    if not function_stack[-1]['message_lineno']:
+                        function_stack[-1]['message_lineno'] = token.lineno
+                    if string_value is not None:
+                        message_buffer.append(string_value)
+
+            elif token.type == 'operator' and token.value == ',':
+                # We're at the end of a function call argument.
+                if message_buffer:
+                    function_stack[-1]['messages'].append(''.join(message_buffer))
+                    message_buffer.clear()
+                else:
+                    function_stack[-1]['messages'].append(None)
+
+        elif function_stack and token.type == 'operator' and token.value == ')':
+            function_stack.pop()
+
+        if in_translator_comments and translator_comments[-1][0] < lineno:
+            # We have a newline between the comment lines, so they don't belong together anymore.
+            in_translator_comments = False
+
+        last_token = token

--- a/odoo/tools/babel/python_extractor.py
+++ b/odoo/tools/babel/python_extractor.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import ast
+import tokenize
+from tokenize import COMMENT, NAME, OP, STRING, generate_tokens
+from typing import TYPE_CHECKING
+
+from babel.util import parse_encoding, parse_future_flags
+
+if TYPE_CHECKING:
+    from collections.abc import Collection, Generator, Mapping
+    from typing import IO, TypeAlias, TypedDict
+
+    """
+    Types used by the extractor
+    """
+    # Tuple specifying which of the translation function's arguments contains localizable strings.
+    #   e.g. (1, 2)
+    #   -> Indicates the first and second argument are translatable terms, like in `ngettext`
+    #   e.g. ((1, 'c'), 2)
+    #   -> Indicates the first argument is a context key and the second is the translatable term, like in `pgettext`
+    #   e.g. None
+    #   -> Indicates there is only one argument translatable, like in `gettext`
+    _SimpleKeyword: TypeAlias = tuple[int | tuple[int, int] | tuple[int, str], ...] | None
+    # A `_SimpleKeyword` or a `dict` mapping the expected number of function arguments against the `_SimpleKeyword`
+    _Keyword: TypeAlias = dict[int | None, _SimpleKeyword] | _SimpleKeyword
+    # The result of extracting terms, a 4-tuple containing:
+    # (lineno: int, messages: str | tuple[str, ...], comments: list[str], context: str | None)
+    #   - `lineno`: The line number of the extracted term(s)
+    #   - `messages`: The extracted term(s). A single one or multiple in case of e.g. `ngettext`
+    #   - `comments`: The extracted translator comments for the term(s)
+    #   - `context`: The (optional) context key associated with the term(s)
+    _ExtractionResult: TypeAlias = tuple[int, str | tuple[str, ...], list[str], str | None]
+
+    # The possible options to pass to the extraction function
+    class _PyOptions(TypedDict, total=False):
+        encoding: str
+
+
+# New tokens in Python 3.12, or None on older versions
+FSTRING_START = tokenize.FSTRING_START if hasattr(tokenize, 'FSTRING_START') else None
+FSTRING_MIDDLE = tokenize.FSTRING_MIDDLE if hasattr(tokenize, 'FSTRING_MIDDLE') else None
+FSTRING_END = tokenize.FSTRING_END if hasattr(tokenize, 'FSTRING_END') else None
+
+
+def _parse_python_string(value: str, encoding: str, future_flags: int) -> str | None:
+    # Unwrap quotes in a safe manner, maintaining the string's encoding
+    code = compile(
+        f'# coding={encoding!s}\n{value}',
+        '<string>',
+        'eval',
+        ast.PyCF_ONLY_AST | future_flags,
+    )
+    if isinstance(code, ast.Expression):
+        body = code.body
+        if isinstance(body, ast.Constant):
+            return body.value
+        if isinstance(body, ast.JoinedStr):  # f-string
+            if all(isinstance(node, ast.Constant) for node in body.values):
+                return ''.join(node.value for node in body.values)
+    return None
+
+
+def extract_python(
+    fileobj: IO[bytes],
+    keywords: Mapping[str, _Keyword],
+    comment_tags: Collection[str],
+    options: _PyOptions,
+) -> Generator[_ExtractionResult, None, None]:
+    """
+    Extract all translatable terms from a Python source file.
+
+    This function is modified from the official Babel extractor to support arbitrarily nested function calls.
+
+    :param fileobj: The Python source file
+    :param keywords: The translation keywords (function names) mapping
+    :param comment_tags: The keywords to extract translator comments
+    :param options: Extractor options for parsing the Python file
+    :yield: Tuples in the following form: `(lineno, funcname, message, comments)`
+    """
+    encoding = parse_encoding(fileobj) or options.get('encoding', 'utf-8')
+    future_flags = parse_future_flags(fileobj, encoding)
+
+    def next_line():
+        return fileobj.readline().decode(encoding)
+
+    tokens = generate_tokens(next_line)
+
+    # Keep the stack of all function calls and its related contextual variables, so we can handle nested gettext calls.
+    function_stack = []
+    # Keep the last encountered function/variable name for when we encounter an opening parenthesis.
+    last_name = None
+    # Keep track of whether we're in a class or function definition.
+    in_def = False
+    # Keep track of whether we're in a block of translator comments.
+    in_translator_comments = False
+    # Keep track of the last encountered translator comments.
+    translator_comments = []
+    # Keep track of the (split) strings encountered.
+    message_buffer = []
+    # Current prefix of a Python 3.12 (PEP 701) f-string, or None if we're not currently parsing one.
+    current_fstring_start = None
+
+    for token, value, (lineno, _), _, _ in tokens:
+        if token == NAME and value in ('def', 'class'):
+            # We're entering a class or function definition.
+            in_def = True
+            continue
+
+        if in_def and token == OP and value in ('(', ':'):
+            # We're in a class or function definition and should not do anything.
+            in_def = False
+            continue
+
+        if token == OP and value == '(' and last_name:
+            # We're entering a function call.
+            cur_translator_comments = translator_comments
+            if function_stack and function_stack[-1]['function_lineno'] == lineno:
+                # If our current function call is on the same line as the previous one,
+                # copy their translator comments, since they also apply to us.
+                cur_translator_comments = function_stack[-1]['translator_comments']
+
+            # We add all information needed later for the current function call.
+            function_stack.append({
+                'function_lineno': lineno,
+                'function_name': last_name,
+                'message_lineno': None,
+                'messages': [],
+                'translator_comments': cur_translator_comments,
+            })
+            translator_comments = []
+            message_buffer.clear()
+
+        elif token == COMMENT:
+            # Strip the comment character from the line.
+            value = value[1:].strip()
+            if in_translator_comments and translator_comments[-1][0] == lineno - 1:
+                # We're already in a translator comment. Continue appending.
+                translator_comments.append((lineno, value))
+                continue
+
+            for comment_tag in comment_tags:
+                if value.startswith(comment_tag):
+                    # The comment starts with one of the translator comment keywords, so let's start capturing it.
+                    in_translator_comments = True
+                    translator_comments.append((lineno, value))
+                    break
+
+        elif function_stack and function_stack[-1]['function_name'] in keywords:
+            # We're inside a translation function call.
+            if token == OP and value == ')':
+                # The call has ended, so we yield the translatable term(s).
+                messages = function_stack[-1]['messages']
+                lineno = function_stack[-1]['message_lineno'] or function_stack[-1]['function_lineno']
+                cur_translator_comments = function_stack[-1]['translator_comments']
+
+                if message_buffer:
+                    messages.append(''.join(message_buffer))
+                    message_buffer.clear()
+                else:
+                    messages.append(None)
+
+                messages = tuple(messages) if len(messages) > 1 else messages[0]
+                if cur_translator_comments and cur_translator_comments[-1][0] < lineno - 1:
+                    # The translator comments are not immediately preceding the current term, so we skip them.
+                    cur_translator_comments = []
+
+                yield (
+                    lineno,
+                    function_stack[-1]['function_name'],
+                    messages,
+                    [comment[1] for comment in cur_translator_comments],
+                )
+
+                function_stack.pop()
+
+            elif token == STRING:
+                # We've encountered a string inside a translation function call.
+                string_value = _parse_python_string(value, encoding, future_flags)
+                if not function_stack[-1]['message_lineno']:
+                    function_stack[-1]['message_lineno'] = lineno
+                if string_value is not None:
+                    message_buffer.append(string_value)
+
+            # Python 3.12+, see https://peps.python.org/pep-0701/#new-tokens
+            elif token == FSTRING_START:
+                current_fstring_start = value
+            elif token == FSTRING_MIDDLE:
+                if current_fstring_start is not None:
+                    current_fstring_start += value
+            elif token == FSTRING_END:
+                if current_fstring_start is not None:
+                    fstring = current_fstring_start + value
+                    string_value = _parse_python_string(fstring, encoding, future_flags)
+                    if string_value is not None:
+                        message_buffer.append(string_value)
+
+            elif token == OP and value == ',':
+                # End of a function call argument
+                if message_buffer:
+                    function_stack[-1]['messages'].append(''.join(message_buffer))
+                    message_buffer.clear()
+                else:
+                    function_stack[-1]['messages'].append(None)
+
+        elif function_stack and token == OP and value == ')':
+            # This is the end of an non-translation function call. Just pop it from the stack.
+            function_stack.pop()
+
+        if in_translator_comments and translator_comments[-1][0] < lineno:
+            # We have a newline between the comment lines, so they don't belong together anymore.
+            in_translator_comments = False
+
+        if token == NAME:
+            last_name = value
+            if function_stack and not function_stack[-1]['message_lineno']:
+                function_stack[-1]['message_lineno'] = lineno
+
+        if current_fstring_start is not None and token not in {FSTRING_START, FSTRING_MIDDLE}:
+            # In Python 3.12, tokens other than FSTRING_* mean the f-string is dynamic,
+            # so we don't wan't to extract it.
+            # And if it's FSTRING_END, we've already handled it above.
+            # Let's forget that we're in an f-string.
+            current_fstring_start = None

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -1357,7 +1357,7 @@ class TranslationModuleReader(TranslationReader):
             return module, fabsolutepath, frelativepath, display_path
         return None, None, None, None
 
-    def _babel_extract_terms(self, fname, path, root, extract_method="python", trans_type='code',
+    def _babel_extract_terms(self, fname, path, root, extract_method='odoo.tools.babel:extract_python', trans_type='code',
                                extra_comments=None, extract_keywords={'_': None}):
 
         module, fabsolutepath, _, display_path = self._verified_module_filepaths(fname, path, root)
@@ -1366,7 +1366,7 @@ class TranslationModuleReader(TranslationReader):
         extra_comments = extra_comments or []
         src_file = file_open(fabsolutepath, 'rb')
         options = {}
-        if extract_method == 'python':
+        if 'python' in extract_method:
             options['encoding'] = 'UTF-8'
             translations = code_translations.get_python_translations(module, self._lang)
         else:
@@ -1407,13 +1407,13 @@ class TranslationModuleReader(TranslationReader):
             _logger.debug("Scanning files of modules at %s", path)
             for root, _dummy, files in os.walk(path, followlinks=True):
                 for fname in fnmatch.filter(files, '*.py'):
-                    self._babel_extract_terms(fname, path, root, 'python',
+                    self._babel_extract_terms(fname, path, root, 'odoo.tools.babel:extract_python',
                                               extra_comments=[PYTHON_TRANSLATION_COMMENT],
                                               extract_keywords={'_': None, '_lt': None})
                 if fnmatch.fnmatch(root, '*/static/src*'):
                     # Javascript source files
                     for fname in fnmatch.filter(files, '*.js'):
-                        self._babel_extract_terms(fname, path, root, 'javascript',
+                        self._babel_extract_terms(fname, path, root, 'odoo.tools.babel:extract_javascript',
                                                   extra_comments=[JAVASCRIPT_TRANSLATION_COMMENT],
                                                   extract_keywords={'_t': None})
                     # QWeb template files


### PR DESCRIPTION
To generate the .pot files with all translatable terms, we need to extract all these terms from the Python and Javascript files using an extractor.

Up till now we used the default Babel extractors provided in their library. However we had some shortcomings related to nested function calls in the native extractors.

Both extractors didn't support nested calls like e.g.
```python
_("Hello %s", _("Person"))
_(
    "Hello %s",
    random_function(", ".join([_("Person 1"), _("Person 2")])),
)
```

In this commit we modified the existing Babel extractors and added them in our codebase to use as custom extractors for our source code. This way people can use nested gettext calls without relying on workarounds.

[task-3940389](https://www.odoo.com/odoo/project.task/3940389)