### PR TITLE
[FIX] pos_self_order: new tracking number is generated once order is sent

### DIFF
--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -15,7 +15,9 @@ class PosSelfOrderController(http.Controller):
 
         # Create the order
         ir_sequence_session = pos_config.env['ir.sequence'].with_context(company_id=pos_config.company_id.id).next_by_code(f'pos.order_{pos_session.id}')
-        sequence_number = re.findall(r'\d+', ir_sequence_session)[0]
+        sequence_number = order.get('sequence_number')
+        if not sequence_number:
+            sequence_number = re.findall(r'\d+', ir_sequence_session)[0]
         order_reference = self._generate_unique_id(pos_session.id, pos_config.id, sequence_number, device_type)
         fiscal_position = (
             pos_config.takeaway_fp_id


### PR DESCRIPTION
Steps to reproduce :
====
1.Activate mobile menu in restaurant config.
2.Open mobile menu.
3.Make an order up to confirmation page (tracking number is available). 4.Refresh the page
5.Go to My Order and pay again , new tracking number is generated.

Issue:
====
- A new tracking number is being generated, even though the order was previously sent and already has an existing tracking number.

Fix :
====
- Preventing the creation of a new tracking number if the order already has one.

task - 4259426
