### PR TITLE
[IMP] account: Add smart button linking invoices and adjusting entries

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -219,6 +219,31 @@ class AccountMove(models.Model):
         related="statement_line_id.statement_id"
     )
 
+    # === Adjusting Entries fields === #
+    adjusting_entry_origin_move_ids = fields.Many2many(
+        comodel_name='account.move',
+        relation='adjusting_entries__account_move',
+        column1='move_id',
+        column2='adjusting_entry_move_id',
+        string="Adjusting Entry Origin Moves",
+    )
+    adjusting_entry_origin_label = fields.Char(compute="_compute_adjusting_entry_origin_label")
+    adjusting_entry_origin_moves_count = fields.Integer(
+        string="Adjusting Entry Origin Moves Count",
+        compute='_compute_adjusting_entry_origin_moves_count',
+    )
+    adjusting_entries_move_ids = fields.Many2many(
+        comodel_name='account.move',
+        relation='adjusting_entries__account_move',
+        column1='adjusting_entry_move_id',
+        column2='move_id',
+        string="Created Adjusting Entries",
+    )
+    adjusting_entries_count = fields.Integer(
+        string="Adjusting Entries Count",
+        compute='_compute_adjusting_entries_count',
+    )
+
     # === Cash basis feature fields === #
     # used to keep track of the tax cash basis reconciliation. This is needed
     # when cancelling the source: it will post the inverse journal entry to
@@ -1171,6 +1196,25 @@ class AccountMove(models.Model):
     def _compute_payment_count(self):
         for invoice in self:
             invoice.payment_count = len(invoice.matched_payment_ids)
+
+    @api.depends('adjusting_entries_move_ids')
+    def _compute_adjusting_entries_count(self):
+        for move in self:
+            move.adjusting_entries_count = len(move.adjusting_entries_move_ids)
+
+    @api.depends('adjusting_entry_origin_move_ids')
+    def _compute_adjusting_entry_origin_moves_count(self):
+        for move in self:
+            move.adjusting_entry_origin_moves_count = len(move.adjusting_entry_origin_move_ids)
+
+    @api.depends_context('lang')
+    @api.depends('adjusting_entry_origin_move_ids')
+    def _compute_adjusting_entry_origin_label(self):
+        for move in self:
+            if len(move.adjusting_entry_origin_move_ids) == 1:
+                move.adjusting_entry_origin_label = dict(self._fields['move_type'].selection)[move.adjusting_entry_origin_move_ids.move_type]
+            else:
+                move.adjusting_entry_origin_label = False
 
     @api.depends('invoice_payment_term_id', 'invoice_date', 'currency_id', 'amount_total_in_currency_signed', 'invoice_date_due')
     def _compute_needed_terms(self):
@@ -5012,6 +5056,15 @@ class AccountMove(models.Model):
             'domain': [('id', 'in', self.tax_cash_basis_created_move_ids.ids)],
             'views': [(self.env.ref('account.view_move_tree').id, 'list'), (False, 'form')],
         }
+
+    def open_adjusting_entries(self):
+        self.ensure_one()
+        return self.adjusting_entries_move_ids._get_records_action(name="Adjusting Entries")
+
+    def open_adjusting_entry_origin_moves(self):
+        self.ensure_one()
+        label = self.adjusting_entry_origin_label if len(self.adjusting_entries_move_ids) == 1 else 'Invoices'
+        return self.adjusting_entry_origin_move_ids._get_records_action(name=label)
 
     def action_switch_move_type(self):
         if any(move.posted_before for move in self):

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -879,6 +879,27 @@
                                         <span class="o_stat_text">Cash Basis Entries</span>
                                     </div>
                             </button>
+                            <button name="open_adjusting_entries"
+                                    class="oe_stat_button"
+                                    icon="fa-bars"
+                                    type="object"
+                                    invisible="not adjusting_entries_move_ids">
+                                    <field name="adjusting_entries_count" string="Adjusting Entries" widget="statinfo"/>
+                            </button>
+                            <button name="open_adjusting_entry_origin_moves"
+                                    class="oe_stat_button"
+                                    icon="fa-bars"
+                                    type="object"
+                                    invisible="not adjusting_entry_origin_move_ids">
+                                    <div invisible="adjusting_entry_origin_moves_count != 1" class="o_stat_info">
+                                        <span class="o_stat_text">
+                                            <field name="adjusting_entry_origin_label"/>
+                                        </span>
+                                    </div>
+                                    <field name="adjusting_entry_origin_moves_count"
+                                           invisible="adjusting_entry_origin_moves_count == 1"
+                                           string="Invoices" widget="statinfo"/>
+                            </button>
                         </div>
 
                         <!-- Payment status for invoices / receipts -->

--- a/addons/account/wizard/account_automatic_entry_wizard.py
+++ b/addons/account/wizard/account_automatic_entry_wizard.py
@@ -331,6 +331,7 @@ class AccountAutomaticEntryWizard(models.TransientModel):
             'ref': self._format_strings(ref_format, self.move_line_ids[0].move_id),
             'date': fields.Date.to_string(self.date),
             'journal_id': self.journal_id.id,
+            'adjusting_entry_origin_move_ids': self.move_line_ids.move_id.ids,
         }}
         # complete the account.move data
         for date, grouped_lines in groupby(self.move_line_ids, get_lock_safe_date):
@@ -343,6 +344,7 @@ class AccountAutomaticEntryWizard(models.TransientModel):
                 'ref': self._format_strings(ref_format, grouped_lines[0].move_id, amount),
                 'date': fields.Date.to_string(date),
                 'journal_id': self.journal_id.id,
+                'adjusting_entry_origin_move_ids': self.move_line_ids.move_id.ids,
             }
 
         # compute the account.move.lines and the total amount per move


### PR DESCRIPTION
When applying cut-off on invoice journal items, adjusting entries were created without a direct link to the corresponding invoice.

A smart button was added to the invoice leading to the adjustment of entries. 
A smart button was added to the adjusting entry leading to the related invoice.

task-4267272

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
