### PR TITLE
[IMP] web: add text as supported types in char widget

### DIFF
--- a/addons/web/static/src/views/fields/char/char_field.js
+++ b/addons/web/static/src/views/fields/char/char_field.js
@@ -106,7 +106,7 @@ export class CharField extends Component {
 export const charField = {
     component: CharField,
     displayName: _t("Text"),
-    supportedTypes: ["char"],
+    supportedTypes: ["char", "text"],
     supportedOptions: [
         {
             label: _t("Dynamic placeholder"),

--- a/addons/web/static/tests/views/fields/char_field.test.js
+++ b/addons/web/static/tests/views/fields/char_field.test.js
@@ -154,6 +154,20 @@ test("char field in form view", async () => {
     });
 });
 
+test("basic rendering text field", async () => {
+    Product._fields.description = fields.Text();
+    Product._records = [{ id: 1, description: "Description as text" }];
+    await mountView({
+        type: "form",
+        resModel: "product",
+        resId: 1,
+        arch: '<form><field name="description" widget="char"/></form>',
+    });
+
+    expect(".o_field_widget input[type='text']").toHaveCount(1);
+    expect(".o_field_widget input[type='text']").toHaveValue("Description as text");
+});
+
 test("setting a char field to empty string is saved as a false value", async () => {
     expect.assertions(1);
 


### PR DESCRIPTION
This commit adds the text fields as a supported type for the char widget.

task-id: 4224192
