### PR TITLE
[FIX] pos_preparation_display: prevent splited order display

### DIFF
--- a/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
+++ b/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
@@ -71,6 +71,7 @@ export class SplitBillScreen extends Component {
                         ...line.serialize(),
                         qty: this.qtyTracker[line.uuid],
                         order_id: newOrder.id,
+                        skip_change: true,
                     },
                     false,
                     true


### PR DESCRIPTION
Prior to this commit, splitting an order would create a new order, causing it to appear again on the preparation display. This could lead to the kitchen preparing the same order twice. The sequence of events was as follows:

1. The order is placed.
2. The kitchen receives and prepares the order.
3. The waiter delivers the order to the table.
4. The client receives the bill and requests a split.

At the point of splitting, a new order is created. This duplicate order should not be sent to the kitchen as it represents a meal that has already been prepared and consumed. This commit resolves this issue by preventing display of duplicate orders to the kitchen during order splitting.

opw-4247067

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
