### PR TITLE
[FIX] account_edi_ubl_cii: enable factur-x for custom PDF reports

### DIFF
--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -377,7 +377,10 @@ class AccountMoveSend(models.TransientModel):
         if invoice.invoice_pdf_report_id:
             return
 
-        content, _report_format = self.env['ir.actions.report'].with_company(invoice.company_id)._render('account.account_invoices', invoice.ids)
+        content, _report_format = self.env['ir.actions.report']\
+            .with_company(invoice.company_id)\
+            .with_context(from_account_move_send=True)\
+            ._render('account.account_invoices', invoice.ids)
 
         invoice_data['pdf_attachment_values'] = {
             'raw': content,

--- a/addons/account_edi_ubl_cii/models/__init__.py
+++ b/addons/account_edi_ubl_cii/models/__init__.py
@@ -14,3 +14,4 @@ from . import account_move
 from . import res_partner
 from . import res_company
 from . import res_config_settings
+from . import ir_actions_report

--- a/addons/account_edi_ubl_cii/models/ir_actions_report.py
+++ b/addons/account_edi_ubl_cii/models/ir_actions_report.py
@@ -1,0 +1,31 @@
+import io
+
+from odoo import models
+
+
+class IrActionsReport(models.Model):
+    _inherit = 'ir.actions.report'
+
+    def _render_qweb_pdf_prepare_streams(self, report_ref, data, res_ids=None):
+        # EXTENDS base
+        collected_streams = super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids)
+
+        # allows to add factur-x.xml to custom PDF templates (comma separated list of template names)
+        custom_templates = self.env['ir.config_parameter'].sudo().get_param('account.custom_templates_facturx_list', '')
+        custom_templates = [report.strip() for report in custom_templates.split(',')]
+
+        if (
+            collected_streams
+            and res_ids
+            and len(res_ids) == 1
+            and (self._is_invoice_report(report_ref) or self._get_report(report_ref).report_name in custom_templates)
+            and not self.env.context.get('from_account_move_send')  # only triggered from the 'print' action report
+        ):
+            # Generate and embed Factur-X
+            invoice = self.env['account.move'].browse(res_ids)
+            if invoice.is_sale_document() and invoice.state == 'posted':
+                pdf_stream = collected_streams[invoice.id]['stream']
+                invoice_data = {'pdf_attachment_values': {'raw': pdf_stream.getvalue()}}
+                self.env['account.move.send']._hook_invoice_document_after_pdf_report_render(invoice, invoice_data)
+                collected_streams[invoice.id]['stream'] = io.BytesIO(invoice_data['pdf_attachment_values']['raw'])
+        return collected_streams


### PR DESCRIPTION
It is currently not possible to embed the factur-x.xml in custom pdf templates, although it is supported in 17.4.

In this commit, we add the possibility to to do so, by adding a system parameter "account.custom_templates_facturx_list" that contains a list of the custom report names (field `report_name` on `ir.actions.report`) for which we want to embed a factur-x.xml.

We also re-introduce the extension of
`_render_qweb_pdf_prepare_streams`. In addition, we add a context_key `from_account_move_send` to avoid adding the Factur-X twice in case we are in the Send & Print flow (see
`_hook_invoice_document_after_pdf_report_render`).

See https://github.com/odoo/odoo/pull/179548

opw-4160945