### PR TITLE
[FIX] test_http: webjson with nodemo data requires setup

### DIFF
--- a/odoo/addons/test_http/tests/test_webjson.py
+++ b/odoo/addons/test_http/tests/test_webjson.py
@@ -38,6 +38,13 @@ class TestHttpWebJson_1(TestHttpBase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+
+        # enable explicitely and make sure demo has permissions
+        cls.env['ir.config_parameter'].set_param('web.json.enabled', True)
+        cls.user_demo.write({
+            'groups_id': [Command.link(cls.env.ref('base.group_allow_export').id)],
+        })
+
         cls.milky_way = cls.env.ref('test_http.milky_way')
         cls.earth = cls.env.ref('test_http.earth')
         with file_open('test_http/static/src/img/gizeh.png', 'rb') as file:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Need to setup the user and enable the /json route when running tests with nodata because by default the route is not enabled.

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
