### PR TITLE
[FIX] event: resolve dialog issue

### DIFF
--- a/addons/event/static/src/client_action/event_barcode.js
+++ b/addons/event/static/src/client_action/event_barcode.js
@@ -118,14 +118,14 @@ export class EventScanView extends Component {
         if (this.isMultiEvent) {
             this.actionService.doAction("event.event_registration_action", {
                 additionalContext: {
-                    is_registration_desk_view: true,
+                    is_registration_desk_view: true, // To remove in master
                 },
             });
         } else {
             this.actionService.doAction("event.event_registration_action_kanban", {
                 additionalContext: {
                     active_id: this.eventId,
-                    is_registration_desk_view: true,
+                    is_registration_desk_view: true, // To remove in master
                     search_default_unconfirmed: true,
                     search_default_confirmed: true,
                 },

--- a/addons/event/views/event_registration_views.xml
+++ b/addons/event/views/event_registration_views.xml
@@ -339,7 +339,7 @@
         <field name="name">Attendees</field>
         <field name="view_mode">kanban,tree,form</field>
         <field name="domain">[('event_id', '=', active_id)]</field>
-        <field name="context">{'default_event_id': active_id}</field>
+        <field name="context">{'default_event_id': active_id, 'is_registration_desk_view': True}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 No Attendees yet!
@@ -353,7 +353,7 @@
         <field name="res_model">event.registration</field>
         <field name="name">Attendees</field>
         <field name="view_mode">kanban,tree,form</field>
-        <field name="context">{'search_default_filter_is_ongoing': True}</field>
+        <field name="context">{'search_default_filter_is_ongoing': True, 'is_registration_desk_view': True}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 No Attendees expected yet!


### PR DESCRIPTION
Steps to reproduce
===================
- Open the barcode interface by selecting attendee from the barcode in the registration desk.
- Click on any record it will open a dialog and the attendee is registered.
- Now refresh the page again click on any record.
- Form view will be opened this time instead of dialog.

Technical
==========
Context is added to the action from the js side when we click on the `select attendee` button and we loose that when we refresh the page.

This commit resolves the issue by adding the context directly in the action from XML side so when we refresh the page, the action will be loaded again and we will not lose the context.

task-4273707