### PR TITLE
[FIX] mail: no font italics in ChatHub +X counter

### DIFF
--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -52,7 +52,7 @@
                 <t t-out="hiddenCounter"/>
             </div>
             <button class="o-mail-ChatHub-bubbleBtn btn outline-0">
-                <i class="o-mail-ChatHub-hiddenBtnIcon d-flex justify-content-center align-items-center btn rounded-circle shadow-sm fs-2" t-att-class="{ 'o-active': more.isOpen }">+<t t-esc="chatHub.folded.slice(chatHub.maxFolded).length"/></i>
+                <span class="o-mail-ChatHub-hiddenBtnIcon d-flex justify-content-center align-items-center btn rounded-circle shadow-sm fs-2" t-att-class="{ 'o-active': more.isOpen }">+<t t-esc="chatHub.folded.slice(chatHub.maxFolded).length"/></span>
             </button>
         </div>
         <t t-set-slot="content">


### PR DESCRIPTION
See the +7 that was italics before

Before / After
<img width="73" alt="Screenshot 2024-10-21 at 20 55 17" src="https://github.com/user-attachments/assets/3754e36b-5ade-4c28-991c-f3f73cc74d2c"> <img width="61" alt="Screenshot 2024-10-21 at 20 52 36" src="https://github.com/user-attachments/assets/3933af74-8e51-4c0e-8309-2ebbca303bda">
