### PR TITLE
[FIX] im_livechat, hr_homeworking: handle hr_homeworking compatibility

### DIFF
--- a/addons/bus/models/res_users.py
+++ b/addons/bus/models/res_users.py
@@ -17,3 +17,6 @@ class ResUsers(models.Model):
         }
         for user in self:
             user.im_status = presence_by_user.get(user, "offline")
+
+    def _is_user_available(self):
+        return self.im_status == 'online'

--- a/addons/hr/models/hr_employee_base.py
+++ b/addons/hr/models/hr_employee_base.py
@@ -161,7 +161,7 @@ class HrEmployeeBase(models.AbstractModel):
         for employee in self:
             state = 'to_define'
             if check_login:
-                if 'online' in str(employee.user_id.im_status):
+                if employee.user_id._is_user_available():
                     state = 'present'
                 elif 'offline' in str(employee.user_id.im_status) and employee.id not in working_now_list:
                     state = 'absent'

--- a/addons/hr_holidays/models/res_partner.py
+++ b/addons/hr_holidays/models/res_partner.py
@@ -17,7 +17,7 @@ class ResPartner(models.Model):
                     partner.im_status = 'leave_online'
                 elif partner.im_status == 'away':
                     partner.im_status = 'leave_away'
-                else:
+                elif partner.im_status == 'offline':
                     partner.im_status = 'leave_offline'
 
     @api.model

--- a/addons/hr_holidays/models/res_users.py
+++ b/addons/hr_holidays/models/res_users.py
@@ -40,7 +40,7 @@ class User(models.Model):
                     user.im_status = 'leave_online'
                 elif user.im_status == 'away':
                     user.im_status = 'leave_away'
-                else:
+                elif user.im_status == 'offline':
                     user.im_status = 'leave_offline'
 
     @api.model

--- a/addons/hr_homeworking/models/res_users.py
+++ b/addons/hr_homeworking/models/res_users.py
@@ -35,3 +35,7 @@ class User(models.Model):
             im_status = user.im_status
             if im_status == "online" or im_status == "away" or im_status == "offline":
                 user.im_status = "presence_" + location_type + "_" + im_status
+
+    def _is_user_available(self):
+        location_types = self.env['hr.work.location']._fields['location_type'].get_values(self.env)
+        return self.im_status in ['online'] + [f'presence_{location_type}_online' for location_type in location_types]

--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -67,7 +67,7 @@ class ImLivechatChannel(models.Model):
     @api.depends('user_ids.im_status')
     def _compute_available_operator_ids(self):
         for record in self:
-            record.available_operator_ids = record.user_ids.filtered(lambda user: user.im_status == 'online')
+            record.available_operator_ids = record.user_ids.filtered(lambda user: user._is_user_available())
 
     @api.depends('rule_ids.chatbot_script_id')
     def _compute_chatbot_script_count(self):


### PR DESCRIPTION
Steps to reproduce:
- Install hr_homeworking
- Livechat app > website.com > Configure channels
- Mitchell Admin must be among the operators
- Employees > Mitchell Admin > Work information tab
- Set a 'Remote work' location for the current day
- Website app > The livechat popup does not appear (bottom-left)

This happens because hr_homeworking changes the im_status field's value to from 'online' to 'presence_[location_type]_online'. That change was not reflected by the function which computes operator availability, meaning the operator will never show as online on days they have a location set.

Additionally, im_status 'leave_online' should not be considered as a status that marks available operators. Unfortunately, since locations can be created at will we can't make an exhaustive list here.

opw-4196707

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
