### PR TITLE
[FIX] l10n_{ar,cl}: Fix function name causing AttributeError

### DIFF
--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -347,7 +347,7 @@ class AccountMove(models.Model):
         }
         tax_group_ids_to_exclude = self.env['account.tax.group'].browse(tax_group_ids).filtered('l10n_ar_vat_afip_code').ids
         if tax_group_ids_to_exclude:
-            return self.env['account.tax']._exclude_tax_group_from_tax_totals_summary(tax_totals, tax_group_ids_to_exclude)
+            return self.env['account.tax']._exclude_tax_groups_from_tax_totals_summary(tax_totals, tax_group_ids_to_exclude)
         return tax_totals
 
     def _l10n_ar_include_vat(self):

--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -152,7 +152,7 @@ class AccountMove(models.Model):
         }
         tax_group_ids_to_exclude = self.env['account.tax.group'].browse(tax_group_ids).filtered(lambda x: x.l10n_cl_sii_code == 14).ids
         if tax_group_ids_to_exclude:
-            return self.env['account.tax']._exclude_tax_group_from_tax_totals_summary(tax_totals, tax_group_ids_to_exclude)
+            return self.env['account.tax']._exclude_tax_groups_from_tax_totals_summary(tax_totals, tax_group_ids_to_exclude)
         return tax_totals
 
     def _l10n_cl_include_sii(self):


### PR DESCRIPTION
The function `_exclude_tax_group_from_tax_totals_summary` does not exist. It should be `_exclude_tax_groups_from_tax_totals_summary` instead.

This is the same issue for the l10n_cl and l10n_ar module since it's just a call to a non-existent function.

### Steps to reproduce:
- Install the l10n_ar module
- Create an invoice with the document type set to "Invoice C"
- Add a line that includes a tax
- Try to print using the "PDF without payment" button

### Traceback:
```
File "/Users/louis/Development/odoo_src/core/odoo/odoo/addons/base/models/ir_qweb.py", line 600, in _render
  result = ''.join(rendering)
           ^^^^^^^^^^^^^^^^^^
File "<778>", line 107, in template_778
File "<778>", line 89, in template_778_content
File "<778>", line 77, in template_778_t_call_0
File "<1056>", line 2228, in template_1056
odoo.addons.base.models.ir_qweb.QWebException: Error while rendering the template AttributeError: 'account.tax' object has no attribute '_exclude_tax_group_from_tax_totals_summary' Template: l10n_ar.report_invoice_document
Path: /t/t/div[2]/div/div[4]/div[1]/div[1]/div/table/t[1]/t[2]
Node: <t t-set="currency" t-value="o.currency_id"/>
```
opw-4253265
