### PR TITLE
[FIX] account: prevent error for checking OCR status

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3744,7 +3744,8 @@ class AccountMove(models.Model):
         if not float_is_zero(tax_amount_rounding_error, precision_rounding=self.currency_id.rounding):
             for subtotal in totals['subtotals']:
                 if _('Untaxed Amount') == subtotal['name']:
-                    subtotal['tax_groups'][0]['tax_amount_currency'] += tax_amount_rounding_error
+                    if subtotal['tax_groups']:
+                        subtotal['tax_groups'][0]['tax_amount_currency'] += tax_amount_rounding_error
                     totals['total_amount_currency'] = amount_total
                     self.tax_totals = totals
                     break


### PR DESCRIPTION
The error occurs at [1] because we are attempting to fetch the first record of ``tax_groups`` from ``subtotal``, but ``tax_groups`` is empty. As a result, there is no valid index for ``subtotal['tax_groups']``, leading to an index error.

Traceback: 
---
```
IndexError: list index out of range
  File "odoo/http.py", line 2365, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1892, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1955, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 137, in retrying
    result = func()
  File "odoo/http.py", line 1922, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2169, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 329, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 728, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 35, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 517, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "home/odoo/src/enterprise/18.0/iap_extract/models/extract_mixin.py", line 214, in check_ocr_status
    record._check_ocr_status()
  File "home/odoo/src/enterprise/18.0/iap_extract/models/extract_mixin.py", line 338, in _check_ocr_status
    self.with_company(self.company_id)._fill_document_with_results(ocr_results)
  File "home/odoo/src/enterprise/18.0/account_invoice_extract/models/account_invoice.py", line 732, in _fill_document_with_results
    self._save_form(ocr_results)
  File "home/odoo/src/enterprise/18.0/account_invoice_extract/models/account_invoice.py", line 938, in _save_form
    self._check_total_amount(total_ocr)
  File "addons/account/models/account_move.py", line 3738, in _check_total_amount
    subtotal['tax_groups'][0]['tax_amount_currency'] += tax_amount_rounding_error
```
[1]- https://github.com/odoo/odoo/blob/c047bf3d89e630c98c61bc45df7391fe0732c343/addons/account/models/account_move.py#L3747

sentry-6012011017

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
