### PR TITLE
[FIX] calendar: unwanted activity creation

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -533,7 +533,7 @@ class Meeting(models.Model):
         # get list of models ids and filter out None values directly
         model_ids = list(filter(None, {values.get('res_model_id', defaults.get('res_model_id')) for values in vals_list}))
         model_name = defaults.get('res_model')
-        valid_activity_model_ids = model_name and self.env[model_name].sudo().browse(model_ids).filtered(lambda m: 'activity_ids' in m).ids or []
+        valid_activity_model_ids = model_name and model_name not in self._get_activity_excluded_models() and self.env[model_name].sudo().browse(model_ids).filtered(lambda m: 'activity_ids' in m).ids or []
         if meeting_activity_type and not defaults.get('activity_ids'):
             for values in vals_list:
                 # created from calendar: try to create an activity on the related record
@@ -1337,6 +1337,16 @@ class Meeting(models.Model):
     # ------------------------------------------------------------
     # TOOLS
     # ------------------------------------------------------------
+
+    @api.model
+    def _get_activity_excluded_models(self):
+        """
+        For some models, we don't want to automatically create activities when a calendar.event is created.
+        (This is the case notably for appointment.types)
+        This hook method allows to specify those models.
+        See calendar.event create method for details.
+        """
+        return []
 
     def _reset_attendees_status(self):
         """ Reset attendees status to pending and accept event for current user. """


### PR DESCRIPTION
Some modules (i.e., Appointment) uses calendar.event, but they don't want to create an activity every time a user books a meeting.
This PR indroduce a helper function, which return a list of models, in which we don't want to create activities.

Task-4243603
