### PR TITLE
[FIX] account: prevent error when opening invoice preview without invoice date

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -597,7 +597,7 @@
                         <!-- Preview (only customer invoices) -->
                         <button name="preview_invoice" type="object" string="Preview" data-hotkey="o"
                                 title="Preview invoice"
-                                attrs="{'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund'))]}"/>
+                                attrs="{'invisible': ['|', ('move_type', 'not in', ('out_invoice', 'out_refund')), ('state', '==', 'cancel')]}"/>
                         <!-- Reverse -->
                         <button name="%(action_view_account_move_reversal)d" string="Reverse Entry"
                                 type="action" groups="account.group_account_invoice" data-hotkey="z"


### PR DESCRIPTION
Currently, an error occurs when the user attempts to preview an invoice, and invoice date is not available.

Step to produce:

- Install the ```account``` module.
- Create a new invoice, add a customer name and invoice line, and add a 'Payment Terms' which have an 'Early Discount' available.
- 'Cancel' this invoice.
- Click on the 'Preview' button (ensure that the invoice has no date).

```TypeError: unsupported operand type(s) for +: 'bool' and 'relativedelta'```

An error occurs when the system attempts to calculate the discount days with the invoice date, but the invoice date is not available there.

To resolve this issue, we hide the preview button on canceled invoices.

Sentry-6006569495

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
