### PR TITLE
[FIX] event_sale: fix missing price_incl access for public user

### DIFF
--- a/addons/event_sale/models/event_ticket.py
+++ b/addons/event_sale/models/event_ticket.py
@@ -108,7 +108,7 @@ class EventTicket(models.Model):
         compute_sudo=True)
     price_incl = fields.Float(
         string='Price include', compute='_compute_price_incl',
-        digits='Product Price', readonly=False)
+        digits='Product Price', readonly=False, compute_sudo=True)
 
     def _compute_price_reduce_taxinc(self):
         for event in self:


### PR DESCRIPTION
__Current behavior before commit:__

Events with products that use a pricelist with `discount_policy` set `without_discount` cause 403 for public users on event pages if website setting `show_line_subtotals_tax_selection` = `tax_included`.

__Reason:__
This is because of access right issues on taxes for `price_incl` being displayed on the event page.

__Fix:__
Added `compute_sudo=True` to the field `price_incl`.

__Steps:__
1. Create new product `detailed_type` `event` with a high price Ex:100.
2. Set the website pricelist entry for this price as lower price Ex:50.
3. Change pricelist `discount_policy` to `without_discount`.
4. Change website setting: (Display Product Price) to (Tax Included)
4. Create event with custom product.
5. Publish event and view the event page from a public user.

opw-4264353

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
