### PR TITLE
[FIX] web: error when selecting an export template with fields without group permission

### DIFF
--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -374,7 +374,7 @@ class Export(http.Controller):
 
         return [
             {'name': field['name'], 'label': fields_data[field['name']]}
-            for field in export_fields_list
+            for field in export_fields_list if field['name'] in fields_data
         ]
 
     def fields_info(self, model, export_fields):

--- a/doc/cla/corporate/stesiconsultingsrl.md
+++ b/doc/cla/corporate/stesiconsultingsrl.md
@@ -15,3 +15,4 @@ List of contributors:
 Michele Di Croce dicroce.m@stesi.eu https://github.com/micheledic
 Francesco Moccia moccia.f@stesi.eu https://github.com/stesifrancesco
 Arcadio Pinto pinto.a@stesi.eu https://github.com/ArcadioPinto
+Gabriele Portente portente.g@stesi.consulting https://github.com/gportente


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Described in #184497 

Current behavior before PR:
Error when selecting a template that contains field you don't have access to

Desired behavior after PR is merged:
No error occurs



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
