### PR TITLE
[FIX] payment_authorize: fix validation currency

### DIFF
--- a/addons/payment_authorize/models/payment_provider.py
+++ b/addons/payment_authorize/models/payment_provider.py
@@ -94,18 +94,6 @@ class PaymentProvider(models.Model):
 
         return 0.01
 
-    def _get_validation_currency(self):
-        """ Override of payment to return the currency for Authorize.Net validation operations.
-
-        :return: The validation currency
-        :rtype: recordset of `res.currency`
-        """
-        res = super()._get_validation_currency()
-        if self.code != 'authorize':
-            return res
-
-        return self.available_currency_ids[0]
-
     def _authorize_get_inline_form_values(self):
         """ Return a serialized JSON of the required values to render the inline form.
 


### PR DESCRIPTION
Issue -->

The field `available_currency_ids` is an empty recordset since `authorize` supports all currencies.
We're assuming that `authorize` supports all currencies because it uses the base `_get_supported_currencies` 
method which returns all currencies.

Solution --> Return the company currency as validation currency if no currency is set on the payment provider.

opw-4252974

