### PR TITLE
[FIX] point_of_sale: Align TOTAL and CHANGE labels on POS receipts to the start

### DIFF
--- a/addons/point_of_sale/static/src/css/pos_receipts.css
+++ b/addons/point_of_sale/static/src/css/pos_receipts.css
@@ -46,7 +46,7 @@
 
 .pos-receipt .pos-receipt-amount {
     font-size: 125%;
-    padding-left: 6em;
+    text-align: start;
 }
 
 .pos-receipt .pos-receipt-title {


### PR DESCRIPTION
Description:
This PR adjusts the alignment of the `TOTAL` and `CHANGE` labels on the POS receipts by modifying the CSS. Specifically, it changes the `padding-left: 6em` rule to `text-align: start`. The reason for this update is to ensure that the labels are consistently aligned at the start, improving readability and layout in different screen sizes and environments.

Previous behavior:
The `TOTAL` and `CHANGE` labels used excessive left padding (`padding-left: 6em`), which caused misalignment in some cases.
![Screenshot from 2024-10-24 11-32-27](https://github.com/user-attachments/assets/7e1cae6d-cef0-43a5-a0cc-da83091d1f13)


New behavior:
The labels are now aligned to the start using `text-align: start`, resulting in a cleaner and more consistent layout.
![Screenshot from 2024-10-24 11-32-55](https://github.com/user-attachments/assets/8467e68a-c6a8-49da-bead-46be573de4d0)


This change enhances the overall appearance of the POS receipts and maintains consistency across different locales and layouts.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
