### PR TITLE
[FIX] account,hr: Prevent non HR people from accessing employees bank accounts

### DIFF
--- a/addons/account/security/account_security.xml
+++ b/addons/account/security/account_security.xml
@@ -302,5 +302,17 @@
         <field name="model_id" ref="model_account_report_external_value"/>
         <field name="domain_force">[('company_id', 'in', company_ids)]</field>
     </record>
+
+    <!--
+        Allow billing officers from accessing res.partner.bank
+        This right is restricted in HR to prevent accessing
+        employees bank account for non HR people.
+    -->
+    <record id="ir_rule_res_partner_bank_billing_officers" model="ir.rule">
+        <field name="name">Billing: Allow accessing employee bank accounts</field>
+        <field name="model_id" ref="base.model_res_partner_bank"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('account.group_account_invoice'))]"/>
+    </record>
 </data>
 </odoo>

--- a/addons/hr/security/hr_security.xml
+++ b/addons/hr/security/hr_security.xml
@@ -60,5 +60,19 @@
         <field name="model_id" ref="model_hr_plan_activity_type"/>
         <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
+
+    <record id="ir_rule_res_partner_bank_internal_users" model="ir.rule">
+        <field name="name">HR: Prevent non HR officers from accessing employee bank accounts</field>
+        <field name="model_id" ref="base.model_res_partner_bank"/>
+        <field name="domain_force">[('partner_id.employee_ids', '=', False)]</field>
+        <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+    </record>
+
+    <record id="ir_rule_res_partner_bank_employees" model="ir.rule">
+        <field name="name">HR: Allow HR officers from accessing employee bank accounts</field>
+        <field name="model_id" ref="base.model_res_partner_bank"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('hr.group_hr_user'))]"/>
+    </record>
 </data>
 </odoo>


### PR DESCRIPTION
Assign to an employee's contact a bank account 
Have a test user with no access to any app
With the test user open the contact app list view
select the employee contact
Actions > Export
Select 'Banks/Account Number'
Export

Issue: in the spreadsheet the bank account of the employee is visible

Backporting https://github.com/odoo/odoo/commit/84e8aa90dd030f9848ae29254e270af700bf528f

opw-4115048
