### PR TITLE
[FIX] account: prevent an error when open a preview of invoice

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5409,6 +5409,8 @@ class AccountMove(models.Model):
     def _get_invoice_next_payment_values(self, custom_amount=None):
         self.ensure_one()
         term_lines = self.line_ids.filtered(lambda line: line.display_type == 'payment_term')
+        if not term_lines:
+            return {}
         installments = term_lines._get_installments_data()
         not_reconciled_installments = [x for x in installments if not x['reconciled']]
         overdue_installments = [x for x in not_reconciled_installments if x['type'] == 'overdue']


### PR DESCRIPTION
Currently, an error occurs when the user attempts to preview an invoice, and invoice has no invoice lines.

Step to produce:

- Install the ```account``` module.
- Create a new invoice, add a customer name, and 'Cancel' this invoice.
- Click on 'Preview' button(ensure that no invoice lines have been added).

```ValueError: Expected singleton: account.move()```

An error occurs when the system tries to get installment data from the move line at [1], and the move lines are not available in the invoice.

Link [1]:  https://github.com/odoo/odoo/blob/430656132044f8d675712d5b6cbfef807880d024/addons/account/models/account_move.py#L5411-L5412

To handle this issue, pass empty data for installments if the move line is not available in the invoice.

Sentry-5978934688


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
