### PR TITLE
[FIX] test_assetsbundle: remove implicit dependency on website

### DIFF
--- a/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
+++ b/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
@@ -2033,4 +2033,4 @@ class TestErrorManagement(HttpCase):
             'path': 'test_assetsbundle/static/src/css/test_error.scss',
         })
         with mute_logger('odoo.addons.base.models.assetsbundle'):
-            self.start_tour('/', 'css_error_tour_frontend', login='admin')
+            self.start_tour('/', 'css_error_tour_frontend')


### PR DESCRIPTION
When website is not installed and the user is logged in, the frontend is not loaded by the client making the test
`test_assets_bundle_css_error_frontend` invalid (frontend assets are not loaded on backend pages).
