### PR TITLE
[IMP] mrp: hide MO cost on Done productions

### DIFF
--- a/addons/mrp/static/src/components/mo_overview/mrp_mo_overview.js
+++ b/addons/mrp/static/src/components/mo_overview/mrp_mo_overview.js
@@ -54,11 +54,12 @@ export class MoOverview extends Component {
             this.state.showOptions.realCosts = false;
         }
         if (this.isProductionDone) {
-            // Hide Availabilities / Receipts / Status columns when the MO is done.
+            // Hide Availabilities / Receipts / Status / MO Cost columns when the MO is done.
             this.state.showOptions.availabilities = false;
             this.state.showOptions.receipts = false;
             this.state.showOptions.replenishments = false;
             this.state.showOptions.unitCosts = true;
+            this.state.showOptions.moCosts = false;
         }
         this.state.showOptions.uom = reportValues.context.show_uom;
         this.context = reportValues.context;


### PR DESCRIPTION
This commit hides the MO Cost column of MO overview report if the underlying MO is done.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
