### PR TITLE
[FIX] website_sale: don't add Public User as parent for delivery address

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1479,6 +1479,10 @@ class WebsiteSale(payment_portal.PaymentPortal):
             address_values['website_id'] = order_sudo.website_id.id
 
         commercial_partner = order_sudo.partner_id.commercial_partner_id
+        # Avoid linking the address to the default archived 'Public user' partner.
+        if commercial_partner.active:
+            address_values['parent_id'] = commercial_partner.id
+
         if address_type == 'billing':
             if order_sudo._is_anonymous_cart():
                 # New billing addresses of public customers will be their contact address.
@@ -1487,13 +1491,8 @@ class WebsiteSale(payment_portal.PaymentPortal):
                 address_values['type'] = 'other'
             else:
                 address_values['type'] = 'invoice'
-
-            # Avoid linking the address to the default archived 'Public user' partner.
-            if commercial_partner.active:
-                address_values['parent_id'] = commercial_partner.id
         elif address_type == 'delivery':
             address_values['type'] = 'delivery'
-            address_values['parent_id'] = commercial_partner.id
 
     def _create_new_address(self, address_values, address_type, use_same, order_sudo):
         """ Create a new partner, must be called after the data has been verified

--- a/addons/website_sale/tests/test_address.py
+++ b/addons/website_sale/tests/test_address.py
@@ -54,6 +54,7 @@ class TestCheckoutAddress(BaseUsersCommon, WebsiteSaleCommon):
     def test_01_create_shipping_address_specific_user_account(self):
         ''' Ensure `website_id` is correctly set (specific_user_account) '''
         p = self.env.user.partner_id
+        p.active = True
         so = self._create_so(partner_id=p.id)
 
         with MockRequest(self.env, website=self.website, sale_order_id=so.id) as req:


### PR DESCRIPTION
Versions
--------
- saas-17.4

Fixed in 18.0+ via #174073

Steps
-----
1. Enable Demo payment w/ express checkout;
2. as anonymous user, add a deliverable product to cart;
3. go to checkout;
4. finalize order using the "Pay with Demo" button;
6. on the back-end, check the newly created contact for the order.

Issue
-----
Newly created contact has "Public User" listed as company.

Cause
-----
The `_complete_address_values` method introced by 453cfab758505 avoids adding "Public User" as `parent_id` value for addresses of type 'billing' but overlooked taking the same precaution for the 'shipping' address type.

This was inadvertently fixed in 087c48c4ed2ef, which modified the method to add Click & Collect.

Solution
--------
Avoid adding the archived "Public User" as `parent_id`, regardless of address type.

opw-4235452
