### PR TITLE
[FIX] point_of_sale,pos_sale: set sales team for all orders

### DIFF
--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -270,3 +270,16 @@ registry.category("web_tour.tours").add("CategLabelCheck", {
             ProductScreen.OrderButtonNotContain("Drinks"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("CrmTeamTour", {
+    test: true,
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            ProductScreen.back(),
+            FloorScreen.clickTable("5"),
+            ProductScreen.back(),
+        ].flat(),
+});

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -299,3 +299,13 @@ class TestFrontend(TestFrontendCommon):
     def test_12_category_check(self):
         self.pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('CategLabelCheck')
+
+    def test_13_crm_team(self):
+        if self.env['ir.module.module']._get('pos_sale').state != 'installed':
+            self.skipTest("'pos_sale' module is required")
+        sale_team = self.env['crm.team'].search([], limit=1)
+        self.pos_config.crm_team_id = sale_team
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('CrmTeamTour')
+        order = self.env['pos.order'].search([], limit=1)
+        self.assertEqual(order.crm_team_id.id, sale_team.id)


### PR DESCRIPTION
When modifying an existing order in the PoS the sales team would be unset.

Steps to reproduce:
-------------------
* Open a table and add some items to it
* Leave the table and go back on it 2 times
* Validate the order
> Observation: Go on the sale report and group by sale team, your order
will appear under the "None" section

Why the fix:
------------
We make sure that when we write on the order we will the values of the crm team defined on the pos config

opw-4232473
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
