### PR TITLE
[FIX] survey: correctly set the string 'Date' in survey certification

### DIFF
--- a/addons/survey/views/survey_report_templates.xml
+++ b/addons/survey/views/survey_report_templates.xml
@@ -37,8 +37,8 @@
 
                     <div class="certification-bottom">
                         <div class="certification-date-wrapper">
-                            <div class="certification-date" t-field="user_input.create_date" t-options='{"widget": "date"}'/>
                             <span>Date</span>
+                            <div class="certification-date" t-field="user_input.create_date" t-options='{"widget": "date"}'/>
                         </div>
                         <div class="certification-company">
                             <span class="certification-company-logo" t-field="user_input.env.company.logo" t-options="{'widget': 'image'}" role="img"/>
@@ -93,8 +93,8 @@
 
                     <div class="certification-bottom">
                             <div class="certification-date-wrapper">
-                                <b><div class="certification-date" t-field="user_input.create_date" t-options='{"widget": "date"}'/></b>
                                 <span>Date</span>
+                                <b><div class="certification-date" t-field="user_input.create_date" t-options='{"widget": "date"}'/></b>
                             </div>
                             <div class="certification-seal"/>
                             <div class="certification-company">


### PR DESCRIPTION
* Before this commit: when user print the certification the string 'Date' is display on the bottom of the date

* After this commit: The 'Date' string is display on the top of date

* Note: in v17 the string 'Date' is on the right side so this fix will make it on the left side in v17





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
