### PR TITLE
[IMP] portal: improve pagination to enhance ux and seo

### DIFF
--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -21,6 +21,11 @@ def pager(url, total, page=1, step=30, scope=5, url_args=None):
 
     This method computes url, page range to display, ... in the pager.
 
+    Enhanced pager logic for SEO optimization:
+    - Shows first and last page in pagination
+    - Shows current page with -1 and +1 neighbors
+    - Adds ellipses when necessary
+
     :param str url : base url of the page link
     :param int total : number total of item to be splitted into pages
     :param int page : current page
@@ -33,19 +38,30 @@ def pager(url, total, page=1, step=30, scope=5, url_args=None):
     page_count = int(math.ceil(float(total) / step))
 
     page = max(1, min(int(page if str(page).isdigit() else 1), page_count))
-    scope -= 1
 
-    pmin = max(page - int(math.floor(scope/2)), 1)
-    pmax = min(pmin + scope, page_count)
-
-    if pmax - pmin < scope:
-        pmin = pmax - scope if pmax - scope > 0 else 1
+    page_previous = max(1, page - 1)
+    page_next = min(page_count, page + 1)
 
     def get_url(page):
         _url = "%s/page/%s" % (url, page) if page > 1 else url
         if url_args:
             _url = "%s?%s" % (_url, urls.url_encode(url_args))
         return _url
+
+    # Build page list based on conditions
+    if page_count <= 5:
+        page_list = list(range(1, page_count + 1))
+    elif page <= 3:
+        page_list = [1, 2, 3, 4, "…", page_count]
+    elif page >= page_count - 2:
+        page_list = [1, "…"] + list(range(page_count - 3, page_count + 1))
+    else:
+        page_list = [1, "…", page - 1, page, page + 1, "…", page_count]
+
+    pages = [
+        {"num": p, "url": get_url(p) if p != "…" else None, "is_current": p == page}
+        for p in page_list
+    ]
 
     return {
         "page_count": page_count,
@@ -58,29 +74,19 @@ def pager(url, total, page=1, step=30, scope=5, url_args=None):
             'url': get_url(1),
             'num': 1
         },
-        "page_start": {
-            'url': get_url(pmin),
-            'num': pmin
-        },
         "page_previous": {
-            'url': get_url(max(pmin, page - 1)),
-            'num': max(pmin, page - 1)
+            'url': get_url(page_previous),
+            'num': page_previous
         },
         "page_next": {
-            'url': get_url(min(pmax, page + 1)),
-            'num': min(pmax, page + 1)
-        },
-        "page_end": {
-            'url': get_url(pmax),
-            'num': pmax
+            'url': get_url(page_next),
+            'num': page_next
         },
         "page_last": {
             'url': get_url(page_count),
             'num': page_count
         },
-        "pages": [
-            {'url': get_url(page_num), 'num': page_num} for page_num in range(pmin, pmax+1)
-        ]
+        "pages": pages
     }
 
 

--- a/addons/portal/tests/__init__.py
+++ b/addons/portal/tests/__init__.py
@@ -3,6 +3,7 @@
 from . import test_addresses
 from . import test_login
 from . import test_message_format_portal
+from . import test_pager
 from . import test_portal
 from . import test_portal_wizard
 from . import test_tours

--- a/addons/portal/tests/test_pager.py
+++ b/addons/portal/tests/test_pager.py
@@ -1,0 +1,54 @@
+from odoo.tests.common import TransactionCase
+
+from odoo.addons.portal.controllers.portal import pager
+
+
+class TestPager(TransactionCase):
+
+    def test_pager_functionality(self):
+        """Test the custom pager functionality."""
+        test_cases = [
+            # Case 1: Total items fit in one page
+            {'total': 20, 'page': 1, 'expected_pages': [1]},
+            # Case 2: Exactly two pages, first page active
+            {'total': 50, 'page': 1, 'expected_pages': [1, 2]},
+            # Case 3: Exactly five pages, middle page active
+            {'total': 150, 'page': 3, 'expected_pages': [1, 2, 3, 4, 5]},
+            # Case 4: Large number of pages, ellipses in the middle
+            {'total': 300, 'page': 5, 'expected_pages': [1, '…', 4, 5, 6, '…', 10]},
+            # Case 5: Large number of pages, first page active
+            {'total': 300, 'page': 1, 'expected_pages': [1, 2, 3, 4, '…', 10]},
+            # Case 6: Large number of pages, last page active
+            {'total': 300, 'page': 10, 'expected_pages': [1, '…', 7, 8, 9, 10]},
+        ]
+        for case in test_cases:
+            result = pager(
+                url=case.get('url', '/test'),
+                total=case['total'],
+                page=case['page'],
+                step=30,
+                scope=5,
+                url_args=None,
+            )
+
+            # Calculate expected page count
+            expected_page_count = (case['total'] + 30 - 1) // 30
+            pages = [p['num'] for p in result['pages']]
+
+            # Assertions
+            with self.subTest(case=case):
+                self.assertEqual(
+                    pages,
+                    case['expected_pages'],
+                    f"Expected pages mismatch for case: {case}"
+                )
+                self.assertEqual(
+                    result['page']['num'],
+                    case['page'],
+                    f"Current page mismatch for case: {case}"
+                )
+                self.assertEqual(
+                    result['page_count'],
+                    expected_page_count,
+                    f"Page count mismatch for case: {case}"
+                )

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -632,7 +632,9 @@
                 </a>
             </li>
             <t t-foreach="pager['pages']" t-as="page">
-                <li t-attf-class="page-item #{'active' if page['num'] == pager['page']['num'] else ''}"> <a t-att-href="page['url']" t-attf-class="page-link #{extraLinkClass}" t-out="page['num']"/></li>
+                <li t-attf-class="page-item #{'active' if page['num'] == pager['page']['num'] else ''} #{'disabled' if page['num'] == '…' else ''}">
+                    <a t-att-href="page['url']" t-attf-class="page-link #{extraLinkClass} #{'px-0' if page['num'] == '…' else ''}" t-out="page['num']"/>
+                </li>
             </t>
             <li t-attf-class="page-item #{'disabled' if pager['page']['num'] == pager['page_count'] else ''}">
                 <a t-att-href="pager['page_next']['url'] if pager['page']['num'] != pager['page_count'] else None" t-attf-class="page-link #{extraLinkClass}">


### PR DESCRIPTION
**Prior to this commit:**
- Only 5 pages were shown at a time, making it difficult to navigate to the first or the last page from the middle.
- Users had to traverse through multiple pages to reach the start or end.

**Post this commit:**
- The first and last pages are now always displayed, providing quick access for users.
- The pagination behavior is optimized for SEO, following Google’s advice.
- Instead of showing +2 and -2 items around the current page, the first and last page are always visible to highlight their importance along with showing +1 and -1 page around the current page

These changes enhance navigation and improve the shop page’s SEO performance.

**Affected version**-master
Task-4267640