### PR TITLE
[FIX] hr_holidays, mail: im_status fa - plane not consistent

### DIFF
--- a/addons/hr_holidays/static/src/persona_model_patch.js
+++ b/addons/hr_holidays/static/src/persona_model_patch.js
@@ -1,0 +1,18 @@
+/** @odoo-module */
+
+import { Persona } from "@mail/core/common/persona_model";
+import { patch } from "@web/core/utils/patch";
+
+patch(Persona.prototype, {
+    updateImStatus(newStatus) {
+        if (newStatus == "online" && this.out_of_office_date_end) {
+            this.im_status = "leave_online";
+        } else if (newStatus == "offline" && this.out_of_office_date_end) {
+            this.im_status = "leave_offline";
+        } else if (newStatus == "away" && this.out_of_office_date_end) {
+            this.im_status = "leave_away";
+        } else {
+            return super.updateImStatus(...arguments);
+        }
+    },
+});

--- a/addons/hr_holidays/static/src/thread_icon.patch.xml
+++ b/addons/hr_holidays/static/src/thread_icon.patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.ThreadIcon" t-inherit-mode="extension">
         <xpath expr="//*[@name='chat_static']" position="replace">
-            <div t-if="chatPartner.im_status === 'leave_online'" class="o-mail-ThreadIcon-online fa fa-fw fa-plane" title="Online"/>
+            <div t-if="chatPartner.im_status === 'leave_online'" class="o-mail-ThreadIcon-online fa fa-fw fa-plane text-success" title="Online"/>
             <div t-elif="chatPartner.im_status === 'leave_offline'" class="fa fa-fw fa-plane" title="Out of office"/>
             <div t-elif="chatPartner.im_status === 'leave_away'" class="fa fa-fw fa-plane o-yellow" title="Away"/>
             <t t-else="">$0</t>

--- a/addons/hr_holidays/static/tests/helpers/mock_server/models/res_partner.js
+++ b/addons/hr_holidays/static/tests/helpers/mock_server/models/res_partner.js
@@ -1,11 +1,25 @@
 /** @odoo-module **/
 
