### PR TITLE
[FIX] api: remove dependency on python3.12 or typing_extensions

### DIFF
--- a/odoo/orm/types.py
+++ b/odoo/orm/types.py
@@ -10,7 +10,10 @@ from .registry import Registry
 try:
     from typing_extensions import Self
 except ImportError:
-    from typing import Self
+    try:
+        from typing import Self
+    except ImportError:
+        Self = typing.TypeVar("Self")
 
 DomainType = list[str | tuple[str, str, typing.Any]]
 ContextType = Mapping[str, typing.Any]

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,7 +78,6 @@ rjsmin==1.2.0 ; python_version >= '3.11'
 rl-renderPM==4.0.3 ; sys_platform == 'win32' and python_version >= '3.12'  # Needed by reportlab 4.1.0 but included in deb package
 urllib3==1.26.5 ; python_version < '3.12' # indirect / min version = 1.25.8 (Focal with security backports)
 urllib3==2.0.7  ; python_version >= '3.12'  # (Noble) Compatibility with cryptography
-typing_extensions==4.4.0 ; python_version < '3.12'
 vobject==0.9.6.1
 Werkzeug==2.0.2 ; python_version <= '3.10' 
 Werkzeug==2.2.2 ; python_version > '3.10' and python_version < '3.12'


### PR DESCRIPTION
odoo should be able to run without pip requirement and on python 3.12.

Right now, it will fail with the message

`ImportError: cannot import name 'Self' from 'typing' (/usr/lib/python3.10/typing.py) `

When starting odoo

This should solve the issue.


This pr also removes the typing extension that was missed and shouldn't have been added. The version does not match ubuntu versions and this should not be required to run odoo. 