### PR TITLE
[FIX] sale_project: make sure the modal is closed before doing next step

### DIFF
--- a/addons/sale_project/static/tests/tours/task_create_sol_tour.js
+++ b/addons/sale_project/static/tests/tours/task_create_sol_tour.js
@@ -48,9 +48,7 @@ registry.category("web_tour.tours").add("task_create_sol_tour", {
         in_modal: false,
         run: "click",
     }, {
-        trigger: ".o_form_button_save",
-        content: "Save task",
-        run: "click",
+        trigger: "body:not(:has(.modal))",
     }, {
         trigger: ".o_field_widget[name='sale_line_id'] input",
         content: "Check if the Sales Order Item is saved correctly.",
@@ -59,6 +57,10 @@ registry.category("web_tour.tours").add("task_create_sol_tour", {
                 console.error("Sales Order Item is not saved correctly.");
             }
         },
+    }, {
+        trigger: ".o_form_button_save",
+        content: "Save task",
+        run: "click",
     },
     // Those steps are currently needed in order to prevent the following issue:
     // "Form views in edition mode are automatically saved when the page is closed, which leads to stray network requests and inconsistencies."

--- a/addons/sale_project/static/tests/tours/task_create_sol_tour.js
+++ b/addons/sale_project/static/tests/tours/task_create_sol_tour.js
@@ -48,7 +48,9 @@ registry.category("web_tour.tours").add("task_create_sol_tour", {
         in_modal: false,
         run: "click",
     }, {
-        trigger: "body:not(:has(.modal))",
+        trigger: ".o_form_button_save",
+        content: "Save task",
+        run: "click",
     }, {
         trigger: ".o_field_widget[name='sale_line_id'] input",
         content: "Check if the Sales Order Item is saved correctly.",
@@ -57,10 +59,6 @@ registry.category("web_tour.tours").add("task_create_sol_tour", {
                 console.error("Sales Order Item is not saved correctly.");
             }
         },
-    }, {
-        trigger: ".o_form_button_save",
-        content: "Save task",
-        run: "click",
     },
     // Those steps are currently needed in order to prevent the following issue:
     // "Form views in edition mode are automatically saved when the page is closed, which leads to stray network requests and inconsistencies."


### PR DESCRIPTION
Before this commit, the `task_create_sol_tour` could fail before the step did not wait enough the modal be closed before saving the form and so the form view could not be saved before going in the project app.

This commit adds a step to make sure the modal is closed and does the step to save the form view when we check everything in the form view to make sure the form view will be saved before leaving the view.

runbot-77457
