### PR TITLE
[FIX] mail: im_status flickering

### DIFF
--- a/addons/mail/static/src/core/common/im_status_service_patch.js
+++ b/addons/mail/static/src/core/common/im_status_service_patch.js
@@ -20,7 +20,7 @@ export const imStatusServicePatch = {
                 if (!persona) {
                     return; // Do not store unknown persona's status
                 }
-                persona.im_status = im_status;
+                persona.debouncedSetImStatus(im_status);
                 if (persona.type !== "guest" || persona.notEq(store.self)) {
                     return; // Partners are already handled by the original service
                 }

--- a/addons/mail/static/src/core/common/persona_model.js
+++ b/addons/mail/static/src/core/common/persona_model.js
@@ -1,6 +1,7 @@
 /* @odoo-module */
 
 import { AND, Record } from "@mail/core/common/record";
+import { debounce } from "@web/core/utils/timing";
 
 /**
  * @typedef {'offline' | 'bot' | 'online' | 'away' | 'im_partner' | undefined} ImStatus
@@ -24,6 +25,15 @@ export class Persona extends Record {
     static insert(data) {
         return super.insert(...arguments);
     }
+    static new() {
+        const record = super.new(...arguments);
+        record.debouncedSetImStatus = debounce(
+            (newStatus) => (record.im_status = newStatus),
+            this.IM_STATUS_DEBOUNCE_DELAY
+        );
+        return record;
+    }
+    static IM_STATUS_DEBOUNCE_DELAY = 1000;
 
     channelMembers = Record.many("ChannelMember");
     /** @type {number} */
@@ -34,6 +44,7 @@ export class Persona extends Record {
     landlineNumber;
     /** @type {string} */
     mobileNumber;
+    debouncedSetImStatus;
     storeAsTrackedImStatus = Record.one("Store", {
         /** @this {import("models").Persona} */
         compute() {

--- a/addons/mail/static/tests/discuss_app/im_status_tests.js
+++ b/addons/mail/static/tests/discuss_app/im_status_tests.js
@@ -2,10 +2,12 @@
 
 import { startServer } from "@bus/../tests/helpers/mock_python_environment";
 
+import { Persona } from "@mail/core/common/persona_model";
 import { Command } from "@mail/../tests/helpers/command";
 import { start } from "@mail/../tests/helpers/test_utils";
 
 import { click, contains } from "@web/../tests/utils";
+import { patchWithCleanup } from "@web/../tests/helpers/utils";
 
 QUnit.module("im status");
 
@@ -61,7 +63,8 @@ QUnit.test("change icon on change partner im_status", async () => {
         channel_member_ids: [Command.create({ partner_id: pyEnv.currentPartnerId })],
         channel_type: "chat",
     });
-    const { openDiscuss } = await start({ hasTimeControl: true });
+    patchWithCleanup(Persona, { IM_STATUS_DEBOUNCE_DELAY: 0 });
+    const { openDiscuss } = await start();
     openDiscuss(channelId);
     await contains(".o-mail-ImStatus i[title='Online']");
 


### PR DESCRIPTION
When a user disconnects from a device, the server assumes he is
disconnected until another device/browser says otherwise. However,
this can lead to small flickers. This PR fixes the issue by debouncing
the update of the im status field of the persona model. This way, there
is no flickering.

Steps to reproduce the issue:
- Open two browser windows with mitchell admin in the discuss app
(incognito + regular windows).
- Go to the chat with your self, where the im status can be seen.
- Reload one tab several times: you can sometimes see a flicker from
online to offline.

task-4236550