### PR TITLE
[FIX] point_of_sale: add missing demo data for QUnit tests

### DIFF
--- a/addons/point_of_sale/static/tests/unit/utils.js
+++ b/addons/point_of_sale/static/tests/unit/utils.js
@@ -4,7 +4,14 @@ import { registry } from "@web/core/registry";
 
 registry.category("mock_server").add("pos.session/load_pos_data", async function (route, args) {
     return {
-        "res.company": { id: 1 },
+        "res.company": {
+            id: 1,
+            account_fiscal_country_id: {
+                id: 1,
+                name: "United States of America",
+                code: "US",
+            },
+        },
         "pos.session": { id: 1 },
         "pos.printer": [],
         "pos.config": { id: 1, uuid: "TEST-UUID", trusted_config_ids: [] },


### PR DESCRIPTION
How to reproduce:
1. install l10n_pe_edi_pos
2. run `test_pos_js`

The following traceback is obtained:

```
QUnit test failed: point_of_sale > Chrome > mount the Chrome :
message: "Promise rejected during "mount the Chrome": Cannot make the
given value reactive"
```

It is actually raised because in l10n_pe_edi_pos, we try to access `company.account_fiscal_country_id.code` and the fiscal_country is undefined (`Cannot read properties of undefined (reading 'code')`). Adding demo data fixes the error.

runbot-71686
