### PR TITLE
[FIX] spreadsheet: do not crash on invalid model

### DIFF
--- a/addons/spreadsheet/i18n/spreadsheet.pot
+++ b/addons/spreadsheet/i18n/spreadsheet.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 18.0\n"
+"Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-25 07:49+0000\n"
-"PO-Revision-Date: 2024-10-25 07:49+0000\n"
+"POT-Creation-Date: 2024-11-13 13:04+0000\n"
+"PO-Revision-Date: 2024-11-13 13:04+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -3152,6 +3152,7 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/spreadsheet/static/src/pivot/odoo_pivot.js:0
 #: code:addons/spreadsheet/static/src/pivot/pivot_helpers.js:0
+#: code:addons/spreadsheet/static/src/pivot/pivot_model.js:0
 msgid "Field %s does not exist"
 msgstr ""
 
@@ -8174,6 +8175,21 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet.js:0
 msgid "The minute component of the time."
+msgstr ""
+
+#. module: spreadsheet
+#. odoo-javascript
+#: code:addons/spreadsheet/static/src/data_sources/data_source.js:0
+#: code:addons/spreadsheet/static/src/pivot/odoo_pivot_loader.js:0
+msgid "The model \"%(model)s\" does not exist."
+msgstr ""
+
+#. module: spreadsheet
+#. odoo-javascript
+#: code:addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.js:0
+msgid ""
+"The model (%(model)s) of this global filter is not valid (it may have been "
+"renamed/deleted)."
 msgstr ""
 
 #. module: spreadsheet

--- a/addons/spreadsheet/static/src/data_sources/odoo_views_data_source.js
+++ b/addons/spreadsheet/static/src/data_sources/odoo_views_data_source.js
@@ -1,7 +1,7 @@
 /** @odoo-module */
 // @ts-check
 
-import { LOADING_ERROR, LoadableDataSource } from "./data_source";
+import { LOADING_ERROR, LoadableDataSource, getFields } from "./data_source";
 import { Domain } from "@web/core/domain";
 import { user } from "@web/core/user";
 import { omit } from "@web/core/utils/objects";
