### PR TITLE
[IMP] core: authenticate/_login, use env instead of creating cursor

### DIFF
--- a/addons/auth_oauth/controllers/main.py
+++ b/addons/auth_oauth/controllers/main.py
@@ -151,7 +151,7 @@ class OAuthController(http.Controller):
                 url = '/odoo?menu_id=%s' % menu
 
             credential = {'login': login, 'token': key, 'type': 'oauth_token'}
-            auth_info = request.session.authenticate(dbname, credential)
+            auth_info = request.session.authenticate(request.env, credential)
             resp = request.redirect(_get_login_redirect_url(auth_info['uid'], url), 303)
             resp.autocorrect_location_header = False
 

--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -163,9 +163,8 @@ class AuthSignupHome(Home):
 
     def _signup_with_values(self, token, values):
         login, password = request.env['res.users'].sudo().signup(values, token)
-        request.env.cr.commit()     # as authenticate will use its own cursor we need to commit the current transaction
         credential = {'login': login, 'password': password, 'type': 'password'}
-        request.session.authenticate(request.db, credential)
+        request.session.authenticate(request.env, credential)
 
 class AuthBaseSetup(BaseSetup):
     @http.route()

--- a/addons/auth_signup/models/res_users.py
+++ b/addons/auth_signup/models/res_users.py
@@ -118,14 +118,12 @@ class ResUsers(models.Model):
                 raise SignupError(_('Signup is not allowed for uninvited users'))
         return self._create_user_from_template(values)
 
-    @classmethod
-    def authenticate(cls, db, credential, user_agent_env):
-        auth_info = super().authenticate(db, credential, user_agent_env)
+    def authenticate(self, credential, user_agent_env):
+        auth_info = super().authenticate(credential, user_agent_env)
         try:
-            with cls.pool.cursor() as cr:
-                env = api.Environment(cr, auth_info['uid'], {})
-                if env.user._should_alert_new_device():
-                    env.user._alert_new_device()
+            env = self.env(user=auth_info['uid'])
+            if env.user._should_alert_new_device():
+                env.user._alert_new_device()
         except MailDeliveryException:
             pass
         return auth_info

--- a/addons/base_import_module/controllers/main.py
+++ b/addons/base_import_module/controllers/main.py
@@ -15,7 +15,7 @@ class ImportModule(Controller):
             if not request.db:
                 raise Exception(_("Could not select database '%s'", request.db))
             credential = {'login': login, 'password': password, 'type': 'password'}
-            request.session.authenticate(request.db, credential)
+            request.session.authenticate(request.env, credential)
             # request.uid is None in case of MFA
             if request.uid and request.env.user._is_admin():
                 return request.env['ir.module.module']._import_zipfile(mod_file, force=force == '1')[0]

--- a/addons/web/controllers/database.py
+++ b/addons/web/controllers/database.py
@@ -80,8 +80,11 @@ class Database(http.Controller):
             country_code = post.get('country_code') or False
             dispatch_rpc('db', 'create_database', [master_pwd, name, bool(post.get('demo')), lang, password, post['login'], country_code, post['phone']])
             credential = {'login': post['login'], 'password': password, 'type': 'password'}
-            request.session.authenticate(name, credential)
-            request.session.db = name
+            with odoo.modules.registry.Registry(name).cursor() as cr:
+                env = odoo.api.Environment(cr, None, {})
+                request.session.authenticate(env, credential)
+                request._save_session()
+                request.session.db = name
             return request.redirect('/odoo')
         except Exception as e:
             _logger.exception("Database creation error.")

--- a/addons/web/controllers/home.py
+++ b/addons/web/controllers/home.py
@@ -119,7 +119,7 @@ class Home(http.Controller):
             try:
                 credential = {key: value for key, value in request.params.items() if key in CREDENTIAL_PARAMS and value}
                 credential.setdefault('type', 'password')
