### PR TITLE
[FIX] pos_restaurant: remove unnecessary 'addPendingOrder' call

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/components/product_screen/product_screen.js
+++ b/addons/pos_restaurant/static/src/overrides/components/product_screen/product_screen.js
@@ -1,6 +1,6 @@
 import { ProductScreen } from "@point_of_sale/app/screens/product_screen/product_screen";
 import { patch } from "@web/core/utils/patch";
-import { onMounted, useState } from "@odoo/owl";
+import { useState } from "@odoo/owl";
 
 patch(ProductScreen.prototype, {
     /**
@@ -11,10 +11,6 @@ patch(ProductScreen.prototype, {
 
         this.uiState = useState({
             clicked: false,
-        });
-
-        onMounted(() => {
-            this.pos.addPendingOrder([this.pos.get_order().id]);
         });
     },
     get selectedOrderlineQuantity() {


### PR DESCRIPTION


Description of the issue/feature this PR addresses:
 - Rremove redundant call to `addPendingOrder`.

Current behavior before PR:

 - Currently, `addPendingOrder` is invoked once by the `point_of_sale` module, and immediately again by `pos_restaurant` [when](https://github.com/odoo/odoo/blob/875ea840b913fd31ef73df9e10e4426df6195bfc/addons/pos_restaurant/static/src/overrides/components/product_screen/product_screen.js#L16-L18) the ProductScreen component mounts.

Desired behavior after PR is merged:
 - Following the fix for #182495, the  'addPendingOrder' call in pos_restaurant becomes redundant and is no longer necessary.
 - As now we call the same function in root component.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
