### PR TITLE
[IMP] mass_mailing: add hook class to allow overriding mailing form view

### DIFF
--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -84,7 +84,7 @@
                             string="Remove from Templates"/>
                         <field name="state" readonly="1" widget="statusbar" statusbar_visible="draft,in_queue,sending,done"/>
                     </header>
-                    <div class="alert alert-info" role="alert"
+                    <div class="alert alert-info o_mass_mailing_alert_message" role="alert"
                             invisible="state not in ['in_queue', 'done'] and sent == 0 and canceled == 0 and scheduled == 0 and failed == 0 and not warning_message">
                         <div class="o_mails_canceled" invisible="canceled == 0">
                             <button class="btn btn-link py-0"

--- a/addons/web_editor/static/src/xml/snippets.xml
+++ b/addons/web_editor/static/src/xml/snippets.xml
@@ -157,7 +157,7 @@
             </div>
 
             <div t-if="!this.hasSnippetGroups" class="o_snippet_search_filter" t-att-class="{ 'd-none': state.currentTab !== constructor.tabs.BLOCKS }">
-                <input type="text" class="o_snippet_search_filter_input" t-ref="search-input" t-model="state.search" placeholder="Search for a block (e.g. numbers, image wall, ...)"/>
+                <input type="text" class="o_snippet_search_filter_input" t-ref="search-input" t-model="state.search" placeholder="Search for a block (e.g. numbers, image, ...)"/>
                 <i role="button" class="fa fa-times o_snippet_search_filter_reset" t-att-class="{ 'd-none': state.search === ''}" t-on-click="() => state.search = ''"/>
             </div>
 


### PR DESCRIPTION
This PR changes the name of the 'image wall' placeholder in the snippet menu's search bar to 'image' since it returns no results.

It also adds a hook class to the alert box over the mailing form view
to allow modifying it in inherited view.

Task-3901336

