### PR TITLE
[FIX] point_of_sale: Trusted pos only show pos from the current company

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -183,7 +183,7 @@ class PosConfig(models.Model):
     auto_validate_terminal_payment = fields.Boolean(default=True, help="Automatically validates orders paid with a payment terminal.")
     trusted_config_ids = fields.Many2many("pos.config", relation="pos_config_trust_relation", column1="is_trusting",
                                           column2="is_trusted", string="Trusted Point of Sale Configurations",
-                                          domain="[('id', '!=', pos_config_id), ('module_pos_restaurant', '=', False)]")
+                                          domain="[('id', '!=', pos_config_id), ('module_pos_restaurant', '=', False), ('company_id', '=', company_id)]")
 
     @api.depends('payment_method_ids')
     def _compute_cash_control(self):


### PR DESCRIPTION
Steps to reproduce:
-------------------
* Make sure you have atleast 2 companies created
* Create atleast one PoS in each company
* Go in one of the company settings and look for Trusted Point of sale
> Observation: You are able to select the PoS from the other company

Why the fix:
------------
Adapt the domain to filter out PoS that are not part of the current company

opw-4161351
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
