### PR TITLE
[FIX] web: domain field: validate domain when edited in debug

### DIFF
--- a/addons/web/static/src/views/fields/domain/domain_field.js
+++ b/addons/web/static/src/views/fields/domain/domain_field.js
@@ -28,8 +28,14 @@ export class DomainField extends Component {
             this.displayedDomain = this.props.value;
             this.loadCount(this.props);
         });
-        onWillUpdateProps((nextProps) => {
+        onWillUpdateProps(async (nextProps) => {
             this.isDebugEdited = this.isDebugEdited && this.props.readonly === nextProps.readonly;
+            // Check the manually edited domain and reflect it in the widget if its valid
+            if (this.isDebugEdited) {
+                const proms = [];
+                this.env.bus.trigger("RELATIONAL_MODEL:NEED_LOCAL_CHANGES", { proms });
+                await Promise.all([...proms]);
+            }
             if (!this.isDebugEdited) {
                 this.displayedDomain = nextProps.value;
                 this.loadCount(nextProps);

--- a/addons/web/static/tests/views/fields/domain_field_tests.js
+++ b/addons/web/static/tests/views/fields/domain_field_tests.js
@@ -580,7 +580,7 @@ QUnit.module("Fields", (hooks) => {
 
             const webClient = await createWebClient({
                 serverData,
-                mockRPC(route, { method, args }) {
+                mockRPC(route, { method, args, domain }) {
                     if (method === "search_count") {
                         assert.step(JSON.stringify(args[0]));
                     }
@@ -588,7 +588,7 @@ QUnit.module("Fields", (hooks) => {
                         throw new Error("should not save");
                     }
                     if (route === "/web/domain/validate") {
-                        return false;
+                        return JSON.stringify(domain) === "[[\"abc\",\"=\",1]]";
                     }
                 },
             });
@@ -658,6 +658,9 @@ QUnit.module("Fields", (hooks) => {
                 mockRPC(route, { method, args }) {
                     if (method === "search_count") {
                         assert.step(JSON.stringify(args[0]));
+                    }
+                    if (route === "/web/domain/validate") {
+                        return true;
                     }
                 },
             });


### PR DESCRIPTION
Loosly backported from https://github.com/odoo/odoo/pull/139593 to allow manual domain edit that is reflected in the domain editor widget instantly.

This commit changes the behavior of the domain field such that it performs a quick validation of the domain after it has been edited in the debug allowing and letting us reflect the changes instantly in the editor.

Current behavior before PR:

When we edit the domain in debug mode, it isn't reflected instantly

![Peek 23-10-2024 13-35](https://github.com/user-attachments/assets/b83ea0f2-d949-45c1-88e6-cf017d777346)


Desired behavior after PR is merged:

Now the changes are reflected in the widget as soon as we make them

![Peek 23-10-2024 13-34](https://github.com/user-attachments/assets/f6c6e20a-3f13-4570-af72-0e67718a1f22)


cc @Tecnativa TT51315

fyi @carlosdauden 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
