### PR TITLE
[FIX] website: restore carousel auto slide behaviors (2)

### DIFF
--- a/addons/website/static/src/js/content/snippets.animation.js
+++ b/addons/website/static/src/js/content/snippets.animation.js
@@ -581,6 +581,8 @@ publicWidget.registry.CarouselBootstrapUpgradeFix = publicWidget.Widget.extend({
         "[data-snippet='s_image_gallery'] .carousel",
         "[data-snippet='s_carousel'] .carousel",
         "[data-snippet='s_quotes_carousel'] .carousel",
+        "[data-snippet='s_quotes_carousel_minimal'] .carousel",
+        "[data-snippet='s_carousel_intro'] .carousel",
     ].join(", "),
     disabledInEditableMode: false,
     events: {


### PR DESCRIPTION
Follow-up of [1]. It fixed carousels for new databases and for databases upgraded from a version < 18.0 but half-fixed the issue for existing databases in 18.0. Indeed, in this version, 2 new carousel snippets were introduced. Technically, the problem can be solved by updating the website app and re-adding a new carousel but this commit will make existing ones work too.

At some point, we'll migrate the XML content avoiding the need for this compatibility JS.

[1]: https://github.com/odoo/odoo/commit/91cff43970689431a2d81efdde604b6af709f820
