### PR TITLE
[IMP] l10n_uy: add tax included taxes data.

### DIFF
--- a/addons/l10n_uy/data/template/account.tax-uy.csv
+++ b/addons/l10n_uy/data/template/account.tax-uy.csv
@@ -1,25 +1,41 @@
-"id","name","description","invoice_label","l10n_uy_tax_category","amount","amount_type","type_tax_use","tax_group_id","repartition_line_ids/repartition_type","repartition_line_ids/document_type","repartition_line_ids/tag_ids","repartition_line_ids/account_id","description@es","invoice_label@es"
-"vat1","22%","VAT Sales (22%)","VAT Sales (22%)","vat","22.0","percent","sale","tax_group_iva_22","base","invoice","+Base Sales 22%","","IVA Ventas (22%)","IVA Ventas (22%)"
-"","","","","","","","","","tax","invoice","+Sales VAT 22%","uy_code_21402","",""
-"","","","","","","","","","base","refund","-Taxable Sales Base","","",""
-"","","","","","","","","","tax","refund","-VAT Sales - received","uy_code_21402","",""
-"vat2","10%","VAT Sales (10%)","VAT Sales (10%)","vat","10.0","percent","sale","tax_group_iva_10","base","invoice","+Base Sales 10%","","IVA Ventas (10%)","IVA Ventas (10%)"
-"","","","","","","","","","tax","invoice","+Sales VAT 10%","uy_code_21401","",""
-"","","","","","","","","","base","refund","-Taxable Sales Base","","",""
-"","","","","","","","","","tax","refund","-VAT Sales - received","uy_code_21401","",""
-"vat3","0% EXEMPT","VAT Exempt Sales","VAT Exempt Sales","vat","0.0","percent","sale","tax_group_exenton","base","invoice","+Base Sales 0%","","Ventas Exentos IVA","Ventas Exentos IVA"
-"","","","","","","","","","tax","invoice","","uy_code_21405","",""
-"","","","","","","","","","base","refund","-Taxable Sales Base","","",""
-"","","","","","","","","","tax","refund","","uy_code_21405","",""
-"vat4","22%","VAT Purchases (22%)","VAT Purchases (22%)","vat","22.0","percent","purchase","tax_group_iva_22","base","invoice","+Base Purchases 22%","","IVA Compras (22%)","IVA Compras (22%)"
-"","","","","","","","","","tax","invoice","+VAT Purchases 22%","uy_code_11502","",""
-"","","","","","","","","","base","refund","-Tax Base Purchases","","",""
-"","","","","","","","","","tax","refund","-VAT Purchases - paid","uy_code_11502","",""
-"vat5","10%","VAT Purchases (10%)","VAT Purchases (10%)","vat","10.0","percent","purchase","tax_group_iva_10","base","invoice","+Base Purchases 10%","","IVA Compras (10%)","IVA Compras (10%)"
-"","","","","","","","","","tax","invoice","+VAT Purchases 10%","uy_code_11501","",""
-"","","","","","","","","","base","refund","-Tax Base Purchases","","",""
-"","","","","","","","","","tax","refund","-VAT Purchases - paid","uy_code_11501","",""
-"vat6","0% EXEMPT","Purchases Exempt from VAT","Purchases Exempt from VAT","vat","0.0","percent","purchase","tax_group_exenton","base","invoice","+Base Purchases 0%","","Compras Exento IVA","Compras Exentos IVA"
-"","","","","","","","","","tax","invoice","","uy_code_11503","",""
-"","","","","","","","","","base","refund","-Tax Base Purchases","","",""
-"","","","","","","","","","tax","refund","","uy_code_11503","",""
+id,name,description,invoice_label,l10n_uy_tax_category,amount,amount_type,type_tax_use,tax_group_id,repartition_line_ids/repartition_type,repartition_line_ids/document_type,repartition_line_ids/tag_ids,repartition_line_ids/account_id,price_include,description@es,invoice_label@es
+vat1,22%,VAT Sales (22%),VAT Sales (22%),vat,22,percent,sale,tax_group_iva_22,base,invoice,+Base Sales 22%,,,IVA Ventas (22%),IVA Ventas (22%)
+,,,,,,,,,tax,invoice,+Sales VAT 22%,uy_code_21402,,,
+,,,,,,,,,base,refund,-Taxable Sales Base,,,,
+,,,,,,,,,tax,refund,-VAT Sales - received,uy_code_21402,,,
+vat2,10%,VAT Sales (10%),VAT Sales (10%),vat,10,percent,sale,tax_group_iva_10,base,invoice,+Base Sales 10%,,,IVA Ventas (10%),IVA Ventas (10%)
+,,,,,,,,,tax,invoice,+Sales VAT 10%,uy_code_21401,,,
+,,,,,,,,,base,refund,-Taxable Sales Base,,,,
+,,,,,,,,,tax,refund,-VAT Sales - received,uy_code_21401,,,
+vat3,0% EXEMPT,VAT Exempt Sales,VAT Exempt Sales,vat,0,percent,sale,tax_group_exenton,base,invoice,+Base Sales 0%,,,Ventas Exentos IVA,Ventas Exentos IVA
+,,,,,,,,,tax,invoice,,uy_code_21405,,,
+,,,,,,,,,base,refund,-Taxable Sales Base,,,,
+,,,,,,,,,tax,refund,,uy_code_21405,,,
+vat4,22%,VAT Purchases (22%),VAT Purchases (22%),vat,22,percent,purchase,tax_group_iva_22,base,invoice,+Base Purchases 22%,,,IVA Compras (22%),IVA Compras (22%)
+,,,,,,,,,tax,invoice,+VAT Purchases 22%,uy_code_11502,,,
+,,,,,,,,,base,refund,-Tax Base Purchases,,,,
+,,,,,,,,,tax,refund,-VAT Purchases - paid,uy_code_11502,,,
+vat5,10%,VAT Purchases (10%),VAT Purchases (10%),vat,10,percent,purchase,tax_group_iva_10,base,invoice,+Base Purchases 10%,,,IVA Compras (10%),IVA Compras (10%)
+,,,,,,,,,tax,invoice,+VAT Purchases 10%,uy_code_11501,,,
+,,,,,,,,,base,refund,-Tax Base Purchases,,,,
+,,,,,,,,,tax,refund,-VAT Purchases - paid,uy_code_11501,,,
+vat6,0% EXEMPT,Purchases Exempt from VAT,Purchases Exempt from VAT,vat,0,percent,purchase,tax_group_exenton,base,invoice,+Base Purchases 0%,,,Compras Exento IVA,Compras Exentos IVA
+,,,,,,,,,tax,invoice,,uy_code_11503,,,
+,,,,,,,,,base,refund,-Tax Base Purchases,,,,
+,,,,,,,,,tax,refund,,uy_code_11503,,,
+vat7,22% included,VAT Included Sales (22%),VAT Included Sales (22%),vat,22,percent,sale,tax_group_iva_22,base,invoice,+Base Sales 22%,,True,IVA Ventas Incluído (22%),IVA Ventas Incluído (22%)
+,,,,,,,,,tax,invoice,+Sales VAT 22%,uy_code_21402,,,
+,,,,,,,,,base,refund,-Taxable Sales Base,,,,
+,,,,,,,,,tax,refund,-VAT Sales - received,uy_code_21402,,,
+vat8,10% included,VAT Included Sales (10%),VAT Included Sales (10%),vat,10,percent,sale,tax_group_iva_10,base,invoice,+Base Sales 10%,,True,IVA Ventas Incluído (10%),IVA Ventas Incluído (10%)
+,,,,,,,,,tax,invoice,+Sales VAT 10%,uy_code_21401,,,
+,,,,,,,,,base,refund,-Taxable Sales Base,,,,
+,,,,,,,,,tax,refund,-VAT Sales - received,uy_code_21401,,,
+vat9,22% included,VAT Included Purchases (22%),VAT Included Purchases (22%),vat,22,percent,purchase,tax_group_iva_22,base,invoice,+Base Purchases 22%,,True,IVA Compras Incluído (22%),IVA Compras Incluído (22%)
+,,,,,,,,,tax,invoice,+VAT Purchases 22%,uy_code_11502,,,
+,,,,,,,,,base,refund,-Tax Base Purchases,,,,
+,,,,,,,,,tax,refund,-VAT Purchases - paid,uy_code_11502,,,
+vat10,10% included,VAT Included Purchases (10%),VAT Included Purchases (10%),vat,10,percent,purchase,tax_group_iva_10,base,invoice,+Base Purchases 10%,,True,IVA Compras Incluído (10%),IVA Compras Incluído (10%)
+,,,,,,,,,tax,invoice,+VAT Purchases 10%,uy_code_11501,,,
+,,,,,,,,,base,refund,-Tax Base Purchases,,,,
+,,,,,,,,,tax,refund,-VAT Purchases - paid,uy_code_11501,,,


### PR DESCRIPTION
This PR updates l10n_uy by adding 22% and 10% VAT-included tax options for sales and purchases, supporting Uruguay’s practice of using both tax-included and tax-excluded amounts per document. The data aligns with XML requirements by specifying VAT inclusion at the document level, enabling accurate automatic vendor bill creation from XML imports.
Task Adhoc side: 43467
Task latam side: 1282




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
