### PR TITLE
[FIX] maintenance: avoid traceback when computing display_name

### DIFF
--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -134,7 +134,7 @@ class MaintenanceEquipment(models.Model):
     def _compute_display_name(self):
         for record in self:
             if record.serial_no:
-                record.display_name = record.name + '/' + record.serial_no
+                record.display_name = (record.name or '') + '/' + record.serial_no
             else:
                 record.display_name = record.name
 


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Create a new database and install only the Maintenance app.
- Go to Equipment and create a new one.
- Navigate to the product information.
- Set a "Serial Number"

Problem:
A traceback is triggered when we try to compute the field display_name
using `self.name + self.serial_no`, but `self.name`` is not yet set
and is therefore False:

```
record.display_name = record.name + '/' + record.serial_no
                      ~~~~~~~~~~~~^~~~~
TypeError: unsupported operand type(s) for +: 'bool' and 'str'
```

opw-[4261222](https://www.odoo.com/web#id=4261222&view_type=form&model=project.task)