### PR TITLE
[IMP] mrp: last_working_user_id O2M > M2O

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -5,7 +5,7 @@ from dateutil.relativedelta import relativedelta
 from collections import defaultdict
 import json
 
-from odoo import api, fields, models, _
+from odoo import Command, _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools import float_compare, format_datetime, float_is_zero, float_round
 
@@ -124,7 +124,7 @@ class MrpWorkorder(models.Model):
     is_user_working = fields.Boolean(
         'Is the Current User Working', compute='_compute_working_users') # technical: is the current user working
     working_user_ids = fields.One2many('res.users', string='Working user on this work order.', compute='_compute_working_users')
-    last_working_user_id = fields.One2many('res.users', string='Last user that worked on this work order.', compute='_compute_working_users')
+    last_working_user_id = fields.Many2one('res.users', string='Last user that worked on this work order.', compute='_compute_working_users')
     costs_hour = fields.Float(
         string='Cost per hour',
         default=0.0, aggregator="avg")
@@ -396,14 +396,16 @@ class MrpWorkorder(models.Model):
     def _compute_working_users(self):
         """ Checks whether the current user is working, all the users currently working and the last user that worked. """
         for order in self:
-            order.working_user_ids = [(4, order.id) for order in order.time_ids.filtered(lambda time: not time.date_end).sorted('date_start').mapped('user_id')]
+            no_date_end_times = order.time_ids.filtered(lambda time: not time.date_end).sorted('date_start')
+            order.working_user_ids = [Command.link(user.id) for user in no_date_end_times.user_id]
             if order.working_user_ids:
                 order.last_working_user_id = order.working_user_ids[-1]
             elif order.time_ids:
-                order.last_working_user_id = order.time_ids.filtered('date_end').sorted('date_end')[-1].user_id if order.time_ids.filtered('date_end') else order.time_ids[-1].user_id
+                times_with_date_end = order.time_ids.filtered('date_end').sorted('date_end')
+                order.last_working_user_id = times_with_date_end[-1].user_id if times_with_date_end else order.time_ids[-1].user_id
             else:
                 order.last_working_user_id = False
-            if order.time_ids.filtered(lambda x: (x.user_id.id == self.env.user.id) and (not x.date_end) and (x.loss_type in ('productive', 'performance'))):
+            if no_date_end_times.filtered(lambda x: (x.user_id.id == self.env.user.id) and (x.loss_type in ('productive', 'performance'))):
                 order.is_user_working = True
             else:
                 order.is_user_working = False

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -355,6 +355,7 @@
         <field name="model">mrp.workorder</field>
         <field name="arch" type="xml">
             <kanban class="o_mrp_workorder_kanban" create="0" sample="1">
+                <field name="last_working_user_id"/>
                 <field name="working_user_ids"/>
                 <field name="working_state"/>
                 <field name="date_start"/>
@@ -380,12 +381,10 @@
                                 <field name="product_id"/>, <field name="qty_production" class="ms-1"/> <field name="product_uom_id"/><t t-if="record.finished_lot_id.value">, </t> <field t-if="record.finished_lot_id.value" name="finished_lot_id" class="ms-1"/>
                             </h5>
                             <div class="o_kanban_workorder_status d-flex ms-auto" t-if="record.state.raw_value == 'progress'">
-                                <span t-if="record.working_state.raw_value != 'blocked' and record.working_user_ids.raw_value.length > 0"><i class="fa fa-play fs-6" role="img" aria-label="Run" title="Run"/></span>
-                                <span t-if="record.working_state.raw_value != 'blocked' and record.working_user_ids.raw_value.length == 0 and record.last_working_user_id.raw_value"><i class="fa fa-pause" role="img" aria-label="Pause" title="Pause"/></span>
-                                <span t-if="record.working_state.raw_value == 'blocked' and (record.working_user_ids.raw_value.length == 0 or record.last_working_user_id.raw_value)"><i class="fa fa-stop" role="img" aria-label="Stop" title="Stop"/></span>
-                                <t name="user_avatar" t-if="record.last_working_user_id.raw_value">
-                                    <field name="last_working_user_id" widget="image" options="{'preview_image': 'avatar_128'}" class="ms-1" alt="Avatar"/>
-                                </t>
+                                <span t-if="record.working_state.raw_value != 'blocked' and record.working_user_ids.raw_value.length > 0" class="fa fa-play fs-6" role="img" aria-label="Is running" title="Is running"/>
+                                <span t-if="record.working_state.raw_value != 'blocked' and record.working_user_ids.raw_value.length == 0 and record.last_working_user_id.raw_value" class="fa fa-pause" role="img" aria-label="Is paused" title="Is paused"/>
+                                <span t-if="record.working_state.raw_value == 'blocked' and (record.working_user_ids.raw_value.length == 0 or record.last_working_user_id.raw_value)" class="fa fa-stop" role="img" aria-label="Is stopped" title="Is stopped"/>
+                                <field t-if="record.last_working_user_id.raw_value" name="last_working_user_id" widget="image" options="{'preview_image': 'avatar_128'}" class="ms-1 o_avatar"/>
                             </div>
                         </footer>
                     </t>


### PR DESCRIPTION
Before this commit, the `mrp.workorder` field `last_working_user_id` was a `One2Many` field which doesn't make sense since this field is either false, either linked to a single `res.users` record (see compute method.)

Make a bit of cleanings in `workcenter_line_kanban`.

Also, rewrite a bit `_compute_working_users`:
- Rename `order` into `user` since it is a `res.users` record;
- Refactor a little all the `filter`'s to make it a little more easier to read.

Enterprise PR: odoo/enterprise#72308