### PR TITLE
[FIX] account: old_value_char can be empty string

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -350,7 +350,7 @@ class AccountTax(models.Model):
         if not self.is_used:
             return
 
-        old_line_values_dict = ast.literal_eval(old_values_str)
+        old_line_values_dict = ast.literal_eval(old_values_str or '{}')
         new_line_values_dict = ast.literal_eval(new_values_str)
 
         # Categorize the lines that were added/removed/modified


### PR DESCRIPTION
In rare cases, the message logging code on account.tax can crash. To reproduce, apply https://github.com/odoo/odoo/pull/184390 and set up a new database with `-i l10n_br_edi,accountant` and then:

1/ Create a new invoice
2/ Set customer "BR Company Customer Estimated Profit",
3/ Add line with “Regular Consumable Product”,
4/ Switch the fiscal position to Avatax Brazil,
5/ Compute Taxes,
6/ Add line with “Added Taxes Consumable Product”,
7/ Compute Taxes,

Traceback:
```
...
File ".../addons/account/models/account_tax.py", line 423, in _message_log
  self._message_log_repartition_lines(tracked_value_id[2]['old_value_char'], tracked_value_id[2]['new_value_char'])
File ".../addons/account/models/account_tax.py", line 353, in _message_log_repartition_lines
  old_line_values_dict = ast.literal_eval(old_values_str)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File ".../odoo/_monkeypatches/literal_eval.py", line 28, in literal_eval
  return orig_literal_eval(expr)
           ^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.12/ast.py", line 66, in literal_eval
  node_or_string = parse(node_or_string.lstrip(" \t"), mode='eval')
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.12/ast.py", line 52, in parse
  return compile(source, filename, mode, flags,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "<unknown>", line 0

SyntaxError: invalid syntax
```

Alternatively, the following shell code reproduces the issue as well on the same database:

```
from odoo import Command

br_company = env['res.company'].search([('name', '=', 'BR Company')])
active_tax = env['account.tax'].search([('name', '=', '3% COFINS')])

move = env['account.move'].with_company(br_company).create({
    'move_type': 'out_invoice',
    'invoice_line_ids': [
        Command.create({
            'price_unit': 100,
            'tax_ids': [Command.set(active_tax.ids)],
        })
    ],
})

inactive_tax = env['account.tax'].with_context(active_test=False).search([('name', '=', 'ICMS ST Excl.')])
inactive_tax.active = True
env['account.move.line'].with_company(br_company).create({
    'move_id': move.id,
    'price_unit': 100,
    'tax_ids': [Command.set(inactive_tax.ids)],
})

env.cr.flush()
```

opw-4239515