### PR TITLE
[FIX] l10n_hu_edi: bank account number error

### DIFF
--- a/addons/l10n_hu_edi/models/account_move.py
+++ b/addons/l10n_hu_edi/models/account_move.py
@@ -315,8 +315,8 @@ class AccountMove(models.Model):
     # === EDI: Flow === #
 
     def _l10n_hu_edi_check_invoices(self):
-        errors = []
         hu_vat_regex = re.compile(r'\d{8}-[1-5]-\d{2}')
+        hu_bank_account_regex = re.compile(r'\d{8}-\d{8}-\d{8}|\d{8}-\d{8}|[A-Z]{2}\d{2}[0-9A-Za-z]{11,30}')
 
         # This contains all the advance invoices that correspond to final invoices in `self`.
         advance_invoices = self.filtered(lambda m: not m._is_downpayment()).invoice_line_ids._get_downpayment_lines().mapped('move_id')
@@ -346,6 +346,11 @@ class AccountMove(models.Model):
                 'records': self.company_id.filtered(lambda c: c.currency_id.name != 'HUF'),
                 'message': _('Please use HUF as company currency!'),
                 'action_text': _('View Company/ies'),
+            },
+            'partner_bank_account_invalid': {
+                'records': self.partner_bank_id.filtered(lambda p: not hu_bank_account_regex.fullmatch(p.acc_number)),
+                'message': _('Please set a valid recipient bank account number!'),
+                'action_text': _('View partner(s)'),
             },
             'partner_vat_missing': {
                 'records': self.partner_id.commercial_partner_id.filtered(

--- a/addons/l10n_hu_edi/models/l10n_hu_edi_connection.py
+++ b/addons/l10n_hu_edi/models/l10n_hu_edi_connection.py
@@ -235,9 +235,9 @@ class L10nHuEdiConnection:
                 })
             for message_xml in processing_result_xml.iterfind('api:technicalValidationMessages', namespaces=XML_NAMESPACES):
                 processing_result['technical_validation_messages'].append({
-                    'validation_result_code': message_xml.findtext('api:validationResultCode', namespaces=XML_NAMESPACES),
-                    'validation_error_code': message_xml.findtext('api:validationErrorCode', namespaces=XML_NAMESPACES),
-                    'message': message_xml.findtext('api:message', namespaces=XML_NAMESPACES),
+                    'validation_result_code': message_xml.findtext('common:validationResultCode', namespaces=XML_NAMESPACES),
+                    'validation_error_code': message_xml.findtext('common:validationErrorCode', namespaces=XML_NAMESPACES),
+                    'message': message_xml.findtext('common:message', namespaces=XML_NAMESPACES),
                 })
             if return_original_request:
                 try:


### PR DESCRIPTION
If the bank account number is not in a valid format, it is rejected by `NAV`.

When that happened we returned a `(None) None: None` error message, which is not very useful. This was due to an error in xml namespace when looking for the error message. Now, we return the proper error message.

We also check that the bank account number is in a valid format before sending it to `NAV` and **warn** the user. The user is still free to send the document anyway.

Task-id: 4254627

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
