### PR TITLE
[FIX] base: allow cookies when it is required or has a user in env

### DIFF
--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -316,4 +316,4 @@ class IrHttp(models.AbstractModel):
 
     @classmethod
     def _is_allowed_cookie(cls, cookie_type):
-        return True
+        return True if cookie_type == 'required' else bool(request.env.user)


### PR DESCRIPTION
Currently, an exception is generated when the user tries to open the UTM link by following steps.

- Install 'website_links' (for creating a link tracker).
- Go to Link Tracker  >  New  >  Fill all details
- Set the target URL as 'http://localhost:8069/odoo'
- Copy Tracked URL > Open url in incognito mode or new browser

error: `ValueError: Expected singleton: res.users()`

This is because when we open this type of link, the code line [1] tries to set a cookie, and since we have not logged in (not even have a dummy user) at the time of checking, the method `has_group` generate an error from line [2] because `self(user)` is required. 

In the previous version, the `has_group` method did not require self, but after a code refactor with  https://github.com/odoo/odoo/commit/cb31d4352c741a5f8a927a65debb8e027e87df22#diff-16e37db365c1ea1f2e6c79aeb60c80f68f1a5c75970e8e3f198eb18af56278ddL1037-L1043, it needed a record in self.

This commit will fix the above issue by allowing cookie when its type is
required or the request environment has user.

[1]- https://github.com/odoo/odoo/blob/871d20d8ffb00737fe8192223385cdad69fe12e1/addons/utm/models/ir_http.py#L21 [2]- https://github.com/odoo/odoo/blob/871d20d8ffb00737fe8192223385cdad69fe12e1/odoo/addons/base/models/res_users.py#L1133

sentry-5281961509

