### PR TITLE
[FIX] point_of_sale: add missing demo data for QUnit tests

### DIFF
--- a/addons/point_of_sale/static/tests/unit/pos_app_tests.js
+++ b/addons/point_of_sale/static/tests/unit/pos_app_tests.js
@@ -85,6 +85,18 @@ export class MockPosData {
             models: {
                 "product.product": { relations: {}, fields: {}, data: [] },
                 "product.pricelist": { relations: {}, fields: {}, data: [] },
+                "res.country": {
+                    fields: {
+                        code: { string: "Code", type: "string" },
+                    },
+                    data: [
+                        {
+                            id: 1,
+                            name: "United States of America",
+                            code: "US",
+                        },
+                    ],
+                },
                 "pos.session": {
                     relations: {},
                     fields: {},
@@ -102,10 +114,16 @@ export class MockPosData {
                             string: "Tax rounding method",
                             type: "string",
                         },
+                        account_fiscal_country_id: {
+                            string: "Account fiscal country",
+                            type: "many2one",
+                            relation: "res.country",
+                        },
                     },
                     data: [
                         {
                             tax_calculation_rounding_method: "round_globally",
+                            account_fiscal_country_id: 1,
                         },
                     ],
                 },


### PR DESCRIPTION
How to reproduce:
1. install l10n_pe_edi_pos
2. run `test_pos_js`

The following traceback is obtained:

```
Error received after termination: QUnit test failed: point_of_sale >
Chrome > test unsynch data error filtering :
	message: "Promise rejected during "test unsynch data error
filtering": Cannot read properties of undefined (reading 'code')"
```

Adding demo data fixes the error.

runbot-73446