### PR TITLE
[FIX] hr_attendance: use hours_last_month with widget float_time

### DIFF
--- a/addons/hr_attendance/views/hr_employee_view.xml
+++ b/addons/hr_attendance/views/hr_employee_view.xml
@@ -18,7 +18,7 @@
                         help="Worked hours this month">
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_value">
-                            <field name="hours_last_month_display" widget="float_time"/> Hours
+                            <field name="hours_last_month" widget="float_time"/> Hours
                         </span>
                         <span class="o_stat_text">
                             This Month
@@ -66,7 +66,7 @@
                         help="Worked hours this month">
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_value">
-                            <field name="hours_last_month_display" widget="float_time"/> Hours
+                            <field name="hours_last_month" widget="float_time"/> Hours
                         </span>
                         <span class="o_stat_text">
                             This Month


### PR DESCRIPTION
Before this commit, the char field `hours_last_month_display` was used
in the views with the widget `float_time`, the issue with this, is that
the widget `float_time` allows only float type fields.

Now, we use the float field `hours_last_month` in the views.

task-id: 4224192