### PR TITLE
[FIX] core: idempotent html_sanitize

### DIFF
--- a/addons/mail/models/mail_render_mixin.py
+++ b/addons/mail/models/mail_render_mixin.py
@@ -363,9 +363,10 @@ class MailRenderMixin(models.AbstractModel):
                 value = escape(value or '')
                 return value if tag.lower() == 't' else f"<{tag}>{value}</{tag}>"
 
-            # normalize the HTML (add a parent div to avoid modification of the template
-            # it will be removed by html_normalize)
+            # normalize the HTML (add a parent div to avoid modification of the template)
             template_src = html_normalize(f'<div>{template_src}</div>')
+            if template_src.startswith('<div>') and template_src.endswith('</div>'):
+                template_src = template_src[5:-6]
 
             result[record.id] = Markup(re.sub(
                 r'''<(\w+)[\s|\n]+t-out=[\s|\n]*(\'|\")((\w|\.)+)(\2)[\s|\n]*((\/>)|(>[\s|\n]*([^<>]*?))[\s|\n]*<\/\1>)''',

--- a/addons/website/controllers/form.py
+++ b/addons/website/controllers/form.py
@@ -304,7 +304,7 @@ class WebsiteForm(http.Controller):
             # If there isn't, put the custom data in a message instead
             if default_field.name:
                 if default_field.ttype == 'html' or model_name == 'mail.mail':
-                    custom_content = nl2br_enclose(custom_content)
+                    custom_content = nl2br(custom_content)
                 record.update({default_field.name: custom_content})
             elif hasattr(record, '_message_log'):
                 record._message_log(

--- a/odoo/addons/base/tests/test_mail.py
+++ b/odoo/addons/base/tests/test_mail.py
@@ -50,10 +50,16 @@ class TestSanitizer(BaseCase):
             ("lala<p>yop</p>xxx", "<p>lala</p><p>yop</p>xxx"),  # trailing text
             ("Merci à l'intérêt pour notre produit.nous vous contacterons bientôt. Merci",
                 u"<p>Merci à l'intérêt pour notre produit.nous vous contacterons bientôt. Merci</p>"),  # unicode
+            ('<div>a<div>b</div></div>', '<div>a<div>b</div></div>'),
+            ('<div><div>a</div></div>', '<div><div>a</div></div>'),
+            ('<script> alert(1) </script>', ''),
+            ('<head><title>Title of the document</title><head>', ''),
         ]
         for content, expected in cases:
             html = html_sanitize(content)
             self.assertEqual(html, expected, 'html_sanitize is broken')
+            html = html_sanitize(html)
+            self.assertEqual(html, expected, 'html_sanitize is not idempotent')
 
     def test_comment_malformed(self):
         html = '''<!-- malformed-close --!> <img src='x' onerror='alert(1)'></img> --> comment <!-- normal comment --> --> out of context balise --!>'''

--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -355,6 +355,7 @@ class Test_New_ApiMixed(models.Model):
     lang = fields.Selection(string='Language', selection='_get_lang')
     reference = fields.Reference(string='Related Document',
         selection='_reference_models')
+    comment0 = fields.Html()
     comment1 = fields.Html(sanitize=False)
     comment2 = fields.Html(sanitize_attributes=True, strip_classes=False)
     comment3 = fields.Html(sanitize_attributes=True, strip_classes=True)

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -3147,6 +3147,14 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
             for index, record in enumerate(records):
                 record.write({'harry': index + 2})
 
+    def test_html_sanitize(self):
+        record = self.env['test_new_api.mixed'].create({})
+        record_value = write_value = "<div>EXTERNAL SUBMISSION - Customer not verified<br>\n<br>\n<p>### TOUR DATA ###</p></div>"
+        record.comment0 = write_value
+        self.assertEqual(record.comment0, record_value)
+        record.invalidate_recordset()
+        self.assertEqual(record.comment0, record_value)
+
 
 class TestX2many(TransactionExpressionCase):
 

--- a/odoo/addons/test_new_api/tests/test_views.py
+++ b/odoo/addons/test_new_api/tests/test_views.py
@@ -20,7 +20,7 @@ class TestDefaultView(common.TransactionCase):
         )
         self.assertEqual(
             etree.tostring(self.env['test_new_api.mixed']._get_default_form_view()),
-            b'<form><sheet string="Test New API Mixed"><group><group><field name="foo"/></group></group><group><field name="text"/></group><group><group><field name="truth"/><field name="number"/><field name="date"/><field name="now"/><field name="reference"/></group><group><field name="count"/><field name="number2"/><field name="moment"/><field name="lang"/></group></group><group><field name="comment1"/></group><group><field name="comment2"/></group><group><field name="comment3"/></group><group><field name="comment4"/></group><group><field name="comment5"/></group><group><group><field name="currency_id"/></group><group><field name="amount"/></group></group><group><separator/></group></sheet></form>'
+            b'<form><sheet string="Test New API Mixed"><group><group><field name="foo"/></group></group><group><field name="text"/></group><group><group><field name="truth"/><field name="number"/><field name="date"/><field name="now"/><field name="reference"/></group><group><field name="count"/><field name="number2"/><field name="moment"/><field name="lang"/></group></group><group><field name="comment0"/></group><group><field name="comment1"/></group><group><field name="comment2"/></group><group><field name="comment3"/></group><group><field name="comment4"/></group><group><field name="comment5"/></group><group><group><field name="currency_id"/></group><group><field name="amount"/></group></group><group><separator/></group></sheet></form>'
         )
 
 


### PR DESCRIPTION
[FIX] core: idempotent html_normalize

Before this commit `html_normalize` was not idempotent. When an HTML field is
written, its cache value will be sanitized once but the value flushed to the
database will be sanitized twice, which causes cache inconsistency. Also when
an HTML field is specified when create, its cache value and the value flushed
to the database are only sanitized once which might be different from the
flushed value when write.

For example, before the commit
```
input string:      '<div>a<div>b</div></div>'
normalize once:    'a<div>b</div>'
normalize twice:   '<p>a</p><div>b</div>'
normalize 3 times: '<p>a</p><div>b</div>'
```
```
written string:    '<div><div>a</div></div>'
normalize once:    '<div>a</div>'
normalize twice:   'a'
normalize 3 times: '<p>a</p>'
normalize 4 times: '<p>a</p>'
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
