### PR TITLE
[FIX] analytic: prevent error when the user clicks view button in analytic

### DIFF
--- a/addons/analytic/models/analytic_distribution_model.py
+++ b/addons/analytic/models/analytic_distribution_model.py
@@ -92,3 +92,15 @@ class AccountAnalyticDistributionModel(models.Model):
             return [(fname, 'in', value)]
         else:
             return [(fname, 'in', [value, False])]
+
+    # Dead method, removed in master
+    def action_read_distribution_model(self):
+        self.ensure_one()
+        return {
+            'name': self.display_name,
+            'type': 'ir.actions.act_window',
+            'view_type': 'form',
+            'view_mode': 'form',
+            'res_model': 'account.analytic.distribution.model',
+            'res_id': self.id,
+        }


### PR DESCRIPTION
The `action_read_distribution_model` method was removed from the following commit.

https://github.com/odoo/odoo/pull/182278/commits/777dea298fd74f2349ca22d05fe7f48596216dfe

Since the client's non-updated views still call it, but get a traceback as it doesn't exist anymore.

Error:-
```
AttributeError: The method 'action_read_distribution_model' does not exist on the model 'account.analytic.distribution.model'
```

We add it again to fix the issue.

sentry-5804153543

