### PR TITLE
[FIX] portal: show state options in the user portal

### DIFF
--- a/addons/portal/static/src/js/portal.js
+++ b/addons/portal/static/src/js/portal.js
@@ -34,7 +34,7 @@ publicWidget.registry.portalDetails = publicWidget.Widget.extend({
         var countryID = ($country.val() || 0);
         this.$stateOptions.detach();
         var $displayedState = this.$stateOptions.filter('[data-country_id=' + countryID + ']');
-        var nb = $displayedState.appendTo(this.$state).show().length;
+        var nb = $displayedState.appendTo(this.$state).removeClass('d-none').show().length;
         this.$state.parent().toggle(nb >= 1);
     },
 


### PR DESCRIPTION
Steps to reproduce the bug:
1. Go to Website and select My Account
2. Press Edit Information
3. State/Province field doesn't populate

The reason why:

The state `option` elements are by default all hidden using `display:
none`, and in JS we only show the states by the selected country, using
JQuery's `show` method.

In 17.2, we were hiding the `option` with `style="display:none;"` and
that worked well. However, in 17.4, `option` elements were hidden in
commit https://github.com/odoo/odoo/commit/da2c32470c63b8a45ddfb3565c158feece33c924 using the bootstrap class `d-none` (to cleanup the
code), which also does `display: none`, but adds `!important` to it,
making JQuery's `show` method useless.

The fix:
Manually removing `d-none` class with JQuery's `removeClass`.

opw-4275240