### PR TITLE
[FIX] website_forum: fix traceback when user tries to sort website forum posts

### DIFF
--- a/addons/website_forum/controllers/website_forum.py
+++ b/addons/website_forum/controllers/website_forum.py
@@ -123,7 +123,7 @@ class WebsiteForum(WebsiteProfile):
             # retro-compatibility for V8 and google links
             try:
                 sorting = werkzeug.urls.url_unquote_plus(sorting)
-                Post._order_to_sql(sorting, None)
+                Post._order_to_sql(sorting, Post._where_calc([]))
             except (UserError, ValueError):
                 sorting = False
 


### PR DESCRIPTION
Currently, a traceback is occurring when the user tries to sort a website forum posts.

To reproduce this issue:

1) Install website_forum
2) Open `Forum` in the website and tries to sort based on activity

Error:- 
```
AttributeError: 'NoneType' object has no attribute 'groupby'
```

Here in the website_forum post, the query was passed as None, 
and because of the recent changes from the below-mentioned commit, 
a traceback occurs from the line[1].

https://github.com/odoo/odoo/blob/0bac60a7085c51ac8cb4f793b013dbea927d180c/addons/website_forum/controllers/website_forum.py#L126

Line[1]:-
https://github.com/odoo/odoo/blob/0bac60a7085c51ac8cb4f793b013dbea927d180c/odoo/models.py#L5614-L5615

Commit:-
https://github.com/odoo/odoo/pull/183925/commits/6b1df3fddedec486bc20010131ea8da566dade32

We can resolve this issue by passing an empty query instead of None.

sentry-6008918989
