### PR TITLE
[FIX] base: remove test_sync_recorder

### DIFF
--- a/odoo/addons/base/tests/test_profiler.py
+++ b/odoo/addons/base/tests/test_profiler.py
@@ -416,51 +416,6 @@ class TestProfiling(TransactionCase):
         self.assertEqual(entries.pop(0)['exec_context'], ((stack_level, {'letter': 'a'}), (stack_level, {'letter': 'c'})))
         self.assertEqual(entries.pop(0)['exec_context'], ((stack_level, {'letter': 'a'}),))
 
-    def test_sync_recorder(self):
-        if sys.gettrace() is not None:
-            self.skipTest(f'Cannot start SyncCollector, settrace already set: {sys.gettrace()}')
-
-        def a():
-            b()
-            c()
-
-        def b():
-            pass
-
-        def c():
-            d()
-            d()
-
-        def d():
-            pass
-
-        with Profiler(description='test', collectors=['traces_sync'], db=None) as p:
-            a()
-
-        stacks = [r['stack'] for r in p.collectors[0].entries]
-
-        # map stack frames to their function name, and check
-        stacks_methods = [[frame[2] for frame in stack] for stack in stacks]
-        self.assertEqual(stacks_methods, [
-            ['a'],
-            ['a', 'b'],
-            ['a'],
-            ['a', 'c'],
-            ['a', 'c', 'd'],
-            ['a', 'c'],
-            ['a', 'c', 'd'],
-            ['a', 'c'],
-            ['a'],
-            [],
-            ['__exit__'],
-            ['__exit__', 'stop']  # could be removed by cleaning two last frames, or removing last frames only contained in profiler.py
-        ])
-
-        # map stack frames to their line number, and check
-        stacks_lines = [[frame[1] for frame in stack] for stack in stacks]
-        self.assertEqual(stacks_lines[1][0] + 1, stacks_lines[3][0],
-                         "Call of b() in a() should be one line before call of c()")
-
     def test_qweb_recorder(self):
         template = self.env['ir.ui.view'].create({
             'name': 'test',
@@ -647,3 +602,52 @@ class TestPerformance(BaseCase):
             time.sleep(1)
         entry_count = len(res.collectors[0].entries)
         self.assertLess(entry_count, 5)  # ~3
+
+
+@tagged('-standard', 'profiling')
+class TestSyncRecorder(BaseCase):
+    # this test was made non standard because it can break for strange reason because of additionnal _remove or signal_handler frame
+    def test_sync_recorder(self):
+        if sys.gettrace() is not None:
+            self.skipTest(f'Cannot start SyncCollector, settrace already set: {sys.gettrace()}')
+
+        def a():
+            b()
+            c()
+
+        def b():
+            pass
+
+        def c():
+            d()
+            d()
+
+        def d():
+            pass
+
+        with Profiler(description='test', collectors=['traces_sync'], db=None) as p:
+            a()
+
+        stacks = [r['stack'] for r in p.collectors[0].entries]
+
+        # map stack frames to their function name, and check
+        stacks_methods = [[frame[2] for frame in stack] for stack in stacks]
+        self.assertEqual(stacks_methods, [
+            ['a'],
+            ['a', 'b'],
+            ['a'],
+            ['a', 'c'],
+            ['a', 'c', 'd'],
+            ['a', 'c'],
+            ['a', 'c', 'd'],
+            ['a', 'c'],
+            ['a'],
+            [],
+            ['__exit__'],
+            ['__exit__', 'stop']  # could be removed by cleaning two last frames, or removing last frames only contained in profiler.py
+        ])
+
+        # map stack frames to their line number, and check
+        stacks_lines = [[frame[1] for frame in stack] for stack in stacks]
+        self.assertEqual(stacks_lines[1][0] + 1, stacks_lines[3][0],
+                         "Call of b() in a() should be one line before call of c()")


### PR DESCRIPTION
The test_sync_recorder was breaking for strange reason because of extra elements in the stack

A first attempt was made trying to remove last elements but in some case a `_remove` or `signal_handler` can appear in the middle. It looks to complex to adapt the test to work in all those cases. Moving it to a non standard test looks like the simplest solution for now.

runbot error [73473](https://runbot.odoo.com/web#id=73473&cids=1&menu_id=424&action=573&model=runbot.build.error&view_type=form)

