### PR TITLE
[FIX] point_of_sale: prompt for lot/serial on scanned tracked products

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -664,8 +664,8 @@ export class PosStore extends Reactive {
         // It will return an instance of pos.pack.operation.lot
         // ---
         // This actions cannot be handled inside pos_order.js or pos_order_line.js
-        if (values.product_id.isTracked() && configure) {
-            const code = opts.code;
+        const code = opts.code;
+        if (values.product_id.isTracked() && (configure || code)) {
             let pack_lot_ids = {};
             const packLotLinesToEdit =
                 (!values.product_id.isAllowOnlyOneLot() &&


### PR DESCRIPTION
This commit addresses an issue where scanning a product configured for lot/serial tracking would add the product directly to the order without prompting the user for the required serial or lot number.

opw-4261671

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
