### PR TITLE
[FIX] packaging: remove typing_extensions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -78,7 +78,6 @@ rjsmin==1.2.0 ; python_version >= '3.11'
 rl-renderPM==4.0.3 ; sys_platform == 'win32' and python_version >= '3.12'  # Needed by reportlab 4.1.0 but included in deb package
 urllib3==1.26.5 ; python_version < '3.12' # indirect / min version = 1.25.8 (Focal with security backports)
 urllib3==2.0.7  ; python_version >= '3.12'  # (Noble) Compatibility with cryptography
-typing_extensions==4.4.0 ; python_version < '3.12'
 vobject==0.9.6.1
 Werkzeug==2.0.2 ; python_version <= '3.10' 
 Werkzeug==2.2.2 ; python_version > '3.10' and python_version < '3.12'


### PR DESCRIPTION
The typing_extensions is for dev only and should not be required to run Odoo.

Also see #184452