### PR TITLE
[FIX] web, mail, html_editor: translation button alignment

### DIFF
--- a/addons/html_editor/static/src/fields/html_field.scss
+++ b/addons/html_editor/static/src/fields/html_field.scss
@@ -7,23 +7,11 @@ textarea.o_codeview {
 }
 
 div.o_field_html {
-    span.o_field_translate {
-        font-size: 15px;
-        position: absolute;
-        right: 5px;
-        top: 5px;
-    }
-
     .o_show_codeview span.o_field_translate {
         right: 40px;
     }
 
     .o_field_translate .note-editable {
         padding-right: 40px;
-    }
-
-    textarea.o_field_translate:hover + .o_field_text_buttons .o_field_translate,
-    textarea.o_field_translate:focus + .o_field_text_buttons .o_field_translate {
-        visibility: visible;
     }
 }

--- a/addons/mail/static/src/views/web/fields/emojis_char_field/emojis_char_field.xml
+++ b/addons/mail/static/src/views/web/fields/emojis_char_field/emojis_char_field.xml
@@ -5,7 +5,7 @@
         <xpath expr="//span[1]" position="attributes">
             <attribute name="t-ref">targetReadonlyElement</attribute>
         </xpath>
-        <xpath expr="//*[hasclass('o_field_char_buttons')]/button" position="before">
+        <xpath expr="//*[hasclass('o_field_input_buttons')]/button" position="before">
             <t t-call="mail.EmojisFieldButton">
                 <t t-set="positionCenter" t-value="true"/>
             </t>

--- a/addons/mail/static/src/views/web/fields/emojis_text_field/emojis_text_field.xml
+++ b/addons/mail/static/src/views/web/fields/emojis_text_field/emojis_text_field.xml
@@ -5,7 +5,7 @@
         <xpath expr="//span[1]" position="attributes">
             <attribute name="t-ref">targetReadonlyElement</attribute>
         </xpath>
-        <xpath expr="//*[hasclass('o_field_text_buttons')]" position="inside">
+        <xpath expr="//*[hasclass('o_field_input_buttons')]" position="inside">
             <t t-call="mail.EmojisFieldButton"/>
         </xpath>
     </t>

--- a/addons/web/static/src/views/fields/char/char_field.scss
+++ b/addons/web/static/src/views/fields/char/char_field.scss
@@ -6,20 +6,38 @@
     }
 }
 
