### PR TITLE
[IMP] core: improve jsonb company dependent sql

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2947,15 +2947,20 @@ class BaseModel(metaclass=MetaModel):
             return SQL("COALESCE(%s)", SQL(", ").join(sql_field_langs))
 
         if field.company_dependent:
-            fallback = field.get_company_dependent_fallback(self)
-            fallback = field.convert_to_column(field.convert_to_write(fallback, self), self)
             sql_field = SQL(
-                "COALESCE(%(column)s->%(company_id)s,to_jsonb(%(fallback)s::%(column_type)s))",
+                "%(column)s->%(company_id)s",
                 column=sql_field,
                 company_id=str(self.env.company.id),
-                fallback=fallback,
-                column_type=SQL(field._column_type[1]),
             )
+            fallback = field.get_company_dependent_fallback(self)
+            fallback = field.convert_to_column(field.convert_to_write(fallback, self), self)
+            if fallback not in (None, 0):  # 0, 0.0, False, None
+                sql_field = SQL(
+                    'COALESCE(%(field)s, to_jsonb(%(fallback)s::%(column_type)s))',
+                    field=sql_field,
+                    fallback=fallback,
+                    column_type=SQL(field._column_type[1]),
+                )
             if field.type in ('boolean', 'integer', 'float', 'monetary'):
                 return SQL('(%s)::%s', sql_field, SQL(field._column_type[1]))
             # here the specified value for a company might be NULL e.g. '{"1": null}'::jsonb
@@ -3207,7 +3212,7 @@ class BaseModel(metaclass=MetaModel):
         ):
             sql = SQL("(%s OR %s IS NULL)", sql, sql_field)
 
-        if not need_wildcard and is_number_field and not field.company_dependent:
+        if not need_wildcard and is_number_field:
             cmp_value = field.convert_to_record(field.convert_to_cache(value, self), self)
             if (
                 operator == '>=' and cmp_value <= 0


### PR DESCRIPTION
this commit changes the SQL for jsonb company dependent when fallback is not defined. The new sql allows DB managers to add index per company for some company dependent column which is not expected to be sparse.

for field is not expected to be sparse
1. set index=False, company_dependent=True
2. add index per company for the result of `_field_to_sql``

e.g. `CREATE INDEX idx_name ON table USING btree (((col->'1')::float))` or 
`CREATE INDEX idx_name ON table USING btree (((col->'1'->>0)::varchar))`

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
