### PR TITLE
[IMP] website_sale_collect: confirm SO when 'on_site' payment method

### DIFF
--- a/addons/website_sale_collect/data/payment_provider_data.xml
+++ b/addons/website_sale_collect/data/payment_provider_data.xml
@@ -20,7 +20,7 @@
         <field name="redirect_form_view_id" ref="payment_custom.redirect_form"/>
         <field name="pending_msg" type="html">
             <p>
-                <i>Your order has been saved.</i> Please come to the store to pay for your products.
+                <i>Your order has been confirmed.</i><br/>Please come to the store to pay for your products.
             </p>
         </field>
     </record>

--- a/addons/website_sale_collect/i18n/website_sale_collect.pot
+++ b/addons/website_sale_collect/i18n/website_sale_collect.pot
@@ -18,8 +18,8 @@ msgstr ""
 #. module: website_sale_collect
 #: model_terms:payment.provider,pending_msg:website_sale_collect.payment_provider_on_site
 msgid ""
-"<i>Your order has been saved.</i> Please come to the store to pay for your "
-"products."
+"<i>Your order has been confirmed.</i><br> Please come to the store to pay "
+"for your products."
 msgstr ""
 
 #. module: website_sale_collect

--- a/addons/website_sale_collect/models/__init__.py
+++ b/addons/website_sale_collect/models/__init__.py
@@ -2,6 +2,7 @@
 
 from . import delivery_carrier
 from . import payment_provider
+from . import payment_transaction
 from . import product_template
 from . import res_config_settings
 from . import sale_order

--- a/addons/website_sale_collect/models/payment_transaction.py
+++ b/addons/website_sale_collect/models/payment_transaction.py
@@ -1,0 +1,18 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class PaymentTransaction(models.Model):
+    _inherit = 'payment.transaction'
+
+    def _post_process(self):
+        """ Override of `payment` to confirm orders with the on_site payment method and trigger
+        a picking creation. """
+        on_site_pending_txs = self.filtered(
+            lambda tx: tx.provider_id.custom_mode == 'on_site' and tx.state == 'pending'
+        )
+        on_site_pending_txs.sale_order_ids.filtered(
+            lambda so: so.state == 'draft'
+        ).with_context(send_email=True).action_confirm()
+        super()._post_process()

--- a/addons/website_sale_collect/tests/test_payment.py
+++ b/addons/website_sale_collect/tests/test_payment.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests import HttpCase, tagged
+from odoo.tools import mute_logger
 
 from odoo.addons.website_sale_collect.tests.common import OnSiteCommon
 
@@ -26,3 +27,16 @@ class TestOnSitePayment(HttpCase, OnSiteCommon):
         self.assertTrue(not any(
             p.code == 'custom' and p.custom_mode == 'on_site' for p in compatible_providers
         ))
+
+    def test_choosing_on_site_payment_confirms_order(self):
+        order = self._create_so(carrier_id=self.carrier.id, state='draft')
+        tx = self._create_transaction(
+            flow='direct',
+            sale_order_ids=[order.id],
+            state='pending',
+            payment_method_id=self.provider.payment_method_ids.id,
+        )
+        with mute_logger('odoo.addons.sale.models.payment_transaction'):
+            tx._post_process()
+
+        self.assertEqual(order.state, 'sale')


### PR DESCRIPTION
As on_site payment provider is a custom one, transaction is created as pending. Therefore, SO is not confirmed and picking is not created which
 is not convenient for the customer.

task-4267776


