### PR TITLE
[FIX] l10n_es_edi_tbai: round BaseImponible value to 2 decimals

### DIFF
--- a/addons/l10n_es_edi_tbai/data/template_LROE_bizkaia.xml
+++ b/addons/l10n_es_edi_tbai/data/template_LROE_bizkaia.xml
@@ -124,10 +124,10 @@
                             <DetalleIVA t-foreach="iva_values" t-as="tax">
                                 <CompraBienesCorrientesGastosBienesInversion t-out="tax['code']"/>
                                 <InversionSujetoPasivo t-out="'N' if tax['rec'].l10n_es_type != 'sujeto_isp' else 'S'"/>
-                                <BaseImponible t-out="tax['base']"/>
+                                <BaseImponible t-out="format_float(tax['base'])"/>
                                 <TipoImpositivo t-out="tax['rec'].amount"/>
-                                <CuotaIVASoportada t-out="tax['tax']"/>
-                                <CuotaIVADeducible t-out="tax['tax']"/>
+                                <CuotaIVASoportada t-out="format_float(tax['tax'])"/>
+                                <CuotaIVADeducible t-out="format_float(tax['tax'])"/>
                             </DetalleIVA>
                         </IVA>
                     </t>

--- a/addons/l10n_es_edi_tbai/tests/common.py
+++ b/addons/l10n_es_edi_tbai/tests/common.py
@@ -254,10 +254,10 @@ class TestEsEdiTbaiCommon(AccountEdiTestCommon):
                     <DetalleIVA>
                         <CompraBienesCorrientesGastosBienesInversion>C</CompraBienesCorrientesGastosBienesInversion>
                         <InversionSujetoPasivo>N</InversionSujetoPasivo>
-                        <BaseImponible>4000.0</BaseImponible>
+                        <BaseImponible>4000.00</BaseImponible>
                         <TipoImpositivo>21.0</TipoImpositivo>
-                        <CuotaIVASoportada>840.0</CuotaIVASoportada>
-                        <CuotaIVADeducible>840.0</CuotaIVADeducible>
+                        <CuotaIVASoportada>840.00</CuotaIVASoportada>
+                        <CuotaIVADeducible>840.00</CuotaIVADeducible>
                     </DetalleIVA>
                 </IVA>
         </FacturaRecibida>
@@ -303,17 +303,17 @@ class TestEsEdiTbaiCommon(AccountEdiTestCommon):
                     <DetalleIVA>
                         <CompraBienesCorrientesGastosBienesInversion>C</CompraBienesCorrientesGastosBienesInversion>
                         <InversionSujetoPasivo>N</InversionSujetoPasivo>
-                        <BaseImponible>4000.0</BaseImponible>
+                        <BaseImponible>4000.00</BaseImponible>
                         <TipoImpositivo>21.0</TipoImpositivo>
-                        <CuotaIVASoportada>840.0</CuotaIVASoportada>
-                        <CuotaIVADeducible>840.0</CuotaIVADeducible>
+                        <CuotaIVASoportada>840.00</CuotaIVASoportada>
+                        <CuotaIVADeducible>840.00</CuotaIVADeducible>
                     </DetalleIVA><DetalleIVA>
                         <CompraBienesCorrientesGastosBienesInversion>G</CompraBienesCorrientesGastosBienesInversion>
                         <InversionSujetoPasivo>N</InversionSujetoPasivo>
-                        <BaseImponible>8000.0</BaseImponible>
+                        <BaseImponible>8000.00</BaseImponible>
                         <TipoImpositivo>21.0</TipoImpositivo>
-                        <CuotaIVASoportada>1680.0</CuotaIVASoportada>
-                        <CuotaIVADeducible>1680.0</CuotaIVADeducible>
+                        <CuotaIVASoportada>1680.00</CuotaIVASoportada>
+                        <CuotaIVADeducible>1680.00</CuotaIVADeducible>
                     </DetalleIVA>
                 </IVA>
             </FacturaRecibida>


### PR DESCRIPTION
Steps to reproduce:
- Install Accounting and l10n_es_edi_tbai
- Switch to a Spanish company (e.g. ES Company)
- In Accounting settings, select "Hacienda Foral de Bizkaia" as "Tax Agency for TBAI"
- Create a vendor bill:
  * Vendor: [a Spanish vendor]
  * Invoice Lines: (These amounts are important)

      Quantity  |  Price  |  Taxes
    --------------------------------
         2      | 2896.74 |  21% G
         4      |  121.52 |  21% G

- Confirm the bill
- Sent bill to TicketBAI

Issue:
The generated xml will be rejected because "BaseImponible" value has more than 2 decimals.

Cause:
A floating point issue during the computation of "BaseImponible" with these specific values.

opw-3987704

closes odoo/odoo#170724

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
