### PR TITLE
[FIX] resource, survey: wrong type on test

### DIFF
--- a/addons/resource/static/tests/components/section_one2many_field_tests.js
+++ b/addons/resource/static/tests/components/section_one2many_field_tests.js
@@ -25,7 +25,7 @@ QUnit.module("SectionOneToManyField", (hooks) => {
                     fields: {
                         display_type: { type: "char" },
                         title: { type: "char", string: "Title" },
-                        int: { type: "number", string: "integer" },
+                        int: { type: "integer", string: "number" },
                     },
                     records: [
                         {

--- a/addons/survey/static/tests/components/question_page_list_renderer_tests.js
+++ b/addons/survey/static/tests/components/question_page_list_renderer_tests.js
@@ -23,11 +23,11 @@ QUnit.module("QuestionPageListRenderer", (hooks) => {
                 },
                 lines_sections: {
                     fields: {
-                        sequence: { type: "number" },
+                        sequence: { type: "integer" },
                         is_page: { type: "boolean" },
                         title: { type: "char", string: "Title" },
                         question_type: { type: "string" },
-                        random_questions_count: { type: "number", string: "Question Count" },
+                        random_questions_count: { type: "integer", string: "Question Count" },
                     },
                     records: [
                         {


### PR DESCRIPTION
Number is not a supported type for a field, field types must be one of the types found in : odoo/odoo/fields.py

task-id: 4224192
