### PR TITLE
[FIX] fix partner_credit/tax_totals key name

### DIFF
--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -191,7 +191,7 @@ class AccountMove(models.Model):
         for move in self.filtered(lambda m: m.is_invoice(include_receipts=True)):
             sale_orders = move.line_ids.sale_line_ids.order_id
             amount_total_currency = move.currency_id._convert(
-                move.tax_totals['amount_total'],
+                move.tax_totals['total_amount'],
                 move.company_currency_id,
                 move.company_id,
                 move.date

--- a/doc/cla/individual/gschaer
+++ b/doc/cla/individual/gschaer
@@ -1,0 +1,11 @@
+Switzerland, 2024-10-21
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Guillaume Schaer gschaer@users.noreply.github.com https://github.com/gschaer


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

The value `move.tax_totals` is defined in `/addons/account/models/account_move.py` by calling  the function `_get_tax_totals_summary` from `account_tax`:

https://github.com/odoo/odoo/blob/5714ee114fb5c4b9d1342159b07efa27f16a7c8d/addons/account/models/account_move.py#L1551

The `_get_tax_totals_summary` generates a dict with the total amount stored as `total_amount` and not `amount_total`

https://github.com/odoo/odoo/blob/5714ee114fb5c4b9d1342159b07efa27f16a7c8d/addons/account/models/account_tax.py#L1870

https://github.com/odoo/odoo/blob/5714ee114fb5c4b9d1342159b07efa27f16a7c8d/addons/account/models/account_tax.py#L2052-L2053

**Current behavior before PR:**
Server throws a KeyError as `amount_total` doesn't exist in `move.tax_totals`

**Desired behavior after PR is merged:**
`move.tax_totals` is computed correctly

Fixes https://github.com/odoo/odoo/issues/184408

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
