### PR TITLE
[FIX] core: correctly handle deferred constraints

### DIFF
--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -31,6 +31,20 @@ _logger = logging.getLogger(__name__)
 _schema = logging.getLogger('odoo.schema')
 
 
+def _uniquify(dupes):
+    """
+    Return unique elements from `dupes` keeping the last instance
+    Elements in `dupes` may not be hasheable, comparison is done by equality
+    Example: [A, B, A] -> [B, A]
+    """
+    res = []
+    for item in reversed(dupes):
+        if item not in res:
+            res.append(item)
+    res.reverse()
+    return res
+
+
 class Registry(Mapping):
     """ Model registry for a particular database.
 
@@ -113,7 +127,7 @@ class Registry(Mapping):
         self._assertion_report = odoo.tests.result.OdooTestResult()
         self._fields_by_model = None
         self._ordinary_tables = None
-        self._constraint_queue = deque()
+        self._constraint_stacks = defaultdict(list)  # key order is important
         self.__cache = LRU(8192)
 
         # modules fully loaded (maintained during init phase by `loading` module)
@@ -470,32 +484,45 @@ class Registry(Mapping):
 
     def post_constraint(self, func, *args, **kwargs):
         """ Call the given function, and delay it if it fails during an upgrade. """
+        key = "{!r} {!r} {!r}".format(func, args[:3], dict(kwargs, definition=None))
         try:
-            if (func, args, kwargs) not in self._constraint_queue:
-                # Module A may try to apply a constraint and fail but another module B inheriting
-                # from Module A may try to reapply the same constraint and succeed, however the
-                # constraint would already be in the _constraint_queue and would be executed again
-                # at the end of the registry cycle, this would fail (already-existing constraint)
-                # and generate an error, therefore a constraint should only be applied if it's
-                # not already marked as "to be applied".
-                func(*args, **kwargs)
-        except Exception as e:
-            if self._is_install:
-                _schema.error(*e.args)
-            else:
-                _schema.info(*e.args)
-                self._constraint_queue.append((func, args, kwargs))
+            func(*args, **kwargs)
+        except sql.TableError as e:
+            _schema.info(e.args[0])
+            # Try to apply the constraint once the registry is fully loaded. We keep multiple
+            # constraints under same key because we still want to attempt to add a constraint
+            # even if some override failed.
+            self._constraint_stacks[key].append((func, args, kwargs))
+        else:
+            # If a module successfully applies a constraint, we remove all queued constraints with
+            # same name ignoring the definition. In effect, if module A defines a constraint that is
+            # overridden by module B (loaded after) with a different definition, whenever we load A,
+            # the original constraint may fail to be applied, hence it is queued. The issue is that
+            # later when we post process the queue the constraint still fails to be added. The
+            # solution is to clean the previously enqeueud constraints that were just overriden.
+            removed = self._constraint_stacks.pop(key, [])
+            same = _uniquify(removed)
+            if same:
+                _schema.info("Skipping already applied constraints: %s", same)
 
     def finalize_constraints(self):
         """ Call the delayed functions from above. """
-        while self._constraint_queue:
-            func, args, kwargs = self._constraint_queue.popleft()
-            try:
-                func(*args, **kwargs)
-            except Exception as e:
-                # warn only, this is not a deployment showstopper, and
-                # can sometimes be a transient error
-                _schema.warning(*e.args)
+        for key, funcs_data in reversed(self._constraint_stacks.items()):
+            errors = []
+            for (func, args, kwargs) in reversed(funcs_data):
+                try:
+                    func(*args, **kwargs)
+                except sql.TableError as e:
+                    errors.append(e.args[0])
+                else:
+                    if errors:
+                        errors = _uniquify(errors)
+                        _schema.warning("Constraint %s added, with previous errors:\n%s", key, "\n".join(errors))
+                    break
+            else:
+                errors = _uniquify(errors)
+                _schema.error("Couldn't apply constraint %s, errors:\n%s", key, "\n".join(errors))
+        self._constraint_stacks.clear()
 
     def init_models(self, cr, model_names, context, install=True):
         """ Initialize a list of models (given by their name). Call methods

