### PR TITLE
[IMP] web: add char as supported types in text widget

### DIFF
--- a/addons/web/static/src/views/fields/text/text_field.js
+++ b/addons/web/static/src/views/fields/text/text_field.js
@@ -104,7 +104,7 @@ export const textField = {
             default: true,
         },
     ],
-    supportedTypes: ["html", "text"],
+    supportedTypes: ["html", "text", "char"],
     extractProps: ({ attrs, options }) => ({
         placeholder: attrs.placeholder,
         dynamicPlaceholder: options?.dynamic_placeholder || false,

--- a/addons/web/static/tests/views/fields/text_field.test.js
+++ b/addons/web/static/tests/views/fields/text_field.test.js
@@ -48,6 +48,19 @@ test("doesn't have a scrollbar with long content", async () => {
     expect(textarea.clientHeight).toBe(textarea.scrollHeight);
 });
 
+test("basic rendering char field", async () => {
+    Product._fields.name = fields.Char();
+    Product._records = [{ id: 1, name: "Description\nas\ntext" }];
+    await mountView({
+        type: "form",
+        resModel: "product",
+        resId: 1,
+        arch: '<form><field name="name" widget="text"/></form>',
+    });
+    expect(".o_field_text textarea").toHaveCount(1);
+    expect(".o_field_text textarea").toHaveValue("Description\nas\ntext");
+});
+
 test("render following an onchange", async () => {
     Product._fields.name = fields.Char({
         onChange: (record) => {


### PR DESCRIPTION
This commit adds the char fields as a supported type for the text widget. Note that, the text widget is already in use for char fields in the code. Also, since [1], the text widget could be used to have a multi-line char field, without line breaks.

[1]: https://github.com/odoo/odoo/commit/eaacaf122dff62adcdf885f0ffdcb4a506bded27

task-id: 4224192
