### PR TITLE
[FIX] website: autocomplete of searchbar not working in navbar due to cache

### DIFF
--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2899,7 +2899,7 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
     the same parameters (eg. header desktop + header mobile)
 -->
 <template id="header_search_box_input" name="Header Search Box Input">
-    <t t-call="website.website_search_box_input">
+    <t t-call="website.website_search_box_input"  t-nocache="True">
         <t t-set="search_type" t-valuef="all"/>
         <t t-set="action" t-valuef="/website/search"/>
         <t t-set="limit" t-value="limit or '5'"/>


### PR DESCRIPTION
### Before this PR
The autocomplete of the searchbar in the navbar is not working. Just try on runbot to write something, no results. If you press enter there are results

### After this PR
The autocomplete works


### Explanation
The view website_search_box_input is pre-cached empty without the t-set of website.header_search_box_input so the search_type is not set . With no-cache we force to render it without accessing the cache so every t-set is working





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
