### PR TITLE
[FIX] web: revert fix showing empty option when selection is required

### DIFF
--- a/addons/loyalty/static/tests/views/filterable_selection_field_tests.js
+++ b/addons/loyalty/static/tests/views/filterable_selection_field_tests.js
@@ -48,7 +48,7 @@ QUnit.module("Fields", (hooks) => {
                 </form>`,
         });
 
-        assert.containsN(target, "select option", 2);
+        assert.containsN(target, "select option", 3);
         assert.containsOnce(
             target,
             ".o_field_widget[name='program_type'] select option[value='\"coupon\"']",
@@ -71,7 +71,7 @@ QUnit.module("Fields", (hooks) => {
                 </form>`,
         });
 
-        assert.containsN(target, "select option", 2);
+        assert.containsN(target, "select option", 3);
         assert.containsOnce(
             target,
             ".o_field_widget[name='program_type'] select option[value='\"coupon\"']",
@@ -95,7 +95,7 @@ QUnit.module("Fields", (hooks) => {
                 </form>`,
         });
 
-        assert.containsN(target, "select option", 3);
+        assert.containsN(target, "select option", 4);
         assert.containsOnce(
             target,
             ".o_field_widget[name='program_type'] select option[value='\"gift_card\"']",
@@ -110,7 +110,7 @@ QUnit.module("Fields", (hooks) => {
         );
 
         await editSelect(target, ".o_field_widget[name='program_type'] select", '"coupon"');
-        assert.containsN(target, "select option", 2);
+        assert.containsN(target, "select option", 3);
         assert.containsOnce(
             target,
             ".o_field_widget[name='program_type'] select option[value='\"coupon\"']",

--- a/addons/web/static/src/views/fields/selection/selection_field.xml
+++ b/addons/web/static/src/views/fields/selection/selection_field.xml
@@ -8,10 +8,10 @@
         <t t-else="">
             <select class="o_input pe-3" t-on-change="onChange" t-att-id="props.id">
                 <option
-                    t-if="!isRequired"
                     t-att-selected="false === value"
                     t-att-value="stringify(false)"
                     t-esc="this.props.placeholder || ''"
+                    t-attf-style="{{ isRequired ? 'display:none' : '' }}"
                 />
                 <t t-foreach="options" t-as="option" t-key="option[0]">
                     <option

--- a/addons/web/static/tests/views/fields/selection_field_tests.js
+++ b/addons/web/static/tests/views/fields/selection_field_tests.js
@@ -333,26 +333,26 @@ QUnit.module("Fields", (hooks) => {
                 </form>`,
         });
 
-        assert.containsN(
-            target.querySelector(".o_field_widget[name='color']"),
-            "option",
-            3,
-            "Three options in non required field (one blank option)"
+        assert.deepEqual(
+            [...target.querySelectorAll(".o_field_widget[name='color'] option")].map(
+                (option) => option.style.display
+            ),
+            ["", "", ""]
         );
-        assert.containsN(
-            target.querySelector(".o_field_widget[name='feedback_value']"),
-            "option",
-            2,
-            "Two options in required field (no blank option)"
+        assert.deepEqual(
+            [...target.querySelectorAll(".o_field_widget[name='feedback_value'] option")].map(
+                (option) => option.style.display
+            ),
+            ["none", "", ""]
         );
 
         // change value to update widget modifier values
         await editSelect(target, ".o_field_widget[name='feedback_value'] select", '"bad"');
-        assert.containsN(
-            target.querySelector(".o_field_widget[name='color']"),
-            "option",
-            2,
-            "Two options in required field (no blank option)"
+        assert.deepEqual(
+            [...target.querySelectorAll(".o_field_widget[name='color'] option")].map(
+                (option) => option.style.display
+            ),
+            ["none", "", ""]
         );
     });
 
@@ -395,11 +395,11 @@ QUnit.module("Fields", (hooks) => {
 
             // change value to update widget modifier values
             await editSelect(target, ".o_field_widget[name='feedback_value'] select", '"bad"');
-            assert.containsN(
-                target.querySelector(".o_field_widget[name='color']"),
-                "option",
-                2,
-                "Two options in required field (no blank option)"
+            assert.deepEqual(
+                [...target.querySelectorAll(".o_field_widget[name='color'] option")].map(
+                    (option) => option.style.display
+                ),
+                ["none", "", ""]
             );
         }
     );


### PR DESCRIPTION
This reverts commit ad706ab7886e9cf9169c8a47948882ed4468b003.

This commit introduced an unexpected behaviour where the field seems to select by default the first choice but has no value.

