### PR TITLE
[FIX]mrp: workorder list view fixes

### DIFF
--- a/addons/mrp/i18n/mrp.pot
+++ b/addons/mrp/i18n/mrp.pot
@@ -1097,7 +1097,13 @@ msgstr ""
 #. module: mrp
 #. odoo-javascript
 #: code:addons/mrp/static/src/components/wo_list_view_dropdown/wo_list_view_dropdown.xml:0
-msgid "Block WC"
+msgid "Block"
+msgstr ""
+
+#. module: mrp
+#. odoo-javascript
+#: code:addons/mrp/static/src/components/wo_list_view_dropdown/wo_list_view_dropdown.xml:0
+msgid "Unblock"
 msgstr ""
 
 #. module: mrp

--- a/addons/mrp/static/src/components/wo_list_view_dropdown/wo_list_view_dropdown.js
+++ b/addons/mrp/static/src/components/wo_list_view_dropdown/wo_list_view_dropdown.js
@@ -5,8 +5,11 @@ import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { registry } from "@web/core/registry";
 import { rpc } from "@web/core/network/rpc";
 import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
+import { _t } from "@web/core/l10n/translation";
 import { user } from "@web/core/user";
 import { useService } from "@web/core/utils/hooks";
+
+const workcenterStatusBlocked = "blocked";
 
 export class MOListViewDropdown extends Component {
     static template = "mrp.MOViewListDropdown";
@@ -19,11 +22,12 @@ export class MOListViewDropdown extends Component {
     setup() {
         this.orm = useService("orm");
         this.action = useService("action");
-        this.state = useState({
+        this.workorderState = useState({
             state: this.props.record.data.state,
         });
         this.colorIcons = {
             "done": "o_status_success",
+            [workcenterStatusBlocked]: "o_status_danger",
         };
     }
 
@@ -33,11 +37,24 @@ export class MOListViewDropdown extends Component {
     }
 
     get statusColor() {
-        return this.colorIcons[this.state.state] || "";
+        const state = this.isBlocked ? workcenterStatusBlocked : this.workorderState.state;
+        return this.colorIcons[state] || "";
     }
 
-    async block() {
-        if (this.props.record.data.working_state == "blocked") {
+    get isBlocked() {
+        return this.props.record.data.working_state == workcenterStatusBlocked;
+    }
+
+    get blockTitle(){
+        if (this.isBlocked) {
+            return _t("Unblock");
+        }
+        return _t("Block");
+    }
+
+    async toggleBlock() {
+        if (this.isBlocked) {
+            await this.callOrm("button_unblock");
             return;
         }
         const options = {
@@ -50,14 +67,7 @@ export class MOListViewDropdown extends Component {
     }
 
     async markAsDone() {
-        let ids = this.props.record.model.root.selection?.map((element) => element.evalContext.id);
-        // if no records selected, take the current clicked one
-        if (!ids || (ids && ids.length == 0)) {
-            ids = [this.props.record.resId];
-        }
-
-        await this.orm.call("mrp.workorder", "action_mark_as_done", [ids]);
-        await this.reload();
+        await this.callOrm("action_mark_as_done");
     }
 
     async printWO() {
@@ -71,9 +81,20 @@ export class MOListViewDropdown extends Component {
             user.context
         );
     }
+
+    async callOrm(functionName){
+        let ids = this.props.record.model.root.selection?.map((element) => element.evalContext.id);
+        // if no records selected, take the current clicked one
+        if (!ids || ids.length == 0) {
+            ids = [this.props.record.resId];
+        }
+        await this.orm.call("mrp.workorder", functionName, [ids]);
+        await this.reload();
+    }
 }
 
 export const moListViewDropdown = {
+    listViewWidth: 20,
     component: MOListViewDropdown,
 };
 

--- a/addons/mrp/static/src/components/wo_list_view_dropdown/wo_list_view_dropdown.scss
+++ b/addons/mrp/static/src/components/wo_list_view_dropdown/wo_list_view_dropdown.scss
@@ -9,6 +9,9 @@
     .o_status_success {
         background-color: $o-success;
     }
+    .o_status_danger {
+        background-color: $o-danger;
+    }
 }
 
 td.o_data_cell:has(> div.o_widget_mo_view_list_dropdown) {

--- a/addons/mrp/static/src/components/wo_list_view_dropdown/wo_list_view_dropdown.xml
+++ b/addons/mrp/static/src/components/wo_list_view_dropdown/wo_list_view_dropdown.xml
@@ -17,9 +17,9 @@
                 </DropdownItem>
                 <DropdownItem
                     class="`d-flex align-items-center`"
-                    onSelected="() => this.block()">
+                    onSelected="() => this.toggleBlock()">
                         <span t-attf-class="fa fa-lg fa-times-circle text-danger me-2"/>
-                        <span>Block WC</span>
+                        <span t-esc="this.blockTitle"></span>
                 </DropdownItem>
                 <div role="separator" class="dropdown-divider"/>
                 <DropdownItem

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -87,17 +87,15 @@
                 <field name="state" widget="badge" decoration-warning="state == 'progress'" decoration-success="state == 'done'" decoration-danger="state == 'cancel'" decoration-info="state not in ('progress', 'done', 'cancel')"
                   column_invisible="parent and parent.state == 'draft'"
                   invisible="production_state == 'draft'"/>
-                <button name="button_start" type="object" string="Start" class="btn-success px-3"
-                  invisible="production_state in ('draft', 'done', 'cancel') or working_state == 'blocked' or state in ('done', 'cancel') or is_user_working"/>
-                <button name="button_pending" type="object" string="Pause" class="btn-warning px-3"
+                <button name="button_start" type="object" title="Start" class="btn-success px-2"
+                  invisible="production_state in ('draft', 'done', 'cancel') or working_state == 'blocked' or state in ('done', 'cancel') or is_user_working" icon="fa-play"/>
+                <button name="button_pending" type="object" title="Pause" class="btn-warning px-2" icon="fa-pause"
                   invisible="production_state in ('draft', 'done', 'cancel') or working_state == 'blocked' or not is_user_working"/>
-                <button name="button_finish" type="object" string="Done" class="btn-success px-3"
+                <button name="button_finish" type="object" title="Done" class="btn-success px-2" icon="fa-check"
                   invisible="production_state in ('draft', 'done', 'cancel') or working_state == 'blocked' or not is_user_working"/>
-                <button name="button_unblock" type="object" string="Unblock" context="{'default_workcenter_id': workcenter_id}" class="btn-danger px-3"
-                  invisible="production_state in ('draft', 'done', 'cancel') or working_state != 'blocked'"/>
                 <widget name="mo_view_list_dropdown"/>
                 <field name="show_json_popover" column_invisible="True"/>
-                <field name="json_popover" widget="mrp_workorder_popover" string=" " invisible="not show_json_popover"/>
+                <field name="json_popover" widget="mrp_workorder_popover" string=" " invisible="not show_json_popover"  width="30px"/>
             </list>
         </field>
     </record>

--- a/addons/web/static/src/views/widgets/widget.js
+++ b/addons/web/static/src/views/widgets/widget.js
@@ -32,6 +32,18 @@ viewWidgetRegistry.addValidation({
         type: [Function, { type: Array, element: Object, shape: { name: String, type: String } }],
         optional: true,
     },
+    listViewWidth: {
+        type: [
+            Number,
+            {
+                type: Array,
+                element: Number,
+                validate: (array) => array.length === 1 || array.length === 2,
+            },
+            Function,
+        ],
+        optional: true,
+    },
     supportedAttributes: supportedInfoValidation,
     supportedOptions: supportedInfoValidation,
 });


### PR DESCRIPTION
- changed the "start", "pause" and "done" button text to icons to be able to set the button column size at a fixed value
- moved the unblock button in the dropdown
- made the previous block button toggle between block and unblock
- change the dropdown bullet to red when blocked

