### PR TITLE
[FIX] account: wrong supported type on widget

### DIFF
--- a/addons/account/static/src/components/json_checkboxes/json_checkboxes.js
+++ b/addons/account/static/src/components/json_checkboxes/json_checkboxes.js
@@ -31,7 +31,7 @@ export class JsonCheckboxes extends Component {
 
 export const jsonCheckboxes = {
     component: JsonCheckboxes,
-    supportedTypes: ["jsonb"],
+    supportedTypes: ["json"],
 }
 
 registry.category("fields").add("account_json_checkboxes", jsonCheckboxes);


### PR DESCRIPTION
The supported type of a widget, must be one of the types found in : odoo/odoo/fields.py. In this precise case, the type is 'json'.

task-id: 4224192