-import '@mail/../tests/helpers/mock_server/models/res_partner'; // ensure mail overrides are applied first
+import "@mail/../tests/helpers/mock_server/models/res_partner"; // ensure mail overrides are applied first
 
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
 patch(MockServer.prototype, {
+    _mockResPartnerComputeImStatus(partner) {
+        if (partner.out_of_office_date_end) {
+            if (partner.im_status === "online") {
+                return "leave_online";
+            } else if (partner.im_status === "away") {
+                return "leave_away";
+            } else {
+                return "leave_offline";
+            }
+        } else {
+            return super._mockResPartnerComputeImStatus(partner);
+        }
+    },
+
     /**
      * Overrides to add out of office to employees.
      *
@@ -13,11 +27,9 @@ patch(MockServer.prototype, {
      */
     _mockResPartnerMailPartnerFormat(ids) {
         const partnerFormats = super._mockResPartnerMailPartnerFormat(...arguments);
-        const partners = this.getRecords(
-            'res.partner',
-            [['id', 'in', ids]],
-            { active_test: false },
-        );
+        const partners = this.getRecords("res.partner", [["id", "in", ids]], {
+            active_test: false,
+        });
         for (const partner of partners) {
             // Not a real field but ease the testing
             partnerFormats.get(partner.id).out_of_office_date_end = partner.out_of_office_date_end;

--- a/addons/hr_holidays/static/tests/helpers/model_definitions_setup.js
+++ b/addons/hr_holidays/static/tests/helpers/model_definitions_setup.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
-import { insertModelFields } from '@bus/../tests/helpers/model_definitions_helpers';
+import { insertModelFields } from "@bus/../tests/helpers/model_definitions_helpers";
 
-insertModelFields('res.partner', {
-    out_of_office_date_end: { type: 'date' },
+insertModelFields("res.partner", {
+    out_of_office_date_end: { type: "date", default: () => false },
 });

--- a/addons/hr_holidays/static/tests/im_status_tests.js
+++ b/addons/hr_holidays/static/tests/im_status_tests.js
@@ -1,0 +1,46 @@
+/* @odoo-module */
+
+import { startServer } from "@bus/../tests/helpers/mock_python_environment";
+
+import { start } from "@mail/../tests/helpers/test_utils";
+import { Persona } from "@mail/core/common/persona_model";
+import { Command } from "@mail/../tests/helpers/command";
+
+import { contains } from "@web/../tests/utils";
+import { patchWithCleanup } from "@web/../tests/helpers/utils";
+
+QUnit.module("im_status");
+
+QUnit.test("change icon on change partner im_status for leave variants", async () => {
+    const pyEnv = await startServer();
+    pyEnv["res.partner"].write([pyEnv.currentPartnerId], {
+        im_status: "online",
+        out_of_office_date_end: "2023-01-01",
+    });
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [Command.create({ partner_id: pyEnv.currentPartnerId })],
+        channel_type: "chat",
+    });
+    patchWithCleanup(Persona, { IM_STATUS_DEBOUNCE_DELAY: 0 });
+    const { openDiscuss } = await start();
+    openDiscuss(channelId);
+    await contains(".o-mail-ImStatus .fa-plane[title='Online']");
+
+    pyEnv["bus.bus"]._sendone("broadcast", "bus.bus/im_status_updated", {
+        partner_id: pyEnv.currentPartnerId,
+        im_status: "offline",
+    });
+    await contains(".o-mail-ImStatus .fa-plane[title='Out of office']");
+
+    pyEnv["bus.bus"]._sendone("broadcast", "bus.bus/im_status_updated", {
+        partner_id: pyEnv.currentPartnerId,
+        im_status: "away",
+    });
+    await contains(".o-mail-ImStatus .fa-plane[title='Idle']");
+
+    pyEnv["bus.bus"]._sendone("broadcast", "bus.bus/im_status_updated", {
+        partner_id: pyEnv.currentPartnerId,
+        im_status: "online",
+    });
+    await contains(".o-mail-ImStatus .fa-plane[title='Online']");
+});

--- a/addons/mail/static/src/core/common/persona_model.js
+++ b/addons/mail/static/src/core/common/persona_model.js
@@ -28,7 +28,7 @@ export class Persona extends Record {
     static new() {
         const record = super.new(...arguments);
         record.debouncedSetImStatus = debounce(
-            (newStatus) => (record.im_status = newStatus),
+            (newStatus) => record.updateImStatus(newStatus),
             this.IM_STATUS_DEBOUNCE_DELAY
         );
         return record;
@@ -103,6 +103,10 @@ export class Persona extends Record {
 
     get emailWithoutDomain() {
         return this.email.substring(0, this.email.lastIndexOf("@"));
+    }
+
+    updateImStatus(newStatus) {
+        this.im_status = newStatus;
     }
 }
 

--- a/addons/mail/static/tests/helpers/mock_server/models/res_partner.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/res_partner.js
@@ -239,6 +239,9 @@ patch(MockServer.prototype, {
             ).values(),
         ];
     },
+    _mockResPartnerComputeImStatus(partner) {
+        return partner.im_status;
+    },
     /**
      * Simulates `mail_partner_format` on `res.partner`.
      *
@@ -268,7 +271,7 @@ patch(MockServer.prototype, {
                         active: partner.active,
                         email: partner.email,
                         id: partner.id,
-                        im_status: partner.im_status,
+                        im_status: this._mockResPartnerComputeImStatus(partner),
                         is_company: partner.is_company,
                         name: partner.name,
                         type: "partner",


### PR DESCRIPTION
**Current behavior before PR:**

prior to this PR fa-plane icon does not displayed after user comes online/offline/away while on leave without any reload.

**Desired behavior after PR is merged:**

now fa-plane icon is displayed with respective color of im_status without any reload

task-4237384

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
