### PR TITLE
[FIX] sale_project: show new created task through the sale order

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -57,7 +57,7 @@ class SaleOrder(models.Model):
     @api.depends('order_line.product_id.project_id')
     def _compute_tasks_ids(self):
         tasks_per_so = self.env['project.task']._read_group(
-            domain=['&', ('display_project_id', '!=', False), '|', ('sale_line_id', 'in', self.order_line.ids), ('sale_order_id', 'in', self.ids)],
+            domain=self._tasks_ids_domain(),
             fields=['sale_order_id', 'ids:array_agg(id)'],
             groupby=['sale_order_id'],
         )
@@ -147,9 +147,12 @@ class SaleOrder(models.Model):
                 action['views'] = [(form_view_id, 'form')]
                 action['res_id'] = self.tasks_ids.id
         # filter on the task of the current SO
-        action['domain'] = [('id', 'in', self.tasks_ids.ids)]
+        action['domain'] = self._tasks_ids_domain()
         action.setdefault('context', {})
         return action
+
+    def _tasks_ids_domain(self):
+        return ['&', ('display_project_id', '!=', False), '|', ('sale_line_id', 'in', self.order_line.ids), ('sale_order_id', 'in', self.ids)]
 
     def action_view_project_ids(self):
         self.ensure_one()


### PR DESCRIPTION
Issue:
  In the task action view of the sale order, the task ID is passed in the action domain, which results in showing only
  old tasks. Newly created tasks are not visible because their   IDs are not included in the domain.

Solution:
  Instead of passing task ids, we now check for project_id, sale_order_id, or sale_line_id  to ensure the new tasks are properly displayed.

Steps to Reproduce:
   - Install the sale_project module.
   - Create a Sale Order (SO).
   - Add a product configured to create a project with tasks.
   - Click on the "Tasks" smart button from the SO.
   - Go to the Kanban view.
   - Create a new task and give a name.
   - Reload the page.
   - Check if the task is visible (the issue was that new tasks were not visible).

Affected PR:
  https://github.com/odoo/odoo/pull/135771/files

task-4224564
