### PR TITLE
[FIX] web: remove invisible fields from default export fields

### DIFF
--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -439,6 +439,7 @@ export class ListController extends Component {
             this.props.archInfo.columns
                 .filter((col) => col.type === "field")
                 .filter((col) => !col.optional || this.optionalActiveFields[col.name])
+                .filter((col) => !evaluateBooleanExpr(col.column_invisible, this.props.context))
                 .map((col) => this.props.fields[col.name])
                 .filter((field) => field.exportable !== false)
         );

--- a/addons/web/static/tests/views/view_dialogs/export_data_dialog_tests.js
+++ b/addons/web/static/tests/views/view_dialogs/export_data_dialog_tests.js
@@ -1094,6 +1094,40 @@ QUnit.module("ViewDialogs", (hooks) => {
         );
     });
 
+    QUnit.test("Export dialog: no column_invisible fields in default export list", async function (assert) {
+        await makeView({
+            serverData,
+            type: "list",
+            resModel: "partner",
+            arch: `
+                <tree>
+                    <field name="foo"/>
+                    <field name="bar" column_invisible="1"/>
+                </tree>`,
+            actionMenus: {},
+            mockRPC(route) {
+                if (route === "/web/export/formats") {
+                    return Promise.resolve([{ tag: "csv", label: "CSV" }]);
+                }
+                if (route === "/web/export/get_fields") {
+                    return Promise.resolve(fetchedFields.root);
+                }
+            }
+        });
+
+        await openExportDataDialog();
+        assert.containsOnce(
+            target,
+            ".modal .o_export_field",
+            "there is only one field in export field list."
+        );
+        assert.strictEqual(
+            target.querySelector(".modal .o_export_field").textContent,
+            "Foo",
+            "the field to export corresponds to the visible one in the list view"
+        );
+    });
+
     QUnit.test(
         "Export dialog: export list contains field with 'default_export: true'",
         async function (assert) {


### PR DESCRIPTION
Currently, the invisible fields are considered in the export default
fields.
It doesn't make sense from a user perspective as those are generally
technical fields used for computation.
This wasn't the case prior to v17.

The fix is to filter the invisible fields.

task-4277023