### PR TITLE
[FIX] point_of_sale: fix traceback when user close register having draft orders

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -137,7 +137,7 @@ class PosOrder(models.Model):
             line = line[2]
 
             if line.get('combo_line_ids'):
-                filtered_lines = list(filter(lambda l: l[2].get('id') and l[2].get('id') in line.get('combo_line_ids'), order_vals['lines']))
+                filtered_lines = list(filter(lambda l: l[0] in [0, 1] and l[2].get('id') and l[2].get('id') in line.get('combo_line_ids'), order_vals['lines']))
                 acc[line['uuid']] = [l[2]['uuid'] for l in filtered_lines]
 
             line['combo_line_ids'] = False


### PR DESCRIPTION
A traceback occurs when the user tries to close a register having the draft orders.

To reproduce this issue:

1) Open a `furniture register` in the POS
2) Add a `combo product` and close the register
3) Click on Review Orders and delete the existing orders 
4) Now click on the `Back` button and repeat steps 2 and 3 
5) An error occurred in the terminal

Error:-
 ```
IndexError: list index out of range
```

In the `_prepare_combo_line_uuids` the `order_vals['lines']` contains multiple lines. 
For each line, there are two data possibilities of data.

If line[0] contains 0 or 1, the data should be like `[0, 0, {.......}]`, 
if the line[0] doesn't contain 0 or 1 the data should be like `[3, 4]`.

Clearly, it leads to a traceback when the filter is used in `order_vals['lines']` 
and tries to access 2nd index through lambda.

https://github.com/odoo/odoo/blob/82867bc13ea2beb50234ad6e23717ad61d047e7c/addons/point_of_sale/models/pos_order.py#L133-L140

Adding an extra check in the filter will resolve this issue.

sentry-5990190061
