### PR TITLE
[IMP] web, auth_signup: make auth pages editable

### DIFF
--- a/addons/auth_signup/views/auth_signup_login_templates.xml
+++ b/addons/auth_signup/views/auth_signup_login_templates.xml
@@ -40,6 +40,7 @@
 
         <template id="auth_signup.signup" name="Sign up login">
             <t t-call="web.login_layout">
+                <div class="oe_structure" id="oe_structure_signup_top"/>
                 <form class="oe_signup_form" role="form" method="post" t-if="not message" data-captcha="signup">
                   <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
 
@@ -58,11 +59,13 @@
                         <div class="o_login_auth"/>
                     </div>
                 </form>
+                <div class="oe_structure" id="oe_structure_signup_bottom"/>
             </t>
         </template>
 
         <template id="auth_signup.reset_password" name="Reset password">
             <t t-call="web.login_layout">
+                <div class="oe_structure" id="oe_structure_reset_password_top"/>
                 <div t-if="message" class="oe_login_form clearfix">
                     <p class="alert alert-success" t-if="message" role="status">
                         <t t-esc="message"/>
@@ -102,6 +105,7 @@
                     </div>
 
                 </form>
+                <div class="oe_structure" id="oe_structure_reset_password_bottom"/>
 
             </t>
         </template>

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -137,6 +137,7 @@
 
     <template id="web.login" name="Login">
         <t t-call="web.login_layout">
+            <div class="oe_structure" id="oe_structure_login_top"/>
             <owl-component t-if="not login" name="web.user_switch" />
             <form t-attf-class="oe_login_form #{'' if login else 'd-none'}" role="form" t-attf-action="/web/login" method="post" onsubmit="this.action = '/web/login' + location.hash" data-captcha="login">
                 <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
@@ -177,6 +178,7 @@
                 <input type="hidden" name="type" value="password"/>
                 <input type="hidden" name="redirect" t-att-value="redirect"/>
             </form>
+            <div class="oe_structure" id="oe_structure_login_bottom"/>
         </t>
     </template>
 


### PR DESCRIPTION
Previously, snippets could not be dropped on these pages:
/web/login
/web/signup
/web/reset_password

With this improvement, these pages are now editable, allowing snippets to be added at the top and bottom area of these pages.

task-3859891