### PR TITLE
[IMP] mass_mailing: support dynamic domains

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -1500,7 +1500,7 @@ class MailingMailing(models.Model):
     def _parse_mailing_domain(self):
         self.ensure_one()
         try:
-            mailing_domain = literal_eval(self.mailing_domain)
+            mailing_domain = self.env['mailing.filter']._evaluate_domain(self.mailing_domain)
         except Exception:
             mailing_domain = [('id', 'in', [])]
         return mailing_domain

--- a/addons/mass_mailing/models/mailing_filter.py
+++ b/addons/mass_mailing/models/mailing_filter.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from ast import literal_eval
+import ast
+import odoo.tools.safe_eval as safe_eval
 
 from odoo import api, fields, models, _
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 
 
 class MailingFilter(models.Model):
@@ -22,13 +23,55 @@ class MailingFilter(models.Model):
     mailing_model_id = fields.Many2one('ir.model', string='Recipients Model', required=True, ondelete='cascade')
     mailing_model_name = fields.Char(string='Recipients Model Name', related='mailing_model_id.model')
 
+    @staticmethod
+    def _evaluate_domain(domain):
+        """Evaluate domain string as python code using safe_eval
+
+        :param str domain: the domain to evaluate
+        :returns dict: evaluation context given to safe_eval
+        """
+        # to_utc is a purely JS concept where datetime is localized by default
+        # as that is the default in python, and to_utc is undefined, we can disregard it
+        domain = domain.replace('.to_utc()', '')
+        evaluated_domain = safe_eval.safe_eval(domain, {
+            'context_today': safe_eval.datetime.datetime.today,
+            'datetime': safe_eval.datetime,
+            'dateutil': safe_eval.dateutil,
+            'relativedelta': safe_eval.dateutil.relativedelta.relativedelta,
+            'time': safe_eval.time,
+        })
+        assert isinstance(evaluated_domain, list)
+        return evaluated_domain
+
+    @staticmethod
+    def _combine_dynamic_domains(domain_a, domain_b):
+        """Combines two string domains that contain non-literals."""
+        domains = [domain_a, domain_b]
+        parsed_domains = []
+        for domain in domains:
+            try:
+                parsed_domain = ast.parse(domain, mode="eval", filename="domain")
+                # only manipulate list elements
+                if not isinstance(parsed_domain.body, ast.List):
+                    raise UserError(_("A valid domain is expected, got: %(domain_expression)s", domain_expression=domain))
+                parsed_domains.append(parsed_domain)
+            except SyntaxError as se:
+                raise UserError(
+                    _("Invalid domain %(domain_expression)s: %(syntax_error)s", domain_expression=domain, syntax_error=se)
+                )
+        new_domain = ast.parse("[]", mode="eval")
+        # add as many "AND" as domain that need to be joined
+        new_domain.body.elts.extend([ast.Constant('&')] * (sum(bool(domain.body.elts) for domain in parsed_domains) - 1))
+        new_domain.body.elts.extend(element for domain in parsed_domains for element in domain.body.elts)
+        return ast.unparse(new_domain)
+
     @api.constrains('mailing_domain', 'mailing_model_id')
     def _check_mailing_domain(self):
         """ Check that if the mailing domain is set, it is a valid one """
         for mailing_filter in self:
             if mailing_filter.mailing_domain != "[]":
                 try:
