### PR TITLE
[FIX] auth_signup: prevent error when resetting the password

### DIFF
--- a/addons/auth_signup/static/src/js/reset_password.js
+++ b/addons/auth_signup/static/src/js/reset_password.js
@@ -1,0 +1,25 @@
+odoo.define("auth_signup.reset_password", function (require) {
+    "use strict";
+
+    var publicWidget = require("web.public.widget");
+
+    publicWidget.registry.ResetPasswordForm = publicWidget.Widget.extend({
+        selector: ".oe_reset_password_form",
+        events: {
+            submit: "_onSubmit",
+        },
+
+        //--------------------------------------------------------------------------
+        // Handlers
+        //--------------------------------------------------------------------------
+
+        /**
+         * @private
+         */
+        _onSubmit: function () {
+            var $btn = this.$('.oe_login_buttons > button[type="submit"]');
+            $btn.attr("disabled", "disabled");
+            $btn.prepend('<i class="fa fa-refresh fa-spin"/> ');
+        },
+    });
+});


### PR DESCRIPTION
When the user tries to reset the password, a traceback will appear.

Steps to reproduce the error:
- Install ``auth_signup``
- Configure "Outgoing mail server"
- Now Log out
- Click on Sign in > Reset Password > Enter your email >
  Click on ``Reset Password`` twice

Traceback:
```
InFailedSqlTransaction: current transaction is aborted, commands ignored until end of transaction block

  File "odoo/http.py", line 2365, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1892, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1955, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 137, in retrying
    result = func()
  File "odoo/http.py", line 1922, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2082, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 331, in _dispatch
    result.flatten()
  File "odoo/http.py", line 1389, in flatten
    self.response.append(self.render())
  File "odoo/http.py", line 1381, in render
    return request.env["ir.ui.view"]._render_template(self.template, self.qcontext)
  File "home/odoo/src/enterprise/18.0/web_studio/models/ir_ui_view.py", line 1315, in _render_template
    return super(View, self)._render_template(template, values)
  File "odoo/addons/base/models/ir_ui_view.py", line 2185, in _render_template
    return self.env['ir.qweb']._render(template, values)
  File "odoo/tools/profiler.py", line 306, in _tracked_method_render
    return method_render(self, template, values, **options)
  File "odoo/addons/base/models/ir_qweb.py", line 597, in _render
    template_functions, def_name = irQweb._compile(template)
  File "odoo/tools/profiler.py", line 314, in _tracked_compile
    return method_compile(self, template)
  File "odoo/addons/base/models/ir_qweb.py", line 666, in _compile
    return self._load_values(base_key_cache, generate_functions)
  File "odoo/addons/base/models/ir_qweb.py", line 2524, in _load_values
    return get_value()
  File "odoo/addons/base/models/ir_qweb.py", line 635, in generate_functions
    code, options, def_name = self._generate_code(template)
  File "odoo/addons/base/models/ir_qweb.py", line 691, in _generate_code
    element, document, ref = self._get_template(template)
  File "odoo/addons/base/models/ir_qweb.py", line 822, in _get_template
    doc_or_elem, ref = self._load(ref_alias) or (None, None)
  File "odoo/addons/base/models/ir_qweb.py", line 859, in _load
    view = IrUIView._get(ref)
  File "odoo/addons/base/models/ir_ui_view.py", line 2085, in _get
    return self.browse(self._get_view_id(view_ref))
  File "odoo/addons/base/models/ir_ui_view.py", line 2073, in _get_view_id
    view = self.sudo().search([('key', '=', template)], limit=1)
  File "odoo/models.py", line 1717, in search
    return self.search_fetch(domain, [], offset=offset, limit=limit, order=order)
  File "odoo/models.py", line 1749, in search_fetch
    return self._fetch_query(query, fields_to_fetch)
  File "odoo/models.py", line 4180, in _fetch_query
    fetched = self.browse(query)
  File "odoo/models.py", line 6154, in browse
    if not ids:
  File "odoo/tools/query.py", line 261, in __bool__
    return bool(self.get_result_ids())
  File "odoo/tools/query.py", line 225, in get_result_ids
    self._ids = tuple(id_ for id_, in self._env.execute_query(self.select()))
  File "odoo/api.py", line 962, in execute_query
    self.cr.execute(query)
  File "odoo/sql_db.py", line 354, in execute
    res = self._obj.execute(query, params)
```

After this commit, user can not click on ``Reset Password`` button multiple times.

sentry-5661309399

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
