### PR TITLE
[IMP] website, web_editor: introduce `s_quotes_carousel_compact` snippet

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -2931,6 +2931,9 @@ we-select.o_grid we-toggler {
             [data-snippet="s_quotes_carousel"] {
                 height: 550px;
             }
+            [data-snippet="s_quotes_carousel_compact"] {
+                height: 350px;
+            }
             [data-snippet="s_three_columns"] .figure-img[style*="height:50vh"] {
                 /* In Travel theme. */
                 height: 500px !important;

--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -101,6 +101,7 @@
         'views/snippets/s_quotes_carousel.xml',
         'views/snippets/s_numbers_grid.xml',
         'views/snippets/s_quotes_carousel_minimal.xml',
+        'views/snippets/s_quotes_carousel_compact.xml',
         'views/snippets/s_numbers.xml',
         'views/snippets/s_contact_info.xml',
         'views/snippets/s_numbers_boxed.xml',

--- a/addons/website/static/src/components/dialog/add_page_dialog.js
+++ b/addons/website/static/src/components/dialog/add_page_dialog.js
@@ -139,6 +139,7 @@ export class AddPageTemplatePreview extends Component {
                 section[data-snippet="s_carousel_intro"],
                 section[data-snippet="s_carousel_cards"],
                 section[data-snippet="s_quotes_carousel_minimal"],
+                section[data-snippet="s_quotes_carousel_compact"],
                 section[data-snippet="s_quotes_carousel"] {
                     height: ${carouselHeight} !important;
                 }

--- a/addons/website/static/src/snippets/s_blockquote/001.scss
+++ b/addons/website/static/src/snippets/s_blockquote/001.scss
@@ -14,7 +14,7 @@
         width: map-get($spacers, 1);
     }
 
-    &:not(.s_blockquote_with_line) .s_blockquote_line_elt, &:not(.s_blockquote_with_icon) .s_blockquote_wrap_icon {
+    &:not(.s_blockquote_with_line) .s_blockquote_line_elt, &:not(.s_blockquote_with_icon) .s_blockquote_wrap_icon, .s_blockquote_infos {
         display: none;
     }
 }

--- a/addons/website/views/snippets/s_blockquote.xml
+++ b/addons/website/views/snippets/s_blockquote.xml
@@ -57,7 +57,8 @@
         </div>
 
         <div data-selector=".s_blockquote" data-target=".s_blockquote_infos">
-            <we-select string="Author Alignment">
+            <we-checkbox string="Author" data-name="toggle_blockquote_author_opt" data-select-class="d-flex"/>
+            <we-select string="Alignment" class="o_we_sublevel_1" data-dependencies="toggle_blockquote_author_opt">
                 <we-button data-select-class="flex-row align-items-start justify-content-start text-start">Left</we-button>
                 <we-button data-select-class="flex-column align-items-center text-center">Center</we-button>
                 <we-button data-select-class="flex-row-reverse align-items-start justify-content-start text-end">Right</we-button>

--- a/addons/website/views/snippets/s_quotes_carousel_compact.xml
+++ b/addons/website/views/snippets/s_quotes_carousel_compact.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_quotes_carousel_compact" name="Quotes Compact">
+    <section class="s_quotes_carousel_wrapper" data-vxml="001" data-vcss="002">
+        <t t-set="uniq" t-value="datetime.datetime.now().microsecond"/>
+        <div t-attf-id="myQuoteCarouselCompact{{uniq}}" class="s_quotes_carousel s_quotes_carousel_compact s_carousel_default carousel carousel-dark slide" data-bs-ride="true" data-bs-interval="10000" data-option-name="CarouselBottomControllers">
+            <!-- Content -->
+            <div class="carousel-inner">
+                <!-- #01 -->
+                <div class="o_cc o_cc2 carousel-item active pt40 pb80 px-md-0" data-name="Slide">
+                    <div class="container">
+                        <div class="row">
+                            <blockquote data-name="Blockquote" data-snippet="s_blockquote" class="s_blockquote s_blockquote_default o_animable position-relative d-flex flex-column gap-4 w-100 me-auto my-4 p-1 fst-normal" data-vcss="001">
+                                <div class="s_blockquote_line_elt position-absolute top-0 start-0 bottom-0 bg-o-color-1"/>
+                                <div class="s_blockquote_wrap_icon position-absolute top-0 start-50 translate-middle w-100">
+                                    <i class="s_blockquote_icon fa fa-quote-right fa-3x d-block mx-auto" role="img"/>
+                                </div>
+                                <p class="s_blockquote_quote my-auto h2-fs">" This company transformed our business. <br/>Their solutions are innovative and reliable. "</p>
+                                <div class="s_blockquote_infos gap-2 flex-row align-items-start justify-content-start w-100 text-start">
+                                    <img src="/web/image/website.s_quotes_carousel_demo_image_3" class="s_blockquote_avatar img rounded-circle" alt=""/>
+                                    <div class="s_blockquote_author">
+                                        <span class="o_small">
+                                            <strong>Jane DOE</strong><br/>
+                                            <span class="text-muted">CEO of MyCompany</span>
+                                        </span>
+                                    </div>
+                                </div>
+                            </blockquote>
+                        </div>
+                    </div>
+                </div>
+                <!-- #02 -->
+                <div class="o_cc o_cc2 carousel-item pt40 pb80 px-md-0" data-name="Slide">
+                    <div class="container">
+                        <div class="row">
+                            <blockquote data-name="Blockquote" data-snippet="s_blockquote" class="s_blockquote s_blockquote_default o_animable position-relative d-flex flex-column gap-4 w-100 me-auto my-4 p-1 fst-normal" data-vcss="001">
+                                <div class="s_blockquote_line_elt position-absolute top-0 start-0 bottom-0 bg-o-color-1"/>
+                                <div class="s_blockquote_wrap_icon position-absolute top-0 start-50 translate-middle w-100">
+                                    <i class="s_blockquote_icon fa fa-quote-right fa-3x d-block mx-auto" role="img"/>
+                                </div>
+                                <p class="s_blockquote_quote my-auto h2-fs">" A trusted partner for growth. <br/>Professional, efficient, and always ahead of the curve. "</p>
+                                <div class="s_blockquote_infos gap-2 flex-row align-items-start justify-content-start w-100 text-start">
+                                    <img src="/web/image/website.s_quotes_carousel_demo_image_4" class="s_blockquote_avatar img rounded-circle" alt=""/>
+                                    <div class="s_blockquote_author">
+                                        <span class="o_small">
+                                            <strong>John DOE</strong><br/>
+                                            <span class="text-muted">CCO of MyCompany</span>
+                                        </span>
+                                    </div>
+                                </div>
+                            </blockquote>
+                        </div>
+                    </div>
+                </div>
+                <!-- #03 -->
+                <div class="o_cc o_cc2 carousel-item pt40 pb80 px-md-0" data-name="Slide">
+                    <div class="container">
+                        <div class="row">
+                            <blockquote data-name="Blockquote" data-snippet="s_blockquote" class="s_blockquote s_blockquote_default o_animable position-relative d-flex flex-column gap-4 w-100 me-auto my-4 p-1 fst-normal" data-vcss="001">
+                                <div class="s_blockquote_line_elt position-absolute top-0 start-0 bottom-0 bg-o-color-1"/>
+                                <div class="s_blockquote_wrap_icon position-absolute top-0 start-50 translate-middle w-100">
+                                    <i class="s_blockquote_icon fa fa-quote-right fa-3x d-block mx-auto" role="img"/>
+                                </div>
+                                <p class="s_blockquote_quote my-auto h2-fs">" Outstanding service and results! <br/>They exceeded our expectations in every project. "</p>
+                                <div class="s_blockquote_infos gap-2 flex-row align-items-start justify-content-start w-100 text-start">
+                                    <img src="/web/image/website.s_quotes_carousel_demo_image_5" class="s_blockquote_avatar img rounded-circle" alt=""/>
+                                    <div class="s_blockquote_author">
+                                        <span class="o_small">
+                                            <strong>Iris DOE</strong><br/>
+                                            <span class="text-muted">Manager of MyCompany</span>
+                                        </span>
+                                    </div>
+                                </div>
+                            </blockquote>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="o_horizontal_controllers container position-absolute start-50 bottom-0 translate-middle-x w-100 mb-md-4 o_not_editable">
+                <div class="o_horizontal_controllers_row row gap-3 gap-lg-5 justify-content-between flex-nowrap flex-row-reverse mx-0">
+                    <!-- Controls -->
+                    <div class="o_arrows_wrapper gap-2 w-auto p-0">
+                        <button class="carousel-control-prev o_not_editable" contenteditable="false" t-attf-data-bs-target="#myQuoteCarouselCompact{{uniq}}" data-bs-slide="prev" aria-label="Previous" title="Previous">
+                            <span class="carousel-control-prev-icon" aria-hidden="true"/>
+                            <span class="visually-hidden">Previous</span>
+                        </button>
+                        <button class="carousel-control-next o_not_editable" contenteditable="false" t-attf-data-bs-target="#myQuoteCarouselCompact{{uniq}}" data-bs-slide="next" aria-label="Next" title="Next">
+                            <span class="carousel-control-next-icon" aria-hidden="true"/>
+                            <span class="visually-hidden">Next</span>
+                        </button>
+                    </div>
+                    <!-- Indicators -->
+                    <div class="s_carousel_indicators_numbers carousel-indicators align-items-center flex-shrink-1 w-auto">
+                        <button type="button" t-attf-data-bs-target="#myQuoteCarouselCompact{{uniq}}" data-bs-slide-to="0" class="active" aria-label="Carousel indicator"/>
+                        <button type="button" t-attf-data-bs-target="#myQuoteCarouselCompact{{uniq}}" data-bs-slide-to="1" aria-label="Carousel indicator"/>
+                        <button type="button" t-attf-data-bs-target="#myQuoteCarouselCompact{{uniq}}" data-bs-slide-to="2" aria-label="Carousel indicator"/>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -340,6 +340,9 @@
                 <t t-snippet="website.s_quotes_carousel_minimal" string="Quotes Minimal" group="people" label="Carousel">
                     <keywords>cite, testimonials, endorsements, reviews, feedback, statements, references, sayings, comments, appreciations, citations, carousel</keywords>
                 </t>
+                <t t-snippet="website.s_quotes_carousel_compact" string="Quotes Compact" group="people" label="Carousel">
+                    <keywords>cite, testimonials, endorsements, reviews, feedback, statements, references, sayings, comments, appreciations, citations, carousel</keywords>
+                </t>
 
                 <!-- Text group -->
                 <t t-snippet="website.s_title" string="Title" group="text">
@@ -656,7 +659,7 @@
 <template id="snippet_options_carousel">
     <div data-js="Carousel"
          data-selector="section"
-         data-exclude=".s_carousel_intro_wrapper, .s_carousel_cards_wrapper"
+         data-exclude=".s_carousel_intro_wrapper, .s_carousel_cards_wrapper, .s_quotes_carousel_wrapper"
          data-target="> .carousel">
         <we-row string="Slide">
             <we-button data-add-slide="true" data-no-preview="true" class="o_we_bg_brand_primary">Add Slide</we-button>
@@ -691,7 +694,7 @@
 
 <template id="snippet_options_carousel_bottom_controllers" inherit_id="website.snippet_options_carousel" primary="True">
     <xpath expr="//div" position="attributes">
-        <attribute name="data-target">.s_carousel_intro</attribute>
+        <attribute name="data-target">.s_carousel_intro, .s_quotes_carousel_compact</attribute>
         <attribute name="data-exclude"/>
         <attribute name="data-js">Carousel</attribute>
     </xpath>


### PR DESCRIPTION
### Add toggle to hide author in `s_blockquote`
This PR adds a toggle in the Web Editor to allow the user to hide the author in the `s_blockquote` snippet.

### Introduce `s_quotes_carousel_compact` snippet
This PR adds the new `s_quotes_carousel_compact` snippet.

task-4174008
Part of task-4077427

---
Requires:
- https://github.com/odoo/design-themes/pull/993

---
<img width="1502" alt="Capture d’écran 2024-10-22 à 10 06 18" src="https://github.com/user-attachments/assets/333b881c-0a20-49a6-8ebb-a2589fe1fc56">



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
