### PR TITLE
[IMP] hw_drivers: update logging levels methods

### DIFF
--- a/addons/hw_drivers/main.py
+++ b/addons/hw_drivers/main.py
@@ -92,9 +92,7 @@ class Manager(Thread):
             _logger.info('Ignoring sending the devices to the database: no associated database')
 
     def run(self):
-        """
-        Thread that will load interfaces and drivers and contact the odoo server with the updates
-        """
+        """Thread that will load interfaces and drivers and contact the odoo server with the updates"""
         self.server_url = helpers.get_odoo_server_url()
         helpers.start_nginx_server()
 
@@ -125,6 +123,7 @@ class Manager(Thread):
 
         # Set scheduled actions
         schedule and schedule.every().day.at("00:00").do(helpers.get_certificate_status)
+        schedule and schedule.every().day.at("00:00").do(helpers.reset_log_level)
 
         # Set up the websocket connection
         if self.server_url and iot_client.iot_channel:

--- a/addons/hw_drivers/server_logger.py
+++ b/addons/hw_drivers/server_logger.py
@@ -8,7 +8,6 @@ import urllib3.exceptions
 
 from odoo.addons.hw_drivers.tools import helpers
 from odoo.netsvc import DBFormatter
-from odoo.tools import config
 
 _logger = logging.getLogger(__name__)
 
@@ -128,7 +127,7 @@ def close_server_log_sender_handler():
 
 
 def get_odoo_config_log_to_server_option():
-    return config.get(IOT_LOG_TO_SERVER_CONFIG_NAME, True)  # Enabled by default
+    return helpers.get_conf(IOT_LOG_TO_SERVER_CONFIG_NAME, section='options') or True  # Enabled by default
 
 
 def check_and_update_odoo_config_log_to_server_option(new_state):
@@ -136,7 +135,7 @@ def check_and_update_odoo_config_log_to_server_option(new_state):
     :return: wherever the config file need to be updated or not
     """
     if get_odoo_config_log_to_server_option() != new_state:
-        config[IOT_LOG_TO_SERVER_CONFIG_NAME] = new_state
+        helpers.update_conf({IOT_LOG_TO_SERVER_CONFIG_NAME, new_state}, section='options')
         _server_log_sender_handler.toggle_active(new_state)
         return True
     return False

--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -656,3 +656,17 @@ def parse_url(url):
         "url": f"{url.scheme}://{url.netloc}",
         **search_params,
     }
+
+
+def reset_log_level():
+    """Reset the log level to the default one if the reset timestamp is reached
+    This timestamp is set by the log controller in `hw_posbox_homepage/homepage.py` when the log level is changed
+    """
+    log_level_reset_timestamp = get_conf('log_level_reset_timestamp')
+    if log_level_reset_timestamp and float(log_level_reset_timestamp) <= time.time():
+        _logger.info("Resetting log level to default.")
+        update_conf({
+            'log_level_reset_timestamp': '',
+            'log_handler': ':WARNING',
+            'log_level': 'warn',
+        })

--- a/addons/hw_posbox_homepage/controllers/homepage.py
+++ b/addons/hw_posbox_homepage/controllers/homepage.py
@@ -1,16 +1,17 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import json
-import subprocess
-import threading
-import logging
-import platform
 import jinja2
+import json
+import logging
 import os
+import platform
+import subprocess
 import sys
+import threading
+import time
 
 from pathlib import Path
-from odoo import http, tools
+from odoo import http
 from odoo.addons.hw_drivers.tools import helpers
 from odoo.addons.hw_drivers.main import iot_devices
 from odoo.addons.web.controllers.home import Home
@@ -349,35 +350,23 @@ class IotBoxOwlHomePage(Home):
                 'message': 'Invalid logger name',
             }
 
-        need_config_save = False
         if name == 'log-to-server':
-            need_config_save |= check_and_update_odoo_config_log_to_server_option(
-                value
-            )
+            check_and_update_odoo_config_log_to_server_option(value)
 
         name = name[len(IOT_LOGGING_PREFIX):]
         if name == 'root':
-            need_config_save |= self._update_logger_level(
-                '', value, AVAILABLE_LOG_LEVELS)
+            self._update_logger_level('', value, AVAILABLE_LOG_LEVELS)
         elif name == 'odoo':
-            need_config_save |= self._update_logger_level(
-                'odoo', value, AVAILABLE_LOG_LEVELS)
-            need_config_save |= self._update_logger_level(
-                'werkzeug', value if value != 'debug' else 'info', AVAILABLE_LOG_LEVELS)
+            self._update_logger_level('odoo', value, AVAILABLE_LOG_LEVELS)
+            self._update_logger_level('werkzeug', value if value != 'debug' else 'info', AVAILABLE_LOG_LEVELS)
         elif name.startswith(INTERFACE_PREFIX):
             logger_name = name[len(INTERFACE_PREFIX):]
-            need_config_save |= self._update_logger_level(
-                logger_name, value, AVAILABLE_LOG_LEVELS_WITH_PARENT, 'interfaces')
+            self._update_logger_level(logger_name, value, AVAILABLE_LOG_LEVELS_WITH_PARENT, 'interfaces')
         elif name.startswith(DRIVER_PREFIX):
             logger_name = name[len(DRIVER_PREFIX):]
-            need_config_save |= self._update_logger_level(
-                logger_name, value, AVAILABLE_LOG_LEVELS_WITH_PARENT, 'drivers')
+            self._update_logger_level(logger_name, value, AVAILABLE_LOG_LEVELS_WITH_PARENT, 'drivers')
         else:
             _logger.warning('Unhandled iot logger: %s', name)
-
-        if need_config_save:
-            with helpers.writable():
-                tools.config.save()
 
         return {
             'status': 'success',
@@ -406,28 +395,31 @@ class IotBoxOwlHomePage(Home):
         return handlers_loggers_level
 
     def _update_logger_level(self, logger_name, new_level, available_log_levels, handler_folder=False):
-        """
-        Update (if necessary) Odoo's configuration and logger to the given logger_name to the given level.
+        """Update (if necessary) Odoo's configuration and logger to the given logger_name to the given level.
         The responsibility of saving the config file is not managed here.
+
         :param logger_name: name of the logging logger to change level
         :param new_level: new log level to set for this logger
         :param available_log_levels: iterable of logs levels allowed (for initial check)
-        :param handler_folder: optional string of the IoT handler folder name ('interfaces' or 'drivers')
-        :return: wherever some changes were performed or not on the config
+        :param str handler_folder: optional string of the IoT handler folder name ('interfaces' or 'drivers')
         """
