### PR TITLE
[FIX] pos_sms: use mobile number to send SMS

### DIFF
--- a/addons/pos_sms/static/src/overrides/receipt_screen.js
+++ b/addons/pos_sms/static/src/overrides/receipt_screen.js
@@ -29,7 +29,7 @@ patch(ReceiptScreen.prototype, {
         }
 
         this.state.mode = mode;
-        this.state.input = this.currentOrder.partner_id?.phone || "";
+        this.state.input = this.currentOrder.partner_id?.mobile || "";
     },
     get isValidInput() {
         return this.state.mode === "phone"


### PR DESCRIPTION
Prior to this commit, the phone field was used to send SMS, which could be incorrect.

Enterprise PR: https://github.com/odoo/enterprise/pull/72449

opw-4273085

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
