### PR TITLE
[FIX] stock: add language to context in traceability report

### DIFF
--- a/addons/stock/static/src/client_actions/stock_traceability_report_backend.js
+++ b/addons/stock/static/src/client_actions/stock_traceability_report_backend.js
@@ -50,7 +50,7 @@ export class TraceabilityReport extends Component {
             lines: this.props.state?.lines || [],
         });
 
-        const { active_id, active_model, auto_unfold, context, lot_name, ttype, url } =
+        const { active_id, active_model, auto_unfold, context, lot_name, ttype, url, lang } =
             this.props.action.context;
         this.controllerUrl = url;
 
@@ -61,6 +61,7 @@ export class TraceabilityReport extends Component {
             model: active_model || false,
             lot_name: lot_name || false,
             ttype: ttype || false,
+            lang: lang || false,
         });
 
         this.display = {


### PR DESCRIPTION
When the language is not in the context the report will always show the en_US version.

opw-4220270

Description of the issue/feature this PR addresses:

Current behavior before PR:
- translation is bypassed

Desired behavior after PR is merged:
- report will be shown in the correct language



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
