### PR TITLE
[IMP] l10n_es_website_sale: mandatory fields

### DIFF
--- a/addons/l10n_es_website_sale/__init__.py
+++ b/addons/l10n_es_website_sale/__init__.py
@@ -1,0 +1,1 @@
+from . import controllers

--- a/addons/l10n_es_website_sale/__manifest__.py
+++ b/addons/l10n_es_website_sale/__manifest__.py
@@ -1,0 +1,14 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'Spanish Website',
+    'version': '1.0',
+    'category': 'Accounting/Localizations/Website',
+    'description': "E-commerce localization for Spain.",
+    'depends': [
+        'website_sale',
+        'l10n_es',
+    ],
+    'installable': True,
+    'auto_install': True,
+    'license': 'LGPL-3',
+}

--- a/addons/l10n_es_website_sale/controllers/__init__.py
+++ b/addons/l10n_es_website_sale/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/addons/l10n_es_website_sale/controllers/main.py
+++ b/addons/l10n_es_website_sale/controllers/main.py
@@ -1,0 +1,20 @@
+from odoo.addons.website_sale.controllers.main import WebsiteSale
+from odoo.http import request
+
+
+class L10nESWebsiteSale(WebsiteSale):
+
+    def _get_mandatory_address_fields(self, country_sudo):
+        field_names = super()._get_mandatory_address_fields(country_sudo)
+
+        if request.website.sudo().company_id.country_code == country_sudo.code == 'ES':
+            field_names.update(('vat', 'state_id'))
+
+        return field_names
+
+    def _complete_address_values(self, address_values, address_type, use_same, order_sudo):
+        super()._complete_address_values(address_values, address_type, use_same, order_sudo)
+        vat_without_country_code = address_values.get('vat', '')[2:]
+        address_values.update({
+            'is_company': not vat_without_country_code[0].isdigit() and vat_without_country_code[0] not in ('X', 'Y', 'Z'),
+        })


### PR DESCRIPTION
This commit make the fields VAT and region_id mandatory in the website delivery view only for spain company and spain customers.

task-4273920