### PR TITLE
[FIX] pos_loyalty: correctly detect gift card and eWallet

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/components/ticket_screen/ticket_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/ticket_screen/ticket_screen.js
@@ -44,13 +44,6 @@ patch(TicketScreen.prototype, {
         );
     },
     _isEWalletGiftCard(orderline) {
-        const linkedProgramIds = this.pos.models["loyalty.program"].getBy(
-            "trigger_product_ids",
-            orderline.product.id
-        );
-        if (linkedProgramIds) {
-            return linkedProgramIds.length > 0;
-        }
         if (orderline.is_reward_line) {
             const reward = this.pos.models["loyalty.reward"].get(orderline.reward_id);
             const program = reward && reward.program_id;

--- a/addons/pos_loyalty/static/tests/tours/PosLoyaltyTour.js
+++ b/addons/pos_loyalty/static/tests/tours/PosLoyaltyTour.js
@@ -5,6 +5,7 @@ import * as ProductScreen from "@point_of_sale/../tests/tours/helpers/ProductScr
 import * as SelectionPopup from "@point_of_sale/../tests/tours/helpers/SelectionPopupTourMethods";
 import * as Dialog from "@point_of_sale/../tests/tours/helpers/DialogTourMethods";
 import * as Notification from "@point_of_sale/../tests/tours/helpers/generic_components/NotificationTourMethods";
+import * as TicketScreen from "@point_of_sale/../tests/tours/helpers/TicketScreenTourMethods";
 import { registry } from "@web/core/registry";
 import { scan_barcode } from "@point_of_sale/../tests/tours/helpers/utils";
 
@@ -529,5 +530,22 @@ registry.category("web_tour.tours").add("PosRewardProductScanGS1", {
             PosLoyalty.hasRewardLine("50% on your order", "-575.00"),
             PosLoyalty.orderTotalIs("575.00"),
             PosLoyalty.finalizeOrder("Cash", "575.00"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("RefundRulesProduct", {
+    test: true,
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            ProductScreen.clickDisplayedProduct("product_a"),
+            PosLoyalty.finalizeOrder("Cash", "1000"),
+            ProductScreen.isShown(),
+            ...ProductScreen.clickRefund(),
+            TicketScreen.filterIs("Paid"),
+            TicketScreen.selectOrder("-0001"),
+            ProductScreen.pressNumpad("1"),
+            TicketScreen.confirmRefund(),
+            ProductScreen.isShown(),
         ].flat(),
 });


### PR DESCRIPTION
When adding a rules in loyalty program that had a product set, if you try to refund an order containing this product you would get an error

Steps to reproduce:
-------------------
* Create a loyalty program with a rules that has product_ids set to any product.
* Open PoS and make an order with the product set on the loyalty program
* Validate the order
* Try to refund the order
> Observation: You get an error saying you cannot refund giftcards or
  eWallets

Why the fix:
------------
This was happening because `trigger_product_ids` is related to `rule_ids.product_ids`. And when checking if a product is a giftcard or eWallet we first checked that `trigger_product_ids` was set. Now we only check the type of the program linked to a product.

opw-4206226
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
