### PR TITLE
[FIX] l10n_in_withholding: handle operations on false values

### DIFF
--- a/addons/l10n_in_withholding/models/l10n_in_section_alert.py
+++ b/addons/l10n_in_withholding/models/l10n_in_section_alert.py
@@ -32,7 +32,7 @@ class L10nInSectionAlert(models.Model):
     @api.depends('tax_source_type')
     def _compute_display_name(self):
         for record in self:
-            record.display_name = f"{record.tax_source_type.upper()} {record.name}"
+            record.display_name = f"{record.tax_source_type.upper()} {record.name or ''}" if record.tax_source_type else f"{record.name or ''}"
 
     def _get_warning_message(self):
         warning = ", ".join(self.mapped('name'))

--- a/addons/l10n_in_withholding/wizard/l10n_in_withhold_wizard.py
+++ b/addons/l10n_in_withholding/wizard/l10n_in_withhold_wizard.py
@@ -14,7 +14,7 @@ class L10nInWithholdWizard(models.TransientModel):
     def default_get(self, fields_list):
         result = super().default_get(fields_list)
         active_model = self._context.get('active_model')
-        active_ids = self._context.get('active_ids')
+        active_ids = self._context.get('active_ids', [])
         if len(active_ids) > 1:
             raise UserError(_("You can only create a withhold for only one record at a time."))
         if active_model not in ('account.move', 'account.payment') or not active_ids:


### PR DESCRIPTION
Added a check for `tax_source_type` and  in the `_compute_display_name` method to handle cases where these fields may be `False` for new records. This prevents errors caused by calling `upper()` on a `False` value.

Added a check on active_ids to prevent calling `len()` on empty value
