### PR TITLE
[FIX] mail: missing create or view thread action in mobile view

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/message_actions.js
+++ b/addons/mail/static/src/discuss/core/public_web/message_actions.js
@@ -3,7 +3,7 @@ import { _t } from "@web/core/l10n/translation";
 
 messageActionsRegistry.add("create-or-view-thread", {
     condition: (component) =>
-        component.isOriginThread &&
+        component.message.thread?.eq(component.props.thread) &&
         component.message.thread.hasSubChannelFeature &&
         component.store.self.isInternalUser,
     icon: "fa fa-comments-o",


### PR DESCRIPTION
**Current behavior before PR:**

Users were unable to create or view threads from message actions on mobile devices due to an incorrectly written condition. The condition checked `component.isOriginThread`, but in mobile, the component is `MessageActionMenuMobile` insead of `Message`, which does not have the isOriginThread method.

**Desired behavior after PR is merged:**

This PR fixes the issue, allowing the create or view thread actions to display properly on mobile.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
