### PR TITLE
[FIX] sale,account: fix warning class issue

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
@@ -203,8 +203,6 @@ export class ProductLabelSectionAndNoteField extends Many2OneField {
             return "fw-bold";
         } else if (this.isNote()) {
             return "fst-italic";
-        } else if (!this.productName) {
-            return "text-warning";
         }
         return "";
     }

--- a/addons/sale/static/src/js/sale_product_field.js
+++ b/addons/sale/static/src/js/sale_product_field.js
@@ -130,9 +130,23 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
     get isCombo() {
         return this.props.record.data.product_type === 'combo';
     }
+    get isDownpayment() {
+        return this.props.record.data.is_downpayment;
+    }
 
     get configurationButtonHelp() {
         return _t("Edit Configuration");
+    }
+
+    /**
+     * @override
+     */
+    get sectionAndNoteClasses() {
+        const className = super.sectionAndNoteClasses;
+        if (!className && !this.productName && !this.isDownpayment) {
+            return "text-warning";
+        }
+        return className;
     }
 
     onClick(ev) {


### PR DESCRIPTION
Purpose of this commit to remove warning class on
product section and note widget when it's not a
necessary.

This commit move warning class code from account to sale as product field is not require on invoice
lines and user can confirm invoice without product so there is no need to add warning class on invoice also add condition in sale to not display warning
class on down payment lines.