--- a/odoo/tools/sql.py
+++ b/odoo/tools/sql.py
@@ -174,6 +174,11 @@ def get_depending_views(cr, table, column):
     cr.execute(q, [table, column])
     return cr.fetchall()
 
+
+class TableError(Exception):
+    pass
+
+
 def set_not_null(cr, tablename, columnname):
     """ Add a NOT NULL constraint on the given column. """
     query = 'ALTER TABLE "{}" ALTER COLUMN "{}" SET NOT NULL'.format(tablename, columnname)
@@ -182,7 +187,7 @@ def set_not_null(cr, tablename, columnname):
             cr.execute(query, log_exceptions=False)
             _schema.debug("Table %r: column %r: added constraint NOT NULL", tablename, columnname)
     except Exception:
-        raise Exception("Table %r: unable to set NOT NULL on column %r", tablename, columnname)
+        raise TableError("Table %r: unable to set NOT NULL on column %r" % (tablename, columnname))
 
 def drop_not_null(cr, tablename, columnname):
     """ Drop the NOT NULL constraint on the given column. """
@@ -210,7 +215,7 @@ def add_constraint(cr, tablename, constraintname, definition):
             cr.execute(query2, (definition,), log_exceptions=False)
             _schema.debug("Table %r: added constraint %r as %s", tablename, constraintname, definition)
     except Exception:
-        raise Exception("Table %r: unable to add constraint %r as %s", tablename, constraintname, definition)
+        raise TableError("Table %r: unable to add constraint %r as %s" % (tablename, constraintname, definition))
 
 def drop_constraint(cr, tablename, constraintname):
     """ drop the given constraint. """


### PR DESCRIPTION
When a module redefines a constraint the ORM fails to add it. It puts the operation in a deferred queue and tries to apply them after all modules are loaded. This causes issues with constraints redefinition. E.g. if module A defines a constraint that's overridden in module B and some data is added in the DB that violates the constraint in A. Then each time we reload the DB the ORM would try to re-add the constraint in A and it will fail each time.

Up to now we just output a warning in the logs when the constraint cannot be added in the post processing of the constraints. In this patch we propose to remove any pending operation for a constraint with the same name, ignoring the definition. This would essentially make an override properly work. Under the assumption that when a constraint is being applied, any previous one that failed (and are queued) with the same name can be ignored since it's being overridden.

Example in current modules: the redefinition of `unique_login` constraint in `res.users` in `website` module,
https://github.com/odoo/odoo/blob/09fa1db600c31d2d04f0504f0412cbbc85ff7e3d/addons/website/models/res_users.py#L18 overriding the definition in `base`.
https://github.com/odoo/odoo/blob/09fa1db600c31d2d04f0504f0412cbbc85ff7e3d/odoo/addons/base/models/res_users.py#L414

If we create two users with same login but different websites the original constraint in base cannot be applied and it fails in `finalize_constraints`
https://github.com/odoo/odoo/blob/09fa1db600c31d2d04f0504f0412cbbc85ff7e3d/odoo/modules/registry.py#L574-L577

```
odoo.schema:577 Table 'res_users': unable to add constraint 'res_users_login_key' as UNIQUE (login)
```

Example upgrade logs (target 16): if none of the constraints above can be applied (duplicated login and website user):
```
2024-10-18 13:36:43,689 341966 ERROR test_15_16 odoo.schema: Couldn't apply constraint <function add_constraint at 0x70e3455c2340> (<odoo.sql_db.Cursor object at 0x70e3448a3500>, 'res_users', 'res_users_login_key') {'definition': None}, errors:
Table 'res_users': unable to add constraint 'res_users_login_key' as unique (login, website_id)
Table 'res_users': unable to add constraint 'res_users_login_key' as UNIQUE (login)
```

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
