### PR TITLE
[IMP] website_sale, _*: hide location selector if only one location

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -874,7 +874,6 @@ class WebsiteSale(payment_portal.PaymentPortal):
                 order_sudo.partner_shipping_id == order_sudo.partner_invoice_id
             ),
             'only_services': order_sudo.only_services,
-            'json_pickup_location_data': json.dumps(order_sudo.pickup_location_data or {}),
             **self._prepare_address_data(partner_sudo, **kwargs),
             'address_url': '/shop/address',
         }

--- a/addons/website_sale/views/delivery_form_templates.xml
+++ b/addons/website_sale/views/delivery_form_templates.xml
@@ -75,7 +75,7 @@
             />
             <div
                 name="o_pickup_location_details"
-                t-attf-class="ms-4 {{'' if is_selected and pickup_location_data else 'd-none'}}"
+                t-attf-class="ms-4 {{'' if pickup_location_data else 'd-none'}}"
             >
                 <span>
                     <b name="o_pickup_location_name" t-out="pickup_location_data.get('name', '')"/>
@@ -96,11 +96,11 @@
                     aria-label="Change location"
                     t-att-data-location-id="pickup_location_data.get('id')"
                     t-att-data-zip-code="pickup_location_data.get('zip_code')"
-                    t-att-data-pickup-location-data="is_selected and json_pickup_location_data"
+                    t-att-data-pickup-location-data="json.dumps(pickup_location_data)"
                 />
             </div>
             <button
-                t-if="not (is_selected and pickup_location_data)"
+                t-if="not pickup_location_data"
                 name="o_pickup_location_selector"
                 type="button"
                 class="btn btn-primary ms-4"

--- a/addons/website_sale_collect/controllers/main.py
+++ b/addons/website_sale_collect/controllers/main.py
@@ -27,8 +27,24 @@ class WebsiteSaleCollect(WebsiteSale):
 
     def _prepare_checkout_page_values(self, order_sudo, **query_params):
         """ Override of `website_sale` to include the unavailable products for the selected pickup
-        location. """
+        location and set the pickup location when there is only one warehouse available. """
         res = super()._prepare_checkout_page_values(order_sudo, **query_params)
+
+        res['default_pickup_locations'] = {
+            in_store_dm.id: {
+                'pickup_location_data': (
+                    pickup_location_data := in_store_dm._in_store_get_close_locations(
+                        partner_address=order_sudo.partner_shipping_id,
+                    )[0]
+                ),
+                'unavailable_order_lines': order_sudo._get_unavailable_order_lines(
+                    pickup_location_data['id']
+                ),
+            }
+            for in_store_dm in order_sudo._get_delivery_methods().filtered(
+                lambda dm: dm.delivery_type == 'in_store' and len(dm.warehouse_ids) == 1
+            ) - order_sudo.carrier_id # If Pickup is selected, assume location data is included.
+        }
         if order_sudo.carrier_id.delivery_type == 'in_store' and order_sudo.pickup_location_data:
             res['unavailable_order_lines'] = order_sudo._get_unavailable_order_lines(
                 order_sudo.pickup_location_data.get('id')

--- a/addons/website_sale_collect/models/product_template.py
+++ b/addons/website_sale_collect/models/product_template.py
@@ -15,13 +15,14 @@ class ProductTemplate(models.Model):
         res = super()._get_additionnal_combination_info(
             product_or_template, quantity, date, website
         )
+        order_sudo = request.cart
         if (
             bool(website.sudo().in_store_dm_id)  # Click & Collect is enabled.
+            and len(order_sudo.carrier_id.warehouse_ids) > 1
             and product_or_template.is_product_variant
             and product_or_template.is_storable
         ):
             res['show_click_and_collect_availability'] = True
-            order_sudo = request.cart
             if (
                 order_sudo
                 and order_sudo.carrier_id.delivery_type == 'in_store'

--- a/addons/website_sale_collect/views/delivery_form_templates.xml
+++ b/addons/website_sale_collect/views/delivery_form_templates.xml
@@ -2,7 +2,10 @@
 <odoo>
 
     <template id="unavailable_products_warning">
-        <div name="unavailable_products_warning" class="alert alert-warning mt-2">
+        <div
+            name="unavailable_products_warning"
+            t-attf-class="alert alert-warning mt-2 {{'' if is_selected else 'd-none'}}"
+        >
             Some of the products are not available at <strong><t t-out="wh_name"/></strong>.
             <div
                 t-foreach="unavailable_order_lines"
@@ -54,13 +57,25 @@
         <xpath expr="//t[@t-set='is_pickup_needed']" position="attributes">
             <attribute name="t-value" add="dm.delivery_type=='in_store'" separator=" or "/>
         </xpath>
+        <t t-set="pickup_location_data" position="after">
+            <t t-if="not pickup_location_data and default_pickup_locations.get(dm.id)">
+                <t
+                    t-set="pickup_location_data"
+                    t-value="default_pickup_locations[dm.id].get('pickup_location_data', {})"
+                />
+                <t
+                    t-set="unavailable_order_lines"
+                    t-value="default_pickup_locations[dm.id].get('unavailable_order_lines', {})"
+                />
+            </t>
+        </t>
         <div name="o_pickup_location" position="after">
-            <t t-if="dm.delivery_type=='in_store' and order.carrier_id.id==dm.id">
+            <t t-if="dm.delivery_type=='in_store' and pickup_location_data">
                 <t
                     t-if="unavailable_order_lines"
                     t-call="website_sale_collect.unavailable_products_warning"
                 >
-                    <t t-set="wh_name" t-value="order.pickup_location_data.get('name')"/>
+                    <t t-set="wh_name" t-value="pickup_location_data.get('name')"/>
                 </t>
             </t>
         </div>


### PR DESCRIPTION
_*= website_sale_collect

Prior this commit:
- In the product page, the widget would be shown even if there was only one location.
- In the checkout page, the customer would have to manually open the location selector to choose the pickup location, even when there was only one option.

Post this commit:
- In the product page, the widget will not show if there is only one location.
- In the checkout page, when the customer selects 'Pick in Store', if there is only one location then it will be automatically selected without needing to open the location selector.

task-4224426

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
