### PR TITLE
[FIX] web_editor: remove border-color from forced grouped styles

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -45,7 +45,6 @@ const GROUPED_STYLES = {
     border: [
         "border-top-width", "border-right-width", "border-bottom-width", "border-left-width",
         "border-top-style", "border-right-style", "border-bottom-style", "border-left-style",
-        "border-top-color", "border-right-color", "border-bottom-color", "border-left-color",
     ],
     padding: ["padding-top", "padding-bottom", "padding-left", "padding-right"],
     margin: ["margin-top", "margin-bottom", "margin-left", "margin-right"],
@@ -1639,13 +1638,6 @@ function _getMatchedCSSRules(node, cssRules, checkBlacklisted = false) {
         delete processedStyle['border-bottom-right-radius'];
         delete processedStyle['border-top-left-radius'];
         delete processedStyle['border-top-right-radius'];
-    }
-    if (processedStyle['border-left-color']) {
-        processedStyle['border-color'] = processedStyle['border-left-color'];
-        delete processedStyle['border-right-color'];
-        delete processedStyle['border-bottom-color'];
-        delete processedStyle['border-top-color'];
-        delete processedStyle['border-left-color'];
     }
     if (processedStyle['border-left-width']) {
         processedStyle['border-width'] = processedStyle['border-left-width'];

--- a/addons/web_editor/static/tests/convert_inline_tests.js
+++ b/addons/web_editor/static/tests/convert_inline_tests.js
@@ -635,9 +635,9 @@ QUnit.module('convert_inline', {}, function () {
         // Some positional properties (eg., padding-right, margin-left) are not
         // concatenated (eg., as padding, margin) because they were defined with
         // variables (var) or calculated (calc).
-        const containerStyle = `border-width: 0px; border-color: rgb(55, 65, 81); border-radius: 0px; border-style: none; margin: 0px auto; box-sizing: border-box; max-width: 1320px; padding-left: 16px; padding-right: 16px; width: 100%;`;
-        const rowStyle = `border-width: 0px; border-color: rgb(55, 65, 81); border-radius: 0px; border-style: none; padding: 0px; box-sizing: border-box; margin-left: -16px; margin-right: -16px; margin-top: 0px;`;
-        const colStyle = `border-width: 0px; border-color: rgb(55, 65, 81); border-radius: 0px; border-style: none; box-sizing: border-box; margin-top: 0px; padding-left: 16px; padding-right: 16px; max-width: 100%; width: 100%;`;
+        const containerStyle = `border-width: 0px; border-radius: 0px; border-style: none; margin: 0px auto; box-sizing: border-box; max-width: 1320px; padding-left: 16px; padding-right: 16px; width: 100%;`;
+        const rowStyle = `border-width: 0px; border-radius: 0px; border-style: none; padding: 0px; box-sizing: border-box; margin-left: -16px; margin-right: -16px; margin-top: 0px;`;
+        const colStyle = `border-width: 0px; border-radius: 0px; border-style: none; box-sizing: border-box; margin-top: 0px; padding-left: 16px; padding-right: 16px; max-width: 100%; width: 100%;`;
         assert.strictEqual($editable.html(),
             `<div class="container" style="${containerStyle}" width="100%">` +
             `<div class="row" style="${rowStyle}">` +
@@ -1001,7 +1001,7 @@ QUnit.module('convert_inline', {}, function () {
         $iframeEditable.append(`<div class="o_layout" style="padding: 50px;"></div>`);
         convertInline.classToStyle($iframeEditable, convertInline.getCSSRules($iframeEditable[0].ownerDocument));
         assert.strictEqual($iframeEditable.html(),
-            `<div class="o_layout" style="border-width:0px;border-color:rgb(255, 255, 255);border-radius:0px;border-style:none;margin:0px;box-sizing:border-box;font-size:50px;color:white;background-color:red;padding: 50px;"></div>`,
+            `<div class="o_layout" style="border-width:0px;border-radius:0px;border-style:none;margin:0px;box-sizing:border-box;font-size:50px;color:white;background-color:red;padding: 50px;"></div>`,
             "should have given all styles of body to .o_layout");
         styleSheet.deleteRule(0);
 


### PR DESCRIPTION
Issue:
======
- The border-color of the table is different in light mode and dark mode.
- convert_inline_test which have the border-color fails because it depends
  if we are in enterprise or community. Issue [1].

Steps to reproduce the issue:
=============================
- Go to any record with chatter
- Switch dark mode
- Add a table
- Log it
- Switch light mode
- The border-color is different than a table added in light mode.

Origin of the issue:
====================
We already have a commit [2] that removes the border-colors from the
cssRules since it really depends on the mode. After this [3] we forced
to apply the border-color from the computed value which will be wrong.

Solution:
=========
We remove the border-color from the forced styles.

[1]: https://runbot.odoo.com/web#id=103155&view_type=form&model=runbot.build.error&menu_id=405&cids=1
[2]: https://github.com/odoo/odoo/commit/16ab970fa33119a4fc1a9c5dd249ca467ff3b2c8
[3]: https://github.com/odoo/odoo/commit/1e654e8f7e0a403a25b595be410614dfc8a69179