### PR TITLE
[IMP] web: add one2many as supported types in many2ManyTagsField widget

### DIFF
--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
@@ -257,7 +257,7 @@ export const many2ManyTagsField = {
             help: _t("Set an integer field to use colors with the tags."),
         },
     ],
-    supportedTypes: ["many2many"],
+    supportedTypes: ["many2many", "one2many"],
     relatedFields: ({ options }) => {
         const relatedFields = [{ name: "display_name", type: "char" }];
         if (options.color_field) {


### PR DESCRIPTION
This commit adds the one2many fields as supported type for the many2ManyTagsField widget. Note that, a test already exists on many2many_tags_fields.test.js

task-id: 4224192