### PR TITLE
[FIX] project: _create_next_occurrence_values called unnecessarily

### DIFF
--- a/addons/project/models/project_task_recurrence.py
+++ b/addons/project/models/project_task_recurrence.py
@@ -83,10 +83,14 @@ class ProjectTaskRecurrence(models.Model):
         self.ensure_one()
         # Prevent double mail_followers creation
         self = self.with_context(mail_create_nosubscribe=True)
-        create_values = self._create_next_occurrence_values(occurrence_from)
-        date_deadline = create_values['date_deadline']
-        if not (self.repeat_type == 'until' and date_deadline and date_deadline.date() > self.repeat_until):
-            self.env['project.task'].sudo().create(create_values)
+        if (
+            self.repeat_type != 'until' or
+            not occurrence_from.date_deadline or self.repeat_until and
+            (occurrence_from.date_deadline + self._get_recurrence_delta()).date() <= self.repeat_until
+        ):
+            self.env['project.task'].sudo().create(
+                self._create_next_occurrence_values(occurrence_from)
+            )
 
     def _create_next_occurrence_values(self, occurrence_from):
         self.ensure_one()


### PR DESCRIPTION
Currently, the _create_next_occurence_values method is always called, even if no next occurences need to be created. This is bad, because if the next condition in the code is falsy, we would have created child tasks for nothing since childs are created using copy() in the method to handle recursion.

This PR will fix it by checking beforehand if any next occurence should be made, and call _create_next_occurrence_values only if so.

task-4269547