### PR TITLE
[IMP] hw_drivers: fetch db_uuid and enterprise_code on setup

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -205,13 +205,13 @@ def check_image():
     return {'major': version[0], 'minor': version[1]}
 
 
-def save_conf_server(url, token, db_uuid, enterprise_code):
+def save_conf_server(url, token, db_uuid=None, enterprise_code=None):
     """
     Save server configurations in odoo.conf
     :param url: The URL of the server
     :param token: The token to authenticate the server
-    :param db_uuid: The database UUID
-    :param enterprise_code: The enterprise code
+    :param db_uuid: The database UUID (optional)
+    :param enterprise_code: The enterprise code (optional)
     """
     update_conf({
         'remote_server': url,


### PR DESCRIPTION
Currently, we provide the IoT Box the `db_uuid` and the `enterprise_code` through the connection link generated by the
db.
In order to reduce the size of this link and the information it contains, we move those two parameters to a `/iot/db_info`
fetch when Odoo starts on the IoT Box.

We also avoid the user to enter manually its `enterprise_code` if he changes his subscription, as the IoT Box will fetch
it automatically.

Enterprise PR: [https://github.com/odoo/enterprise/pull/72610](https://github.com/odoo/enterprise/pull/72610)
Task: 4282684