### PR TITLE
[IMP] html_editor: UX improvements (movenode, excalidraw)

### DIFF
--- a/addons/html_editor/__manifest__.py
+++ b/addons/html_editor/__manifest__.py
@@ -22,6 +22,7 @@ This addon provides an extensible, maintainable editor.
         'web.assets_backend': [
             'html_editor/static/src/**/*',
             ('remove', 'html_editor/static/src/components/history_dialog/history_dialog.dark.scss'),
+            ('remove', 'html_editor/static/src/main/movenode.dark.scss'),
             ('include', 'html_editor.assets_media_dialog'),
         ],
         'html_editor.assets_media_dialog': [
@@ -32,6 +33,7 @@ This addon provides an extensible, maintainable editor.
         ],
         "web.assets_web_dark": [
             'html_editor/static/src/components/history_dialog/history_dialog.dark.scss',
+            'html_editor/static/src/main/movenode.dark.scss',
         ],
         'web.assets_unit_tests': [
             'html_editor/static/tests/**/*',

--- a/addons/html_editor/static/src/main/movenode.dark.scss
+++ b/addons/html_editor/static/src/main/movenode.dark.scss
@@ -1,0 +1,4 @@
+.oe-sidewidget-move {
+    color: rgb(255, 255, 255);
+    background-color: $o-view-background-color;
+}

--- a/addons/html_editor/static/src/main/movenode_plugin.js
+++ b/addons/html_editor/static/src/main/movenode_plugin.js
@@ -228,7 +228,7 @@ export class MoveNodePlugin extends Plugin {
         }
 
         this.moveWidget = this.document.createElement("div");
-        this.moveWidget.className = "oe-sidewidget-move fa fa-sort";
+        this.moveWidget.className = "oe-sidewidget-move oi oi-draggable";
         this.widgetContainer.append(this.moveWidget);
 
         let moveWidgetOffsetTop = 0;

--- a/addons/html_editor/static/src/others/embedded_components/core/excalidraw/readonly_excalidraw.xml
+++ b/addons/html_editor/static/src/others/embedded_components/core/excalidraw/readonly_excalidraw.xml
@@ -16,7 +16,7 @@
                 <iframe class="flex-grow-1 position-relative" t-att-src="templateState.source" allowfullscreen="true"/>
                 <div t-if="!isMobile" t-on-mousedown.prevent="onHandleMouseDown"
                     t-attf-class="{{ this.displayState.isResizing ? 'visible' : '' }} o_embedded_draw_handle o_embedded_draw_handle_right fa fa-arrows-h align-self-end position-absolute bottom-0 end-0"/>
-                <a title="Open in new Window" t-att-href="templateState.source" target="_blank" role="button" class="fa fa-external-link end-0 top-0 position-absolute pe-3 pt-3"/>
+                <a title="Open in new Window" t-att-href="templateState.source" target="_blank" role="button" class="btn btn-secondary end-0 top-0 mt-1 me-1 position-absolute">Open</a>
             </div>
         </div>
     </t>

--- a/addons/html_editor/static/src/others/embedded_components/plugins/excalidraw_plugin/excalidraw_dialog/excalidraw_dialog.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/excalidraw_plugin/excalidraw_dialog/excalidraw_dialog.js
@@ -18,21 +18,26 @@ export class ExcalidrawDialog extends Component {
 
     setup() {
         super.setup();
-        this.state = useState({});
+        this.state = useState({
+            hasError: false,
+            isInputEmpty: true,
+        });
         this.inputRef = useAutofocus({ refName: "urlInput" });
         useExternalListener(window, "keydown", this.onKeyDown.bind(this));
     }
 
     onKeyDown(event) {
-        this.state.hasError = false;
         if (event.key === "Enter") {
             this.saveURL();
         }
     }
 
     checkInput() {
-        let potentialURL = this.inputRef.el.value;
+        this.state.hasError = false;
+        this.state.isInputEmpty = false;
+        let potentialURL = this.inputRef.el.value?.trim();
         if (!potentialURL) {
+            this.state.isInputEmpty = true;
             return false;
         }
         potentialURL = checkURL(potentialURL, excalidrawWebsiteDomainList);

--- a/addons/html_editor/static/src/others/embedded_components/plugins/excalidraw_plugin/excalidraw_dialog/excalidraw_dialog.xml
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/excalidraw_plugin/excalidraw_dialog/excalidraw_dialog.xml
@@ -7,16 +7,15 @@
                 Sorry, we could not find your drawing, please verify that the URL is valid.
             </div>
             <div class="alert alert-info d-flex" role="alert" t-else="">
-                <i class="fa fa-info-circle py-1 pe-2"/><div>Collaborative Links require joining, while Embed Links directly show the drawing.</div>
+                <div>Open the share menu of your Excalidraw scene and paste its shareable or embed link here.</div>
             </div>
             <input class="o_input" type="text" t-ref="urlInput"
-                t-on-paste.stop="() => this.state.hasError = false"
-                t-on-input.stop="() => this.state.hasError = false"
                 t-on-keydown.stop="onKeyDown"
-                t-on-focusout.stop="() => this.checkInput()"
+                t-on-input.stop="() => this.checkInput()"
                 placeholder="e.g. https://link.excalidraw.com/..."/>
             <t t-set-slot="footer">
-                <button class="btn btn-primary" t-on-click="saveURL">Insert Drawing</button>
+                <button class="btn btn-primary" t-on-click="saveURL"
+                    t-att-disabled="state.hasError or state.isInputEmpty">Insert Drawing</button>
                 <button class="btn btn-secondary" t-on-click="props.close">Discard</button>
             </t>
         </Dialog>


### PR DESCRIPTION
This commit improves the movenode handle in dark mode and the excalidraw
EmbeddedComponent based on feedback we received/saw online.

Specifications
==============
1. The handle widget icon has been changed.
2. Made exalicadraw model's url input required along with some
   other UI change.
3. In the excalidraw embed, 'Open' button UI has been changed.

Task-4246990