### PR TITLE
[IMP] test_mail_full: introduce _get_sign_token_params

### DIFF
--- a/addons/portal/tests/__init__.py
+++ b/addons/portal/tests/__init__.py
@@ -1,8 +1,8 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_login
 from . import test_message_format_portal
 from . import test_portal
+from . import test_portal_controller_common
 from . import test_tours
 from . import test_portal_wizard

--- a/addons/portal/tests/test_portal_controller_common.py
+++ b/addons/portal/tests/test_portal_controller_common.py
@@ -1,0 +1,17 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo
+from odoo.addons.mail.tests.test_controller_common import TestControllerCommon
+
+
+@odoo.tests.tagged("-at_install", "post_install")
+class TestPortalControllerCommon(TestControllerCommon):
+    def _get_sign_token_params(self, record):
+        access_token = record._portal_ensure_token()
+        partner = record.env["res.partner"].create({"name": "Sign Partner"})
+        _hash = record._sign_token(partner.id)
+        token = {"token": access_token}
+        bad_token = {"token": "incorrect token"}
+        sign = {"hash": _hash, "pid": partner.id}
+        bad_sign = {"hash": "incorrect hash", "pid": partner.id}
+        return token, bad_token, sign, bad_sign, partner

--- a/addons/project/tests/test_project_thread_controller.py
+++ b/addons/project/tests/test_project_thread_controller.py
@@ -5,10 +5,11 @@ from odoo.addons.mail.tests.test_thread_controller import (
     MessagePostSubTestData,
     TestThreadControllerCommon,
 )
+from odoo.addons.portal.tests.test_portal_controller_common import TestPortalControllerCommon
 
 
 @odoo.tests.tagged("-at_install", "post_install")
