### PR TITLE
[FIX] mail: remove "done" filter from activity view

### DIFF
--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -276,8 +276,6 @@
                 <filter string="Future" name="filter_date_deadline_future"
                         domain="[('date_deadline', '&gt;', context_today().strftime('%Y-%m-%d'))
                         ]"/>
-                <separator/>
-                <filter string="Done" name="filter_archived" domain="[('active', '=', False)]"/>
                 <separator />
                 <group expand="0" string="Group By">
                     <filter string="Deadline" name="date_deadline" context="{'group_by': 'date_deadline'}"/>


### PR DESCRIPTION
Removed the "done" filter from the activity view as it does not make sense to filter by activities marked as "done."
In Odoo, done activities are automatically deleted https://github.com/odoo/odoo/blob/d2909a47911146f9c45bdea0f927d4132b61879b/addons/mail/models/mail_activity.py#L559 making it impossible to list them when applying this filter. This change prevents confusion for users.

Steps to reproduce:
Activate developer mode
settings/technical/activity overview
Filter by "Done" activities

opw-4257104


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
