### PR TITLE
[FIX] account: avoid report changes

### DIFF
--- a/addons/account/security/ir.model.access.csv
+++ b/addons/account/security/ir.model.access.csv
@@ -20,7 +20,7 @@ access_res_currency_rate_account_manager,res.currency.rate account manager,base.
 
 access_account_invoice_report_readonly,account.invoice.report_user,model_account_invoice_report,account.group_account_readonly,1,0,0,0
 access_account_invoice_report_billing,account.invoice.report_billing,model_account_invoice_report,account.group_account_invoice,1,0,0,0
-access_account_invoice_report,account.invoice.report,model_account_invoice_report,account.group_account_manager,1,1,1,1
+access_account_invoice_report,account.invoice.report,model_account_invoice_report,account.group_account_manager,1,0,0,0
 
 access_account_incoterms_all,account.incoterms all,model_account_incoterms,,1,0,0,0
 access_account_incoterms_manager,account.incoterms manager,model_account_incoterms,account.group_account_manager,1,1,1,1


### PR DESCRIPTION
An Odoo server error occurs when attempting to change the main partner, country, sales team (if sales is installed) or document type (if l10n_latam_invoice_document is installed) in a report from the invoice analysis.

**Steps to reproduce:**

1. Go to Accounting > Reporting > Management > Invoice Analysis.
2. Click on the pivot icon (on the far right).
3. Click on any amount.
4. A list of invoices should appear.
5. Click on any invoice.
6. Change the main partner or country and save.

An Odoo server error would occur (see screenshots attached)
![bug_invoice_analysis#1](https://github.com/user-attachments/assets/30e54399-bda1-480e-862b-952cad8630cf)
![bug_invoice_analysis#2](https://github.com/user-attachments/assets/9ef569b7-2117-4a8a-81f7-8959cb1ba947)

After speaking with one of the product owners, it was confirmed that changing these fields should not be functionally allowed, consistent with the behavior in version 17.0 and onwards.

opw-4246387


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
