### PR TITLE
[FIX] account: Fix dispatching on negative lines

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -2376,17 +2376,8 @@ class AccountTax(models.Model):
             def get_tax_key(tax_data):
                 return frozendict({'tax': tax_data['tax'], 'is_reverse_charge': tax_data['is_reverse_charge']})
 
-            base_line_fields = (
-                'total_excluded_currency', 'raw_total_excluded_currency',
-                'total_excluded', 'raw_total_excluded',
-                'total_included_currency', 'raw_total_included_currency',
-                'total_included', 'raw_total_included',
-                'delta_base_amount_currency', 'delta_base_amount',
-            )
-            tax_data_fields = (
-                'base_amount_currency', 'base_amount', 'tax_amount_currency', 'tax_amount',
-                'raw_base_amount_currency', 'raw_base_amount', 'raw_tax_amount_currency', 'raw_tax_amount',
-            )
+            base_line_fields = ('total_excluded_currency', 'total_excluded', 'total_included_currency', 'total_included')
+            tax_data_fields = ('base_amount_currency', 'base_amount', 'tax_amount_currency', 'tax_amount')
 
             if is_zero:
                 for field in base_line_fields:

--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -470,9 +470,9 @@ class AccountMove(models.Model):
                     tax_data['base_amount'] *= 0.5
                     tax_data['base_amount_currency'] *= 0.5
 
-        AccountTax._round_base_lines_tax_details(base_lines, self.company_id, tax_lines=tax_lines)
         dispatched_results = self.env['account.tax']._dispatch_negative_lines(base_lines)
         base_lines = dispatched_results['result_lines'] + dispatched_results['orphan_negative_lines']
+        AccountTax._round_base_lines_tax_details(base_lines, self.company_id, tax_lines=tax_lines)
         base_lines_aggregated_values = AccountTax._aggregate_base_lines_tax_details(base_lines, self._l10n_it_edi_grouping_function_base_lines)
         self._l10n_it_edi_add_base_lines_xml_values(base_lines_aggregated_values, is_downpayment)
         base_lines = sorted(base_lines, key=lambda base_line: base_line['it_values']['numero_linea'])


### PR DESCRIPTION
The method '_round_base_lines_tax_details' must be called after the dispatching of negative lines. Suppose a line has a delta due to round globally with price included taxes.
 Then this line is refunded completely by a line without a delta.
The current delta is lost and probably should go to another line.

task-id: 4261885

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
