### PR TITLE
[FIX] mail: public channel invitation on mobile showing thread over welcome page

### DIFF
--- a/addons/mail/static/src/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/core/public_web/thread_model_patch.js
@@ -70,7 +70,11 @@ patch(Thread.prototype, {
         if (pushState) {
             this.setActiveURL();
         }
-        if (this.store.env.services.ui.isSmall && this.model !== "mail.box") {
+        if (
+            this.store.env.services.ui.isSmall &&
+            this.model !== "mail.box" &&
+            !this.store.shouldDisplayWelcomeViewInitially
+        ) {
             this.open();
         }
     },


### PR DESCRIPTION
**Current behavior before PR:**

Opening a public channel invitation on mobile showed the thread instead of the welcome page because ui.isSmall triggered the thread to open over it.
Before / After
<p>
  <img src="https://github.com/user-attachments/assets/4665efff-3732-4613-a04b-ac78105467d1" width="200px" />
  <img src="https://github.com/user-attachments/assets/34225a7b-f07e-42f7-ac8e-f8fdf5f8b710" width="200px" />
</p>



**Desired behavior after PR is merged:**

This PR ensures that the welcome page is displayed first.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
