### PR TITLE
[FIX] payment_ogone: retry tx in redirect flow on 3DS auth request

### DIFF
--- a/addons/payment_ogone/__manifest__.py
+++ b/addons/payment_ogone/__manifest__.py
@@ -14,6 +14,11 @@
 
         'data/payment_provider_data.xml',
     ],
+    'assets': {
+        'web.assets_frontend': [
+            'payment_ogone/static/src/js/payment_form.js',
+        ],
+    },
     'pre_init_hook': 'pre_init_hook',
     'post_init_hook': 'post_init_hook',
     'uninstall_hook': 'uninstall_hook',

--- a/addons/payment_ogone/const.py
+++ b/addons/payment_ogone/const.py
@@ -77,6 +77,11 @@ PAYMENT_STATUS_MAPPING = {
     'declined': (2,),
 }
 
+# See https://epayments-support.ingenico.com/en/get-started/transaction-management/transaction-error-codes
+PAYMENT_ERROR_TYPES_MAPPING = {
+    40001139: '3ds-authentication-required',
+}
+
 # The codes of the payment methods to activate when Ogone is activated.
 DEFAULT_PAYMENT_METHOD_CODES = {
     # Primary payment methods.

--- a/addons/payment_ogone/i18n/payment_ogone.pot
+++ b/addons/payment_ogone/i18n/payment_ogone.pot
@@ -37,6 +37,12 @@ msgid "Could not establish the connection to the API."
 msgstr ""
 
 #. module: payment_ogone
+#. odoo-python
+#: code:addons/payment_ogone/models/payment_transaction.py:0
+msgid "Error code: %s"
+msgstr ""
+
+#. module: payment_ogone
 #: model:ir.model.fields,field_description:payment_ogone.field_payment_provider__ogone_hash_function
 msgid "Hash function"
 msgstr ""
@@ -143,6 +149,12 @@ msgstr ""
 msgid ""
 "This provider is deprecated.\n"
 "                    Consider disabling it and moving to <strong>Stripe</strong>."
+msgstr ""
+
+#. module: payment_ogone
+#. odoo-python
+#: code:addons/payment_ogone/models/payment_transaction.py:0
+msgid "Unknown reason"
 msgstr ""
 
 #. module: payment_ogone

--- a/addons/payment_ogone/static/src/js/payment_form.js
+++ b/addons/payment_ogone/static/src/js/payment_form.js
@@ -1,0 +1,22 @@
+import PaymentForm from '@payment/js/payment_form';
+
+PaymentForm.include({
+    /**
+     * Allow forcing redirect to 3-D Secure authentication for Ogone token flow.
+     *
+     * @override method from @payment/js/payment_form
+     * @private
+     * @param {string} providerCode - The code of the selected payment option's provider.
+     * @param {number} paymentOptionId - The id of the selected payment option.
+     * @param {string} paymentMethodCode - The code of the selected payment method, if any.
+     * @param {object} processingValues - The processing values of the transaction.
+     * @return {void}
+     */
+    _processTokenFlow(providerCode, paymentOptionId, paymentMethodCode, processingValues) {
+        if (providerCode === 'ogone' && processingValues.force_flow === 'redirect') {
+            this._processRedirectFlow(...arguments);
+        } else {
+            this._super(...arguments);
+        }
+    }
+});


### PR DESCRIPTION
Versions
--------
- saas-17.4+

Steps
-----
Try to pay with saved payment method.

Issue
-----
> The payment has been declined: Authentication required.
> The financial institution insists on 3-D Secure.

Cause
-----
Bank may insist on 3-D Secure authentication, failing the payment transaction, which isn't handled in the `payment_token` flow.

Solution
--------
If 3-D Secure authentication is requested, reset transaction to draft, and attempt redirect flow.

> [!Note]
> Doesn't work for automated payments (subscriptions).

opw-4223022