### PR TITLE
[FIX] website: allow empty default value for model select fields

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -1112,7 +1112,21 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
      * Apply the we-list on the target and rebuild the input(s)
      */
     renderListItems: async function (previewMode, value, params) {
-        const valueList = JSON.parse(value);
+        let valueList = JSON.parse(value);
+        if (this._getSelect()) {
+            // Default entry only for fields rendered as select.
+            // Remove previous default.
+            valueList = valueList.filter(value => value.id !== "" || value.display_name !== "");
+            // Add default in first position if no default value is set.
+            const hasDefault = valueList.some(value => value.selected);
+            if (valueList.length && !hasDefault) {
+                valueList.unshift({
+                    id: "",
+                    display_name: "",
+                    selected: true,
+                });
+            }
+        }
 
         // Synchronize the possible values with the fields whose visibility
         // depends on the current field
@@ -1193,7 +1207,13 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
             case 'toggleRequired':
                 return this.$target[0].classList.contains(params.activeValue) ? params.activeValue : 'false';
             case 'renderListItems':
-                return JSON.stringify(this._getListItems());
+                // TODO In master use a parameter.
+                this.__getListItems_forWidgetState = true;
+                try {
+                    return JSON.stringify(this._getListItems());
+                } finally {
+                    delete this.__getListItems_forWidgetState;
+                }
             case 'setVisibilityDependency':
                 return this.$target[0].dataset.visibilityDependency || '';
         }
@@ -1503,6 +1523,15 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
         let options = [];
         if (select) {
             options = [...select.querySelectorAll('option')];
+            if (
+                this.__getListItems_forWidgetState &&
+                options.length &&
+                options[0].value === "" &&
+                options[0].textContent === "" &&
+                options[0].selected === true
+            ) {
+                options.shift();
+            }
         } else if (multipleInputs) {
             options = [...multipleInputs.querySelectorAll('.checkbox input, .radio input')];
         }

--- a/addons/website/static/tests/tours/website_form_editor_frontend.js
+++ b/addons/website/static/tests/tours/website_form_editor_frontend.js
@@ -43,7 +43,7 @@ tour.register("website_form_editor_tour_submit", {
                         ":has(.s_website_form_field:has(label:contains('Your Message')).o_has_error)" +
                         ":has(.s_website_form_field:has(label:contains('Products')).o_has_error)" +
                         ":has(.s_website_form_field:has(label:contains('Service')):not(.o_has_error))" +
-                        ":has(.s_website_form_field:has(label:contains('State')):not(.o_has_error))" +
+                        ":has(.s_website_form_field:has(label:contains('State')).o_has_error)" +
                         ":has(.s_website_form_field:has(label:contains('Invoice Scan')):not(.o_has_error))",
         trigger:  "input[name=subject]",
         run:      "text Jane Smith"
@@ -63,7 +63,7 @@ tour.register("website_form_editor_tour_submit", {
                         ":has(.s_website_form_field:has(label:contains('Your Message')).o_has_error)" +
                         ":has(.s_website_form_field:has(label:contains('Products')).o_has_error)" +
                         ":has(.s_website_form_field:has(label:contains('Service')):not(.o_has_error))" +
-                        ":has(.s_website_form_field:has(label:contains('State')):not(.o_has_error))" +
+                        ":has(.s_website_form_field:has(label:contains('State')).o_has_error)" +
                         ":has(.s_website_form_field:has(label:contains('Invoice Scan')):not(.o_has_error))",
         trigger:  "textarea[name=body_html]",
         run:      "text A useless message"
@@ -83,7 +83,7 @@ tour.register("website_form_editor_tour_submit", {
                         ":has(.s_website_form_field:has(label:contains('Your Message')):not(.o_has_error))" +
                         ":has(.s_website_form_field:has(label:contains('Products')).o_has_error)" +
                         ":has(.s_website_form_field:has(label:contains('Service')):not(.o_has_error))" +
-                        ":has(.s_website_form_field:has(label:contains('State')):not(.o_has_error))" +
+                        ":has(.s_website_form_field:has(label:contains('State')).o_has_error)" +
                         ":has(.s_website_form_field:has(label:contains('Invoice Scan')):not(.o_has_error))",
         trigger:  "input[name=Products][value='Wiko Stairway']"
     },
@@ -98,6 +98,11 @@ tour.register("website_form_editor_tour_submit", {
     {
         content:  "Check a service",
         trigger:  "input[name='Service'][value='Development Service']"
+    },
+    {
+        content:  "Select a State",
+        trigger:  "select[name='State']",
+        run:      "text Canada",
     },
     {
         content:  "Complete Your Name field",


### PR DESCRIPTION
When model selection field is used in a form, its default value is
always one of the available values. Because of this, if the field is
required, it does not force the user to pick a value, but it provides a
possibly incorrect default value.

This commit makes an empty value available for selection if no default
value is chosen.
The behavior is also made available on custom fields, if such an empty
value had been manually created, it will be replaced by this
implementation.

Steps to reproduce:
- Install website_form_project
- Add a form in a page
- Select the "Create a Task" action
- Add the "Analytic Account" field to the form
- Make the field required

=> There was no way to have no default value by default.

opw-4268164