### PR TITLE
[FIX] website_sale: update breadcrumb on category creation

### DIFF
--- a/addons/website_sale/models/product_public_category.py
+++ b/addons/website_sale/models/product_public_category.py
@@ -44,6 +44,7 @@ class ProductPublicCategory(models.Model):
                 lambda cat: cat.name or _("New")
             ))
 
+    @api.depends('parent_path')
     def _compute_parents_and_self(self):
         for category in self:
             if category.parent_path:


### PR DESCRIPTION
Problem:
When creating a new e-commerce category, the breadcrumb displays "Unnamed" instead of the actual category name. This happens because the `parents_and_self` field is not recomputed when `parent_path` changes, despite the former depending on the latter.

Solution:
Ensure that `parents_and_self` is recomputed whenever `parent_path` is updated, so that the correct name is reflected in the breadcrumb.

Steps to reproduce:
- Open the form to create a new e-commerce category.
- After saving, the breadcrumb displays "Unnamed" instead of the actual category name.

opw-4267144

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
