### PR TITLE
[FIX] stock,stock_delivery,sale_stock: make deliveryslip report fields more readable

### DIFF
--- a/addons/sale_stock/report/stock_report_deliveryslip.xml
+++ b/addons/sale_stock/report/stock_report_deliveryslip.xml
@@ -6,7 +6,7 @@
                 <strong>Customer Reference:</strong>
                 <p t-field="o.sudo().sale_id.client_order_ref" class="m-0">Customer reference</p>
             </div>
-            <div class="col-auto justify-content-end" t-if="o.sudo().sale_id.incoterm">
+            <div class="col-auto col-3 justify-content-end" t-if="o.sudo().sale_id.incoterm">
                 <strong>Incoterm:</strong>
                 <p t-if="o.sudo().sale_id.incoterm_location" t-out="'%s %s' % (o.sudo().sale_id.incoterm.code, o.sudo().sale_id.incoterm_location)">Incoterm details</p>
                 <p t-else="" t-field="o.sudo().sale_id.incoterm.display_name">Incoterm details</p>

--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -46,7 +46,7 @@
                         <span t-field="o.name">WH/OUT/0001</span>
                     </h2>
                     <div class="oe_structure"></div>
-                    <div class="row mt32 mb32">
+                    <div class="report-wrapping-flexbox clearfix row mt32 mb32">
                         <div t-if="o.origin" class="col-auto col-3 mw-100 mb-2" name="div_origin">
                             <strong>Order:</strong>
                             <p t-field="o.origin" class="m-0">S0001</p>

--- a/addons/web/static/src/webclient/actions/reports/report.scss
+++ b/addons/web/static/src/webclient/actions/reports/report.scss
@@ -218,6 +218,15 @@ blockquote {
     -webkit-box-flex: 1 !important;
 }
 
+.report-wrapping-flexbox {
+    // overriding the `display` prop of `.row`
+    display: block !important;
+}
+
+.report-wrapping-flexbox > .col-auto {
+    float: left;
+}
+
 // Report footer need to support bootstrap columns (2, 3 and 4 columns)
 // Even if the width is smaller than the media querry limit from bootstrap.
 // This need come from the footer being editable via the Odoo editor.


### PR DESCRIPTION
Before this PR, If the deliveryslip report had many fields, say more than 5, they will be all placed on the same line, and it will be very hard to read them since they will be squashed.

This is problem is more relevant when the language used for the report is a language where the words are usually long, like the german language.

Now, we force at most 4 fields per line, which makes the report layout cleaner in most cases.

Before
<img width="613" alt="image" src="https://github.com/user-attachments/assets/49d88491-96d1-4ce3-9e06-73be713956cf">


After
<img width="615" alt="image" src="https://github.com/user-attachments/assets/d20337d6-dcc1-46f0-8386-18f67091538c">


opw-4227666

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
