### PR TITLE
[FIX] mail: fix html_mail_field error on Safari

### DIFF
--- a/addons/mail/static/src/views/web/fields/html_mail_field/convert_inline.js
+++ b/addons/mail/static/src/views/web/fields/html_mail_field/convert_inline.js
@@ -38,7 +38,7 @@ const RE_OFFSET_MATCH = /(^| )offset(-[\w\d]+)*( |$)/;
 const RE_PADDING_MATCH = /[ ]*padding[^;]*;/g;
 const RE_PADDING = /([\d.]+)/;
 const RE_WHITESPACE = /[\s\u200b]*/;
-const SELECTORS_IGNORE = /(^\*$|:hover|:before|:after|:active|:link|::|'|\([^(),]+[,(])/;
+const SELECTORS_IGNORE = /(^\*$|:hover|:before|:after|:active|:link|::|'|\([^(),]+[,(])|@page/;
 // CSS properties relating to font, which Outlook seem to have trouble inheriting.
 const FONT_PROPERTIES_TO_INHERIT = [
     "color",


### PR DESCRIPTION
Issue
On Safari iOS, editing `html_mail` fields (such as "Email signature" in user profile or "Subject" in Quotation send by mail) throws an error: `@page is not a valid selector` at save.

Change
Add `@page` to the list of ignored selectors as it was done in commit 7b68c9eaf8ad94ecbcc3893bf6cc220b7e9b6636 as it is currently not supported by all browsers.

opw-4256252