### PR TITLE
[IMP] {hr,sale}_timesheet: delete inaccurate fields in tasks analysis

### DIFF
--- a/addons/hr_timesheet/report/project_report.py
+++ b/addons/hr_timesheet/report/project_report.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models, api
+from odoo import fields, models
 
 
 class ReportProjectTaskUser(models.Model):
@@ -13,26 +12,20 @@ class ReportProjectTaskUser(models.Model):
     remaining_hours_percentage = fields.Float('Time Remaining Percentage', readonly=True, groups="hr_timesheet.group_hr_timesheet_user")
     progress = fields.Float('Progress', aggregator='avg', readonly=True, groups="hr_timesheet.group_hr_timesheet_user")
     overtime = fields.Float(readonly=True, export_string_translation=False, groups="hr_timesheet.group_hr_timesheet_user")
-    total_hours_spent = fields.Float("Total Time Spent", help="Time spent on this task, including its sub-tasks.", groups="hr_timesheet.group_hr_timesheet_user")
-    subtask_effective_hours = fields.Float("Time Spent on Sub-Tasks", help="Time spent on the sub-tasks (and their own sub-tasks) of this task.", groups="hr_timesheet.group_hr_timesheet_user")
 
     def _select(self):
-        return super()._select() +  """,
+        return super()._select() + """,
                 CASE WHEN COALESCE(t.allocated_hours, 0) = 0 THEN NULL ELSE t.effective_hours * 100 / t.allocated_hours END as progress,
                 NULLIF(t.effective_hours, 0) as effective_hours,
-                t.allocated_hours - t.effective_hours - t.subtask_effective_hours as remaining_hours,
+                CASE WHEN COALESCE(t.allocated_hours, 0) = 0 THEN NULL ELSE t.allocated_hours - t.effective_hours END as remaining_hours,
                 CASE WHEN t.allocated_hours > 0 THEN t.remaining_hours / t.allocated_hours ELSE 0 END as remaining_hours_percentage,
-                t.allocated_hours,
-                NULLIF(t.overtime, 0) as overtime,
-                NULLIF(t.total_hours_spent, 0) as total_hours_spent,
-                t.subtask_effective_hours
+                NULLIF(t.allocated_hours, 0) as allocated_hours,
+                NULLIF(t.overtime, 0) as overtime
         """
 
     def _group_by(self):
         return super()._group_by() + """,
                 t.effective_hours,
-                t.subtask_effective_hours,
                 t.allocated_hours,
-                t.overtime,
-                t.total_hours_spent
+                t.overtime
         """

--- a/addons/hr_timesheet/report/project_report_view.xml
+++ b/addons/hr_timesheet/report/project_report_view.xml
@@ -13,7 +13,6 @@
                     <field name="allocated_hours" widget="timesheet_uom" type="measure"/>
                     <field name="effective_hours" widget="timesheet_uom" type="measure"/>
                     <field name="overtime" widget="timesheet_uom"/>
-                    <field name="total_hours_spent" widget="timesheet_uom"/>
                     <field name="remaining_hours" widget="timesheet_uom" type="measure"/>
                     <field name="remaining_hours_percentage" invisible="1"/>
                 </xpath>
@@ -27,9 +26,7 @@
             <field name="arch" type="xml">
                 <pivot position="inside">
                     <field name="allocated_hours" widget="timesheet_uom" type="measure"/>
-                    <field name="effective_hours" widget="timesheet_uom"/>
-                    <field name="subtask_effective_hours" widget="timesheet_uom"/>
-                    <field name="total_hours_spent" widget="timesheet_uom" type="measure"/>
+                    <field name="effective_hours" widget="timesheet_uom" type="measure"/>
                     <field name="remaining_hours" widget="timesheet_uom" type="measure"/>
                     <field name="overtime" widget="timesheet_uom" type="measure"/>
                     <field name="remaining_hours_percentage" invisible="1"/>

--- a/addons/sale_timesheet/report/project_report_view.xml
+++ b/addons/sale_timesheet/report/project_report_view.xml
@@ -6,9 +6,9 @@
             <field name="model">report.project.task.user</field>
             <field name="inherit_id" ref="project.view_task_project_user_pivot"/>
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='total_hours_spent']" position='before'>
+                <field name="remaining_hours" position="after">
                     <field name="remaining_hours_so" widget="timesheet_uom"/>
-                </xpath>
+                </field>
              </field>
         </record>
 
@@ -22,7 +22,7 @@
                 </field>
              </field>
         </record>
-    
+
         <record id="view_task_project_user_fsm_graph_base_inherited" model="ir.ui.view">
             <field name="name">report.project.task.user.fsm.graph.base.inherited</field>
             <field name="model">report.project.task.user</field>


### PR DESCRIPTION
`effective_hours` is supposed to sum the time recorded on a task, but not on its subtasks. Yet, the latter was also summed in, so that's not was is expected.
Also, it is added again to get `total_hours_spent`...

Easy solution:
Drop `total_hours_spent` and `subtask_effective_hours`, which were a little overkill anyway,
and only keep `effective_hours` that is the sum of the time spent on both the task and its subtasks.

Also, we no longer compute `remaining_hours` if there is no `allocated_hours`, because it doesn't make sense.

task-4269588

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
