### PR TITLE
[FIX] web_editor: prevents iframes from loading in snippet menu

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -3196,6 +3196,16 @@ var SnippetsMenu = Widget.extend({
         // TODO: Remove in master and add it back in the template.
         const $vAlignOption = $html.find("#row_valign_snippet_option");
         $vAlignOption[0].dataset.js = "vAlignment";
+
+        // Replace the "src" attribute of iframes with "data-o-src-on-drop" to
+        // prevent the iframes from loading in the snippet menu. This is a fix
+        // in stable that is no longer needed in later versions, where the
+        // snippets' HTML code is no longer rendered in the snippet menu.
+        const iframeEls = $html.find("[data-snippet] iframe[src]");
+        for (const iframeEl of iframeEls) {
+            iframeEl.dataset.oSrcOnDrop = iframeEl.getAttribute("src");
+            iframeEl.removeAttribute("src");
+        }
     },
     /**
      * Creates a snippet editor to associated to the given snippet. If the given
@@ -3496,6 +3506,14 @@ var SnippetsMenu = Widget.extend({
                     });
                     dynamicSvg.src = colorCustomizedURL.pathname + colorCustomizedURL.search;
                 });
+
+                // The iframes must be loaded when the drag-and-drop starts and not when the snippet
+                // menu is loaded.
+                const iframeEls = $toInsert[0].querySelectorAll("iframe[data-o-src-on-drop]");
+                for (const iframeEl of iframeEls) {
+                    iframeEl.setAttribute("src", iframeEl.dataset.oSrcOnDrop);
+                    delete iframeEl.dataset.oSrcOnDrop;
+                }
 
                 if (!$selectorSiblings.length && !$selectorChildren.length) {
                     console.warn($snippet.find('.oe_snippet_thumbnail_title').text() + " have not insert action: data-drop-near or data-drop-in");


### PR DESCRIPTION
Steps to reproduce the issue:

- In website edit mode.
- Inspect the HTML code of the "Video" snippet in the snippet menu.
- The YouTube iframe is loaded even though the "Video" snippet has not
been dropped into the page.

We need to fix this in stable because a recent update of Chrome [1] is
now triggering an error during several tests in edit mode on runbot.
This error is due to the fact that we are contacting the YouTube API
during the tests, which cannot be done when a test is being executed on
runbot. Note that this fix is no longer necessary starting from version
saas-17.4 because, from this version, the HTML code of the snippets are
no longer in the snippet menu.

After this commit, snippets containing an iframe will have their iframe
loaded only when the drag-and-drop starts.

[1]: https://developer.chrome.com/release-notes/125#the_compute_pressure_api

runbot-102187