### PR TITLE
[FW][FIX] l10n_ar_withholding: repeated taxes in chart of accounts

### DIFF
--- a/addons/l10n_ar_withholding/data/template/account.tax-ar_ex.csv
+++ b/addons/l10n_ar_withholding/data/template/account.tax-ar_ex.csv
@@ -3,7 +3,3 @@
 "","","","","","","","","","","tax","invoice","base_retencion_suss_sufrida","",""
 "","","","","","","","","","","base","refund","","",
 "","","","","","","","","","","tax","refund","base_retencion_suss_sufrida","",""
-"ex_tax_retencion_ganancias_sufrida","WTH Earnings I","Retención Earnings incurred","True",4,"percent",0,"tax_group_withholding","none","customer","base","invoice","","""Ret Ganancias S","Retención Ganancias Sufrida"
-"","","","","","","","","","","tax","invoice","base_retencion_ganancias_sufrida","",""
-"","","","","","","","","","","base","refund","","",
-"","","","","","","","","","","tax","refund","base_retencion_ganancias_sufrida","",""

--- a/addons/l10n_ar_withholding/data/template/account.tax-ar_ri.csv
+++ b/addons/l10n_ar_withholding/data/template/account.tax-ar_ri.csv
@@ -3,11 +3,6 @@ ri_tax_withholding_vat_incurred,VAT WTH  I,none,percent,Withholding VAT incurred
 ,,,,,,,,,,,,,,,,tax,invoice,ri_retencion_iva_sufrida,,
 ,,,,,,,,,,,,,,,,base,refund,,,
 ,,,,,,,,,,,,,,,,tax,refund,ri_retencion_iva_sufrida,,
-ri_tax_withholding_suss_incurred,WTH SUSS I,none,percent,SUSS Withholding incurred,True,10,tax_group_withholding,customer,,,,,0,,,,,,Ret SUSS S,Retención SUSS Sufrida
-,,,,,,,,,,,,,,,,base,invoice,,,
-,,,,,,,,,,,,,,,,tax,invoice,base_retencion_suss_sufrida,,
-,,,,,,,,,,,,,,,,base,refund,,,
-,,,,,,,,,,,,,,,,tax,refund,base_retencion_suss_sufrida,,
 ri_tax_withholding_ganancias_incurred,Earnings WTH  I,none,percent,Earnings withholding incurred,True,4,tax_group_withholding,customer,,,,,0,,,,,,Ret Ganancias S,Retención Ganancias Sufrida
 ,,,,,,,,,,,,,,,,base,invoice,,,
 ,,,,,,,,,,,,,,,,tax,invoice,base_retencion_ganancias_sufrida,,


### PR DESCRIPTION
Adhoc-task: 40503

Description of the issue/feature this PR addresses:
  1- We removed the following taxes to avoid duplication:
  
  "ex_tax_retencion_suss_sufrida", "WTH SUSS I", which is already located here(https://github.com/odoo/odoo/pull/184976/files#diff-4bca1b8ca406e3c79fa6697dcb06168a41e3a1a031fcfc467322ae0d78483523R2)
  
  "ex_tax_retencion_ganancias_sufrida", "WTH Earnings I", which is already located here (https://github.com/odoo/odoo/pull/184976/files#diff-4bca1b8ca406e3c79fa6697dcb06168a41e3a1a031fcfc467322ae0d78483523R7) and here (https://github.com/odoo/odoo/pull/184976/files#diff-4bca1b8ca406e3c79fa6697dcb06168a41e3a1a031fcfc467322ae0d78483523R12)
  
  2- We moved the taxes from files to match the same structure as l10n_ar

Current behavior before PR:
After downloading l10n_ar_withholding and checking the taxes, we realized some duplicates.
[[FIX]l10n_ar_withholding: repeated taxes in chart of accounts.webm](https://github.com/odoo/odoo/assets/109111493/56776d61-86f1-4632-98a4-c9e192cc5f3a)

Desired behavior after PR is merged:
The taxes are no longer duplicated.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
