### PR TITLE
[REF] mail, various: remove notification email actions in addons

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1935,41 +1935,6 @@ class CrmLead(models.Model):
                 _('Deadline: %s', self.date_deadline.strftime(get_lang(self.env).date_format)))
         return render_context
 
-    def _notify_get_recipients_groups(self, message, model_description, msg_vals=None):
-        """ Handle salesman recipients that can convert leads into opportunities
-        and set opportunities as won / lost. """
-        groups = super()._notify_get_recipients_groups(
-            message, model_description, msg_vals=msg_vals
-        )
-        if not self:
-            return groups
-
-        local_msg_vals = dict(msg_vals or {})
-
-        self.ensure_one()
-        if self.type == 'lead':
-            convert_action = self._notify_get_action_link('controller', controller='/lead/convert', **local_msg_vals)
-            salesman_actions = [{'url': convert_action, 'title': _('Convert to opportunity')}]
-        else:
-            won_action = self._notify_get_action_link('controller', controller='/lead/case_mark_won', **local_msg_vals)
-            lost_action = self._notify_get_action_link('controller', controller='/lead/case_mark_lost', **local_msg_vals)
-            salesman_actions = [
-                {'url': won_action, 'title': _('Mark Won')},
-                {'url': lost_action, 'title': _('Mark Lost')}]
-
-        salesman_group_id = self.env.ref('sales_team.group_sale_salesman').id
-        new_group = (
-            'group_sale_salesman',
-            lambda pdata: pdata['type'] == 'user' and salesman_group_id in pdata['groups'],
-            {
-                'actions': salesman_actions,
-                'active': True,
-                'has_button_access': True,
-            }
-        )
-
-        return [new_group] + groups
-
     def _notify_get_reply_to(self, default=None):
         """ Override to set alias of lead and opportunities to their sales team if any. """
         aliases = self.mapped('team_id').sudo()._notify_get_reply_to(default=default)

