### PR TITLE
[FIX] stock: unable to add serial numbers

### DIFF
--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -231,6 +231,7 @@
                             <field name="location_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations" invisible="picking_type_code == 'incoming'" readonly="state == 'done'"/>
                             <field name="location_dest_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations" invisible="picking_type_code == 'outgoing'" readonly="state == 'done'"/>
                             <field name="backorder_id" invisible="not backorder_id"/>
+                            <field name="use_create_lots" invisible="1"/> <!-- used by embedded stock.move list view below -->
                         </group>
                         <group>
                             <label for="scheduled_date"/>


### PR DESCRIPTION
The `use_create_lots` field was missing in the parent view after this https://github.com/odoo/odoo/pull/137031/commits/ecc6a3c0776501ca79604af21fd5515f74f6b7e8#diff-7a1e0a179b7361b04b4bb165dbfc18fabd2fc972ff190fbf21144db03f9b86b1L139 , causing a silent failure in the `options` condition for allowing users to create new lots/serial numbers. As a result, users were unable to add serial numbers during receipt creation because the condition `options="{'create': [('parent.use_create_lots', '=', True)]}"` was never met.

Steps to reproduce the error:
1. Create a new product with lot/serial number tracking.
2. Create a receipt for that product.
3. Try to add serial numbers to the receipt.

The expected behavior is to be able to add serial numbers, but users were blocked from doing so due to the missing field.
To resolve this, the `use_create_lots` field has been added to the parent view, ensuring that the condition for allowing lot creation works as expected.

opw-4150626



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
