### PR TITLE
[FIX] web: Safari withResolvers support

### DIFF
--- a/addons/web/static/lib/pdfjs/build/pdf.js
+++ b/addons/web/static/lib/pdfjs/build/pdf.js
@@ -94,6 +94,18 @@ __webpack_require__.d(__webpack_exports__, {
   version: () => (/* reexport */ version)
 });
 
+// POLYFILLS
+if (typeof Promise.withResolvers === 'undefined') {
+  Promise.withResolvers = function () {
+    let resolve, reject
+    const promise = new Promise((res, rej) => {
+      resolve = res
+      reject = rej
+    })
+    return { promise, resolve, reject }
+  }
+}
+
 ;// CONCATENATED MODULE: ./src/shared/util.js
 const isNodeJS = typeof process === "object" && process + "" === "[object process]" && !process.versions.nw && !(process.versions.electron && process.type && process.type !== "browser");
 const IDENTITY_MATRIX = [1, 0, 0, 1, 0, 0];

--- a/addons/web/static/lib/pdfjs/build/pdf.worker.js
+++ b/addons/web/static/lib/pdfjs/build/pdf.worker.js
@@ -49,6 +49,18 @@ __webpack_require__.d(__webpack_exports__, {
   WorkerMessageHandler: () => (/* reexport */ WorkerMessageHandler)
 });
 
+// POLYFILLS
+if (typeof Promise.withResolvers === 'undefined') {
+  Promise.withResolvers = function () {
+    let resolve, reject
+    const promise = new Promise((res, rej) => {
+      resolve = res
+      reject = rej
+    })
+    return { promise, resolve, reject }
+  }
+}
+
 ;// CONCATENATED MODULE: ./src/shared/util.js
 const isNodeJS = typeof process === "object" && process + "" === "[object process]" && !process.versions.nw && !(process.versions.electron && process.type && process.type !== "browser");
 const IDENTITY_MATRIX = [1, 0, 0, 1, 0, 0];

--- a/addons/web/static/lib/pdfjs/web/viewer.js
+++ b/addons/web/static/lib/pdfjs/web/viewer.js
@@ -51,6 +51,18 @@ __webpack_require__.d(__webpack_exports__, {
   PDFViewerApplicationOptions: () => (/* reexport */ AppOptions)
 });
 
+// POLYFILLS
+if (typeof Promise.withResolvers === 'undefined') {
+  Promise.withResolvers = function () {
+    let resolve, reject
+    const promise = new Promise((res, rej) => {
+      resolve = res
+      reject = rej
+    })
+    return { promise, resolve, reject }
+  }
+}
+
 ;// CONCATENATED MODULE: ./web/ui_utils.js
 const DEFAULT_SCALE_VALUE = "auto";
 const DEFAULT_SCALE = 1.0;


### PR DESCRIPTION
To reproduce:
=============
try open PDF viewer in Safari on iOS 17.3 or below, it won't work.

Problem:
========
Safari on iOS 17.3 or below doesn't support `Promise.withResolvers`

Solution:
=========
polyfilling `Promise.withResolvers` in concerned files.

opw-4232179

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
