### PR TITLE
[FIX] l10n_sa_edi_pos: fix rights when getting payment means

### DIFF
--- a/addons/l10n_sa_edi_pos/models/account_edi_xml_ubl_21_zatca.py
+++ b/addons/l10n_sa_edi_pos/models/account_edi_xml_ubl_21_zatca.py
@@ -10,6 +10,6 @@ class AccountEdiXmlUBL21Zatca(models.AbstractModel):
             Return payment means code to be used to set the value on the XML file
         """
         res = super()._l10n_sa_get_payment_means_code(invoice)
-        if invoice._l10n_sa_is_simplified() and invoice.pos_order_ids.payment_ids:
-            res = invoice.pos_order_ids.payment_ids[0].payment_method_id.type
+        if invoice._l10n_sa_is_simplified() and invoice.sudo().pos_order_ids.payment_ids:
+            res = invoice.sudo().pos_order_ids.payment_ids[0].payment_method_id.type
         return res


### PR DESCRIPTION
**Steps to reproduce:**
- Install l10n_sa_edi_pos
- Switch to a Saudi Arabian company (e.g. SA Company)
- Create a user with admin rights for Invoicing, but no right for POS and Inventory
- Connect with that user
- Create an invoice for an Individual contact
- Click on "Send & Print"

**Issue:**
A traceback is raised because the system tries to access some POS orders to get the payment means code, but the user hasn't the rights for that.

opw-4192948




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
