### PR TITLE
[FIX] website: allow forms without emails to be submitted when logged in

### DIFF
--- a/addons/website/controllers/form.py
+++ b/addons/website/controllers/form.py
@@ -265,7 +265,7 @@ class WebsiteForm(http.Controller):
 
         authenticate_message = False
         email_field_name = request.env[model_name]._mail_get_primary_email_field()
-        if email_field_name and hasattr(record, '_message_log'):
+        if email_field_name and hasattr(record, '_message_log') and email_field_name in values:
             warning_icon = ""
             if request.session.uid:
                 user_email = request.env.user.email


### PR DESCRIPTION
Since [1] e-mails from forms are compared to the logged in user's e-mail when a website form is submitted. Because of this forms without e-mail cannot be used anymore when the user is not logged in.

This commit removes this comparison for forms that do not contain an e-mail field.

Steps to reproduce:
- Install website_hr_recruitment
- Drop a form into the home page
- Set the form action to "Apply for a Job"
- Remove the e-mail field
- Save
- Submit the form

=> An error occurred

[1]: https://github.com/odoo/odoo/commit/1aa5cbb06be85e94c01f8f55ef57b9415b9bb50f

task-4282750