### PR TITLE
[FIX] website_hr_recruitment: survive form submit while logged in

### DIFF
--- a/addons/website_hr_recruitment/controllers/main.py
+++ b/addons/website_hr_recruitment/controllers/main.py
@@ -357,7 +357,10 @@ class WebsiteHrRecruitment(WebsiteForm):
             # pop the fields since there are only useful to generate a candidate record
             partner_name = values.pop('partner_name')
             partner_phone = values.pop('partner_phone', None)
-            partner_email = values.pop('email_from', None)
+            if request.session.uid:
+                partner_email = values.get('email_from', None)
+            else:
+                partner_email = values.pop('email_from', None)
             if partner_phone and partner_email:
                 candidate = request.env['hr.candidate'].sudo().search([
                     ('email_from', '=', partner_email),


### PR DESCRIPTION
In [1], `email_from` was made mandatory when submitting a form as a logged in user.
In [2], `email_from` was removed from the form parameters once consumed by the job application form.
Because of these, the job application form fails when submitted while being logged in.

This commit avoids this error by not consuming the `email_from` field in the job application handling when the user is logged in.

[1]: https://github.com/odoo/odoo/commit/1aa5cbb06be85e94c01f8f55ef57b9415b9bb50f
[2]: https://github.com/odoo/odoo/commit/05f9f43b93e10745b130a7ee185261e9a259ef2a

task-4280924