### PR TITLE
[FIX] stock: prevent error for empty picking

### DIFF
--- a/addons/stock/wizard/stock_picking_return.py
+++ b/addons/stock/wizard/stock_picking_return.py
@@ -101,7 +101,7 @@ class ReturnPicking(models.TransientModel):
     def _compute_moves_locations(self):
         for wizard in self:
             product_return_moves = [Command.clear()]
-            if not wizard.picking_id._can_return():
+            if wizard.picking_id and not wizard.picking_id._can_return():
                 raise UserError(_("You may only return Done pickings."))
             # In case we want to set specific default values (e.g. 'to_refund'), we must fetch the
             # default values for creation.


### PR DESCRIPTION
The error occurs because we are deleting stock picking from one tab and trying to return that picking from another tab.

Steps to reproduce:
---
- Install ``sale_stock`` module
- Go to receipt > open one receipt(state:  Draft or Ready)
- Now duplicate that tab > delete that receipt from one tab and click on 'Return' button in another tab

Traceback: 
---
``ValueError: Expected singleton: stock.picking()``

At [1], we are facing an error because we are accessing the ``_can_return`` method but don't have a stock picking ID.

[1]- https://github.com/odoo/odoo/blob/f613b87c38d208730ba2470e0a26a110c2089b66/addons/stock/wizard/stock_picking_return.py#L104

sentry-6012377745

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
