### PR TITLE
[FIX] website: keep searchbar open on longpress on Safari

### DIFF
--- a/addons/website/static/src/snippets/s_searchbar/000.js
+++ b/addons/website/static/src/snippets/s_searchbar/000.js
@@ -3,6 +3,7 @@
 import { KeepLast } from "@web/core/utils/concurrency";
 import publicWidget from '@web/legacy/js/public/public_widget';
 
+import { isBrowserSafari } from "@web/core/browser/feature_detection";
 import { renderToElement, renderToString } from "@web/core/utils/render";
 import { debounce } from '@web/core/utils/timing';
 
@@ -13,6 +14,8 @@ publicWidget.registry.searchBar = publicWidget.Widget.extend({
     events: {
         'input .search-query': '_onInput',
         'focusout': '_onFocusOut',
+        "mousedown .o_dropdown_menu .dropdown-item": "_onMousedown",
+        "mouseup .o_dropdown_menu .dropdown-item": "_onMouseup",
         'keydown .search-query, .dropdown-item': '_onKeydown',
         'search .search-query': '_onSearch',
     },
@@ -251,8 +254,22 @@ publicWidget.registry.searchBar = publicWidget.Widget.extend({
      * @private
      */
     _onFocusOut: function () {
-        if (!this.$el.has(document.activeElement).length) {
+        if (!this.linkHasFocus && !this.$el.has(document.activeElement).length) {
             this._render();
+        }
+    },
+    _onMousedown(ev) {
+        // On Safari, links and buttons are not focusable by default. We need
+        // to get around that behavior to avoid _onFocusOut() from triggering
+        // _render(), as this would prevent the click from working.
+        if (isBrowserSafari) {
+            this.linkHasFocus = true;
+        }
+    },
+    _onMouseup(ev) {
+        // See comment in _onMousedown.
+        if (isBrowserSafari) {
+            this.linkHasFocus = false;
         }
     },
     /**


### PR DESCRIPTION
Steps to reproduce:
- On Safari, click on the searchbar from the header
- Type anything that gives results (e.g.: "a")
- Make a long press on a result.
=> The search results are closed without leading to the page.

This is due to Safari not focusing links and buttons by design (!)[1].
The condition in `_onFocusOut` (no element in the searchbox is the
active element) is thus true and the searchbox is rerendered, making the
click unresponsive.

[1]: https://bugs.webkit.org/show_bug.cgi?id=22261#c68

opw-4116832