### PR TITLE
[IMP] web, project: add widget to getPropertyFieldInfo function

### DIFF
--- a/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_list.js
+++ b/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_list.js
@@ -45,7 +45,11 @@ export class SubtaskKanbanList extends Component {
     get fieldInfo() {
         return {
             state: {
-                ...getPropertyFieldInfo({ name: "state", type: "project_task_state_selection" }),
+                ...getPropertyFieldInfo({
+                    name: "state",
+                    type: "selection",
+                    widget: "project_task_state_selection",
+                }),
                 viewType: "kanban",
             },
         };

--- a/addons/web/static/src/views/fields/field.js
+++ b/addons/web/static/src/views/fields/field.js
@@ -129,13 +129,13 @@ export function fieldVisualFeedback(field, record, fieldName, fieldInfo) {
 }
 
 export function getPropertyFieldInfo(propertyField) {
-    const { name, relatedPropertyField, string, type } = propertyField;
+    const { name, relatedPropertyField, string, type, widget } = propertyField;
 
     const fieldInfo = {
         name,
         string,
         type,
-        widget: type,
+        widget: widget || type,
         options: {},
         column_invisible: "False",
         invisible: "False",


### PR DESCRIPTION
Until now, if a widget needed to be specified for the renderer, a hack was needed, the widget needed to be set as a field type. The task 4224192 aim to add a warning when using a widget on a wrong field (field type) and the current hack will raise the warning.

This commit adds widget, a new parameter, to the getPropertyFieldInfo function. This parameter, will allow specifying the widget that we want to use on the fieldInfo.

task-id: 4224192