### PR TITLE
[IMP] point_of_sale,pos_restaurant: restructured kitchen ticket

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -4,10 +4,8 @@ import { _t } from "@web/core/l10n/translation";
 import { formatDate, formatDateTime, serializeDateTime } from "@web/core/l10n/dates";
 import { omit } from "@web/core/utils/objects";
 import { parseUTCString, qrCodeSrc, random5Chars, uuidv4 } from "@point_of_sale/utils";
-import { renderToElement } from "@web/core/utils/render";
 import { floatIsZero, roundPrecision } from "@web/core/utils/numbers";
 import { computeComboItems } from "./utils/compute_combo_items";
-import { changesToOrder } from "./utils/order_change";
 
 const { DateTime } = luxon;
 const formatCurrency = registry.subRegistries.formatters.content.monetary[1];
@@ -33,6 +31,7 @@ export class PosOrder extends Base {
             : {
                   lines: {},
                   generalNote: "",
+                  sittingMode: "dine in",
               };
         this.general_note = vals.general_note || "";
         this.tracking_number =
@@ -154,80 +153,8 @@ export class PosOrder extends Base {
         });
     }
 
-    // NOTE args added [unwatchedPrinter]
-    async printChanges(skipped = false, orderPreparationCategories, cancelled, unwatchedPrinter) {
-        const orderChange = changesToOrder(this, skipped, orderPreparationCategories, cancelled);
-        const d = new Date();
-
-        let isPrintSuccessful = true;
-
-        let hours = "" + d.getHours();
-        hours = hours.length < 2 ? "0" + hours : hours;
-
-        let minutes = "" + d.getMinutes();
-        minutes = minutes.length < 2 ? "0" + minutes : minutes;
-
-        orderChange.new.sort((a, b) => {
-            const sequenceA = a.pos_categ_sequence;
-            const sequenceB = b.pos_categ_sequence;
-            if (sequenceA === 0 && sequenceB === 0) {
-                return a.pos_categ_id - b.pos_categ_id;
-            }
-
-            return sequenceA - sequenceB;
-        });
-
-        for (const printer of unwatchedPrinter) {
-            const changes = this._getPrintingCategoriesChanges(
-                printer.config.product_categories_ids,
-                orderChange
-            );
-            if (changes["new"].length > 0 || changes["cancelled"].length > 0) {
-                const printingChanges = {
-                    new: changes["new"],
-                    cancelled: changes["cancelled"],
-                    table_name: this.table_id?.name,
-                    floor_name: this.table_id?.floor_id?.name,
-                    name: this.pos_reference || "unknown order",
-                    time: {
-                        hours,
-                        minutes,
-                    },
-                    tracking_number: this.tracking_number,
-                };
-                const receipt = renderToElement("point_of_sale.OrderChangeReceipt", {
-                    changes: printingChanges,
-                });
-                const result = await printer.printReceipt(receipt);
-                if (!result.successful) {
-                    isPrintSuccessful = false;
-                }
-            }
-        }
-
-        return isPrintSuccessful;
-    }
-
     get isBooked() {
         return Boolean(this.uiState.booked || !this.is_empty() || typeof this.id === "number");
-    }
-
-    _getPrintingCategoriesChanges(categories, currentOrderChange) {
-        const filterFn = (change) => {
-            const product = this.models["product.product"].get(change["product_id"]);
-            const categoryIds = product.parentPosCategIds;
-
-            for (const categoryId of categoryIds) {
-                if (categories.includes(categoryId)) {
-                    return true;
-                }
-            }
-        };
-
-        return {
-            new: currentOrderChange["new"].filter(filterFn),
-            cancelled: currentOrderChange["cancelled"].filter(filterFn),
-        };
     }
 
     get hasChange() {
@@ -250,12 +177,15 @@ export class PosOrder extends Base {
                         line.get_quantity();
                 } else {
                     this.last_order_preparation_change.lines[line.preparationKey] = {
-                        attribute_value_ids: line.attribute_value_ids.map((a) =>
-                            a.serialize({ orm: true })
-                        ),
+                        attribute_value_ids: line.attribute_value_ids.map((a) => ({
+                            ...a.serialize({ orm: true }),
+                            name: a.name,
+                        })),
                         uuid: line.uuid,
+                        isCombo: line.combo_item_id?.id,
                         product_id: line.get_product().id,
                         name: line.get_full_product_name(),
+                        basic_name: line.get_product().name,
                         note: line.getNote(),
                         quantity: line.get_quantity(),
                     };
@@ -266,12 +196,14 @@ export class PosOrder extends Base {
         });
 
         // Checks whether an orderline has been deleted from the order since it
-        // was last sent to the preparation tools. If so we delete it to the changes.
+        // was last sent to the preparation tools or updated. If so we delete older changes.
         for (const [key, change] of Object.entries(this.last_order_preparation_change.lines)) {
-            if (!this.models["pos.order.line"].getBy("uuid", change.uuid)) {
+            const orderline = this.models["pos.order.line"].getBy("uuid", change.uuid);
+            if (!orderline || change.note.trim() !== orderline.note.trim()) {
                 delete this.last_order_preparation_change.lines[key];
             }
         }
+        this.last_order_preparation_change.sittingMode = this.takeaway ? "takeaway" : "dine in";
         this.last_order_preparation_change.generalNote = this.general_note;
     }
 

--- a/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
+++ b/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
@@ -2,70 +2,64 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="point_of_sale.OrderChangeReceipt">
-        <div class="pos-receipt">
-            <div class="pos-receipt-order-data"><t t-esc="changes.name" /></div>
-            <t t-if="changes.floor_name || changes.table_name">
-                <br />
+        <div class="pos-receipt m-0 p-0">
+            <!-- Receipt Header -->
+            <div class="receipt-header text-center">
                 <div class="pos-receipt-title">
-                    <t t-esc="changes.floor_name" /> / <t t-esc="changes.table_name"/>
+                    <t t-if="changes.diningModeUpdate">
+                        <t t-if="changes.takeaway">Dine In -&gt; Take Out</t>
+                        <t t-else="">Take Out -&gt; Dine In</t>
+                    </t>
+                    <t t-else="">
+                        <t t-if="changes.takeaway">Take Out</t>
+                        <t t-else="">Dine In</t>
+                    </t>
                 </div>
-            </t>
-            <div class="pos-receipt-title">
-                <t t-esc="changes.tracking_number"/>
+                <div class="fs-2">
+                    <span><t t-esc="changes.config_name"/> : <t t-esc="changes.time"/></span><br/>
+                    <span>By: <t t-esc="changes.employee_name"/></span>
+                </div>
+                <span class="my-4" style="font-size: 120%;">
+                    <t t-if="changes.table_name">Table <strong><t t-esc="changes.table_name"/></strong></t>
+                    <t t-if="changes.tracking_number" class="fw-light my-3"> # <strong><t t-esc="changes.tracking_number"/></strong></t>
+                </span>
             </div>
-            <br />
-            <br />
-            <t t-if="changes.cancelled.length > 0">
-                <div class="pos-order-receipt-cancel">
-                    <div class="pos-receipt-title">
-                        CANCELLED
-                        <t t-esc='changes.time.hours'/>:<t t-esc='changes.time.minutes'/>
-                    </div>
-                    <br />
-                    <br />
-                    <t t-foreach="changes.cancelled" t-as="change" t-key="change_index">
-                        <div class="multiprint-flex">
-                            <span class="product-quantity" t-esc="change.quantity"/>
-                            <span class="product-name" t-esc="change.name"/>
-                        </div>
-                        <t t-if="change.note">
-                            <div>
-                                NOTE
-                                <span class="pos-receipt-right-align">...</span>
-                            </div>
-                            <div><span class="pos-receipt-left-padding">--- <t t-esc="change.note" /></span></div>
-                            <br/>
-                        </t>
-                    </t>
-                    <br />
-                    <br />
-                </div>
-            </t>
-            <t t-if="changes.new.length > 0">
-                <div class="pos-receipt-title">
-                    NEW
-                    <t t-esc='changes.time.hours'/>:<t t-esc='changes.time.minutes'/>
-                </div>
-                <br />
-                <br />
-                <t t-foreach="changes.new" t-as="change" t-key="change_index">
-                    <div class="multiprint-flex">
-                        <span class="product-quantity" t-esc="change.quantity"/>
-                        <span class="product-name" t-esc="change.name"/>
-                    </div>
-                    <t t-if="change.note">
-                        <div>
-                            NOTE
-                            <span class="pos-receipt-right-align">...</span>
-                        </div>
-                        <div><span class="pos-receipt-left-padding">--- <t t-esc="change.note" /></span></div>
-                        <br/>
-                    </t>
+            <div class="text-center lh-1">---------------------------------------------------------------------</div>
+
+            <!-- Receipt Body -->
+            <div class="pos-receipt-body mb-4">
+                <!-- Operational Title -->
+                <t t-if="operational_title">
+                    <div class="pos-receipt-title text-center" t-esc="operational_title" />
                 </t>
-                <br />
-                <br />
-            </t>
+                <!-- Order Lines -->
+                <div t-foreach="changedlines" t-as="line" t-key="change_index">
+                    <div t-attf-class="orderline #{line.isCombo ? 'mx-5 px-2' : 'mx-1'}">
+                        <div class="d-flex medium">
+                            <span class="me-3" t-esc="line.quantity"/> <span class="product-name" t-esc="line.basic_name"/>
+                        </div>
+                        <div t-if="line.attribute_value_ids?.length" class="mx-5 fs-2">
+                            <t t-foreach="line.attribute_value_ids" t-as="attribute" t-key="attribute.id">
+                                <p class="p-0 m-0">
+                                    - <t t-esc="attribute.name" /><br/>
+                                </p>
+                            </t>
+                        </div>
+                        <div t-if="line.note" class="fs-2 fst-italic">
+                            <t t-esc="line.note.split('\n').join(', ')"/><br/>
+                        </div>
+                    </div>
+                </div>
+                <!-- General Note -->
+                <!-- if no orderline change that means general note change to handle with less arguments -->
+                <t t-if="(!changedlines.length or fullReceipt) and changes.order_note.length">
+                    <div class="fs-2 my-5 fst-italic">
+                        <t t-if="changes.order_note">
+                            <t t-esc="changes.order_note.split('\n').join(', ')"/><br/>
+                        </t>
+                    </div>
+                </t>
+            </div>
         </div>
     </t>
-
 </templates>

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -3,6 +3,7 @@
 import { Mutex } from "@web/core/utils/concurrency";
 import { markRaw } from "@odoo/owl";
 import { floatIsZero } from "@web/core/utils/numbers";
+import { renderToElement } from "@web/core/utils/render";
 import { registry } from "@web/core/registry";
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { deduceUrl, random5Chars, uuidv4, getOnNotified } from "@point_of_sale/utils";
@@ -1507,26 +1508,13 @@ export class PosStore extends Reactive {
     async sendOrderInPreparation(order, cancelled = false) {
         if (this.printers_category_ids_set.size) {
             try {
-                const changes = changesToOrder(
+                const orderChange = changesToOrder(
                     order,
                     false,
                     this.orderPreparationCategories,
                     cancelled
                 );
-                if (changes.cancelled.length > 0 || changes.new.length > 0) {
-                    const isPrintSuccessful = await order.printChanges(
-                        false,
-                        this.orderPreparationCategories,
-                        cancelled,
-                        this.unwatched.printers
-                    );
-                    if (!isPrintSuccessful) {
-                        this.dialog.add(AlertDialog, {
-                            title: _t("Printing failed"),
-                            body: _t("Failed in printing the changes in the order"),
-                        });
-                    }
-                }
+                this.printChanges(order, orderChange);
             } catch (e) {
                 console.info("Failed in printing the changes in the order", e);
             }
@@ -1545,6 +1533,162 @@ export class PosStore extends Reactive {
             await this.syncAllOrders();
         }
     }
+
+    async printChanges(order, orderChange) {
+        const unsuccedPrints = [];
+        const lastChangedLines = order.last_order_preparation_change.lines;
+        orderChange.new.sort((a, b) => {
+            const sequenceA = a.pos_categ_sequence;
+            const sequenceB = b.pos_categ_sequence;
+            if (sequenceA === 0 && sequenceB === 0) {
+                return a.pos_categ_id - b.pos_categ_id;
+            }
+
+            return sequenceA - sequenceB;
+        });
+
+        for (const printer of this.unwatched.printers) {
+            const changes = this._getPrintingCategoriesChanges(
+                printer.config.product_categories_ids,
+                orderChange
+            );
+            const toPrintArray = this.preparePrintingData(order, changes);
+            const diningModeUpdate = orderChange.modeUpdate;
+            if (diningModeUpdate || !Object.keys(lastChangedLines).length) {
+                // Prepare orderlines based on the dining mode update
+                const lines =
+                    diningModeUpdate && Object.keys(lastChangedLines).length
+                        ? lastChangedLines
+                        : order.lines;
+
+                // converting in format we need to show on xml
+                const orderlines = Object.entries(lines).map(([key, value]) => ({
+                    basic_name: diningModeUpdate ? value.basic_name : value.product_id.name,
+                    isCombo: diningModeUpdate ? value.isCombo : value.combo_item_id?.id,
+                    quantity: diningModeUpdate ? value.quantity : value.qty,
+                    note: value.note,
+                    attribute_value_ids: value.attribute_value_ids,
+                }));
+
+                // Print detailed receipt
+                const printed = await this.printReceipts(
+                    order,
+                    printer,
+                    "New",
+                    orderlines,
+                    true,
+                    diningModeUpdate
+                );
+                if (!printed) {
+                    unsuccedPrints.push("Detailed Receipt");
+                }
+            } else {
+                // Print all receipts related to line changes
+                for (const [key, value] of Object.entries(toPrintArray)) {
+                    const printed = await this.printReceipts(order, printer, key, value, false);
+                    if (!printed) {
+                        unsuccedPrints.push(key);
+                    }
+                }
+                // Print Order Note if changed
+                if (orderChange.generalNote) {
+                    const printed = await this.printReceipts(order, printer, "Message", []);
+                    if (!printed) {
+                        unsuccedPrints.push("General Message");
+                    }
+                }
+            }
+        }
+
+        // printing errors
+        if (unsuccedPrints.length) {
+            const failedReceipts = unsuccedPrints.join(", ");
+            this.dialog.add(AlertDialog, {
+                title: _t("Printing failed"),
+                body: _t("Failed in printing %s changes of the order", failedReceipts),
+            });
+        }
+    }
+
+    async printReceipts(order, printer, title, lines, fullReceipt = false, diningModeUpdate) {
+        let time;
+        if (order.write_date) {
+            time = order.write_date?.split(" ")[1].split(":");
+            time = time[0] + "h" + time[1];
+        }
+
+        const printingChanges = {
+            table_name: order.table_id ? order.table_id.table_number : "",
+            config_name: order.config_id.name,
+            time: order.write_date ? time : "",
+            tracking_number: order.tracking_number,
+            takeaway: order.config_id.takeaway && order.takeaway,
+            employee_name: order.employee_id?.name || order.user_id?.name,
+            order_note: order.general_note,
+            diningModeUpdate: diningModeUpdate,
+        };
+
+        const receipt = renderToElement("point_of_sale.OrderChangeReceipt", {
+            operational_title: title,
+            changes: printingChanges,
+            changedlines: lines,
+            fullReceipt: fullReceipt,
+        });
+        const result = await printer.printReceipt(receipt);
+        return result.successful;
+    }
+
+    preparePrintingData(order, changes) {
+        const order_modifications = {};
+        const pdisChangedLines = order.last_order_preparation_change.lines;
+
+        if (changes["new"].length) {
+            order_modifications["New"] = changes["new"];
+        }
+        if (changes["noteUpdated"].length) {
+            order_modifications["Note"] = changes["noteUpdated"];
+        }
+        // Handle removed lines
+        if (changes["cancelled"].length) {
+            if (changes["new"].length) {
+                order_modifications["Cancelled"] = changes["cancelled"];
+            } else {
+                const allCancelled = changes["cancelled"].every((line) => {
+                    const pdisLine = pdisChangedLines[line.uuid + " - " + line.note];
+                    return !pdisLine || pdisLine.quantity <= line.quantity;
+                });
+                if (
+                    allCancelled &&
+                    Object.keys(pdisChangedLines).length == changes["cancelled"].length
+                ) {
+                    order_modifications["Cancel"] = changes["cancelled"];
+                } else {
+                    order_modifications["Cancelled"] = changes["cancelled"];
+                }
+            }
+        }
+        return order_modifications;
+    }
+
+    _getPrintingCategoriesChanges(categories, currentOrderChange) {
+        const filterFn = (change) => {
+            const product = this.models["product.product"].get(change["product_id"]);
+            const categoryIds = product.parentPosCategIds;
+
+            for (const categoryId of categoryIds) {
+                if (categories.includes(categoryId)) {
+                    return true;
+                }
+            }
+        };
+
+        return {
+            new: currentOrderChange["new"].filter(filterFn),
+            cancelled: currentOrderChange["cancelled"].filter(filterFn),
+            noteUpdated: currentOrderChange["noteUpdated"].filter(filterFn),
+        };
+    }
+
     closeScreen() {
         this.addOrderIfEmpty();
         const { name: screenName } = this.get_order().get_screen_data();

--- a/addons/point_of_sale/static/src/css/pos_receipts.css
+++ b/addons/point_of_sale/static/src/css/pos_receipts.css
@@ -9,10 +9,6 @@
     display: flex;
 }
 
-.pos-receipt .pos-receipt-right-align .tax-letter{
-    margin-left: 0.5em;
-}
-
 .pos-receipt .pos-receipt-center-align {
     text-align: center;
 }
@@ -56,14 +52,6 @@
 .pos-receipt .pos-receipt-header {
     font-size: 125%;
     text-align: center;
-}
-
-.pos-receipt .pos-order-receipt-cancel {
-    color: red;
-}
-
-.pos-receipt .pos-receipt-customer-note {
-    word-break: break-all;
 }
 
 .pos-payment-terminal-receipt {

--- a/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.js
+++ b/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.js
@@ -68,13 +68,18 @@ patch(ControlButtons.prototype, {
             { once: true }
         );
     },
-    clickTakeAway() {
+    async clickTakeAway() {
         const isTakeAway = !this.currentOrder.takeaway;
         const defaultFp = this.pos.config?.default_fiscal_position_id ?? false;
         const takeawayFp = this.pos.config.takeaway_fp_id;
 
         this.currentOrder.takeaway = isTakeAway;
         this.currentOrder.update({ fiscal_position_id: isTakeAway ? takeawayFp : defaultFp });
+        if (typeof this.currentOrder.id == "number") {
+            this.pos.data.write("pos.order", [this.currentOrder.id], {
+                takeaway: isTakeAway ? true : false,
+            });
+        }
     },
     editFloatingOrderName(order) {
         this.dialog.add(TextInputPopup, {

--- a/addons/pos_restaurant/static/src/overrides/components/product_screen/actionpad_widget/actionpad_widget.js
+++ b/addons/pos_restaurant/static/src/overrides/components/product_screen/actionpad_widget/actionpad_widget.js
@@ -22,7 +22,7 @@ patch(ActionpadWidget.prototype, {
         hasChange =
             hasChange.generalNote == ""
                 ? true // for the case when removed all general note
-                : hasChange.count || hasChange.generalNote;
+                : hasChange.count || hasChange.generalNote || hasChange.modeUpdate;
         return hasChange;
     },
     get swapButtonClasses() {

--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -80,9 +80,23 @@ patch(PosStore.prototype, {
             return acc;
         }, {});
 
+        const nbNoteChange = Object.keys(orderChanges.noteUpdated).length;
+        if (nbNoteChange) {
+            categories["noteUpdate"] = { count: nbNoteChange, name: _t("Note") };
+        }
+        // Only send modeUpdate if there's already an older mode in progress.
+        const currentOrder = this.get_order();
+        if (
+            orderChanges.modeUpdate &&
+            Object.keys(currentOrder.last_order_preparation_change.lines).length
+        ) {
+            const displayName = currentOrder.takeaway ? _t("Take out") : _t("Dine in");
+            categories["modeUpdate"] = { count: 1, name: displayName };
+        }
+
         return [
             ...Object.values(categories),
-            ...("generalNote" in orderChanges ? [{ count: 1, name: _t("General Note") }] : []),
+            ...("generalNote" in orderChanges ? [{ count: 1, name: _t("Message") }] : []),
         ];
     },
     createNewOrder() {

--- a/addons/pos_restaurant/static/src/scss/restaurant.scss
+++ b/addons/pos_restaurant/static/src/scss/restaurant.scss
@@ -54,15 +54,6 @@
     }
 }
 
-.multiprint-flex {
-    display: flex;
-    margin-bottom: 10px;
-}
-
-.multiprint-flex .product-quantity {
-    margin-right: 50px;
-}
-
 .submit-order {
     min-height: 70px;
 }

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -272,6 +272,8 @@ class TestFrontend(TestFrontendCommon):
         self.start_pos_tour('SplitBillScreenTour2')
 
     def test_07_split_bill_screen(self):
+        # disable kitchen printer to avoid printing errors
+        self.pos_config.is_order_printer = False
         self.pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('SplitBillScreenTour3')
 
@@ -282,6 +284,7 @@ class TestFrontend(TestFrontendCommon):
     def test_09_combo_split_bill(self):
         setup_product_combo_items(self)
         self.office_combo.write({'lst_price': 40})
+        self.pos_config.is_order_printer = False
         self.pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('SplitBillScreenTour4ProductCombo')
 


### PR DESCRIPTION
In this commit:
-------------------
- We have changed the entire kitchen ticket structure added many important data
to make it more usefule such as
    - Diferent title related to the order changes.
    - Proper orderline formation with internal notes and addons.
    - Who has taken the order.
    - Floor, table name with order number and time of order changes.
    - Also adapted sitting mode (Dine in, Take out) changes.
- Changed the getOrderChanges functionas below
    - Identified and separated only note updates in line
    - Added some required informations like comboline and attributes.
- Enabled Order button when sitting mode updated (Dinein <-> Takeout)
    - For this we have saved the sittingMode data in last order changes.

Task: 4264433
