### PR TITLE
[FIX] l10n_fr_facturx_chorus_pro: udpate PartyIdentification tag

### DIFF
--- a/addons/l10n_fr_facturx_chorus_pro/i18n/fr.po
+++ b/addons/l10n_fr_facturx_chorus_pro/i18n/fr.po
@@ -82,3 +82,18 @@ msgstr "Dernière modification le"
 #: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_payment__purchase_order_reference
 msgid "Purchase order reference"
 msgstr "Engagement Juridique"
+
+#. module: l10n_fr_facturx_chorus_pro
+#. odoo-python
+#: code:addons/l10n_fr_facturx_chorus_pro/models/account_edi_xml_ubl_bis3.py:0
+#, python-format
+msgid ""
+"The siret is mandatory for french suppliers when invoicing to Chorus Pro."
+msgstr "Le siret est obligatoire pour les fournisseurs français lors de la facturation à Chorus Pro."
+
+#. module: l10n_fr_facturx_chorus_pro
+#. odoo-python
+#: code:addons/l10n_fr_facturx_chorus_pro/models/account_edi_xml_ubl_bis3.py:0
+#, python-format
+msgid "The siret is mandatory for the customer when invoicing to Chorus Pro."
+msgstr "Le siret est obligatoire pour le client lors de la facturation à Chorus Pro."

--- a/addons/l10n_fr_facturx_chorus_pro/i18n/l10n_fr_facturx_chorus_pro.pot
+++ b/addons/l10n_fr_facturx_chorus_pro/i18n/l10n_fr_facturx_chorus_pro.pot
@@ -81,3 +81,18 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_payment__purchase_order_reference
 msgid "Purchase order reference"
 msgstr ""
+
+#. module: l10n_fr_facturx_chorus_pro
+#. odoo-python
+#: code:addons/l10n_fr_facturx_chorus_pro/models/account_edi_xml_ubl_bis3.py:0
+#, python-format
+msgid ""
+"The siret is mandatory for french suppliers when invoicing to Chorus Pro."
+msgstr ""
+
+#. module: l10n_fr_facturx_chorus_pro
+#. odoo-python
+#: code:addons/l10n_fr_facturx_chorus_pro/models/account_edi_xml_ubl_bis3.py:0
+#, python-format
+msgid "The siret is mandatory for the customer when invoicing to Chorus Pro."
+msgstr ""

--- a/addons/l10n_fr_facturx_chorus_pro/models/account_edi_xml_ubl_bis3.py
+++ b/addons/l10n_fr_facturx_chorus_pro/models/account_edi_xml_ubl_bis3.py
@@ -1,4 +1,4 @@
-from odoo import models
+from odoo import models, _
 
 
 CHORUS_PRO_PEPPOL_ID = "0009:11000201100044"
@@ -7,27 +7,18 @@ CHORUS_PRO_PEPPOL_ID = "0009:11000201100044"
 class AccountEdiXmlUBLBIS3(models.AbstractModel):
     _inherit = 'account.edi.xml.ubl_bis3'
 
-    """ See Pagero documentation: https://www.pagero.com/onboarding/aife/aife-en#requirements """
-
-    def _get_partner_party_identification_vals_list(self, partner):
-        """
-        Pagero doc states that the 'siret' of the final customer (that has the Chorus peppol ID) should be located in
-        the PartyIdentificiation node
-        """
-        # EXTENDS 'account.edi.xml.ubl_bis3'
-        if (
-            partner.peppol_eas
-            and partner.peppol_endpoint
-            and partner.peppol_eas + ":" + partner.peppol_endpoint == CHORUS_PRO_PEPPOL_ID
-            and 'siret' in partner._fields
-            and partner.siret
-        ):
-            return [{
-                'id': partner.siret,
-            }]
-        return super()._get_partner_party_identification_vals_list(partner)
+    """
+    See Pagero documentation: https://www.pagero.com/onboarding/aife/aife-en#requirements
+    Chorus Pro documentation: https://communaute.chorus-pro.gouv.fr/wp-content/uploads/2017/07/Specifications_Externes_Annexe_EDI_V4.22.pdf
+    """
 
     def _export_invoice_vals(self, invoice):
+        """
+        * Pagero doc states that the siret of the final customer (that has the Chorus peppol ID) should be located in
+        the PartyIdentification node.
+        * Chorus Pro doc states that french suppliers should mention their siret, and european non-french suppliers
+        should put their VAT
+        """
         # EXTENDS 'account.edi.xml.ubl_bis3'
         vals = super()._export_invoice_vals(invoice)
         if invoice.buyer_reference:
