### PR TITLE
[FIX] point_of_sale, pos_restaurant: always show change value

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -208,6 +208,7 @@ class PosOrder(models.Model):
                 'is_change': True,
             }
             order.add_payment(return_payment_vals)
+            order._compute_prices()
 
     def _prepare_tax_base_line_values(self):
         """ Convert pos order lines into dictionaries that would be used to compute taxes later.
@@ -437,10 +438,10 @@ class PosOrder(models.Model):
                 raise UserError(_("You can't: create a pos order from the backend interface, or unset the pricelist, or create a pos.order in a python test with Form tool, or edit the form view in studio if no PoS order exist"))
             currency = order.currency_id
             order.amount_paid = sum(payment.amount for payment in order.payment_ids)
-            order.amount_return = sum(payment.amount < 0 and payment.amount or 0 for payment in order.payment_ids)
+            order.amount_return = -sum(payment.amount < 0 and payment.amount or 0 for payment in order.payment_ids)
             order.amount_tax = currency.round(sum(self._amount_line_tax(line, order.fiscal_position_id) for line in order.lines))
             order.amount_total = order.amount_tax + currency.round(sum(line.price_subtotal for line in order.lines))
-            order.amount_difference = order.amount_paid - order.amount_total
+            order.amount_difference = currency.round(order.amount_paid - order.amount_total) or 0
 
     def _compute_batch_amount_all(self):
         """

--- a/addons/point_of_sale/static/tests/tours/utils/ticket_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/ticket_screen_util.js
@@ -192,6 +192,14 @@ export function receiptTotalIs(amount) {
         },
     ];
 }
+export function receiptChangeIs(amount) {
+    return [
+        {
+            trigger: `.receipt-screen .receipt-change:contains("${amount}")`,
+            run: () => {},
+        },
+    ];
+}
 export function back() {
     return {
         isActive: ["mobile"],

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -295,3 +295,25 @@ registry.category("web_tour.tours").add("CategLabelCheck", {
             ProductScreen.OrderButtonNotContain("Drinks"),
         ].flat(),
 });
+registry.category("web_tour.tours").add("OrderChange", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola", true, "1.0"),
+            ProductScreen.clickOrderButton(),
+            {
+                ...Dialog.confirm(),
+                content:
+                    "acknowledge printing error ( because we don't have printer in the test. )",
+            },
+            ProductScreen.orderlinesHaveNoChange(),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickNumpad("+10"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            TicketScreen.receiptChangeIs("7.80"),
+        ].flat(),
+});

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -311,3 +311,7 @@ class TestFrontend(TestFrontendCommon):
     def test_13_category_check(self):
         self.pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('CategLabelCheck')
+
+    def test_14_change_synced_order(self):
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('OrderChange')


### PR DESCRIPTION
When using the restaurant, orders that were sent to the kitchen did not show the change amount on the receipt.

Steps to reproduce:
-------------------
* Open restaurant
* Select any table, add items to the order
* Select **Order**
* Select **Payment**
* Select any payment method
* Pay more than the order
* Validate
> Observation: The receipt show a change of 0.0

Why the fix:
------------
Before this commit: https://github.com/odoo/odoo/commit/1649ee1a757ab1a095fd92f7605ac2b004568352 the change could get computed on an onchange:
https://github.com/odoo/odoo/blob/662f63b630cae8604179174cdd67536f3300bb53/addons/point_of_sale/models/pos_order.py#L417-L427

By definiton, onchanges will only trigger from web form views. In our case, the onchange was never triggered when synchronizing orders from the UI, even though we would make a change to the payment_ids when adding the change line. After the above mentioned commit, the code inside the onchange was put into a separate function `_compute_prices()` which is still called in the onchange but also in the `write` function.

When an order was previously synced from the UI, we call the write function. https://github.com/odoo/odoo/blob/430656132044f8d675712d5b6cbfef807880d024/addons/point_of_sale/models/pos_order.py#L124

By going into `_compute_prices` in the write method, we compute the `amount_return` before the change line was added to the order.
https://github.com/odoo/odoo/blob/430656132044f8d675712d5b6cbfef807880d024/addons/point_of_sale/models/pos_order.py#L128

Computing `amount_return` before adding the change line is problematic since it is computed with regards to the negative payment lines. https://github.com/odoo/odoo/blob/430656132044f8d675712d5b6cbfef807880d024/addons/point_of_sale/models/pos_order.py#L440

To solve our solution, we call `_compute_prices` after we add the change line. `amount_return` represents the change given to a client. If we give `10$` back to a client, the change payment line will have an amount of `-10$` but `amount_return` should be positive 10. (Thus the change of `-`)

We also add a small fix for `amount_difference` which can have precision error and thus show something like `-0.0`.

opw-4253292