### PR TITLE
[FIX] pos_razorpay: traceback occurs while payment using razorpay terminal

### DIFF
--- a/addons/pos_razorpay/static/src/app/payment_razorpay.js
+++ b/addons/pos_razorpay/static/src/app/payment_razorpay.js
@@ -94,7 +94,7 @@ export class PaymentRazorpay extends PaymentInterface {
             return Promise.resolve();
         }
 
-        const orderId = order.name.replace(" ", "").replaceAll("-", "").toUpperCase();
+        const orderId = order.pos_reference.replace(" ", "").replaceAll("-", "").toUpperCase();
         const referencePrefix = this.pos.config.name.replace(/\s/g, "").slice(0, 4);
         localStorage.setItem(
             "referenceId",


### PR DESCRIPTION
Before this commit:
==========
- After the changes made in the [PR](https://github.com/odoo/odoo/pull/183085), we assign the value of `order.name` after the order is processed in the backend. As a result, when we try to pass `referenceId` for Razorpay terminal payment, `order.name` is undefined, leading to an error when using the `replace` method on an undefined value.

After this commit:
==========
- We are using the `pos_reference` from the order to generate the `referenceId` for passing to Razorpay terminal payment.

task-4276739