### PR TITLE
[FIX] point_of_sale: remove product image from receipt when no  order lines

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -3,7 +3,7 @@
     <t t-name="point_of_sale.OrderReceipt">
         <div class="pos-receipt p-2">
             <ReceiptHeader data="props.data.headerData" />
-            <OrderWidget lines="props.data.orderlines" t-slot-scope="scope">
+            <OrderWidget t-if="props.data.orderlines?.length" lines="props.data.orderlines" t-slot-scope="scope">
                 <t t-set="line" t-value="scope.line"/>
                 <Orderline line="omit(scope.line, 'customerNote')" class="{ 'pe-none': true, 'px-0': true }">
                     <li t-if="line.customerNote" class="customer-note w-100 p-2 my-1 rounded text-break">


### PR DESCRIPTION
Before this commit:
==
- When there is no order line(s) in the order, a message saying 'Start adding products' along with a cart icon will be displayed on the receipt.

After this commit:
==
- Added a check for the product image, which will be displayed when order line(s) exist.

task - 4267700


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
