### PR TITLE
[FIX] website: allow use of custom templates for the website search

### DIFF
--- a/addons/website/static/src/snippets/s_searchbar/000.js
+++ b/addons/website/static/src/snippets/s_searchbar/000.js
@@ -147,7 +147,7 @@ publicWidget.registry.searchBar = publicWidget.Widget.extend({
             const results = res['results'];
             let template = 'website.s_searchbar.autocomplete';
             const candidate = template + '.' + this.searchType;
-            if (candidate in renderToString.app.rawTemplates) {
+            if (renderToString.app.getRawTemplate(candidate)) {
                 template = candidate;
             }
             this.$menu = $(renderToElement(template, {


### PR DESCRIPTION
With commit [1], `qweb.has_template` was replaced with its owl
equivalent. Later, commit [2] further refactored this and consequently
broke the possibility to use custom templates based on search type for
website search.

[1]: https://github.com/odoo/odoo/commit/123ba4ffccd6fc3895a18f3503690ba1593e3023
[2]: https://github.com/odoo/odoo/commit/21ecc7400f2211773713781c619f066a5fb37963