### PR TITLE
[FIX] web: make control panel breadcrumb tooltips translatable

### DIFF
--- a/addons/web/i18n/web.pot
+++ b/addons/web/i18n/web.pot
@@ -1383,6 +1383,13 @@ msgid "BACK arrow"
 msgstr ""
 
 #. module: web
+#. odoo-javascript
+#: code:addons/web/static/src/search/control_panel/control_panel.js:0
+#, python-format
+msgid "Back to “%s”"
+msgstr ""
+
+#. module: web
 #: model:ir.model.fields,field_description:web.field_base_document_layout__layout_background_image
 msgid "Background Image"
 msgstr ""
@@ -6466,6 +6473,13 @@ msgstr ""
 
 #. module: web
 #. odoo-javascript
+#: code:addons/web/static/src/views/list/list_controller.xml:0
+#, python-format
+msgid "Select all records matching the search"
+msgstr ""
+
+#. module: web
+#. odoo-javascript
 #: code:addons/web/static/src/core/datetime/datetime_picker.js:0
 #, python-format
 msgid "Select century"
@@ -6480,14 +6494,6 @@ msgstr ""
 
 #. module: web
 #. odoo-javascript
-#: code:addons/web/static/src/legacy/xml/base.xml:0
-#, python-format
-msgid "Select all records matching the search"
-msgstr ""
-
-#. module: web
-#. odoo-javascript
-#: code:addons/web/static/src/legacy/xml/base.xml:0
 #: code:addons/web/static/src/views/view_dialogs/export_data_dialog.xml:0
 #, python-format
 msgid "Select field"

--- a/addons/web/static/src/search/control_panel/control_panel.js
+++ b/addons/web/static/src/search/control_panel/control_panel.js
@@ -94,6 +94,10 @@ export class ControlPanel extends Component {
         });
     }
 
+    getBreadcrumbTooltip({ name }) {
+        return _t("Back to “%s”", name);
+    }
+
     getScrollingElement() {
         return this.root.el.parentElement;
     }

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -105,7 +105,7 @@
                     </li>
                     <t t-foreach="visiblePathBreadcrumbs" t-as="breadcrumb" t-key="breadcrumb.jsId">
                         <li class="breadcrumb-item d-inline-flex min-w-0" t-att-class="{ o_back_button: breadcrumb_last }" t-att-data-hotkey="breadcrumb_last and 'b'" t-on-click.prevent="() => this.onBreadcrumbClicked(breadcrumb.jsId)">
-                            <a href="#" class="fw-bold text-truncate" t-att-data-tooltip="'Back to &quot;' + breadcrumb.name + '&quot;'"><t t-call="web.Breadcrumb.Name"/></a>
+                            <a href="#" class="fw-bold text-truncate" t-att-data-tooltip="getBreadcrumbTooltip(breadcrumb)"><t t-call="web.Breadcrumb.Name"/></a>
                         </li>
                     </t>
                 </ol>


### PR DESCRIPTION
Control panel breadcrumb tooltips aren't translated. This is because the tooltip is defined with a t-att-*, and dynamic attributes are never translatable.

This commit redefines the tooltip in a different way that allows translation.

opw-4160838

Enterprise: https://github.com/odoo/enterprise/pull/72501