### PR TITLE
[FIX] website: fix product ribbon shadow overlap on shop page

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1632,6 +1632,10 @@ $ribbon-padding: 100px;
     white-space: nowrap;
     text-align: center;
     pointer-events: none;
+
+    &:empty {
+        display: none;
+    }
 }
 
 .o_ribbon_right {


### PR DESCRIPTION
In 17.4, the `o_ribbon_right` class was applied to all product ribbons on the
shop page, causing empty ribbon shadows to overlap and crop the top-right corner
of product images.

This CSS rule (`display: none`) hides shadows on empty ribbons, preventing
overlap. This approach matches the fix in later versions to avoid layout issues.

This is done already in the v18 with this commit
https://github.com/odoo/odoo/commit/b5b8a133eb67f01cabec01a1dc874e8a27a3bb46#diff-f338780f594d6b1f46eda5d3fb9fed86f3c3c8f65522fb93e639534e9d92cdb2R1832

opw-4190631