### PR TITLE
[IMP] mail, _*: improve mail test tools, provide various fixes related to email normalized

### DIFF
--- a/addons/mass_mailing/models/mail_mail.py
+++ b/addons/mass_mailing/models/mail_mail.py
@@ -77,8 +77,10 @@ class MailMail(models.Model):
             if not email_values['email_to']:
                 continue
 
-            emails = tools.email_split(email_values['email_to'][0])
-            email_to = emails[0] if emails else False
+            # prepare links with normalize email
+            email_normalized = tools.email_normalize(email_values['email_to'][0], strict=False)
+            email_to = email_normalized or email_values['email_to'][0]
+
             unsubscribe_url = self.mailing_id._get_unsubscribe_url(email_to, self.res_id)
             unsubscribe_oneclick_url = self.mailing_id._get_unsubscribe_oneclick_url(email_to, self.res_id)
             view_url = self.mailing_id._get_view_url(email_to, self.res_id)

--- a/addons/mass_mailing/tests/test_mailing_list.py
+++ b/addons/mass_mailing/tests/test_mailing_list.py
@@ -116,8 +116,8 @@ class TestMailingListMerge(MassMailCommon):
                 subscription.list_id = self.mailing_list_2
                 subscription.opt_out = False
             contact = contact_form.save()
-        self.assertEqual(contact.subscription_ids[0].opt_out_datetime, datetime(2022, 1, 1, 12, 0, 0))
-        self.assertFalse(contact.subscription_ids[1].opt_out_datetime)
+        self.assertEqual(contact.subscription_ids.filtered(lambda s: s.list_id == self.mailing_list_1).opt_out_datetime, datetime(2022, 1, 1, 12, 0, 0))
+        self.assertFalse(contact.subscription_ids.filtered(lambda s: s.list_id == self.mailing_list_2).opt_out_datetime)
 
     @users('user_marketing')
     def test_mailing_list_action_send_mailing(self):

--- a/addons/mass_mailing_sms/tests/common.py
+++ b/addons/mass_mailing_sms/tests/common.py
@@ -70,9 +70,24 @@ class MassSMSCase(SMSCase, MockLinkTracker):
             ('res_id', 'in', records.ids)
         ])
 
+        traces_info = []
+        for trace in traces:
+            record = records.filtered(lambda r: r.id == trace.res_id)
+            if record:
+                traces_info.append(
+                    f'Trace: doc {trace.res_id} on {trace.sms_number} - status {trace.trace_status} (rec {record.id})'
+                )
+            else:
+                traces_info.append(
+                    f'Trace: doc {trace.res_id} on {trace.sms_number} - status {trace.trace_status}'
+                )
+        debug_info = '\n'.join(traces_info)
         self.assertTrue(all(s.model == records._name for s in traces))
         # self.assertTrue(all(s.utm_campaign_id == mailing.campaign_id for s in traces))
-        self.assertEqual(set(s.res_id for s in traces), set(records.ids))
+        self.assertEqual(
+            {s.res_id for s in traces}, set(records.ids),
+            f'Should find one trace / record. Found\n{debug_info}'
+        )
 
         # check each trace
         if not sms_links_info:
@@ -89,7 +104,7 @@ class MassSMSCase(SMSCase, MockLinkTracker):
                 lambda t: t.sms_number == number and t.trace_status == status and (t.res_id == record.id if record else True)
             )
             self.assertTrue(len(trace) == 1,
-                            'SMS: found %s notification for number %s, (status: %s) (1 expected)' % (len(trace), number, status))
+                            'SMS: found %s notification for number %s, (status: %s) (1 expected)\n%s' % (len(trace), number, status, debug_info))
             self.assertTrue(bool(trace.sms_id_int))
 
             if check_sms:

--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -7,7 +7,7 @@
     'category': 'Sales/Point of Sale',
     'sequence': 40,
     'summary': 'User-friendly PoS interface for shops and restaurants',
