### PR TITLE
[PERF] sale_stock: add small cache for downpayment

### DIFF
--- a/addons/sale_stock/models/account_move.py
+++ b/addons/sale_stock/models/account_move.py
@@ -112,6 +112,13 @@ class AccountMove(models.Model):
 
         return res
 
+    def _get_anglo_saxon_price_ctx(self):
+        ctx = super()._get_anglo_saxon_price_ctx()
+        move_is_downpayment = self.invoice_line_ids.filtered(
+            lambda line: any(line.sale_line_ids.mapped("is_downpayment"))
+        )
+        return dict(ctx, move_is_downpayment=move_is_downpayment)
+
 
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
@@ -125,13 +132,17 @@ class AccountMoveLine(models.Model):
         price_unit = super(AccountMoveLine, self)._stock_account_get_anglo_saxon_price_unit()
 
         so_line = self.sale_line_ids and self.sale_line_ids[-1] or False
-        down_payment = self.move_id.invoice_line_ids.filtered(lambda line: any(line.sale_line_ids.mapped('is_downpayment')))
+        move_is_downpayment = self.env.context.get("move_is_downpayment")
+        if move_is_downpayment is None:
+            move_is_downpayment = self.move_id.invoice_line_ids.filtered(
+            lambda line: any(line.sale_line_ids.mapped("is_downpayment"))
+        )
         if so_line:
             is_line_reversing = False
-            if self.move_id.move_type == 'out_refund' and not down_payment:
+            if self.move_id.move_type == 'out_refund' and not move_is_downpayment:
                 is_line_reversing = True
             qty_to_invoice = self.product_uom_id._compute_quantity(self.quantity, self.product_id.uom_id)
-            if self.move_id.move_type == 'out_refund' and down_payment:
+            if self.move_id.move_type == 'out_refund' and move_is_downpayment:
                 qty_to_invoice = -qty_to_invoice
             account_moves = so_line.invoice_lines.move_id.filtered(lambda m: m.state == 'posted' and bool(m.reversed_entry_id) == is_line_reversing)
 

--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -113,6 +113,8 @@ class AccountMove(models.Model):
             if not move.is_sale_document(include_receipts=True) or not move.company_id.anglo_saxon_accounting:
                 continue
 
+            anglo_saxon_price_ctx = move._get_anglo_saxon_price_ctx()
+
             for line in move.invoice_line_ids:
 
                 # Filter out lines being not eligible for COGS.
@@ -128,7 +130,7 @@ class AccountMove(models.Model):
 
                 # Compute accounting fields.
                 sign = -1 if move.move_type == 'out_refund' else 1
-                price_unit = line._stock_account_get_anglo_saxon_price_unit()
+                price_unit = line.with_context(anglo_saxon_price_ctx)._stock_account_get_anglo_saxon_price_unit()
                 amount_currency = sign * line.quantity * price_unit
 
                 if move.currency_id.is_zero(amount_currency) or float_is_zero(price_unit, precision_digits=price_unit_prec):
@@ -165,6 +167,12 @@ class AccountMove(models.Model):
                     'tax_ids': [],
                 })
         return lines_vals_list
+
+    def _get_anglo_saxon_price_ctx(self):
+        """ To be overriden in modules overriding _stock_account_get_anglo_saxon_price_unit
+        to optimize computations that only depend on account.move and not account.move.line
+        """
+        return self.env.context
 
     def _stock_account_get_last_step_stock_moves(self):
         """ To be overridden for customer invoices and vendor bills in order to


### PR DESCRIPTION
Currently when checking if an account.move has downpayments we need to call `filtered` on `self.invoice_line_ids.sale_line_ids`. This can be pretty heavy, especially in
`_stock_account_get_anglo_saxon_price_unit` as this method will be called for each account.move.line linked to the invoice being posted.

This commit introduces a small method `_get_anglo_saxon_price_ctx` that can be overriden to add data to the context 
that will be used in `_stock_account_get_anglo_saxon_price_unit`. This is done in `sale_stock` to avoid the computation of downpayments for each account.move.line.

#### Benchmark
Customer database posting an invoice with 5000 lines and 1190 linked sale.orders, products in FIFO.
Timing of `_stock_account_get_anglo_saxon_price_unit`: 10min -> 2min30.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
