### PR TITLE
[FIX] l10n_it_edi: check country_id before assigning fiscal code

### DIFF
--- a/addons/l10n_it_edi/models/res_partner.py
+++ b/addons/l10n_it_edi/models/res_partner.py
@@ -39,10 +39,14 @@ class ResPartner(models.Model):
 
     @api.onchange('vat', 'country_id')
     def _l10n_it_onchange_vat(self):
-        if not self.l10n_it_codice_fiscale and self.vat and (self.country_id.code == "IT" or self.vat.startswith("IT")):
-            self.l10n_it_codice_fiscale = self._l10n_it_normalize_codice_fiscale(self.vat)
-        elif self.country_id.code not in [False, "IT"]:
-            self.l10n_it_codice_fiscale = ""
+        if self.vat and (
+            self.country_code == "IT"
+            if self.country_code
+            else self.vat.startswith("IT")
+        ):
+            self.l10n_it_codice_fiscale = self._l10n_it_edi_normalized_codice_fiscale(self.vat)
+        else:
+            self.l10n_it_codice_fiscale = False
 
     @api.constrains('l10n_it_codice_fiscale')
     def validate_codice_fiscale(self):

--- a/addons/l10n_it_edi/tests/__init__.py
+++ b/addons/l10n_it_edi/tests/__init__.py
@@ -4,3 +4,4 @@ from . import common
 from . import test_edi_export
 from . import test_edi_import
 from . import test_edi_reverse_charge
+from . import test_res_partner

--- a/addons/l10n_it_edi/tests/test_res_partner.py
+++ b/addons/l10n_it_edi/tests/test_res_partner.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo.exceptions import UserError
-from odoo.tests.common import TransactionCase, tagged
+from odoo.tests.common import Form, TransactionCase, tagged
 
 
 @tagged('post_install_l10n', 'post_install', '-at_install')
@@ -59,3 +59,15 @@ class TestResPartner(TransactionCase):
             partners += self.env['res.partner'].create({'name': f'partner_{i}', 'l10n_it_codice_fiscale': code})
 
         self.assertEqual(len(partners), len(valid_codes))
+
+    def test_non_italian_partner_codice_fiscale(self):
+        mexican_partner = self.env['res.partner'].create({
+            'name': 'Mexican Customer',
+            'country_id': self.env.ref('base.mx').id,
+        })
+
+        partner_form = Form(mexican_partner)
+        partner_form.vat = "ITR230522NW8"
+        mexican_partner = partner_form.save()
+
+        self.assertFalse(mexican_partner.l10n_it_codice_fiscale, "A non-italian partner should not be given an l10n_it_codice_fiscale")


### PR DESCRIPTION
### Steps to reproduce the issue:

1. Activate Italian Localization
2. Create a contact in any country but Italy
3. Assign VAT number starting with 'IT' (Tax ID or Identification Number)
4. Save and receive error:

>     Invalid Codice Fiscale '[VAT number]': should be like 'MRTMTT91D08F205J' for physical person and '12345670546' for businesses.

### Explanation:

When `country_id` or `vat` is changing, `_l10n_it_onchange_vat` will try to create a `l10n_it_codice_fiscale` if `res.partner` respects some conditions. Those conditions are flawed because if `country_id` is not Italy but `vat` starts with "IT", it will enter the condition.

(Kind of a hack: if `country_id` is set after a `l10n_it_codice_fiscale` has been added to `res.partner`, the first condition will not be met but the second will, and `l10n_codice_fiscale` will turn back to False.)

### Fix reasoning:

We will only check conditions related to `vat` and `country_id` and always perform changes to avoid inconsistencies where `vat` is no longer correct but `l10n_it_codice_fiscale` did not change and is still valid.

opw-4261959
