### PR TITLE
[FIX] mail: add a reaction icon in public page

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -157,7 +157,7 @@
                         'rounded-start-1': isStart,
                         'rounded-end-1': isEnd,
                     }">
-                        <i class="fa fa-lg" t-att-class="action.icon"/>
+                        <i class="fa-lg" t-att-class="action.icon"/>
                     </button>
                 </t>
                 <div t-if="messageActions.actions.length gt quickActionCount" class="d-flex rounded-0">
@@ -166,7 +166,7 @@
                         <t t-set-slot="content">
                             <t t-foreach="messageActions.actions.slice(quickActionCount - 1)" t-as="action" t-key="action.id">
                                 <DropdownItem class="'px-2 py-1 d-flex align-items-center rounded-0'" onSelected="action.onClick" attrs="{ title: action.title}">
-                                    <i class="fa fa-fw" t-att-class="action.icon"/>
+                                    <i class="fa-fw" t-att-class="action.icon"/>
                                     <span class="mx-2" t-esc="action.title"/>
                                 </DropdownItem>
                             </t>

--- a/addons/mail/static/src/core/common/message_action_menu_mobile.xml
+++ b/addons/mail/static/src/core/common/message_action_menu_mobile.xml
@@ -5,7 +5,7 @@
             <div class="btn-group d-flex flex-column rounded-3 gap-1 p-3" t-on-click.stop="">
                 <t t-foreach="messageActions.actions.slice(quickActionCount)" t-as="action" t-key="action.id">
                     <button class="btn px-3 py-3 d-flex align-items-center rounded-0 btn-group-item gap-3 user-select-none bg-200" t-att-class="{ 'rounded-top-3': action_first, 'rounded-bottom-3': action_last }" t-on-click="() => this.onClickAction(action)">
-                        <i class="fa fa-lg fa-fw fs-2" t-att-class="action.icon"/>
+                        <i class="fa-lg fa-fw fs-2" t-att-class="action.icon"/>
                         <span class="fs-4" t-esc="action.title"/>
                     </button>
                 </t>

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -78,7 +78,7 @@ messageActionsRegistry
     })
     .add("reply-to", {
         condition: (component) => component.props.message.canReplyTo(component.props.thread),
-        icon: "fa-reply",
+        icon: "fa fa-reply",
         title: _t("Reply"),
         onClick: (component) => {
             const message = toRaw(component.props.message);
@@ -90,7 +90,7 @@ messageActionsRegistry
     .add("toggle-star", {
         condition: (component) => component.props.message.canToggleStar,
         icon: (component) =>
-            component.props.message.starred ? "fa-star o-mail-Message-starred" : "fa-star-o",
+            component.props.message.starred ? "fa fa-star o-mail-Message-starred" : "fa fa-star-o",
         title: _t("Mark as Todo"),
         onClick: (component) => component.props.message.toggleStar(),
         sequence: 30,
@@ -98,14 +98,14 @@ messageActionsRegistry
     })
     .add("mark-as-read", {
         condition: (component) => component.props.thread?.eq(component.store.inbox),
-        icon: "fa-check",
+        icon: "fa fa-check",
         title: _t("Mark as Read"),
         onClick: (component) => component.props.message.setDone(),
         sequence: 40,
     })
     .add("reactions", {
         condition: (component) => component.message.reactions.length,
-        icon: "fa-smile-o",
+        icon: "fa fa-smile-o",
         title: _t("View Reactions"),
         onClick: (component) => component.openReactionMenu(),
         sequence: 50,
@@ -122,14 +122,14 @@ messageActionsRegistry
         condition: (component) =>
             component.props.thread?.model === "discuss.channel" &&
             component.store.self.type === "partner",
-        icon: "fa-eye-slash",
+        icon: "fa fa-eye-slash",
         title: _t("Mark as Unread"),
         onClick: (component) => component.props.message.onClickMarkAsUnread(component.props.thread),
         sequence: 70,
     })
     .add("edit", {
         condition: (component) => component.props.message.editable,
-        icon: "fa-pencil",
+        icon: "fa fa-pencil",
         title: _t("Edit"),
         onClick: (component) => {
             const message = toRaw(component.props.message);
@@ -149,7 +149,7 @@ messageActionsRegistry
     })
     .add("delete", {
         condition: (component) => component.props.message.editable,
-        icon: "fa-trash",
+        icon: "fa fa-trash",
         title: _t("Delete"),
         onClick: async (component) => {
             const message = toRaw(component.message);
@@ -177,7 +177,7 @@ messageActionsRegistry
     .add("download_files", {
         condition: (component) =>
             component.message.attachment_ids.length > 1 && component.store.self.isInternalUser,
-        icon: "fa-download",
+        icon: "fa fa-download",
         title: _t("Download Files"),
         onClick: (component) =>
             download({
@@ -192,7 +192,7 @@ messageActionsRegistry
     .add("toggle-translation", {
         condition: (component) => component.props.message.isTranslatable(component.props.thread),
         icon: (component) =>
-            `fa-language ${component.state.showTranslation ? "o-mail-Message-translated" : ""}`,
+            `fa fa-language ${component.state.showTranslation ? "o-mail-Message-translated" : ""}`,
         title: (component) => (component.state.showTranslation ? _t("Revert") : _t("Translate")),
         onClick: (component) => component.onClickToggleTranslation(),
         sequence: 100,
@@ -201,7 +201,7 @@ messageActionsRegistry
         condition: (component) =>
             component.message.message_type &&
             component.message.message_type !== "user_notification",
-        icon: "fa-link",
+        icon: "fa fa-link",
         title: _t("Copy Link"),
         onClick: (component) => component.message.copyLink(),
         sequence: 110,

--- a/addons/mail/static/src/discuss/core/public_web/message_actions.js
+++ b/addons/mail/static/src/discuss/core/public_web/message_actions.js
@@ -6,7 +6,7 @@ messageActionsRegistry.add("create-or-view-thread", {
         component.isOriginThread &&
         component.message.thread.hasSubChannelFeature &&
         component.store.self.isInternalUser,
-    icon: "fa-comments-o",
+    icon: "fa fa-comments-o",
     onClick: (component) => {
         if (component.message.linkedSubChannel) {
             component.message.linkedSubChannel.open();

--- a/addons/mail/static/src/discuss/message_pin/common/message_actions.js
+++ b/addons/mail/static/src/discuss/message_pin/common/message_actions.js
@@ -5,7 +5,7 @@ messageActionsRegistry.add("pin", {
     condition: (component) =>
         component.store.self.type === "partner" &&
         component.props.thread?.model === "discuss.channel",
-    icon: "fa-thumb-tack",
+    icon: "fa fa-thumb-tack",
     title: (component) => (component.props.message.pinned_at ? _t("Unpin") : _t("Pin")),
     onClick: (component) => component.props.message.pin(),
     sequence: 65,


### PR DESCRIPTION
Current behavior before PR:

On mobile, when a guest joined a public channel via an invitation URL, the `Add a Reaction` icon appeared as `[]` instead of the `oi-smile-add` icon. This was due to Font Awesome loading after `odoo_ui_icons`, causing a conflict with the `fa` class.
Before / After
![image](https://github.com/user-attachments/assets/14662850-082a-4fa3-a29e-6216ad0387a7)


Desired behavior after PR is merged:

This PR fixes the issue, and now the `Add a Reaction` icon displays correctly.

Related enterprise: [enterprise/ #72507](https://github.com/odoo/enterprise/pull/72507)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
