### PR TITLE
[IMP] pos_hr,**:added minimal right profile

### DIFF
--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.xml
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.xml
@@ -62,10 +62,10 @@
                                 </span>
                             </div>
                             <div class="p-2 pos-burger-menu-items">
-                                <DropdownItem t-if="!isDisplayStandalone" onSelected="() => window.open(this.appUrl)">
+                                <DropdownItem t-if="!isDisplayStandalone and this.pos.cashier._role != 'minimal'" onSelected="() => window.open(this.appUrl)">
                                     Install App
                                 </DropdownItem>
-                                <DropdownItem t-if="showCashMoveButton" onSelected="() => this.pos.cashMove()">
+                                <DropdownItem t-if="showCashMoveButton and this.pos.cashier._role != 'minimal'" onSelected="() => this.pos.cashMove()">
                                     Cash In/Out
                                 </DropdownItem>
                                 <DropdownItem t-if="showToggleProductView" onSelected="() => this.toggleProductView()">
@@ -87,7 +87,7 @@
                                 <DropdownItem onSelected="() => this.pos.closeSession()">
                                     Close Register
                                 </DropdownItem>
-                                <DropdownItem t-if="this.env.debug" onSelected="() => debug.toggleWidget()">
+                                <DropdownItem t-if="this.env.debug and this.pos.cashier._role != 'minimal'" onSelected="() => debug.toggleWidget()">
                                     Debug Window
                                 </DropdownItem>
                                 <DropdownItem t-if="!this.pos.data.network.offline" onSelected="() => this.reloadProducts()">

--- a/addons/point_of_sale/static/src/app/components/popups/opening_control_popup/opening_control_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/opening_control_popup/opening_control_popup.xml
@@ -32,6 +32,7 @@
             </div>
             <t t-set-slot="footer">
                 <button class="button btn btn-lg btn-primary"
+                t-if="!(this.pos.cashier._role === 'minimal')"
                     t-on-click="confirm"
                     t-att-disabled="!env.utils.isValidFloat(state.openingCash)">
                     Open Register

