### PR TITLE
[FIX] mail: inbox notif from chatter should not play sound

### DIFF
--- a/addons/mail/static/src/core/common/out_of_focus_service.js
+++ b/addons/mail/static/src/core/common/out_of_focus_service.js
@@ -26,7 +26,7 @@ export class OutOfFocusService {
         this.notificationService = services.notification;
     }
 
-    async notify(message, channel) {
+    async notify(message, thread) {
         const modelsHandleByPush = ["mail.thread", "discuss.channel"];
         if (
             modelsHandleByPush.includes(message.thread?.model) &&
@@ -39,10 +39,10 @@ export class OutOfFocusService {
         if (!author) {
             notificationTitle = _t("New message");
         } else {
-            if (channel.channel_type === "channel") {
+            if (message.thread?.channel_type === "channel") {
                 notificationTitle = _t("%(author name)s from %(channel name)s", {
                     "author name": author.name,
-                    "channel name": channel.displayName,
+                    "channel name": message.thread.displayName,
                 });
             } else {
                 notificationTitle = author.name;
@@ -54,6 +54,7 @@ export class OutOfFocusService {
         );
         this.sendNotification({
             message: notificationContent,
+            sound: message.thread?.model === "discuss.channel",
             title: notificationTitle,
             type: "info",
         });
@@ -83,22 +84,22 @@ export class OutOfFocusService {
      * @param {string} [param0.type] The type to be passed to the no
      * service when native notifications can't be sent.
      */
-    sendNotification({ message, title, type }) {
+    sendNotification({ message, sound = true, title, type }) {
         if (!this.canSendNativeNotification) {
-            this.sendOdooNotification(message, { title, type });
+            this.sendOdooNotification(message, { sound, title, type });
             return;
         }
         if (!this.multiTab.isOnMainTab()) {
             return;
         }
         try {
-            this.sendNativeNotification(title, message);
+            this.sendNativeNotification(title, message, { sound });
         } catch (error) {
             // Notification without Serviceworker in Chrome Android doesn't works anymore
             // So we fallback to the notification service in this case
             // https://bugs.chromium.org/p/chromium/issues/detail?id=481856
             if (error.message.includes("ServiceWorkerRegistration")) {
-                this.sendOdooNotification(message, { title, type });
+                this.sendOdooNotification(message, { sound, title, type });
             } else {
                 throw error;
             }
@@ -110,15 +111,19 @@ export class OutOfFocusService {
      * @param {Object} options
      */
     async sendOdooNotification(message, options) {
+        const { sound } = options;
+        delete options.sound;
         this.notificationService.add(message, options);
-        this._playSound();
+        if (sound) {
+            this._playSound();
+        }
     }
 
     /**
      * @param {string} title
      * @param {string} message
      */
-    sendNativeNotification(title, message) {
+    sendNativeNotification(title, message, { sound = true } = {}) {
         const notification = new Notification(title, {
             body: message,
             icon: "/mail/static/src/img/odoobot_transparent.png",
@@ -127,7 +132,9 @@ export class OutOfFocusService {
             window.focus();
             notification.close();
         });
-        this._playSound();
+        if (sound) {
+            this._playSound();
+        }
     }
 
     async _playSound() {

--- a/addons/mail/static/src/core/public_web/out_of_focus_service_patch.js
+++ b/addons/mail/static/src/core/public_web/out_of_focus_service_patch.js
@@ -15,13 +15,13 @@ patch(OutOfFocusService.prototype, {
         this.titleService.setCounters({ discuss: undefined });
     },
     notify(message) {
-        super.notify(...arguments);
         if (this.contributingMessageLocalIds.has(message.localId)) {
             return;
         }
         this.contributingMessageLocalIds.add(message.localId);
         this.counter++;
         this.titleService.setCounters({ discuss: this.counter });
+        super.notify(...arguments);
     },
 });
 outOfFocusService.dependencies = [...outOfFocusService.dependencies, "title"];

--- a/addons/mail/static/src/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/core/public_web/thread_model_patch.js
@@ -30,9 +30,11 @@ const ThreadPatch = {
                         (channel_notifications === "mentions" &&
                             message.recipients?.includes(this.store.self)))))
         ) {
-            const chatWindow = this.store.ChatWindow.get({ thread: this });
-            if (!chatWindow) {
-                this.store.ChatWindow.insert({ thread: this }).fold();
+            if (this.model === "discuss.channel") {
+                const chatWindow = this.store.ChatWindow.get({ thread: this });
+                if (!chatWindow) {
+                    this.store.ChatWindow.insert({ thread: this }).fold();
+                }
             }
             this.store.env.services["mail.out_of_focus"].notify(message, this);
         }

--- a/addons/mail/static/src/core/web/mail_core_web_service.js
+++ b/addons/mail/static/src/core/web/mail_core_web_service.js
@@ -41,7 +41,7 @@ export class MailCoreWeb {
             if (message.thread && notifId > message.thread.message_needaction_counter_bus_id) {
                 message.thread.message_needaction_counter++;
             }
-            message.thread?.notifyMessageToUser(message);
+            this.store.env.services["mail.out_of_focus"].notify(message);
         });
         this.busService.subscribe("mail.message/mark_as_read", (payload, { id: notifId }) => {
             const { message_ids: messageIds, needaction_inbox_counter } = payload;

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -27,11 +27,13 @@ import {
     makeKwArgs,
     mockService,
     onRpc,
+    patchWithCleanup,
     serverState,
     withUser,
 } from "@web/../tests/web_test_helpers";
 
 import { rpc } from "@web/core/network/rpc";
+import { OutOfFocusService } from "@mail/core/common/out_of_focus_service";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -1383,7 +1385,55 @@ test("out-of-focus notif on needaction message in group chat contributes only on
     await contains(".o-mail-DiscussSidebar-item:has(.badge:contains(1))", {
         text: "Mitchell Admin and Dumbledore",
     });
+    await contains(".o_notification", { count: 1 });
     expect(titleService.current).toBe("(1) Inbox");
+});
+
+test("inbox notifs shouldn't play sound nor open chat bubble", async () => {
+    const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
+    const partnerId = pyEnv["res.partner"].create({ name: "Dumbledore" });
+    const userId = pyEnv["res.users"].create({ partner_id: partnerId });
+    pyEnv["discuss.channel"].create({
+        name: "general",
+        channel_member_ids: [Command.create({ partner_id: serverState.partnerId })],
+        channel_type: "channel",
+    });
+    mockService("presence", { isOdooFocused: () => false });
+    onRpcBefore("/mail/action", async (args) => {
+        if (args.init_messaging) {
+            step("init_messaging");
+        }
+    });
+    patchWithCleanup(OutOfFocusService.prototype, {
+        _playSound() {
+            step("play_sound");
+        },
+    });
+    await start();
+    await assertSteps(["init_messaging"]);
+    // simulate receiving a new needaction message with odoo out-of-focused
+    const adminId = serverState.partnerId;
+    await withUser(userId, () =>
+        rpc("/mail/message/post", {
+            post_data: {
+                body: "@Michell Admin",
+                partner_ids: [adminId],
+                message_type: "comment",
+            },
+            thread_id: partnerId,
+            thread_model: "res.partner",
+        })
+    );
+    await contains(".o-mail-MessagingMenu-counter", { text: "1" });
+    // check no chat window nor chat bubble spawn: can be delayed, hence opening and folding chat by hand
+    await click("button.dropdown i[aria-label='Messages']");
+    await click(".o-mail-MessagingMenu button:contains(general)");
+    await contains(".o-mail-ChatWindow:contains(general)");
+    await contains(".o-mail-ChatWindow", { count: 1 });
+    await click(".o-mail-ChatWindow button[title='Fold']");
+    await contains(".o-mail-ChatBubble", { count: 1 }); // no other chat bubble other than manually folded one
+    await assertSteps([]); // no sound alert whatsoever
 });
 
 test("should auto-pin chat when receiving a new DM", async () => {


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/182347

PR above improved out-of-focus counter, one of such improvements is to take new inbox messages into account.

However, doing so had to unintended side-effect to make them play sound, open chat bubble, and display more than 1 notification.

This happens because the inbox notification were treated like new message in chat notifications.

This commit fixes the issue by limiting PR above of inbox new messages to contribute for the out-of-focus counter. In other words, the following behaviors have been fixed:
- new inbox messages from chatter no longer open a chat bubble
- new inbox messages from chatter no longer play sound
- new inbox messages from chatter only show 1 notification at most