### PR TITLE
[FIX] web: dynamic placeholder popover not closing

### DIFF
--- a/addons/web/static/src/core/model_field_selector/model_field_selector_popover.js
+++ b/addons/web/static/src/core/model_field_selector/model_field_selector_popover.js
@@ -226,7 +226,7 @@ export class ModelFieldSelectorPopover extends Component {
         this.keepLast.add(Promise.resolve());
         this.state.page.selectedName = field.name;
         this.props.update(this.state.page.path);
-        this.props.close();
+        this.props.close(true);
     }
 
     onDebugInputKeydown(ev) {

--- a/addons/web/static/src/core/model_field_selector/model_field_selector_popover.xml
+++ b/addons/web/static/src/core/model_field_selector/model_field_selector_popover.xml
@@ -19,7 +19,7 @@
                    title="Close"
                    role="img"
                    aria-label="Close"
-                   t-on-click="props.close"
+                   t-on-click="() => props.close()"
                 />
                 <t t-if="props.showSearchInput">
                     <div class="o_model_field_selector_popover_search mt-2">

--- a/addons/web/static/src/views/fields/dynamic_placeholder_popover.js
+++ b/addons/web/static/src/views/fields/dynamic_placeholder_popover.js
@@ -23,8 +23,8 @@ export class DynamicPlaceholderPopover extends Component {
     filter(fieldDef) {
         return !["one2many", "boolean", "many2many"].includes(fieldDef.type) && fieldDef.searchable;
     }
-    closeFieldSelector() {
-        if (this.state.path) {
+    closeFieldSelector(isPathSelected = false) {
+        if (isPathSelected) {
             this.state.isPathSelected = true;
             return;
         }

--- a/addons/web/static/tests/views/fields/dynamic_placeholder_tests.js
+++ b/addons/web/static/tests/views/fields/dynamic_placeholder_tests.js
@@ -1,0 +1,164 @@
+/** @odoo-module **/
+
+import { click, getFixture, triggerEvent, triggerHotkey } from "@web/../tests/helpers/utils";
+import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
+
+let serverData;
+let target;
+
+QUnit.module("Dynamic placeholder", (hooks) => {
+    hooks.beforeEach(() => {
+        target = getFixture();
+        serverData = {
+            models: {
+                partner: {
+                    fields: {
+                        char: {
+                            string: "Char",
+                            type: "char",
+                        },
+                        placeholder: {
+                            string: "Placeholder",
+                            type: "char",
+                            default: "partner",
+                        },
+                        product_id: {
+                            string: "Product",
+                            type: "many2one",
+                            relation: "product",
+                            searchable: true,
+                        },
+                    },
+                    records: [
+                        {
+                            id: 1,
+                            char: "yop",
+                            product_id: 37,
+                        },
+                        {
+                            id: 2,
+                            char: "blip",
+                            product_id: 41,
+                        },
+                    ],
+                },
+                product: {
+                    fields: {
+                        name: { string: "Product Name", type: "char", searchable: true },
+                    },
+                    records: [
+                        {
+                            id: 37,
+                            name: "xphone",
+                        },
+                        {
+                            id: 41,
+                            name: "xpad",
+                        },
+                    ],
+                },
+            },
+        };
+
+        setupViewRegistries();
+    });
+
+    QUnit.test("dynamic placeholder close on click out", async (assert) => {
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: /* xml */ `
+                <form>
+                    <field name="placeholder" invisible="1"/>
+                    <sheet>
+                        <group>
+                            <field
+                                name="char"
+                                options="{
+                                    'dynamic_placeholder': true,
+                                    'dynamic_placeholder_model_reference_field': 'placeholder'
+                                }"
+                            />
+                        </group>
+                    </sheet>
+                </form>
+            `,
+        });
+
+        await triggerEvent(target, ".o_field_char input", "keydown", { key: "#" });
+        assert.containsOnce(target, ".o_model_field_selector_popover");
+        await click(target, ".o_content");
+        assert.containsNone(target, ".o_model_field_selector_popover");
+        await triggerEvent(target, ".o_field_char input", "keydown", { key: "#" });
+        await click(target, ".o_model_field_selector_popover_item_relation");
+        await click(target, ".o_content");
+        assert.containsNone(target, ".o_model_field_selector_popover");
+    });
+
+    QUnit.test("dynamic placeholder close with escape", async (assert) => {
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: /* xml */ `
+                <form>
+                    <field name="placeholder" invisible="1"/>
+                    <sheet>
+                        <group>
+                            <field
+                                name="char"
+                                options="{
+                                    'dynamic_placeholder': true,
+                                    'dynamic_placeholder_model_reference_field': 'placeholder'
+                                }"
+                            />
+                        </group>
+                    </sheet>
+                </form>
+            `,
+        });
+
+        await triggerEvent(target, ".o_field_char input", "keydown", { key: "#" });
+        assert.containsOnce(target, ".o_model_field_selector_popover");
+        await triggerHotkey("Escape");
+        assert.containsNone(target, ".o_model_field_selector_popover");
+        await triggerEvent(target, ".o_field_char input", "keydown", { key: "#" });
+        await click(target, ".o_model_field_selector_popover_item_relation");
+        await triggerHotkey("Escape");
+        assert.containsNone(target, ".o_model_field_selector_popover");
+    });
+
+    QUnit.test("dynamic placeholder close when clicking on the cross", async (assert) => {
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: /* xml */ `
+                <form>
+                    <field name="placeholder" invisible="1"/>
+                    <sheet>
+                        <group>
+                            <field
+                                name="char"
+                                options="{
+                                    'dynamic_placeholder': true,
+                                    'dynamic_placeholder_model_reference_field': 'placeholder'
+                                }"
+                            />
+                        </group>
+                    </sheet>
+                </form>
+            `,
+        });
+
+        await triggerEvent(target, ".o_field_char input", "keydown", { key: "#" });
+        assert.containsOnce(target, ".o_model_field_selector_popover");
+        await click(target, ".o_model_field_selector_popover_close");
+        assert.containsNone(target, ".o_model_field_selector_popover");
+        await triggerEvent(target, ".o_field_char input", "keydown", { key: "#" });
+        await click(target, ".o_model_field_selector_popover_item_relation");
+        await click(target, ".o_model_field_selector_popover_close");
+        assert.containsNone(target, ".o_model_field_selector_popover");
+    });
+});


### PR DESCRIPTION
This commit fixes an issue where the dynamic placeholder popover would not fully close upon pressing escape or clicking on the cross when a relation field was selected. This is because its previous condition for changing state instead of closing was if it had some field path selected upon closing the model field selector popover. This would not handle well the case where a relation is selected before closing. The fix is therefore to specify inside calls to the close function of the model field selector popover whether it closed because a final value was selected or not.

task-4066184