### PR TITLE
[FIX] base: core routing in Debian Bookworm

### DIFF
--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -41,11 +41,11 @@ class RequestUID(object):
 
 
 class ModelConverter(werkzeug.routing.BaseConverter):
+    regex = r'[0-9]+'
 
     def __init__(self, url_map, model=False):
-        super(ModelConverter, self).__init__(url_map)
+        super().__init__(url_map)
         self.model = model
-        self.regex = r'([0-9]+)'
 
     def to_python(self, value):
         _uid = RequestUID(value=value, converter=self)
@@ -57,12 +57,11 @@ class ModelConverter(werkzeug.routing.BaseConverter):
 
 
 class ModelsConverter(werkzeug.routing.BaseConverter):
+    regex = r'[0-9,]+'
 
     def __init__(self, url_map, model=False):
-        super(ModelsConverter, self).__init__(url_map)
+        super().__init__(url_map)
         self.model = model
-        # TODO add support for slug in the form [A-Za-z0-9-] bla-bla-89 -> id 89
-        self.regex = r'([0-9,]+)'
 
     def to_python(self, value):
         _uid = RequestUID(value=value, converter=self)


### PR DESCRIPTION
For the longest time, the base `ModelConverter` (and `ModelsConverter`) have added a group around their regex. That was (apparently) never useful but Werkzeug didn't care.

Except, it turns out, Werkzeug 2.2 specifically, which is the one we require for Python 3.11, because it's the one bundled in Debian Bookworm.

In this version and this version only werkzeug gets tripped up by our extra group, and doubles up the parameters. This makes it very hard to see as:

- we need a version which uses at least two converters, at least one of which is `model` or `models` in non-last position
- we need to realise that the latter converter gets a copy of the former

The first one is relatively common (70 cases in community, of which 48 use multiple `model` or `models`), however the part where it has to be test and noticed is a lot less likely as we don't routinely test this configuration. Unless somebody happens to use 3.11 locally and follow the `requirements.txt` when installing odoo...

Fixes runbot error 73290

Repro case:

- install tox
- create a file `tox.ini` containing:

    ```ini
    [tox]
    requires = tox >= 4
    env_list = werkzeug{016,10,21,22,23,3}

    [testenv]
    deps =
        pytest
        werkzeug016: werkzeug~=0.16.0
        werkzeug10: werkzeug~=1.0.0
        werkzeug21: werkzeug~=2.1.0
        werkzeug22: werkzeug~=2.2.0
        werkzeug23: werkzeug~=2.3.0
        werkzeug3: werkzeug~=3.0
    commands = pytest app.py
    ```
- create a file `app.py` containing:

    ```python
    import json

    import pytest
    from werkzeug.wrappers import Response
    from werkzeug.test import Client
    from werkzeug.routing import Map, Rule, BaseConverter

    class ModelConverter(BaseConverter):
        regex = r'([0-9]+)'

        def to_python(self, value: str) -> int:
            return int(value)

    class ModelsConverter(BaseConverter):
        regex = r'([0-9,]+)'

        def to_python(self, value: str) -> list[int]:
            return [int(v) for v in value.split(',')]

    url_map = Map(
        [
            Rule("/id/<id:a>"),
            Rule("/id/<id:a>/<id:b>"),
            Rule("/ids/<ids:as>"),
            Rule("/ids/<ids:as>/<id:b>"),
        ],
        strict_slashes=False,
        converters={
            'id': ModelConverter,
            'ids': ModelsConverter,
        }
    )

    def application(environ, start_response):
        urls = url_map.bind_to_environ(environ)
        endpoint, args = urls.match()

        start_response('200 OK', [('Content-Type', 'text/plain')])
        return [json.dumps(args)]

    @pytest.mark.parametrize('url,res', [
        ("/id/1", {'a': 1}),
        ("/id/1/2", {'a': 1, 'b': 2}),
        ("/ids/1,2,3", {"as": [1, 2, 3]}),
        ("/ids/1,2,3/4", {"as": [1, 2, 3], "b": 4}),
    ])
    def test_routing(url, res):
        c = Client(application, Response)
        r = c.get(url)
        assert json.loads(r.get_data()) == res
    ```

- run `tox`
- observe that Werkzeug 2.2 and that version only blows up on cases 2 and 4

Removing the parenthesis inside the regexes fixes the issue.
