### PR TITLE
[IMP] mail, test_discuss_full: add missing date for avatar caching

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -494,7 +494,7 @@ class DiscussChannel(models.Model):
                     "invitedMembers": Store.many(
                         members,
                         "DELETE",
-                        fields={"channel": [], "persona": ["name", "im_status"]},
+                        fields={"channel": [], "persona": ["name", "im_status", "write_date"]},
                     ),
                 },
             )
@@ -936,7 +936,9 @@ class DiscussChannel(models.Model):
             # add RTC sessions info
             invited_members = invited_members_by_channel[channel]
             info["invitedMembers"] = Store.many(
-                invited_members, "ADD", fields={"channel": [], "persona": ["name", "im_status"]}
+                invited_members,
+                "ADD",
+                fields={"channel": [], "persona": ["name", "im_status", "write_date"]},
             )
             # sudo: discuss.channel.rtc.session - reading sessions of accessible channel is acceptable
             info["rtcSessions"] = Store.many(channel.sudo().rtc_session_ids, "ADD", extra=True)

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -453,7 +453,9 @@ class DiscussChannelMember(models.Model):
                 self.channel_id,
                 {
                     "invitedMembers": Store.many(
-                        members, "ADD", fields={"channel": [], "persona": ["name", "im_status"]}
+                        members,
+                        "ADD",
+                        fields={"channel": [], "persona": ["name", "im_status", "write_date"]},
                     ),
                 },
             )

--- a/addons/mail/models/discuss/discuss_channel_rtc_session.py
+++ b/addons/mail/models/discuss/discuss_channel_rtc_session.py
@@ -143,7 +143,7 @@ class DiscussChannelRtcSession(models.Model):
             data = rtc_session._read_format(fields, load=False)[0]
             data["channel_member_id"] = Store.one(
                 rtc_session.channel_member_id,
-                fields={"channel": [], "persona": ["name", "im_status"]},
+                fields={"channel": [], "persona": ["name", "im_status", "write_date"]},
             )
             store.add(rtc_session, data)
 

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -77,6 +77,9 @@ class TestChannelRTC(MailCommon):
                                 "id": channel_member.partner_id.id,
                                 "im_status": channel_member.partner_id.im_status,
                                 "name": channel_member.partner_id.name,
+                                "write_date": fields.Datetime.to_string(
+                                    channel_member.partner_id.write_date
+                                ),
                             },
                         ],
                     },
@@ -119,6 +122,9 @@ class TestChannelRTC(MailCommon):
                         "id": channel_member.partner_id.id,
                         "im_status": channel_member.partner_id.im_status,
                         "name": channel_member.partner_id.name,
+                        "write_date": fields.Datetime.to_string(
+                            channel_member.partner_id.write_date
+                        ),
                     },
                 ],
                 "Rtc": {
@@ -189,6 +195,9 @@ class TestChannelRTC(MailCommon):
                                 "id": channel_member.partner_id.id,
                                 "im_status": channel_member.partner_id.im_status,
                                 "name": channel_member.partner_id.name,
+                                "write_date": fields.Datetime.to_string(
+                                    channel_member.partner_id.write_date
+                                ),
                             },
                         ],
                     },
@@ -220,6 +229,9 @@ class TestChannelRTC(MailCommon):
                                 "id": channel_member_test_user.partner_id.id,
                                 "im_status": channel_member_test_user.partner_id.im_status,
                                 "name": channel_member_test_user.partner_id.name,
+                                "write_date": fields.Datetime.to_string(
+                                    channel_member_test_user.partner_id.write_date
+                                ),
                             },
                         ],
                     },
@@ -295,6 +307,9 @@ class TestChannelRTC(MailCommon):
                                 "id": channel_member.partner_id.id,
                                 "im_status": channel_member.partner_id.im_status,
                                 "name": channel_member.partner_id.name,
+                                "write_date": fields.Datetime.to_string(
+                                    channel_member.partner_id.write_date
+                                ),
                             },
                         ],
                     },
@@ -329,6 +344,9 @@ class TestChannelRTC(MailCommon):
                                 "id": channel_member.partner_id.id,
                                 "im_status": channel_member.partner_id.im_status,
                                 "name": channel_member.partner_id.name,
+                                "write_date": fields.Datetime.to_string(
+                                    channel_member.partner_id.write_date
+                                ),
                             },
                         ],
                     },
@@ -376,6 +394,9 @@ class TestChannelRTC(MailCommon):
                                 "id": channel_member_test_guest.guest_id.id,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
                                 "name": channel_member_test_guest.guest_id.name,
+                                "write_date": fields.Datetime.to_string(
+                                    channel_member_test_guest.guest_id.write_date
+                                ),
                             },
                         ],
                         "res.partner": [
@@ -383,6 +404,9 @@ class TestChannelRTC(MailCommon):
                                 "id": channel_member_test_user.partner_id.id,
                                 "im_status": channel_member_test_user.partner_id.im_status,
                                 "name": channel_member_test_user.partner_id.name,
+                                "write_date": fields.Datetime.to_string(
+                                    channel_member_test_user.partner_id.write_date
+                                ),
                             },
                         ],
                     },
