### PR TITLE
[FIX] hr: fix type of field on test

### DIFF
--- a/addons/hr/static/tests/legacy/m2x_avatar_employee_tests.js
+++ b/addons/hr/static/tests/legacy/m2x_avatar_employee_tests.js
@@ -302,7 +302,7 @@ QUnit.module("M2XAvatarEmployee", ({ beforeEach }) => {
                         fields: {
                             employee_id: {
                                 string: "employee",
-                                type: "one2many",
+                                type: "many2one",
                                 relation: "hr.employee",
                             },
                         },


### PR DESCRIPTION
This commit fixes the type of field, in a test for the widget many2one_avatar_employee

task-id: 4224192
