### PR TITLE
[FIX] l10n_au, l10n_nz: revise duplicate labels shown on company

### DIFF
--- a/addons/l10n_au/views/res_company_views.xml
+++ b/addons/l10n_au/views/res_company_views.xml
@@ -7,19 +7,17 @@
         <field name="inherit_id" ref="base.view_company_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='vat']" position="attributes">
-                <attribute name="nolabel">1</attribute>
+                <attribute name="invisible" add="country_code == 'AU'" separator=" or "/> 
             </xpath>
-            <field name="vat" position="before">
-                <label for="vat" invisible="country_code == 'AU'" />
-                <label for="vat" string="ABN" invisible="country_code != 'AU'" />
-            </field>
+            <xpath expr="//field[@name='vat']" position="after">
+                <field name="vat" string="ABN" invisible="country_code != 'AU'"/>
+            </xpath>
             <xpath expr="//field[@name='company_registry']" position="attributes">
-                <attribute name="nolabel">1</attribute>
+                <attribute name="invisible" add="country_code == 'AU'" separator=" or "/> 
             </xpath>
-            <field name="company_registry" position="before">
-                <label for="company_registry" invisible="country_code == 'AU'" />
-                <label for="company_registry" string="ACN" invisible="country_code != 'AU'" />
-            </field>
+            <xpath expr="//field[@name='company_registry']" position="after">
+                <field name="company_registry" string="ACN" invisible="country_code != 'AU'"/>
+            </xpath>
         </field>
     </record>
 

--- a/addons/l10n_nz/views/res_company_views.xml
+++ b/addons/l10n_nz/views/res_company_views.xml
@@ -6,19 +6,17 @@
         <field name="inherit_id" ref="base.view_company_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='vat']" position="attributes">
-                <attribute name="nolabel">1</attribute>
+                <attribute name="invisible" add="country_code == 'NZ'" separator=" or "/> 
             </xpath>
-            <field name="vat" position="before">
-                <label for="vat" invisible="country_code == 'NZ'" />
-                <label for="vat" string="GST" invisible="country_code != 'NZ'" />
-            </field>
+            <xpath expr="//field[@name='vat']" position="after">
+                <field name="vat" string="GST" invisible="country_code != 'NZ'"/>
+            </xpath>
             <xpath expr="//field[@name='company_registry']" position="attributes">
-                <attribute name="nolabel">1</attribute>
+                <attribute name="invisible" add="country_code == 'NZ'" separator=" or "/> 
             </xpath>
-            <field name="company_registry" position="before">
-                <label for="company_registry" invisible="country_code == 'NZ'" />
-                <label for="company_registry" string="NZBN" invisible="country_code != 'NZ'" />
-            </field>
+            <xpath expr="//field[@name='company_registry']" position="after">
+                <field name="company_registry" string="NZBN" invisible="country_code != 'NZ'"/>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Problem: When both l10n_au and l10_nz are installed, the company form displays multiple labels for affected fields, vat and company_registry.

Solution: The company form should only display a label
per field to avoid confusions. Each view per localization
will make the affected field on the parent view invisible
and then add in the same affected fields but with a different label.


Steps to Reproduce on Runbot:
1. Install l10_au and l10_nz
2. Observe the forms for all companies
3. See that there's duplicate labels for fields, vat and company_registry

opw-4250742


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
