### PR TITLE
[FIX] models: provide localized datetime to `weeknumber` function

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2526,7 +2526,7 @@ class BaseModel(metaclass=MetaModel):
                         if granularity == 'week':
                             year, week = date_utils.weeknumber(
                                 babel.Locale.parse(locale),
-                                range_start,
+                                value,  # provide date or datetime without UTC conversion
                             )
                             label = f"W{week} {year:04}"
 


### PR DESCRIPTION
Versions
--------
- saas-17.4+

Steps
-----
1. Set localization to UK English (or any using ISO week numbering);
2. use Europe/Brussels timezone;
3. set a task's deadline to 2024-01-01 00:00:00;
4. go to task list view;
5. group by Deadline > Week.

Issue
-----
Task is grouped under W52 2023.
The correct ISO week number for this date is 1.[^1]

Cause
-----
Commit 75c63315169c added a custom `weeknumber` function to `date_utils` to circumvent the issues with Babel's week numbering.

If given a `datetime` object, it should be localized with the appropriate timezone instead of being passed as UTC.

Solution
--------
The value provided to the `_read_group_format_result` is already in the localized timezone. This gets assigned to `range_start`, which gets converted to UTC.

Instead of passing `range_start` to `weeknumber`, we can provide it the unmodified `value` variable.

opw-4188099

[^1]: https://www.calendar-365.co.uk/calendar/2024/January.html