### PR TITLE
[FIX] account: When loading chart template, don't unlink shared records

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -201,10 +201,17 @@ class AccountChartTemplate(models.AbstractModel):
         company.chart_template = template_code
 
         if not reload_template and (not company.root_id._existing_accounting() or self.env.ref('base.module_account').demo):
+            children_companies = self.env['res.company'].search([('id', 'child_of', company.id)])
             for model in ('account.move',) + TEMPLATE_MODELS[::-1]:
                 if not company.parent_id:
                     company_field = 'company_id' if 'company_id' in self.env[model] else 'company_ids'
-                    self.env[model].sudo().with_context(active_test=False).search([(company_field, 'child_of', company.id)]).with_context({MODULE_UNINSTALL_FLAG: True}).unlink()
+                    records = self.env[model].sudo().with_context(active_test=False).search([(company_field, 'child_of', company.id)])
+                    if company_field == 'company_ids':
+                        records_to_keep = records.filtered(lambda r: r.company_ids - children_companies)
+                        records -= records_to_keep
+                        for records_for_companies in records_to_keep.grouped('company_ids').values():
+                            records_for_companies.company_ids -= children_companies
+                    records.with_context({MODULE_UNINSTALL_FLAG: True}).unlink()
 
         data = self._get_chart_template_data(template_code)
         template_data = data.pop('template_data')

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -393,7 +393,7 @@ class ResCompany(models.Model):
         companies = super().create(vals_list)
         for company in companies:
             if root_template := company.parent_ids[0].chart_template:
-                def try_loading(company=company):
+                def try_loading(company=company, root_template=root_template):
                     self.env['account.chart.template']._load(
                         root_template,
                         company,

--- a/addons/account/tests/test_chart_template.py
+++ b/addons/account/tests/test_chart_template.py
@@ -632,12 +632,42 @@ class TestChartTemplate(AccountTestInvoicingCommon):
             patch.object(AccountChartTemplate, '_get_chart_template_data', side_effect=test_get_data, autospec=True)
         ):
             self.env['account.chart.template'].try_loading('other_test', company=self.company, install_demo=True)
+
+            # Create a branch and an unrelated company
+            branch, other_company = self.env['res.company'].create([
+                {
+                    'name': 'Test Branch',
+                    'parent_id': self.company.id,
+                },
+                {
+                    'name': 'Other Test Company',
+                },
+            ])
+            # Run precommit hook to load the template on the branch
+            self.env.cr.precommit.run()
+
         self.assertEqual(self.company.chart_template, 'other_test')
+        self.assertEqual(branch.chart_template, 'other_test')
         self.assertFalse(self.company.anglo_saxon_accounting)
+
+        # Setup a shared account, belonging to the company, the branch, and the unrelated company
+        shared_account = self.env['account.account'].create([{
+            'name': 'Shared Account',
+            'company_ids': [Command.set((self.company | branch | other_company).ids)],
+            'code_mapping_ids': [
+                Command.create({'company_id': self.company.id, 'code': '180001'}),
+                Command.create({'company_id': branch.id, 'code': '180001'}),
+                Command.create({'company_id': other_company.id, 'code': '180001'}),
+            ],
+        }])
 
         with patch.object(AccountChartTemplate, '_get_chart_template_data', side_effect=test_get_data, autospec=True):
             self.env['account.chart.template'].try_loading('test', company=self.company, install_demo=True)
         self.assertEqual(self.company.chart_template, 'test')
+        self.assertEqual(branch.chart_template, 'test')
+
+        # Check that the shared account was not deleted, but just unlinked from the company and the branch.
+        self.assertEqual(shared_account.company_ids, other_company)
 
     def test_update_tax_with_non_existent_tag(self):
         """ Tests that when we update the CoA with a tax that has a tag that does not exist yet we raise an error.


### PR DESCRIPTION
When loading a chart template on a root company, we check whether any journal items have already been created for the company, and if not, we delete the existing accounting configuration before loading the new CoA.

However, we must take care in the case of records that are shared between several companies, to just unlink them from the active company, rather than delete them (which would affect other companies as well).

This commit fixes that.

task-none