-                auth_info = request.session.authenticate(request.db, credential)
+                auth_info = request.session.authenticate(request.env, credential)
                 request.params['login_success'] = True
                 return request.redirect(self._login_redirect(auth_info['uid'], redirect=redirect))
             except odoo.exceptions.AccessDenied as e:

--- a/addons/website/models/res_users.py
+++ b/addons/website/models/res_users.py
@@ -67,8 +67,7 @@ class ResUsers(models.Model):
         current_website = self.env['website'].sudo().get_current_website()
         return current_website.auth_signup_uninvited or super(ResUsers, self)._get_signup_invitation_scope()
 
-    @classmethod
-    def authenticate(cls, db, credential, user_agent_env):
+    def authenticate(self, credential, user_agent_env):
         """ Override to link the logged in user's res.partner to website.visitor.
         If a visitor already exists for that user, assign it data from the
         current anonymous visitor (if exists).
@@ -77,9 +76,9 @@ class ResUsers(models.Model):
         visitor_pre_authenticate_sudo = None
         if request and request.env:
             visitor_pre_authenticate_sudo = request.env['website.visitor']._get_visitor_from_request()
-        auth_info = super().authenticate(db, credential, user_agent_env)
+        auth_info = super().authenticate(credential, user_agent_env)
         if auth_info.get('uid') and visitor_pre_authenticate_sudo:
-            env = api.Environment(request.env.cr, auth_info['uid'], {})
+            env = self.env(user=auth_info['uid'])
             user_partner = env.user.partner_id
             visitor_current_user_sudo = env['website.visitor'].sudo().search([
                 ('partner_id', '=', user_partner.id)

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -909,34 +909,31 @@ class ResUsers(models.Model):
     def _get_login_order(self):
         return self._order
 
-    @classmethod
-    def _login(cls, db, credential, user_agent_env):
+    def _login(self, credential, user_agent_env):
         login = credential['login']
         ip = request.httprequest.environ['REMOTE_ADDR'] if request else 'n/a'
         try:
-            with cls.pool.cursor() as cr:
-                self = api.Environment(cr, SUPERUSER_ID, {})[cls._name]
-                with self._assert_can_auth(user=login):
-                    user = self.search(self._get_login_domain(login), order=self._get_login_order(), limit=1)
-                    if not user:
-                        raise AccessDenied()
-                    user = user.with_user(user)
-                    auth_info = user._check_credentials(credential, user_agent_env)
-                    tz = request.cookies.get('tz') if request else None
-                    if tz in pytz.all_timezones and (not user.tz or not user.login_date):
-                        # first login or missing tz -> set tz to browser tz
-                        user.tz = tz
-                    user._update_last_login()
+            with self._assert_can_auth(user=login):
+                user = self.sudo().search(self._get_login_domain(login), order=self._get_login_order(), limit=1)
+                if not user:
+                    # ruff: noqa: TRY301
+                    raise AccessDenied()
+                user = user.with_user(user).sudo()
+                auth_info = user._check_credentials(credential, user_agent_env)
+                tz = request.cookies.get('tz') if request else None
+                if tz in pytz.all_timezones and (not user.tz or not user.login_date):
+                    # first login or missing tz -> set tz to browser tz
+                    user.tz = tz
+                user._update_last_login()
         except AccessDenied:
-            _logger.info("Login failed for db:%s login:%s from %s", db, login, ip)
+            _logger.info("Login failed for login:%s from %s", login, ip)
             raise
 
-        _logger.info("Login successful for db:%s login:%s from %s", db, login, ip)
+        _logger.info("Login successful for login:%s from %s", login, ip)
 
         return auth_info
 
-    @classmethod
-    def authenticate(cls, db, credential, user_agent_env):
+    def authenticate(self, credential, user_agent_env):
         """Verifies and returns the user ID corresponding to the given
         ``credential``, or False if there was no matching user.
 
