### PR TITLE
[FIX] account: report invoice layout with taxes in multi-currency

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -398,10 +398,10 @@
                     </p>
                     <t t-foreach="tax_totals['subtotals']" t-as="subtotal">
                         <tr class="o_subtotal">
+                            <td>
+                                <span t-out="subtotal['name']">Untaxed amount</span>
+                            </td>
                             <td class="text-end">
-                                <td>
-                                    <span t-out="subtotal['name']">Untaxed amount</span>
-                                </td>
                                 <span t-out="subtotal['base_amount']"
                                       t-options='{"widget": "monetary", "display_currency": currency}'
                                 >27.00</span>


### PR DESCRIPTION
If you have an invoice with a different currency, and with taxes, 
the layout of the Taxes box in company currency has a weird placement 
with the Untaxed Amount

task-4269524




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
