### PR TITLE
[FIX] mrp_account: leave labour cost on expense accounts

### DIFF
--- a/addons/mrp_account/models/mrp_production.py
+++ b/addons/mrp_account/models/mrp_production.py
@@ -3,7 +3,7 @@
 from ast import literal_eval
 from collections import defaultdict
 
-from odoo import api, fields, models, _
+from odoo import fields, models, _
 from odoo.tools import float_round
 
 
@@ -97,7 +97,7 @@ class MrpProduction(models.Model):
                 'line_ids': [(0, 0, {
                     'name': desc,
                     'ref': desc,
-                    'balance': amt,
+                    'balance': -amt,
                     'account_id': acc.id,
                 }) for acc, amt in labour_amounts.items()]
             })

--- a/addons/mrp_account/models/stock_move.py
+++ b/addons/mrp_account/models/stock_move.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from collections import defaultdict
 
 from odoo import models
-from odoo.tools import float_round
 
 
 class StockMove(models.Model):
@@ -40,39 +38,3 @@ class StockMove(models.Model):
     def _is_production_consumed(self):
         self.ensure_one()
         return self.location_dest_id.usage == 'production' and self.location_id._should_be_valued()
-
-    def _generate_valuation_lines_data(self, partner_id, qty, debit_value, credit_value, debit_account_id, credit_account_id, svl_id, description):
-        rslt = super()._generate_valuation_lines_data(partner_id, qty, debit_value, credit_value, debit_account_id, credit_account_id, svl_id, description)
-
-        product_expense_account = self.product_id.product_tmpl_id.get_product_accounts()['expense']
-        labour_amounts = defaultdict(float)
-        for wo in self.production_id.workorder_ids:
-            account = wo.workcenter_id.expense_account_id or product_expense_account
-            labour_amounts[account] += wo._cal_cost()
-
-        cost_share = 1
-        if self.production_id.move_byproduct_ids:
-            if self.cost_share:
-                cost_share = self.cost_share / 100
-            else:
-                cost_share = float_round(1 - sum(self.production_id.move_byproduct_ids.mapped('cost_share')) / 100, precision_rounding=0.0001)
-
-        currency = self.env.company.currency_id
-        workcenter_total_cost = 0
-        for acc, amt in labour_amounts.items():
-            amount = float_round(amt * cost_share, precision_rounding=currency.rounding)
-            if not currency.is_zero(amount):
-                workcenter_total_cost += amount
-                rslt['labour_credit_line_vals_' + acc.code] = {
-                    'name': description,
-                    'product_id': self.product_id.id,
-                    'quantity': qty,
-                    'product_uom_id': self.product_id.uom_id.id,
-                    'ref': description,
-                    'partner_id': partner_id,
-                    'balance': -amount,
-                    'account_id': acc.id,
-                }
-        if not currency.is_zero(workcenter_total_cost):
-            rslt['credit_line_vals']['balance'] += workcenter_total_cost
-        return rslt

--- a/addons/mrp_account/tests/test_mrp_account.py
+++ b/addons/mrp_account/tests/test_mrp_account.py
@@ -7,8 +7,7 @@ from odoo.addons.mrp.tests.common import TestMrpCommon
 from odoo.addons.stock_account.tests.test_account_move import TestAccountMoveStockCommon
 from odoo.tests import Form, tagged
 from odoo.tests.common import new_test_user
-from odoo import fields
-from odoo import Command
+from odoo import fields, Command
 
 
 class TestMrpAccount(TestMrpCommon):
@@ -510,9 +509,13 @@ class TestMrpAccountMove(TestAccountMoveStockCommon):
 
         account_move = production.move_finished_ids.stock_valuation_layer_ids.account_move_id
         self.assertRecordValues(account_move.line_ids, [
-            {'credit': 9.99, 'debit': 0.00},  # Credit Line
+            {'credit': 10.0, 'debit': 0.00},  # Credit Line
             {'credit': 0.00, 'debit': 10.00},  # Debit Line
-            {'credit': 0.01, 'debit': 0.00},  # Labor Credit Line
+        ])
+        labour_move = workorder.time_ids.account_move_line_id.move_id
+        self.assertRecordValues(labour_move.line_ids, [
+            {'credit': 0.01, 'debit': 0.00},
+            {'credit': 0.00, 'debit': 0.01},
         ])
 
     def test_labor_cost_balancing_with_cost_share(self):
@@ -546,10 +549,14 @@ class TestMrpAccountMove(TestAccountMoveStockCommon):
         production._post_inventory()
         production.button_mark_done()
 
-        account_move = production.move_finished_ids.filtered(lambda fm: fm.product_id == self.product_A)\
+        account_move = production.move_finished_ids.filtered(lambda fm: fm.product_id == self.product_A) \
             .stock_valuation_layer_ids.account_move_id
         self.assertRecordValues(account_move.line_ids, [
-            {'credit': 9.99, 'debit': 0.00},  # Credit Line
+            {'credit': 10.0, 'debit': 0.00},  # Credit Line
             {'credit': 0.00, 'debit': 10.00},  # Debit Line
-            {'credit': 0.01, 'debit': 0.00},  # Labor Credit Line
+        ])
+        labour_move = workorder.time_ids.account_move_line_id.move_id
+        self.assertRecordValues(labour_move.line_ids, [
+            {'credit': 0.01, 'debit': 0.00},
+            {'credit': 0.00, 'debit': 0.01},
         ])


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/169257, we've created separate valuation journal items for MO employee and workcenter costs with items on expense accounts that can be set on a per-workcenter basis. However, in the final product account move, we move these amounts back to the Cost of Production account as to not have a net impact on the expense accounts after production.

This PR leaves the labor costs on the WC expense accounts instead of putting them back on the COP account in the final product account move.

**To reproduce:**
- Enable automatic accounting with FIFO for all products
- Create storable products F and C
- Purchase 100 C with unit price 50 and receive the products
- Create a BOM for F with component 1 C and 1 WO (60 min, assembly 1)
- Create, confirm and produce MO for 1 F
- Open accounting and view the newly created journal entries

**Current behavior:**
- On the entry for F, an expense item is created with a credit value equal to the labor cost.
- On the labor entry, an expense item is created with a debit value equal to the labor cost, and a Cost of Production item with matching credit.

**Expected behavior:**
- The entry for the final product should have no expense entries for labor, only the COP credit and SV debit (final product value).
- The entry for labor should have a credit value on the expense item, and a matching debit value on the Cost of Production item.

task-4267713