### PR TITLE
[FIX] html_editor: add step is missing when resizing icon

### DIFF
--- a/addons/html_editor/static/src/main/media/icon_plugin.js
+++ b/addons/html_editor/static/src/main/media/icon_plugin.js
@@ -122,11 +122,11 @@ export class IconPlugin extends Plugin {
                     if (classString.match(/^fa-[2-5]x$/)) {
                         selectedIcon.classList.remove(classString);
                     }
-                    this.dispatch("ADD_STEP");
                 }
                 if (payload !== "1") {
                     selectedIcon.classList.add(`fa-${payload}x`);
                 }
+                this.dispatch("ADD_STEP");
                 break;
             }
             case "TOGGLE_SPIN_ICON": {

--- a/addons/html_editor/static/tests/icon.test.js
+++ b/addons/html_editor/static/tests/icon.test.js
@@ -3,6 +3,7 @@ import { click, waitFor } from "@odoo/hoot-dom";
 import { setupEditor } from "./_helpers/editor";
 import { animationFrame } from "@odoo/hoot-mock";
 import { setContent } from "./_helpers/selection";
+import { undo } from "./_helpers/user_actions";
 
 test("icon toolbar is displayed", async () => {
     await setupEditor(`<p><span class="fa fa-glass">[]</span></p>`);
@@ -85,4 +86,15 @@ test("Can set icon color", async () => {
     expect(".o-we-toolbar").toHaveCount(1); // toolbar still open
     expect(".o_font_color_selector").toHaveCount(0); // selector closed
     expect("span.fa-glass").toHaveStyle({ color: "rgb(107, 173, 222)" });
+});
+
+test("Can undo to 1x size after applying 2x size", async () => {
+    const { editor } = await setupEditor(`<p><span class="fa fa-glass">[]</span></p>`);
+    await waitFor(".o-we-toolbar");
+    expect("span.fa-glass").toHaveCount(1);
+    await click("button[name='icon_size_2']");
+    expect("span.fa-glass.fa-2x").toHaveCount(1);
+    undo(editor);
+    expect("span.fa-glass").toHaveCount(1);
+    expect("span.fa-glass.fa-2x").toHaveCount(0);
 });


### PR DESCRIPTION
**Behaviour before PR:**

Steps to reproduce:

- Add an icon.
- Change it's size from 1x to 2x or whatever.
- Try to undo. Icon is removed at all instead of resizing to 1x.

**Behaviour after PR:**

Now undo works properly after changing icon's size.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
