### PR TITLE
[FIX] test_data_module_install: add test_data_module to dependencies

### DIFF
--- a/odoo/addons/test_data_module_install/__manifest__.py
+++ b/odoo/addons/test_data_module_install/__manifest__.py
@@ -5,4 +5,5 @@
     'category': 'Hidden/Tests',
     'sequence': 10,
     'license': 'LGPL-3',
+    'depends': ['test_data_module']
 }


### PR DESCRIPTION
The test depended on a module that was not in the depends.

