### PR TITLE
[FIX] web_tour: tour_enabled on form view

### DIFF
--- a/addons/web_tour/models/res_users.py
+++ b/addons/web_tour/models/res_users.py
@@ -4,7 +4,7 @@ from odoo import models, fields, api
 class ResUsers(models.Model):
     _inherit = "res.users"
 
-    tour_enabled = fields.Boolean(compute='_compute_tour_enabled', store=True, readonly=False)
+    tour_enabled = fields.Boolean(compute='_compute_tour_enabled', store=True, readonly=False, string="Onboarding")
 
     @api.depends("create_date")
     def _compute_tour_enabled(self):

--- a/addons/web_tour/static/src/tour_service/tour_service.js
+++ b/addons/web_tour/static/src/tour_service/tour_service.js
@@ -246,7 +246,11 @@ export const tourService = {
             }
 
             if (tourState.getCurrentTour()) {
-                resumeTour();
+                if (tourState.getCurrentConfig().mode === "auto" || toursEnabled) {
+                    resumeTour();
+                } else {
+                    tourState.clear();
+                }
             } else if (session.current_tour) {
                 startTour(session.current_tour.name, {
                     mode: "manual",

--- a/addons/web_tour/views/res_users_views.xml
+++ b/addons/web_tour/views/res_users_views.xml
@@ -6,7 +6,7 @@
     <field name="inherit_id" ref="base.view_users_form"/>
     <field name="arch" type="xml">
         <xpath expr="//field[@name='tz']" position="after">
-            <field name="tour_enabled"/>
+            <field name="tour_enabled" widget="boolean_toggle"/>
         </xpath>
     </field>
   </record>


### PR DESCRIPTION
Before this commit, changing tour_enabled on the form
view of the user was not deactivating the running tour.

After this commit, the running tour is deactivated if the
tour_enabled is false when loading the tour service.

TASK-ID: 4276412


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
