### PR TITLE
[FIX] mail: access to the left partner or guest avatar

### DIFF
--- a/addons/mail/models/__init__.py
+++ b/addons/mail/models/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 # core models (required for mixins)
@@ -52,6 +51,7 @@ from . import bus_presence
 from . import ir_action_act_window
 from . import ir_actions_server
 from . import ir_attachment
+from . import ir_binary
 from . import ir_config_parameter
 from . import ir_http
 from . import ir_mail_server

--- a/addons/mail/models/ir_binary.py
+++ b/addons/mail/models/ir_binary.py
@@ -1,0 +1,20 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class IrBinary(models.AbstractModel):
+    _inherit = "ir.binary"
+
+    def _find_record_check_access(self, record, access_token, field):
+        if record._name in ["res.partner", "mail.guest"] and field == "avatar_128":
+            current_partner, current_guest = self.env["res.partner"]._get_current_persona()
+            if current_partner or current_guest:
+                # access to the avatar is allowed if there is access to a messages
+                if record._name == "res.partner":
+                    domain = [("author_id", "=", record.id)]
+                else:
+                    domain = [("author_guest_id", "=", record.id)]
+                if self.env["mail.message"].search_count(domain, limit=1):
+                    return record.sudo()
+        return super()._find_record_check_access(record, access_token, field)

--- a/addons/mail/tests/discuss/test_avatar_acl.py
+++ b/addons/mail/tests/discuss/test_avatar_acl.py
@@ -89,6 +89,54 @@ class TestAvatarAcl(HttpCase):
         res = self.url_open(url=self.get_avatar_url(partner))
         self.assertEqual(res.headers["Content-Disposition"], f'inline; filename="{partner.name}.svg"')
 
+    def test_guest_open_left_member_avatar(self):
+        self.authenticate(None, None)
+        guest_1 = self.env["mail.guest"].create({"name": "Guest 1"})
+        guest_2 = self.env["mail.guest"].create({"name": "Guest 2"})
+        user = self.env["res.users"].create(
+            {
+                "email": "testuser1@testuser.com",
+                "groups_id": [Command.set([self.ref("base.group_user")])],
+                "name": "Test User 1",
+                "login": "testuser1",
+                "password": "testuser1",
+            },
+        )
+        partner = user.partner_id
+        channel = self.env["discuss.channel"].create(
+            {
+                "channel_type": "group",
+                "name": "Test channel",
+            }
+        )
+        partner_member, guest_member = channel.add_members(
+            partner_ids=[partner.id], guest_ids=[guest_1.id]
+        )
+        channel.message_post(
+            body="Test",
+            message_type="comment",
+            subtype_xmlid="mail.mt_comment",
+            author_id=partner.id,
+        )
+        channel.with_user(self.env.ref("base.public_user")).with_context(
+            guest=guest_1
+        ).message_post(
+            body="Test",
+            message_type="comment",
+            subtype_xmlid="mail.mt_comment",
+        )
+        (partner_member + guest_member).unlink()
+        for author in [guest_1, partner]:
+            res = self.url_open(url=self.get_avatar_url(author))
+            self.assertEqual(res.headers["Content-Disposition"], "inline; filename=placeholder.png")
+        self.opener.cookies[guest_2._cookie_name] = guest_2._format_auth_cookie()
+        channel.add_members(guest_ids=[guest_2.id])
+        for author in [guest_1, partner]:
+            res = self.url_open(url=self.get_avatar_url(author))
+            self.assertEqual(
+                res.headers["Content-Disposition"], f'inline; filename="{author.name}.svg"'
+            )
+
     def test_partner_open_partner_avatar(self):
         testuser = self.env["res.users"].create(
             {
@@ -199,3 +247,57 @@ class TestAvatarAcl(HttpCase):
         channel.add_members(partner_ids=[partner.id, partner2.id])
         res = self.url_open(url=self.get_avatar_url(partner2))
         self.assertEqual(res.headers["Content-Disposition"], f'inline; filename="{partner2.name}.svg"')
+
+    def test_portal_open_left_member_avatar(self):
+        self.authenticate(None, None)
+        guest = self.env["mail.guest"].create({"name": "Guest 1"})
+        user_1, portal_user = self.env["res.users"].create(
+            [
+                {
+                    "email": "testuser1@testuser.com",
+                    "name": "Test User 1",
+                    "groups_id": [Command.set([self.ref("base.group_user")])],
+                    "login": "testuser1",
+                    "password": "testuser1",
+                },
+                {
+                    "email": "testuser2@testuser.com",
+                    "groups_id": [Command.set([self.ref("base.group_portal")])],
+                    "name": "Test User 2",
+                    "login": "testuser2",
+                    "password": "testuser2",
+                },
+            ]
+        )
+        partner = user_1.partner_id
+        channel = self.env["discuss.channel"].create(
+            {
+                "channel_type": "group",
+                "name": "Test channel",
+            }
+        )
+        partner_member, guest_member = channel.add_members(
+            partner_ids=[partner.id], guest_ids=[guest.id]
+        )
+        channel.message_post(
+            body="Test",
+            message_type="comment",
+            subtype_xmlid="mail.mt_comment",
+            author_id=partner.id,
+        )
+        channel.with_user(self.env.ref('base.public_user')).with_context(guest=guest).message_post(
+            body="Test",
+            message_type="comment",
+            subtype_xmlid="mail.mt_comment",
+        )
+        (partner_member + guest_member).unlink()
+        self.authenticate(portal_user.login, portal_user.login)
+        for author in [guest, partner]:
+            res = self.url_open(url=self.get_avatar_url(author))
+            self.assertEqual(res.headers["Content-Disposition"], "inline; filename=placeholder.png")
+        channel.add_members(partner_ids=[portal_user.partner_id.id])
+        for author in [guest, partner]:
+            res = self.url_open(url=self.get_avatar_url(author))
+            self.assertEqual(
+                res.headers["Content-Disposition"], f'inline; filename="{author.name}.svg"'
+            )


### PR DESCRIPTION
Steps to reproduce:
- Create a public channel
- Add a non website_published user as a new member
- Log in as that new member and send a message then leave the channel
- Open the channel as a quest
- The author avatar of the message is not there

