### PR TITLE
[FIX] sale_timesheet: fix "Time Remaining on SO" report computation

### DIFF
--- a/addons/sale_timesheet/report/project_report.py
+++ b/addons/sale_timesheet/report/project_report.py
@@ -20,5 +20,5 @@ class ReportProjectTaskUser(models.Model):
 
     def _from(self):
         return super()._from() + """
-            LEFT JOIN sale_order_line sol ON t.id = sol.task_id
+            LEFT JOIN sale_order_line sol ON t.sale_line_id = sol.id
         """

--- a/addons/sale_timesheet/tests/__init__.py
+++ b/addons/sale_timesheet/tests/__init__.py
@@ -18,3 +18,4 @@ from . import test_project_pricing_type
 from . import test_project_update
 from . import test_sale_timesheet_accrued_entries
 from . import test_sale_timesheet_report
+from . import test_task_analysis

--- a/addons/sale_timesheet/tests/test_task_analysis.py
+++ b/addons/sale_timesheet/tests/test_task_analysis.py
@@ -1,0 +1,30 @@
+from odoo.tests import tagged
+
+from .common import TestCommonSaleTimesheet
+
+
+@tagged('post_install', '-at_install')
+class TestSaleTimesheetTaskAnalysis(TestCommonSaleTimesheet):
+    def test_remaining_hours_so(self):
+        sales_order = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+        })
+        so_line_1 = self.env['sale.order.line'].create({
+            'product_id': self.product_order_timesheet3.id,
+            'product_uom_qty': 10,
+            'order_id': sales_order.id,
+        })
+        sales_order.action_confirm()
+
+        task_1 = self.env['project.task'].search([('sale_line_id', '=', so_line_1.id)])
+        task_2 = self.env['project.task'].create({
+            'name': "Task 2",
+            'project_id': task_1.project_id.id,
+            'partner_id': self.partner_a.id,
+            'sale_line_id': so_line_1.id,
+        })
+        self.assertEqual(task_2.remaining_hours_so, 10)
+
+        self.env.flush_all()
+        task_report = self.env['report.project.task.user'].search([('task_id', '=', task_2.id)])
+        self.assertEqual(task_report.remaining_hours_so, task_2.remaining_hours_so)


### PR DESCRIPTION
Steps to reproduce
------------------
1. Create a SO with a product with with the "Prepaid" Invoice Policy and "Hours" unit that creates a task in a project.
2. Create a new billable project and a task in that project, and set the partner of the SO created earlier on the new task.
3. Set the SOL of the SO from step 1 on the task.
4. Check that in the Timesheets notebook, you see a value for "Time Remaining on SO".
5. Go to the reporting and group by project, and display the "Time Remaining on SO".
6. There is a value for the project generated by the SO, but not for the one created manually.

---

This bug occurs because we only account for the task generated by a SOL of the SO when computing the remaining hours on SO in the reporting.
This PR fixes the way it is computed.

Task-4280965
