### PR TITLE
[IMP] portal: allow portal change login field

### DIFF
--- a/addons/portal/static/src/js/address.js
+++ b/addons/portal/static/src/js/address.js
@@ -1,6 +1,7 @@
 import { rpc } from "@web/core/network/rpc";
 import { debounce } from "@web/core/utils/timing";
 import publicWidget from "@web/legacy/js/public/public_widget";
+import { renderToElement } from "@web/core/utils/render";
 
 publicWidget.registry.customerAddress = publicWidget.Widget.extend({
     // /my/address & /my/account
@@ -199,6 +200,8 @@ publicWidget.registry.customerAddress = publicWidget.Widget.extend({
                     fieldName => this.addressForm[fieldName].classList.add('is-invalid')
                 );
 
+                // Remove previous error message in footer
+                document.querySelector(".o_portal_error")?.remove();
                 // Display the error messages
                 // NOTE: setCustomValidity is not used as we would have to reset the error msg on
                 // input update, which is not worth catching for the rare cases where the
@@ -210,6 +213,11 @@ publicWidget.registry.customerAddress = publicWidget.Widget.extend({
                     errorHeader.appendChild(document.createTextNode(message));
                     return errorHeader;
                 });
+                submitButton.before(
+                    renderToElement("portal.error", {
+                        message: "Please fill in the form correctly.",
+                    })
+                );
 
                 this.errorsDiv.replaceChildren(...newErrors);
 

--- a/addons/portal/static/src/xml/portal_security.xml
+++ b/addons/portal/static/src/xml/portal_security.xml
@@ -50,4 +50,12 @@
             </p>
         </div>
     </t>
+    <t t-name="portal.error">
+        <div class="o_portal_error order-md-4 order-2 my-2">
+            <span class="px-3 text-danger">
+                <i class="fa fa-close me-1" role="img" aria-hidden="true" title="Error"/>
+                <t t-esc="message"/>
+            </span>
+        </div>
+    </t>
 </templates>

--- a/addons/portal/views/address_templates.xml
+++ b/addons/portal/views/address_templates.xml
@@ -134,6 +134,18 @@
     </template>
 
     <template id="portal.address_form_fields" name="Address Details">
+        <t t-if="login_field">
+            <div id="div_login" class="col-lg-12 mb-2">
+                <label class="col-form-label" for="o_login">Login ID</label>
+                <input
+                    id="o_login"
+                    type="text"
+                    name="login"
+                    t-att-value="request.env.user.login"
+                    class="form-control"
+                />
+            </div>
+        </t>
         <div id="div_name" class="col-lg-12 mb-2">
             <label class="col-form-label" for="o_name">Full name</label>
             <input
@@ -342,6 +354,7 @@
         <input type="hidden" name="address_type" t-att-value="address_type"/>
         <input type="hidden" name="use_delivery_as_billing" t-att-value="use_delivery_as_billing"/>
         <input type="hidden" name="parent_id" t-att-value="parent_id"/>
+        <input type="hidden" name="login_field" t-att-value="login_field" />
         <t t-if="partner_id">
             <input type="hidden" name="partner_id" t-att-value="partner_id"/>
         </t>
@@ -356,16 +369,16 @@
             <a
                 role="button"
                 t-att-href="discard_url or '/my/'"
-                class="btn btn-outline-secondary w-100 w-md-auto order-md-1 order-3"
+                class="btn btn-outline-secondary w-100 w-md-auto order-md-1 order-4"
             >
                 <i class="fw-light fa fa-angle-left me-2"/>Discard
             </a>
-            <div class="position-relative w-100 d-flex d-md-none justify-content-center align-items-center order-2 my-2 opacity-75">
+            <div class="position-relative w-100 d-flex d-md-none justify-content-center align-items-center order-3 order-md-2 my-2 opacity-75">
                 <hr class="w-100"/>
                 <span class="px-3">or</span>
                 <hr class="w-100"/>
             </div>
-            <button id="save_address" class="btn btn-primary w-100 w-md-auto order-1 order-md-3">
+            <button id="save_address" class="btn btn-primary w-100 w-md-auto order-1 order-md-3 ms-auto gap-2">
                 <t name="save_address_label">Save Address</t>
                 <i class="fw-light fa fa-angle-right ms-2"/>
             </button>


### PR DESCRIPTION
Specifications:
  - Portal users should be able update their login ID through the
  "Edit Information" page on portal view.
    
Before this PR:
  - Only users with administrator rights could update
  login IDs for all users.
  - Portal users were restricted to changing their passwords
  but could not modify their login ID.
    
After this PR:
  - Portal users can update login ID via the "Edit Information"
    page on portal view.
    
task - 4269220

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
