### PR TITLE
[FIX] base: give has_group access to internal user


### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1138,7 +1138,7 @@ class Users(models.Model):
             if not user.id:
                 return False
 
-        if not (self.env.su or user == self.env.user or user._has_group('base.group_user')):
+        if not (self.env.su or user == self.env.user or self.env.user._has_group('base.group_user')):
             # this prevents RPC calls from non-internal users to retrieve
             # information about other users
             raise AccessError(_("You can ony call user.has_group() with your current user."))


### PR DESCRIPTION
The code comment says non-internal users should not have access to
has_group if it's not for themselves. But the code checked the group
of the targetted user, not the current user.

Added test failed without fix failed because an AssertError was not
raised, and an AssertError was raised when it should not have.

note: found when reviewing 18.0 forward-port of d0828eecf60f7c8622d6875b

opw-4096073
