### PR TITLE
[FIX] payment_adyen: add idempotency key for customer-initiated payments

### DIFF
--- a/addons/payment_adyen/controllers/main.py
+++ b/addons/payment_adyen/controllers/main.py
@@ -156,11 +156,15 @@ class AdyenController(http.Controller):
             data.update(captureDelayHours=0)
 
         # Make the payment request to Adyen
+        idempotency_key = payment_utils.generate_idempotency_key(
+            tx_sudo, scope='payment_request_controller'
+        )
         response_content = provider_sudo._adyen_make_request(
             url_field_name='adyen_checkout_api_url',
             endpoint='/payments',
             payload=data,
-            method='POST'
+            method='POST',
+            idempotency_key=idempotency_key,
         )
 
         # Handle the payment request response


### PR DESCRIPTION
Payments initiated by the customer from the payment form could sometimes lead to multiple charges if a webhook notification would arrive at the same time as the payment request's response. This is due to the webhook acquiring a lock in the database when updating the transaction's state, followed by the processing of the payment request's response trying to do the same and thus encountering a concurrent access error. The payment request is thus retried and a new charge is created on Adyen side.

This commit fixes the issue by passing an idempotency key with the payment request. If a payment request is inadvertently retried, Adyen silently ignores it and returns the same response as for the initial request. The response is processed again in Odoo and the customer is smoothly redirected to the payment landing page.