### PR TITLE
[FIX] html_editor: don't update embedded state obsolete property values

### DIFF
--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -712,7 +712,6 @@ export class HistoryPlugin extends Plugin {
         }
         // Reapply the uncommited draft, since this is not an operation which should cancel it
         this.applyMutations(this.currentStep.mutations);
-        this.dispatch("ADD_EXTERNAL_STEP");
     }
     /**
      * @param { HistoryMutation[] } mutations

--- a/addons/html_editor/static/src/others/embedded_component_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_component_plugin.js
@@ -13,6 +13,7 @@ export class EmbeddedComponentPlugin extends Plugin {
         filter_descendants_to_serialize: this.filterDescendantsToSerialize.bind(this),
         is_mutation_record_savable: this.isMutationRecordSavable.bind(this),
         on_change_attribute: this.onChangeAttribute.bind(this),
+        onExternalHistorySteps: this.handleComponents.bind(this, this.editable),
     };
 
     setup() {
@@ -59,7 +60,6 @@ export class EmbeddedComponentPlugin extends Plugin {
                 break;
             }
             case "RESTORE_SAVEPOINT":
-            case "ADD_EXTERNAL_STEP":
             case "HISTORY_RESET_FROM_STEPS":
             case "HISTORY_RESET": {
                 this.handleComponents(this.editable);

--- a/addons/html_editor/static/src/others/embedded_component_utils.js
+++ b/addons/html_editor/static/src/others/embedded_component_utils.js
@@ -519,7 +519,7 @@ export class StateChangeManager {
         for (const key of currentKeys) {
             if (key in (this.config.propertyUpdater || {})) {
                 this.config.propertyUpdater[key](state, previous, next);
-            } else {
+            } else if (JSON.stringify(previous[key]) !== JSON.stringify(next[key])) {
                 replaceProperty(state, key, next[key]);
             }
         }

--- a/addons/html_editor/static/src/others/embedded_components/plugins/table_of_content_plugin/table_of_content_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/table_of_content_plugin/table_of_content_plugin.js
@@ -22,6 +22,7 @@ export class TableOfContentPlugin extends Plugin {
             },
         ],
         mutation_filtered_classes: ["o_embedded_toc_header_highlight"],
+        onExternalHistorySteps: this.delayedUpdateTableOfContents.bind(this, this.editable),
     };
 
     setup() {
@@ -41,9 +42,10 @@ export class TableOfContentPlugin extends Plugin {
                 this.cleanForSave(payload.root);
                 break;
             case "RESTORE_SAVEPOINT":
-            case "ADD_EXTERNAL_STEP":
             case "HISTORY_RESET_FROM_STEPS":
             case "HISTORY_RESET":
+                this.delayedUpdateTableOfContents(this.editable);
+                break;
             case "STEP_ADDED":
                 this.delayedUpdateTableOfContents(payload.stepCommonAncestor);
                 break;


### PR DESCRIPTION
### Issue:
There was an issue when applying embedded state changes from a peer while there
was a pending local embedded state change.

Old unchanged properties of the local embedded change would overwrite peer
changes. Instead, `commitStateChange` must check if a property has changed and
replace the property only if that is the case.

---
Furthermore, this PR introduces another small improvement:
remove editor command "ADD_EXTERNAL_STEP"

This command's purpose was to dispatch the event at each individual external
step, but it was only used for embedded components, and `onExternalHistorySteps`
resource (which handles every batch of collaborative steps) is enough for
embedded components, and it is called less often. This commit therefore removes
`ADD_EXTERNAL_STEP` command.

Small fix to the table of content plugin, only `STEP_ADDED` has a
`stepCommonAncestor` payload property, therefore commands which don't have it
will use `this.editable` instead to search for new headings.

task-4281356