### PR TITLE
[FIX] website_event_booth_exhibitor: one call to now

### DIFF
--- a/addons/website_event_booth_exhibitor/tests/test_wevent_booth_exhibitor.py
+++ b/addons/website_event_booth_exhibitor/tests/test_wevent_booth_exhibitor.py
@@ -30,13 +30,13 @@ class TestWEventBoothExhibitorCommon(HttpCaseWithUserDemo, HttpCaseWithUserPorta
             'country_id': self.env.ref('base.us').id,
             'state_id': self.env.ref('base.state_us_39').id,
         })
-
+        now = datetime.now()
         self.env['event.event'].create({
             'name': 'Test Online Reveal',
             'date_tz': 'Europe/Brussels',
             'stage_id': self.env.ref('event.event_stage_booked').id,
-            'date_begin': datetime.now() + relativedelta(days=1, hour=5, minute=0, second=0),
-            'date_end': datetime.now() + relativedelta(days=1, hour=5, minute=0, second=0),
+            'date_begin': now + relativedelta(days=1, hour=5, minute=0, second=0),
+            'date_end': now + relativedelta(days=1, hour=5, minute=0, second=0),
             'auto_confirm': True,
             'is_published': True,
             'website_menu': True,


### PR DESCRIPTION
The event is create with a date_begin and date_end calling datetime.now consecutively. This can lead to a situation where the date_end is before the date_begin in verry rare case (not monotonic).
This commit fix this by calling datetime.now only once and using the same value for both date_begin and date_end.

runbot error [56986](https://runbot.odoo.com/web#id=56986&cids=1&menu_id=424&action=573&model=runbot.build.error&view_type=form)