### PR TITLE
[FIX] test_sale_product_configurators: ensure consistent pricelist

### DIFF
--- a/addons/test_sale_product_configurators/tests/test_sale_product_matrix.py
+++ b/addons/test_sale_product_configurators/tests/test_sale_product_matrix.py
@@ -40,6 +40,8 @@ class TestSaleMatrixUi(TestMatrixCommon):
             _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
             return
 
+        self.env['product.pricelist'].search([]).unlink()
+
         # Set the template as configurable by matrix.
         self.matrix_template.product_add_mode = "matrix"
 


### PR DESCRIPTION
This is basically a repeat of abe8e38ccc18cfba77317d3fdaf4a066b5f69b79 in a different module, likely for the same reason: in the matrix tour, after preparing and confirming the sale order at the start of the tour the total comes up 20% lower than expected.
