### PR TITLE
[IMP] hw_drivers: remove white background iot display

### DIFF
--- a/addons/hw_drivers/views/pos_display.html
+++ b/addons/hw_drivers/views/pos_display.html
@@ -96,6 +96,9 @@
             .iot-devices-section {
                 display: none;
             }
+            .table {
+                --bs-table-bg: none;
+            }
         </style>
     </head>
     <body>


### PR DESCRIPTION
Bootstrap adds an ugly white background to `table` tags when we add the `table` class.  
We now force it to be transparent.