--- a/addons/event_sale/models/sale_order.py
+++ b/addons/event_sale/models/sale_order.py
@@ -69,26 +69,3 @@ class SaleOrder(models.Model):
         """
         domain = super()._get_product_catalog_domain()
         return expression.AND([domain, [('service_tracking', '!=', 'event')]])
-
-    def _notify_get_recipients_groups(self, message, model_description, msg_vals=None):
-        groups = super()._notify_get_recipients_groups(message, model_description, msg_vals)
-        if not self or self.state != 'sale' or not self.order_line.registration_ids:
-            return groups
-
-        customer_portal_group = next((group for group in groups if group[0] == 'portal_customer'), None)
-        if not customer_portal_group:
-            return groups
-
-        if customer_portal_group[2]['has_button_access']:
-            actions_opt = customer_portal_group[2].setdefault('actions', [])
-            has_single_event = len(self.order_line.event_id) == 1
-            registrations = self.order_line.registration_ids
-            for event, event_registrations in registrations.grouped('event_id').items():
-                actions_opt.append({
-                    'url': url_join(event.get_base_url(), f'/event/{event.id}/my_tickets?' + url_encode({
-                        'registration_ids': str(event_registrations.ids),
-                        'tickets_hash': event._get_tickets_access_hash(event_registrations.ids),
-                    })),
-                    'title': _("Get Your Tickets") if has_single_event else _("%(event_name)s - Tickets", event_name=event.name)
-                })
-        return groups

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -1320,42 +1320,6 @@ Attempting to double-book your time off won't magically make your vacation 2x be
             return leave_notif_subtype or self.env.ref('hr_holidays.mt_leave')
         return super()._track_subtype(init_values)
 
-    def _notify_get_recipients_groups(self, message, model_description, msg_vals=None):
-        """ Handle HR users and officers recipients that can validate or refuse holidays
-        directly from email. """
-        groups = super()._notify_get_recipients_groups(
-            message, model_description, msg_vals=msg_vals
-        )
-        if not self:
-            return groups
-
-        local_msg_vals = dict(msg_vals or {})
-
-        self.ensure_one()
-        hr_actions = []
-        if self.state == 'confirm':
-            app_action = self._notify_get_action_link('controller', controller='/leave/approve', **local_msg_vals)
-            hr_actions += [{'url': app_action, 'title': _('Approve')}]
-        if self.state == 'validate1':
-            app_action = self._notify_get_action_link('controller', controller='/leave/validate', **local_msg_vals)
-            hr_actions += [{'url': app_action, 'title': _('Validate')}]
-        if self.state in ['confirm', 'validate', 'validate1']:
-            ref_action = self._notify_get_action_link('controller', controller='/leave/refuse', **local_msg_vals)
-            hr_actions += [{'url': ref_action, 'title': _('Refuse')}]
-
-        holiday_user_group_id = self.env.ref('hr_holidays.group_hr_holidays_user').id
-        new_group = (
-            'group_hr_holidays_user',
-            lambda pdata: pdata['type'] == 'user' and holiday_user_group_id in pdata['groups'],
-            {
-                'actions': hr_actions,
-                'active': True,
-                'has_button_access': True,
-            }
-        )
-
-        return [new_group] + groups
-
     def message_subscribe(self, partner_ids=None, subtype_ids=None):
         # due to record rule can not allow to add follower and mention on validated leave so subscribe through sudo
         if any(holiday.state in ['validate', 'validate1'] for holiday in self):

--- a/addons/mail/models/fetchmail.py
+++ b/addons/mail/models/fetchmail.py
@@ -62,7 +62,6 @@ for name in POP3_ATTRIBUTES:
 
 class FetchmailServer(models.Model):
     """Incoming POP/IMAP mail server account"""
-
     _description = 'Incoming Mail Server'
     _order = 'priority'
 

--- a/addons/mail/models/mail_canned_response.py
+++ b/addons/mail/models/mail_canned_response.py
@@ -5,10 +5,8 @@ from odoo.addons.mail.tools.discuss import Store
 
 
 class MailCannedResponse(models.Model):
-    """
-    Canned Response: content that will automatically replace the shortcut of your choosing. This content can still be adapted before sending your message.
-    """
-
+    """ Canned Response: content that automatically replaces shortcuts of your
+    choosing. This content can still be adapted before sending your message. """
     _description = "Canned Response"
     _order = "id desc"
     _rec_name = "source"

--- a/addons/mail/models/mail_followers.py
+++ b/addons/mail/models/mail_followers.py
@@ -106,8 +106,8 @@ class MailFollowers(models.Model):
         Purpose of this method is to fetch all data necessary to notify recipients
         in a single query. It fetches data from
 
-         * followers (partners and channels) of records that follow the given
-           subtype if records and subtype are set;
+         * followers of records that follow the given subtype if records and
+           subtype are set;
          * partners if pids is given;
 
         :param records: fetch data from followers of ``records`` that follow
@@ -120,19 +120,22 @@ class MailFollowers(models.Model):
 
         :return dict: recipients data based on record.ids if given, else a generic
           '0' key to keep a dict-like return format. Each item is a dict based on
-          recipients partner ids formatted like
-          {'active': whether partner is active;
-           'id': res.partner ID;
-           'is_follower': True if linked to a record and if partner is a follower;
-           'lang': lang of the partner;
-           'groups': groups of the partner's user. If several users exist preference
-                is given to internal user, then share users. In case of multiples
-                users of same kind groups are unioned;
+          recipients partner ids formatted like {
+            'active': whether partner is active;
+            'id': res.partner ID;
+            'is_follower': True if linked to a record and if partner is a follower;
+            'lang': lang of the partner;
+            'groups': groups of the partner's user (see 'uid'). If several users
+                of the same kind (e.g. several internal users) exist groups are
+                concatenated;
             'notif': notification type ('inbox' or 'email'). Overrides may change
                 this value (e.g. 'sms' in sms module);
             'share': if partner is a customer (no user or share user);
             'ushare': if partner has users, whether all are shared (public or portal);
-            'type': summary of partner 'usage' (portal, customer, internal user);
+            'type': summary of partner 'usage' (a string among 'portal', 'customer',
+                'internal user');
+            'uid': linked 'res.users' ID. If several users exist preference is
+                given to internal user, then share users;
           }
         """
         self.env['mail.followers'].flush_model(['partner_id', 'subtype_ids'])