@@ -36,4 +27,29 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
         if invoice.purchase_order_reference:
             # Pagero doc states that the 'Commitment Number' should be in the OrderReference/ID node
             vals['vals']['order_reference'] = invoice.purchase_order_reference
+
+        customer = vals['customer'].commercial_partner_id
+        if customer.peppol_eas + ":" + customer.peppol_endpoint == CHORUS_PRO_PEPPOL_ID:
+            for role in ('supplier', 'customer'):
+                partner = vals[role].commercial_partner_id
+                if 'siret' in partner._fields and partner.siret and partner.country_code == 'FR':
+                    vals['vals'][f'accounting_{role}_party_vals']['party_vals']['party_identification_vals'] = [{
+                        'id': partner.siret,
+                        'id_attrs': {'schemeName': 1},
+                    }]
+                else:
+                    vals['vals'][f'accounting_{role}_party_vals']['party_vals']['party_identification_vals'] = [{
+                        'id': partner.vat,
+                        'id_attrs': {'schemeName': 2},
+                    }]
         return vals
+
+    def _export_invoice_constraints(self, invoice, vals):
+        constraints = super()._export_invoice_constraints(invoice, vals)
+        customer, supplier = vals['customer'].commercial_partner_id, vals['supplier']
+        if customer.peppol_eas + ":" + customer.peppol_endpoint == CHORUS_PRO_PEPPOL_ID:
+            if 'siret' not in customer._fields or not customer.siret:
+                constraints['chorus_customer'] = _("The siret is mandatory for the customer when invoicing to Chorus Pro.")
+            if supplier.country_code == 'FR' and ('siret' not in supplier._fields or not supplier.siret):
+                constraints['chorus_supplier'] = _("The siret is mandatory for french suppliers when invoicing to Chorus Pro.")
+        return constraints

--- a/addons/l10n_fr_facturx_chorus_pro/tests/test_chorus_pro_xml.py
+++ b/addons/l10n_fr_facturx_chorus_pro/tests/test_chorus_pro_xml.py
@@ -13,6 +13,7 @@ class TestChorusProXml(AccountTestInvoicingCommon):
     def setUpClass(cls, chart_template_ref='fr'):
         super().setUpClass(chart_template_ref=chart_template_ref)
         cls.company = cls.company_data['company']
+        cls.company.siret = "02546465000024"
         chorus_eas, chorus_endpoint = CHORUS_PRO_PEPPOL_ID.split(":")
         cls.chorus_pro_partner = cls.env['res.partner'].create({
             'name': "Chorus Pro - Commune de Nantes",
@@ -22,6 +23,7 @@ class TestChorusProXml(AccountTestInvoicingCommon):
             # Peppol ID for the AIFE (= Chorus Pro)
             'peppol_eas': chorus_eas,
             'peppol_endpoint': chorus_endpoint,
+            'country_id': cls.env.ref('base.fr').id,
         })
 
     def test_export_invoice_chorus_pro(self):
@@ -45,8 +47,13 @@ class TestChorusProXml(AccountTestInvoicingCommon):
         self.assertEqual(endpoint_node.text, chorus_endpoint)
         self.assertEqual(endpoint_node.attrib, {'schemeID': chorus_eas})
 
-        final_receiver = xml_etree.findtext("{*}AccountingCustomerParty/{*}Party/{*}PartyIdentification/{*}ID")
-        self.assertEqual(final_receiver, "21440109300015")
+        supplier_identification_node = xml_etree.find("{*}AccountingSupplierParty/{*}Party/{*}PartyIdentification/{*}ID")
+        self.assertEqual(supplier_identification_node.text, "02546465000024")
+        self.assertEqual(supplier_identification_node.attrib, {'schemeName': '1'})
+
+        customer_identification_node = xml_etree.find("{*}AccountingCustomerParty/{*}Party/{*}PartyIdentification/{*}ID")
+        self.assertEqual(customer_identification_node.text, "21440109300015")
+        self.assertEqual(customer_identification_node.attrib, {'schemeName': '1'})
 
         self.assertEqual(xml_etree.findtext("{*}BuyerReference"), "buyer_ref_123")
         self.assertEqual(xml_etree.findtext("{*}OrderReference/{*}ID"), "order_ref_123")


### PR DESCRIPTION
Currently, when sending a Bis 3 xml to Pagero, which in turn sends it to Chorus Pro, the invoice is rejected by Chorus.

This is because the `PartyIdentification` tag for the `AccountingSupplierParty` should be filled with the siret of the supplier if it is located in France, or with the VAT if it is located in the EU.

Surprisingly, the xml received by Chorus contains a `PartyIdentification` that has most probably be added by Pagero, but it is filled with a VAT, and causes a rejection from Chorus since the supplier is french.

opw-4139689
