### PR TITLE
[FIX] mail: new button shouldn't be visible

### DIFF
--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -351,7 +351,7 @@
         <field name="name">mail.activity.view.kanban.open.target</field>
         <field name="model">mail.activity</field>
         <field name="arch" type="xml">
-            <kanban string="Activity" action="action_open_document" type="object">
+            <kanban string="Activity" action="action_open_document" type="object" create="False">
                 <templates>
                     <field name="active" invisible="1"/>
                     <t t-name="kanban-box">


### PR DESCRIPTION
Current behaviour:
---
When being on the kanban view of "my activities", the new button is visible but doesn't do anything.

Expected behaviour:
---
The button shouldn't be visible, because you shouldn't be able to create activities in the kanban view.

Steps to reproduce:
---
1. Install contacts
2. Go to contacts
3. Click on the clock in the upper right
4. Click on "View all activities"
5. Switch to kanban view
6. Click on "New"
7. Nothing happens

Fix:
---
Disabled the "new" button

opw-4210619

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
