### PR TITLE
[FIX] l10n_ar, l10n_cl: prevent error when print & send invoice

### DIFF
--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -347,7 +347,7 @@ class AccountMove(models.Model):
         }
         tax_group_ids_to_exclude = self.env['account.tax.group'].browse(tax_group_ids).filtered('l10n_ar_vat_afip_code').ids
         if tax_group_ids_to_exclude:
-            return self.env['account.tax']._exclude_tax_group_from_tax_totals_summary(tax_totals, tax_group_ids_to_exclude)
+            return self.env['account.tax']._exclude_tax_groups_from_tax_totals_summary(tax_totals, tax_group_ids_to_exclude)
         return tax_totals
 
     def _l10n_ar_include_vat(self):

--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -152,7 +152,7 @@ class AccountMove(models.Model):
         }
         tax_group_ids_to_exclude = self.env['account.tax.group'].browse(tax_group_ids).filtered(lambda x: x.l10n_cl_sii_code == 14).ids
         if tax_group_ids_to_exclude:
-            return self.env['account.tax']._exclude_tax_group_from_tax_totals_summary(tax_totals, tax_group_ids_to_exclude)
+            return self.env['account.tax']._exclude_tax_groups_from_tax_totals_summary(tax_totals, tax_group_ids_to_exclude)
         return tax_totals
 
     def _l10n_cl_include_sii(self):


### PR DESCRIPTION
When the customer tries to print & send an invoice,
a traceback will appear.

Steps to reproduce the error:
- Install ``l10n_ar`` module
- Switch to ``(AR) Exento`` company
- Create a tax (Type: Sales) > Advanced Options > Tax Group (VAT 2.5%)
- Create a new invoice > add a product > add that tax > Confirm
- Print & Send > Print & Send

Traceback:
```
AttributeError: 'account.tax' object has no attribute '_exclude_tax_group_from_tax_totals_summary'
  File "<1878>", line 2220, in template_1878
  File "<1878>", line 2202, in template_1878_content
  File "<1878>", line 1292, in template_1878_t_call_0
  File "<1878>", line 166, in template_1878_t_call_6
  File "addons/l10n_ar/models/account_move.py", line 350, in _l10n_ar_get_invoice_totals_for_report
    return self.env['account.tax']._exclude_tax_group_from_tax_totals_summary(tax_totals, tax_group_ids_to_exclude)
```

https://github.com/odoo/odoo/blob/8502e87f4c7543d66c3dc0b12d1260c1d72d05ec/addons/l10n_ar/models/account_move.py#L350

https://github.com/odoo/odoo/blob/8502e87f4c7543d66c3dc0b12d1260c1d72d05ec/addons/l10n_cl/models/account_move.py#L155 Here, ``_exclude_tax_group_from_tax_totals_summary`` method is used instead of ``_exclude_tax_groups_from_tax_totals_summary`` method.
So, it will lead to the above traceback.

sentry-5999534010

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
