### PR TITLE
[FIX] web: avoid resetting the signature on edit mode

### DIFF
--- a/addons/portal/static/src/js/portal_signature.js
+++ b/addons/portal/static/src/js/portal_signature.js
@@ -81,6 +81,9 @@ var SignatureForm = publicWidget.Widget.extend({
      * @see NameAndSignature.resetSignature();
      */
     resetSignature: function () {
+        if (this.isDestroyed()) {
+            return;
+        }
         return this.nameAndSignature.resetSignature();
     },
 


### PR DESCRIPTION
Problem:
In 16.0, when in edit mode, the signature field (`o_web_sign_signature`) is removed from the DOM, but `this.$signatureField` continues to reference the original DOM node, which is no longer accessible. This causes issues when interacting with the signature field.

Solution:
Check if component is not destroyed on `resetSignature`

Steps to reproduce:
- Create a Sales Order.
- Enter customer preview.
- Enable edit mode.
- Click "Accept & Sign."
- A traceback occurs.

opw-4216372