-    'depends': ['stock_account', 'barcodes', 'web_editor', 'digest'],
+    'depends': ['stock_account', 'barcodes', 'web_editor', 'digest', 'phone_validation'],
     'uninstall_hook': 'uninstall_hook',
     'data': [
         'security/point_of_sale_security.xml',

--- a/addons/test_mail/models/__init__.py
+++ b/addons/test_mail/models/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import test_discuss_models
 from . import test_mail_corner_case_models
+from . import test_mail_feature_models
 from . import test_mail_models
 from . import test_mail_thread_models

--- a/addons/test_mail/models/test_mail_feature_models.py
+++ b/addons/test_mail/models/test_mail_feature_models.py
@@ -1,7 +1,8 @@
-# -*- coding: utf-8 -*-
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import fields, models
+
+# ------------------------------------------------------------
+# PROPERTIES
+# ------------------------------------------------------------
 
 
 class MailTestProperties(models.Model):

--- a/addons/test_mass_mailing/tests/test_blacklist_behavior.py
+++ b/addons/test_mass_mailing/tests/test_blacklist_behavior.py
@@ -63,7 +63,7 @@ class TestAutoBlacklist(common.TestMassMailCommon):
             # is not sufficient
             with freeze_time(new_dt), patch.object(Cursor, 'now', lambda *args, **kwargs: new_dt):
                 traces += self._create_bounce_trace(new_mailing, target, dt=datetime.datetime.now() - datetime.timedelta(weeks=idx+2))
-                self.gateway_mail_bounce(new_mailing, target, bounce_base_values)
+                self.gateway_mail_trace_bounce(new_mailing, target, bounce_base_values)
 
         # mass mail record: ok, not blacklisted yet
         with self.mock_mail_gateway(mail_unlink_sent=False):
@@ -76,7 +76,7 @@ class TestAutoBlacklist(common.TestMassMailCommon):
         )
 
         # call bounced
-        self.gateway_mail_bounce(mailing, target, bounce_base_values)
+        self.gateway_mail_trace_bounce(mailing, target, bounce_base_values)
 
         # check blacklist
         blacklist_record = self.env['mail.blacklist'].sudo().search([('email', '=', target.email_normalized)])

--- a/addons/test_mass_mailing/tests/test_mailing.py
+++ b/addons/test_mass_mailing/tests/test_mailing.py
@@ -107,13 +107,13 @@ class TestMassMailing(TestMassMailCommon):
         self.assertMailingStatistics(mailing, expected=5, delivered=5, sent=5)
 
         # simulate a click
-        self.gateway_mail_click(mailing, recipients[0], 'https://www.odoo.be')
+        self.gateway_mail_trace_click(mailing, recipients[0], 'https://www.odoo.be')
         mailing.invalidate_recordset()
         self.assertMailingStatistics(mailing, expected=5, delivered=5, sent=5, opened=1, clicked=1)
 
         # simulate a bounce
         self.assertEqual(recipients[1].message_bounce, 0)
-        self.gateway_mail_bounce(mailing, recipients[1])
+        self.gateway_mail_trace_bounce(mailing, recipients[1])
         mailing.invalidate_recordset()
         self.assertMailingStatistics(mailing, expected=5, delivered=4, sent=5, opened=1, clicked=1, bounced=1)
         self.assertEqual(recipients[1].message_bounce, 1)
