### PR TITLE
[FIX] sale,website_sale: fix product/combo configurator translations

### DIFF
--- a/addons/sale/i18n/sale.pot
+++ b/addons/sale/i18n/sale.pot
@@ -4699,8 +4699,8 @@ msgstr ""
 
 #. module: sale
 #. odoo-javascript
-#: code:addons/sale/static/src/js/product_list/product_list.xml:0
-msgid "Total:"
+#: code:addons/sale/static/src/js/product_list/product_list.js:0
+msgid "Total: %s"
 msgstr ""
 
 #. module: sale

--- a/addons/sale/static/src/js/product_list/product_list.js
+++ b/addons/sale/static/src/js/product_list/product_list.js
@@ -20,6 +20,10 @@ export class ProductList extends Component {
         this.optionalProductsTitle = _t("Add optional products");
     }
 
+    get totalMessage() {
+        return _t("Total: %s", this.getFormattedTotal());
+    }
+
     /**
      * Return the total of the product in the list, in the currency of the `sale.order`.
      *

--- a/addons/sale/static/src/js/product_list/product_list.xml
+++ b/addons/sale/static/src/js/product_list/product_list.xml
@@ -22,9 +22,11 @@
                 </tr>
                 <tr t-if="!this.props.areProductsOptional">
                     <td colspan="4" class="border-bottom-0 text-end">
-                        <span name="sale_product_configurator_list_total" class="h4">
-                            Total: <span t-out="getFormattedTotal()"/>
-                        </span>
+                        <span
+                            name="sale_product_configurator_list_total"
+                            class="h4"
+                            t-out="totalMessage"
+                        />
                     </td>
                 </tr>
             </tbody>

--- a/addons/website_sale/i18n/website_sale.pot
+++ b/addons/website_sale/i18n/website_sale.pot
@@ -3862,6 +3862,12 @@ msgid "Total number of views on products"
 msgstr ""
 
 #. module: website_sale
+#. odoo-javascript
+#: code:addons/website_sale/static/src/js/product_list/product_list.js:0
+msgid "Total: %s"
+msgstr ""
+
+#. module: website_sale
 #: model:ir.model.fields,help:website_sale.field_website_snippet_filter__product_cross_selling
 msgid ""
 "True only for product filters that require a product_id because they relate "

--- a/addons/website_sale/static/src/js/product_list/product_list.js
+++ b/addons/website_sale/static/src/js/product_list/product_list.js
@@ -12,4 +12,11 @@ patch(ProductList.prototype, {
             this.optionalProductsTitle = _t("Available options");
         }
     },
+
+    get totalMessage() {
+        if (this.env.isFrontend) {
+            return _t("Total: %s", this.getFormattedTotal());
+        }
+        return super.totalMessage(...arguments);
+    },
 });


### PR DESCRIPTION
Backend translations are not loaded in the frontend, and since the product/combo configurators are defined in the backend and overridden in the frontend, any translations used both in the backend and the frontend need to be defined in both.

opw-4182798