### PR TITLE
[FIX] web,sale_project: improve all tasks list view perf

### DIFF
--- a/addons/sale_project/static/src/views/project_task_list/project_task_list_sale_line.js
+++ b/addons/sale_project/static/src/views/project_task_list/project_task_list_sale_line.js
@@ -5,15 +5,34 @@ import { ProjectTaskListRenderer } from "@project/views/project_task_list/projec
 import { getRawValue } from "@web/views/kanban/kanban_record";
 
 patch(ProjectTaskListRenderer.prototype, {
-    isCellReadonly(column, record) {
-        const readonly = super.isCellReadonly(column, record);
-        const selection = this.props.list.selection;
-        if (column.name === "sale_line_id" && selection.length) {
-            const partnerId = getRawValue(selection[0], "partner_id");
-            return readonly || selection.some(
-                (task) => getRawValue(task, "partner_id") !== partnerId
+    /**
+     * This method prevents from computing the selection once for each cell when
+     * rendering the list. Indeed, `selection` is a getter which browses all
+     * records, so computing it for each cell slows down the rendering a lot on
+     * large tables. Moreover, it also prevents from iterating over the selection
+     * to compare tasks' partners.
+     *
+     * It returns true iff the selected tasks all have the same partner.
+     */
+    haveSelectedTasksSamePartner() {
+        if (this._haveSelectedTasksSamePartner === undefined) {
+            const selection = this.props.list.selection;
+            const partnerId = selection.length && getRawValue(selection[0], "partner_id");
+            this._haveSelectedTasksSamePartner = selection.every(
+                (task) => getRawValue(task, "partner_id") === partnerId
             );
+            Promise.resolve().then(() => {
+                delete this._haveSelectedTasksSamePartner;
+            });
         }
-        return readonly;
+        return this._haveSelectedTasksSamePartner;
     },
+
+    isCellReadonly(column, record) {
+        let readonly = false;
+        if (column.name === "sale_line_id") {
+            readonly = !this.haveSelectedTasksSamePartner();
+        }
+        return readonly || super.isCellReadonly(column, record);
+    }
 });

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -244,7 +244,7 @@
                     <t t-set="isInvisible" t-value="evalInvisible(column.invisible, record) or !(column.name in record.data)"/>
                     <td t-on-keydown="(ev) => this.onCellKeydown(ev, group, record)"
                         class="o_data_cell cursor-pointer"
-                        t-att-class="getCellClass(column, record)"
+                        t-att-class="this.getCellClass(column, record)"
                         t-att-name="column.name"
                         t-att-colspan="column.colspan"
                         t-att-data-tooltip="!isInvisible ? getCellTitle(column, record) : false"
@@ -257,7 +257,7 @@
                     </td>
                 </t>
                 <t t-if="column.type === 'button_group'">
-                    <td t-on-keydown="(ev) => this.onCellKeydown(ev, group, record)" class="o_data_cell w-print-0 p-print-0 cursor-pointer" t-att-class="getCellClass(column, record)" t-on-click="(ev) => this.onButtonCellClicked(record, column, ev)" tabindex="-1">
+                    <td t-on-keydown="(ev) => this.onCellKeydown(ev, group, record)" class="o_data_cell w-print-0 p-print-0 cursor-pointer" t-att-class="this.getCellClass(column, record)" t-on-click="(ev) => this.onButtonCellClicked(record, column, ev)" tabindex="-1">
                         <div class="d-flex flex-wrap gap-1">
                             <t t-foreach="column.buttons" t-as="button" t-key="button.id">
                                 <ViewButton t-if="!evalInvisible(button.invisible, record)"
@@ -277,7 +277,7 @@
                     </td>
                 </t>
                 <t t-if="column.type === 'widget'">
-                    <td class="o_data_cell" t-att-class="getCellClass(column, record)">
+                    <td class="o_data_cell" t-att-class="this.getCellClass(column, record)">
                         <Widget t-props="column.props" record="record"/>
                     </td>
                 </t>


### PR DESCRIPTION
This commit fixes a performance issue with the "All tasks" list view. The issue especially arose when the view was grouped by stages (because groups are opened by default in that case) and when it contained a lot of stages, each of them containing a lot of records. In the worst case, the view could have to render up to 800 records (80 per group, 10 groups opened), and it could take around 20seconds. With this commit, the rendering part is done in around 400ms.

This commit actually fixes 2 issues.

First, in sale_project, there was an override of `isCellReadonly` to force the `sale_line_id` to be readonly if several records with different partners (`partner_id` field) were selected. This override accessed `this.props.list.selection` once per cell (all cells, not only for the `sale_line_id` column), and this is actually a getter which browses through all records, to generate the list of selected ones. This was thus quadratic. This commit applies a similar logic as in [1] to compute the selection only once for the whole table.

Second, [1] wasn't as optimal as expected. Indeed, we tried to compute a flag only once for the whole template rendering, by setting a variable on `this`. However, the ListRenderer template using `t-call` to render each row, a new rendering context is created for each row. By doing
```xml
    t-att-class="getCellClass(column, record)"
```
the `this` inside `getCellClass` is that rendering context object, so it can't be used to share a flag from a row to another. Explicitely calling `getCellClass` on `this` ensures that the `this` inside the function is the instance, which is the same for all rows.

[1] https://github.com/odoo/odoo/pull/153858

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
