### PR TITLE
[FIX] html_editor: traceback on cropped image

### DIFF
--- a/addons/html_editor/static/src/main/media/image_crop.js
+++ b/addons/html_editor/static/src/main/media/image_crop.js
@@ -53,13 +53,25 @@ export class ImageCrop extends Component {
             capture: true,
         });
 
-        onMounted(this.show);
+        onMounted(() => {
+            this.hasModifiedImageClass = this.media.classList.contains("o_modified_image_to_save");
+            if (this.hasModifiedImageClass) {
+                this.media.classList.remove("o_modified_image_to_save");
+            }
+            this.show();
+        });
         onWillDestroy(this.closeCropper);
     }
 
     closeCropper() {
         this.cropper?.destroy?.();
         this.media.setAttribute("src", this.initialSrc);
+        if (
+            this.hasModifiedImageClass &&
+            !this.media.classList.contains("o_modified_image_to_save")
+        ) {
+            this.media.classList.add("o_modified_image_to_save");
+        }
         this.props?.onClose?.();
     }
 


### PR DESCRIPTION
**Current behavior before PR:**

After modifying an image, clicking any cropper button generated a traceback.
this occurred because clicking the button triggered a blur event, and tries to
save modified image in saveModifiedImage method.
In the saveModifiedImage method, the image src was split. However, since the
cropper container was open, the image had its original src rather than the
cropped one. As a result, attempting to split the original src caused the
traceback.

**Desired behavior after PR is merged:**

Now, before opening the cropper, the o_modified_image_to_save class will be
removed from the image. This ensures that when blur events are triggered by
clicking the cropper buttons, the savePendingImages method does not call
saveModifiedImage to save the image and once the cropper is closed, the
o_modified_image_to_save class will be added back to the image if it is
not already present.

task:4263575

