### PR TITLE
[FIX] account: error when loading a different CoA

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -676,7 +676,7 @@ class AccountChartTemplate(models.AbstractModel):
         # Set default transfer account on the internal transfer reconciliation model
         reco = self.ref('internal_transfer_reco', raise_if_not_found=False)
         if reco:
-            reco.line_ids.write({'account_id': company.transfer_account_id.id})
+            reco.line_ids.sudo().write({'account_id': company.transfer_account_id.id})
 
     def _get_property_accounts(self, additional_properties):
         return {


### PR DESCRIPTION
Install account and a localization (i.e. l10n_ar)
Switch to Company "(AR) Exento"
Open Settings>Invoicing
Change current Chart of Account to something else
Save

Error will block the action

This operation is allowed for the following groups:
        - Technical/Show Full Accounting Features

Contact your administrator to request access if necessary.

This occurs because the permissions necessary to write on the
AccountReconcileModelLine are loaded when installing module `accountant`

opw-4227071