### PR TITLE
[IMP] mail: reintroduce format_list on mail.message

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -559,7 +559,7 @@ class MailMessage(models.Model):
             "Records: %(records)s, User: %(user)s",
             type=self._description,
             operation=operation,
-            records=self.ids[:6],
+            records=format_list(self.env, list(map(str, self.ids[:6]))),
             user=self.env.uid,
         ))
 


### PR DESCRIPTION
format_list was remove
https://github.com/odoo/odoo/commit/298c96045ecaff6cdd89cf192d5ed3a7eb931e98#diff-6039bdf622bf5417d796a812415303924107a9c8b37be05731aeaedd10beab21R550

But it's probably an oversight. This PR réintroduce the format_list
