### PR TITLE
[IMP] website: add disclaimer snippet

### DIFF
--- a/addons/html_builder/static/src/core/drop_zone_plugin.js
+++ b/addons/html_builder/static/src/core/drop_zone_plugin.js
@@ -52,7 +52,10 @@ export class DropZonePlugin extends Plugin {
             return true;
         },
         selection_placeholder_container_predicates: (container) => {
-            if (container.classList.contains("oe_structure")) {
+            if (
+                container.classList.contains("oe_structure") ||
+                container.id === "o_snippet_above_header" // Specific case for dropzone above header
+            ) {
                 return false;
             }
         },
@@ -471,12 +474,13 @@ export class DropZonePlugin extends Plugin {
         { selectorSiblings, selectorChildren, selectorSanitized, selectorGrids },
         { toInsertInline, isContentInIframe = true } = {}
     ) {
-        const isIgnored = (el) => el.matches(".o_we_no_overlay") || !isVisible(el);
+        const isIgnored = (el) =>
+            el.matches(".o_we_no_overlay, .oe_no_drop_above") || !isVisible(el);
         let hookEls = [];
         for (const parentEl of selectorChildren) {
             const validChildrenEls = [...parentEl.children].filter((el) => !isIgnored(el));
             hookEls.push(...validChildrenEls);
-            parentEl.prepend(this.createDropzone(parentEl));
+            parentEl.append(this.createDropzone(parentEl));
         }
         hookEls.push(...selectorSiblings);
         const systemNodeSelectors = this.getResource("system_node_selectors").join(",");

--- a/addons/html_builder/static/src/sidebar/block_tab.js
+++ b/addons/html_builder/static/src/sidebar/block_tab.js
@@ -71,7 +71,6 @@ export class BlockTab extends Component {
                 this.cancelDragAndDrop = this.shared.history.makeSavePoint();
                 this.dragState = {};
                 let snippetEl;
-                const baseSectionEl = snippet.content.cloneNode(true);
                 this.state.ongoingInsertion = true;
                 await new Promise((resolve) => {
                     this.snippetModel.openSnippetDialog(
@@ -82,7 +81,7 @@ export class BlockTab extends Component {
 
                                 // Add the dropzones corresponding to a section and
                                 // make them invisible.
-                                const selectors = this.shared.dropzone.getSelectors(baseSectionEl);
+                                const selectors = this.shared.dropzone.getSelectors(snippetEl);
                                 const dropzoneEls =
                                     this.shared.dropzone.activateDropzones(selectors);
                                 this.editable

--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -137,6 +137,7 @@
         'views/snippets/s_kickoff.xml',
         'views/snippets/s_discovery.xml',
         'views/snippets/s_bento_banner.xml',
+        'views/snippets/s_headline.xml',
         'views/snippets/s_striped.xml',
         'views/snippets/s_intro_pill.xml',
         'views/snippets/s_big_number.xml',

--- a/addons/website/static/src/builder/plugins/options/headline_option.xml
+++ b/addons/website/static/src/builder/plugins/options/headline_option.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="website.HeadlineOption">
+    <BuilderRow label.translate="Show On" preview="false">
+        <BuilderSelect action="'showOnPage'">
+            <BuilderSelectItem actionValue="'allPages'">All pages</BuilderSelectItem>
+            <BuilderSelectItem actionValue="'currentPage'">This page</BuilderSelectItem>
+        </BuilderSelect>
+    </BuilderRow>
+</t>
+
+</templates>

--- a/addons/website/static/src/builder/plugins/options/headline_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/headline_option_plugin.js
@@ -1,0 +1,47 @@
+import { Plugin } from "@html_editor/plugin";
+import { registry } from "@web/core/registry";
+import { BuilderAction } from "@html_builder/core/builder_action";
+import { BaseOptionComponent } from "@html_builder/core/utils";
+
+class HeadlineOption extends BaseOptionComponent {
+    static template = "website.HeadlineOption";
+    static selector = ".s_headline";
+}
+class HeadlineOptionPlugin extends Plugin {
+    static id = "headlineOption";
+    resources = {
+        builder_options: [HeadlineOption],
+        builder_actions: {
+            ShowOnPageAction,
+        },
+        dropzone_selector: [
+            {
+                selector: ".s_headline",
+                dropNear: ".s_headline",
+                dropIn: "#o_snippet_above_header",
+            },
+        ],
+    };
+}
+
+export class ShowOnPageAction extends BuilderAction {
+    static id = "showOnPage";
+
+    isApplied({ editingElement: el, value }) {
+        const snippetPosition = el.closest("#o_snippet_above_header") ? "allPages" : "currentPage";
+        return value === snippetPosition;
+    }
+    apply({ editingElement: el, value }) {
+        const snippetEl = el.closest(".s_headline");
+        // Decide target container:
+        // "allPages": move snippet to dedicated `#o_snippet_above_header`.
+        // "currentPage": move snippet to first editable content area.
+        const targetContainerEl =
+            value === "allPages"
+                ? this.editable.querySelector("#o_snippet_above_header")
+                : this.editable.querySelector("main .oe_structure.o_savable");
+        targetContainerEl?.prepend(snippetEl);
+    }
+}
+
+registry.category("website-plugins").add(HeadlineOptionPlugin.id, HeadlineOptionPlugin);

--- a/addons/website/static/src/builder/plugins/options/website_background_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/website_background_option_plugin.js
@@ -33,7 +33,7 @@ export class WebsiteBackgroundBGColorImageOption extends BaseWebsiteBackgroundOp
 }
 export class WebsiteBackgroundBGColorOption extends BaseWebsiteBackgroundOption {
     static selector =
-        "section .row > div, .s_text_highlight, .s_mega_menu_thumbnails_footer, .s_hr, .s_cta_badge";
+        "section .row > div, .s_text_highlight, .s_mega_menu_thumbnails_footer, .s_hr, .s_cta_badge, .s_headline";
     static exclude = `.s_col_no_bgcolor, .s_col_no_bgcolor.row > div, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .s_image_gallery .row > div, .s_text_cover .row > .o_not_editable, [data-snippet] :not(.oe_structure) > .s_hr, ${CARD_PARENT_HANDLERS}, .s_website_form_cover .row > .o_not_editable, .s_bento_grid .row > div, .s_banner_categories .row > div, ${BLOCKQUOTE_PARENT_HANDLERS}, .s_bento_grid_avatars .row > div`;
     static defaultProps = {
         withColors: true,

--- a/addons/website/static/src/snippets/s_headline/000.scss
+++ b/addons/website/static/src/snippets/s_headline/000.scss
@@ -1,0 +1,6 @@
+.o_header_sidebar {
+    .s_headline {
+        writing-mode: vertical-lr;
+        height: 100%;
+    }
+}

--- a/addons/website/static/tests/tours/snippet_headline.js
+++ b/addons/website/static/tests/tours/snippet_headline.js
@@ -1,0 +1,27 @@
+import {
+    clickOnSnippet,
+    changeOptionInPopover,
+    registerWebsitePreviewTour,
+    insertSnippet,
+} from "@website/js/tours/tour_utils";
+
+registerWebsitePreviewTour(
+    "snippet_headline_tour",
+    {
+        url: "/",
+        edition: true,
+    },
+    () => [
+        ...insertSnippet({ id: "s_headline", name: "Headline", groupName: "Contact & Forms" }),
+        {
+            content: "Check whether the Headline snippet is dropped above navbar",
+            trigger: ":iframe #o_snippet_above_header .s_headline",
+        },
+        ...clickOnSnippet({ id: "s_headline", name: "Headline" }),
+        ...changeOptionInPopover("Headline", "Show On", "[data-action-value='currentPage']"),
+        {
+            content: "Check whether snippet moved to #wrap",
+            trigger: ":iframe #wrap .s_headline",
+        },
+    ]
+);

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -42,6 +42,7 @@ class TestSnippets(HttpCase):
             's_snippet_group',  # Snippet groups are not snippets
             's_inline_text',
             's_drag_image_preview_test',
+            's_headline',  # Avoid specific case where snippet should be dropped outside #wrap
         ]
         snippets_names = ','.join({
             f"{el.attrib['data-oe-snippet-key']}:{el.attrib.get('data-o-group', '')}"
@@ -113,6 +114,9 @@ class TestSnippets(HttpCase):
 
     def test_12_snippet_images_wall(self):
         self.start_tour('/', 'snippet_images_wall', login='admin')
+
+    def test_13_snippet_headline(self):
+        self.start_tour("/", "snippet_headline_tour", login="admin")
 
     def test_snippet_popup_with_scrollbar_and_animations(self):
         website = self.env.ref('website.default_website')

--- a/addons/website/views/snippets/s_headline.xml
+++ b/addons/website/views/snippets/s_headline.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="s_headline" name="Headline">
+        <div class="s_headline oe_no_drop_above o_colored_level o_cc o_cc5 pt4 pb4">
+            <div style="text-align: center;">
+                <small> Free Returns and Standard Shipping </small>
+            </div>
+        </div>
+    </template>
+
+    <record id="website.s_headline_000_scss" model="ir.asset">
+        <field name="name">Headline 000 SCSS</field>
+        <field name="bundle">web.assets_frontend</field>
+        <field name="path">website/static/src/snippets/s_headline/000.scss</field>
+    </record>
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -400,6 +400,9 @@
             <t t-snippet="website.s_form_aside" string="Form Aside" t-forbid-sanitize="form" group="contact_and_forms" label="Form">
                 <keywords>contact, collect, submission, input, fields, questionnaire, survey, registration, request, image, picture, photo, illustration, media, visual, get-in-touch</keywords>
             </t>
+            <t t-snippet="website.s_headline" string="Headline" group="contact_and_forms" label="Headline">
+                <keywords>banner, highlight, headline, promo, messagebar, announcement, header, contrasted, disclaimer</keywords>
+            </t>
 
             <!-- Catalog group -->
             <t t-snippet="website.s_floating_blocks" string="Floating Cards" group="catalog" label="Parallax">

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -217,6 +217,11 @@
         </t>
     </xpath>
 
+    <xpath expr="//header//nav" position="before">
+        <!-- Reserved div to drop the snippet above header -->
+        <div id="o_snippet_above_header" class="oe_empty"/>
+    </xpath>
+
     <xpath expr="//footer" position="attributes">
         <attribute name="data-name">Footer</attribute>
         <!-- Background now controlled by css configuration, using color combinations -->
@@ -1383,6 +1388,9 @@
 <template id="template_header_sidebar" inherit_id="website.layout" name="Template Header Sidebar" active="False">
     <xpath expr="//header" position="attributes">
         <attribute name="t-attf-class" add="o_header_sidebar" separator=" "/>
+    </xpath>
+    <xpath expr="//*[@id='o_snippet_above_header']" position="attributes">
+        <attribute name="t-attf-class" add="d-flex" separator=" "/>
     </xpath>
     <xpath expr="//header//nav" position="replace">
         <t t-call="website.navbar"


### PR DESCRIPTION
This commit introduces the new snippet `s_disclaimer`. Users can also
the have option to add a page specific disclaimer warning.

![image](https://github.com/user-attachments/assets/23f90bcf-8bf9-4e7d-b262-e1cb811828c2)

![image](https://github.com/user-attachments/assets/088707d9-58db-4eef-8f26-85c8e84700e8)


task-3658333