### PR TITLE
[FIX] web: keep export template fields order

### DIFF
--- a/addons/test_import_export/tests/test_export.py
+++ b/addons/test_import_export/tests/test_export.py
@@ -108,6 +108,28 @@ class TestExport(XlsxCreatorCase):
             ],
         )
 
+    def test_export_template(self):
+        def get_namelist(export_id):
+            res = self.url_open(
+                "/web/export/namelist",
+                data=json.dumps({"params": {"model": 'res.users', 'export_id': export_id}}),
+                headers={"Content-Type": "application/json"}
+            )
+            return json.loads(res.content)['result']
+
+        export = self.env['ir.exports'].create([{
+            'name': 'Export of 3 fields',
+            'resource': 'res.users',
+            'export_fields': [(0, 0, {'name': 'partner_id'}),
+                              (0, 0, {'name': 'login'}),
+                              (0, 0, {'name': 'active'})]
+        }])
+
+        self.assertEqual(get_namelist(export.id),
+                         [{'field_type': 'many2one', 'id': 'partner_id', 'string': 'Related Partner'},
+                          {'field_type': 'char', 'id': 'login', 'string': 'Login'},
+                          {'field_type': 'boolean', 'id': 'active', 'string': 'Active'}])
+
 
 @tagged('-at_install', 'post_install')
 class TestGroupedExport(XlsxCreatorCase):

--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -493,7 +493,8 @@ class Export(http.Controller):
                     'field_type': field_dict['type'],
                 })
 
-        return field_info
+        indexes_dict = {fname: i for i, fname in enumerate(export_fields)}
+        return sorted(field_info, key=lambda field_dict: indexes_dict[field_dict['id']])
 
     def graft_subfields(self, model, prefix, prefix_string, fields):
         export_fields = [field.split('/', 1)[1] for field in fields]


### PR DESCRIPTION
Issue
When loading a template of fields to export, the list of fields is ordered by their technical name and not by their actual position in the list when the template was saved.

Cause
issue since e3647790830f95de932cb10c39a8232dd97e4221
The `ir.exports.line` are in order of their position in the list at creation in `export_fields`, however `fields_info` sorts the fields by their technical name and may not preserve order
https://github.com/odoo/odoo/blob/e3647790830f95de932cb10c39a8232dd97e4221/addons/web/controllers/export.py#L409

opw-4241915