### PR TITLE
[FIX] cloud_storage: fix override of mail upload controller

### DIFF
--- a/addons/cloud_storage/controllers/attachment.py
+++ b/addons/cloud_storage/controllers/attachment.py
@@ -27,6 +27,6 @@ class CloudAttachmentController(AttachmentController):
 
         # append upload url to the response to allow the client to directly
         # upload files to the cloud storage
-        attachment = request.env["ir.attachment"].browse(data["data"]["Attachment"][0]["id"]).sudo()
+        attachment = request.env["ir.attachment"].browse(data["data"]["ir.attachment"][0]["id"]).sudo()
         data["upload_info"] = attachment._generate_cloud_storage_upload_info()
         return request.make_json_response(data)

--- a/addons/cloud_storage_azure/tests/__init__.py
+++ b/addons/cloud_storage_azure/tests/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_cloud_storage_azure
+from . import test_cloud_storage_azure_attachment_controller

--- a/addons/cloud_storage_azure/tests/test_cloud_storage_azure.py
+++ b/addons/cloud_storage_azure/tests/test_cloud_storage_azure.py
@@ -15,8 +15,7 @@ from .. import uninstall_hook
 from ..models.ir_attachment import CloudStorageAzureUserDelegationKeys, get_cloud_storage_azure_user_delegation_key
 
 
-class TestCloudStorageAzure(TransactionCase):
-
+class TestCloudStorageAzureCommon(TransactionCase):
     def setUp(self):
         super().setUp()
         self.DUMMY_AZURE_ACCOUNT_NAME = 'accountname'
@@ -53,6 +52,8 @@ class TestCloudStorageAzure(TransactionCase):
 
         CloudStorageAzureUserDelegationKeys.clear()
 
+
+class TestCloudStorageAzure(TestCloudStorageAzureCommon):
     def test_get_user_delegation_key_success(self):
         request_num = 0
 

--- a/addons/cloud_storage_azure/tests/test_cloud_storage_azure_attachment_controller.py
+++ b/addons/cloud_storage_azure/tests/test_cloud_storage_azure_attachment_controller.py
@@ -1,0 +1,88 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import json
+import re
+from requests import Response
+from unittest.mock import patch
+
+import odoo
+from odoo.tools.misc import file_open
+from odoo.addons.cloud_storage_azure.tests.test_cloud_storage_azure import (
+    TestCloudStorageAzureCommon,
+)
+from odoo.addons.mail.tests.test_attachment_controller import TestAttachmentControllerCommon
+
+
+@odoo.tests.tagged("-at_install", "post_install")
+class TestCloudStorageAttachmentController(
+    TestAttachmentControllerCommon, TestCloudStorageAzureCommon
+):
+    def test_cloud_storage_azure_attachment_upload(self):
+        """Test uploading an attachment with azure cloud storage."""
+        thread = self.env["res.partner"].create({"name": "Test"})
+        self.env["ir.config_parameter"].set_param("cloud_storage_provider", "azure")
+        self._authenticate_user(self.user_demo)
+
+        def post(url, **kwargs):
+            response = Response()
+            if url.startswith("https://login.microsoftonline.com"):
+                response.status_code = 200
+                response._content = bytes(json.dumps({"access_token": "xxx"}), "utf-8")
+            if "blob.core.windows.net" in url:
+                response.status_code = 200
+                response._content = self.DUMMY_USER_DELEGATION_KEY_XML
+            return response
+
+        with patch(
+            "odoo.addons.cloud_storage_azure.utils.cloud_storage_azure_utils.requests.post", post
+        ):
+            with file_open("addons/web/__init__.py") as file:
+                res = self.url_open(
+                    url="/mail/attachment/upload",
+                    data={
+                        "csrf_token": odoo.http.Request.csrf_token(self),
+                        "is_pending": True,
+                        "thread_id": thread.id,
+                        "thread_model": thread._name,
+                        "cloud_storage": True,
+                    },
+                    files={"ufile": file},
+                )
+                res.raise_for_status()
+                attachment = self.env["ir.attachment"].search([], order="id desc", limit=1)
+                # ignore signature in url
+                content = re.sub(
+                    r'"url": "https://accountname\.blob\.core\.windows\.net/.*?"',
+                    '"url": "[url]"',
+                    res.content.decode("utf-8"),
+                )
+                self.assertEqual(
+                    json.loads(content),
+                    {
+                        "data": {
+                            "ir.attachment": [
+                                {
+                                    "access_token": False,
+                                    "checksum": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+                                    "create_date": odoo.fields.Datetime.to_string(
+                                        attachment.create_date
+                                    ),
+                                    "filename": "__init__.py",
+                                    "id": attachment.id,
+                                    "mimetype": "text/x-python",
+                                    "name": "__init__.py",
+                                    "res_name": False,
+                                    "size": 0,
+                                    "thread": False,
+                                    "voice": False,
+                                }
+                            ],
+                        },
+                        "upload_info": {
+                            "headers": {"x-ms-blob-type": "BlockBlob"},
+                            "method": "PUT",
+                            "response_status": 201,
+                            "url": "[url]",
+                        },
+                    },
+                )

