### PR TITLE
[FIX] mrp: workorder buttons in MO form view

### DIFF
--- a/addons/stock/static/src/views/list/auto_column_width_list_renderer.js
+++ b/addons/stock/static/src/views/list/auto_column_width_list_renderer.js
@@ -1,17 +1,8 @@
 /** @odoo-module **/
 
 import { ListRenderer } from "@web/views/list/list_renderer";
-import { useEffect } from "@odoo/owl";
 
 export class AutoColumnWidthListRenderer extends ListRenderer {
     static props = [...ListRenderer.props];
-    setup() {
-        super.setup();
-        useEffect(
-            () => {
-                this.keepColumnWidths = false;
-            },
-            () => [this.columns]
-        );
-    }
+    static useMagicColumnWidths = false;
 }

--- a/addons/web/static/src/views/list/column_width_hook.js
+++ b/addons/web/static/src/views/list/column_width_hook.js
@@ -300,8 +300,13 @@ export function useMagicColumnWidths(tableRef, getState) {
         // When a vertical scrollbar appears/disappears, it may (depending on the browser/os) change
         // the available width. When it does, we want to keep the current widths, but tweak them a
         // little bit s.t. the table fits in the new available space.
-        if (!columnWidths || allowedWidthDiff > 0) {
-            columnWidths = computeWidths(table, state, allowedWidth, columnWidths);
+        if (!columnWidths || allowedWidthDiff > 0 || !renderer.constructor.useMagicColumnWidths) {
+            columnWidths = computeWidths(
+                table,
+                state,
+                allowedWidth,
+                renderer.constructor.useMagicColumnWidths ? columnWidths : false
+            );
         }
 
         // Set the computed widths in the DOM.
@@ -410,15 +415,12 @@ export function useMagicColumnWidths(tableRef, getState) {
         }
     }
 
-    // Side effects
-    if (renderer.constructor.useMagicColumnWidths) {
-        useEffect(forceColumnWidths);
-        const debouncedResizeCallback = useDebounced(() => {
-            resetWidths();
-            forceColumnWidths();
-        }, 200);
-        useExternalListener(window, "resize", debouncedResizeCallback);
-    }
+    useEffect(forceColumnWidths);
+    const debouncedResizeCallback = useDebounced(() => {
+        resetWidths();
+        forceColumnWidths();
+    }, 200);
+    useExternalListener(window, "resize", debouncedResizeCallback);
 
     // API
     return {


### PR DESCRIPTION
The column containing the buttons start/pause/stop does not recompute it's size when one of the button appears/disappears, but it does when the column/the page is resized.

In this fix, we revert https://github.com/odoo/odoo/pull/169177 which was not relevant anymore and we ensure to recompute the width every time if we're not using the magic column width.

![image](https://github.com/user-attachments/assets/af620f95-3933-4772-a099-452824c5cade)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
