### PR TITLE
[FIX] mrp_subcontracting: subcontracting portal view

### DIFF
--- a/addons/mrp_subcontracting/static/src/scss/subcontracting_portal.scss
+++ b/addons/mrp_subcontracting/static/src/scss/subcontracting_portal.scss
@@ -1,3 +1,3 @@
 .o_subcontracting_portal {
-    height: 90%;
+    height: 80vh;
 }


### PR DESCRIPTION
Prior to this commit, the portal view height was very small that users could not see purchase orders details easily. This commit fixes that issue.

closes odoo/odoo#181390

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
