### PR TITLE
[FIX] pos_sale: properly format order dates

### DIFF
--- a/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderRow.js
+++ b/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderRow.js
@@ -4,6 +4,7 @@ odoo.define('pos_sale.SaleOrderRow', function (require) {
     const PosComponent = require('point_of_sale.PosComponent');
     const Registries = require('point_of_sale.Registries');
     const utils = require('web.utils');
+    const { deserializeDateTime } = require("@web/core/l10n/dates");
 
     /**
      * @props {models.Order} order
@@ -25,7 +26,7 @@ odoo.define('pos_sale.SaleOrderRow', function (require) {
             return this.order.name;
         }
         get date() {
-            return moment(this.order.date_order).format('YYYY-MM-DD hh:mm A');
+            return deserializeDateTime(this.order.date_order).toFormat("yyyy-MM-dd HH:mm a");
         }
         get partner() {
             const partner = this.order.partner_id;


### PR DESCRIPTION
Problem:
In PoS (version 16.0), the order dates in the order list are not properly formatted, leading to incorrect date display.

Solution:
Apply the same date formatting fix used in version 17.0+ to ensure the dates are displayed correctly in the PoS order list. Reference fix in 17.0+:
https://github.com/odoo/odoo/blob/78b215ebb4f6124a43fd38f1103fe58286c3fa69/addons/pos_sale/static/src/app/order_management_screen/sale_order_row/sale_order_row.js#L35

Steps to reproduce:
- Create a Sales Order.
- Open PoS.
- Display the list of orders.
- The date is displayed incorrectly in the list.

opw-4253780

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