-class TestProjectThreadController(TestThreadControllerCommon):
+class TestProjectThreadController(TestThreadControllerCommon, TestPortalControllerCommon):
     def test_message_post_partner_ids_project(self):
         """Test partner_ids of message_post for task.
         Followers of task and followers of related project are allowed to be
@@ -18,13 +19,7 @@ class TestProjectThreadController(TestThreadControllerCommon):
         self.env["project.collaborator"].create(
             {"project_id": project.id, "partner_id": self.user_portal.partner_id.id}
         )
-        access_token = task._portal_ensure_token()
-        partner = self.env["res.partner"].create({"name": "Sign Partner"})
-        _hash = task._sign_token(partner.id)
-        token = {"token": access_token}
-        bad_token = {"token": "incorrect token"}
-        sign = {"hash": _hash, "pid": partner.id}
-        bad_sign = {"hash": "incorrect hash", "pid": partner.id}
+        token, bad_token, sign, bad_sign, partner = self._get_sign_token_params(task)
         all_partners = (
             self.user_portal + self.user_employee + self.user_demo + self.user_admin
         ).partner_id

--- a/addons/test_mail_full/tests/test_message_reaction_controller_portal.py
+++ b/addons/test_mail_full/tests/test_message_reaction_controller_portal.py
@@ -4,55 +4,52 @@ import odoo
 from odoo.addons.mail.tests.test_message_reaction_controller import (
     TestMessageReactionControllerCommon,
 )
+from odoo.addons.portal.tests.test_portal_controller_common import TestPortalControllerCommon
 
 
 @odoo.tests.tagged("-at_install", "post_install")
-class TestPortalMessageReactionController(TestMessageReactionControllerCommon):
+class TestPortalMessageReactionController(
+    TestMessageReactionControllerCommon, TestPortalControllerCommon
+):
     def test_message_reaction_portal_no_partner(self):
         """Test access of message reaction for portal without partner."""
         record = self.env["mail.test.portal.no.partner"].create({"name": "Test"})
+        token, bad_token, sign, bad_sign, partner = self._get_sign_token_params(record)
         message = record.message_post(body="portal no partner")
-        token = record._portal_ensure_token()
-        partner = self.env["res.partner"].create({"name": "Sign Partner"})
-        _hash = record._sign_token(partner.id)
-        token_param = {"token": token}
-        incorrect_token_param = {"token": "incorrect token"}
-        hash_pid_param = {"hash": _hash, "pid": partner.id}
-        incorrect_hash_pid_param = {"hash": "incorrect hash", "pid": partner.id}
         self._execute_subtests(
             message,
             (
                 (self.user_public, False),
-                (self.user_public, False, incorrect_token_param),
-                (self.user_public, False, incorrect_hash_pid_param),
+                (self.user_public, False, bad_token),
+                (self.user_public, False, bad_sign),
                 # False because no portal partner, no guest
-                (self.user_public, False, token_param),
-                (self.user_public, True, hash_pid_param, {"partner": partner}),
+                (self.user_public, False, token),
+                (self.user_public, True, sign, {"partner": partner}),
                 (self.guest, False),
-                (self.guest, False, incorrect_token_param),
-                (self.guest, False, incorrect_hash_pid_param),
-                (self.guest, True, token_param),
-                (self.guest, True, hash_pid_param, {"partner": partner}),
+                (self.guest, False, bad_token),
+                (self.guest, False, bad_sign),
+                (self.guest, True, token),
+                (self.guest, True, sign, {"partner": partner}),
                 (self.user_portal, False),
-                (self.user_portal, False, incorrect_token_param),
-                (self.user_portal, False, incorrect_hash_pid_param),
-                (self.user_portal, True, token_param),
-                (self.user_portal, True, hash_pid_param),
+                (self.user_portal, False, bad_token),
+                (self.user_portal, False, bad_sign),
+                (self.user_portal, True, token),
+                (self.user_portal, True, sign),
                 (self.user_employee, True),
-                (self.user_employee, True, incorrect_token_param),
-                (self.user_employee, True, incorrect_hash_pid_param),
-                (self.user_employee, True, token_param),
-                (self.user_employee, True, hash_pid_param),
+                (self.user_employee, True, bad_token),
+                (self.user_employee, True, bad_sign),
+                (self.user_employee, True, token),
+                (self.user_employee, True, sign),
                 (self.user_demo, True),
-                (self.user_demo, True, incorrect_token_param),
-                (self.user_demo, True, incorrect_hash_pid_param),
-                (self.user_demo, True, token_param),
-                (self.user_demo, True, hash_pid_param),
+                (self.user_demo, True, bad_token),
+                (self.user_demo, True, bad_sign),
+                (self.user_demo, True, token),
+                (self.user_demo, True, sign),
                 (self.user_admin, True),
-                (self.user_admin, True, incorrect_token_param),
-                (self.user_admin, True, incorrect_hash_pid_param),
-                (self.user_admin, True, token_param),
-                (self.user_admin, True, hash_pid_param),
+                (self.user_admin, True, bad_token),
+                (self.user_admin, True, bad_sign),
+                (self.user_admin, True, token),
+                (self.user_admin, True, sign),
             ),
         )
 

--- a/addons/test_mail_full/tests/test_portal_attachment_controller.py
+++ b/addons/test_mail_full/tests/test_portal_attachment_controller.py
@@ -2,44 +2,39 @@
 
 import odoo
 from odoo.addons.mail.tests.test_attachment_controller import TestAttachmentControllerCommon
+from odoo.addons.portal.tests.test_portal_controller_common import TestPortalControllerCommon
 
 
 @odoo.tests.tagged("-at_install", "post_install")
-class TestPortalAttachmentController(TestAttachmentControllerCommon):
+class TestPortalAttachmentController(TestAttachmentControllerCommon, TestPortalControllerCommon):
     def test_attachment_upload_portal(self):
         """Test access to upload an attachment on portal"""
         record = self.env["mail.test.portal.no.partner"].create({"name": "Test"})
-        token = record._portal_ensure_token()
-        partner = self.env["res.partner"].create({"name": "Sign Partner"})
-        _hash = record._sign_token(partner.id)
-        token_param = {"token": token}
-        incorrect_token_param = {"token": "incorrect token"}
-        hash_pid_param = {"hash": _hash, "pid": partner.id}
-        incorrect_hash_pid_param = {"hash": "incorrect hash", "pid": partner.id}
+        token, bad_token, sign, bad_sign, _ = self._get_sign_token_params(record)
         self._execute_subtests(
             record,
             (
                 (self.user_public, False),
-                (self.user_public, True, token_param),
-                (self.user_public, True, hash_pid_param),
+                (self.user_public, True, token),
+                (self.user_public, True, sign),
                 (self.guest, False),
-                (self.guest, True, token_param),
-                (self.guest, True, hash_pid_param),
+                (self.guest, True, token),
+                (self.guest, True, sign),
                 (self.user_portal, False),
-                (self.user_portal, False, incorrect_token_param),
-                (self.user_portal, False, incorrect_hash_pid_param),
-                (self.user_portal, True, token_param),
-                (self.user_portal, True, hash_pid_param),
+                (self.user_portal, False, bad_token),
+                (self.user_portal, False, bad_sign),
+                (self.user_portal, True, token),
+                (self.user_portal, True, sign),
                 (self.user_employee, True),
-                (self.user_employee, True, token_param),
-                (self.user_employee, True, hash_pid_param),
+                (self.user_employee, True, token),
+                (self.user_employee, True, sign),
                 (self.user_demo, True),
-                (self.user_demo, True, token_param),
-                (self.user_demo, True, hash_pid_param),
+                (self.user_demo, True, token),
+                (self.user_demo, True, sign),
                 (self.user_admin, True),
-                (self.user_admin, True, incorrect_token_param),
-                (self.user_admin, True, incorrect_hash_pid_param),
-                (self.user_admin, True, token_param),
-                (self.user_admin, True, hash_pid_param),
+                (self.user_admin, True, bad_token),
+                (self.user_admin, True, bad_sign),
+                (self.user_admin, True, token),
+                (self.user_admin, True, sign),
             ),
         )

--- a/addons/test_mail_full/tests/test_portal_message_update_controller.py
+++ b/addons/test_mail_full/tests/test_portal_message_update_controller.py
@@ -2,20 +2,17 @@
 
 import odoo
 from odoo.addons.mail.tests.test_message_update_controller import TestMessageUpdateControllerCommon
+from odoo.addons.portal.tests.test_portal_controller_common import TestPortalControllerCommon
 
 
 @odoo.tests.tagged("-at_install", "post_install")
-class TestPortalMessageUpdateController(TestMessageUpdateControllerCommon):
+class TestPortalMessageUpdateController(
+    TestMessageUpdateControllerCommon, TestPortalControllerCommon
+):
     def test_message_update_portal(self):
         """Test Only Admin and Portal User can update a portal user message on a record with no assigned partner."""
         record = self.env["mail.test.portal.no.partner"].create({"name": "Test"})
-        token = record._portal_ensure_token()
-        partner = self.env["res.partner"].create({"name": "Sign Partner"})
-        _hash = record._sign_token(partner.id)
-        token_param = {"token": token}
-        incorrect_token_param = {"token": "incorrect token"}
-        hash_pid_param = {"hash": _hash, "pid": partner.id}
-        incorrect_hash_pid_param = {"hash": "incorrect hash", "pid": partner.id}
+        token, bad_token, sign, bad_sign, _ = self._get_sign_token_params(record)
         message = record.message_post(
             body=self.message_body,
             author_id=self.user_portal.partner_id.id,
@@ -25,26 +22,26 @@ class TestPortalMessageUpdateController(TestMessageUpdateControllerCommon):
             message,
             (
                 (self.user_public, False),
-                (self.user_public, False, token_param),
-                (self.user_public, False, hash_pid_param),
+                (self.user_public, False, token),
+                (self.user_public, False, sign),
                 (self.guest, False),
-                (self.guest, False, token_param),
-                (self.guest, False, hash_pid_param),
+                (self.guest, False, token),
+                (self.guest, False, sign),
                 (self.user_portal, False),
-                (self.user_portal, False, incorrect_token_param),
-                (self.user_portal, False, incorrect_hash_pid_param),
-                (self.user_portal, True, token_param),
-                (self.user_portal, True, hash_pid_param),
+                (self.user_portal, False, bad_token),
+                (self.user_portal, False, bad_sign),
+                (self.user_portal, True, token),
+                (self.user_portal, True, sign),
                 (self.user_employee, False),
-                (self.user_employee, False, token_param),
-                (self.user_employee, False, hash_pid_param),
+                (self.user_employee, False, token),
+                (self.user_employee, False, sign),
                 (self.user_demo, False),
-                (self.user_demo, False, token_param),
-                (self.user_demo, False, hash_pid_param),
+                (self.user_demo, False, token),
+                (self.user_demo, False, sign),
                 (self.user_admin, True),
-                (self.user_admin, True, incorrect_token_param),
-                (self.user_admin, True, incorrect_hash_pid_param),
-                (self.user_admin, True, token_param),
-                (self.user_admin, True, hash_pid_param),
+                (self.user_admin, True, bad_token),
+                (self.user_admin, True, bad_sign),
+                (self.user_admin, True, token),
+                (self.user_admin, True, sign),
             ),
         )

--- a/addons/test_mail_full/tests/test_portal_thread_controller.py
+++ b/addons/test_mail_full/tests/test_portal_thread_controller.py
@@ -5,20 +5,15 @@ from odoo.addons.mail.tests.test_thread_controller import (
     MessagePostSubTestData,
     TestThreadControllerCommon,
 )
+from odoo.addons.portal.tests.test_portal_controller_common import TestPortalControllerCommon
 
 
 @odoo.tests.tagged("-at_install", "post_install")
-class TestPortalThreadController(TestThreadControllerCommon):
+class TestPortalThreadController(TestThreadControllerCommon, TestPortalControllerCommon):
     def test_message_post_access_portal_no_partner(self):
         """Test access of message post for portal without partner."""
         record = self.env["mail.test.portal.no.partner"].create({"name": "Test"})
-        access_token = record._portal_ensure_token()
-        partner = self.env["res.partner"].create({"name": "Sign Partner"})
-        _hash = record._sign_token(partner.id)
-        token = {"token": access_token}
-        bad_token = {"token": "incorrect token"}
-        sign = {"hash": _hash, "pid": partner.id}
-        bad_sign = {"hash": "incorrect hash", "pid": partner.id}
+        token, bad_token, sign, bad_sign, partner = self._get_sign_token_params(record)
 
         def test_access(user, allowed, route_kw=None, exp_author=None):
             return MessagePostSubTestData(user, allowed, route_kw=route_kw, exp_author=exp_author)
@@ -117,13 +112,7 @@ class TestPortalThreadController(TestThreadControllerCommon):
         """Test partner_ids of message_post for portal record without partner.
         Only followers are allowed to be mentioned by non-internal users."""
         record = self.env["mail.test.portal.no.partner"].create({"name": "Test"})
-        access_token = record._portal_ensure_token()
-        partner = self.env["res.partner"].create({"name": "Sign Partner"})
-        _hash = record._sign_token(partner.id)
-        token = {"token": access_token}
-        bad_token = {"token": "incorrect token"}
-        sign = {"hash": _hash, "pid": partner.id}
-        bad_sign = {"hash": "incorrect hash", "pid": partner.id}
+        token, bad_token, sign, bad_sign, partner = self._get_sign_token_params(record)
         all_partners = (
             self.user_portal + self.user_employee + self.user_demo + self.user_admin
         ).partner_id


### PR DESCRIPTION
Since getting security params to test a record in portal is a common usage and already present in some tests, this commit introduces `_get_sign_token_params` for such cases.
