### PR TITLE
[FIX] purchase: fix tour by providing appropriate class

### DIFF
--- a/addons/purchase/static/src/js/tours/purchase.js
+++ b/addons/purchase/static/src/js/tours/purchase.js
@@ -48,20 +48,19 @@ tour.register('purchase_tour' , {
     content: _t("Let's create your first request for quotation."),
     position: "bottom",
 }, {
-    trigger: ".o_form_editable .o_field_many2one[name='partner_id']",
+    trigger: ".o_form_editable .o_field_res_partner_many2one[name='partner_id']",
     extra_trigger: ".o_purchase_order",
     content: _t("Search a vendor name, or create one on the fly."),
     position: "bottom",
     run: function (actions) {
-        actions.text("Agrolait", this.$anchor.find("input"));
+        actions.text("Azure Interior", this.$anchor.find("input"));
     },
 }, {
-    trigger: ".ui-menu-item > a",
+    trigger: ".ui-menu-item > a:contains('Azure Interior')",
     auto: true,
     in_modal: false,
 }, {
     trigger: ".o_field_x2many_list_row_add > a",
-    extra_trigger: ".o_field_many2one[name='partner_id'] .o_external_button",
     content: _t("Add some products or services to your quotation."),
     position: "bottom",
 }, {
@@ -76,21 +75,16 @@ tour.register('purchase_tour' , {
         var keyDownEvent = jQuery.Event("keydown");
         keyDownEvent.which = 42;
         this.$anchor.trigger(keyDownEvent);
-        var $descriptionElement = $('.o_form_editable textarea[name="name"]');
-        // when description changes, we know the product has been created
-        $descriptionElement.change(function () {
-            $descriptionElement.addClass('product_creation_success');
-        });
     },
 }, {
-    trigger: '.ui-menu.ui-widget .ui-menu-item a:contains("DESK0001")',
+    trigger: "a:contains('DESK0001')",
     auto: true,
 }, {
-    trigger: '.o_form_editable textarea[name="name"].product_creation_success',
+    trigger: "td[name='name'][data-tooltip*='DESK0001']",
     auto: true,
     run: function () {} // wait for product creation
 }, {
-    trigger: ".o_form_editable input[name='product_qty'] ",
+    trigger: "div.o_field_widget[name='product_qty'] input ",
     extra_trigger: ".o_purchase_order",
     content: _t("Indicate the product quantity you want to order."),
     position: "right",
@@ -115,7 +109,10 @@ tour.register('purchase_tour' , {
     position: "left",
     run: 'click',
 }, {
-    trigger: ".o_field_widget [name=price_unit]",
+    content: "Select price",
+    trigger: 'tbody tr.o_data_row .o_list_number[name="price_unit"]',
+}, {
+    trigger: 'tbody tr.o_data_row .o_list_number[name="price_unit"] input',
     extra_trigger: ".o_purchase_order",
     content: _t("Once you get the price from the vendor, you can complete the purchase order with the right price."),
     position: "right",


### PR DESCRIPTION
Before this commit:
===================
- The purchase tour was failing because the tour's JavaScript used
  an incorrect class selector (targeting 'partner_id'), which prevented
  it from locating the intended DOM element. Consequently,
  the sequence of actions was interrupted, causing the tour to break midway.

After this commit:
===================
- The issue has been resolved by updating the tour to use the correct and
  unique class selector. This ensures the tour accurately targets the
  intended element, allowing it to proceed without interruptions.
  As a result, the purchase tour runs successfully and achieves its intended purpose.

TaskId: 4268662