### PR TITLE
[FIX] hw_drivers: change IoT box version number

### DIFF
--- a/addons/hw_drivers/controllers/driver.py
+++ b/addons/hw_drivers/controllers/driver.py
@@ -50,7 +50,7 @@ class DriverController(http.Controller):
     def check_certificate(self):
         """
         This route is called when we want to check if certificate is up-to-date
-        Used in iot-box cron.daily, deprecated since image 24_08 but needed for compatibility with the image 24_01
+        Used in iot-box cron.daily, deprecated since image 24_10 but needed for compatibility with the image 24_01
         """
         helpers.get_certificate_status()
 

--- a/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
@@ -44,7 +44,7 @@ class DisplayDriver(Driver):
         self.rendered_html = ''
         if self.device_identifier != 'distant_display':
             # helpers.get_version returns a string formatted as: <L|W><version> (L: Linux, W: Windows)
-            self.browser = 'chromium-browser' if float(helpers.get_version()[1:]) >= 24.08 else 'firefox'
+            self.browser = 'chromium-browser' if float(helpers.get_version()[1:]) >= 24.10 else 'firefox'
             self.browser_process_name = 'chromium' if self.browser == 'chromium-browser' else self.browser
             self._x_screen = device.get('x_screen', '0')
             self.load_url()
@@ -92,7 +92,7 @@ class DisplayDriver(Driver):
         ]
         subprocess.Popen([self.browser, self.url, *browser_args], env=browser_env)
 
-        # To remove when everyone is on version >= 24.08: chromium has '--start-fullscreen' option
+        # To remove when everyone is on version >= 24.10: chromium has '--start-fullscreen' option
         if self.browser == 'firefox':
             self.call_xdotools('F11')
 

--- a/addons/hw_drivers/iot_handlers/interfaces/DisplayInterface_L.py
+++ b/addons/hw_drivers/iot_handlers/interfaces/DisplayInterface_L.py
@@ -21,7 +21,7 @@ class DisplayInterface(Interface):
         display_devices = {}
 
         if screeninfo is None:
-            # On IoT image < 24.08 we don't have screeninfo installed, so we can't get the connected displays
+            # On IoT image < 24.10 we don't have screeninfo installed, so we can't get the connected displays
             # We return a single display with x_screen = 0, to open a browser anyway, in case one is connected
             display_identifier = 'hdmi_0'
             display_devices[display_identifier] = {

--- a/addons/point_of_sale/tools/posbox/posbox_create_image.sh
+++ b/addons/point_of_sale/tools/posbox/posbox_create_image.sh
@@ -29,7 +29,7 @@ MOUNT_POINT="${__dir}/root_mount"
 OVERWRITE_FILES_BEFORE_INIT_DIR="${__dir}/overwrite_before_init"
 OVERWRITE_FILES_AFTER_INIT_DIR="${__dir}/overwrite_after_init"
 VERSION=17.0
-VERSION_IOTBOX=24.08
+VERSION_IOTBOX=24.10
 
 
 # ask user for the branch/version


### PR DESCRIPTION
New image development was started in August but
now being released in October, so bump version from 24.08 -> 24.10.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
