### PR TITLE
[IMP] base: improve partner kanban

### DIFF
--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -225,7 +225,8 @@
                                                 <field name="avatar_128" class="o_kanban_image_fill w-100" widget="image" options="{'img_class': 'object-fit-cover'}" alt="Contact image"/>
                                             </aside>
                                             <main class="ps-2 ps-md-0">
-                                                <field name="name" class="fw-bold"/>
+                                                <field name="name" invisible="not name" class="fw-bold"/>
+                                                <field name="type" invisible="name" class="fw-bold"/>
                                                 <field name="function"/>
                                                 <field name="email" widget="email"/>
                                                 <div t-if="record.type.raw_value != 'contact'">
@@ -407,7 +408,8 @@
                                 <t t-if="!record.is_company.raw_value">
                                     <div class="o_kanban_image_fill position-relative w-100">
                                         <field name="avatar_128" alt="Contact image" class="h-100" widget="image" options="{'img_class': 'object-fit-cover'}"/>
-                                        <field t-if="record.parent_id.raw_value" name="parent_id" class="position-absolute bottom-0 end-0 w-25 bg-light" widget="image" options="{'preview_image': 'image_128', 'img_class': 'object-fit-contain'}"/>
+                                        <field t-if="record.parent_id.raw_value and record.parent_id.image_128" name="parent_id" class="position-absolute bottom-0 end-0 w-25 bg-light" widget="image" options="{'preview_image': 'image_128', 'img_class': 'object-fit-contain'}"/>
+                                        <field t-elif="record.parent_id.raw_value and !record.parent_id.image_128" name="parent_id" class="position-absolute bottom-0 end-0 w-25 bg-light" widget="image" options="{'preview_image': 'avatar_128', 'img_class': 'object-fit-contain'}"/>
                                     </div>
                                 </t>
                                 <t t-else="">


### PR DESCRIPTION
In the partner form, making sure that a child contact always have a name to display.
If an explicit name wasn't specified, using the type. Not using the display name to
prevent any wording repetitions.

In the partner main kanban, if the contact is the child of a company without logo,
do not display the camera picture but display the building icon as done in the card
of that company.

Task-4276450

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