--- a/addons/cloud_storage_google/tests/__init__.py
+++ b/addons/cloud_storage_google/tests/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_cloud_storage_google
+from . import test_cloud_storage_google_attachment_controller

--- a/addons/cloud_storage_google/tests/test_cloud_storage_google.py
+++ b/addons/cloud_storage_google/tests/test_cloud_storage_google.py
@@ -14,8 +14,7 @@ from odoo.exceptions import UserError
 from .. import uninstall_hook
 
 
-class TestCloudStorageGoogle(TransactionCase):
-
+class TestCloudStorageGoogleCommon(TransactionCase):
     def setUp(self):
         if not service_account:
             self.skipTest('google.oauth2 is not installed')
@@ -41,6 +40,8 @@ class TestCloudStorageGoogle(TransactionCase):
         ICP.set_param('cloud_storage_google_bucket_name', self.bucket_name)
         ICP.set_param('cloud_storage_google_account_info', self.DUMMY_GOOGLE_ACCOUNT_INFO)
 
+
+class TestCloudStorageGoogle(TestCloudStorageGoogleCommon):
     def test_generate_signed_url(self):
         file_name = ' ¥®°²Æçéðπ⁉€∇⓵▲☑♂♥✓➔『にㄅ㊀中한︸🌈🌍👌😀.txt'
         attachment = self.env['ir.attachment'].create([{

--- a/addons/cloud_storage_google/tests/test_cloud_storage_google_attachment_controller.py
+++ b/addons/cloud_storage_google/tests/test_cloud_storage_google_attachment_controller.py
@@ -1,0 +1,68 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import json
+import re
+
+import odoo
+from odoo.tools.misc import file_open
+from odoo.addons.cloud_storage_google.tests.test_cloud_storage_google import (
+    TestCloudStorageGoogleCommon,
+)
+from odoo.addons.mail.tests.test_attachment_controller import TestAttachmentControllerCommon
+
+
+@odoo.tests.tagged("-at_install", "post_install")
+class TestCloudStorageAttachmentController(
+    TestAttachmentControllerCommon, TestCloudStorageGoogleCommon
+):
+    def test_cloud_storage_google_attachment_upload(self):
+        """Test uploading an attachment with google cloud storage."""
+        thread = self.env["res.partner"].create({"name": "Test"})
+        self.env["ir.config_parameter"].set_param("cloud_storage_provider", "google")
+        self._authenticate_user(self.user_demo)
+
+        with file_open("addons/web/__init__.py") as file:
+            res = self.url_open(
+                url="/mail/attachment/upload",
+                data={
+                    "csrf_token": odoo.http.Request.csrf_token(self),
+                    "is_pending": True,
+                    "thread_id": thread.id,
+                    "thread_model": thread._name,
+                    "cloud_storage": True,
+                },
+                files={"ufile": file},
+            )
+            res.raise_for_status()
+            attachment = self.env["ir.attachment"].search([], order="id desc", limit=1)
+            # ignore signature in url
+            content = re.sub(
+                r'"url": "https://storage\.googleapis\.com/.*?"',
+                '"url": "[url]"',
+                res.content.decode("utf-8"),
+            )
+            self.assertEqual(
+                json.loads(content),
+                {
+                    "data": {
+                        "ir.attachment": [
+                            {
+                                "access_token": False,
+                                "checksum": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+                                "create_date": odoo.fields.Datetime.to_string(
+                                    attachment.create_date
+                                ),
+                                "filename": "__init__.py",
+                                "id": attachment.id,
+                                "mimetype": "text/x-python",
+                                "name": "__init__.py",
+                                "res_name": False,
+                                "size": 0,
+                                "thread": False,
+                                "voice": False,
+                            }
+                        ],
+                    },
+                    "upload_info": {"method": "PUT", "response_status": 200, "url": "[url]"},
+                },
+            )

--- a/addons/mail/tests/test_controller_common.py
+++ b/addons/mail/tests/test_controller_common.py
@@ -10,13 +10,14 @@ class TestControllerCommon(HttpCaseWithUserDemo, MailCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.maxDiff = None
         cls._create_portal_user()
         cls.user_public = cls.env.ref("base.public_user")
         cls.guest = cls.env["mail.guest"].create({"name": "Guest"})
         last_message = cls.env["mail.message"].search([], order="id desc", limit=1)
         cls.fake_message = cls.env["mail.message"].browse(last_message.id + 1000000)
 
-    def _authenticate_user(self, user, guest):
+    def _authenticate_user(self, user=None, guest=None):
         if not user or user == self.user_public:
             self.authenticate(None, None)
         else:


### PR DESCRIPTION
Store now returns `ir.attachment` and not `Attachment` as model name.

Note: post kwargs backed-ported fix at https://github.com/odoo/odoo/pull/184506

opw-4260378