### PR TITLE
[FIX] l10n_eu_oss: prevent error when clicking on Refresh tax mapping

### DIFF
--- a/addons/l10n_eu_oss/models/res_company.py
+++ b/addons/l10n_eu_oss/models/res_company.py
@@ -29,7 +29,7 @@ class Company(models.Model):
             ('model', '=', 'account.tax.group')])
         for company in self:
             # instantiate OSS taxes on the first branch with a TAX ID, default on root company
-            company = company.parent_ids.filtered(lambda c: c.vat)[-1:] or self.root_id
+            company = company.parent_ids.filtered(lambda c: c.vat)[-1:] or company.root_id
             invoice_repartition_lines, refund_repartition_lines = company._get_repartition_lines_oss()
             taxes = self.env['account.tax'].search([
                 *self.env['account.tax']._check_company_domain(company),


### PR DESCRIPTION
When the user selects multiple companies and clicks on Refresh tax mapping,
a traceback will appear.

Steps to reproduce the error:
- Install ``l10n_eu_oss`` module
- Select multiple companies
- Go to Invoicing > Configuration > Settings > Taxes >
  EU Intra-community Distance Selling > Click on Refresh tax mapping

Traceback:
```
ValueError: Expected singleton: res.company(1, 2)
  File "odoo/http.py", line 2364, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1891, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1954, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 137, in retrying
    result = func()
  File "odoo/http.py", line 1921, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2168, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 330, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 728, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 40, in call_button
    action = call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 517, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/l10n_eu_oss/models/res_config_settings.py", line 13, in refresh_eu_tax_mapping
    self.env.companies._map_eu_taxes()
  File "addons/l10n_eu_oss/models/res_company.py", line 34, in _map_eu_taxes
    invoice_repartition_lines, refund_repartition_lines = company._get_repartition_lines_oss()
  File "addons/l10n_eu_oss/models/res_company.py", line 105, in _get_repartition_lines_oss
    self.ensure_one()
  File "odoo/models.py", line 6213, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
```

https://github.com/odoo/odoo/blob/bbcef64e3296efa2b985e8d08dfe0573dc62dbb4/addons/l10n_eu_oss/models/res_company.py#L32
Here, ``self`` is used instead of ``company``, When self has multiple companies,
It will lead to the above traceback.

sentry-6002997139

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
