### PR TITLE
[FIX] point_of_sale: ensure unique product display in PoS

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -236,6 +236,12 @@ export class PosStore extends Reactive {
             ]);
         }
 
+        for (const product of this.models["product.product"].filter(
+            (p) => !productIds.has(p.id) && p.product_template_variant_value_ids.length > 0
+        )) {
+            productByTmplId[product.raw.product_tmpl_id].push(product);
+        }
+
         for (const products of Object.values(productByTmplId)) {
             const nbrProduct = products.length;
 


### PR DESCRIPTION
Before this commit, product variants not initially loaded but fetched during the processing of product attributes would remain visible, leading to duplicate product displays.

opw-4246879

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
