### PR TITLE
[FIX] point_of_sale: use correct price attribute

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -292,7 +292,7 @@ export class ProductScreen extends Component {
     }
 
     getProductPrice(product) {
-        const price = product.list_price === product.lst_price ? false : product.list_price;
+        const price = product.list_price === product.lst_price ? false : product.lst_price;
         return this.pos.getProductPriceFormatted(product, price);
     }
 


### PR DESCRIPTION
Problem:
In the product listing, the wrong price attribute `list_price` was used instead of `lst_price`. This causes discrepancies in price display in `saas-17.4`, where the list shows non-converted prices, while the correct converted price is shown in the cart.

Solution:
Update the product listing to use the correct `lst_price` attribute, ensuring that the displayed prices are correctly converted.

Steps to Reproduce:
- Create a PoS session with a different currency.
- When opening the PoS interface, the product list displays the non-converted price. However, when adding the product to the cart, it shows the converted price.

opw-4212288

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
