### PR TITLE
[FIX] l10n_fr_pos_cert: fix hidden old unit price on products screen

### DIFF
--- a/addons/l10n_fr_pos_cert/static/src/xml/ProductScreen.xml
+++ b/addons/l10n_fr_pos_cert/static/src/xml/ProductScreen.xml
@@ -3,7 +3,7 @@
 
     <t t-name="l10n_fr_pos_cert.ProductScreen" t-inherit="point_of_sale.ProductScreen" t-inherit-mode="extension">
 		<xpath expr="//Orderline" position="inside" >
-            <t t-if="pos.is_french_country() !== false and line.price_manually_set === 'manual'">
+            <t t-if="pos.is_french_country() !== false and line.price_type === 'manual'">
                 <li class="info">
                     Old unit price:
                     <span class="oldPrice">

--- a/doc/cla/individual/NEDJIMAbelgacem.md
+++ b/doc/cla/individual/NEDJIMAbelgacem.md
@@ -1,0 +1,11 @@
+Belgium, 2024-11-23
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Nedjima Belgacem gb_nedjima@esi.dz https://github.com/NEDJIMAbelgacem


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
The "Old unit price" text in the POS products screen is not showing properly when the l10n_fr_pos_cert is installed.

Desired behavior after PR is merged:
The  "Old unit price" text will be showing up properly using simular code to what is on https://github.com/odoo/odoo/blob/a0ab0ce39bf4cba5e90eae109bcd006b39e31c6c/addons/l10n_fr_pos_cert/static/src/xml/OrderReceipt.xml#L14 
 



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
