### PR TITLE
[FIX] website_event: allow editing of short description on Events page

### DIFF
--- a/addons/website_event/static/tests/tours/website_event.js
+++ b/addons/website_event/static/tests/tours/website_event.js
@@ -1,60 +1,97 @@
 /** @odoo-module **/
 
-    import { _t } from "@web/core/l10n/translation";
-    import wTourUtils from "@website/js/tours/tour_utils";
+import wTourUtils from "@website/js/tours/tour_utils";
 
-    import { markup } from "@odoo/owl";
+function websiteCreateEventTourSteps() {
+    return [
+        {
+            content: "Click here to add new content to your website.",
+            trigger: ".o_menu_systray .o_new_content_container > a",
+            consumeVisibleOnly: true,
+        },
+        {
+            content: "Click here to create a new event.",
+            trigger: "a[data-module-xml-id='base.module_website_event']",
+        },
+        {
+            content:
+                "Create a name for your new event and click `Continue`. e.g: Technical Training",
+            trigger: ".modal-dialog div[name='name'] input",
+            run: "text Technical Training",
+        },
+        {
+            content: "Open date range picker. Pick a Start date for your event",
+            trigger: ".modal-dialog div[name=date_begin]",
+            run: () => {
+                document.querySelector("input[data-field='date_begin']").value =
+                    "09/30/2020 08:00:00";
+                document
+                    .querySelector("input[data-field='date_begin']")
+                    .dispatchEvent(new Event("change"));
 
-    wTourUtils.registerWebsitePreviewTour("website_event_tour", {
+                document.querySelector("input[data-field='date_end']").value =
+                    "10/02/2020 23:00:00";
+                document
+                    .querySelector("input[data-field='date_end']")
+                    .dispatchEvent(new Event("change"));
+
+                document.querySelector("input[data-field='date_begin']").click();
+            },
+        },
+        {
+            content: "Click `Continue` to create the event.",
+            trigger: ".modal-footer button.btn-primary",
+            extra_trigger: ".modal-dialog input[type=text][value!='']",
+        },
+        {
+            content: "Drag this block and drop it in your page.",
+            trigger:
+                "#oe_snippets.o_loaded #snippet_structure .oe_snippet:eq(2) .oe_snippet_thumbnail",
+            run: "drag_and_drop_native iframe #wrapwrap > main",
+        },
+        {
+            content: "Once you click on save, your event is updated.",
+            trigger: "button[data-action=save]",
+            // Wait until the drag and drop is resolved (causing a history step)
+            // before clicking save.
+            extra_trigger:
+                ".o_we_external_history_buttons button[data-action=undo]:not([disabled])",
+        },
+        {
+            content: "Click to publish your event.",
+            trigger: ".o_menu_systray_item .o_switch_danger_success",
+            extra_trigger: "iframe body:not(.editor_enable)",
+        },
+    ];
+}
+
+function websiteEditEventTourSteps() {
+    return [
+        {
+            content: "Redirect to Event Page",
+            trigger: "iframe span:contains('Back to events')",
+            run: "click",
+        },
+        ...wTourUtils.clickOnEditAndWaitEditMode(),
+        {
+            content: "edit the short description of the event",
+            trigger: "iframe .o_wevent_events_list small",
+            run: "text new short description",
+        },
+        ...wTourUtils.clickOnSave(),
+        {
+            content: "is short description updated?",
+            trigger: "iframe .o_wevent_events_list small:contains('new short description')",
+            isCheck: true,
+        },
+    ];
+}
+
+wTourUtils.registerWebsitePreviewTour(
+    "website_event_tour",
+    {
         test: true,
         url: "/",
-    }, () => [{
-        content: _t("Click here to add new content to your website."),
-        trigger: ".o_menu_systray .o_new_content_container > a",
-        consumeVisibleOnly: true,
-        position: 'bottom',
-    }, {
-        trigger: "a[data-module-xml-id='base.module_website_event']",
-        content: _t("Click here to create a new event."),
-        position: "bottom",
-    }, {
-        trigger: '.modal-dialog div[name="name"] input',
-        content: markup(_t("Create a name for your new event and click <em>\"Continue\"</em>. e.g: Technical Training")),
-        run: 'text Technical Training',
-        position: "left",
-    }, {
-        trigger: '.modal-dialog div[name=date_begin]',
-        content: _t("Open date range picker. Pick a Start date for your event"),
-        run: function () {
-            $('input[data-field="date_begin"]').val('09/30/2020 08:00:00').change();
-            $('input[data-field="date_end"]').val('10/02/2020 23:00:00').change();
-            $('input[data-field="date_begin"]').click();
-        }
-    }, {
-        trigger: '.modal-footer button.btn-primary',
-        extra_trigger: '.modal-dialog input[type=text][value!=""]',
-        content: markup(_t("Click <em>Continue</em> to create the event.")),
-        position: "right",
-    }, {
-        trigger: "#oe_snippets.o_loaded #snippet_structure .oe_snippet:eq(2) .oe_snippet_thumbnail",
-        content: _t("Drag this block and drop it in your page."),
-        position: "bottom",
-        run: "drag_and_drop_native iframe #wrapwrap > main",
-    }, {
-        trigger: "button[data-action=save]",
-        content: _t("Once you click on save, your event is updated."),
-        position: "bottom",
-        // Wait until the drag and drop is resolved (causing a history step)
-        // before clicking save.
-        extra_trigger: ".o_we_external_history_buttons button[data-action=undo]:not([disabled])",
-    }, {
-        trigger: ".o_menu_systray_item .o_switch_danger_success",
-        extra_trigger: "iframe body:not(.editor_enable)",
-        content: _t("Click to publish your event."),
-        position: "top",
-    }, {
-        trigger: ".o_website_edit_in_backend > a",
-        content: _t("Click here to customize your event further."),
-        position: "bottom",
-        isCheck: true,
-    }]);
+    },
+    () => [...websiteCreateEventTourSteps(), ...websiteEditEventTourSteps()]
+);

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -345,8 +345,10 @@
                                 <span t-field="event.name" itemprop="name"/>
                             </h5>
                             <!-- Start Date & Time -->
-                            <small class="o_not_editable opacity-75" itemprop="description" t-out="event.subtitle">
+                            <!-- TODO remove t-out one in master -->
+                            <small t-if="False" class="o_not_editable opacity-75" itemprop="description" t-out="event.subtitle">
                             </small>
+                            <small class="opacity-75" itemprop="description" t-field="event.subtitle"/>
                         </div>
                         <!-- Location -->
                         <small class="o_not_editable fw-bold" itemprop="location" t-out="event.address_id" t-options="{'widget': 'contact', 'fields': ['city'], 'no_marker': 'true'}"/>


### PR DESCRIPTION
Steps to reproduce the issue:

1. Navigate to the Events page.
2. Activate the Web Editor.
3. Attempt to edit the Event's short description.

Issue: The short description of the event was previously not editable directly from the Events page. the reason behind that is they have used `t-out` instead of `t-field` in template. `t-out` lacks the necessary attributes to enable field updates.

Solution: This PR adds the necessary attributes to the short description element, making it editable from the Events page.

Updated the tour functionality to test the latest changes of Event's short description.

task-4014153
