### PR TITLE
[REF] pos_l10n_se: rename to l10n_se_pos

### DIFF
--- a/addons/web/tooling/_eslintignore
+++ b/addons/web/tooling/_eslintignore
@@ -329,8 +329,8 @@ addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet.js
 !pos_iot/**/*
 !pos_iot_six
 !pos_iot_six/**/*
-!pos_l10n_se
-!pos_l10n_se/**/*
+!l10n_se_pos
+!l10n_se_pos/**/*
 !pos_online_payment_self_order_preparation_display
 !pos_online_payment_self_order_preparation_display/**/*
 !pos_order_tracking_display

--- a/addons/web/tooling/_jsconfig.json
+++ b/addons/web/tooling/_jsconfig.json
@@ -77,7 +77,7 @@
             "@pos_hr_mobile/*": ["pos_hr_mobile/static/src/*"],
             "@pos_iot/*": ["pos_iot/static/src/*"],
             "@pos_iot_six/*": ["pos_iot_six/static/src/*"],
-            "@pos_l10n_se/*": ["pos_l10n_se/static/src/*"],
+            "@l10n_se_pos/*": ["l10n_se_pos/static/src/*"],
             "@pos_online_payment_self_order_preparation_display/*": [
                 "pos_online_payment_self_order_preparation_display/static/src/*"
             ],


### PR DESCRIPTION
In this commit:
===
Renamed the module from pos_l10n_se to l10n_se_pos for consistency with naming conventions.

task-4107545

Related: https://github.com/odoo/enterprise/pull/72249
Related: https://github.com/odoo/upgrade/pull/6634
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
