### PR TITLE
[FIX] base, mail, account: properly forward _post_add_create kwargs

### DIFF
--- a/addons/account/models/ir_attachment.py
+++ b/addons/account/models/ir_attachment.py
@@ -181,4 +181,4 @@ class IrAttachment(models.Model):
         moves_per_id = self.env['account.move'].browse([attachment.res_id for attachment in move_attachments]).grouped('id')
         for attachment in move_attachments:
             moves_per_id[attachment.res_id]._check_and_decode_attachment(attachment)
-        super()._post_add_create()
+        super()._post_add_create(**kwargs)

--- a/addons/mail/models/discuss/ir_attachment.py
+++ b/addons/mail/models/discuss/ir_attachment.py
@@ -25,6 +25,6 @@ class IrAttachment(models.Model):
         return attachment_format
 
     def _post_add_create(self, **kwargs):
-        super()._post_add_create()
+        super()._post_add_create(**kwargs)
         if kwargs.get('voice'):
             self.env["discuss.voice.metadata"].create([{"attachment_id": attachment.id} for attachment in self])

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -666,7 +666,7 @@ class IrAttachment(models.Model):
             Attachments.check('create', values={'res_model':res_model, 'res_id':res_id})
         return super().create(vals_list)
 
-    def _post_add_create(self):
+    def _post_add_create(self, **kwargs):
         pass
 
     def generate_access_token(self):


### PR DESCRIPTION
Follow up of https://github.com/odoo/odoo/pull/171393

The method should forward all kwargs to the super call.

Issue manifesting in particular in 18.0 when attempting to fix cloud storage at https://github.com/odoo/odoo/pull/184331