### PR TITLE
[FIX] web_editor: prevent infinite loop when ctype is not block outside

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/deleteForward.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/deleteForward.js
@@ -172,6 +172,8 @@ HTMLElement.prototype.oDeleteForward = function (offset) {
             // If the next sibling is a whitespace, remove it.
             nextSibling.remove();
             nextSibling = this.nextSibling;
+        } else {
+            break;
         }
     }
 

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -499,6 +499,15 @@ X[]
                         contentAfter: `<p>test[]</p><p>abc</p>`,
                     });
                 });
+                it('should remove whitespace and merge paragraph with heading', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: `<h1><strong>abc[]</strong>\n</h1><p>abc</p>`,
+                        stepFunction: async editor => {
+                            await deleteForward(editor);
+                        },
+                        contentAfter: `<h1><strong>abc</strong>[]abc</h1>`,
+                    });
+                });
             });
             describe('white spaces', () => {
                 describe('no intefering spaces', () => {


### PR DESCRIPTION
**Current behavior before PR:**

- The while loop responsible for removing whitespaces could enter an infinite loop if the ctype was not a block element.

**Desired behavior after PR is merged:**

- Now, the loop will breaks when ctype is not block outside, avoiding the infinite loop.
