### PR TITLE
[FIX] stock: display the quant name in detailed operation

### DIFF
--- a/addons/stock/static/src/fields/stock_move_line_x2_many_field.js
+++ b/addons/stock/static/src/fields/stock_move_line_x2_many_field.js
@@ -43,7 +43,6 @@ export class SMLX2ManyField extends X2ManyField {
                     for (const ml of this.props.record.data.move_line_ids.records) {
                         const entry = quants_by_key[[ml.data.product_id[0], ml.data.lot_id?.[0] || false, ml.data.location_id[0], ml.data.package_id?.[0] || false, ml.data.owner_id?.[0] || false].toString()];
                         if (!entry) {  // product not storable or has no quant yet
-                            ml.data.quant_id = [false, 0];
                             continue;
                         }
                         ml.data.quant_id = [entry[0], entry[1]];


### PR DESCRIPTION
Bug introcued by this commit: https://github.com/odoo/odoo/pull/174984/commits/7bcfc3a1107650deff9dd8af02a3717304cb7d4e

Steps to reproduce the bug:
- Create a storable product “P1” tracked by serial number
- update the qty with SN1
- Create a delivery order with SN1
- Validate it
- go to the product and come back to the delivery
- click on  detailed operation in the move line

Problem:
“Unnamed” is displayed instead of the display_name of the quant

opw-4279953
opw-4277630
opw-4276882
opw-4276058
opw-4252901
