### PR TITLE
[FIX] point_of_sale: stop creating useless sequence for each session

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -240,18 +240,6 @@ class PosSession(models.Model):
             sessions = super().create(vals_list)
         sessions.action_pos_session_open()
 
-        date_string = fields.Date.today().isoformat()
-        ir_sequence = self.env['ir.sequence'].sudo().search([('code', '=', f'pos.order_{date_string}')])
-        if not ir_sequence:
-            self.env['ir.sequence'].sudo().create({
-                'name': _("PoS Order"),
-                'padding': 0,
-                'code': f'pos.order_{date_string}',
-                'number_next': 1,
-                'number_increment': 1,
-                'company_id': self.env.company.id,
-            })
-
         return sessions
 
     def unlink(self):


### PR DESCRIPTION
When starting a PoS session a useless sequence was created every time

Steps to reproduce:
-------------------
* Open a PoS session on different days
> Observation: Go to the sequence list in the settings, there is one
sequence for each days you opened a session

Why the fix:
------------
The sequence was actually not used so we just remove it.

opw-4166554
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