@@ -510,6 +513,10 @@ GROUP BY fol.id%s%s""" % (
                         update[fol_id] = {'subtype_ids': update_cmd}
 
         return new, update
+
+    # --------------------------------------------------
+    # Misc discuss
+    # --------------------------------------------------
 
     def _to_store(self, store: Store, fields=None):
         if fields is None:

--- a/addons/mail/models/mail_gateway_allowed.py
+++ b/addons/mail/models/mail_gateway_allowed.py
@@ -17,7 +17,6 @@ class MailGatewayAllowed(models.Model):
     from an automated-source. This model stores those trusted source and this restriction
     won't apply to them.
     """
-
     _description = 'Mail Gateway Allowed'
 
     email = fields.Char('Email Address', required=True)

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -886,8 +886,7 @@ class MailMessage(models.Model):
             target = ids_by_model if message in self else prefetch_ids_by_model
             target[message.model].add(message.res_id)
         return {
-            model_name: self.env[model_name]
-            .browse(ids)
+            model_name: self.env[model_name].browse(ids)
             .with_prefetch(tuple(ids_by_model[model_name] | prefetch_ids_by_model[model_name]))
             for model_name, ids in ids_by_model.items()
         }
@@ -895,24 +894,13 @@ class MailMessage(models.Model):
     def _record_by_message(self):
         records_by_model_name = self._records_by_model_name()
         return {
-            message: self.env[message.model]
-            .browse(message.res_id)
+            message: self.env[message.model].browse(message.res_id)
             .with_prefetch(records_by_model_name[message.model]._prefetch_ids)
             for message in self.filtered(lambda m: m.model and m.res_id)
         }
 