-                    self.env[mailing_filter.mailing_model_id.model].search_count(literal_eval(mailing_filter.mailing_domain))
+                    self.env[mailing_filter.mailing_model_id.model].search_count(self._evaluate_domain(mailing_filter.mailing_domain))
                 except:
                     raise ValidationError(
                         _("The filter domain is not valid for this recipients.")

--- a/addons/mass_mailing/tests/__init__.py
+++ b/addons/mass_mailing/tests/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import common
+from . import test_dynamic_domain_helpers
 from . import test_mailing_ab_testing
 from . import test_mailing_internals
 from . import test_mailing_list

--- a/addons/mass_mailing/tests/test_dynamic_domain_helpers.py
+++ b/addons/mass_mailing/tests/test_dynamic_domain_helpers.py
@@ -1,0 +1,79 @@
+from freezegun import freeze_time
+
+from odoo.addons.mass_mailing.models.mailing_filter import MailingFilter
+from odoo.exceptions import UserError
+from odoo.tests import BaseCase
+from odoo.tools import mute_logger
+
+
+class TestDynamicDomainHelpers(BaseCase):
+
+    @mute_logger('odoo.tools.translate')
+    def test_domain_combination(self):
+        combine = MailingFilter._combine_dynamic_domains
+        failing_triplets = [
+            (False, False, TypeError),
+            ('', '', UserError),
+            ('[]', '', UserError),
+            ('["&", (1, "=", 1)', '[]', UserError),  # unmatched hook, python syntax error
+            ([], '[]', TypeError),
+            ('list()', '[]', UserError),  # the first one is not syntactically a list
+        ]
+        for domain_a, domain_b, exception in failing_triplets:
+            with self.subTest(domain_a=domain_a, domain_b=domain_b):
+                with self.assertRaises(exception):
+                    combine(domain_a, domain_b)
+
+        success_triplets = [
+            ('[]', '[]', '[]'),
+            ('[]', '[(1, "=", 1)]', "[(1, '=', 1)]"),
+            ('[(1, "!=", 0)]', '[(0, "!=", 1)]', "['&', (1, '!=', 0), (0, '!=', 1)]"),
+            (
+                '["|", ("name", "like", "_bob%"), ("rating", ">", 3)]',
+                '["|", ("rating", "<", 6), ("name", "like", "a%")]',
+                "['&', '|', ('name', 'like', '_bob%'), ('rating', '>', 3), '|', ('rating', '<', 6), ('name', 'like', 'a%')]",
+            ),
+            (
+                '[("create_date", "<", context_today())]',
+                '[("create_date", "<", context_today() - relativedelta(days=1))]',
+                "['&', ('create_date', '<', context_today()), ('create_date', '<', context_today() - relativedelta(days=1))]",
+            ),
+            (
+                '[1,object,"string"]',
+                '[int,int(1),isinstance,lambda x: x + 1]',
+                "['&', 1, object, 'string', int, int(1), isinstance, lambda x: x + 1]",
+            ),  # it will actually merge any list of expressions
+        ]
+        for domain_a, domain_b, expected in success_triplets:
+            with self.subTest(domain_a=domain_a, domain_b=domain_b, expected=expected):
+                self.assertEqual(combine(domain_a, domain_b), expected)
+
+    @freeze_time('2030-05-24')
+    @mute_logger('odoo.tools.translate')
+    def test_domain_evaluation(self):
+        evaluate = MailingFilter._evaluate_domain
+        failing_domains = [
+            ("()", AssertionError),  # has to be a list
+            ("'[]'", AssertionError),
+            ("[(1, '=', 1/0)]", ZeroDivisionError),
+            ("['name', 'like', datetime.__file__]", NameError),  # basic safety checks, should be raised by safe_eval
+            ("import os; ['name', 'like', os.getenv('USER')]", SyntaxError),
+        ]
+        for domain_expression, exception in failing_domains:
+            with self.subTest(domain_expression=domain_expression):
+                with self.assertRaises(exception):
+                    evaluate(domain_expression)
+
+        success_pairs = [
+            ("list()", []),
+            ("list(range(1, 4))", [1, 2, 3]),
+            ("['|', (1, '=', 1), (1, '>', 0)]", ['|', (1, '=', 1), (1, '>', 0)]),
+            ("[(2, '=', 1 + 1)]", [(2, '=', 2)]),
+            (
+                "[('create_date', '<', datetime.datetime.combine(context_today() - relativedelta(days=100), datetime.time(1, 2, 3)).to_utc().strftime('%Y-%m-%d %H:%M:%S'))]",
+                [('create_date', '<', "2030-02-13 01:02:03")],
+            ),  # use the date utils used by front-end domains
+        ]
+        for domain_expression, domain_value in success_pairs:
+            with self.subTest(domain_expression=domain_expression, domain_value=domain_value):
+                self.assertEqual(evaluate(domain_expression), domain_value)

--- a/addons/mass_mailing/tests/test_mailing_internals.py
+++ b/addons/mass_mailing/tests/test_mailing_internals.py
@@ -29,6 +29,9 @@ class TestMassMailValues(MassMailCommon):
         super(TestMassMailValues, cls).setUpClass()
         cls._create_mailing_list()
 
+    def _eval_domain(self, domain):
+        return self.env['mailing.filter']._evaluate_domain(domain)
+
     @users('user_marketing')
     def test_mailing_body_cropped_vml_image(self):
         """ Testing mail mailing responsive bg-image cropping for Outlook.
@@ -377,6 +380,45 @@ class TestMassMailValues(MassMailCommon):
                 # If configured, check if dedicated email outgoing server is
                 # on mailing record
                 self.assertEqual(mailing.mail_server_id, mail_server)
+
+    @users('user_marketing')
+    @mute_logger('odoo.sql_db')
+    def test_mailing_computed_fields_dynamic_domain(self):
+        """Ensure dynamic domain evaluation works and isn't obviously unsafe."""
+        filters = self.env['mailing.filter'].create([
+            {'name': 'Literals Filter',
+             'mailing_domain': [('create_uid', '=', '1')],
+             'mailing_model_id': self.env['ir.model']._get('discuss.channel').id
+             },
+            {'name': 'String Literals Filter',
+             'mailing_domain': "[('create_uid', '=', '1')]",
+             'mailing_model_id': self.env['ir.model']._get('discuss.channel').id
+             },
+            {'name': 'Dynamic Filter',
+             'mailing_domain': "[('id', '=', 1 + 1)]",
+             'mailing_model_id': self.env['ir.model']._get('discuss.channel').id
+             },
+            {'name': 'Dynamic Date Context Methods',
+             'mailing_domain': "[('create_date', '<=', (datetime.datetime(2042, 12, 31) + relativedelta(days=1)).to_utc().strftime('%Y-%m-%d'))]",
+             'mailing_model_id': self.env['ir.model']._get('discuss.channel').id
+             },
+            {'name': 'Dynamic Date Object',
+             'mailing_domain': "[('create_date', '<=', datetime.datetime(2042, 12, 31) + relativedelta(days=1))]",
+             'mailing_model_id': self.env['ir.model']._get('discuss.channel').id
+             }
+        ])
+        domains = [
+            [('create_uid', '=', '1')], [('create_uid', '=', '1')], [('id', '=', 2)],
+            [('create_date', '<=', '2043-01-01')], [('create_date', '<=', datetime(2043, 1, 1))],
+        ]
+        for mailing_filter, domain in zip(filters, domains):
+            self.assertListEqual(self._eval_domain(mailing_filter.mailing_domain), domain)
+        with self.assertRaises(ValidationError):
+            self.env['mailing.filter'].create({
+                'name': 'Illegal Dynamic Filter',
+                'mailing_domain': "[('id', '=', datetime.sys.hash_info)]",
+                'mailing_model_id': self.env['ir.model']._get('discuss.channel').id
+            })
 
     @users('user_marketing')
     def test_mailing_computed_fields_form(self):


### PR DESCRIPTION
Allow mailings to fully use front-end time-relative domains to support flows such as "send this mailing to all customers who have purchased something within the last month" which is particularly useful in the context of marketing automation.

task-4240689
