### PR TITLE
[FIX] web: resolving traceback on the event registrations page

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -270,11 +270,11 @@ export function makeActionManager(env, router = _router) {
         const results = await Promise.all(keys.map((k) => breadcrumbCache[k]));
         const controllersToRemove = [];
         for (const [controller, res] of zip(controllers, results)) {
-            if ("display_name" in res) {
+            if (res && "display_name" in res) {
                 controller.displayName = res.display_name;
             } else {
                 controllersToRemove.push(controller);
-                if ("error" in res) {
+                if (res && "error" in res) {
                     console.warn(
                         "The following element was removed from the breadcrumb and from the url.\n",
                         controller.state,


### PR DESCRIPTION
**How to reproduce:**
- Navigate to an event.
- Click on 'Registration Desk'.
- Click on 'Select Attendee'.
- Refresh the browser window. 

Ref: ﻿﻿https://tinyurl.com/y2hxjbew

**Technical reason:**
In the web, there's an if condition that checks if 'display_name' is in 'res', but it doesn't account for the possibility that 'res' might be undefined.

**After this commit:**
The traceback will be resolved.

Task-4272942
