### PR TITLE
[FIX] base_automation: ensure consistent eval context

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -71,7 +71,7 @@ def get_webhook_request_payload():
         payload = request.get_json_data()
     except ValueError:
         payload = {**request.httprequest.args}
-    return payload
+    return payload or {}
 
 
 class BaseAutomation(models.Model):
@@ -568,13 +568,12 @@ class BaseAutomation(models.Model):
         eval_context = {
             'datetime': safe_eval.datetime,
             'dateutil': safe_eval.dateutil,
+            'payload': payload,
             'time': safe_eval.time,
             'uid': self.env.uid,
             'user': self.env.user,
             'model': model,
         }
-        if payload is not None:
-            eval_context['payload'] = payload
         return eval_context
 
     def _get_cron_interval(self, automations=None):

--- a/addons/base_automation/models/ir_actions_server.py
+++ b/addons/base_automation/models/ir_actions_server.py
@@ -88,7 +88,5 @@ class ServerAction(models.Model):
         eval_context = super()._get_eval_context(action)
         if action and action.state == "code":
             eval_context['json'] = json_scriptsafe
-            payload = get_webhook_request_payload()
-            if payload:
-                eval_context["payload"] = payload
+            eval_context['payload'] = get_webhook_request_payload()
         return eval_context


### PR DESCRIPTION
- Create a web hook
- In the web hook action, use the `payload` variable
- Call the webhook URL with a POST request with no data

The web hook crashes because the variable `payload` is undefined.

The root cause comes from [1] which returns `None` in this specific case since `get_data` returns `null`.
Since the `payload` is `None`, is is not included in the `eval_context`, leading to a crash.

[1] https://github.com/odoo/odoo/blob/4ad762c406c942b1975060756c261444ad5a9971/odoo/http.py#L1574

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
