### PR TITLE
[FIX] l10n_in_withholding: readonly TDS amount in withhold wizard

### DIFF
--- a/addons/l10n_in_withholding/wizard/l10n_in_withhold_wizard.py
+++ b/addons/l10n_in_withholding/wizard/l10n_in_withhold_wizard.py
@@ -249,7 +249,6 @@ class L10nInWithholdWizardLine(models.TransientModel):
         string="TDS Amount",
         compute='_compute_amount',
         store=True,
-        readonly=False
     )
 
     #  ===== Constraints =====


### PR DESCRIPTION
Before this commit:
The TDS amount in the wizard was editable, so users were able to change it manually.

After this commit:
The TDS amount in the wizard is now read-only and can’t be changed, since it’s calculated based on the base amount and TDS tax.
