### PR TITLE
[FIX] base: distinguish between Congo (DRC) and Congo (Republic)

### DIFF
--- a/odoo/addons/base/data/res_country_data.xml
+++ b/odoo/addons/base/data/res_country_data.xml
@@ -261,13 +261,13 @@
             <field eval="236" name="phone_code" />
         </record>
         <record id="cd" model="res.country">
-            <field name="name">Democratic Republic of the Congo</field>
+            <field name="name">Congo (DRC)</field>
             <field name="code">cd</field>
             <field name="currency_id" ref="CDF" />
             <field eval="243" name="phone_code" />
         </record>
         <record id="cg" model="res.country">
-            <field name="name">Congo</field>
+            <field name="name">Congo (Republic)</field>
             <field name="code">cg</field>
             <field name="currency_id" ref="XAF" />
             <field eval="242" name="phone_code" />


### PR DESCRIPTION
Rebublic of the Congo (Congo (Republic)) and Democratic Republic
of the Congo (Congo (DRC)) are two different countries. Using
"Congo" alone is ambigous. So, this commits fixes this issue and
distinguishes between them to avoid confusing.

Task-4266235