### PR TITLE
[FIX] mail: ensure prepareMessageBody is called after editing is canceled

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -168,9 +168,6 @@ export class Message extends Component {
         });
         useEffect(
             () => {
-                if (this.messageBody.el) {
-                    this.prepareMessageBody(this.messageBody.el);
-                }
                 if (this.shadowBody.el) {
                     const bodyEl = document.createElement("span");
                     bodyEl.innerHTML = this.state.showTranslation
@@ -190,6 +187,14 @@ export class Message extends Component {
                 this.props.messageSearch?.searchTerm,
                 this.message.body,
             ]
+        );
+        useEffect(
+            () => {
+                if (!this.state.isEditing) {
+                    this.prepareMessageBody(this.messageBody.el);
+                }
+            },
+            () => [this.state.isEditing, this.message.body]
         );
     }
 

--- a/addons/mail/static/src/core/web_portal/message_patch.js
+++ b/addons/mail/static/src/core/web_portal/message_patch.js
@@ -18,6 +18,9 @@ patch(Message.prototype, {
      * @param {HTMLElement} bodyEl
      */
     prepareMessageBody(bodyEl) {
+        if (!bodyEl) {
+            return;
+        }
         super.prepareMessageBody(...arguments);
         Array.from(bodyEl.querySelectorAll(".o-mail-read-more-less")).forEach((el) => el.remove());
         this.insertReadMoreLess(bodyEl);


### PR DESCRIPTION
This PR fixes an issue where `prepareMessageBody` is not called after canceling the edit of a message. Since there are no changes to `message.body`, the visual updates are not reapplied.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
