### PR TITLE
[IMP] website: introduce `s_comparisons_horizontal` snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -74,6 +74,7 @@
         'views/snippets/s_countdown.xml',
         'views/snippets/s_product_catalog.xml',
         'views/snippets/s_comparisons.xml',
+        'views/snippets/s_comparisons_horizontal.xml',
         'views/snippets/s_company_team.xml',
         'views/snippets/s_company_team_basic.xml',
         'views/snippets/s_company_team_shapes.xml',

--- a/addons/website/views/snippets/s_comparisons_horizontal.xml
+++ b/addons/website/views/snippets/s_comparisons_horizontal.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_comparisons_horizontal" name="Comparisons Horizontal">
+    <section class="s_comparisons_horizontal o_colored_level pt64 pb48">
+        <div class="container">
+            <h2 class="h3-fs">Our Pricing</h2>
+            <p class="lead">Discover what is the best pricing for you.</p>
+            <div class="row">
+                <div class="col-12 col-lg-6 pb16 pt16" data-name="Card">
+                    <div class="s_card card o_cc o_cc1 h-100 my-0" data-vxml="001" data-snippet="s_card" data-name="Card">
+                        <div class="card-body">
+                            <div class="row">
+                                <div class="col-12 col-lg-6">
+                                    <h3 class="card-title h5-fs">Professional</h3>
+                                    <div class="my-2">
+                                        <strong class="h2-fs">$ 65.00</strong>
+                                        <small class="text-muted">/ month</small>
+                                    </div>
+                                    <p class="card-text small">Comprehensive tools for growing businesses. Optimize your processes and productivity across your team.</p>
+                                    <a href="/contactus" class="btn btn-secondary mb-2">Start Now</a>
+                                </div>
+                                <div class="col-12 col-lg-6">
+                                    <ul class="list-group list-group-flush text-start">
+                                        <li class="list-group-item px-0 bg-transparent text-reset"><span class="fa fa-check-circle-o"/>  Complete CRM for any team</li>
+                                        <li class="list-group-item px-0 bg-transparent text-reset"><span class="fa fa-check-circle-o"/>  Access all modules</li>
+                                        <li class="list-group-item px-0 bg-transparent text-reset"><span class="fa fa-check-circle-o"/>  Limited Customization</li>
+                                        <li class="list-group-item px-0 bg-transparent text-reset"><span class="fa fa-check-circle-o"/>  Email support</li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="card-footer" style="text-align: center;">
+                            <small>Instant setup, satisfied or reimbursed.</small>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-12 col-lg-6 pb16 pt16" data-name="Card">
+                    <div class="s_card card o_cc o_cc1 h-100 my-0" data-vxml="001" data-snippet="s_card" data-name="Card">
+                        <div class="card-body">
+                            <div class="row">
+                                <div class="col-12 col-lg-6">
+                                    <h3 class="card-title h5-fs">Expert</h3>
+                                    <div class="my-2">
+                                        <strong class="h2-fs">$ 125.00</strong>
+                                        <small class="text-muted">/ month</small>
+                                    </div>
+                                    <p class="card-text small">Advanced solution for enterprises. Cutting-edge features and top-tier support for maximum performance.</p>
+                                    <a href="/contactus" class="btn btn-primary mb-2">Start Now</a>
+                                </div>
+                                <div class="col-12 col-lg-6">
+                                    <ul class="list-group list-group-flush text-start">
+                                        <li class="list-group-item px-0 bg-transparent text-reset"><span class="fa fa-check-circle-o"/>  PaaS Access</li>
+                                        <li class="list-group-item px-0 bg-transparent text-reset"><span class="fa fa-check-circle-o"/>  Unlimited CRM support</li>
+                                        <li class="list-group-item px-0 bg-transparent text-reset"><span class="fa fa-check-circle-o"/>  All modules &amp; features</li>
+                                        <li class="list-group-item px-0 bg-transparent text-reset"><span class="fa fa-check-circle-o"/>  Unlimited customization</li>
+                                        <li class="list-group-item px-0 bg-transparent text-reset"><span class="fa fa-check-circle-o"/>  24/7 Support</li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="card-footer" style="text-align: center;">
+                            <small>Instant setup, satisfied or reimbursed.</small>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -201,6 +201,9 @@
                 <t t-snippet="website.s_comparisons" string="Comparisons" group="content">
                     <keywords>pricing, promotion, price, feature-comparison, side-by-side, evaluation, competitive, overview</keywords>
                 </t>
+                <t t-snippet="website.s_comparisons_horizontal" string="Comparisons Horizontal" group="content">
+                    <keywords>comparison, price, pricing, engage, call to action, cta, box, shop, table, cart, product, cost, charges, fees, tariffs, prices, expenses</keywords>
+                </t>
                 <t t-snippet="website.s_features_grid" string="Features Grid" group="content">
                     <keywords>promotion, characteristic, quality, highlights, specs, advantages, functionalities, exhibit, details, capabilities, attributes, promotion</keywords>
                 </t>
@@ -783,7 +786,7 @@
              which the s_card options should be bound (instead of the s_card).
              Note: defined here to be set above all the other options that might
              need it. -->
-        <t t-set="card_parent_handlers" t-value="'.s_three_columns .row > div, .s_comparisons .row > div, .s_cards_grid .row > div, .s_cards_soft .row > div, .s_product_list .row > div, .s_newsletter_centered .row > div, .s_company_team_spotlight .row > div'"/>
+        <t t-set="card_parent_handlers" t-value="'.s_three_columns .row > div, .s_comparisons .row > div, .s_cards_grid .row > div, .s_cards_soft .row > div, .s_product_list .row > div, .s_newsletter_centered .row > div, .s_company_team_spotlight .row > div, .s_comparisons_horizontal .row > div'"/>
 
         <!-- Binding the option on the snippet if it is not a s_card with a
              handler parent -->


### PR DESCRIPTION
This commit introduces the `s_comparisons_horizontal` snippet.

| ![image](https://github.com/user-attachments/assets/64ec833b-fff6-42a2-875c-01faa93bb0de) |
|--------|

task-4105264
Part of task-4077427

Design-themes: https://github.com/odoo/design-themes/pull/992

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
