### PR TITLE
[FIX] maintenance: add widget upgrade boolean to enterprise module

### DIFF
--- a/addons/maintenance/views/res_config_settings_views.xml
+++ b/addons/maintenance/views/res_config_settings_views.xml
@@ -12,7 +12,7 @@
                     <app data-string="Maintenance" string="Maintenance" name="maintenance" groups="maintenance.group_equipment_manager">
                         <block title="Custom Worksheets">
                             <setting help="Create custom worksheet templates">
-                                <field name="module_maintenance_worksheet"/>
+                                <field name="module_maintenance_worksheet" widget="upgrade_boolean"/>
                             </setting>
                         </block>
                     </app>


### PR DESCRIPTION
* Module maintenance worksheet is from enterprise, we should add widget upgrade_boolean for it to avoid misunderstanding from customer

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
