### PR TITLE
[IMP] web: add char, one2many and many2one as supported types in stat…

### DIFF
--- a/addons/web/static/src/views/fields/stat_info/stat_info_field.js
+++ b/addons/web/static/src/views/fields/stat_info/stat_info_field.js
@@ -19,7 +19,7 @@ export class StatInfoField extends Component {
     get formattedValue() {
         const field = this.props.record.fields[this.props.name];
         const formatter = formatters.get(field.type);
-        return formatter(this.props.record.data[this.props.name] || 0, {
+        return formatter(this.props.record.data[this.props.name], {
             digits: this.props.digits,
             field,
         });
@@ -42,7 +42,7 @@ export const statInfoField = {
             availableTypes: ["char"],
         },
     ],
-    supportedTypes: ["float", "integer", "monetary"],
+    supportedTypes: ["float", "integer", "monetary", "char", "one2many", "many2one"],
     isEmpty: () => false,
     extractProps: ({ attrs, options, string }) => {
         // Sadly, digits param was available as an option and an attr.

--- a/addons/web/static/tests/views/fields/stat_info_field.test.js
+++ b/addons/web/static/tests/views/fields/stat_info_field.test.js
@@ -41,6 +41,102 @@ test("StatInfoField formats decimal precision", async () => {
     });
 });
 
+test("StatInfoField widget on a chart fields", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: /* xml */ `
+            <form>
+                <button class="oe_stat_button" name="items" icon="fa-gear">
+                    <field name="foo" widget="statinfo" />
+                </button>
+            </form>
+        `,
+    });
+
+    expect("button.oe_stat_button .o_field_widget .o_stat_value:eq(0)").toHaveText("yop");
+});
+
+test("StatInfoField widget on a char field (unset value)", async () => {
+    Partner._records = [{ id: 1, foo: "" }];
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: /* xml */ `
+            <form>
+                <button class="oe_stat_button" name="items" icon="fa-gear">
+                    <field name="foo" widget="statinfo" />
+                </button>
+            </form>
+        `,
+    });
+
+    expect("button.oe_stat_button .o_field_widget .o_stat_value:eq(0)").toHaveText("");
+});
+
+test("StatInfoField widget on a one2many field (one record)", async () => {
+    Partner._fields.child_ids = fields.One2many({ string: "one2many field", relation: "partner" });
+    Partner._records.push({ id: 2, foo: "plop", child_ids: [1] });
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 2,
+        arch: /* xml */ `
+            <form>
+                <button class="oe_stat_button" name="items" icon="fa-gear">
+                    <field name="child_ids" widget="statinfo" />
+                </button>
+            </form>
+        `,
+    });
+
+    expect("button.oe_stat_button .o_field_widget .o_stat_value:eq(0)").toHaveText("1 record");
+});
+
+test("StatInfoField widget on a one2many field (multiple records)", async () => {
+    Partner._fields.child_ids = fields.One2many({ string: "one2many field", relation: "partner" });
+    Partner._records.push({ id: 3, foo: "plop3" });
+    Partner._records.push({ id: 4, foo: "plop4" });
+    Partner._records.push({ id: 2, foo: "plop", child_ids: [1, 3, 4] });
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 2,
+        arch: /* xml */ `
+            <form>
+                <button class="oe_stat_button" name="items" icon="fa-gear">
+                    <field name="child_ids" widget="statinfo" />
+                </button>
+            </form>
+        `,
+    });
+
+    expect("button.oe_stat_button .o_field_widget .o_stat_value:eq(0)").toHaveText("3 records");
+});
+
+test("StatInfoField widget on a many2one field", async () => {
+    Partner._fields.name = fields.Char();
+    Partner._fields.parent_id = fields.Many2one({ relation: "partner" });
+    Partner._records[0].name = "Parent";
+    Partner._records.push({ id: 2, name: "child", parent_id: 1 });
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 2,
+        arch: /* xml */ `
+            <form>
+                <button class="oe_stat_button" name="items" icon="fa-gear">
+                    <field name="parent_id" widget="statinfo" />
+                </button>
+            </form>
+        `,
+    });
+
+    expect("button.oe_stat_button .o_field_widget .o_stat_value:eq(0)").toHaveText("Parent");
+});
+
 test.tags("desktop")("StatInfoField in form view on desktop", async () => {
     await mountView({
         type: "form",
@@ -96,12 +192,14 @@ test.tags("mobile")("StatInfoField in form view on mobile", async () => {
     });
 });
 
-test.tags("desktop")("StatInfoField in form view with specific label_field on desktop", async () => {
-    await mountView({
-        type: "form",
-        resModel: "partner",
-        resId: 1,
-        arch: /* xml */ `
+test.tags("desktop")(
+    "StatInfoField in form view with specific label_field on desktop",
+    async () => {
+        await mountView({
+            type: "form",
+            resModel: "partner",
+            resId: 1,
+            arch: /* xml */ `
             <form>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
@@ -115,18 +213,19 @@ test.tags("desktop")("StatInfoField in form view with specific label_field on de
                 </sheet>
             </form>
         `,
-    });
+        });
 
-    expect("button.oe_stat_button .o_field_widget .o_stat_info").toHaveCount(1, {
-        message: "should have one stat button",
-    });
-    expect("button.oe_stat_button .o_field_widget .o_stat_value").toHaveText("10", {
-        message: "should have 10 as value",
-    });
-    expect("button.oe_stat_button .o_field_widget .o_stat_text").toHaveText("yop", {
-        message: "should have 'yop' as text, since it is the value of field foo",
-    });
-});
+        expect("button.oe_stat_button .o_field_widget .o_stat_info").toHaveCount(1, {
+            message: "should have one stat button",
+        });
+        expect("button.oe_stat_button .o_field_widget .o_stat_value").toHaveText("10", {
+            message: "should have 10 as value",
+        });
+        expect("button.oe_stat_button .o_field_widget .o_stat_text").toHaveText("yop", {
+            message: "should have 'yop' as text, since it is the value of field foo",
+        });
+    }
+);
 
 test.tags("mobile")("StatInfoField in form view with specific label_field on mobile", async () => {
     await mountView({


### PR DESCRIPTION
… info widget

This commit adds the char, one2many and many2one fields as supported types for the stat info widget. Note that, the stat info widget is already used with char, one2many and many2one fields in the code.

task-id: 4224192