-    def _to_store(
-        self,
-        store: Store,
-        /,
-        *,
-        fields=None,
-        format_reply=True,
-        msg_vals=None,
-        for_current_user=False,
-        add_followers=False,
-        followers=None,
-    ):
+    def _to_store(self, store, /, *, fields=None, format_reply=True, msg_vals=None,
+                  for_current_user=False, add_followers=False, followers=None):
         """Add the messages to the given store.
 
         :param format_reply: if True, also get data about the parent message if it exists.

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -6,7 +6,7 @@ import itertools
 import logging
 from ast import literal_eval
 
-from odoo import _, api, fields, models, tools, Command
+from odoo import _, api, fields, models, tools
 from odoo.exceptions import ValidationError, UserError
 from odoo.tools import is_html_empty
 from odoo.tools.safe_eval import safe_eval, time

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3111,7 +3111,7 @@ class MailThread(models.AbstractModel):
         :param record message: <mail.message> record being notified. May be
           void as 'msg_vals' superseeds it;
         :param dict msg_vals: values dict used to create the message, allows to
-          skip message usage and spare some queries;
+          skip message usage and spare some queries if given;
 
         Kwargs allow to pass various parameters that are given to sub notification
         methods. See those methods for more details about supported parameters.
@@ -3151,12 +3151,12 @@ class MailThread(models.AbstractModel):
             # and send the <mail.mail>, <mail.push> and the <bus.bus> notifications
             self._notify_thread_by_inbox(message, recipients_data, msg_vals=msg_vals, **kwargs)
             self._notify_thread_by_email(message, recipients_data, msg_vals=msg_vals, **kwargs)
-            self._notify_thread_by_web_push(message, recipients_data, msg_vals, **kwargs)
+            self._notify_thread_by_web_push(message, recipients_data, msg_vals=msg_vals, **kwargs)
 
         return recipients_data
 
     def _notify_thread_by_inbox(self, message, recipients_data, msg_vals=False, **kwargs):
-        """ Notificaty recipients inbox of a message. It does two main things :
+        """ Notify recipients inbox of a message. It is done in two main steps
 
           * create inbox notifications for users;
           * send bus notifications;
@@ -3164,20 +3164,10 @@ class MailThread(models.AbstractModel):
         :param record message: <mail.message> record being notified. May be
           void as 'msg_vals' superseeds it;
         :param list recipients_data: list of recipients data based on <res.partner>
-          records formatted like [
-          {
-            'active': partner.active;
-            'id': id of the res.partner being recipient to notify;
-            'is_follower': follows the message related document;
-            'lang': its lang;
-            'groups': res.group IDs if linked to a user;
-            'notif': 'inbox', 'email', 'sms' (SMS App);
-            'share': is partner a customer (partner.partner_share);
-            'type': partner usage ('customer', 'portal', 'user');
-            'ushare': are users shared (if users, all users are shared);
-          }, {...}]. See ``MailThread._notify_get_recipients()``;
+          records formatted like a list of dicts containing information. See
+          ``MailThread._notify_get_recipients()``;
         :param dict msg_vals: values dict used to create the message, allows to
-          skip message usage and spare some queries;
+          skip message usage and spare some queries if given;
         """
         inbox_pids_uids = sorted(
             [(r["id"], r["uid"]) for r in recipients_data if r["notif"] == "inbox"]
@@ -3225,20 +3215,10 @@ class MailThread(models.AbstractModel):
         :param record message: <mail.message> record being notified. May be
           void as 'msg_vals' superseeds it;
         :param list recipients_data: list of recipients data based on <res.partner>
-          records formatted like [
-          {
-            'active': partner.active;
-            'id': id of the res.partner being recipient to notify;
-            'is_follower': follows the message related document;
-            'lang': its lang;
-            'groups': res.group IDs if linked to a user;
-            'notif': 'inbox', 'email', 'sms' (SMS App);
-            'share': is partner a customer (partner.partner_share);
-            'type': partner usage ('customer', 'portal', 'user');
-            'ushare': are users shared (if users, all users are shared);
-          }, {...}]. See ``MailThread._notify_get_recipients()``;
+          records formatted like a list of dicts containing information. See
+          ``MailThread._notify_get_recipients()``;
         :param dict msg_vals: values dict used to create the message, allows to
-          skip message usage and spare some queries;
+          skip message usage and spare some queries if given;
 
         :param bool mail_auto_delete: delete notification emails once sent;
 
@@ -3365,7 +3345,9 @@ class MailThread(models.AbstractModel):
         an evaluation context to render the notification layout.
 
         :param message: ``mail.message`` record to notify;
-        :param list recipients_data: see ``MailThread._notify_get_recipients``;
+        :param list recipients_data: list of recipients data based on <res.partner>
+          records formatted like a list of dicts containing information. See
+          ``MailThread._notify_get_recipients()``;
         :param msg_vals: dictionary of values used to create the message. If
           given it may be used to access values related to ``message``;
 
@@ -3455,7 +3437,7 @@ class MailThread(models.AbstractModel):
         :param record message: <mail.message> record being notified. May be
           void as 'msg_vals' superseeds it;
         :param dict msg_vals: values dict used to create the message, allows to
-          skip message usage and spare some queries;
+          skip message usage and spare some queries if given;
         :param str model_description: description of current model, given to
           avoid fetching it and easing translation support;
         :param record force_email_company: <res.company> record used when rendering
@@ -3552,14 +3534,15 @@ class MailThread(models.AbstractModel):
         :param dict recipients_group: a dict containing data for the recipients,
           see @ _notify_get_recipients_groups;
         :param dict msg_vals: values dict used to create the message, allows to
-          skip message usage and spare some queries;
+          skip message usage and spare some queries if given;
         :param dict render_values: values to render the notification layout;
 
         At this point expected values are
           render_values: company, is_discussion, lang, message, model_description,
                          record, record_name, signature, subtype, tracking_values,
                          website_url
-          recipients_group: button_access, has_button_access, recipients
+          recipients_group: active, button_access, has_button_access,
+                            notification_group_name, recipients
 
         :return str: rendered complete layout;
         """
@@ -3654,22 +3637,14 @@ class MailThread(models.AbstractModel):
         duplicated notifications in case of a mention in a channel of `chat` type.
 
         :param message: ``mail.message`` record to notify;
-        :param recipients_data: list of recipients information (based on res.partner
-          records), formatted like
-            [{'active': partner.active;
-              'id': id of the res.partner being recipient to notify;
-              'groups': res.group IDs if linked to a user;
-              'notif': 'inbox', 'email', 'sms' (SMS App);
-              'share': partner.partner_share;
-              'type': 'customer', 'portal', 'user;'
-             }, {...}].
-          See ``MailThread._notify_get_recipients``;
+        :param list recipients_data: list of recipients data based on <res.partner>
+          records formatted like a list of dicts containing information. See
+          ``MailThread._notify_get_recipients()``;
         :param msg_vals: dictionary of values used to create the message. If given it
           may be used to access values related to ``message`` without accessing it
           directly. It lessens query count in some optimized use cases by avoiding
           access message content in db;
         """
-
         msg_vals = dict(msg_vals or {})
         partner_ids = self._extract_partner_ids_for_notifications(message, msg_vals, recipients_data)
         if not partner_ids:
@@ -3776,7 +3751,7 @@ class MailThread(models.AbstractModel):
         :param record message: <mail.message> record being notified. May be
           void as 'msg_vals' superseeds it;
         :param dict msg_vals: values dict used to create the message, allows to
-          skip message usage and spare some queries;
+          skip message usage and spare some queries if given;
 
         Kwargs allow to pass various parameters that are used by sub notification
         methods. See those methods for more details about supported parameters.
@@ -3800,11 +3775,13 @@ class MailThread(models.AbstractModel):
             'active': partner.active;
             'id': id of the res.partner being recipient to notify;
             'is_follower': follows the message related document;
-            'lang': its lang;
+            'lang': partner lang;
             'groups': res.group IDs if linked to a user;
             'notif': 'inbox', 'email', 'sms' (SMS App);
             'share': is partner a customer (partner.partner_share);
             'type': partner usage ('customer', 'portal', 'user');
+            'uid': user ID (in case of multiple users, internal then first found
+                by ID);)
             'ushare': are users shared (if users, all users are shared);
           }, {...}]
         """
@@ -3894,7 +3871,7 @@ class MailThread(models.AbstractModel):
         :param str model_description: description of current model, given to
           avoid fetching it and easing translation support;
         :param dict msg_vals: values dict used to create the message, allows to
-          skip message usage and spare some queries;
+          skip message usage and spare some queries if given;
 
         :return: list of groups definition
         """
