### PR TITLE
[IMP] account: remove 'disabled' company filter

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -91,8 +91,8 @@ class AccountReport(models.Model):
 
     filter_multi_company = fields.Selection(
         string="Multi-Company",
-        selection=[('disabled', "Disabled"), ('selector', "Use Company Selector"), ('tax_units', "Use Tax Units")],
-        compute=lambda x: x._compute_report_option_filter('filter_multi_company', 'disabled'), readonly=False, store=True, depends=['root_report_id', 'section_main_report_ids'],
+        selection=[('selector', "Use Company Selector"), ('tax_units', "Use Tax Units")],
+        compute=lambda x: x._compute_report_option_filter('filter_multi_company', 'selector'), readonly=False, store=True, depends=['root_report_id', 'section_main_report_ids'],
     )
     filter_date_range = fields.Boolean(
         string="Date Range",

--- a/addons/l10n_cz/data/tax_report.xml
+++ b/addons/l10n_cz/data/tax_report.xml
@@ -6,7 +6,6 @@
         <field name="availability_condition">country</field>
         <field name="country_id" ref="base.cz"/>
         <field name="filter_hierarchy">optional</field>
-        <field name="filter_multi_company">disabled</field>
         <field name="default_opening_date_filter">previous_month</field>
         <field name="filter_date_range" eval="True"/>
         <field name="filter_period_comparison" eval="True"/>


### PR DESCRIPTION
The 'disabled' value of the multi-company filter is used to tell the report it should only consider the active company (and its branches), ignoring all other companies that would be selected. Though, it's not widely used, and the reports using it probably might run just as well with 'selector'.

Also, it can create a bit of confusion, since it's not obvious to the user which report uses or doesn't use the selector.

In this commit we simplify this by removing the 'disabled' value for the multi-company filter.

task-4260664

Related to https://github.com/odoo/enterprise/pull/72402
Related to https://github.com/odoo/upgrade/pull/6646