### PR TITLE
[FIX] spreadsheet: append (copy) when duplicating

### DIFF
--- a/addons/spreadsheet/static/src/list/plugins/list_core_plugin.js
+++ b/addons/spreadsheet/static/src/list/plugins/list_core_plugin.js
@@ -117,8 +117,10 @@ export class ListCorePlugin extends OdooCorePlugin {
                 break;
             }
             case "DUPLICATE_ODOO_LIST": {
-                const { listId, newListId } = cmd;
-                this._addList(newListId, deepCopy(this.lists[listId].definition));
+                const { listId, newListId, duplicatedListName } = cmd;
+                const duplicatedList = deepCopy(this.lists[listId].definition);
+                duplicatedList.name = duplicatedListName ?? duplicatedList.name + " (copy)";
+                this._addList(newListId, duplicatedList);
                 this.history.update("nextId", parseInt(newListId, 10) + 1);
                 break;
             }

--- a/addons/spreadsheet/static/tests/lists/list_plugin.test.js
+++ b/addons/spreadsheet/static/tests/lists/list_plugin.test.js
@@ -37,7 +37,6 @@ const { DEFAULT_LOCALE, PIVOT_TABLE_CONFIG } = spreadsheet.constants;
 const { toZone } = spreadsheet.helpers;
 const { cellMenuRegistry } = spreadsheet.registries;
 
-
 describe.current.tags("headless");
 defineSpreadsheetModels();
 defineSpreadsheetActions();
@@ -635,7 +634,7 @@ test("Can see record on vectorized list index", async function () {
     model.dispatch("CREATE_SHEET", { sheetId: "42" });
     model.dispatch("ACTIVATE_SHEET", {
         sheetIdFrom: model.getters.getActiveSheetId(),
-        sheetIdTo: "42"
+        sheetIdTo: "42",
     });
     setCellContent(model, "C1", "1");
     setCellContent(model, "C2", "2");
@@ -972,9 +971,11 @@ test("Can duplicate a list", async () => {
     const listIds = model.getters.getListIds();
     expect(model.getters.getListIds().length).toBe(2);
 
+    const originalListDefinition = model.getters.getListDefinition(listId);
     const expectedDuplicatedDefinition = {
-        ...model.getters.getListDefinition(listId),
+        ...originalListDefinition,
         id: "2",
+        name: `${originalListDefinition.name} (copy)`,
     };
     expect(model.getters.getListDefinition(listIds[1])).toEqual(expectedDuplicatedDefinition);
 


### PR DESCRIPTION
## Description

This commit appends "(copy)" to the name when a
list or pivot is duplicated.

Task: 4269121




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
