### PR TITLE
[FIX] web_editor, website_blog: new update translation controller

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -976,3 +976,8 @@ class Web_Editor(http.Controller):
                 raise UserError(_("Sorry, we could not generate a response. Please try again later."))
         except AccessError:
             raise AccessError(_("Oops, it looks like our AI is unreachable!"))
+
+    @http.route("/web_editor/field/translation/update", type="json", auth="user", website=True)
+    def update_field_translation(self, model, record_id, field_name, translations):
+        record = request.env[model].browse(record_id)
+        return record.web_update_field_translations(field_name, translations)

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -2469,14 +2469,12 @@ export class Wysiwyg extends Component {
                     [$(x).data('oe-translation-source-sha')]: this._getEscapedElement($(x)).html()
                 })
             ));
-            return this.orm.call(
-                $els.data('oe-model'),
-                'web_update_field_translations',
-                [
-                    [+$els.data('oe-id')],
-                    $els.data('oe-field'),
-                    translations,
-                ], { context });
+            return rpc('/web_editor/field/translation/update', {
+                model: $els.data('oe-model'),
+                record_id: [+$els.data('oe-id')],  
+                field_name: $els.data('oe-field'),
+                translations,                
+            });
         } else {
             var viewID = $el.data('oe-id');
             if (!viewID) {

--- a/addons/website_blog/tests/test_website_blog_flow.py
+++ b/addons/website_blog/tests/test_website_blog_flow.py
@@ -1,7 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import json
 
 from odoo.exceptions import UserError
-from odoo.tests.common import users
+from odoo.tests.common import users, HttpCase, tagged
 from odoo.addons.website.tools import MockRequest
 from odoo.addons.website_blog.tests.common import TestWebsiteBlogCommon
 from odoo.addons.portal.controllers.mail import PortalChatter
@@ -115,21 +116,36 @@ class TestWebsiteBlogFlow(TestWebsiteBlogCommon):
         self.assertEqual(self.test_blog_post.teaser, "Test Content...")
 
 
-class TestWebsiteBlogTranslationFlow(TestWebsiteBlogCommon):
-    def setUp(self):
-        self.parseltongue = self.env['res.lang'].create({
+@tagged('-at_install', 'post_install')
+class TestWebsiteBlogTranslationFlow(HttpCase, TestWebsiteBlogCommon):
+    
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.parseltongue = cls.env['res.lang'].create({
             'name': 'Parseltongue',
             'code': 'pa_GB',
             'iso_code': 'pa_GB',
             'url_code': 'pa_GB',
         })
-        self.env["base.language.install"].create({
+        cls.env["base.language.install"].create({
             'overwrite': True,
-            'lang_ids': [(6, 0, [self.parseltongue.id])],
+            'lang_ids': [(6, 0, [cls.parseltongue.id])],
         }).lang_install()
+        cls.headers = {"Content-Type": "application/json"}
+
+    def _build_payload(self, params=None):
+        """
+        Helper to properly build jsonrpc payload
+        """
+        return {
+            "jsonrpc": "2.0",
+            "method": "call",
+            "id": 0,
+            "params": params or {},
+        }
 
     def test_teaser_manual(self):
-        super().setUp()
         blog_post_parseltongue = self.test_blog_post.with_context(lang=self.parseltongue.code)
 
         # No manual teaser, ensure everything works as expected in multi langs
@@ -171,3 +187,40 @@ class TestWebsiteBlogTranslationFlow(TestWebsiteBlogCommon):
         self.assertEqual(blog_post_parseltongue.teaser, "New Parseltongue Content...", "Should still fallback to content")
         self.assertEqual(self.test_blog_post.teaser_manual, "English Teaser Manual")
         self.assertFalse(blog_post_parseltongue.teaser_manual, "Should still be empty")
+
+    def test_update_field_translation(self):
+        """Test updating the translated text when default lang isn't en_US"""
+        self.authenticate('admin', 'admin')
+
+        # Setup
+        br_lang = self.env['res.lang']._activate_lang('pt_BR')
+        en_lang = self.env['res.lang']._activate_lang('en_US')
+        
+        website = self.env['website'].browse(1)
+        website.language_ids += br_lang
+        website.default_lang_id = br_lang
+
+        blog_post = self.env['blog.post'].with_context(lang=br_lang.code).create({
+            'name':'Test Blog',
+            'content':'Todos os blogs', 
+        })
+        # sha256 encoding of 'Todos os blogs'
+        sha = 'c10cb3d9aeec6fe03ed86f24efb262c65ed9de7e9263db1605e3196c343de7a3'
+
+        # Ensure that initial translations for 'en_US' and 'pt_BR' are different
+        blog_post.update_field_translations('content', {
+            en_lang.code: {'Todos os blogs' : 'All blogs'}
+        })
+        self.assertEqual('Todos os blogs', blog_post.with_context(lang=br_lang.code).content)
+        self.assertEqual('All blogs', blog_post.with_context(lang=en_lang.code).content)
+        
+        # Test updating translation
+        payload = self._build_payload({
+            'model': blog_post._name,
+            'record_id': blog_post.id,
+            'field_name': 'content',
+            'translations': {en_lang.code: {sha: 'Updated blogs'}},
+        })
+        self.url_open('/web_editor/field/translation/update', data=json.dumps(payload), headers=self.headers)
+        self.assertEqual('Todos os blogs', blog_post.with_context(lang=br_lang.code).content)
+        self.assertEqual('Updated blogs', blog_post.with_context(lang=en_lang.code).content)


### PR DESCRIPTION
In the current implementation, updating translations for a `blog.post`
via the route
`/web/dataset/call_kw/blog.post/web_update_field_translations`
fails to apply changes when the post has already been translated once.
This issue is caused by how the system fetches `website.default_lang_id`
from the request.

__Current behavior before commit:__
When editing a previously translated field for `blog.post` or
`product.template`, the system retrieves the website from the request to
determine the `source_lang`. This is used to search for the original
term in the source language and update its translation. However, due to
the `website=True` parameter not being set for the controller,the system
defaults to English (`source_lang = 'en_US'`). As a result:

1. The system searches for the original word in English, even if it
exists in another language.
2. The translation update fails because the original word cannot be
found in English.

__Description of the fix:__
A new controller was introduced to specifically handle translation
updates, ensuring the correct language is fetched and the translation
logic is applied correctly.

__Steps to reproduce the issue:__
1. Add 2 or more languages to the website.
2. Set the default language to any language other than English (US).
3. Create a blog post and write text in the default language.
4. Switch to another language, translate the text and save.
5. Edit the translated text again.
The last edits are not saved.

- bug introduced in: [#06346b0][1]
- opw-4239512

[1]: https://github.com/odoo/odoo/commit/06346b049a3a13a9a8b63a4f60151ec24fabb59e