--- a/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.js
@@ -19,7 +19,8 @@ export class ProductInfoPopup extends Component {
     _hasMarginsCostsAccessRights() {
         const isAccessibleToEveryUser = this.pos.config.is_margins_costs_accessible_to_every_user;
         const isCashierManager = this.pos.getCashier().role === "manager";
-        return isAccessibleToEveryUser || isCashierManager;
+        const isMinimalCashier = this.pos.getCashier().role === "minimal";
+        return isAccessibleToEveryUser || isCashierManager || isMinimalCashier;
     }
     editProduct() {
         this.pos.editProduct(this.props.productTemplate);

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_line/partner_line.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_line/partner_line.js
@@ -2,6 +2,7 @@ import { Component } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { usePos } from "@point_of_sale/app/hooks/pos_hook";
 
 export class PartnerLine extends Component {
     static template = "point_of_sale.PartnerLine";
@@ -18,6 +19,7 @@ export class PartnerLine extends Component {
     ];
 
     setup() {
+        this.pos = usePos();
         this.ui = useService("ui");
     }
 }

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_line/partner_line.xml
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_line/partner_line.xml
@@ -10,7 +10,7 @@
                         <b t-esc="props.partner.name or ''" />
                         <div class="company-field text-bg-muted" t-esc="props.partner.parent_name or ''" />
                     </div>
-                    <Dropdown>
+                    <Dropdown t-if="this.pos.cashier._role !== 'minimal'">
                         <button class="btn btn-ligth fa fa-bars" />
                         <t t-set-slot="content">
                             <DropdownItem onSelected="() => props.onClickEdit(props.partner)">
@@ -71,19 +71,21 @@
                     </button>
                 </td>
                 <td class="edit-partner-button-cell align-middle">
-                    <Dropdown>
-                        <button class="btn btn-light btn-lg lh-lg border float-end">
-                            <i class="fa fa-fw fa-bars"/>
-                        </button>
-                        <t t-set-slot="content">
-                            <DropdownItem onSelected="() => props.onClickEdit(props.partner)">
-                                Edit Details
-                            </DropdownItem>
-                            <DropdownItem onSelected="() => props.onClickOrders(props.partner)">
-                                All Orders
-                            </DropdownItem>
-                        </t>
-                    </Dropdown>
+                    <t t-if="this.pos.cashier._role !== 'minimal'">
+                        <Dropdown>
+                            <button class="btn btn-light btn-lg lh-lg border float-end">
+                                <i class="fa fa-fw fa-bars"/>
+                            </button>
+                            <t t-set-slot="content">
+                                <DropdownItem onSelected="() => props.onClickEdit(props.partner)">
+                                    Edit Details
+                                </DropdownItem>
+                                <DropdownItem onSelected="() => props.onClickOrders(props.partner)">
+                                    All Orders
+                                </DropdownItem>
+                            </t>
+                        </Dropdown>
+                    </t>
                 </td>
             </tr>
         </t>

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.xml
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.xml
@@ -4,7 +4,7 @@
     <t t-name="point_of_sale.PartnerList">
         <Dialog bodyClass="'partner-list overflow-y-auto'" contentClass="'h-100'">
             <t t-set-slot="header">
-                <button t-if="!ui.isSmall" class="btn btn-primary btn-lg lh-lg" role="img" aria-label="Add a customer"
+                <button t-if="!ui.isSmall and this.pos.cashier._role !== 'minimal'" class="btn btn-primary btn-lg lh-lg" role="img" aria-label="Add a customer"
                         t-on-click="() => this.editPartner()"
                         title="Add a customer">
                 Create 
@@ -46,7 +46,7 @@
             </div>
             <t t-set-slot="footer">
                 <div class="d-flex justify-content-start flex-wrap gap-2 w-100">
-                    <button t-if="ui.isSmall" class="btn btn-primary btn-lg lh-lg" role="img" aria-label="Add a customer"
+                    <button t-if="ui.isSmall and this.pos.cashier._role !== 'minimal'" class="btn btn-primary btn-lg lh-lg" role="img" aria-label="Add a customer"
                         t-on-click="() => this.editPartner()"
                         title="Add a customer">
                     New 

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
@@ -144,7 +144,7 @@
         <div class="paymentmethods-container mb-3" t-att-class="ui.isSmall ? 'my-2 rounded-3' : 'flex-grow-1'">
             <div class="paymentmethods  gap-1 gap-lg-2" t-att-class="{ 'd-grid p-1 gap-1 overflow-y-auto rounded-3 bg-300': ui.isSmall, 'd-flex flex-column gap-lg-2': !ui.isSmall }">
                 <t t-foreach="payment_methods_from_config" t-as="paymentMethod" t-key="paymentMethod.id">
-                    <div class="button paymentmethod btn btn-light btn-lg lh-lg flex-fill"
+                    <div t-if="!(this.pos.cashier._role === 'minimal' and paymentMethod.type === 'pay_later')" class="button paymentmethod btn btn-light btn-lg lh-lg flex-fill"
                         t-att-class="{'opacity-50': this.pos.paymentTerminalInProgress and paymentMethod.use_payment_terminal}"
                         t-on-click="() => this.addNewPaymentLine(paymentMethod)">
                         <div class="payment-method-display d-flex align-items-center gap-2 text-wrap text-start lh-sm">

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -26,16 +26,16 @@
                     type="'customer'"
                     class="buttonClass"
                     icon="'fa fa-sticky-note'"/>
-                <button class="o_pricelist_button btn btn-secondary btn-lg py-5" t-on-click="() => this.clickPricelist()">
+                <button t-if="this.pos.cashier._role != 'minimal'" class="o_pricelist_button btn btn-secondary btn-lg py-5" t-on-click="() => this.clickPricelist()">
                     <i class="fa fa-th-list me-2" role="img" aria-label="Price list" title="Price list" />
                     <t t-if="currentOrder?.pricelist_id" t-esc="currentOrder.pricelist_id.display_name" />
                     <t t-else="">Pricelist</t>
                 </button>
-                <button class="btn btn-secondary btn-lg py-5" t-on-click="() => this.clickRefund()">
+                <button t-if="this.pos.cashier._role != 'minimal'" class="btn btn-secondary btn-lg py-5" t-on-click="() => this.clickRefund()">
                     <i class="fa fa-undo me-1" role="img" aria-label="Refund" title="Refund" />
                     Refund
                 </button>
-                <button t-if="pos.models['account.fiscal.position'].length"
+                <button t-if="pos.models['account.fiscal.position'].length and this.pos.cashier._role != 'minimal'"
                     class="control-button o_fiscal_position_button"
                     t-att-class="buttonClass"
                     t-on-click="() => this.clickFiscalPosition()">
@@ -44,7 +44,7 @@
                     <t t-if="currentOrder?.fiscal_position_id" t-esc="currentOrder.fiscal_position_id.display_name" />
                     <t t-else="">Tax</t>
                 </button>
-                <button class="btn btn-secondary btn-lg py-5" t-on-click="() => this.pos.onDeleteOrder(this.pos.getOrder())">
+                <button t-if="this.pos.cashier._role != 'minimal'" class="btn btn-secondary btn-lg py-5" t-on-click="() => this.pos.onDeleteOrder(this.pos.getOrder())">
                     <i class="fa fa-trash me-1" role="img" /> Cancel Order 
                 </button>
             </div>

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -126,11 +126,17 @@ export class ProductScreen extends Component {
 
         return getButtons(DEFAULT_LAST_ROW, [
             { value: "quantity", text: _t("Qty") },
-            { value: "discount", text: _t("%"), disabled: !this.pos.config.manual_discount },
+            {
+                value: "discount",
+                text: _t("%"),
+                disabled: !this.pos.config.manual_discount || this.pos.cashier._role === "minimal",
+            },
             {
                 value: "price",
                 text: _t("Price"),
-                disabled: !this.pos.cashierHasPriceControlRights(),
+                disabled:
+                    !this.pos.cashierHasPriceControlRights() ||
+                    this.pos.cashier._role === "minimal",
             },
             BACKSPACE,
         ]).map((button) => ({

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -77,7 +77,7 @@
                                     <div class="col wide p-2">
                                         <div><t t-esc="order.pos_reference"></t></div>
                                     </div>
-                                    <div t-if="!shouldHideDeleteButton(order)" class="col very-narrow delete-button p-2" name="delete" t-on-click.stop="() => this.pos.onDeleteOrder(order)">
+                                    <div t-if="!shouldHideDeleteButton(order) and this.pos.cashier._role !== 'minimal'" class="col very-narrow delete-button p-2" name="delete" t-on-click.stop="() => this.pos.onDeleteOrder(order)">
                                         <i class="fa fa-trash" aria-hidden="true"/>
                                     </div>
                                     <div t-else="" class="col very-narrow p-2"></div>
@@ -95,7 +95,7 @@
                                         <div class="orderStatus"><t t-esc="getStatus(order)"></t></div>
                                     </div>
                                     <div class="col p-2">
-                                        <div t-if="!shouldHideDeleteButton(order)" class="col very-narrow delete-button p-2 rounded-2" name="delete" t-on-click.stop="() => this.pos.onDeleteOrder(order)">
+                                        <div t-if="!shouldHideDeleteButton(order) and this.pos.cashier._role !== 'minimal'" class="col very-narrow delete-button p-2 rounded-2" name="delete" t-on-click.stop="() => this.pos.onDeleteOrder(order)">
                                             <i class="fa fa-trash" aria-hidden="true"/> Delete
                                         </div>
                                     </div>
@@ -170,11 +170,12 @@
                                 </div>
                                 <div class="subpads d-flex flex-column">
                                     <Numpad class="'pb-2'" buttons="getNumpadButtons()"/>
-                                    <ActionpadWidget
-                                        partner="getSelectedOrder()?.getPartner()"
-                                        actionName.translate="Refund"
-                                        actionToTrigger.bind="onDoRefund"
-                                    />
+                                        <ActionpadWidget
+                                            t-if="this.pos.cashier._role !== 'minimal'"
+                                            partner="getSelectedOrder()?.getPartner()"
+                                            actionName.translate="Refund"
+                                            actionToTrigger.bind="onDoRefund"
+                                        />
                                 </div>
                             </t>
                             <div t-else="" class="pads border-top d-flex gap-2" >

--- a/addons/pos_discount/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/pos_discount/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -4,7 +4,7 @@
         <xpath
             expr="//t[@t-if='props.showRemainingButtons']/div/button[hasclass('o_pricelist_button')]"
             position="before">
-            <button t-if="pos.config.module_pos_discount and pos.config.discount_product_id"
+            <button t-if="pos.config.module_pos_discount and pos.config.discount_product_id and pos.cashier._role !== 'minimal'"
                 class="js_discount"
                 t-att-class="buttonClass"
                 t-on-click="() => this.clickDiscount()">

--- a/addons/pos_hr/models/pos_config.py
+++ b/addons/pos_hr/models/pos_config.py
@@ -6,6 +6,9 @@ from odoo import models, fields, api
 class PosConfig(models.Model):
     _inherit = 'pos.config'
 
+    minimal_employee_ids = fields.Many2many(
+        'hr.employee', 'pos_hr_minimal_employee_hr_employee', string="Employees with minimal access",
+        help='If left empty, all employees can log in to PoS')
     basic_employee_ids = fields.Many2many(
         'hr.employee', 'pos_hr_basic_employee_hr_employee', string="Employees with basic access",
         help='If left empty, all employees can log in to PoS')
@@ -13,14 +16,26 @@ class PosConfig(models.Model):
         'hr.employee', 'pos_hr_advanced_employee_hr_employee', string="Employees with manager access",
         help='If left empty, only Odoo users have extended rights in PoS')
 
+    @api.onchange('minimal_employee_ids')
+    def _onchange_minimal_employee_ids(self):
+        for employee in self.minimal_employee_ids:
+            if employee in self.basic_employee_ids:
+                self.basic_employee_ids -= employee
+            if employee in self.advanced_employee_ids:
+                self.advanced_employee_ids -= employee
+
     @api.onchange('basic_employee_ids')
     def _onchange_basic_employee_ids(self):
         for employee in self.basic_employee_ids:
             if employee in self.advanced_employee_ids:
                 self.advanced_employee_ids -= employee
+            if employee in self.minimal_employee_ids:
+                self.minimal_employee_ids -= employee
 
     @api.onchange('advanced_employee_ids')
     def _onchange_advanced_employee_ids(self):
         for employee in self.advanced_employee_ids:
             if employee in self.basic_employee_ids:
                 self.basic_employee_ids -= employee
+            if employee in self.minimal_employee_ids:
+                self.minimal_employee_ids -= employee

--- a/addons/pos_hr/models/res_config_settings.py
+++ b/addons/pos_hr/models/res_config_settings.py
@@ -11,15 +11,29 @@ class ResConfigSettings(models.TransientModel):
         help='If left empty, all employees can log in to PoS')
     pos_advanced_employee_ids = fields.Many2many(related='pos_config_id.advanced_employee_ids', readonly=False,
         help='If left empty, only Odoo users have extended rights in PoS')
+    pos_minimal_employee_ids = fields.Many2many(related='pos_config_id.minimal_employee_ids', readonly=False,
+        help='If left empty, all employees can log in to PoS')
+
+    @api.onchange('pos_minimal_employee_ids')
+    def _onchange_minimal_employee_ids(self):
+        for employee in self.pos_minimal_employee_ids:
+            if employee in self.pos_basic_employee_ids:
+                self.pos_basic_employee_ids -= employee
+            if employee in self.pos_advanced_employee_ids:
+                self.pos_advanced_employee_ids -= employee
 
     @api.onchange('pos_basic_employee_ids')
     def _onchange_basic_employee_ids(self):
         for employee in self.pos_basic_employee_ids:
             if employee in self.pos_advanced_employee_ids:
                 self.pos_advanced_employee_ids -= employee
+            if employee in self.pos_minimal_employee_ids:
+                self.pos_minimal_employee_ids -= employee
 
     @api.onchange('pos_advanced_employee_ids')
     def _onchange_advanced_employee_ids(self):
         for employee in self.pos_advanced_employee_ids:
             if employee in self.pos_basic_employee_ids:
                 self.pos_basic_employee_ids -= employee
+            if employee in self.pos_minimal_employee_ids:
+                self.pos_minimal_employee_ids -= employee

--- a/addons/pos_hr/views/pos_config.xml
+++ b/addons/pos_hr/views/pos_config.xml
@@ -8,12 +8,16 @@
             <xpath expr="//div[@id='warning_text_employees']" position='replace'>
                 <field name="company_id" invisible="1" />
                 <div class="row">
+                    <label for="advanced_employee_ids" string="Advanced rights" class="col-lg-5 o_light_label" />
+                    <field name="advanced_employee_ids" widget="many2many_tags" placeholder="Select Employee(s)" domain="[('company_id', '=', company_id)]" />
+                </div>
+                <div class="row">
                     <label for="basic_employee_ids" string="Basic rights" class="col-lg-5 o_light_label" />
                     <field name="basic_employee_ids" widget="many2many_tags" placeholder="All Employees" domain="[('company_id', '=', company_id)]" />
                 </div>
                 <div class="row">
-                    <label for="advanced_employee_ids" string="Advanced rights" class="col-lg-5 o_light_label" />
-                    <field name="advanced_employee_ids" widget="many2many_tags" placeholder="Select Employee(s)" domain="[('company_id', '=', company_id)]" />
+                    <label for="minimal_employee_ids" string="Minimal rights" class="col-lg-5 o_light_label" />
+                    <field name="minimal_employee_ids" widget="many2many_tags" placeholder="Select Employee(s)" domain="[('company_id', '=', company_id)]" />
                 </div>
             </xpath>
         </field>

--- a/addons/pos_hr/views/res_config_settings_views.xml
+++ b/addons/pos_hr/views/res_config_settings_views.xml
@@ -7,12 +7,16 @@
         <field name="arch" type="xml">
             <xpath expr="//div[@id='warning_text_employees']" position='replace'>
                 <div class="row">
+                    <label for="pos_advanced_employee_ids" string="Advanced rights" class="col-lg-4 o_light_label" />
+                    <field name="pos_advanced_employee_ids" widget="many2many_tags" placeholder="Select Employee(s)" domain="[('company_id', '=', company_id)]" />
+                </div>
+                <div class="row">
                     <label for="pos_basic_employee_ids" string="Basic rights" class="col-lg-4 o_light_label" />
                     <field name="pos_basic_employee_ids" widget="many2many_tags" placeholder="All Employees" domain="[('company_id', '=', company_id)]" />
                 </div>
                 <div class="row">
-                    <label for="pos_advanced_employee_ids" string="Advanced rights" class="col-lg-4 o_light_label" />
-                    <field name="pos_advanced_employee_ids" widget="many2many_tags" placeholder="Select Employee(s)" domain="[('company_id', '=', company_id)]" />
+                    <label for="pos_minimal_employee_ids" string="Minimal rights" class="col-lg-4 o_light_label" />
+                    <field name="pos_minimal_employee_ids" widget="many2many_tags" placeholder="Select Employee(s)" domain="[('company_id', '=', company_id)]" />
                 </div>
             </xpath>
         </field>

--- a/addons/pos_loyalty/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/pos_loyalty/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -23,7 +23,7 @@
                     <i class="fa fa-barcode me-1"/>Enter Code
                 </button>
             </t>
-            <t t-if="pos.models['loyalty.program'].length">
+            <t t-if="pos.models['loyalty.program'].length and this.pos.cashier._role !== 'minimal'">
                 <button class="control-button"
                     t-att-class="buttonClass"
                     t-attf-class="{{getPotentialRewards().length ? 'highlight text-action' : 'disabled'}}"
@@ -33,7 +33,7 @@
             </t>
         </xpath>
         <xpath expr="//t[@t-if='props.showRemainingButtons']/div/button[hasclass('o_pricelist_button')]" position="before">
-            <t t-if="pos.models['loyalty.program'].some((p) => ['coupons', 'promotion'].includes(p.program_type))">
+            <t t-if="pos.models['loyalty.program'].some((p) => ['coupons', 'promotion'].includes(p.program_type)) and this.pos.cashier._role !== 'minimal'">
                 <button class="btn btn-secondary btn-lg py-5" t-att-class="{'disabled': !pos.getOrder().isProgramsResettable()}"
                     t-on-click="() => this.pos.resetPrograms()">
                     <i class="fa fa-star me-1"/>Reset Programs

--- a/addons/pos_sale/static/src/app/components/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/pos_sale/static/src/app/components/screens/product_screen/control_buttons/control_buttons.xml
@@ -4,7 +4,7 @@
         <xpath
             expr="//t[@t-if='props.showRemainingButtons']/div/button[hasclass('o_pricelist_button')]"
             position="before">
-            <button t-att-class="buttonClass" t-on-click="() => this.onClickQuotation()">
+            <button t-if="this.pos.cashier._role != 'minimal'" t-att-class="buttonClass" t-on-click="() => this.onClickQuotation()">
                 <i class="fa fa-link me-1" role="img" aria-label="Set Sale Order" title="Set Sale Order" /> Quotation/Order
             </button>
         </xpath>

--- a/addons/pos_self_order/static/src/overrides/components/product_info_banner/product_info_banner.xml
+++ b/addons/pos_self_order/static/src/overrides/components/product_info_banner/product_info_banner.xml
@@ -2,18 +2,18 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.ProductInfoBanner" t-inherit="point_of_sale.ProductInfoBanner" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('section-product-info-title')]" position="after">
-            <div class="section-self-order-availability mt-3 mb-4 pb-4 border-bottom text-start d-flex align-items-center">
-                <h3 class="section-title">Self-ordering:</h3>
-                <div class="section-self-order-availability-body d-flex ms-auto">
-                    <div class="form-check form-switch">
-                        <input class="form-check-input" type="checkbox" t-att-checked="props.productTemplate.self_order_available" t-on-click="() => this.switchSelfAvailability()" />
+                <div t-if="this.pos.cashier._role !== 'minimal'"  class="section-self-order-availability mt-3 mb-4 pb-4 border-bottom text-start d-flex align-items-center">
+                    <h3 class="section-title">Self-ordering:</h3>
+                    <div class="section-self-order-availability-body d-flex ms-auto">
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" type="checkbox" t-att-checked="props.productTemplate.self_order_available" t-on-click="() => this.switchSelfAvailability()" />
+                        </div>
+                        <span>
+                            <t t-if="props.productTemplate.self_order_available">Available</t>
+                            <t t-else="">Not available</t>
+                        </span>
                     </div>
-                    <span>
-                        <t t-if="props.productTemplate.self_order_available">Available</t>
-                        <t t-else="">Not available</t>
-                    </span>
                 </div>
-            </div>
         </xpath>
     </t>
 </templates>


### PR DESCRIPTION
**=point_of_sale, pos_restaurant, pos_self_order

Following this commit:
====
- Minimal right option is added in res.config.setting and also in pos.config when "Log in with Employees" option is enabled.
- This right gives minimal right to the user to access the POS like :
   - Only able to access order and switch floor view.
   - In action button no access is given to Refund , Pricelist, Tax, Cancel Order and Quotation/Order options.
   - No access to create or edit customers.
   - No access to allow payment with Customer Account.
   - No access for edit payment option.

task - 4261251
