### PR TITLE
[FIX] website, *: prevent website configurator flickering

### DIFF
--- a/addons/web/static/tests/webclient/actions/load_state_tests.js
+++ b/addons/web/static/tests/webclient/actions/load_state_tests.js
@@ -682,7 +682,7 @@ QUnit.module("ActionManager", (hooks) => {
     });
 
     QUnit.test("load a window action without id (in a multi-record view)", async function (assert) {
-        assert.expect(14);
+        assert.expect(15);
         patchWithCleanup(browser.sessionStorage, {
             getItem(k) {
                 assert.step(`getItem session ${k}`);
@@ -717,6 +717,7 @@ QUnit.module("ActionManager", (hooks) => {
         assert.containsOnce(target, ".o_list_view", "should display a list view");
         assert.verifySteps([
             "/web/webclient/load_menus",
+            "getItem session current_action",
             "/web/action/load",
             "get_views",
             "web_search_read",
@@ -1142,7 +1143,7 @@ QUnit.module("ActionManager", (hooks) => {
                 target.querySelector(".o_nocontent_help").innerText
             );
 
-            assert.verifySteps(["getItem session current_action"]);
+            assert.verifySteps(["getItem session current_action", "getItem session current_action"]);
         }
     );
 });

--- a/addons/web/static/tests/webclient/actions/window_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/window_action_tests.js
@@ -1769,6 +1769,9 @@ QUnit.module("ActionManager", (hooks) => {
                     setItem(k, value) {
                         assert.deepEqual(JSON.parse(value), expectedAction);
                     },
+                    getItem(k) {
+                        return null;
+                    },
                 }),
             });
             const webClient = await createWebClient({ serverData });

--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -179,6 +179,7 @@
             'website/static/src/scss/website_visitor_views.scss',
             'website/static/src/scss/website.theme_install.scss',
             'website/static/src/js/backend/**/*',
+            'website/static/src/js/web/**/*',
             'website/static/src/client_actions/*/*',
             ('remove', 'website/static/src/client_actions/website_preview/website_preview_test_mode.js'),
             'website/static/src/components/fields/*',

--- a/addons/website/static/src/js/web/webclient.js
+++ b/addons/website/static/src/js/web/webclient.js
@@ -1,0 +1,26 @@
+/** @odoo-module **/
+
+import { patch } from "@web/core/utils/patch";
+import { WebClient } from "@web/webclient/webclient";
+import { browser } from "@web/core/browser/browser";
+import { useState } from "@odoo/owl";
+
+patch(WebClient.prototype, "web", {
+    /**
+     * Overrides setup() method of Webclient to prevent
+     * the flikering of the navbar during website
+     * configurator
+     *
+     * @override
+     */
+    setup() {
+        this._super(...arguments);
+        let isWebsiteConfiguration = false;
+        if(browser.sessionStorage && (this.currentAction = browser.sessionStorage.getItem("current_action"))){
+            isWebsiteConfiguration = this.currentAction.includes("action_website_configuration");
+        }
+        this.state = useState({
+            fullscreen: isWebsiteConfiguration
+        });
+    }
+});


### PR DESCRIPTION
*: web

Before this PR:
Users were facing an issue of flickering when trying to configure a newly created website. The reason behind this was that the target was decided after the web client was mounted. When the action target is evaluated (i.e., new, current, or fullscreen), the navbar was hidden based on the target.

In this PR, the state of the web client is now set based on the current action, specifically setting the fullscreen state for the website configurator to address the flickering issue.

task-3050040