### PR TITLE
[FIX] website_livechat: make livechat up-to-date with available operator

### DIFF
--- a/addons/website_livechat/views/website_livechat.xml
+++ b/addons/website_livechat/views/website_livechat.xml
@@ -9,7 +9,7 @@
             <xpath expr="//head">
                 <t t-if="not no_livechat and website and website.channel_id">
                     <script>
-                        <t t-call="im_livechat.loader">
+                        <t t-call="im_livechat.loader" t-nocache="Should be up-to-date with available operators">
                             <t t-set="info" t-value="website._get_livechat_channel_info()"/>
                         </t>
                     </script>


### PR DESCRIPTION
__Current behavior before commit:__
The `info` variable contains the entry `isAvailable` used [here][1]. This should be updated as soon as a livechat operator enters or leaves the channel. However since this view is cached (by [this line][2]) it happens that the livechat bubble appears without any operators available and vice versa.

__Description of the fix:__
Add a t-nocache to prevent `info` from being cached and always be up-to-date.

__Steps to reproduce the issue:__
On runbot this behavior is inconsistent since each worker has its own cache. It is however consistent in local with only one worker. Make sure you are **not** in debug mode

1. Set a livechat channel on the website, make sure there is no chatbot on it
2. Enter the livechat channel with the admin
3. Open the website on an incognito window (the chat bubble should be there)
4. Leave the livechat channel with the admin
4. Refresh the incognito window

The chat bubble is still there.

Note that the chat bubble might not appear at all even when the admin enter the livechat if the opposite has been cached before.

opw-4233744

[1]: https://github.com/odoo/odoo/blob/837a6a8/addons/im_livechat/views/im_livechat_channel_templates.xml#L100
[2]: https://github.com/odoo/odoo/blob/2997afa/addons/website/views/website_templates.xml#L86