### PR TITLE
[FIX] mail: fix inaccurate deleted starred message test

### DIFF
--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -15,6 +15,7 @@ import {
     triggerHotkey,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, expect, test } from "@odoo/hoot";
+import { delay } from "@odoo/hoot-dom";
 import { Deferred, mockDate, mockTimeZone, tick } from "@odoo/hoot-mock";
 import { Command, mockService, onRpc, serverState, withUser } from "@web/../tests/web_test_helpers";
 import { deserializeDateTime } from "@web/core/l10n/dates";
@@ -1840,5 +1841,6 @@ test("Delete starred message decrements starred counter once", async () => {
     await click(":nth-child(1 of .o-mail-Message) [title='Expand']");
     await click(".o-mail-Message-moreMenu [title='Delete']");
     await click("button", { text: "Confirm" });
+    await delay(50);
     await contains("button", { count: 1, text: "Starred2" });
 });


### PR DESCRIPTION
Before this PR, the test introduced in 4c9c4a3333b016eaeeac3618c4b9c1c96ab35a69 does not accurately check that the number of starred messages is correct, as it only checks that the shown number of starred messages is 2 not taking into account the possibility of it decrementing subsequently.

This PR fixes the issue by introducing a delay that ensures all effects are completed before checking the number of starred messages.
