### PR TITLE
[FIX] base: del 0 val parent_res_id when duplicating filter

### DIFF
--- a/odoo/addons/base/models/ir_filters.py
+++ b/odoo/addons/base/models/ir_filters.py
@@ -39,6 +39,11 @@ class IrFilters(models.Model):
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)
+        # NULL Integer field value read as 0, wouldn't matter except in this case will trigger
+        # check_res_id_only_when_embedded_action
+        for vals in vals_list:
+            if vals.get('embedded_parent_res_id') == 0:
+                del vals['embedded_parent_res_id']
         return [dict(vals, name=_("%s (copy)", ir_filter.name)) for ir_filter, vals in zip(self, vals_list)]
 
     def write(self, vals):


### PR DESCRIPTION
**Current behavior:**
Duplicating a user-defined filter will fail and trigger an exception.

**Expected behavior:**
Record duplicates.

**Steps to reproduce:**
1. Go to some menu, create a filter

2. In technical settings, go to user-defined-filters menu

3. Select one and duplicate it -> Exception

**Cause of issue:**
The SQL constraint check_res_id_only_when_embedded_action is triggering because `embedded_parent_res_id` is an Integer type field which, when NULL in postgres, will be interpreted by the ORM as 0 when the record we want to duplicate has its values copied.

**Fix:**
In the copy_data override for `ir.filters`, delete the key, value pair for `embedded_parent_res_id` if its value is 0. The only case this problem arises in, is when we copy values from an existing filter record and directly use them for creating a new one- i.e., on duplication/copy.

opw-4234421