### PR TITLE
[FIX] point_of_sale: fix iot box rename script

### DIFF
--- a/addons/point_of_sale/tools/posbox/configuration/rename_iot.sh
+++ b/addons/point_of_sale/tools/posbox/configuration/rename_iot.sh
@@ -18,8 +18,7 @@ function connect () {
     sudo mount -o remount,rw /root_bypass_ramdisks
 
 		sudo sed -i "s/${HOSTNAME}/${IOT_NAME}/g" ${HOSTS}
-		echo "${IOT_NAME}" > /tmp/hostname
-		sudo cp /tmp/hostname "${HOST_FILE}"
+		echo "${IOT_NAME}" | sudo tee "${HOST_FILE}"
 
 		echo "interface=wlan0" > /root_bypass_ramdisks/etc/hostapd/hostapd.conf
 		echo "ssid=${IOT_NAME}" >> /root_bypass_ramdisks/etc/hostapd/hostapd.conf


### PR DESCRIPTION
Sometimes when renaming the IoT box, it
would instead rename to `localhost.localdomain`.
This was due to the script writing to the `/tmp`
directory, which sometimes gets full and causes
the `/etc/hostname` file to become empty.

The fix is simply to bypass using the `/tmp` directory at all in the script.

task-4210432

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
