### PR TITLE
[FIX] purchase: fill incorterm fields outsite the view

### DIFF
--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -864,13 +864,12 @@ class TestPurchase(AccountTestInvoicingCommon):
         po_1.origin = "s0003"
         po_1.user_id = user_1
         po_1.payment_term_id = payment_term_id_1
-        po_1.incoterm_id = incoterm_id_1
-        po_1.incoterm_location = "my hub"
         with po_1.order_line.new() as po_line:
             po_line.product_id = self.product_a
             po_line.product_qty = 1
             po_line.price_unit = 100
         po_1 = po_1.save()
+        po_1.incoterm_id = incoterm_id_1
 
         po_2 = Form(PurchaseOrder)
         po_2.partner_id = self.partner_a
@@ -878,8 +877,6 @@ class TestPurchase(AccountTestInvoicingCommon):
         po_2.origin = "s0004"
         po_2.user_id = user_2
         po_2.payment_term_id = payment_term_id_2
-        po_2.incoterm_id = incoterm_id_2
-        po_2.incoterm_location = "my warehouse"
 
         with po_2.order_line.new() as po_line_1:
             po_line_1.product_id = self.product_a
@@ -890,6 +887,7 @@ class TestPurchase(AccountTestInvoicingCommon):
             po_line_2.product_qty = 5
             po_line_2.price_unit = 500
         po_2 = po_2.save()
+        po_2.incoterm_id = incoterm_id_2
 
         with self.assertRaises(UserError) as context:
             PurchaseOrder.browse([po_1.id]).action_merge()
@@ -904,4 +902,3 @@ class TestPurchase(AccountTestInvoicingCommon):
         self.assertEqual(po_1.user_id, user_1)
         self.assertEqual(po_1.payment_term_id, payment_term_id_1)
         self.assertEqual(po_1.incoterm_id, incoterm_id_1)
-        self.assertEqual(po_1.incoterm_location, "my hub")


### PR DESCRIPTION
The incorterm_id fields is defined in `purchase` but visible in the form view in `purchase_stock` module. In order to use it in test. We fill them outside the `Form` wrapper. `incorterm_location` is defined in `purchase_stock` thus is removed.

runbot: 75128

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
