### PR TITLE
[FIX] *: remove incorrect use of integer widget

### DIFF
--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -239,7 +239,7 @@
                                         </a>
                                         <div class="col-6">
                                             <span t-att-class="record.oee_target.raw_value and (record.oee.raw_value &lt; record.oee_target.raw_value) and 'text-danger d-flex float-end fw-bolder' or (record.oee.raw_value &gt; record.oee_target.raw_value) and 'text-success d-flex float-end fw-bolder' or 'text-warning d-flex float-end fw-bolder'">
-                                                <field name="oee" widget="integer"/>%
+                                                <field name="oee" digits="[42, 0]"/>%
                                             </span>
                                         </div>
                                     </div>

--- a/addons/mrp/views/res_config_settings_views.xml
+++ b/addons/mrp/views/res_config_settings_views.xml
@@ -65,7 +65,7 @@
                                 <field name="use_manufacturing_lead"/>
                                 <div class="content-group" invisible="not use_manufacturing_lead">
                                     <div class="mt16" >
-                                        <field name="manufacturing_lead" class="oe_inline" widget="integer"/> days before
+                                        <field name="manufacturing_lead" class="oe_inline" digits="[42, 0]"/> days before
                                     </div>
                                 </div>
                             </setting>

--- a/addons/purchase_stock/views/purchase_views.xml
+++ b/addons/purchase_stock/views/purchase_views.xml
@@ -36,7 +36,7 @@
             </xpath>
             <xpath expr="//div[@name='date_planned_div']" position="inside">
                 <button name="%(action_purchase_vendor_delay_report)d" class="oe_link" type="action" context="{'search_default_partner_id': partner_id}" invisible="state in ['purchase', 'done'] or not partner_id">
-                    <span invisible="on_time_rate &lt; 0"><field name="on_time_rate" widget="integer" class="oe_inline"/>% On-Time Delivery</span>
+                    <span invisible="on_time_rate &lt; 0"><field name="on_time_rate" digits="[42, 0]" class="oe_inline"/>% On-Time Delivery</span>
                     <span invisible="on_time_rate &gt;= 0">No On-time Delivery Data</span>
                 </button>
             </xpath>

--- a/addons/purchase_stock/views/res_partner_views.xml
+++ b/addons/purchase_stock/views/res_partner_views.xml
@@ -14,7 +14,7 @@
                         <div class="o_form_field o_stat_info">
                             <div class="o_row" invisible="on_time_rate &lt; 0">
                                 <span class="o_stat_value">
-                                    <field string="On-time Rate" name="on_time_rate" widget="integer"/>
+                                    <field string="On-time Rate" name="on_time_rate" digits="[42, 0]"/>
                                 </span>
                                 <span class="o_stat_value">%</span>
                             </div>

--- a/addons/website_sale_stock/views/product_template_views.xml
+++ b/addons/website_sale_stock/views/product_template_views.xml
@@ -17,7 +17,7 @@
                     <field name="show_availability" class="oe_inline" />
                     <span invisible="not show_availability">
                         <label for="available_threshold" string="only if below" class="o_light_label"/>
-                        <field name="available_threshold" class="oe_inline col-1" widget="integer"/>
+                        <field name="available_threshold" class="oe_inline col-1" digits="[42, 0]"/>
                         Units
                     </span>
                 </div>

--- a/addons/website_sale_stock/views/res_config_settings_views.xml
+++ b/addons/website_sale_stock/views/res_config_settings_views.xml
@@ -35,7 +35,7 @@
                                     <label for="show_availability" string="Show Available Qty" class="p-0 col-4 o_light_label mb-3 mt-2"/>
                                     <field name="show_availability" class="w-auto"/>
                                     <label for="available_threshold" string="only if below" class="o_light_label" invisible="not show_availability"/>
-                                    <field name="available_threshold" class="oe_inline col-1" widget="integer" invisible="not show_availability"/>
+                                    <field name="available_threshold" class="oe_inline col-1" digits="[42, 0]" invisible="not show_availability"/>
                                     <span invisible="not show_availability">Units</span>
                                 </div>
                             </div>


### PR DESCRIPTION
[*] : mrp, purchase_stock, website_sale_stock

This commit will remove the incorrect uses of the integer widget, the integer widget shouldn't be used with a float field. If we want a float field with a representation without decimal digits, we can use the option digits.

The task 4224192 aim to raise an error when using a widget on a wrong field (field type) and the current use of a widget integer in float fields will raise that error.

task-id: 4224192