### PR TITLE
[FIX] mail: proper left spacing for chatter in chat window

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -128,8 +128,8 @@
 <t t-name="mail.ChatWindow.headerContent">
     <div class="o-mail-ChatWindow-threadAvatar my-0 me-1 py-1" t-att-class="{
         'py-2': thread and threadActions.actions.length lte 3,
-        'ms-1': thread and threadActions.actions.length > 4,
-        'ms-3': threadActions.actions.length lte 4 or !thread,
+        'ms-1': thread,
+        'ms-3': !thread,
     }">
         <img t-if="thread" class="rounded o_object_fit_cover" t-att-src="thread.parent_channel_id?.avatarUrl ?? thread.avatarUrl" alt="Thread Image"/>
         <i t-else="" class="fa fa-pencil fa-lg fa-fw py-1"/>


### PR DESCRIPTION
Before / After
<img width="366" alt="Screenshot 2024-10-21 at 20 45 32" src="https://github.com/user-attachments/assets/ece48e77-cb42-4442-8ff1-fc79743ac718"> <img width="369" alt="Screenshot 2024-10-21 at 20 43 38" src="https://github.com/user-attachments/assets/542034a3-1e01-4222-ad18-edd77090f41d">
