### PR TITLE
[IMP] stock_account: default grouping and no filters

### DIFF
--- a/addons/stock_account/views/stock_valuation_layer_views.xml
+++ b/addons/stock_account/views/stock_valuation_layer_views.xml
@@ -105,7 +105,7 @@
         <field name="name">inventory.aging.graph</field>
         <field name="model">stock.valuation.layer</field>
         <field name="arch" type="xml">
-            <graph string="valuation graph" type="line" cumulated="1" >
+            <graph string="valuation graph" type="line" cumulated="1" cumulated_start="1" >
                 <field name="create_date" type="row"/>
                 <field name="value" type="measure"/>
             </graph>
@@ -123,7 +123,7 @@
             'pivot_column_groupby': ['create_date:month'],
             'pivot_row_groupby': ['categ_id'],
             'pivot_measures': ['remaining_qty', 'remaining_value'],
-            'graph_groupbys': ['create_date:day'],
+            'graph_groupbys': ['create_date:month', 'categ_id'],
             }</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face"/>
@@ -145,10 +145,9 @@
                 <field name="warehouse_id" groups="stock.group_stock_multi_warehouses"/>
                 <field name="company_id" groups="base.group_multi_company"/>
                 <separator/>
-                <filter string="Incoming" name="incoming" domain="[('stock_move_id.location_id.usage', 'not in', ('internal', 'transit')), ('stock_move_id.location_dest_id.usage', 'in', ('internal', 'transit'))]"/>
-                <filter string="Outgoing" name="outgoing" domain="[('stock_move_id.location_id.usage', 'in', ('internal', 'transit')), ('stock_move_id.location_dest_id.usage', 'not in', ('internal', 'transit'))]"/>
-                <separator/>
                 <filter string="Has Remaining Qty" name="has_remaining_qty" domain="[('remaining_qty', '>', 0)]"/>
+                <separator/>
+                <filter string="Date" name="date" date="create_date" />
                 <group expand='0' string='Group by...'>
                     <filter string='Product' name="group_by_product_id" context="{'group_by': 'product_id'}"/>
                     <filter string='Lot/Serial Number' name="group_by_lot_id" context="{'group_by': 'lot_id'}"/>


### PR DESCRIPTION
In this commit:
===================
In valuation report-
  - No Filters Applied: The stock valuation report will now display all transactions, including both ins and outs, without any filtering.

  - Default Grouping by Product Category: The report will automatically group entries by product category for better organization and insights.

  - Monthly Grouping by Default: Transactions will be grouped by month by default, enhancing the visibility of trends over time.

task- 3637544

