### PR TITLE
[FIX] {purchase_,}product_matrix: do not create dynamic variant in matrix

### DIFF
--- a/addons/product_matrix/static/src/js/product_matrix_dialog.js
+++ b/addons/product_matrix/static/src/js/product_matrix_dialog.js
@@ -53,7 +53,7 @@ export class ProductMatrixDialog extends Component {
         const inputs = document.getElementsByClassName('o_matrix_input');
         let matrixChanges = [];
         for (let matrixInput of inputs) {
-            if (matrixInput.value && matrixInput.value !== matrixInput.nodeValue) {
+            if (matrixInput.value && matrixInput.value !== matrixInput.attributes.value.nodeValue) {
                 matrixChanges.push({
                     qty: parseFloat(matrixInput.value),
                     ptav_ids: matrixInput.attributes.ptav_ids.nodeValue.split(",").map(

--- a/addons/purchase_product_matrix/static/tests/tours/purchase_product_matrix_tour.js
+++ b/addons/purchase_product_matrix/static/tests/tours/purchase_product_matrix_tour.js
@@ -31,6 +31,13 @@ registry.category("web_tour.tours").add('purchase_matrix_tour', {
         $('.o_matrix_input').val(1);
     }
 }, {
+    trigger: '.o_matrix_input_table',
+    run: function () {
+        // left first cell at 0 to ensure the variant is not created
+        $('.o_matrix_input')[0].value = 0;
+        $('.o_matrix_input')[8].value = 0;
+    }
+}, {
     trigger: 'button:contains("Confirm")',
     run: 'click'
 }, {
@@ -47,7 +54,7 @@ registry.category("web_tour.tours").add('purchase_matrix_tour', {
     trigger: '.o_matrix_input_table',
     run: function () {
         // update some of the matrix values.
-        $('.o_matrix_input').slice(8, 16).val(4);
+        $('.o_matrix_input').slice(9, 16).val(4);
     } // set the qty to 4 for half of the matrix products.
 }, {
     trigger: 'button:contains("Confirm")',

--- a/addons/purchase_product_matrix/tests/test_purchase_matrix.py
+++ b/addons/purchase_product_matrix/tests/test_purchase_matrix.py
@@ -14,13 +14,19 @@ class TestPurchaseMatrixUi(TestMatrixCommon):
         # Ensures some dynamic create variants have been created by the matrix
         # Ensures a PO has been created with exactly x lines ...
 
-        self.assertEqual(len(self.matrix_template.product_variant_ids), 8)
+        self.assertEqual(len(self.matrix_template.product_variant_ids), 7)
         self.assertEqual(len(self.matrix_template.product_variant_ids.product_template_attribute_value_ids), 6)
         self.assertEqual(len(self.matrix_template.attribute_line_ids.product_template_value_ids), 8)
-        self.env['purchase.order.line'].search([('product_id', 'in', self.matrix_template.product_variant_ids.ids)]).order_id.button_confirm()
 
+        # check variant (PAV11, PAV21, PAV31) is not created because the two cell on it were 0
+        dyn = self.matrix_template.product_variant_ids.filtered(
+            lambda p: p.product_template_variant_value_ids.mapped('name') == ['PAV11', 'PAV21', 'PAV31']
+        )
+        self.assertFalse(dyn)
+
+        self.env['purchase.order.line'].search([('product_id', 'in', self.matrix_template.product_variant_ids.ids)]).order_id.button_confirm()
         self.matrix_template.flush_recordset()
-        self.assertEqual(round(self.matrix_template.purchased_product_qty, 2), 56.8)
+        self.assertEqual(round(self.matrix_template.purchased_product_qty, 2), 51.8)
         for variant in self.matrix_template.product_variant_ids:
             # 5 and 9.2 because of no variant attributes
             self.assertIn(round(variant.purchased_product_qty, 2), [5, 9.2])


### PR DESCRIPTION
nodeValue on `input` always return null. To get the previous value of
the input cell, the query should be
`matrixInput.attributes.value.nodeValue`. That way unchanged cell won't
be send to the list of data to be updated.

opw: 3987284

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
