### PR TITLE
[FIX] base: Don't block import if noupdate xmlids are created in modules

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4405,7 +4405,7 @@ class BaseModel(metaclass=MetaModel):
             existing_modules = self.env['ir.module.module'].sudo().search([]).mapped('name')
             for data in to_create:
                 xml_id = data.get('xml_id')
-                if xml_id:
+                if xml_id and not data.get('noupdate'):
                     module_name, sep, record_id = xml_id.partition('.')
                     if sep and module_name in existing_modules:
                         raise UserError(


### PR DESCRIPTION
In odoo#130825, we prevented the import of records that are given an XMLid that belongs to an Odoo module, because such records would be unlinked when the module is updated.

However, if the XMLid has noupdate set to True, then the record will not get unlinked anyway when the module is updated, so we should not block it from being creataed.

This is useful because there are cases where during an import, `_load_records` is called again by the business code.

For example, in 17.0+, when importing a chart of accounts on a new company, the import of the opening balances causes a new 'Unaffected Earnings' account to be created via `_load_records`, with `noupdate=True`.[^1]

[^1]: https://github.com/odoo/odoo/blob/a73e45ff9459ffdc0128327fac47962c6fe27af7/addons/account/models/company.py#L473

task-none
runbot-108001