@@ -951,20 +948,19 @@ class ResUsers(models.Model):
         :return: auth_info
         :rtype: dict
         """
-        auth_info = cls._login(db, credential, user_agent_env=user_agent_env)
+        auth_info = self._login(credential, user_agent_env=user_agent_env)
         if user_agent_env and user_agent_env.get('base_location'):
-            with cls.pool.cursor() as cr:
-                env = api.Environment(cr, auth_info['uid'], {})
-                if env.user.has_group('base.group_system'):
-                    # Successfully logged in as system user!
-                    # Attempt to guess the web base url...
-                    try:
-                        base = user_agent_env['base_location']
-                        ICP = env['ir.config_parameter']
-                        if not ICP.get_param('web.base.url.freeze'):
-                            ICP.set_param('web.base.url', base)
-                    except Exception:
-                        _logger.exception("Failed to update web.base.url configuration parameter")
+            env = self.env(user=auth_info['uid'])
+            if env.user.has_group('base.group_system'):
+                # Successfully logged in as system user!
+                # Attempt to guess the web base url...
+                try:
+                    base = user_agent_env['base_location']
+                    ICP = env['ir.config_parameter']
+                    if not ICP.get_param('web.base.url.freeze'):
+                        ICP.set_param('web.base.url', base)
+                except Exception:
+                    _logger.exception("Failed to update web.base.url configuration parameter")
         return auth_info
 
     @classmethod

--- a/odoo/service/common.py
+++ b/odoo/service/common.py
@@ -23,12 +23,13 @@ def exp_login(db, login, password):
 def exp_authenticate(db, login, password, user_agent_env):
     if not user_agent_env:
         user_agent_env = {}
-    res_users = Registry(db)['res.users']
-    try:
-        credential = {'login': login, 'password': password, 'type': 'password'}
-        return res_users.authenticate(db, credential, {**user_agent_env, 'interactive': False})['uid']
-    except AccessDenied:
-        return False
+    with Registry(db).cursor() as cr:
+        env = odoo.api.Environment(cr, None, {})
+        try:
+            credential = {'login': login, 'password': password, 'type': 'password'}
+            return env['res.users'].authenticate(credential, {**user_agent_env, 'interactive': False})['uid']
+        except AccessDenied:
+            return False
 
 def exp_version():
     return RPC_VERSION_1

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1950,7 +1950,7 @@ class HttpCase(TransactionCase):
             # patching to speedup the check in case the password is hashed with many hashround + avoid to update the password
             with patch('odoo.addons.base.models.res_users.ResUsersPatchedInTest._check_credentials', new=patched_check_credentials):
                 credential = {'login': user, 'password': password, 'type': 'password'}
-                auth_info = self.registry['res.users'].authenticate(session.db, credential, {'interactive': False})
+                auth_info = self.env['res.users'].authenticate(credential, {'interactive': False})
             uid = auth_info['uid']
             env = api.Environment(self.cr, uid, {})
             session.uid = uid


### PR DESCRIPTION
This offers several benefits:
- Clearer code API, no need for each overrides of res.users.authenticate or res.users.login to create their own cursor and their own env each time
- Less complexity: there was no obvious good reason to use a separate/parllel cursor for the login, except the fact the two methods `authenticate` and `_login` were classmethods. This is mostly historical reasons. The fact to use a parallel cursor also leaded to weird behaviors:
  - need to commit the transaction so the second cursor is aware of the changes of the first one, hence the removal of `commit()` occurences in this diff
  - the route /web/session/authenticate was readonly (because auth=None are readonly by default) but still working depsite the fact authenticate does write something in the database: a res.users.log. It was working only because of that parallel second cursor, not in readonly mode.
- Less cursors: the env, and cursor, of the request is re-used, hence creating less cursors / connections to the database during logins. Which is in itself a significant benefit

The code in `exp_authenticate` and the route `/web/session/authenticate` are nevertheless more complicated, it's a trade off. It could be solved by using a common factorization of the additional overhead somewhere in the tooling, but not in a model (such as res.users) or anything available in `safe_eval`, to prevent the possibility to escape your database through server actions.