@@ -57,10 +57,7 @@ export class OdooViewsDataSource extends LoadableDataSource {
 
     async loadMetadata() {
         if (!this._metaData.fields) {
-            this._metaData.fields = await this.serverData.fetch(
-                this._metaData.resModel,
-                "fields_get"
-            );
+            this._metaData.fields = await getFields(this.serverData, this._metaData.resModel);
         }
         this._metaDataLoaded = true;
     }
@@ -69,6 +66,9 @@ export class OdooViewsDataSource extends LoadableDataSource {
      * Ensure that the metadata are loaded. If not, throw an error
      */
     _assertMetaDataLoaded() {
+        if (!this._isModelValid) {
+            throw this.loadError;
+        }
         if (!this._metaDataLoaded) {
             this.loadMetadata();
             throw LOADING_ERROR;

--- a/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.xml
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.xml
@@ -13,11 +13,16 @@
             </div>
             <span t-if="filter.type === 'relation'" class="w-100">
                 <MultiRecordSelector
+                    t-if="isValid"
                     placeholder="' ' + translate(filter.label)"
                     resModel="filter.modelName"
                     resIds="filterValue || []"
                     domain="relationalAllowedDomain"
                     update="(resIds) => this.onTagSelected(filter.id, resIds)" />
+                <ValidationMessages t-else="1"
+                                    messages="[invalidModel]"
+                                    msgType="'error'"/>
+
             </span>
             <div t-if="filter.type === 'date'" class="w-100">
                 <select t-if="filter.rangeType === 'relative'"

--- a/addons/spreadsheet/static/src/list/list_data_source.js
+++ b/addons/spreadsheet/static/src/list/list_data_source.js
@@ -56,6 +56,10 @@ export class ListDataSource extends OdooViewsDataSource {
         this.maxPosition = Math.max(this.maxPosition, position);
     }
 
+    isModelValid() {
+        return this._isModelValid;
+    }
+
     /**
      * @param {string} fieldName
      */
@@ -149,6 +153,12 @@ export class ListDataSource extends OdooViewsDataSource {
      * @returns {string | EvaluationError}
      */
     getListHeaderValue(fieldName) {
+        if (this.isLoading()) {
+            return LOADING_ERROR;
+        }
+        if (!this._isValid || !this._isModelValid) {
+            return this._loadError;
+        }
         if (!this.isMetaDataLoaded()) {
             this._triggerFetching();
             return LOADING_ERROR;
@@ -167,7 +177,7 @@ export class ListDataSource extends OdooViewsDataSource {
         if (this.isLoading()) {
             return LOADING_ERROR;
         }
-        if (!this._isValid) {
+        if (!this._isValid || !this._isModelValid) {
             return this._loadError;
         }
         if (position >= this.maxPositionFetched) {

--- a/addons/spreadsheet/static/src/pivot/odoo_pivot.js
+++ b/addons/spreadsheet/static/src/pivot/odoo_pivot.js
@@ -443,6 +443,10 @@ export class OdooPivot {
         return this.loader.lastUpdate;
     }
 
+    isModelValid() {
+        return this.loader.isModelValid();
+    }
+
     isValid() {
         return this.loader.isValid();
     }

--- a/addons/spreadsheet/static/src/pivot/pivot_model.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_model.js
@@ -89,6 +89,20 @@ export class OdooPivotModel extends PivotModel {
     }
 
     async load(searchParams) {
+        if (
+            this.metaData.activeMeasures.find(
+                (fieldName) => fieldName !== "__count" && !this.metaData.fields[fieldName]
+            )
+        ) {
+            throw new Error(
+                _t(
+                    "Some measures are not available: %s",
+                    this.metaData.activeMeasures
+                        .filter((fieldName) => !this.metaData.fields[fieldName])
+                        .join(", ")
+                )
+            );
+        }
         searchParams.groupBy = [];
         searchParams.orderBy = [];
         await super.load(searchParams);
@@ -334,6 +348,15 @@ export class OdooPivotModel extends PivotModel {
             );
         }
         return displayName;
+    }
+
+    _normalize(groupBy) {
+        const [fieldName] = groupBy.split(":");
+        const field = this.metaData.fields[fieldName];
+        if (!field) {
+            throw new EvaluationError(_t("Field %s does not exist", fieldName));
+        }
+        return super._normalize(groupBy);
     }
 
     /**

--- a/addons/spreadsheet/static/tests/lists/list_plugin.test.js
+++ b/addons/spreadsheet/static/tests/lists/list_plugin.test.js
@@ -1055,3 +1055,29 @@ test("INSERT_ODOO_LIST_WITH_TABLE adds a table that maches the list dimension", 
     expect(table.type).toBe("static");
     expect(table.config).toEqual({ ...PIVOT_TABLE_CONFIG, firstColumn: false });
 });
+
+test("An error is displayed if the list has invalid model", async function () {
+    const { model } = await createSpreadsheetWithList({
+        mockRPC: async function (route, { model, method, kwargs }) {
+            if (model === "unknown" && method === "fields_get") {
+                throw makeServerError({ code: 404 });
+            }
+        },
+    });
+    const listId = model.getters.getListIds()[0];
+    const listDefinition = model.getters.getListModelDefinition(listId);
+    model.dispatch("UPDATE_ODOO_LIST", {
+        listId,
+        list: {
+            ...listDefinition,
+            metaData: {
+                ...listDefinition.metaData,
+                resModel: "unknown",
+            },
+        },
+    });
+    setCellContent(model, "A1", `=ODOO.LIST(1,1,"foo")`);
+    await animationFrame();
+    expect(getCellValue(model, "A1")).toBe("#ERROR");
+    expect(getEvaluatedCell(model, "A1").message).toBe(`The model "unknown" does not exist.`);
+});


### PR DESCRIPTION
Before this commit, if a pivot have an invalid model (renaming, deletion, ...), some tracebacks were raised (opening the side panel, ...)

This commit fixes the issue by handling the case where the pivot model is invalid by showing a clear error in the cell (this commit) and displaying an error in the side panel of the pivot (see enterprise PR)

Task: 4280402

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