@@ -448,6 +472,9 @@ class TestChannelRTC(MailCommon):
                                 "id": channel_member_test_user.partner_id.id,
                                 "im_status": channel_member_test_user.partner_id.im_status,
                                 "name": channel_member_test_user.partner_id.name,
+                                "write_date": fields.Datetime.to_string(
+                                    channel_member_test_user.partner_id.write_date
+                                ),
                             },
                         ],
                     },
@@ -485,6 +512,9 @@ class TestChannelRTC(MailCommon):
                                 "id": channel_member_test_user.partner_id.id,
                                 "im_status": channel_member_test_user.partner_id.im_status,
                                 "name": channel_member_test_user.partner_id.name,
+                                "write_date": fields.Datetime.to_string(
+                                    channel_member_test_user.partner_id.write_date
+                                ),
                             },
                         ],
                     },
@@ -538,6 +568,9 @@ class TestChannelRTC(MailCommon):
                                 "id": channel_member_test_guest.guest_id.id,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
                                 "name": channel_member_test_guest.guest_id.name,
+                                "write_date": fields.Datetime.to_string(
+                                    channel_member_test_guest.guest_id.write_date
+                                ),
                             },
                         ],
                     },
@@ -575,6 +608,9 @@ class TestChannelRTC(MailCommon):
                                 "id": channel_member_test_guest.guest_id.id,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
                                 "name": channel_member_test_guest.guest_id.name,
+                                "write_date": fields.Datetime.to_string(
+                                    channel_member_test_guest.guest_id.write_date
+                                ),
                             },
                         ],
                     },
@@ -636,6 +672,9 @@ class TestChannelRTC(MailCommon):
                                 "id": channel_member_test_user.partner_id.id,
                                 "im_status": channel_member_test_user.partner_id.im_status,
                                 "name": channel_member_test_user.partner_id.name,
+                                "write_date": fields.Datetime.to_string(
+                                    channel_member_test_user.partner_id.write_date
+                                ),
                             },
                         ],
                     },
@@ -687,6 +726,9 @@ class TestChannelRTC(MailCommon):
                                 "id": channel_member_test_guest.guest_id.id,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
                                 "name": channel_member_test_guest.guest_id.name,
+                                "write_date": fields.Datetime.to_string(
+                                    channel_member_test_guest.guest_id.write_date
+                                ),
                             },
                         ],
                     },
@@ -781,6 +823,9 @@ class TestChannelRTC(MailCommon):
                                 "id": channel_member_test_guest.guest_id.id,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
                                 "name": channel_member_test_guest.guest_id.name,
+                                "write_date": fields.Datetime.to_string(
+                                    channel_member_test_guest.guest_id.write_date
+                                ),
                             },
                         ],
                         "res.partner": [
@@ -788,6 +833,9 @@ class TestChannelRTC(MailCommon):
                                 "id": channel_member_test_user.partner_id.id,
                                 "im_status": channel_member_test_user.partner_id.im_status,
                                 "name": channel_member_test_user.partner_id.name,
+                                "write_date": fields.Datetime.to_string(
+                                    channel_member_test_user.partner_id.write_date
+                                ),
                             },
                         ],
                     },
@@ -885,6 +933,9 @@ class TestChannelRTC(MailCommon):
                                 "id": channel_member.partner_id.id,
                                 "im_status": channel_member.partner_id.im_status,
                                 "name": channel_member.partner_id.name,
+                                "write_date": fields.Datetime.to_string(
+                                    channel_member.partner_id.write_date
+                                ),
                             },
                         ],
                     },
@@ -919,6 +970,9 @@ class TestChannelRTC(MailCommon):
                                 "id": channel_member.partner_id.id,
                                 "im_status": channel_member.partner_id.im_status,
                                 "name": channel_member.partner_id.name,
+                                "write_date": fields.Datetime.to_string(
+                                    channel_member.partner_id.write_date
+                                ),
                             },
                         ],
                     },
@@ -966,6 +1020,9 @@ class TestChannelRTC(MailCommon):
                                 "id": channel_member_test_guest.guest_id.id,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
                                 "name": channel_member_test_guest.guest_id.name,
+                                "write_date": fields.Datetime.to_string(
+                                    channel_member_test_guest.guest_id.write_date
+                                ),
                             },
                         ],
                         "res.partner": [
@@ -973,6 +1030,9 @@ class TestChannelRTC(MailCommon):
                                 "id": channel_member_test_user.partner_id.id,
                                 "im_status": channel_member_test_user.partner_id.im_status,
                                 "name": channel_member_test_user.partner_id.name,
+                                "write_date": fields.Datetime.to_string(
+                                    channel_member_test_user.partner_id.write_date
+                                ),
                             },
                         ],
                     },

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -1603,6 +1603,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                     "id": user.partner_id.id,
                     "im_status": "offline",
                     "name": "test2",
+                    "write_date": fields.Datetime.to_string(user.partner_id.write_date),
                 }
             return {
                 "active": True,


### PR DESCRIPTION
In some flows the avatar of the persona was displayed but the date was not known, which led to the avatar not being cached.