### PR TITLE
[FIX] hr_timesheet, sale_timesheet: clear up project hours report

### DIFF
--- a/addons/hr_timesheet/i18n/hr_timesheet.pot
+++ b/addons/hr_timesheet/i18n/hr_timesheet.pot
@@ -1333,11 +1333,15 @@ msgstr ""
 
 #. module: hr_timesheet
 #: model:ir.model.fields,field_description:hr_timesheet.field_project_task__total_hours_spent
-#: model:ir.model.fields,field_description:hr_timesheet.field_report_project_task_user__total_hours_spent
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.project_sharing_inherit_project_task_view_form
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.view_task_form2_inherited
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.view_task_tree2_inherited
 msgid "Total Hours"
+msgstr ""
+
+#. module: hr_timesheet
+#: model:ir.model.fields,field_description:hr_timesheet.field_report_project_task_user__total_hours_spent
+msgid "Hours By Task (Including Subtasks)"
 msgstr ""
 
 #. module: hr_timesheet

--- a/addons/hr_timesheet/models/project_task.py
+++ b/addons/hr_timesheet/models/project_task.py
@@ -126,7 +126,10 @@ class Task(models.Model):
     @api.depends('effective_hours', 'subtask_effective_hours', 'allocated_hours')
     def _compute_remaining_hours(self):
         for task in self:
-            task.remaining_hours = task.allocated_hours - task.effective_hours - task.subtask_effective_hours
+            if not task.allocated_hours:
+                task.remaining_hours = 0.0
+            else:
+                task.remaining_hours = task.allocated_hours - task.effective_hours - task.subtask_effective_hours
 
     @api.depends('effective_hours', 'subtask_effective_hours')
     def _compute_total_hours_spent(self):

--- a/addons/hr_timesheet/report/project_report.py
+++ b/addons/hr_timesheet/report/project_report.py
@@ -13,15 +13,15 @@ class ReportProjectTaskUser(models.Model):
     remaining_hours_percentage = fields.Float('Remaining Hours Percentage', readonly=True)
     progress = fields.Float('Progress', group_operator='avg', readonly=True)
     overtime = fields.Float(readonly=True)
-    total_hours_spent = fields.Float("Total Hours", help="Time spent on this task, including its sub-tasks.")
+    total_hours_spent = fields.Float('Hours By Task (Including Subtasks)', help="Time spent on this task, including its sub-tasks.")
 
     def _select(self):
         return super()._select() +  """,
                 CASE WHEN COALESCE(t.allocated_hours, 0) = 0 THEN 0.0 ELSE LEAST((t.effective_hours * 100) / t.allocated_hours, 100) END as progress,
                 t.effective_hours,
-                t.allocated_hours - t.effective_hours - t.subtask_effective_hours as remaining_hours,
+                CASE WHEN COALESCE(t.allocated_hours, 0) = 0 THEN 0.0 ELSE t.allocated_hours - t.effective_hours END as remaining_hours,
                 CASE WHEN t.allocated_hours > 0 THEN t.remaining_hours / t.allocated_hours ELSE 0 END as remaining_hours_percentage,
-                t.allocated_hours,
+                COALESCE(t.allocated_hours, 0) as allocated_hours,
                 t.overtime,
                 t.total_hours_spent
         """


### PR DESCRIPTION
Steps to reproduce:
- New Project > New Task > Timesheet 10h on task
- New subtask on task > Timesheet 5h on subtask
- Reporting > Tasks Analysis

Remaining hours are computed incorrectly, when no allocated hours are
set on a task, we have null values in database that prevent the
computation of allocated_hours and remaining_hours which also messes up
the project totals. The computation of remaining hours is also only
supposed to occur when we have a non zero amount of allocated hours,
otherwise the remaining hours are always 0.

Additionally, the 'Total Hours' column is confusing for customers
as it is meant to compute the total hours spent on a task (subtasks
included) but is enabled by default when looking at the projects as a
whole which does not make sense.

For instance, with 'Task' parent of 'Subtask':
| Name     | Allocated | Hours spent | Remaining  | Total Hours |
| -------- | --------- | ----------- | ---------- | ----------- |
| Project  | 0         | 15          | -15 (-> 0) | 20          |
| Task     | 0         | 10          | -10 (-> 0) | 15          |
| Subtask  | 0         | 5           | -5  (-> 0) | 5           |

The sum of total hours on project is meaningless and confusing so it is
preferable not to have it enabled by default (Subtask is counted twice,
once in Task and once itself).

opw-4236984

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
