### PR TITLE
[IMP] web_editor,website: improve functionality of contains/not-contains

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -1329,6 +1329,15 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
                     || dependencyEl.nodeName === 'TEXTAREA') && !['set', '!set'].includes(this.$target[0].dataset.visibilityComparator);
             case 'hidden_condition_no_text_opt':
                 return dependencyEl && (dependencyEl.type === 'checkbox' || dependencyEl.type === 'radio' || dependencyEl.nodeName === 'SELECT');
+            case 'hidden_condition_no_text_select_opt':
+                return dependencyEl && (dependencyEl.type === 'checkbox'
+                    || dependencyEl.type === 'radio' || dependencyEl.nodeName === 'SELECT')
+                    && ['selected',
+                    '!selected'].includes(this.$target[0].dataset.visibilityComparator);
+            case 'hidden_condition_no_text_list_opt':
+                return dependencyEl && (dependencyEl.type === 'checkbox'
+                    || dependencyEl.type === 'radio' || dependencyEl.nodeName === 'SELECT')
+                    && ['contains', '!contains'].includes(this.$target[0].dataset.visibilityComparator);
             case 'hidden_condition_num_opt':
                 return dependencyEl && dependencyEl.type === 'number';
             case 'hidden_condition_text_opt':
@@ -1487,10 +1496,10 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
                 const selectOptName =
                     fieldType === "record"
                         ? "hidden_condition_record_opt"
-                        : "hidden_condition_no_text_opt";
-                const selectOptEl = uiFragment.querySelectorAll(
-                    `we-select[data-name="${selectOptName}"]`,
-                )[1];
+                        : "hidden_condition_no_text_select_opt";
+                let selectOptEl = uiFragment.querySelectorAll(
+                    `we-select[data-name="${selectOptName}"]`);
+                selectOptEl = selectOptEl[selectOptEl.length - 1];
                 const inputContainerEl = this.$target[0];
                 const dependencyEl = this._getDependencyEl();
                 if (dependencyEl.nodeName === 'SELECT') {

--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -296,9 +296,18 @@
                     <we-button data-select-data-attribute="!selected">Is not equal to</we-button>
                 </we-select>
             </we-row>
-            <we-select class="o_we_large" data-name="hidden_condition_no_text_opt" data-attribute-name="visibilityCondition" data-no-preview="true">
+            <we-select class="o_we_large"
+                       data-name="hidden_condition_no_text_select_opt"
+                       data-attribute-name="visibilityCondition"
+                       data-no-preview="true">
                 <!-- checkbox, select, radio possible values -->
             </we-select>
+            <we-list-options class="o_we_large"
+                     data-name="hidden_condition_no_text_list_opt"
+                     data-attribute-name="visibilityCondition"
+                     data-no-preview="true">
+                <!-- checkbox, select, radio possible values -->
+            </we-list-options>
             <we-select class="o_we_large" data-name="hidden_condition_record_opt" data-attribute-name="visibilityCondition" data-no-preview="true">
                 <!-- checkbox, select, radio possible values -->
             </we-select>


### PR DESCRIPTION
Steps to Reproduce :
1. Go to website --> Edit Mode
2. Drag and Drop a Contact Us form --> Change the form Action to "
Create an Opportunity"
3. Now add two new fields one is selection field : Sales Person and the
other is a text field
4. Now if the user wants that the said text field should only be visible
if the user selects say 'Mitchell Admin' and 'Marc Demo'
5. This is not currently possible

Specification:
Currently, User cannot choose more than one value for the visibility
condition when the visibility comparator is selected to 'Contains/
Doesn't contains' and the functionality of 'Contains/Doesn't contain'
is similar to 'Is equal to/Is not equal to'.
This commit adds the feature to select more than one value from the list
when the visibility comparator is selected to 'Contains/Doesn't
contains' and the type of dependency field should be either 'select' or
'checkbox' or 'radio'.

task-4203938

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
