### PR TITLE
[FIX] account: prevent singleton error while un-merging multiple account

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -1100,13 +1100,13 @@ class AccountAccount(models.Model):
                 "You do not have the right to perform this operation as you do not have access to the following companies: %s.",
                 ", ".join(c.name for c in forbidden_companies)
             ))
-
-        if any(len(a.company_ids) == 1 for a in self):
-            raise UserError(_(
-                "Account %s cannot be unmerged as it already belongs to a single company. "
-                "The unmerge operation only splits an account based on its companies.",
-                self.display_name,
-            ))
+        for account in self:
+            if len(account.company_ids) == 1:
+                raise UserError(_(
+                    "Account %s cannot be unmerged as it already belongs to a single company. "
+                    "The unmerge operation only splits an account based on its companies.",
+                    account.display_name,
+                ))
 
     def _action_unmerge_get_user_confirmation(self):
         """ Open a RedirectWarning asking the user whether to proceed with the merge. """


### PR DESCRIPTION
Currently an error occurs when the user unmerges two or more charts of accounts with the same company.

error:
`ValueError: Expected singleton: account.account(1249, 1252, 163, 164, 165, 754)`

This is because at [1] `self` used to display name here `self` contains multiple records.

This commit will fix the above issue by looping records of self and using `display_name` of account, which is needed.

[1]- https://github.com/odoo/odoo/blob/0bac60a7085c51ac8cb4f793b013dbea927d180c/addons/account/models/account_account.py#L1108

sentry-5985600163

