### PR TITLE
[FIX] base_import_module: Multiple industry installation

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -142,7 +142,7 @@ class IrModule(models.Model):
                         convert_xml_import(self.env, module, fp, idref, mode, noupdate)
                         if filename in exclude_list:
                             self.env['ir.model.data'].create([{
-                                'name': f"cloc_exclude_{key}",
+                                'name': f"cloc_exclude_{module}_{key}",
                                 'model': self.env['ir.model.data']._xmlid_lookup(f"{module}.{key}")[0],
                                 'module': "__cloc_exclude__",
                                 'res_id': value,


### PR DESCRIPTION
Steps:
- Create a DB with industry addons (SaaS)
- Install one industry (bike_leasing)
- Install a second industry (industry_real_estate)

Actual result:
- External ID conflict
- Constraint violation: ir_model_data_module_name_uniq_index

Expected result:
- No conflict second industry is installed

opw-4264625
opw-4273891

Caused-By: #178190 and https://github.com/odoo/industry/commit/cbeab117a90bc92ea3dfab58973c1931afc73cbd

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
