### PR TITLE
[FIX] pos_sale: ensure sales team is assigned to draft orders

### DIFF
--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -163,6 +163,11 @@ class PosOrder(models.Model):
 
         return inv_line_vals
 
+    def write(self, vals):
+        if 'crm_team_id' in vals:
+            vals['crm_team_id'] = vals['crm_team_id'] if vals.get('crm_team_id') else self.session_id.crm_team_id.id
+        return super().write(vals)
+
 class PosOrderLine(models.Model):
     _inherit = 'pos.order.line'
 


### PR DESCRIPTION
Before this commit, the sales team could be missing from an order captured as draft due to writing a false value.

opw-4230882

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
