### PR TITLE
[FIX] l10n_latam_invoice_document: Retain the current document type if available in options

### DIFF
--- a/addons/l10n_latam_invoice_document/models/account_move.py
+++ b/addons/l10n_latam_invoice_document/models/account_move.py
@@ -212,6 +212,8 @@ class AccountMove(models.Model):
                 document_types = document_types.filtered(lambda x: x.internal_type not in ['credit_note'])
             if rec.debit_origin_id:
                 document_types = document_types.filtered(lambda x: x.internal_type == 'debit_note')
+            if rec.l10n_latam_document_type_id in document_types:
+                document_types = rec.l10n_latam_document_type_id
             rec.l10n_latam_document_type_id = document_types and document_types[0].id
 
     @api.constrains('name', 'partner_id', 'company_id', 'posted_before')


### PR DESCRIPTION
- Added a condition to check if the current l10n_latam_document_type_id is already among the available document types options.
- If the current document type is available, it is retained, and a new document type is not selected.

Description of the issue/feature this PR addresses:
Currently, when selecting document types for invoices or refunds, the system always assigns the first available document type from the list, even if the current document type is still valid.

Current behavior before PR:
The system does not check whether the existing l10n_latam_document_type_id is still valid among the available options and always overrides it with a new document type.

Desired behavior after PR is merged:
The system will retain the current l10n_latam_document_type_id if it is still among the available l10n_latam_available_document_type_ids. Only if the current document type is no longer valid, a new document type will be selected from the filtered options.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
