### PR TITLE
[FIX] account, analytic: fix supportedTypes

### DIFF
--- a/addons/account/static/src/components/account_payment_field/account_payment_field.js
+++ b/addons/account/static/src/components/account_payment_field/account_payment_field.js
@@ -80,7 +80,7 @@ export class AccountPaymentField extends Component {
 
 export const accountPaymentField = {
     component: AccountPaymentField,
-    supportedTypes: ["char"],
+    supportedTypes: ["binary"],
 };
 
 registry.category("fields").add("payment", accountPaymentField);

--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
@@ -637,7 +637,7 @@ export class AnalyticDistribution extends Component {
 
 export const analyticDistribution = {
     component: AnalyticDistribution,
-    supportedTypes: ["char", "text"],
+    supportedTypes: ["json"],
     fieldDependencies: [{ name:"analytic_precision", type: "integer" }],
     supportedOptions: [
         {


### PR DESCRIPTION
This commit fix the supportedTypes of widgets: `analytic_distribution` and `payment`.

task-id: 4224192

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
