### PR TITLE
[FIX] website: discuss bubbles reposition while editing

### DIFF
--- a/addons/website/static/src/components/editor/editor.js
+++ b/addons/website/static/src/components/editor/editor.js
@@ -77,7 +77,8 @@ export class WebsiteEditorComponent extends Component {
             this.state.reloading = false;
         }
         this.websiteService.unblockPreview();
-        document.body.classList.add("o_website_navbar_transition_hide");
+        // setTimeout ensure transition on Firefox
+        setTimeout(() => document.body.classList.add("o_website_navbar_transition_hide"));
         setTimeout(() => document.body.classList.add("o_website_navbar_hide"), 400);
     }
     /**

--- a/addons/website/static/src/components/editor/editor.scss
+++ b/addons/website/static/src/components/editor/editor.scss
@@ -175,3 +175,11 @@
         cursor: default;
     }
 }
+
+.o-mail-ChatHub-bubbles {
+    transition: transform 400ms ease 0s;
+    
+    .o_website_navbar_transition_hide & {
+        transform: translateX(-$o-we-sidebar-width);
+    }
+}


### PR DESCRIPTION
Before this commit, discuss bubbles would appear on top of the editor when editing a website. I was therefore be difficult to select some snippets, especially when the user had a lot of conversations at the same time and he wanted to keep the discuss bubbles visible.

This commit shift the discuss bubbles on edit to solve the issue.

task-4266898