### PR TITLE
[FIX] sale: prevent warning on quotation template

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -716,6 +716,12 @@ class SaleOrder(models.Model):
 
     #=== ONCHANGE METHODS ===#
 
+    def onchange(self, values, field_names, fields_spec):
+        self_with_context = self
+        if not field_names: # Some warnings should not be displayed for the first onchange
+            self_with_context = self.with_context(sale_onchange_first_call=True)
+        return super(SaleOrder, self_with_context).onchange(values, field_names, fields_spec)
+
     @api.onchange('commitment_date', 'expected_date')
     def _onchange_commitment_date(self):
         """ Warn if the commitment dates is sooner than the expected date """
@@ -731,6 +737,8 @@ class SaleOrder(models.Model):
     @api.onchange('company_id')
     def _onchange_company_id_warning(self):
         self.show_update_pricelist = True
+        if self.env.context.get('sale_onchange_first_call'):
+            return
         if self.order_line and self.state == 'draft':
             return {
                 'warning': {

--- a/addons/sale_management/tests/test_sale_order.py
+++ b/addons/sale_management/tests/test_sale_order.py
@@ -431,3 +431,20 @@ class TestSaleOrder(SaleManagementCommon):
             names_NL,
             "Lines shouldn't change once saved",
         )
+
+    def test_warning_quotation(self):
+        """
+        ensure "warning for the change of your quotation's company" isn't triggered
+        during the creation of a quotation when a quotation template is set as default
+        """
+        quotation_template = self.empty_order_template
+        quotation_template.sale_order_template_line_ids = [
+            Command.create({'product_id': self.product.id})
+        ]
+        self.env['ir.default'].set('sale.order', 'sale_order_template_id', quotation_template.id)
+        try:
+            with self.assertLogs('odoo.tests.form.onchange') as log_catcher:
+                Form(self.env['sale.order'])
+        except AssertionError:
+            pass
+        self.assertEqual(len(log_catcher.output), 0, "Form creation shouldn't trigger a warning")


### PR DESCRIPTION
**Issue:**

A warning popup appears incorrectly when a user-defined default is set for the "Quotation Template (Sales Order)" field. This warning is only relevant when the company is changed while creating a quotation.

**Steps to reproduce the issue:**

1- Navigate to Settings > Technical > Actions > User-defined Defaults.
2- Create a new User-defined Default for the field "Quotation Template (Sales Order)" with a default value (in JSON format) of 1 .
3- Go to the Sales module.
4- Create a new quotation.

A warning with the title "Warning for the change of your quotation's company" is displayed (see screenshot attached), despite the company not being changed.
The onchange('company_id') method is triggered by the user-defined default for the quotation template.

<img src="https://github.com/user-attachments/assets/5f046310-05b7-48ab-9781-1ba4a36f2beb" width=400 />


opw-4244961

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
