### PR TITLE
[FIX] sale, website_sale: adapt combo configurator on mobile

### DIFF
--- a/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.scss
+++ b/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.scss
@@ -1,3 +1,9 @@
 .combo-item-grid {
     grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
 }
+
+@include media-breakpoint-down(md) {
+    .sale-combo-configurator-dialog .css_quantity .form-control {
+        max-width: inherit;
+    }
+}

--- a/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.xml
+++ b/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.xml
@@ -11,7 +11,7 @@
                     class="d-inline-block mt-4 mb-3 h4"
                     t-out="combo.name"
                 />
-                <div class="combo-item-grid d-grid gap-4">
+                <div class="combo-item-grid d-flex d-md-grid gap-4 pb-2 pb-md-0 overflow-x-auto">
                     <t t-foreach="combo.combo_items" t-as="comboItem" t-key="comboItem.id">
                         <ProductCard
                             product="getSelectedOrProvidedComboItem(combo.id, comboItem).product"
@@ -40,12 +40,13 @@
                 </button>
                 <!-- This div acts as a spacer to left-align the elements before it and right-align
                 the elements after it. -->
-                <div style="flex: 1"/>
-                <div class="mx-2">
+                <div style="flex: 1" class="d-none d-md-block"/>
+                <div class="w-100 w-md-auto mx-0 mx-md-2">
                     <QuantityButtons
                         quantity="state.quantity"
                         setQuantity="quantity => this.setQuantity(quantity)"
                         isMinusButtonDisabled="state.quantity === 1"
+                        btnClasses="'d-inline-block w-auto'"
                     />
                 </div>
                 <div class="d-flex flex-column justify-content-center">

--- a/addons/sale/static/src/js/product_card/product_card.xml
+++ b/addons/sale/static/src/js/product_card/product_card.xml
@@ -3,7 +3,7 @@
     <t t-name="sale.ProductCard">
         <article
             tabindex="0"
-            t-attf-class="product-card card rounded cursor-pointer {{props.isSelected ? 'selected' : ''}}"
+            t-attf-class="product-card card flex-shrink-0 w-md-auto w-75 rounded cursor-pointer {{props.isSelected ? 'selected' : ''}}"
             t-on-keypress="(event) => event.code === 'Space' ? props.onClick() : () => {}"
             t-on-click="props.onClick"
         >

--- a/addons/sale/static/src/js/quantity_buttons/quantity_buttons.js
+++ b/addons/sale/static/src/js/quantity_buttons/quantity_buttons.js
@@ -9,6 +9,7 @@ export class QuantityButtons extends Component {
         setQuantity: Function,
         isMinusButtonDisabled: { type: Boolean, optional: true },
         isPlusButtonDisabled: { type: Boolean, optional: true },
+        btnClasses: { type: String, optional: true },
     };
 
     /**

--- a/addons/sale/static/src/js/quantity_buttons/quantity_buttons.xml
+++ b/addons/sale/static/src/js/quantity_buttons/quantity_buttons.xml
@@ -3,7 +3,7 @@
     <t t-name="sale.QuantityButtons">
         <div name="quantity_buttons_wrapper" class="input-group justify-content-center">
             <button
-                class="btn btn-secondary d-none d-md-inline-block"
+                t-attf-class="btn btn-secondary {{ props.btnClasses or 'd-none d-md-inline-block' }}"
                 name="sale_quantity_button_minus"
                 aria-label="Remove one"
                 t-att-disabled="props.isMinusButtonDisabled"
@@ -17,7 +17,7 @@
                 t-att-value="props.quantity"
                 t-on-change="setQuantity"/>
             <button
-                class="btn btn-secondary d-none d-md-inline-block"
+                t-attf-class="btn btn-secondary {{ props.btnClasses or 'd-none d-md-inline-block' }}"
                 name="sale_quantity_button_plus"
                 aria-label="Add one"
                 t-att-disabled="props.isPlusButtonDisabled"

--- a/addons/website_sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.xml
+++ b/addons/website_sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.xml
@@ -15,7 +15,7 @@
         </button>
         <button name="sale_combo_configurator_confirm_button" position="after">
             <button
-                class="btn btn-secondary"
+                class="btn btn-secondary flex-grow-1 flex-md-grow-0"
                 t-if="this.props.isFrontend"
                 t-on-click="() => this.confirm({goToCart: false})"
                 t-att-disabled="!areAllCombosSelected"
@@ -25,7 +25,7 @@
         </button>
         <button name="sale_combo_configurator_cancel_button" position="after">
             <button
-                class="btn btn-primary"
+                class="btn btn-primary flex-grow-1 flex-md-grow-0"
                 t-if="this.props.isFrontend"
                 t-on-click="() => this.confirm({goToCart: true})"
                 t-att-disabled="!areAllCombosSelected"

--- a/addons/website_sale/static/src/js/quantity_buttons/quantity_buttons.xml
+++ b/addons/website_sale/static/src/js/quantity_buttons/quantity_buttons.xml
@@ -5,10 +5,10 @@
             <attribute name="class" add="css_quantity" separator=" "/>
         </div>
         <button name="sale_quantity_button_minus" position="attributes">
-            <attribute name="class" remove="btn-secondary" add="btn-light" separator=" "/>
+            <attribute name="t-attf-class" remove="btn-secondary" add="btn-light" separator=" "/>
         </button>
         <button name="sale_quantity_button_plus" position="attributes">
-            <attribute name="class" remove="btn-secondary" add="btn-light" separator=" "/>
+            <attribute name="t-attf-class" remove="btn-secondary" add="btn-light" separator=" "/>
         </button>
     </t>
 </templates>


### PR DESCRIPTION
This commit fix usability issues related to the layout of the combo configurator on mobile.

task-4243795

| Before | After |
|--------|--------|
| <img width="507" alt="Capture d’écran 2024-10-22 à 13 28 53" src="https://github.com/user-attachments/assets/cac3aa9b-165e-49e6-98e3-3dd1eb2d8d9b"> | <img width="489" alt="Capture d’écran 2024-10-22 à 13 30 14" src="https://github.com/user-attachments/assets/fc0da502-291f-4154-af5e-df1e74c8c61f"> |




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
