### PR TITLE
[FIX] survey: missing space in survey certification

### DIFF
--- a/addons/survey/views/survey_report_templates.xml
+++ b/addons/survey/views/survey_report_templates.xml
@@ -26,7 +26,7 @@
                                 </t>
                                 <span t-att-style="certif_style" class="user-name" t-esc="certified_name"/>
 
-                                <br/>by <span class="certification-company" t-field="user_input.env.company.display_name"/> for successfully completing
+                                <br/>by <span class="certification-company" t-field="user_input.env.company.display_name"/>&amp;nbsp; for successfully completing
                                 <br/><b><span class="certification-name" t-field="user_input.survey_id.display_name"/></b>
                              </p>
                         </div>


### PR DESCRIPTION
* STEP TO REPRODUCE: First need to have a long company name, ex: Your Company 123 abc xyz -> Go to survey participant to print certification with modern layout -> Notice that no space between company name and the phrase "for successfully completing".
* * Maybe same issue like
https://github.com/odoo/odoo/commit/9af908335d1afd06da9413b170b648a0126ae5fb
* NOTE: this issue is not happen with classic layout, maybe due the font . And if we add&amp;nbsp; for modern layout, there a little bit extra space for short company name like "YourCompany"

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
