### PR TITLE
[FIX] web: revert fix showing empty option when selection is required

### DIFF
--- a/addons/test_base_automation/static/tests/tour/base_automation_tour.js
+++ b/addons/test_base_automation/static/tests/tour/base_automation_tour.js
@@ -159,6 +159,7 @@ registry.category("web_tour.tours").add("test_base_automation_on_tag_added", {
                 assertEqual(
                     JSON.stringify(options),
                     JSON.stringify({
+                        false: "",
                         on_stage_set: "Stage is set to",
                         on_user_set: "User is set",
                         on_tag_set: "Tag is added",

--- a/addons/web/static/src/views/fields/selection/selection_field.xml
+++ b/addons/web/static/src/views/fields/selection/selection_field.xml
@@ -12,10 +12,10 @@
                 t-on-click.stop="() =&gt; {}"
                 t-att-id="props.id">
                 <option
-                    t-if="!props.required"
                     t-att-selected="false === value"
                     t-att-value="stringify(false)"
                     t-esc="this.props.placeholder || ''"
+                    t-attf-style="{{ props.required ? 'display:none' : '' }}"
                 />
                 <t t-foreach="options" t-as="option" t-key="option[0]">
                     <option

--- a/addons/web/static/tests/views/fields/filterable_selection_field.test.js
+++ b/addons/web/static/tests/views/fields/filterable_selection_field.test.js
@@ -18,6 +18,8 @@ class Program extends models.Model {
 }
 defineModels([Program]);
 
+// Note: the `toHaveCount` always check for one more as there will be an invisible empty option every time.
+
 test(`FilterableSelectionField test whitelist`, async () => {
     await mountView({
         resModel: "program",
@@ -29,7 +31,7 @@ test(`FilterableSelectionField test whitelist`, async () => {
         `,
         resId: 1,
     });
-    expect(`select option`).toHaveCount(2);
+    expect(`select option`).toHaveCount(3);
     expect(`.o_field_widget[name="type"] select option[value='"coupon"']`).toHaveCount(1);
     expect(`.o_field_widget[name="type"] select option[value='"promotion"']`).toHaveCount(1);
 });
@@ -45,7 +47,7 @@ test(`FilterableSelectionField test blacklist`, async () => {
         `,
         resId: 1,
     });
-    expect(`select option`).toHaveCount(2);
+    expect(`select option`).toHaveCount(3);
     expect(`.o_field_widget[name="type"] select option[value='"coupon"']`).toHaveCount(1);
     expect(`.o_field_widget[name="type"] select option[value='"promotion"']`).toHaveCount(1);
 });
@@ -62,13 +64,13 @@ test(`FilterableSelectionField test with invalid value`, async () => {
         `,
         resId: 2,
     });
-    expect(`select option`).toHaveCount(3);
+    expect(`select option`).toHaveCount(4);
     expect(`.o_field_widget[name="type"] select option[value='"gift_card"']`).toHaveCount(1);
     expect(`.o_field_widget[name="type"] select option[value='"coupon"']`).toHaveCount(1);
     expect(`.o_field_widget[name="type"] select option[value='"promotion"']`).toHaveCount(1);
 
     await contains(`.o_field_widget[name="type"] select`).select(`"coupon"`);
-    expect(`select option`).toHaveCount(2);
+    expect(`select option`).toHaveCount(3);
     expect(`.o_field_widget[name="type"] select option[value='"gift_card"']`).toHaveCount(0);
     expect(`.o_field_widget[name="type"] select option[value='"coupon"']`).toHaveCount(1);
     expect(`.o_field_widget[name="type"] select option[value='"promotion"']`).toHaveCount(1);

--- a/addons/web/static/tests/views/fields/selection_field.test.js
+++ b/addons/web/static/tests/views/fields/selection_field.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { click, queryAllValues, queryFirst, queryOne, select } from "@odoo/hoot-dom";
+import { click, queryAll, queryAllValues, queryFirst, queryOne, select } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import {
     clickSave,
@@ -228,15 +228,73 @@ test("required selection widget should not have blank option", async () => {
                 </form>`,
     });
 
-    expect(`.o_field_widget[name='color'] option`).toHaveCount(3);
+    expect(queryAll(".o_field_widget[name='color'] option").map((n) => n.style.display)).toEqual([
+        "",
+        "",
+        "",
+    ]);
 
-    expect(`.o_field_widget[name='feedback_value'] option`).toHaveCount(2);
+    expect(
+        queryAll(".o_field_widget[name='feedback_value'] option").map((n) => n.style.display)
+    ).toEqual(["none", "", ""]);
 
     // change value to update widget modifier values
     await click(".o_field_widget[name='feedback_value'] select");
     await select('"bad"');
     await animationFrame();
-    expect(`.o_field_widget[name='color'] option`).toHaveCount(2);
+    expect(queryAll(".o_field_widget[name='color'] option").map((n) => n.style.display)).toEqual([
+        "none",
+        "",
+        "",
+    ]);
+});
+
+test("required selection widget should have only one blank option", async () => {
+    Partner._fields.feedback_value = fields.Selection({
+        required: true,
+        selection: [
+            ["good", "Good"],
+            ["bad", "Bad"],
+        ],
+        default: "good",
+        string: "Good",
+    });
+
+    Partner._fields.color = fields.Selection({
+        selection: [
+            [false, ""],
+            ["red", "Red"],
+            ["black", "Black"],
+        ],
+        default: "red",
+        string: "Color",
+    });
+
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: /* xml */ `
+                <form>
+                    <field name="feedback_value" />
+                    <field name="color" required="feedback_value == 'bad'" />
+                </form>`,
+    });
+
+    expect(".o_field_widget[name='color'] option").toHaveCount(3, {
+        message: "Three options in non required field (one blank option)",
+    });
+
+    // change value to update widget modifier values
+    await click(".o_field_widget[name='feedback_value'] select");
+    await select('"bad"');
+    await animationFrame();
+
+    expect(queryAll(".o_field_widget[name='color'] option").map((n) => n.style.display)).toEqual([
+        "none",
+        "",
+        "",
+    ]);
 });
 
 test("selection field with placeholder", async () => {


### PR DESCRIPTION
This reverts commit 21b0872db2ca0483955dd11ff75c5d37606560b1.

This commit introduced an unexpected behaviour where the field seems to select by default the first choice but has no value.
