### PR TITLE
[FIX] spreadsheet: do not reload pivot when it is not necessary

### DIFF
--- a/addons/spreadsheet/static/src/pivot/pivot_model.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_model.js
@@ -70,8 +70,10 @@ export class OdooPivotModel extends PivotModel {
     updateMeasures(measures) {
         for (const measure of this.definition.measures) {
             const updatedMeasure = measures.find((m) => m.id === measure.id);
+            if (!updatedMeasure || updatedMeasure.computedBy) {
+                continue;
+            }
             if (
-                !updatedMeasure ||
                 updatedMeasure.fieldName !== measure.fieldName ||
                 updatedMeasure.aggregator !== measure.aggregator
             ) {


### PR DESCRIPTION
Before this commit, the pivot was reloaded even when the user add or remove a computed measure, which does not require a new data fetch.

With this commit, the data is only re-fetched only when the user makes some changes on the measures that require a new data fetch:
- Add/remove a non-computed measure
- Update the fieldName or aggregator of a non-computed measure

Task: 4210672

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
