### PR TITLE
[FIX] website_slides: no tag color on flitered courses

### DIFF
--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -352,7 +352,7 @@
                     <t t-foreach="channel_frontend_tags" t-as="tag">
                         <t t-if="search_tags">
                             <span t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_category=search_slide_category, prevent_redirect=True)"
-                                t-attf-class="post_link cursor-pointer badge o_badge_clickable #{'text-bg-primary' if tag in search_tags else 'o_wslides_channel_tag o_color_0'}" t-esc="tag.name"/>
+                                t-attf-class="post_link cursor-pointer badge o_badge_clickable #{'o_color_'+str(tag.color) if tag in search_tags else 'o_wslides_channel_tag o_color_0'}" t-esc="tag.name"/>
                         </t>
                         <t t-else="">
                             <span t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_category=search_slide_category, prevent_redirect=True)"


### PR DESCRIPTION
After this commit https://github.com/odoo/odoo/commit/b4a5bf03cd81ece2a7fd21a3c5a058ee2d3336fe , we have to hover on tags to see solid/bg colors.
Here, the selected tag's color is 'primary' but due to hovering behavior,
 it will display similar to `o_color_0`,  unless user hover on the tag.

This PR modify selected tags colors to `tag.color` used in 'All courses' page

Task-4274049
