### PR TITLE
[FIX] project: fix test_01_project_tour test tour

### DIFF
--- a/addons/project/static/src/js/tours/project.js
+++ b/addons/project/static/src/js/tours/project.js
@@ -259,13 +259,17 @@ registry.category("web_tour.tours").add('project_tour', {
 }, 
 {
     isActive: ["auto"],
-    trigger: ".dropdown-menu",
+    trigger: ".project_task_state_selection_menu.dropdown-menu",
 },
 {
     isActive: ["auto"],
-    trigger: ".dropdown-menu span.text-danger",
+    trigger: ".project_task_state_selection_menu.dropdown-menu span.text-danger",
     content: markup(_t("Mark the task as <b>Cancelled</b>")),
     run: "click",
+}, {
+    isActive: ["auto"],
+    trigger: ".o-overlay-container:not(:has(.project_task_state_selection_menu))",
+    allowInvisible: true,
 }, {
     isActive: ["auto"],
     trigger: ".o_kanban_record .oe_kanban_content .o_widget_subtask_counter .subtask_list_button:contains('1/2')",


### PR DESCRIPTION
Before this commit, sometimes the test failed because the step to cancelled a sub-task is not yet done in the UI (the record has not yet been reloaded) before the next step is executed.

This commit changes some trigger in some steps to be more precise but also add an additional step to make sure the dropdown showing the task states is correctly closed before checking if the sub-task is correctly marked as done.

runbot-73414
