### PR TITLE
[IMP] l10n_{it,es}_*: add the preferred edi format for E…

### DIFF
--- a/addons/l10n_es_edi_facturae/models/account_move.py
+++ b/addons/l10n_es_edi_facturae/models/account_move.py
@@ -122,7 +122,8 @@ class AccountMove(models.Model):
             and self.is_invoice(include_receipts=True) \
             and (self.partner_id.is_company or self.partner_id.vat) \
             and self.company_id.country_code == 'ES' \
-            and self.company_id.currency_id.name == 'EUR'
+            and self.company_id.currency_id.name == 'EUR' \
+            and self.company_id.sudo().l10n_es_edi_facturae_certificate_ids  # We only enable Facturae if a certificate is valid or has been valid (which will raise an error)
 
     def _l10n_es_edi_facturae_get_filename(self):
         self.ensure_one()

--- a/addons/l10n_es_edi_facturae/models/account_move_send.py
+++ b/addons/l10n_es_edi_facturae/models/account_move_send.py
@@ -22,7 +22,7 @@ class AccountMoveSend(models.AbstractModel):
         results = super()._get_placeholder_mail_attachments_data(move, extra_edis=extra_edis)
 
         partner_edi_format = self._get_default_invoice_edi_format(move)
-        if not move.l10n_es_edi_facturae_xml_id and partner_edi_format == 'es_facturae' and move._l10n_es_edi_facturae_get_default_enable():
+        if partner_edi_format == 'es_facturae' and move._l10n_es_edi_facturae_get_default_enable():
             filename = f'{move.name.replace("/", "_")}_facturae_signed.xml'
             results.append({
                 'id': f'placeholder_{filename}',

--- a/addons/l10n_es_edi_facturae/models/res_partner.py
+++ b/addons/l10n_es_edi_facturae/models/res_partner.py
@@ -77,8 +77,6 @@ class Partner(models.Model):
 
     def _get_suggested_invoice_edi_format(self):
         # EXTENDS 'account'
-        res = super()._get_suggested_invoice_edi_format()
-        if self.country_code == 'ES' and self.company_id.currency_id.name == 'EUR':
+        if self.country_code == 'ES':
             return 'es_facturae'
-        else:
-            return res
+        return super()._get_suggested_invoice_edi_format()

--- a/addons/l10n_es_edi_facturae/tests/__init__.py
+++ b/addons/l10n_es_edi_facturae/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_edi_xml
+from . import test_facturae_misc

--- a/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
@@ -181,16 +181,28 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
 
     def test_cannot_generate_unsigned_xml(self):
         """ Test that no valid certificate prevents a xml generation"""
-        self.certificate.unlink()
+        def _compute_is_valid(self):
+            for cert in self:
+                cert.is_valid = False
+
         random.seed(42)
         with freeze_time(self.frozen_today), \
                 patch(f"{self.certificate_module}.fields.datetime.now", lambda x=None: self.frozen_today), \
+                patch('odoo.addons.certificate.models.certificate.Certificate._compute_is_valid', _compute_is_valid), \
                 patch(f"{self.move_module}.sha1", lambda x: sha1()):
-            invoice = self.create_invoice(partner_id=self.partner_a.id, move_type='out_invoice', invoice_line_ids=[{'price_unit': 100.0, 'tax_ids': [self.tax.id]},],)
+            invoice = self.create_invoice(partner_id=self.partner_a.id, move_type='out_invoice', invoice_line_ids=[{'price_unit': 100.0, 'tax_ids': [self.tax.id]}])
             invoice.action_post()
             wizard = self.create_send_and_print(invoice)
             with self.assertRaises(UserError):
                 wizard.action_send_and_print()
+
+    def test_no_certificate_facturae_not_selected(self):
+        self.certificate.unlink()
+        invoice = self.create_invoice(partner_id=self.partner_a.id, move_type='out_invoice', invoice_line_ids=[{'price_unit': 100.0, 'tax_ids': [self.tax.id]}])
+        invoice.action_post()
+        wizard = self.create_send_and_print(invoice)
+        wizard.action_send_and_print()
+        self.assertFalse(invoice.l10n_es_edi_facturae_xml_id)
 
     def test_tax_withheld(self):
         with freeze_time(self.frozen_today), \

--- a/addons/l10n_es_edi_facturae/tests/test_facturae_misc.py
+++ b/addons/l10n_es_edi_facturae/tests/test_facturae_misc.py
@@ -1,0 +1,24 @@
+from odoo.tests import tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestFacturaeMisc(AccountTestInvoicingCommon):
+
+    @classmethod
+    @AccountTestInvoicingCommon.setup_country('es')
+    def setUpClass(cls):
+        super().setUpClass()
+
+    def test_es_suggested_invoice_edi_format(self):
+        partner_es = self.env['res.partner'].create({
+            'name': "ES partner",
+            'country_id': self.env.ref('base.es').id,
+        })
+        partner_be = self.env['res.partner'].create({
+            'name': "BE partner",
+            'country_id': self.env.ref('base.be').id,
+        })
+        self.assertEqual(partner_es.invoice_edi_format, 'es_facturae')
+        self.assertNotEqual(partner_be.invoice_edi_format, 'es_facturae')

--- a/addons/l10n_es_pos/tests/test_frontend.py
+++ b/addons/l10n_es_pos/tests/test_frontend.py
@@ -50,6 +50,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'vat': "ESA12345674",
             'country_id': self.env.ref("base.es").id,
             'email': "email@gmail.com",
+            'invoice_edi_format': False,
         })
         self._get_main_company().partner_id.write({
             'bank_ids': [Command.create({'acc_number': 'FOO42'})]

--- a/addons/l10n_es_pos/tests/test_frontend.py
+++ b/addons/l10n_es_pos/tests/test_frontend.py
@@ -50,7 +50,6 @@ class TestUi(TestPointOfSaleHttpCommon):
             'vat': "ESA12345674",
             'country_id': self.env.ref("base.es").id,
             'email': "email@gmail.com",
-            'invoice_edi_format': False,
         })
         self._get_main_company().partner_id.write({
             'bank_ids': [Command.create({'acc_number': 'FOO42'})]

--- a/addons/l10n_it_edi/models/res_partner.py
+++ b/addons/l10n_it_edi/models/res_partner.py
@@ -196,3 +196,11 @@ class ResPartner(models.Model):
     def _peppol_eas_endpoint_depends(self):
         # extends account_edi_ubl_cii
         return super()._peppol_eas_endpoint_depends() + ['l10n_it_codice_fiscale']
+
+    def _get_suggested_invoice_edi_format(self):
+        # EXTENDS 'account'
+        res = super()._get_suggested_invoice_edi_format()
+        if self.country_code == 'IT':
+            return 'it_edi_xml'
+        else:
+            return res

--- a/addons/l10n_it_edi/tests/test_res_partner.py
+++ b/addons/l10n_it_edi/tests/test_res_partner.py
@@ -59,3 +59,15 @@ class TestResPartner(TransactionCase):
             partners += self.env['res.partner'].create({'name': f'partner_{i}', 'l10n_it_codice_fiscale': code})
 
         self.assertEqual(len(partners), len(valid_codes))
+
+    def test_it_suggested_invoice_edi_format(self):
+        partner_it = self.env['res.partner'].create({
+            'name': "IT partner",
+            'country_id': self.env.ref('base.it').id,
+        })
+        partner_be = self.env['res.partner'].create({
+            'name': "BE partner",
+            'country_id': self.env.ref('base.be').id,
+        })
+        self.assertEqual(partner_it.invoice_edi_format, 'it_edi_xml')
+        self.assertNotEqual(partner_be.invoice_edi_format, 'it_edi_xml')


### PR DESCRIPTION
…S/IT

Add FatturaPA as the preferred EDI format set by default on Italian partners. Fix the preffered EDI format of Spanish partners to be correctly computed to Facturae.

task-no
