### PR TITLE
[FIX] link_tracker: traceback on creating record

### DIFF
--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -73,7 +73,7 @@ class LinkTracker(models.Model):
     @api.depends('code')
     def _compute_short_url(self):
         for tracker in self:
-            tracker.short_url = urls.url_join(tracker.short_url_host, '%(code)s' % {'code': tracker.code})
+            tracker.short_url = urls.url_join(tracker.short_url_host, tracker.code) if tracker.code else ''
 
     def _compute_short_url_host(self):
         for tracker in self:


### PR DESCRIPTION
After the new `_monkeypatches` of `url_join`/`_check_str_tuple` we're getting TypeError traceback on creating a Link Tracker.

Steps
=====
Install Link Tracker and an associate module(i.e., mass mailing)
Turn on developer mode
Open Link Tracker app and try to create a new record

Traceback: `TypeError: Cannot mix str and bytes arguments (got (False, 'False'))`

Technical:
==========
When creating a new we don't have `short_url_host` or `code`, thus its giving False.
Also, code was in in `""`,  means False , "False",  its unnecessary.

After this commit:
===================
There will be no traceback on creating a Link Tracker.

Task-4279725
