### PR TITLE
[FIX] base: prevent 0 id write on m2o from automation

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -1064,6 +1064,8 @@ class IrActionsServer(models.Model):
             elif action.update_field_id.ttype in ['many2one', 'integer']:
                 try:
                     expr = int(action.value)
+                    if expr == 0 and action.update_field_id.ttype == 'many2one':
+                        expr = False
                 except Exception:
                     pass
             elif action.update_field_id.ttype == 'float':


### PR DESCRIPTION
**Current behavior:**
Setting up an automation rule which attempts to clear an m2o field on a record can result in an exception occurring on rule trigger.

**Expected behavior:**
The targeted field is cleared.

**Steps to reproduce:**
*Concrete example: `-i stock,web_studio`
1. Go to the form view for lots/serial numbers

2. Activate studio, add a new Boolean field and a M2o field (on res.partner for sake of example) in the view

3. Create a new automation rule which runs on `stock.lot` like:
* Trigger: `On save`
* Before Update Domain: `Match all records`
* Apply on: `[('x_studio_new_boolean_field', '=', False)]`

4. Add an action to the rule like:
* Type: `Update Record`
* Action Details: `Update x_studio_new_m2o_field to <blank>`

5. Open a lot record, set the new boolean field to True and enter a partner in the m2o field -> save

6. Set the boolean to False then save again -> web error

**Cause of the issue:**
Setting the field to False is actually evaluated as setting it to 0 -> we write `res.partner(0,)` instead of clearing it. At the conclusion of the automation rule being triggered, there is a `web_save()` which returns a `web_read()` on the (in this instance) `stock.lot` record being written on.

Here, once we see the `x_studio` m2o field in the specification, there is a dict comprehension:
https://github.com/odoo/odoo/blob/b794f0f332f473deb2c04eba60baf4761db3b508/addons/web/models/models.py#L116-L119 Which calls `cleanup()` on the result of a recursive`web_read()` on `res.partner(0,)` which here is returning {'id': 0}. In `cleanup()`: `vals['id'] == 0 == False` -> Try to access `vals['id'].origin` which, of course, raises an exception.

**Fix:**
For m2o fields, evaluate Falsey expr values in `_eval_value()` to explicit `False`.

opw-4252864