### PR TITLE
[IMP] website_editor: autosave custom snippet when drag and drap

### DIFF
--- a/addons/test_website/static/tests/tours/custom_snippets.js
+++ b/addons/test_website/static/tests/tours/custom_snippets.js
@@ -10,7 +10,8 @@ const wTourUtils = require('website.tour_utils');
  * -> drag a banner into page content
  * -> customize banner (set text)
  * -> save banner as custom snippet
- * -> confirm save
+ * -> rename custom snippet
+ * -> check if auto save works and rename snippet
  * -> ensure custom snippet is available
  * -> drag custom snippet
  * -> ensure block appears as banner
@@ -61,13 +62,17 @@ wTourUtils.registerWebsitePreviewTour('test_custom_snippet', {
         extra_trigger: ".oe_snippet[name='Custom Banner'] .oe_snippet_thumbnail:not(.o_we_already_dragging)",
     },
     {
-        content: "set name",
+        content: "set name of custom snippet",
         trigger: ".oe_snippet[name='Custom Banner'] input",
-        run: "text Bruce Banner",
+        run: function () {
+            const inputEl = document.querySelector("input.text-start");
+            inputEl.value = "Bruce Banner";
+            inputEl.dispatchEvent(new Event("focusout"));
+        },
     },
     {
-        content: "confirm rename",
-        trigger: ".oe_snippet[name='Custom Banner'] we-button.o_we_confirm_btn",
+        content: "check if the snippet is auto-saved when the focus is removed from the input field",
+        trigger: ".oe_snippet[name='Bruce Banner']",
     },
     {
         content: "drop custom snippet",

--- a/addons/web_editor/models/ir_ui_view.py
+++ b/addons/web_editor/models/ir_ui_view.py
@@ -501,6 +501,8 @@ class IrUiView(models.Model):
         key = snippet_view.key.split('.')[1]
         custom_key = self._get_snippet_addition_view_key(template_key, key)
         snippet_addition_view = self.search([('key', '=', custom_key)])
+        if not name or snippet_addition_view.name.split()[0] == name:
+            return False
         if snippet_addition_view:
             snippet_addition_view.name = name + ' Block'
         snippet_view.name = name

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -4134,24 +4134,19 @@ var SnippetsMenu = Widget.extend({
         $snippet.find('.oe_snippet_thumbnail').addClass('o_we_already_dragging'); // prevent drag
         const confirmButtonClickHandler = async () => {
             const name = $textInput[0].value.trim();
-            if (name && name !== snippetName) {
-                this._execWithLoadingEffect(async () => {
-                    await this._rpc({
-                        model: 'ir.ui.view',
-                        method: 'rename_snippet',
-                        kwargs: {
-                            'name': name,
-                            'view_id': parseInt(ev.target.dataset.snippetId),
-                            'template_key': this.options.snippets,
-                        },
-                    });
-                }, true);
-            }
-            this._loadSnippetsTemplates(true);
-            // setTimeout(async () => {
-            //     await this._loadSnippetsTemplates(name && name !== snippetName);
-            // }, 100);
-        };
+            this._execWithLoadingEffect(async () => {
+                await this._rpc({
+                    model: 'ir.ui.view',
+                    method: 'rename_snippet',
+                    kwargs: {
+                        'name': name,
+                        'view_id': parseInt(ev.target.dataset.snippetId),
+                        'template_key': this.options.snippets,
+                    },
+                });
+            }, true);
+            await this._loadSnippetsTemplates(name !== snippetName);
+        }
 
         $textInput[0].addEventListener("focusout", confirmButtonClickHandler);
         $input[0].querySelector(".o_we_cancel_btn").addEventListener("mousedown", async () => {

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -4117,13 +4117,11 @@ var SnippetsMenu = Widget.extend({
     _onRenameBtnClick: function (ev) {
         const $snippet = $(ev.target).closest('.oe_snippet');
         const snippetName = $snippet.attr('name');
-        const confirmText = _t('Confirm');
         const cancelText = _t('Cancel');
         const $input = $(`
             <we-input class="o_we_user_value_widget w-100 mx-1">
                 <div>
                     <input type="text" autocomplete="chrome-off" value="${snippetName}" class="text-start"/>
-                    <we-button class="o_we_confirm_btn o_we_text_success fa fa-check" title="${confirmText}"></we-button>
                     <we-button class="o_we_cancel_btn o_we_text_danger fa fa-times" title="${cancelText}"></we-button>
                 </div>
             </we-input>
@@ -4134,9 +4132,9 @@ var SnippetsMenu = Widget.extend({
         $textInput.focus();
         $textInput.select();
         $snippet.find('.oe_snippet_thumbnail').addClass('o_we_already_dragging'); // prevent drag
-        $input.find('.o_we_confirm_btn').click(async () => {
-            const name = $textInput.val();
-            if (name !== snippetName) {
+        const confirmButtonClickHandler = async () => {
+            const name = $textInput[0].value.trim();
+            if (name && name !== snippetName) {
                 this._execWithLoadingEffect(async () => {
                     await this._rpc({
                         model: 'ir.ui.view',
@@ -4149,9 +4147,15 @@ var SnippetsMenu = Widget.extend({
                     });
                 }, true);
             }
-            await this._loadSnippetsTemplates(name !== snippetName);
-        });
-        $input.find('.o_we_cancel_btn').click(async () => {
+            this._loadSnippetsTemplates(true);
+            // setTimeout(async () => {
+            //     await this._loadSnippetsTemplates(name && name !== snippetName);
+            // }, 100);
+        };
+
+        $textInput[0].addEventListener("focusout", confirmButtonClickHandler);
+        $input[0].querySelector(".o_we_cancel_btn").addEventListener("mousedown", async () => {
+            $textInput[0].removeEventListener("focusout", confirmButtonClickHandler);
             await this._loadSnippetsTemplates(false);
         });
     },


### PR DESCRIPTION
Specification:
When a user is renaming a custom snippet and tried to drag and drop another snippet, all unsaved changes to the name gets lost.

This commit introduces a feature to autosave the name of the custom snippet. It allows both custom and other snippets to be dragged and dropped, with automatic saving of changes. Additionally, it prevents saving null names to custom snippets.

task-3581814