+        # We store the timestamp to reset the log level to warning after a week (7 days * 24 hours * 3600 seconds)
+        # This is to avoid sending polluted logs with debug messages to the db
+        conf = {'log_level_reset_timestamp': str(time.time() + 7 * 24 * 3600)}
+
         if new_level not in available_log_levels:
             _logger.warning('Unknown level to set on logger %s: %s', logger_name, new_level)
-            return False
+            return
 
         if handler_folder:
             logger = self._get_iot_handler_logger(logger_name, handler_folder)
             if not logger:
                 _logger.warning('Unable to change log level for logger %s as logger missing', logger_name)
-                return False
+                return
             logger_name = logger.name
 
         ODOO_TOOL_CONFIG_HANDLER_NAME = 'log_handler'
-        LOG_HANDLERS = tools.config[ODOO_TOOL_CONFIG_HANDLER_NAME]
+        LOG_HANDLERS = (helpers.get_conf(ODOO_TOOL_CONFIG_HANDLER_NAME, section='options') or []).split(',')
         LOGGER_PREFIX = logger_name + ':'
         IS_NEW_LEVEL_PARENT = new_level == 'parent'
 
@@ -435,7 +427,7 @@ class IotBoxOwlHomePage(Home):
             intended_to_find = LOGGER_PREFIX + new_level.upper()
             if intended_to_find in LOG_HANDLERS:
                 # There is nothing to do, the entry is already inside
-                return False
+                return
 
         # We remove every occurrence for the given logger
         log_handlers_without_logger = [
@@ -445,24 +437,25 @@ class IotBoxOwlHomePage(Home):
         if IS_NEW_LEVEL_PARENT:
             # We must check that there is no existing entries using this logger (whatever the level)
             if len(log_handlers_without_logger) == len(LOG_HANDLERS):
-                return False
+                return
 
         # We add if necessary new logger entry
         # If it is "parent" it means we want it to inherit from the parent logger.
         # In order to do this we have to make sure that no entries for the logger exists in the
         # `log_handler` (which is the case at this point as long as we don't re-add an entry)
-        tools.config[ODOO_TOOL_CONFIG_HANDLER_NAME] = log_handlers_without_logger
         new_level_upper_case = new_level.upper()
         if not IS_NEW_LEVEL_PARENT:
-            new_entry = [LOGGER_PREFIX + new_level_upper_case]
-            tools.config[ODOO_TOOL_CONFIG_HANDLER_NAME] += new_entry
+            new_entry = LOGGER_PREFIX + new_level_upper_case
+            log_handlers_without_logger.append(new_entry)
             _logger.debug('Adding to odoo config log_handler: %s', new_entry)
+        conf[ODOO_TOOL_CONFIG_HANDLER_NAME] = ','.join(log_handlers_without_logger)
 
         # Update the logger dynamically
         real_new_level = logging.NOTSET if IS_NEW_LEVEL_PARENT else new_level_upper_case
         _logger.debug('Change logger %s level to %s', logger_name, real_new_level)
         logging.getLogger(logger_name).setLevel(real_new_level)
-        return True
+
+        helpers.update_conf(conf, section='options')
 
     def _get_logger_effective_level_str(self, logger):
         return logging.getLevelName(logger.getEffectiveLevel()).lower()


### PR DESCRIPTION
Logging levels updating methods used `odoo.tools` config methods. It was not adapted to the IoT Box as it was polluting the `odoo.conf` file with unwanted parameters.
We now use the `helpers.{update_,get_}conf` methods to only update the required parameters.

This commit also adds a scheduled event everyday at 00:00 to switch back to `:WARNING` log level if it was set more 
than a week before, to reduce the amount of logs sent to the database.

Task: 4173458