@@ -3937,7 +3914,7 @@ class MailThread(models.AbstractModel):
 
         :param list groups: recipients groups;
         :param dict msg_vals: values dict used to create the message, allows to
-          skip message usage and spare some queries;
+          skip message usage and spare some queries if given;
         :param str model_description: description of current model, given to
           avoid fetching it and easing translation support;
 
@@ -3975,28 +3952,18 @@ class MailThread(models.AbstractModel):
         :param record message: <mail.message> record being notified. May be
           void as 'msg_vals' superseeds it;
         :param list recipients_data: list of recipients data based on <res.partner>
-          records formatted like [
-          {
-            'active': partner.active;
-            'id': id of the res.partner being recipient to notify;
-            'is_follower': follows the message related document;
-            'lang': its lang;
-            'groups': res.group IDs if linked to a user;
-            'notif': 'inbox', 'email', 'sms' (SMS App);
-            'share': is partner a customer (partner.partner_share);
-            'type': partner usage ('customer', 'portal', 'user');
-            'ushare': are users shared (if users, all users are shared);
-          }, {...}]. See ``MailThread._notify_get_recipients()``;
+          records formatted like a list of dicts containing information. See
+          ``MailThread._notify_get_recipients()``;
         :param str model_description: description of current model, given to
           avoid fetching it and easing translation support;
         :param dict msg_vals: values dict used to create the message, allows to
