### PR TITLE
[FIX] base: prevent crash when removing a model on module upgrade

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1500,12 +1500,14 @@ class IrModelSelection(models.Model):
                 records.invalidate_recordset([fname])
 
         for selection in self:
-            Model = self.env[selection.field_id.model]
             # The field may exist in database but not in registry. In this case
             # we allow the field to be skipped, but for production this should
             # be handled through a migration script. The ORM will take care of
             # the orphaned 'ir.model.fields' down the stack, and will log a
             # warning prompting the developer to write a migration script.
+            Model = self.env.get(selection.field_id.model)
+            if Model is None:
+                continue
             field = Model._fields.get(selection.field_id.name)
             if not field or not field.store or not Model._auto:
                 continue


### PR DESCRIPTION
When upgrading a module where a model has been removed entirely, the ORM does a clean up for 'ir.model.fields.selection' records.  However, in this case it doesn't work, because the records reference a model that no longer belongs to the registry (if there are no migration scripts).

This commit simply makes the cleanup ignore such a case.  It makes sense, because the whole table will be deleted anyway (if there are no migration scripts).

STEPS
 - install a module that defines a model with a selection field
 - rename or remove the model
 - upgrade the module

This commit fixes #179392.
It was inspired by #104624.

opw-3024537