### PR TITLE
[FIX] mass_mailing: fix template compressed mode

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -535,8 +535,11 @@ export class MassMailingHtmlField extends HtmlField {
             });
             selectedTheme = this._getSelectedTheme(themesParams);
         }
+        const isSnippetsFolded = uiUtils.isSmall() || (selectedTheme && selectedTheme.name === 'basic');
+        this.wysiwyg.setSnippetsMenuFolded(isSnippetsFolded);
+        // Inform the iframe content of the snippets menu visibility
+        this.wysiwyg.$iframeBody.closest('body').toggleClass("has_snippets_sidebar", !isSnippetsFolded);
 
-        this.wysiwyg.setSnippetsMenuFolded(uiUtils.isSmall() || (selectedTheme && selectedTheme.name === 'basic'));
         const editableAreaIsEmpty = value === "" || value === blankEditable;
 
         if (editableAreaIsEmpty) {


### PR DESCRIPTION
related commit: [1]

Issue:
======
mass_mailing view is covered by the snippet sidebar

Steps to reproduce the issue:
=============================
- Create a new mass mailing with any template except the basic
- Save it
- Go back
- Enter again to the mailing
- The sidebar covers a part of the editable area

Spec:
=====
This is an application of the mentioned commit in the case when we don't have to select a new theme.

opw-4227663

[1]: https://github.com/odoo/odoo/commit/3aa9a36ed47d0446e51c8dc991d0f7f6f2bacc80