### PR TITLE
[FIX] hr_holidays: compute display name for report calendar

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report_calendar.py
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, tools, SUPERUSER_ID
+from odoo import api, fields, models, tools
 
 from odoo.addons.base.models.res_partner import _tz_get
 
@@ -79,14 +79,12 @@ class LeaveReportCalendar(models.Model):
         );
         """)
 
-    def _fetch_query(self, query, fields):
-        records = super()._fetch_query(query, fields)
+    def _compute_display_name(self):
         if self.env.context.get('hide_employee_name') and 'employee_id' in self.env.context.get('group_by', []):
-            self.env.cache.update(records, self._fields['name'], [
-                record.name.split(':')[-1].strip()
-                for record in records.with_user(SUPERUSER_ID)
-            ])
-        return records
+            for record in self:
+                record.display_name = record.name.removeprefix(f"{record.employee_id.name}: ")
+        else:
+            super()._compute_display_name()
 
     @api.model
     def get_unusual_days(self, date_from, date_to=None):


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Create a half-day leave of any type allowing custom hours;
2. open All Time Off in Gantt view.

Issue
-----
Leave is displayed as "00 hours".

Cause
-----
PR #177570 changed the way leave hours are displayed, from decimal to HH:MM.

With the `hide_employee_name` context value set, the name of `hr.leave.report.calendar` records was computed by splitting on `':'`, and taking the last part. Before the hour formatting change, this was everything after the employee name. After the formatting change, only the "MM" part remains.

Solution
--------
We can remove the `_fetch_query` override which updates names in cache only, and instead add a `_compute_display_name` override, in turn using the `removeprefix` method added in Python 3.9 to reliably strip the employee name.

opw-4274365