### PR TITLE
[FIX] website: keep Images Wall columns content on option change

### DIFF
--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -122,6 +122,10 @@ const wSnippetMenu = weSnippetEditor.SnippetsMenu.extend({
         // grid padding option so it is not applied on inner rows.
         const $gridPaddingOptions = $html.find('[data-css-property="--grid-item-padding-y"], [data-css-property="--grid-item-padding-x"]');
         $gridPaddingOptions.attr("data-apply-to", ".row.o_grid_mode");
+        // Prevents preview because changing the mode remove custo (e.g. columns
+        // size, inner content, etc.)
+        // TODO: Remove in master, add "data-no-preview" in the XML.
+        $html.find('[data-mode="grid"]')[0].closest("we-select").dataset.noPreview = true;
     },
     /**
      * Depending of the demand, reconfigure they gmap key or configure it

--- a/addons/website/static/src/snippets/s_image_gallery/options.js
+++ b/addons/website/static/src/snippets/s_image_gallery/options.js
@@ -173,16 +173,16 @@ options.registry.gallery = options.Class.extend({
      * Displays the images with the "grid" layout.
      */
     grid: function () {
-        const imgs = this._getImgHolderEls();
+        const columnsContent = this._getColumnsContent();
         var $row = $('<div/>', {class: 'row s_nb_column_fixed'});
         var columns = this._getColumns();
         var colClass = 'col-lg-' + (12 / columns);
         var $container = this._replaceContent($row);
 
-        _.each(imgs, function (img, index) {
-            const $img = $(img.cloneNode(true));
+        _.each(columnsContent, function (columnContent, index) {
             var $col = $('<div/>', {class: colClass});
-            $col.append($img).appendTo($row);
+            $col[0].innerHTML = columnContent;
+            $col.appendTo($row);
             if ((index + 1) % columns === 0) {
                 $row = $('<div/>', {class: 'row s_nb_column_fixed'});
                 $row.appendTo($container);
@@ -283,7 +283,7 @@ options.registry.gallery = options.Class.extend({
     nomode: function () {
         var $row = $('<div/>', {class: 'row s_nb_column_fixed'});
         var imgs = this._getImages();
-        const imgHolderEls = this._getImgHolderEls();
+        const columnsContent = this._getColumnsContent();
 
         this._replaceContent($row);
 
@@ -292,7 +292,7 @@ options.registry.gallery = options.Class.extend({
             if (img.width >= img.height * 2 || img.width > 600) {
                 wrapClass = 'col-lg-6';
             }
-            var $wrap = $('<div/>', {class: wrapClass}).append(imgHolderEls[index]);
+            var $wrap = $('<div/>', {class: wrapClass}).append(columnsContent[index]);
             $row.append($wrap);
         });
     },
@@ -523,6 +523,19 @@ options.registry.gallery = options.Class.extend({
     _getImgHolderEls: function () {
         const imgEls = this._getImages();
         return imgEls.map(imgEl => imgEl.closest("a") || imgEl);
+    },
+    /**
+     * Returns the inner HTML of the parent column for each image.
+     *
+     * @private
+     * @returns {Array.<string>}
+     */
+    _getColumnsContent() {
+        const imgEls = this._getImages();
+        return imgEls.map(imgEl => {
+            const colEl = imgEl.closest("[class^='col-lg-']");
+            return (colEl && colEl.innerHTML) || imgEl.outerHTML;
+        });
     },
     /**
      * Returns the index associated to a given image.


### PR DESCRIPTION
**[FIX] website: keep Images Wall columns content on option change**

Steps to reproduce the issue:

- In Website, edit mode.
- Drag and drop an "Images Wall" snippet onto the "Home" page.
- Select "Grid" for the "Images Wall" mode option.
- Drag and drop a "Badge" into the first column of the "Images Wall".
- Click on the "Add Images" button in "Images Wall" the options.
- Bug: After the new image is added, the "Badge" is removed.

After this commit, the content dropped into "Images Wall" columns is
kept after an option has changed. Note that is not the case if the
option mode is "Masonry", where "Inner snippet" shouldn't be dropped.

opw-4254185

--------------------
**[FIX] website: removes preview mode for Images Wall mode option**

Steps to reproduce the issue:

- In Website, edit mode.
- Drag and drop an "Images Wall" snippet onto the "Home" page.
- Select "Grid" for the "Images Wall" mode option.
- Click on the first column of the snippet and change its size.
- Open the dropdown of the "Mode" option and hover over the items
without clicking on them.
- Click on the page to close the dropdown.
- Bug: The first column has lost its custom size even though another
mode has not been selected.

This commit disables the preview mode for the "Images Wall" mode option.

opw-4254185