-          skip message usage and spare some queries;
+          skip message usage and spare some queries if given;
 
         :return list: list of groups (see '_notify_get_recipients_groups')
           with 'recipients' key filled with matching partners, like
             [{
                 'active': True,
-                'button_access': {},
+                'button_access': {'url': 'https://odoo.com/url', 'title': 'Title'},
                 'has_button_access': False,
                 'notification_group_name': 'user',
                 'recipients': [11],

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -1456,7 +1456,6 @@ class MailCommon(common.TransactionCase, MailCase):
             * description: English:    Lang Chatter Model (depends on test_record._name)
                            translated: Spanish Model Description
           * module
-            * _('NotificationButtonTitle') -> SpanishNotificationButtonTitle (used as link button name in layout)
             * _('View %s') -> SpanishView %s
           * template
             * body: English:    <p>EnglishBody for <t t-out="object.name"/></p> (depends on test_template.body)
@@ -1478,10 +1477,6 @@ class MailCommon(common.TransactionCase, MailCase):
             cls.env['ir.model']._get(test_record._name).with_context(lang=lang_code).name = 'Spanish Model Description'
 
         # Translate some code strings used in mailing
-        code_translations.python_translations[('test_mail', 'es_ES')] = {
-            **code_translations.python_translations[('test_mail', 'es_ES')],
-            'NotificationButtonTitle': 'SpanishButtonTitle'
-        }
         code_translations.python_translations[('mail', 'es_ES')] = {
             **code_translations.python_translations[('mail', 'es_ES')],
             'View %s': 'SpanishView %s'

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -405,11 +405,6 @@ class PurchaseOrder(models.Model):
             access_opt = customer_portal_group[2].setdefault('button_access', {})
             if self.env.context.get('is_reminder'):
                 access_opt['title'] = _('View')
-                actions = customer_portal_group[2].setdefault('actions', list())
-                actions.extend([
-                    {'url': self.get_confirm_url(confirm_type='reminder'), 'title': _('Accept')},
-                    {'url': self.get_update_url(), 'title': _('Update Dates')},
-                ])
             else:
                 access_opt['title'] = _('View Quotation') if self.state in ('draft', 'sent') else _('View Order')
                 access_opt['url'] = self.get_confirm_url()

--- a/addons/sms/models/mail_thread.py
+++ b/addons/sms/models/mail_thread.py
@@ -208,6 +208,7 @@ class MailThread(models.AbstractModel):
         )
 
     def _notify_thread(self, message, msg_vals=False, **kwargs):
+        # Main notification method. Override to add support of sending OCN notifications.
         scheduled_date = self._is_notification_scheduled(kwargs.get('scheduled_date'))
         recipients_data = super(MailThread, self)._notify_thread(message, msg_vals=msg_vals, **kwargs)
         if not scheduled_date:
@@ -219,21 +220,13 @@ class MailThread(models.AbstractModel):
                               resend_existing=False, put_in_queue=False, **kwargs):
         """ Notification method: by SMS.
 
-        :param message: ``mail.message`` record to notify;
-        :param recipients_data: list of recipients information (based on res.partner
-          records), formatted like
-            [{'active': partner.active;
-              'id': id of the res.partner being recipient to notify;
-              'groups': res.group IDs if linked to a user;
-              'notif': 'inbox', 'email', 'sms' (SMS App);
-              'share': partner.partner_share;
-              'type': 'customer', 'portal', 'user;'
-             }, {...}].
-          See ``MailThread._notify_get_recipients``;
-        :param msg_vals: dictionary of values used to create the message. If given it
-          may be used to access values related to ``message`` without accessing it
-          directly. It lessens query count in some optimized use cases by avoiding
-          access message content in db;
+        :param record message: <mail.message> record being notified. May be
+          void as 'msg_vals' superseeds it;
+        :param list recipients_data: list of recipients data based on <res.partner>
+          records formatted like a list of dicts containing information. See
+          ``MailThread._notify_get_recipients()``;
+        :param dict msg_vals: values dict used to create the message, allows to
+          skip message usage and spare some queries if given;
 
         :param sms_numbers: additional numbers to notify in addition to partners
           and classic recipients;

--- a/addons/test_mail/models/test_mail_corner_case_models.py
+++ b/addons/test_mail/models/test_mail_corner_case_models.py
@@ -78,10 +78,6 @@ class MailTestLang(models.Model):
         for group in [g for g in groups if g[0] in('follower', 'customer')]:
             group_options = group[2]
             group_options['has_button_access'] = True
-            group_options['actions'] = [
-                {'url': self._notify_get_action_link('controller', controller='/test_mail/do_stuff', **local_msg_vals),
-                 'title': _('NotificationButtonTitle')}
-            ]
         return groups
 
 # ------------------------------------------------------------

--- a/addons/test_mail/models/test_mail_models.py
+++ b/addons/test_mail/models/test_mail_models.py
@@ -241,14 +241,6 @@ class MailTestTicket(models.Model):
             elif group_name == 'customer':
                 group_data['active'] = True
                 group_data['has_button_access'] = True
-                group_data['actions'] = [{
-                    'url': self._notify_get_action_link(
-                        'controller',
-                        controller='/test_mail/do_stuff',
-                        **local_msg_vals
-                    ),
-                    'title': _('NotificationButtonTitle')
-                }]
 
         return groups
 

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -1887,10 +1887,6 @@ class TestMessagePostLang(MailCommon, TestRecipients):
                                      '"View document" translation failed')
                     self.assertIn(f'View {test_record._description}', body,
                                   '"View document" translation failed')
-                    self.assertNotIn('SpanishButtonTitle', body,
-                                     'Groups-based action names translation failed')
-                    self.assertIn('NotificationButtonTitle', body,
-                                  'Groups-based action names translation failed')
                 else:
                     self.assertNotIn('English Layout for', body, 'Layout translation failed')
                     self.assertIn('Spanish Layout para Spanish Model Description', body,
@@ -1901,10 +1897,6 @@ class TestMessagePostLang(MailCommon, TestRecipients):
                                   '"View document" translation failed')
                     self.assertNotIn(f'View {test_record._description}', body,
                                     '"View document" translation failed')
-                    self.assertIn('SpanishButtonTitle', body,
-                                  'Groups-based action names translation failed')
-                    self.assertNotIn('NotificationButtonTitle', body,
-                                     'Groups-based action names translation failed')
 
     @users('employee')
     @mute_logger('odoo.addons.mail.models.mail_mail')
@@ -1965,8 +1957,6 @@ class TestMessagePostLang(MailCommon, TestRecipients):
                       '"View document" should be translated')
         self.assertNotIn(f'View {test_records[1]._description}', body,
                          '"View document" should be translated')
-        self.assertIn('SpanishButtonTitle', body, 'Groups-based action names should be translated')
-        self.assertNotIn('NotificationButtonTitle', body)
 
     @users('employee')
     @mute_logger('odoo.addons.mail.models.mail_mail')
@@ -2017,10 +2007,6 @@ class TestMessagePostLang(MailCommon, TestRecipients):
                                  '"View document" should be translated')
                 self.assertIn(f'View {test_records[1]._description}', body,
                               '"View document" should be translated')
-                self.assertNotIn('SpanishButtonTitle', body,
-                                 'Groups-based action names should be translated')
-                self.assertIn('NotificationButtonTitle', body,
-                              'Groups-based action names should be translated')
             else:
                 self.assertIn('Spanish Layout para', body,
                               'Layout content should be translated')
@@ -2031,10 +2017,6 @@ class TestMessagePostLang(MailCommon, TestRecipients):
                               '"View document" should be translated')
                 self.assertNotIn(f'View {test_records[1]._description}', body,
                                  '"View document" should be translated')
-                self.assertIn('SpanishButtonTitle', body,
-                              'Groups-based action names should be translated')
-                self.assertNotIn('NotificationButtonTitle', body,
-                                 'Groups-based action names should be translated')
 
     @users('employee')
     @mute_logger('odoo.addons.mail.models.mail_mail')
@@ -2110,17 +2092,13 @@ class TestMessagePostLang(MailCommon, TestRecipients):
                             exp_layout_content_es = 'Spanish Layout para Spanish Model Description'
                             exp_button_en = 'View Lang Chatter Model'
                             exp_button_es = 'SpanishView Spanish Model Description'
-                            exp_action_en = 'NotificationButtonTitle'
-                            exp_action_es = 'SpanishButtonTitle'
                             if email_layout_xmlid:
                                 if exp_lang == 'es_ES':
                                     self.assertIn(exp_layout_content_es, email['body'])
                                     self.assertIn(exp_button_es, email['body'])
-                                    self.assertIn(exp_action_es, email['body'])
                                 else:
                                     self.assertIn(exp_layout_content_en, email['body'])
                                     self.assertIn(exp_button_en, email['body'])
-                                    self.assertIn(exp_action_en, email['body'])
                             else:
                                 # check default layouting applies
                                 if exp_lang == 'es_ES':


### PR DESCRIPTION
RATIONALE

Improve email management and composition in Odoo, ease understanding
and make flow more looking like email discussions.

SPECIFICATIONS

We consider actions to be mainly noise in notification emails as it
bloats email content and hide real content. Since Odoo v18 standard
notification layout does not display them anymore but mechanism has
been kept for backward compatibility. This commit removes it.

Followup of https://github.com/odoo/odoo/pull/185223

Also remove translation tests. Those have been annoying to write, such
sadness.

Task-4284064
Part of Task-4273479: [mail] Email-like chatter flow