### PR TITLE
[FIX] website: fix visibility option value for relational field

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -1385,7 +1385,7 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
                     const inputsInDependencyContainer = dependencyContainerEl.querySelectorAll('.s_website_form_input');
                     for (const el of inputsInDependencyContainer) {
                         const button = document.createElement('we-button');
-                        button.textContent = el.value;
+                        button.textContent = el.labels[0].textContent;
                         button.dataset.selectDataAttribute = el.value;
                         selectOptEl.append(button);
                     }

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -293,6 +293,25 @@ odoo.define('website.tour.form_editor', function (require) {
                         ":has(.checkbox:has(label:contains('Wiko Stairway')):has(input[type='checkbox'][required]))",
             run: function () {},
         },
+        // Check conditional visibility for the relational fields
+        ...selectButtonByData("data-set-visibility='conditional'"),
+        ...selectButtonByData("data-set-visibility-dependency='recipient_ids'"),
+        ...selectButtonByText("Is not equal to"),
+        ...selectButtonByText("Mitchell Admin"),
+        ...wTourUtils.clickOnSave(),
+        {
+            content: "Check 'products' field is visible.",
+            trigger: `iframe .s_website_form:has(${triggerFieldByLabel("Products")}:visible)`,
+            run: () => {}, // it's a check
+        }, {
+            content: "choose the option 'Mitchell Admin' of partner.",
+            trigger: "iframe .checkbox:has(label:contains('Mitchell Admin')) input[type='checkbox']",
+        }, {
+            content: "Check 'products' field is not visible.",
+            trigger: "iframe .s_website_form" +`:has(${triggerFieldByLabel("Products")}:not(:visible))`,
+            run: () => {}, // it's a check
+        },
+        ...wTourUtils.clickOnEditAndWaitEditMode(),
 
         ...addCustomField('selection', 'radio', 'Service', true),
         {


### PR DESCRIPTION
Step to reproduce.
1. Drag and drop a Contact Us Form
2. Select the form action as : " Apply for Job"
3. Select a field Type : "Activities" or "Kanban Stage"
4. Now on other field set visibility depending on this field
5. Now set the visibility options.
-> Visibility value shows ID instead actual value/name.

Prior to this commit, fields with conditional visibility showed the
record's ID instead of its display name when the dependent field was a
checkbox or radio button.

This commit fix the issue by displaying the displayName of the record
instead ID.

task-4267217