### PR TITLE
[FIX] mail: fix jump to present button positioning after opening thread actions

### DIFF
--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -151,23 +151,7 @@ export class Thread extends Component {
         this.setupScroll();
         useEffect(
             () => {
-                if (!this.viewportEl || !this.jumpPresentRef.el) {
-                    return;
-                }
-                const width = this.viewportEl.clientWidth;
-                const height = this.viewportEl.clientHeight;
-                const computedStyle = window.getComputedStyle(this.viewportEl);
-                const ps = parseInt(computedStyle.getPropertyValue("padding-left"));
-                const pe = parseInt(computedStyle.getPropertyValue("padding-right"));
-                const pt = parseInt(computedStyle.getPropertyValue("padding-top"));
-                const pb = parseInt(computedStyle.getPropertyValue("padding-bottom"));
-                this.jumpPresentRef.el.style.transform = `translate(${
-                    this.env.inChatter ? 22 : width - ps - pe - 22
-                }px, ${
-                    this.env.inChatter && !this.env.inChatter.aside
-                        ? 0
-                        : height - pt - pb - (this.env.inChatter?.aside ? 75 : 0)
-                }px)`;
+                this.computeJumpPresentPosition();
             },
             () => [this.jumpPresentRef.el, this.viewportEl]
         );
@@ -259,6 +243,26 @@ export class Thread extends Component {
                 toRaw(nextProps.thread).fetchNewMessages();
             }
         });
+    }
+
+    computeJumpPresentPosition() {
+        if (!this.viewportEl || !this.jumpPresentRef.el) {
+            return;
+        }
+        const width = this.viewportEl.clientWidth;
+        const height = this.viewportEl.clientHeight;
+        const computedStyle = window.getComputedStyle(this.viewportEl);
+        const ps = parseInt(computedStyle.getPropertyValue("padding-left"));
+        const pe = parseInt(computedStyle.getPropertyValue("padding-right"));
+        const pt = parseInt(computedStyle.getPropertyValue("padding-top"));
+        const pb = parseInt(computedStyle.getPropertyValue("padding-bottom"));
+        this.jumpPresentRef.el.style.transform = `translate(${
+            this.env.inChatter ? 22 : width - ps - pe - 22
+        }px, ${
+            this.env.inChatter && !this.env.inChatter.aside
+                ? 0
+                : height - pt - pb - (this.env.inChatter?.aside ? 75 : 0)
+        }px)`;
     }
 
     /**
@@ -458,7 +462,10 @@ export class Thread extends Component {
         useChildSubEnv({
             onImageLoaded: applyScroll,
         });
-        const observer = new ResizeObserver(applyScroll);
+        const observer = new ResizeObserver(() => {
+            this.computeJumpPresentPosition();
+            applyScroll();
+        });
         useEffect(
             (el, mountedAndLoaded) => {
                 if (el && mountedAndLoaded) {


### PR DESCRIPTION
**Current behavior before PR:**

When the `jump to present` button was visible and the user opened any thread actions, the button appeared in the wrong position.The issue occurred because the transform style was not being recalculated when the active action changed.
Before / After
<p>
&nbsp;&nbsp;&nbsp;&nbsp;
  <img src="https://github.com/user-attachments/assets/cf3d4051-20e6-428e-8bba-237e8ef03e8e" width="200px" />
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
  <img src="https://github.com/user-attachments/assets/6e7f1ca0-6adf-4177-a7ea-dd1f7968702d" width="200px" />
</p>

**Desired behavior after PR is merged:**

After this PR, the transform style is correctly calculated, ensuring the `jump to present` button is properly positioned when thread actions are opened.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
