### PR TITLE
[FIX] hr_recruitment: fix refuse reason wizard

### DIFF
--- a/addons/hr_recruitment/i18n/hr_recruitment.pot
+++ b/addons/hr_recruitment/i18n/hr_recruitment.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 08:17+0000\n"
-"PO-Revision-Date: 2024-10-25 08:17+0000\n"
+"POT-Creation-Date: 2024-10-29 10:13+0000\n"
+"PO-Revision-Date: 2024-10-29 10:13+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -380,6 +380,14 @@ msgstr ""
 msgid ""
 "A Python dictionary that will be evaluated to provide default values when "
 "creating new records for this alias."
+msgstr ""
+
+#. module: hr_recruitment
+#. odoo-python
+#: code:addons/hr_recruitment/wizard/applicant_refuse_reason.py:0
+msgid ""
+"At least one applicant doesn't have a email; you can't use send email "
+"option."
 msgstr ""
 
 #. module: hr_recruitment
@@ -1284,12 +1292,6 @@ msgstr ""
 #. module: hr_recruitment
 #: model:ir.model.fields,help:hr_recruitment.field_hr_job__alias_domain
 msgid "Email domain e.g. 'example.com' in 'odoo@example.com'"
-msgstr ""
-
-#. module: hr_recruitment
-#. odoo-python
-#: code:addons/hr_recruitment/wizard/applicant_refuse_reason.py:0
-msgid "Email of the applicant is not set, email won't be sent."
 msgstr ""
 
 #. module: hr_recruitment
@@ -2444,12 +2446,6 @@ msgid "Publish job offers on your website"
 msgstr ""
 
 #. module: hr_recruitment
-#: model:ir.model.fields,field_description:hr_recruitment.field_hr_applicant__rating_ids
-#: model:ir.model.fields,field_description:hr_recruitment.field_hr_candidate__rating_ids
-msgid "Ratings"
-msgstr ""
-
-#. module: hr_recruitment
 #. odoo-python
 #: code:addons/hr_recruitment/models/hr_recruitment_stage.py:0
 #: model:hr.recruitment.stage,legend_done:hr_recruitment.stage_job0
@@ -3035,14 +3031,6 @@ msgstr ""
 
 #. module: hr_recruitment
 #. odoo-python
-#: code:addons/hr_recruitment/wizard/applicant_refuse_reason.py:0
-msgid ""
-"The email will not be sent to the following applicant(s) as they don't have "
-"an email address:"
-msgstr ""
-
-#. module: hr_recruitment
-#. odoo-python
 #: code:addons/hr_recruitment/wizard/applicant_send_mail.py:0
 msgid "The following applicants are missing an email address: %s."
 msgstr ""
@@ -3326,6 +3314,14 @@ msgstr ""
 msgid ""
 "You can define the requirements here. They will be displayed when you hover "
 "over the stage title."
+msgstr ""
+
+#. module: hr_recruitment
+#. odoo-python
+#: code:addons/hr_recruitment/wizard/applicant_refuse_reason.py:0
+msgid ""
+"You can't select Send email option.\n"
+"The email will not be sent to the following applicant(s) as they don't have an email address:"
 msgstr ""
 
 #. module: hr_recruitment

--- a/addons/hr_recruitment/tests/test_recruitment.py
+++ b/addons/hr_recruitment/tests/test_recruitment.py
@@ -113,3 +113,37 @@ class TestRecruitment(TransactionCase):
         self.env['hr.applicant'].create(applicant_data)
         partner_count = self.env['res.partner'].search_count([('email', '=', 'test@thisisatest.com')])
         self.assertEqual(partner_count, 1)
+
+    def test_applicant_refuse_reason(self):
+
+        refuse_reason = self.env['hr.applicant.refuse.reason'].create([{'name': 'Fired'}])
+
+        dup1, dup2, no_dup = self.env['hr.applicant'].create([
+            {
+                'candidate_id': self.env['hr.candidate'].create({'partner_name': 'Application 1'}).id,
+                'partner_name': 'Laurie Poiret',
+                'email_from': 'laurie.poiret@aol.ru',
+            },
+            {
+                'candidate_id': self.env['hr.candidate'].create({'partner_name': 'Application 2'}).id,
+                'partner_name': 'Laurie Poiret (lap)',
+                'email_from': 'laurie.POIRET@aol.ru',
+            },
+            {
+                'candidate_id': self.env['hr.candidate'].create({'partner_name': 'Application 3'}).id,
+                'partner_name': 'Mitchell Admin',
+                'email_from': 'mitchell_admin@example.com',
+            },
+        ])
+
+        applicant_get_refuse_reason = self.env['applicant.get.refuse.reason'].create([{
+            'refuse_reason_id': refuse_reason.id,
+            'applicant_ids': [dup1.id],
+            'duplicates': True
+        }])
+        applicant_get_refuse_reason.action_refuse_reason_apply()
+        self.assertFalse(self.env['hr.applicant'].search([('email_from', 'ilike', 'laurie.poiret@aol.ru')]))
+        self.assertEqual(
+            self.env['hr.applicant'].search([('email_from', 'ilike', 'mitchell_admin@example.com')]),
+            no_dup
+        )

--- a/addons/hr_recruitment/wizard/applicant_refuse_reason_views.xml
+++ b/addons/hr_recruitment/wizard/applicant_refuse_reason_views.xml
@@ -10,21 +10,27 @@
                         <group invisible="not refuse_reason_id">
                             <label for="send_mail" class="me-2" invisible="not refuse_reason_id"/>
                             <div class="d-flex">
-                                <field name="send_mail"/>
+                                <field name="send_mail" readonly="applicant_ids.length > 1 and applicant_without_email"/>
                                 <span class="mx-2" style="padding-top: 1px; padding-bottom: 1px;">to</span>
                                 <field name="applicant_emails" invisible="applicant_ids.length == 1"/>
-                                <field name="single_applicant_email" placeholder="Provide an email" invisible="applicant_ids.length != 1"/>
+                                <field
+                                    name="single_applicant_email"
+                                    placeholder="Provide an email"
+                                    invisible="applicant_ids.length != 1"
+                                    required="applicant_ids.length == 1 and send_mail"/>
+                            </div>
+                            <field name="template_id" invisible="not send_mail" required="send_mail"/>
+                            <label for="duplicates" invisible="duplicates_count == 0"/>
+                            <div class="d-flex" invisible="duplicates_count == 0">
+                                <field name="duplicates" nolabel="1"/>
+                                <span>Refuse the<field name="duplicates_count" class="oe_inline mx-1"/>other application(s)</span>
                             </div>
                         </group>
-                        <field name="template_id" invisible="not send_mail" required="send_mail"/>
-                        <field name="applicant_ids" invisible="1"/>
-                        <label for="duplicates" invisible="duplicates_count == 0"/>
-                        <div class="o_row" invisible="duplicates_count == 0">
-                          <field name="duplicates" nolabel="1"/>
-                             <span>Refuse the <field name="duplicates_count" class="oe_inline"/> other application(s)</span>
-                        </div>
                     </group>
-                    <div class="alert alert-danger" role="alert" invisible="not applicant_without_email">
+                    <div
+                        class="alert alert-danger"
+                        role="alert"
+                        invisible="applicant_ids.length == 1 or not applicant_without_email or not refuse_reason_id">
                         <field name="applicant_without_email" class="mr4"/>
                     </div>
                     <footer>


### PR DESCRIPTION
STEP TO REPRODUCE:
==================
1- Recruitment > All apllicants
2- Select one applicant
3- Click on refuse

You will have a traceback

In this commit, this issue is fixed and the UX was fixed too.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
