### PR TITLE
[FIX] sale_stock: display warehouse_id on the SO by default

### DIFF
--- a/addons/sale_stock/views/sale_order_views.xml
+++ b/addons/sale_stock/views/sale_order_views.xml
@@ -21,7 +21,7 @@
                 </xpath>
                 <xpath expr="//label[@for='commitment_date']" position="before">
                     <field name="warehouse_id" invisible="1" readonly="state == 'sale'"/>  <!-- needed for js logic -->
-                    <field name="warehouse_id" options="{'no_create': True}" groups="stock.group_stock_multi_warehouses" force_save="1" readonly="state == 'sale'"/>
+                    <field name="warehouse_id" options="{'no_create': True}" force_save="1" readonly="state == 'sale'"/>
                     <field name="incoterm" options="{'no_open': True, 'no_create': True}"/>
                     <field name="incoterm_location"/>
                     <field name="picking_policy" required="True" readonly="state not in ['draft', 'sent']"/>


### PR DESCRIPTION
### Steps to reproduce:
- Create a new company and select it
- Create a SO for an Good and try to confirm
> you raise a redirect warning to create a warehouse
- Proceed and create a warehouse
- Try to confirm the SO once more
#### > Since the newly created warehouse was not set on the SO you raise a user Error:
#### > 'You must set a warehouse on your sale order to proceed.'

### Issue:

The 'warehouse_id' should be visible on the SO for it to be set but it is not.

### Cause of the issue:

The field is actually present in the view as soon as your have 2 WH in your company:
https://github.com/odoo/odoo/blob/73a62537c4010831cfab4be40f91dba9c56c2175/addons/sale_stock/views/sale_order_views.xml#L24 https://github.com/odoo/odoo/blob/73a62537c4010831cfab4be40f91dba9c56c2175/addons/stock/models/stock_warehouse.py#L321-L336

opw-4250791
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
