### PR TITLE
[REV] l10n_it_edi: prevent generation of XML if document type is not …

### DIFF
--- a/addons/l10n_it_edi/i18n/l10n_it_edi.pot
+++ b/addons/l10n_it_edi/i18n/l10n_it_edi.pot
@@ -686,13 +686,6 @@ msgstr ""
 
 #. module: l10n_it_edi
 #. odoo-python
-#: code:addons/l10n_it_edi/models/account_move.py:0
-#, python-format
-msgid "Please fill out the Document Type field in the Electronic Invoicing tab."
-msgstr ""
-
-#. module: l10n_it_edi
-#. odoo-python
 #: code:addons/l10n_it_edi/models/account_edi_proxy_user.py:0
 #, python-format
 msgid ""

--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -1236,9 +1236,6 @@ class AccountMove(models.Model):
             if moves := pa_moves.filtered(lambda move: not move.l10n_it_origin_document_type and move.l10n_it_cig and move.l10n_it_cup):
                 message = _("CIG/CUP fields of partner(s) are present, please fill out Origin Document Type field in the Electronic Invoicing tab.")
                 errors['move_missing_origin_document_field'] = build_error(message=message, records=moves)
-        if moves := self.filtered(lambda move: not move.l10n_it_document_type):
-            message = _("Please fill out the Document Type field in the Electronic Invoicing tab.")
-            errors['move_missing_document_type'] = build_error(message=message, records=moves)
         return errors
 
     def _l10n_it_edi_export_taxes_check(self):

--- a/addons/l10n_it_edi/tests/test_edi_export.py
+++ b/addons/l10n_it_edi/tests/test_edi_export.py
@@ -230,7 +230,7 @@ class TestItEdiExport(TestItEdi):
                 }),
             ],
         })
-        self.assertEqual(['partner_address_missing', 'move_missing_document_type'], list(invoice._l10n_it_edi_export_data_check().keys()))
+        self.assertEqual(['partner_address_missing'], list(invoice._l10n_it_edi_export_data_check().keys()))
 
     def test_invoice_non_domestic_simplified(self):
         invoice = self.env['account.move'].with_company(self.company).create({
@@ -246,7 +246,7 @@ class TestItEdiExport(TestItEdi):
                 }),
             ],
         })
-        self.assertEqual(['partner_address_missing', 'move_missing_document_type'], list(invoice._l10n_it_edi_export_data_check().keys()))
+        self.assertEqual(['partner_address_missing'], list(invoice._l10n_it_edi_export_data_check().keys()))
 
     def test_invoice_zero_percent_taxes(self):
         tax_zero_percent_hundred_percent_repartition = self.env['account.tax'].with_company(self.company).create({


### PR DESCRIPTION
… is not set"

This reverts commit fd1da69f8331dbc55be2d164fad381fca1622a67.

The l10n_it_document_type belongs to `l10n_it_edi_ndd` module.
This module exists to add this stored field that was missing.
When the error that this commit tried to fix happens, which is due
to the fact that the compute doesn't find a correct matching document, we
don't want to block the flow. The user can still set a document type himself
through Odoo (if he has the aforementioned module installed) or directly in
the XML.