### PR TITLE
[FIX] l10n_in_withholding: tds tax on partner type not payment type

### DIFF
--- a/addons/l10n_in_withholding/wizard/l10n_in_withhold_wizard.py
+++ b/addons/l10n_in_withholding/wizard/l10n_in_withhold_wizard.py
@@ -132,7 +132,7 @@ class L10nInWithholdWizard(models.TransientModel):
                 'in_refund': 'in_refund_withhold',
             }[move_type]
         else:
-            withhold_type = 'in_withhold' if self.related_payment_id.payment_type == 'outbound' else 'out_withhold'
+            withhold_type = 'in_withhold' if self.related_payment_id.partner_type == 'supplier' else 'out_withhold'
         return withhold_type
 
     # ===== MOVE CREATION METHODS =====


### PR DESCRIPTION
While adding the `TDS` taxes on payment for receipt from vendor and payment to customer, the type of tax i.e purchase or sale should be dependent on partner type i.e supplier or customer.

For the vendor tds taxes should be of purchase type and for the customer it should be of sale type.

task-4262953

