### PR TITLE
[14.0][FIX] product_margin: Use update instead of write

### DIFF
--- a/addons/product_margin/models/product_product.py
+++ b/addons/product_margin/models/product_product.py
@@ -166,5 +166,5 @@ class ProductProduct(models.Model):
             res[product.id]['purchase_gap'] = res[product.id]['normal_cost'] - res[product.id]['total_cost']
             res[product.id]['expected_margin'] = res[product.id].get('sale_expected', 0.0) - res[product.id]['normal_cost']
             res[product.id]['expected_margin_rate'] = res[product.id].get('sale_expected', 0.0) and res[product.id]['expected_margin'] * 100 / res[product.id].get('sale_expected', 0.0) or 0.0
-            product.write(res[product.id])
+            product.update(res[product.id])
         return res


### PR DESCRIPTION
Avoid using write method on compute methods.
Instead using update this will also work for an onchange record set. 
Otherwise it fails, because `write` save the changed values immediately to the database. 