### PR TITLE
[FIX] account: prevent update sanitized_acc_number

### DIFF
--- a/addons/account/tests/test_account_partner.py
+++ b/addons/account/tests/test_account_partner.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import tagged
+from odoo.exceptions import UserError
 from freezegun import freeze_time
 
 
@@ -27,3 +28,26 @@ class TestAccountPartner(AccountTestInvoicingCommon):
         self.init_invoice("out_invoice", partner, "2023-05-15", amounts=[1500], taxes=self.tax_sale_a, post=True)
         self.env.invalidate_all()
         self.assertEqual(partner.days_sales_outstanding, 50)
+
+    def test_res_partner_bank(self):
+        partner = self.env['res.partner'].create({'name': 'MyCustomer'})
+        account = self.env['res.partner.bank'].create({
+            'acc_number': '123456789',
+            'partner_id': partner.id,
+        })
+        account.env.user.groups_id |= self.env.ref('account.group_validate_bank_account')
+        account.allow_out_payment = True
+
+        with self.assertRaisesRegex(UserError, "has been trusted"), self.cr.savepoint():
+            account.write({'acc_number': '1234567890999'})
+        with self.assertRaisesRegex(UserError, "has been trusted"), self.cr.savepoint():
+            account.write({'sanitized_acc_number': '1234567890999'})
+        with self.assertRaisesRegex(UserError, "has been trusted"), self.cr.savepoint():
+            account.write({'partner_id': self.env['res.partner'].create({'name': 'MyCustomer 2'}).id})
+
+        account.allow_out_payment = False
+        account.write({'acc_number': '1234567890999000'})
+
+        account.env.user.groups_id -= self.env.ref('account.group_validate_bank_account')
+        with self.assertRaisesRegex(UserError, "You do not have the rights to trust"), self.cr.savepoint():
+            account.write({'allow_out_payment': True})

--- a/odoo/addons/base/models/res_bank.py
+++ b/odoo/addons/base/models/res_bank.py
@@ -117,6 +117,22 @@ class ResPartnerBank(models.Model):
         for acc in self:
             acc.display_name = f'{acc.acc_number} - {acc.bank_id.name}' if acc.bank_id else acc.acc_number
 
+    def _sanitize_vals(self, vals):
+        if 'sanitized_acc_number' in vals:  # do not allow to write on sanitized directly
+            vals['acc_number'] = vals.pop('sanitized_acc_number')
+        if 'acc_number' in vals:
+            vals['sanitized_acc_number'] = sanitize_account_number(vals['acc_number'])
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            self._sanitize_vals(vals)
+        return super().create(vals_list)
+
+    def write(self, vals):
+        self._sanitize_vals(vals)
+        return super().write(vals)
+
     @api.model
     def _search(self, domain, offset=0, limit=None, order=None, access_rights_uid=None):
         def sanitize(arg):

--- a/odoo/addons/base/tests/test_res_partner_bank.py
+++ b/odoo/addons/base/tests/test_res_partner_bank.py
@@ -31,6 +31,7 @@ class TestResPartnerBank(SavepointCaseWithUserDemo):
 
         # sanitaze the acc_number
         sanitized_acc_number = 'BE001251882303'
+        self.assertEqual(partner_bank.sanitized_acc_number, sanitized_acc_number)
         vals = partner_bank_model.search(
             [('acc_number', '=', sanitized_acc_number)])
         self.assertEqual(1, len(vals))
@@ -49,3 +50,7 @@ class TestResPartnerBank(SavepointCaseWithUserDemo):
         vals = partner_bank_model.search(
             [('acc_number', '=', acc_number.lower())])
         self.assertEqual(1, len(vals))
+
+        # updating the sanitized value will also update the acc_number
+        partner_bank.write({'sanitized_acc_number': 'BE001251882303WRONG'})
+        self.assertEqual(partner_bank.acc_number, partner_bank.sanitized_acc_number)


### PR DESCRIPTION
Before this fix it was possible to update sanitized_acc_number even if it is locked.