-.o_field_char_buttons {
-    right: 0;
-    margin-left: -35px;
-    margin-right: 20px;
+.o_field_widget:has(.o_field_translate + .o_field_input_buttons) {
+    position: relative;
+}
 
-    .o_field_translate {
-        margin-left: 0 !important;
+.o_field_input_buttons {
+    position: absolute;
+    right: 0;
+    height: 100%;
+    display: inline-flex;
+    visibility: hidden;
+
+    .o_field_char & {
+        align-items: center;
+    }
+    .o_field_text & {
+        align-items: flex-start;
+    }
+
+    .btn.o_field_translate {
+        position: relative;
+        right: auto;
+        top: auto;
+
+        &:only-child {
+            padding-right: 10px;
+        }
     }
 }
 
-.o_field_char input.o_field_placeholder {
-    padding-right: 40px;
-}
-
-.o_field_char input.o_field_placeholder.o_field_translate {
-    padding-right: 70px;
+.o_field_widget:hover,
+.o_field_widget:focus-within {
+    .o_field_input_buttons {
+        visibility: visible;
+    }
 }

--- a/addons/web/static/src/views/fields/char/char_field.xml
+++ b/addons/web/static/src/views/fields/char/char_field.xml
@@ -20,7 +20,7 @@
                 t-on-blur="onBlur"
                 t-ref="input"
             />
-            <div class="o_field_char_buttons position-absolute d-inline">
+            <div class="o_field_input_buttons">
                 <t t-if="isTranslatable">
                     <TranslationButton
                         fieldName="props.name"

--- a/addons/web/static/src/views/fields/text/text_field.scss
+++ b/addons/web/static/src/views/fields/text/text_field.scss
@@ -1,24 +1,5 @@
-.o_field_text > div {
-    > textarea {
-        height: auto;
-        resize: none;
-        overflow-y: hidden;
-    }
-}
-.o_field_text_buttons {
-    float: right;
-    margin-left: -35px;
-    margin-right: 10px;
-    margin-top: -40px;
-
-    .o_field_translate {
-        margin-left: 0 !important;
-    }
-}
-
-.o_field_text {
-    textarea.o_field_translate:hover + .o_field_text_buttons .o_field_translate,
-    textarea.o_field_translate:focus + .o_field_text_buttons .o_field_translate {
-        visibility: visible;
-    }
+.o_field_text > div > textarea {
+    height: auto;
+    resize: none;
+    overflow-y: hidden;
 }

--- a/addons/web/static/src/views/fields/text/text_field.xml
+++ b/addons/web/static/src/views/fields/text/text_field.xml
@@ -9,14 +9,17 @@
             <div t-ref="div">
                 <textarea
                     class="o_input"
-                    t-att-class="{'o_field_translate': isTranslatable}"
+                    t-att-class="{
+                        'o_field_translate': isTranslatable,
+                        'o_field_placeholder': props.dynamicPlaceholder,
+                    }"
                     t-att-id="props.id"
                     t-att-placeholder="props.placeholder"
                     t-att-rows="rowCount"
                     t-ref="textarea"
                     t-on-blur="onBlur"
                 />
-                <div class="o_field_text_buttons d-flex flex-row align-items-baseline">
+                <div class="o_field_input_buttons">
                     <TranslationButton
                         t-if="isTranslatable"
                         fieldName="props.name"

--- a/addons/web/static/src/views/fields/translation_button.scss
+++ b/addons/web/static/src/views/fields/translation_button.scss
@@ -1,8 +1,31 @@
 
-.o_list_view .o_field_translate {
-    margin-left: -35px;
-    padding: 0px 1px;
-    text-align: right;
-    width: 35px;
+.btn.o_field_translate {
+    position: absolute;
+    right: 5px;
+    top: 5px;
     vertical-align: top;
+    text-align: right;
+    visibility: hidden;
+
+    &, .o_web_client.o_touch_device & {
+        padding: 0;
+    }
+}
+
+.o_field_widget {
+    &:hover,
+    &:focus-within {
+        .btn.o_field_translate {
+            visibility: visible;
+        }
+    }
+
+    input, textarea {
+        &.o_field_translate, &.o_field_placeholder {
+            padding-right: $o-field-translate-padding;
+        }
+        &.o_field_translate.o_field_placeholder {
+            padding-right: $o-field-translate-padding * 2;
+        }
+    }
 }

--- a/addons/web/static/src/views/fields/translation_button.variables.scss
+++ b/addons/web/static/src/views/fields/translation_button.variables.scss
@@ -1,0 +1,1 @@
+$o-field-translate-padding: 35px;

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -632,39 +632,6 @@
         margin-bottom: 1px;
     }
 
-    // Translate icon
-    span.o_field_translate {
-            padding: 0 $o-form-spacing-unit 0 0 !important;
-            vertical-align: top;
-            position: relative;
-            margin-left: -35px;
-            width: 35px !important; // important is usefull for textarea
-            display: inline-block;
-            text-align: right;
-            border: none;  // usefull for textarea
-            visibility: hidden;
-    }
-
-    div {
-        div:focus-within > div.o_field_char_buttons > span.o_field_translate,
-        div:hover > div.o_field_char_buttons > span.o_field_translate {
-            visibility: visible !important;
-        }
-    }
-
-    div {
-        div:focus-within > span.o_field_translate,
-        div:hover > span.o_field_translate {
-            visibility: visible !important;
-        }
-    }
-
-    input, textarea {
-        &.o_field_translate {
-            padding-right: 25px;
-        }
-    }
-
     .oe_no_translation_content {
         // hide content but show the translate button
         height: 0px;
@@ -689,7 +656,7 @@
     }
 
     iframe.wysiwyg_iframe + .o_field_translate {
-        right: 30px !important;
+        right: $o-field-translate-padding !important;
         top: 7px !important;
     }
 

--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -434,17 +434,12 @@
                         @include o-position-absolute(0, 0);
                     }
                 }
-                > input.o_field_translate,
+                input.o_field_translate,
                 textarea.o_field_translate {
-                    padding-right: 25px;
-                    + span.o_field_translate {
-                        margin-left: -35px;
-                        padding: 0px 1px;
-                        text-align: right;
-                        width: 35px;
-                        vertical-align: top;
-                        font-size: 12px;
-                    }
+                    padding-right: $o-field-translate-padding;
+                }
+                .o_field_input_buttons, .btn.o_field_translate {
+                    visibility: visible;
                 }
                 > .o_row_handle {
                     visibility: hidden; // hide sequence when editing
@@ -582,7 +577,7 @@
         right: 0;
         left: 0;
         justify-content: center;
-        
+
         .o_list_selection_box {
             --#{$variable-prefix}list-group-active-color: #{$white};
             --#{$variable-prefix}list-group-active-border-color: RGB(var(--primary-rgb));


### PR DESCRIPTION
In x2many form field, the translation feature appears at the end of the row and hovers some data.

This commit:
1. Fixes the issue by ensuring that the element is positioned relatively to its container (cf. the translatable field).
2. Refactors the css related to the char_field and text_field translation buttons to avoid negative margins but also to simplify the css.

task-4273364

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
