### PR TITLE
[IMP] website: add the `s_timeline_images` snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -110,6 +110,7 @@
         'views/snippets/s_faq_horizontal.xml',
         'views/snippets/s_opening_hours.xml',
         'views/snippets/s_timeline.xml',
+        'views/snippets/s_timeline_images.xml',
         'views/snippets/s_timeline_list.xml',
         'views/snippets/s_process_steps.xml',
         'views/snippets/s_accordion.xml',

--- a/addons/website/data/image_library.xml
+++ b/addons/website/data/image_library.xml
@@ -1069,5 +1069,17 @@
     <field name="type">url</field>
     <field name="url">/web/image/website.s_cover_default_image</field>
 </record>
+<record id="website.s_timeline_images_default_image_1" model="ir.attachment">
+    <field name="public" eval="True"/>
+    <field name="name">s_timeline_images_default_image_1.jpg</field>
+    <field name="type">url</field>
+    <field name="url">/web/image/website.s_carousel_default_image_2</field>
+</record>
+<record id="website.s_timeline_images_default_image_2" model="ir.attachment">
+    <field name="public" eval="True"/>
+    <field name="name">s_timeline_images_default_image_2.jpg</field>
+    <field name="type">url</field>
+    <field name="url">/web/image/website.s_carousel_default_image_3</field>
+</record>
 
 </odoo>

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1038,6 +1038,8 @@ class Website(models.Model):
             fallback_create_missing_industry_image('s_wavy_grid_default_image_2', 's_image_text_default_image')
             fallback_create_missing_industry_image('s_wavy_grid_default_image_3', 's_text_image_default_image')
             fallback_create_missing_industry_image('s_wavy_grid_default_image_4', 's_carousel_default_image_1')
+            fallback_create_missing_industry_image('s_timeline_images_default_image_1', 's_media_list_default_image_1')
+            fallback_create_missing_industry_image('s_timeline_images_default_image_2', 's_media_list_default_image_2')
 
         except Exception:
             pass

--- a/addons/website/views/snippets/s_timeline_images.xml
+++ b/addons/website/views/snippets/s_timeline_images.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template name="Timeline Images" id="s_timeline_images">
+    <section class="s_timeline_images o_colored_level pt48 pb48">
+        <div class="container">
+            <h2 class="h3-fs" style="text-align: center;">Evolving together</h2>
+            <p class="lead" style="text-align: center;">Highlight your history, showcase growth and key milestones.</p>
+            <div class="position-relative pt-3">
+                <div class="s_timeline_images_row position-relative d-flex flex-column" data-name="Milestone">
+                    <div class="o_dot_line position-absolute top-0 bottom-0 w-0 mb-1 border-start pe-none"/>
+                    <span class="o_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none text-o-color-1" contenteditable="false"/>
+                    <div class="s_timeline_images_content w-100 ps-4">
+                        <div class="row">
+                            <div class="col-12 col-lg-4 pb16">
+                                <small class="text-muted">13/06/2023</small>
+                                <h3 class="h4-fs">First Milestone</h3>
+                            </div>
+                            <div class="col-12 col-lg-8 pb16">
+                                <p>
+                                    <img src="/web/image/website.s_timeline_images_default_image_1" class="img img-fluid rounded" alt="" style="width: 100% !important;"/>
+                                </p>
+                                <p>A timeline is a graphical representation on which important events are marked.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="s_timeline_images_row position-relative d-flex flex-column" data-name="Milestone">
+                    <div class="o_dot_line position-absolute top-0 bottom-0 w-0 mb-1 border-start pe-none"/>
+                    <span class="o_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none text-o-color-1" contenteditable="false"/>
+                    <div class="s_timeline_images_content w-100 ps-4">
+                        <div class="row">
+                            <div class="col-12 col-lg-4 pb16">
+                                <small class="text-muted">13/06/2023</small>
+                                <h3 class="h4-fs">Second Milestone</h3>
+                            </div>
+                            <div class="col-12 col-lg-8 pb16">
+                                <p>
+                                    <img src="/web/image/website.s_timeline_images_default_image_2" class="img img-fluid rounded" alt="" style="width: 100% !important;"/>
+                                </p>
+                                <p>A timeline is a graphical representation on which important events are marked.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+<template id="s_timeline_images_options" inherit_id="website.snippet_options">
+    <xpath expr="//t[@t-call='website.snippet_options_background_options']" position="after">
+        <div data-js="MultipleItems" data-selector=".s_timeline_images">
+            <we-row string="Date">
+                <we-button data-add-item="" data-item=".s_timeline_images_row:first" data-select-item="" data-add-before="true" data-no-preview="true" class="o_we_bg_brand_primary">
+                    Add Date
+                </we-button>
+            </we-row>
+        </div>
+    </xpath>
+    <xpath expr="." position="inside">
+        <div data-selector=".s_timeline_images_row" data-drop-near=".s_timeline_images_row"/>
+    </xpath>
+    <xpath expr="//t[@t-set='o_dot_color_selector']" position="attributes">
+        <attribute name="t-valuef" add=".s_timeline_images .s_timeline_images_row" separator=", "/>
+    </xpath>
+    <xpath expr="//t[@t-set='o_dot_line_color_selector']" position="attributes">
+        <attribute name="t-valuef" add=".s_timeline_images" separator=", "/>
+    </xpath>
+    <xpath expr="//div[@data-js='SnippetMove'][contains(@data-selector,'section')]" position="attributes">
+        <attribute name="data-selector" add=".s_timeline_images_row" separator=","/>
+    </xpath>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -219,6 +219,9 @@
                 <t t-snippet="website.s_timeline_list" string="Timeline List" group="content">
                     <keywords>history, story, events, milestones, chronology, sequence, progression, achievements, changelog, updates, announcements, recent, latest</keywords>
                 </t>
+                <t t-snippet="website.s_timeline_images" string="Timeline Images" group="content">
+                    <keywords>history, story, events, milestones, chronology, sequence, progression, achievements, changelog, updates, announcements, recent, latest, picture, photo, illustration, media, visual</keywords>
+                </t>
                 <t t-snippet="website.s_process_steps" string="Steps" t-forbid-sanitize="true" group="content">
                     <keywords>process, progression, guide, workflow, sequence, instructions, stages, procedure, roadmap</keywords>
                 </t>


### PR DESCRIPTION
This commit adds the `s_timeline_images` snippet.

task-4105285
Part of task-4077427

Design-themes PR: https://github.com/odoo/design-themes/pull/995

| ![image](https://github.com/user-attachments/assets/d913a226-0f5d-4d25-8b3f-ae76c917bf70) |
|--------|
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
