### PR TITLE
[FIX] account{_audit_trail}: cancel asset when using audit trail

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3789,18 +3789,25 @@ class AccountMove(models.Model):
         lock_date = self.company_id._get_user_fiscal_lock_date()
         return not self.inalterable_hash and self.date > lock_date
 
+    def _is_protected_by_audit_trail(self):
+        return False
+
     def _unlink_or_reverse(self):
         if not self:
             return
-        to_reverse = self.env['account.move']
         to_unlink = self.env['account.move']
+        to_cancel = self.env['account.move']
+        to_reverse = self.env['account.move']
         for move in self:
-            if move._can_be_unlinked():
-                to_unlink += move
-            else:
+            if not move._can_be_unlinked():
                 to_reverse += move
+            elif move._is_protected_by_audit_trail():
+                to_cancel += move
+            else:
+                to_unlink += move
         to_unlink.filtered(lambda m: m.state in ('posted', 'cancel')).button_draft()
         to_unlink.filtered(lambda m: m.state == 'draft').unlink()
+        to_cancel.button_cancel()
         return to_reverse._reverse_moves(cancel=True)
 
     def _post(self, soft=True):

--- a/addons/account_audit_trail/models/account_move.py
+++ b/addons/account_audit_trail/models/account_move.py
@@ -15,10 +15,7 @@ class AccountMove(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _unlink_account_audit_trail_except_once_post(self):
-        if not self._context.get('force_delete') and any(
-            move.posted_before and move.company_id.check_account_audit_trail
-            for move in self
-        ):
+        if not self.env.context.get('force_delete') and self._is_protected_by_audit_trail():
             raise UserError(_("To keep the audit trail, you can not delete journal entries once they have been posted.\nInstead, you can cancel the journal entry."))
 
     def unlink(self):
@@ -27,43 +24,24 @@ class AccountMove(models.Model):
             return True
         # Add logger here because in api ondelete account.move.line is deleted and we can't get total amount
         logger_msg = False
-        if any(m.posted_before and m.company_id.check_account_audit_trail for m in self):
-            if self._context.get('force_delete'):
-                moves_details = []
-                for move in self:
-                    entry_details = "{move_name} ({move_id}) amount {amount_total} {currency} and partner {partner_name}".format(
-                        move_name=move.name,
-                        move_id=move.id,
-                        amount_total=move.amount_total,
-                        currency=move.currency_id.name,
-                        partner_name=move.partner_id.display_name,
-                    )
-                    account_balances_per_account = defaultdict(float)
-                    for line in move.line_ids:
-                        account_balances_per_account[line.account_id] += line.balance
-                    account_details = "\n".join(
-                        "- {account_name} ({account_id}) with balance {balance} {currency}".format(
-                            account_name=account.name,
-                            account_id=account.id,
-                            balance=balance,
-                            currency=line.currency_id.name,
-                        )
-                        for account, balance in account_balances_per_account.items()
-                    )
-                    moves_details.append("{entry_details}\n{account_details}".format(
-                        entry_details=entry_details, account_details=account_details
-                    ))
-                logger_msg = "\nForce deleted Journal Entries by {user_name} ({user_id})\nEntries\n{moves_details}".format(
-                    user_name=self.env.user.name,
-                    user_id=self.env.user.id,
-                    moves_details="\n".join(moves_details),
+        if self.env.context.get('force_delete') and self._is_protected_by_audit_trail():
+            moves_details = []
+            for move in self:
+                entry_details = f"{move.name} ({move.id}) amount {move.amount_total} {move.currency_id.name} and partner {move.partner_id.display_name}"
+                account_balances_per_account = defaultdict(float)
+                for line in move.line_ids:
+                    account_balances_per_account[line.account_id] += line.balance
+                account_details = "\n".join(
+                    f"- {account.name} ({account.id}) with balance {balance} {move.currency_id.name}"
+                    for account, balance in account_balances_per_account.items()
                 )
+                moves_details.append(f"{entry_details}\n{account_details}")
+            moves_details = "\n".join(moves_details)
+            logger_msg = f"\nForce deleted Journal Entries by {self.env.user.name} ({self.env.user.id})\nEntries\n{moves_details}"
         res = super().unlink()
         if logger_msg:
             _logger.info(logger_msg)
         return res
 
-    def _can_be_unlinked(self):
-        res = super()._can_be_unlinked()
-        is_part_of_audit_trail = self.posted_before and self.company_id.check_account_audit_trail
-        return res and not is_part_of_audit_trail
+    def _is_protected_by_audit_trail(self):
+        return any(move.posted_before and move.company_id.check_account_audit_trail for move in self)

--- a/addons/account_audit_trail/models/account_move.py
+++ b/addons/account_audit_trail/models/account_move.py
@@ -62,3 +62,8 @@ class AccountMove(models.Model):
         if logger_msg:
             _logger.info(logger_msg)
         return res
+
+    def _can_be_unlinked(self):
+        res = super()._can_be_unlinked()
+        is_part_of_audit_trail = self.posted_before and self.company_id.check_account_audit_trail
+        return res and not is_part_of_audit_trail


### PR DESCRIPTION
At the moment cancelling assets is impossible when audit trail is enabled because it tries to unlink the move. It should be possible, in which case the move should be reversed instead.

By adding a check in _can_be_unlinked to return False in such case, the _unlink_or_reverse method will then properly reverse asset moves as expected.

Back port of https://github.com/odoo/odoo/pull/181193

task-4251586

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
