### PR TITLE
[FIX] website: fix overflow x during animations

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -2063,8 +2063,11 @@ input[value*="data-oe-translation-source-sha"] {
     visibility: visible;
 }
 .o_wanim_overflow_xy_hidden {
-    overflow-x: hidden !important;
-
+    // "overflow-x: hidden" is added to the "body" and not to "html" because if
+    // it's added to "html", when a popup opens, the page scrolls to the top.
+    > body {
+        overflow-x: hidden !important;
+    }
     &.o_rtl, .o_rtl {
         // Fix for Chrome and Edge bug: resolves slow/stuck scrolling during
         // left-overflowing animations on RTL web pages. Note: using overflow on

--- a/addons/website/static/tests/tours/snippet_popup_and_animations.js
+++ b/addons/website/static/tests/tours/snippet_popup_and_animations.js
@@ -76,7 +76,6 @@ registerWebsitePreviewTour("snippet_popup_and_animations", {
     {
         content: "Wait for the page to be scrolled to the top.",
         trigger: ":iframe .s_three_columns .row > :last-child:not(.o_animating)",
-        /* task-4185877
         run() {
             // If the column has been animated successfully, the animation delay
             // should be set to approximately zero when it is not visible.
@@ -86,7 +85,6 @@ registerWebsitePreviewTour("snippet_popup_and_animations", {
                 throw new Error("The scroll animation in the page did not end properly with the cookies bar open.");
             }
         },
-        */
     },
     {
         content: "Close the Cookies Bar.",


### PR DESCRIPTION
Since this commit [1], from which the scrolling element is no longer '#wrapwrap' but HTML, the test 'snippet_popup_and_animations' fails.

This is because during animations, 'overflow-x: hidden' is added to the scrolling element (HTML). At the time a modal shows, an 'overflow: hidden' style is briefly added to the 'body' element, which causes the page to scroll to the top when a modal shows while an animation is playing on the page.

To fix this unwanted behavior, we moved the 'overflow-x: hidden' rule added during animations from the HTML to the body."

[1]: https://github.com/odoo/odoo/commit/189a7c96e6e26825dc05c0c6466576fe63aa091e

task-4185877