### PR TITLE
[IMP] website_sale: set admin as default for salesperson in settings

### DIFF
--- a/addons/website_sale/data/data.xml
+++ b/addons/website_sale/data/data.xml
@@ -57,6 +57,7 @@
 
         <record model="website" id="website.default_website">
             <field name="salesteam_id" ref="sales_team.salesteam_website_sales"/>
+            <field name="salesperson_id" ref="base.user_admin"/>
         </record>
 
         <record id="delivery.free_delivery_carrier" model="delivery.carrier">

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -455,10 +455,6 @@ class Website(models.Model):
 
     def _prepare_sale_order_values(self, partner_sudo):
         self.ensure_one()
-        affiliate_id = request.session.get('affiliate_id')
-        salesperson_user_sudo = self.env['res.users'].sudo().browse(affiliate_id).exists()
-        if not salesperson_user_sudo:
-            salesperson_user_sudo = self.salesperson_id or partner_sudo.parent_id.user_id or partner_sudo.user_id
 
         return {
             'company_id': self.company_id.id,
@@ -466,7 +462,6 @@ class Website(models.Model):
             'partner_id': partner_sudo.id,
             'pricelist_id': self.pricelist_id.id,
             'team_id': self.salesteam_id.id,
-            'user_id': salesperson_user_sudo.id,
             'website_id': self.id,
         }
 


### PR DESCRIPTION
Before this commit:
The Salesperson field in eCommerce settings had no default value, causing missed notifications and unmanaged orders, especially for wire transfers or pending orders.

After this commit:
The database admin is now set as the default Salesperson in eCommerce settings for default website, ensuring the admin is notified of new or pending orders, preventing unmanaged orders.

task-4270127

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
