### PR TITLE
[FIX] sale{_project}: Move method back to sale

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -2018,6 +2018,25 @@ class SaleOrder(models.Model):
                 user_id=order.user_id.id or order.partner_id.user_id.id,
                 note=_("Upsell %(order)s for customer %(customer)s", order=order_ref, customer=customer_ref))
 
+    def _prepare_analytic_account_data(self, prefix=None):
+        """ Prepare SO analytic account creation values.
+
+        :return: `account.analytic.account` creation values
+        :rtype: dict
+        """
+        self.ensure_one()
+        name = self.name
+        if prefix:
+            name = prefix + ": " + self.name
+        project_plan, _other_plans = self.env['account.analytic.plan']._get_all_plans()
+        return {
+            'name': name,
+            'code': self.client_order_ref,
+            'company_id': self.company_id.id,
+            'plan_id': project_plan.id,
+            'partner_id': self.partner_id.id,
+        }
+
     def _prepare_down_payment_section_line(self, **optional_values):
         """ Prepare the values to create a new down payment section.
 

--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -284,25 +284,6 @@ class SaleOrder(models.Model):
             self.env['project.project'].sudo().search([('sale_line_id.order_id', 'in', self.ids)]).sale_line_id = False
         return res
 
-    def _prepare_analytic_account_data(self, prefix=None):
-        """ Prepare SO analytic account creation values.
-
-        :return: `account.analytic.account` creation values
-        :rtype: dict
-        """
-        self.ensure_one()
-        name = self.name
-        if prefix:
-            name = prefix + ": " + self.name
-        project_plan, _other_plans = self.env['account.analytic.plan']._get_all_plans()
-        return {
-            'name': name,
-            'code': self.client_order_ref,
-            'company_id': self.company_id.id,
-            'plan_id': project_plan.id,
-            'partner_id': self.partner_id.id,
-        }
-
     def _compute_completed_task_percentage(self):
         for so in self:
             so.completed_task_percentage = so.tasks_count and so.closed_task_count / so.tasks_count


### PR DESCRIPTION
This fixes issues that arose since 238a41e3

By moving the `_prepare_analytic_account_data` method
from sale to sale_project, any call to this method
in sale_expense would break as sale_expense doesn't depend on project.
Because this method is crucial in the re-invoicing flows we need it
in sale.

Steps to reproduce:
- Install sale_expense without project
- Run the sale_expense tests or test the flow manually (create an expense with mileage as a product, add a sale order to reinvoice it on and move forward to post the expense sheet)
- _prepare_analytic_account_data is missing


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
