### PR TITLE
[FIX] html_editor: close table picker on keydown

### DIFF
--- a/addons/html_editor/static/src/main/table/table_picker.js
+++ b/addons/html_editor/static/src/main/table/table_picker.js
@@ -20,9 +20,6 @@ export class TablePicker extends Component {
             const key = ev.key;
             const isRTL = this.props.direction === "rtl";
             switch (key) {
-                case "Escape":
-                    this.props.overlay.close();
-                    break;
                 case "Enter":
                     ev.preventDefault();
                     this.insertTable();
@@ -56,6 +53,9 @@ export class TablePicker extends Component {
                     } else {
                         this.state.cols += 1;
                     }
+                    break;
+                default:
+                    this.props.overlay.close();
                     break;
             }
         });

--- a/addons/html_editor/static/tests/table/adding_table.test.js
+++ b/addons/html_editor/static/tests/table/adding_table.test.js
@@ -250,3 +250,35 @@ test.tags("desktop")("add table inside non-empty list", async () => {
         </ul>`
     );
 });
+
+test.tags("desktop")(
+    "should close the table picker when any key except arrow keys pressed",
+    async () => {
+        const { el, editor } = await setupEditor("<p>a[]</p>");
+        await insertText(editor, "/");
+        await waitFor(".o-we-powerbox");
+        await insertText(editor, "table");
+        expectContentToBe(el, "<p>a/table[]</p>");
+        await animationFrame();
+        await press("Enter");
+        await waitFor(".o-we-tablepicker");
+        expect(".o-we-tablepicker").toHaveCount(1);
+        expectContentToBe(el, "<p>a[]</p>");
+        await insertText(editor, "b");
+        await animationFrame();
+        expect(".o-we-tablepicker").toHaveCount(0);
+        expectContentToBe(el, "<p>ab[]</p>");
+        await insertText(editor, "/");
+        await waitFor(".o-we-powerbox");
+        await insertText(editor, "table");
+        expectContentToBe(el, "<p>ab/table[]</p>");
+        await animationFrame();
+        await press("Enter");
+        await waitFor(".o-we-tablepicker");
+        expect(".o-we-tablepicker").toHaveCount(1);
+        expectContentToBe(el, "<p>ab[]</p>");
+        await insertText(editor, "/");
+        await animationFrame();
+        expect(".o-we-tablepicker").toHaveCount(0);
+    }
+);


### PR DESCRIPTION
**Current behavior before PR:**

- After opening the table picker, it does not close when typing, unless Escape key was pressed

**Desired behavior after PR is merged:**

- Now, the table picker will close when any key is pressed except for arrow keys.
