### PR TITLE
[FIX] mail, *: use read format in _to_store of mock server

### DIFF
--- a/addons/im_livechat/static/tests/mock_server/mock_models/im_livechat_channel.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/im_livechat_channel.js
@@ -100,7 +100,7 @@ export class LivechatChannel extends models.ServerModel {
             fields = [];
         }
         for (const livechatChannel of this.browse(ids)) {
-            const [res] = this.read(
+            const [res] = this._read_format(
                 [livechatChannel.id],
                 fields.filter((field) => field !== "are_you_inside"),
                 false

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel_member.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel_member.js
@@ -130,7 +130,7 @@ export class DiscussChannelMember extends models.ServerModel {
         const ResPartner = this.env["res.partner"];
 
         for (const member of this.browse(ids)) {
-            const [data] = this.read(
+            const [data] = this._read_format(
                 member.id,
                 Object.keys(fields).filter(
                     (field) =>

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel_rtc_session.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel_rtc_session.js
@@ -55,7 +55,7 @@ export class DiscussChannelRtcSession extends models.ServerModel {
         const DiscussChannelMember = this.env["discuss.channel.member"];
 
         for (const rtcSession of this.browse(ids)) {
-            const [data] = this.read(rtcSession.id, [], makeKwArgs({ load: false }));
+            const [data] = this._read_format(rtcSession.id, [], makeKwArgs({ load: false }));
             data.channelMember = mailDataHelpers.Store.one(
                 DiscussChannelMember.browse(rtcSession.channel_member_id),
                 makeKwArgs({ fields: { channel: [], persona: ["name", "im_status"] } })

--- a/addons/mail/static/tests/mock_server/mock_models/ir_attachment.js
+++ b/addons/mail/static/tests/mock_server/mock_models/ir_attachment.js
@@ -53,7 +53,7 @@ export class IrAttachment extends webModels.IrAttachment {
         }
 
         for (const attachment of this.browse(ids)) {
-            const [data] = this.read(
+            const [data] = this._read_format(
                 attachment.id,
                 fields.filter((field) => !["filename", "size", "thread"].includes(field)),
                 makeKwArgs({ load: false })

--- a/addons/mail/static/tests/mock_server/mock_models/mail_canned_response.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_canned_response.js
@@ -48,6 +48,6 @@ export class MailCannedResponse extends models.ServerModel {
         if (!fields) {
             fields = ["source", "substitution"];
         }
-        store.add(this._name, this.read(ids, fields, false));
+        store.add(this._name, this._read_format(ids, fields, false));
     }
 }

--- a/addons/mail/static/tests/mock_server/mock_models/mail_followers.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_followers.js
@@ -27,7 +27,7 @@ export class MailFollowers extends models.ServerModel {
         }
         const followers = MailFollowers.browse(ids);
         for (const follower of followers) {
-            const [data] = this.read(
+            const [data] = this._read_format(
                 follower.id,
                 Object.keys(fields).filter((field) => !["partner", "thread"].includes(field)),
                 makeKwArgs({ load: false })

--- a/addons/mail/static/tests/mock_server/mock_models/mail_guest.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_guest.js
@@ -18,7 +18,7 @@ export class MailGuest extends models.ServerModel {
         if (!fields) {
             fields = ["im_status", "name", "write_date"];
         }
-        store.add("mail.guest", this.read(ids, fields, false));
+        store.add("mail.guest", this._read_format(ids, fields, false));
     }
 
     _set_auth_cookie(guestId) {

--- a/addons/mail/static/tests/mock_server/mock_models/mail_link_preview.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_link_preview.js
@@ -8,7 +8,7 @@ export class MailLinkPreview extends models.ServerModel {
     /** @param {object} linkPreview */
     _to_store(ids, store) {
         for (const linkPreview of this.browse(ids)) {
-            const [data] = this.read(
+            const [data] = this._read_format(
                 linkPreview.id,
                 [
                     "image_mimetype",

--- a/addons/mail/static/tests/mock_server/mock_models/mail_message.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_message.js
@@ -119,7 +119,7 @@ export class MailMessage extends models.ServerModel {
             MailNotification._filter([["mail_message_id", "in", ids]]).map((n) => n.id)
         );
         for (const message of MailMessage.browse(ids)) {
-            const [data] = this.read(message.id, fields, makeKwArgs({ load: false }));
+            const [data] = this._read_format(message.id, fields, makeKwArgs({ load: false }));
             const thread = message.model && this.env[message.model].browse(message.res_id)[0];
             if (thread) {
                 const thread_data = { module_icon: "/base/static/description/icon.png" };

--- a/addons/mail/static/tests/mock_server/mock_models/mail_notification.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_notification.js
@@ -36,7 +36,7 @@ export class MailNotification extends models.ServerModel {
         const ResPartner = this.env["res.partner"];
 
         for (const notification of this.browse(ids)) {
-            const [data] = this.read(
+            const [data] = this._read_format(
                 notification.id,
                 ["failure_type", "notification_status", "notification_type"],
                 makeKwArgs({ load: false })

--- a/addons/mail/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_partner.js
@@ -236,7 +236,7 @@ export class ResPartner extends webModels.ResPartner {
         const ResUsers = this.env["res.users"];
 
         for (const partner of this.browse(ids)) {
-            const [data] = this.read(
+            const [data] = this._read_format(
                 partner.id,
                 fields.filter(
                     (field) =>

--- a/addons/rating/static/tests/mock_server/models/rating_rating.js
+++ b/addons/rating/static/tests/mock_server/models/rating_rating.js
@@ -15,6 +15,6 @@ export class RatingRating extends models.ServerModel {
         if (!fields) {
             fields = ["rating", "rating_image_url", "rating_text"];
         }
-        store.add(this._name, this.read(ids, fields, false));
+        store.add(this._name, this._read_format(ids, fields, false));
     }
 }

--- a/addons/web/static/tests/_framework/mock_server/mock_model.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_model.js
@@ -1783,9 +1783,16 @@ export class Model extends Array {
         ({ ids: idOrIds, fields = [], load = "_classic_read" } = kwargs);
 
         const fieldNames = fields.length ? unique(["id", ...fields]) : Object.keys(this._fields);
+        return this._read_format(idOrIds, fieldNames, load);
+    }
+
+    _read_format(idOrIds, fnames, load) {
+        const kwargs = getKwArgs(arguments, "ids", "fnames", "load");
+        ({ ids: idOrIds, fnames = [], load = "_classic_read" } = kwargs);
+
         /** @type {ModelRecord[]} */
         const records = [];
-
+        fnames = unique(["id", ...fnames]);
         // Mapping of model records used in the current read call.
         const modelMap = {
             [this._name]: {},
@@ -1793,7 +1800,7 @@ export class Model extends Array {
         for (const record of this) {
             modelMap[this._name][record.id] = record;
         }
-        for (const fieldName of fieldNames) {
+        for (const fieldName of fnames) {
             const field = this._fields[fieldName];
             if (!field) {
                 continue; // the field doesn't exist on the model, so skip it
@@ -1828,7 +1835,7 @@ export class Model extends Array {
                 continue;
             }
             const result = { id: record.id };
-            for (const fieldName of fieldNames) {
+            for (const fieldName of fnames) {
                 const field = this._fields[fieldName];
                 if (!field) {
                     continue; // the field doesn't exist on the model, so skip it


### PR DESCRIPTION
\* = im_livechat, rating, web

Similar as python code, where _read_format returns only id when no field names are provided.

Returning more fields than expected might create issues (race condition of server data overriding client data: eg. rtc session join should not return extra fields), or simply make the test pass due to the extra data when in reality those data are not present.

Back-port from https://github.com/odoo/odoo/pull/183102