### PR TITLE
[FIX] l10n_it_edi: prevent crash when printing IT invoice

### DIFF
--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -1236,9 +1236,11 @@ class AccountMove(models.Model):
             if moves := pa_moves.filtered(lambda move: not move.l10n_it_origin_document_type and move.l10n_it_cig and move.l10n_it_cup):
                 message = _("CIG/CUP fields of partner(s) are present, please fill out Origin Document Type field in the Electronic Invoicing tab.")
                 errors['move_missing_origin_document_field'] = build_error(message=message, records=moves)
-        if moves := self.filtered(lambda move: not move.l10n_it_document_type):
-            message = _("Please fill out the Document Type field in the Electronic Invoicing tab.")
-            errors['move_missing_document_type'] = build_error(message=message, records=moves)
+        if 'l10n_it_document_type' in self._fields:
+            moves = self.filtered(lambda move: not move.l10n_it_document_type)
+            if moves:
+                message = _("Please fill out the Document Type field in the Electronic Invoicing tab.")
+                errors['move_missing_document_type'] = build_error(message=message, records=moves)
         return errors
 
     def _l10n_it_edi_export_taxes_check(self):


### PR DESCRIPTION
The issue:
A traceback occurs when clicking the "Send and Print" button in the Italian localization.

Steps to reproduce:
-Install l10n_it.
-Ensure that l10n_it_edi_ndd is not installed.
-Create an invoice and click "Send and Print".

Explanation:
In account_move of l10n_it_edi, a field is used that is only present in the l10n_it_edi_ndd module, which causes a traceback when the module is not installed.

opw-4269081