### PR TITLE
[IMP] web_editor: add decorative option to image option

### DIFF
--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -719,6 +719,10 @@
                 <we-checkbox data-remove-stretch="true" data-dependencies="shape_img_opt" data-no-preview="true" data-name="toggle_stretch_opt"/>
             </we-row>
         </div>
+        <we-checkbox string="Decorative"
+            data-select-attribute="true"
+            data-attribute-name="aria-hidden"
+            title="This option hides the image from screen readers and SEO, skipping the alt attribute."/>
         <we-input string="Description" class="o_we_large"
             data-select-attribute="" data-attribute-name="alt"
             placeholder="Alt tag"


### PR DESCRIPTION
This commit  added an option to mark images as decorative, using `aria-hidden="true"` for improved SEO and accessibility & avoid image from the screen reader.

![image](https://github.com/user-attachments/assets/2f244c8a-cacd-46da-bb17-dedefd225f89)

task-4210386