@@ -216,33 +216,39 @@ class TestMassMailing(TestMassMailCommon):
                 self.assertMailTraces(
                     [
                         {'email': 'customer.multi.1@example.com, "Test Multi 2" <customer.multi.2@example.com>',
+                         'email_to_mail': False,  # using recipient_ids, not email_to
                          'email_to_recipients': [[f'"{customer_mult.name}" <customer.multi.1@example.com>', f'"{customer_mult.name}" <customer.multi.2@example.com>']],
                          'failure_type': False,
                          'partner': customer_mult,
                          'trace_status': 'sent'},
                         {'email': '"Formatted Customer" <test.customer.format@example.com>',
+                         'email_to_mail': False,  # using recipient_ids, not email_to
                          # mail to avoids double encapsulation
                          'email_to_recipients': [[f'"{customer_fmt.name}" <test.customer.format@example.com>']],
                          'failure_type': False,
                          'partner': customer_fmt,
                          'trace_status': 'sent'},
                         {'email': '"Unicode Customer" <test.customer.😊@example.com>',
+                         'email_to_mail': False,  # using recipient_ids, not email_to
                          # mail to avoids double encapsulation
                          'email_to_recipients': [[f'"{customer_unic.name}" <test.customer.😊@example.com>']],
                          'failure_type': False,
                          'partner': customer_unic,
                          'trace_status': 'sent'},
                         {'email': 'TEST.CUSTOMER.CASE@EXAMPLE.COM',
+                         'email_to_mail': False,  # using recipient_ids, not email_to
                          'email_to_recipients': [[f'"{customer_case.name}" <test.customer.case@example.com>']],
                          'failure_type': False,
                          'partner': customer_case,
                          'trace_status': 'sent'},  # lower cased
                         {'email': 'test.customer.weird@example.com Weird Format',
+                         'email_to_mail': False,  # using recipient_ids, not email_to
                          'email_to_recipients': [[f'"{customer_weird.name}" <test.customer.weird@example.comweirdformat>']],
                          'failure_type': False,
                          'partner': customer_weird,
                          'trace_status': 'sent'},  # concatenates everything after domain
                         {'email': 'Weird Format2 test.customer.weird.2@example.com',
+                         'email_to_mail': False,  # using recipient_ids, not email_to
                          'email_to_recipients': [[f'"{customer_weird_2.name}" <test.customer.weird.2@example.com>']],
                          'failure_type': False,
                          'partner': customer_weird_2,

--- a/addons/test_mass_mailing/tests/test_mailing_statistics.py
+++ b/addons/test_mass_mailing/tests/test_mailing_statistics.py
@@ -42,11 +42,11 @@ class TestMailingStatistics(TestMassMailCommon):
         self.gateway_mail_reply_wrecord(MAIL_TEMPLATE, target_records[0], use_in_reply_to=True)
         self.gateway_mail_reply_wrecord(MAIL_TEMPLATE, target_records[1], use_in_reply_to=True)
         self.gateway_mail_reply_wrecord(MAIL_TEMPLATE, target_records[2], use_in_reply_to=True)
-        self.gateway_mail_click(mailing, target_records[0], 'https://www.odoo.be')
-        self.gateway_mail_click(mailing, target_records[2], 'https://www.odoo.be')
-        self.gateway_mail_click(mailing, target_records[3], 'https://www.odoo.be')
+        self.gateway_mail_trace_click(mailing, target_records[0], 'https://www.odoo.be')
+        self.gateway_mail_trace_click(mailing, target_records[2], 'https://www.odoo.be')
+        self.gateway_mail_trace_click(mailing, target_records[3], 'https://www.odoo.be')
         self.assertEqual(target_records[12].message_bounce, 0)
-        self.gateway_mail_bounce(mailing, target_records[12])
+        self.gateway_mail_trace_bounce(mailing, target_records[12])
         self.assertEqual(target_records[12].message_bounce, 1)
 
         # check mailing statistics


### PR DESCRIPTION
When working on Task-2667099: [mail] Improve default template values
various fixes have been found for some corner cases in mail. This
PR submits them for 18.0 as they are valid for stable.

Testing tools improvements are also added in 18.0 to ease forward
port and adding tests in stable when necessary.

See sub commit for more details.


Task-2667099: [mail] Improve default template values
Task-4264367: [mass_mailing] Store/Compare normalized emails on traces
Prepares Task-4224145: [marketing_automation] Improve test coverage