### PR TITLE
[FIX] web_editor: resolve popup not opening issue.

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -7988,6 +7988,17 @@ registry.SnippetSave = SnippetOptionWidget.extend({
                                     const defaultSnippetName = _.str.sprintf(_t("Custom %s"), this.data.snippetName);
                                     const targetCopyEl = this.$target[0].cloneNode(true);
                                     targetCopyEl.classList.add('s_custom_snippet');
+                                    // when cloning the snippets which has o_snippet_invisible, o_snippet_mobile_invisible or
+                                    // o_snippet_desktop_invisible class will be hidden because of d-none class added on it,
+                                    // so we needs to remove `d-none` explicity in such case from the target.
+                                    const isTargetHidden = [
+                                        "o_snippet_invisible",
+                                        "o_snippet_mobile_invisible",
+                                        "o_snippet_desktop_invisible"
+                                    ].some(className => this.$target[0].classList.contains(className));
+                                    if (isTargetHidden) {
+                                        targetCopyEl.classList.remove("d-none");
+                                    }
                                     delete targetCopyEl.dataset.name;
                                     // By the time onSuccess is called after request_save, the
                                     // current widget has been destroyed and is orphaned, so this._rpc

--- a/addons/website/static/tests/tours/custom_popup_snippet.js
+++ b/addons/website/static/tests/tours/custom_popup_snippet.js
@@ -1,0 +1,34 @@
+/** @odoo-module */
+
+import wTourUtils from "website.tour_utils";
+
+const snippets = [
+    { id: "s_popup", name: "Popup" },
+    { id: "s_popup", name: "Custom Popup" },
+];
+wTourUtils.registerWebsitePreviewTour(
+    "custom_popup_snippet",
+    {
+        test: true,
+        url: "/",
+        edition: true,
+    },
+    [
+        wTourUtils.dragNDrop(snippets[0]),
+        wTourUtils.clickOnSnippet(snippets[0]),
+        {
+            content: "save this snippet to save later",
+            trigger: ".o_we_user_value_widget.fa-save",
+        },
+        {
+            content: "confirm and reload custom snippet",
+            trigger: ".modal-footer > .btn.btn-primary",
+        },
+        wTourUtils.dragNDrop(snippets[1]),
+        {
+            content: "check whether new custom popup is visible or not.",
+            trigger: "iframe #wrap.o_editable [data-name='Custom Popup']",
+            run: () => {}, // This is a check
+        },
+    ]
+);

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -121,3 +121,6 @@ class TestSnippets(HttpCase):
             'url': base + '/web/image/website.s_banner_default_image',
         })
         self.start_tour('/', 'snippet_image_gallery_thumbnail_update', login='admin')
+
+    def test_custom_popup_snippet(self):
+        self.start_tour(self.env["website"].get_client_action_url("/"), "custom_popup_snippet", login="admin")


### PR DESCRIPTION
Steps to Reproduce:

1. Drop a popup snippet on any page (e.g., Home page).
2. In the editor, set "Shown on" to "This Page."
3. Save the snippet for reuse.
4. Drop the same custom snippet on another page (e.g., Contact Us page).
5. Try to make the snippet visible on this page.

Issue:
The user has to click twice to make the popup visible. On the first click, a scroller appears, and the popup becomes visible only on the second click. The reason behind is that at the time of saving snippet for later use, it clones it with `d-none` class.

This commit resolves the issue by explicitly removing the `d-none` from the custom_popup_snippet, ensuring the custom popup appears immediately after being dragged and dropped.

task-4088420