### PR TITLE
[FIX] web: fix trackback in auth-top wizard having no activation code

### DIFF
--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -75,7 +75,7 @@ export class Record extends DataPoint {
 
     _setData(data) {
         this._isEvalContextReady = false;
-        if (this.resId) {
+        if (this.resId && this._config.resModel.split(".")[1] !== 'wizard') {
             this._values = this._parseServerValues(data);
             this._changes = markRaw({});
             Object.assign(this._textValues, this._getTextValues(data));


### PR DESCRIPTION
Currently, a traceback occurs when the user attempts to activate 
the two-factor authentication without providing a verification code.

To reproduce this issue:

1) Open the preferences from the Odoo profile
2) In Account security, enable 2-factor-authentication 
3) Provide your password and attempt to activate it
   without entering a verification code.

Error:- 
```
TypeError: expected string or bytes-like object, got 'bool'
```

Despite being a required field, the activation code is being treated as False. 
This results in a traceback triggered by the following lines of code.

https://github.com/odoo/odoo/blob/e1ab446df93f6c1644501e5c928d6e32b8ea0bc3/addons/auth_totp/wizard/auth_totp_wizard.py#L59-L62

The root of the problem lies in recent changes made by the following commit

Commit:-
https://github.com/odoo/odoo/pull/173282/commits/eb303f248064a3ad457334021ef5381e22584da7

Initially, the `_checkValidity` method was executed first, followed by the `_getChanges` method.

In the `_checkValidity`, we check whether any required fields are missing a value, 
and if so, we raise a notification about the invalid field.

https://github.com/odoo/odoo/blob/e1ab446df93f6c1644501e5c928d6e32b8ea0bc3/addons/web/static/src/model/relational_model/record.js#L424-L425

However, after the aforementioned commit, the `_getChanges` method executes first.
This method assigns `this._changes` based on the resId

In the case of normal models, we do not have a resId initially, so there is no issue.
But for wizards, we do receive a resId because they are transient models.

https://github.com/odoo/odoo/blob/e1ab446df93f6c1644501e5c928d6e32b8ea0bc3/addons/web/static/src/model/relational_model/record.js#L78-L86

As a result, the condition checks execute, and since there are no changes, 
it returns true, leading to the traceback.

https://github.com/odoo/odoo/blob/e1ab446df93f6c1644501e5c928d6e32b8ea0bc3/addons/web/static/src/model/relational_model/record.js#L992-L998

There are two possible solutions to address this issue: either revert the commit or
implement a patch that checks whether the model is a wizard.

sentry-5687998066
