### PR TITLE
[FIX] website_sale: make ProductConfiguratorDialog title translatable

### DIFF
--- a/addons/website_sale/i18n/es.po
+++ b/addons/website_sale/i18n/es.po
@@ -1,12 +1,12 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # 	* website_sale
-# 
+#
 # Translators:
 # Larissa Manderfeld, 2024
 # Pedro M. Baeza <pedro.baeza@tecnativa.com>, 2024
 # Wil Odoo, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~17.4\n"
@@ -15,10 +15,10 @@ msgstr ""
 "PO-Revision-Date: 2024-07-16 11:42+0000\n"
 "Last-Translator: Wil Odoo, 2024\n"
 "Language-Team: Spanish (https://app.transifex.com/odoo/teams/41243/es/)\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
 "Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
 
 #. module: website_sale
@@ -1316,6 +1316,12 @@ msgstr "Ajustes de configuración"
 #: model_terms:ir.ui.view,arch_db:website_sale.res_config_settings_view_form
 msgid "Configure Form"
 msgstr "Configurar formulario"
+
+#. module: website_sale
+#. odoo-javascript
+#: code:addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js:0
+msgid "Configure your product"
+msgstr "Configure su producto"
 
 #. module: website_sale
 #. odoo-python
@@ -4487,16 +4493,6 @@ msgstr "Su correo electrónico"
 #: code:addons/website_sale/static/src/js/website_sale_form_editor.js:0
 msgid "Your Name"
 msgstr "Su nombre"
-
-#. module: website_sale
-#. odoo-python
-#: code:addons/website_sale/models/website.py:0
-msgid ""
-"Your account is not allowed to pay in company %s. Please log out and create "
-"a new account for this website, or contact the website administrator."
-msgstr ""
-"Su cuenta no puede pagar en la compañía %s. Cierre su sesión y cree una "
-"nueva cuenta para este sitio web o contacte al administrador."
 
 #. module: website_sale
 #: model_terms:ir.ui.view,arch_db:website_sale.cart_lines

--- a/addons/website_sale/i18n/nl.po
+++ b/addons/website_sale/i18n/nl.po
@@ -1,13 +1,13 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # 	* website_sale
-# 
+#
 # Translators:
 # Erwin van der Ploeg <erwin@odooexperts.nl>, 2024
 # Wil Odoo, 2024
 # Manon Rondou, 2024
 # Dylan Kiss, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~17.4\n"
@@ -16,10 +16,10 @@ msgstr ""
 "PO-Revision-Date: 2024-07-16 11:42+0000\n"
 "Last-Translator: Dylan Kiss, 2024\n"
 "Language-Team: Dutch (https://app.transifex.com/odoo/teams/41243/nl/)\n"
+"Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: nl\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale
@@ -1316,6 +1316,12 @@ msgstr "Configuratie instellingen"
 #: model_terms:ir.ui.view,arch_db:website_sale.res_config_settings_view_form
 msgid "Configure Form"
 msgstr "Formulier configureren"
+
+#. module: website_sale
+#. odoo-javascript
+#: code:addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js:0
+msgid "Configure your product"
+msgstr "Configureer je product"
 
 #. module: website_sale
 #. odoo-python
@@ -4485,17 +4491,6 @@ msgstr "Je e-mail"
 #: code:addons/website_sale/static/src/js/website_sale_form_editor.js:0
 msgid "Your Name"
 msgstr "Je naam"
-
-#. module: website_sale
-#. odoo-python
-#: code:addons/website_sale/models/website.py:0
-msgid ""
-"Your account is not allowed to pay in company %s. Please log out and create "
-"a new account for this website, or contact the website administrator."
-msgstr ""
-"Met je account mag je niet betalen bij bedrijf %s. Meld je af en maak een "
-"nieuw account aan voor deze website, of neem contact op met de "
-"websitebeheerder."
 
 #. module: website_sale
 #: model_terms:ir.ui.view,arch_db:website_sale.cart_lines

--- a/addons/website_sale/i18n/website_sale.pot
+++ b/addons/website_sale/i18n/website_sale.pot
@@ -1192,6 +1192,12 @@ msgid "Configure Form"
 msgstr ""
 
 #. module: website_sale
+#. odoo-javascript
+#: code:addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js:0
+msgid "Configure your product"
+msgstr ""
+
+#. module: website_sale
 #. odoo-python
 #: code:addons/website_sale/models/website.py:0
 msgid "Confirm"
@@ -4246,14 +4252,6 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/website_sale/static/src/js/website_sale_form_editor.js:0
 msgid "Your Name"
-msgstr ""
-
-#. module: website_sale
-#. odoo-python
-#: code:addons/website_sale/models/website.py:0
-msgid ""
-"Your account is not allowed to pay in company %s. Please log out and create "
-"a new account for this website, or contact the website administrator."
 msgstr ""
 
 #. module: website_sale

--- a/addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
+++ b/addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
@@ -1,5 +1,4 @@
-/** @odoo-module **/
-
+import { _t } from '@web/core/l10n/translation';
 import { patch } from '@web/core/utils/patch';
 import { useSubEnv } from '@odoo/owl';
 import {
@@ -29,6 +28,11 @@ patch(ProductConfiguratorDialog.prototype, {
             this.createProductUrl = '/website_sale/product_configurator/create_product';
             this.updateCombinationUrl = '/website_sale/product_configurator/update_combination';
             this.getOptionalProductsUrl = '/website_sale/product_configurator/get_optional_products';
+            // To be translated, the title must be repeated here. Indeed, only
+            // translations of "frontend modules" are fetched in the context of
+            // website. The original definition of the title is in "sale", which
+            // is not a frontend module.
+            this.title = _t("Configure your product");
         }
 
         useSubEnv({


### PR DESCRIPTION
On the website, the title of the ProductConfigatorDialog is not translated into any language. This is because only "frontend modules" translations are fetched in the context of the website. The title of the dialog is defined in the "sale" module, which is not a frontend module, so the translation is missing.

This commit solves the problem by redefining the string to translate in the website_sale module.

Task-4182798