### PR TITLE
[FIX] spreadsheet: do not translate value of quarters in filters

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/plugins/global_filters_ui_plugin.js
+++ b/addons/spreadsheet/static/src/global_filters/plugins/global_filters_ui_plugin.js
@@ -283,7 +283,7 @@ export class GlobalFiltersUIPlugin extends OdooUIPlugin {
                 }
                 const year = String(DateTime.local().year + value.yearOffset);
                 const period = QUARTER_OPTIONS[value.period];
-                let periodStr = period && period.description;
+                let periodStr = period && "Q" + period.setParam.quarter; // we do not want the translated value (like T1 in French)
                 // Named months aren't in QUARTER_OPTIONS
                 if (!period) {
                     periodStr =


### PR DESCRIPTION
Currently, when using a language that translates the abbreviation of quarters (Q) to anything else, the formula `=filter.value(...)` would return the translated version, which then could not be used on other formulas like `=odoo.balance`, this can be observed by opening the Finance/accounting dashboard while in french and selecting a filter in quarter.

After this fix, the formula filter.value will always return Q1 to Q4 for quarter names.


Task: [4274741](https://www.odoo.com/odoo/project/2328/tasks/4274741)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
