### PR TITLE
[FIX] mrp: document visible on bom

### DIFF
--- a/addons/mrp/static/src/views/mrp_documents_kanban/mrp_documents_kanban_controller.js
+++ b/addons/mrp/static/src/views/mrp_documents_kanban/mrp_documents_kanban_controller.js
@@ -4,10 +4,10 @@ import { patch } from "@web/core/utils/patch";
 import { ProductDocumentKanbanController } from "@product/js/product_document_kanban/product_document_kanban_controller";
 
 patch(ProductDocumentKanbanController.prototype, {
-    buildFormData(formData) {
-        super.buildFormData(formData);
+    setup() {
+        super.setup(...arguments);
         if (this.props.context.attached_on_bom) {
-            formData.append("attached_on_bom", this.props.context.bom_id);
+            this.formData.attached_on_bom = this.props.context.bom_id;
         }
     },
 });


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/176483, the product_document_kanban_controller methods have been modified but not in MRP. The same logic will be applied to mps.

Before
------
When clicking on the document icon of a bom line, and then adding a document, the document whill shortly appear and then disappear because the visibility is not set on bom https://drive.google.com/file/d/1gXiqtU3zEoFP76ue2pk-0FHnf5MyRT-P/view

After
-----
The document visibility is set on 'bom' and the document is visible when added




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
