### PR TITLE
[IMP] web: add monetary as supported types in float widget

### DIFF
--- a/addons/web/static/src/views/fields/float/float_field.js
+++ b/addons/web/static/src/views/fields/float/float_field.js
@@ -120,7 +120,7 @@ export const floatField = {
             help: _t("Use it with the 'User-friendly format' option to customize the formatting."),
         },
     ],
-    supportedTypes: ["float"],
+    supportedTypes: ["float", "monetary"],
     isEmpty: () => false,
     extractProps: ({ attrs, options }) => {
         // Sadly, digits param was available as an option and an attr.


### PR DESCRIPTION
This commit adds the monetary fields as supported type for the float widget. Note that, a test already exists on monetary_fields.test.js

task-id: 4224192
