### PR TITLE
[FIX] http: remove usage of cgi

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -109,7 +109,6 @@ endpoint
 """
 
 import base64
-import cgi
 import collections
 import collections.abc
 import contextlib
@@ -127,7 +126,6 @@ import threading
 import time
 import traceback
 import warnings
-import zlib
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
 from io import BytesIO
@@ -2159,8 +2157,7 @@ class Application:
         if 'Content-Security-Policy' in headers:
             return
 
-        mime, _params = cgi.parse_header(headers.get('Content-Type', ''))
-        if not mime.startswith('image/'):
+        if not headers.get('Content-Type', '').startswith('image/'):
             return
 
         headers['Content-Security-Policy'] = "default-src 'none'"


### PR DESCRIPTION
As part of the removing `Dead Batteries` pep 594, the usage of the `cgi` module is deprecated and it will be removed the standard library in python 3.13. See https://peps.python.org/pep-0594/#cgi

Here the cgi module was used to parse the `Content-Type` of a response and separate the mime part from the parameters. But as the mime part was only used to verify the beginning of the string this separation is not nedeed.

While at it, this commit removes the unused zlib import.
