### PR TITLE
[FIX] mail: disable search messages for empty threads

### DIFF
--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -59,6 +59,9 @@ threadActionsRegistry
                 (!component.props.chatWindow || component.props.chatWindow.isOpen)
             );
         },
+        disabledCondition(component) {
+            return component.thread.isEmpty;
+        },
         panelOuterClass: "o-mail-SearchMessagesPanel",
         icon: "oi oi-fw oi-search",
         iconLarge: "oi oi-fw oi-search",


### PR DESCRIPTION
Current behavior before PR:

In discuss, thread action Search Messages was available
for empty threads as well, which it shouldn't be.

Desired behavior after PR is merged:

In discuss, thread action Search Messages will not
be available for empty threads



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
