### PR TITLE
[IMP] crm: simplify model name

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -86,7 +86,7 @@ PLS_UPDATE_BATCH_STEP = 5000
 
 
 class CrmLead(models.Model):
-    _description = "Lead/Opportunity"
+    _description = "Lead"
     _order = "priority desc, id desc"
     _inherit = ['mail.thread.cc',
                 'mail.thread.blacklist',


### PR DESCRIPTION
The purpose of this PR is to change `crm.lead` model's description to `Lead` from "Lead/Opportunity".

Rationale:
Lead is the "englobing" term and is already used everywhere else (Generate Leads, Similar Leads, Lead Generation Rules, ...)
​It does not look good in all the [emails/notifications](https://www.awesomescreenshot.com/image/51181133?key=bff855eb432cfc8c99b817804d5796dd) about it ​﻿﻿​﻿

Task-4273579
