### PR TITLE
[FIX] base,web: kanban-box: add server-side deprec warning

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_arch_parser.js
+++ b/addons/web/static/src/views/kanban/kanban_arch_parser.js
@@ -150,7 +150,7 @@ export class KanbanArchParser {
         let cardDoc = templateDocs[KANBAN_CARD_ATTRIBUTE];
         const isLegacyArch = !cardDoc;
         if (isLegacyArch) {
-            console.warn("'kanban-box' is deprecated, use 'kanban-card' API instead");
+            console.warn("'kanban-box' is deprecated, define a 'card' template instead");
         }
         if (!cardDoc) {
             cardDoc = templateDocs[LEGACY_KANBAN_BOX_ATTRIBUTE];

--- a/addons/web/static/tests/views/kanban/kanban_color_picker_legacy.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_color_picker_legacy.test.js
@@ -40,7 +40,7 @@ beforeEach(() => {
     const originalConsoleWarn = console.warn;
     patchWithCleanup(console, {
         warn: (msg) => {
-            if (msg !== "'kanban-box' is deprecated, use 'kanban-card' API instead") {
+            if (msg !== "'kanban-box' is deprecated, define a 'card' template instead") {
                 originalConsoleWarn(msg);
             }
         },

--- a/addons/web/static/tests/views/kanban/kanban_view_legacy.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view_legacy.test.js
@@ -189,7 +189,7 @@ beforeEach(() => {
     const originalConsoleWarn = console.warn;
     patchWithCleanup(console, {
         warn: (msg) => {
-            if (msg !== "'kanban-box' is deprecated, use 'kanban-card' API instead") {
+            if (msg !== "'kanban-box' is deprecated, define a 'card' template instead") {
                 originalConsoleWarn(msg);
             }
         },
@@ -2118,7 +2118,7 @@ test("action/type attributes on kanban arch, type='action'", async () => {
 test("Missing t-key is automatically filled with a warning", async () => {
     patchWithCleanup(console, {
         warn: (msg) => {
-            if (msg !== "'kanban-box' is deprecated, use 'kanban-card' API instead") {
+            if (msg !== "'kanban-box' is deprecated, define a 'card' template instead") {
                 expect.step("warning");
             }
         },

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1480,7 +1480,11 @@ actual arch.
     # Node validator
     #------------------------------------------------------
     def _validate_tag_form(self, node, name_manager, node_info):
-        pass
+        self._validate_tag_kanban(node, name_manager, node_info)
+
+    def _validate_tag_kanban(self, node, name_manager, node_info):
+        if node.xpath("//t[@t-name='kanban-box']"):
+            _logger.warning("'kanban-box' is deprecated, define a 'card' template instead")
 
     def _validate_tag_list(self, node, name_manager, node_info):
         # reuse form view validation


### PR DESCRIPTION
A new API for kanban templates has been introduced in [1], which deprecates the former API (the one defining a "kanban-box" template). A client side warning has been added when a legacy kanban view was met. However, there was a lack of server side warning, especially when a legacy kanban arch was introduced. This commit adds this warning.

More information about the new Kanban API can be found in the documentation [2].

[1] https://github.com/odoo/odoo/pull/167751
[2] https://www.odoo.com/documentation/master/developer/reference/user_interface/view_architectures.html#kanban

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
