### PR TITLE
[FIX] pos_restaurant: hide Bill when early printing is not enabled

### DIFF
--- a/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.xml
+++ b/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.xml
@@ -4,11 +4,13 @@
         <xpath expr="//OrderlineNoteButton" position="after">
             <t t-if="pos.config.module_pos_restaurant">
                 <!-- All buttons always displayed -->
-                <button t-att-class="buttonClass"
-                    t-att-disabled="!pos.get_order()?.get_orderlines()?.length"
-                    t-on-click="clickPrintBill">
-                    <i class="fa fa-print me-1"></i>Bill
-                </button>
+                <t t-if="pos.config.iface_printbill">
+                    <button t-att-class="buttonClass"
+                        t-att-disabled="!pos.get_order()?.get_orderlines()?.length"
+                        t-on-click="clickPrintBill">
+                        <i class="fa fa-print me-1"></i>Bill
+                    </button>
+                </t>
                 <button t-att-class="buttonClass" t-on-click="clickTableGuests">
                     <span t-esc="currentOrder?.getCustomerCount() || 0" class="px-2 py-1 rounded-circle text-bg-dark fw-bolder small me-1"/>
                     <span>Guests</span>


### PR DESCRIPTION
This commit fixes an issue where the Bill button was displayed even when early receipt printing was not enabled in the POS configuration.

opw-4274728

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
