### PR TITLE
[FIX] stock_account: avoid traceback when computing avg price from SVL

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -779,7 +779,7 @@ class ProductProduct(models.Model):
             candidates = candidates.with_prefetch(self.env.context.get('candidates_prefetch_ids'))
 
         if len(candidates) > 1:
-            candidates = candidates.sorted(lambda svl: (svl.create_date, svl.id))
+            candidates = candidates.sorted(lambda svl: (svl.create_date, svl.ids))
 
         value_invoiced = self.env.context.get('value_invoiced', 0)
         if 'value_invoiced' in self.env.context:


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Create a storable product “P1”:
   - Route: Dropship
   - Add Azure Interior as the vendor

- Create a sales order:
   - 1 unit of P1
   - Do not set a price list

- Confirm the sales order (SO)
- Go to the generated purchase order (PO) and confirm it
- Go to the dropshipping delivery and confirm it
- Return to the sales order (SO)
- Cancel the SO
- Set it to quotation and add the price list

**Problem:**
A traceback is triggered:
```
    ids = tuple(item.id for item in sorted(self, key=key, reverse=reverse))
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'NewId' and 'NewId'
```

opw-4123825
