### PR TITLE
[FIX] base: prevent traceback when editing the view

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -410,14 +410,16 @@ actual arch.
                     ))
                     err.context = e.context
                     raise err.with_traceback(e.__traceback__) from None
-                elif err.__context__:
+                elif e.__context__:
                     err = ValidationError(_(
                         "Error while validating view (%(view)s):\n\n%(error)s", view=view.key or view.id, error=e.__context__,
                     ))
                     err.context = {'name': 'invalid view'}
                     raise err.with_traceback(e.__context__.__traceback__) from None
                 else:
-                    raise
+                    raise ValidationError(_(
+                        "Error while validating view (%(view)s):\n\n%(error)s", view=view.key or view.id, error=e,
+                    ))
 
         return True
 


### PR DESCRIPTION
When the user edits the view and adds context with invalid syntax,
a traceback will appear.

Steps to reproduce the error:

- Go to Settings > Technical > Views > Open any view
- Add context = ``"[]"`` or context = ``"{a}"`` like this in the view
- Save

Traceback:
```
UnboundLocalError: cannot access local variable 'err' where it is not associated with a value
  File "odoo/http.py", line 2365, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1892, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1955, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 137, in retrying
    result = func()
  File "odoo/http.py", line 1922, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2169, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 329, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 728, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "home/odoo/src/enterprise/18.0/industry_fsm_report/controllers/main.py", line 10, in edit_view
    action = super().edit_view(view_id, studio_view_arch, operations, model, context)
  File "odoo/http.py", line 728, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "home/odoo/src/enterprise/18.0/worksheet/controllers/main.py", line 10, in edit_view
    action = super().edit_view(view_id, studio_view_arch, operations, model, context)
  File "odoo/http.py", line 728, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "home/odoo/src/enterprise/18.0/web_studio/controllers/main.py", line 695, in edit_view
    self._set_studio_view(view, new_arch)
  File "home/odoo/src/enterprise/18.0/web_studio/controllers/main.py", line 456, in _set_studio_view
    studio_view.arch_db = arch
  File "odoo/fields.py", line 1402, in __set__
    records.write({self.name: write_value})
  File "home/odoo/src/enterprise/18.0/web_studio/models/studio_mixin.py", line 33, in write
    res = super(StudioMixin, self).write(vals)
  File "odoo/addons/base/models/ir_ui_view.py", line 535, in write
    res = super(View, self).write(self._compute_defaults(vals))
  File "odoo/models.py", line 4750, in write
    real_recs._validate_fields(vals, inverse_fields)
  File "odoo/models.py", line 1599, in _validate_fields
    check(self)
  File "odoo/addons/base/models/ir_ui_view.py", line 413, in _check_xml
    elif err.__context__:
```

https://github.com/odoo/odoo/blob/69b404c7109ff689381f56520aad758424ec01aa/odoo/addons/base/models/ir_ui_view.py#L413-L418
Here, the ``err`` variable is referenced before the assignment,
So, it will lead to the above traceback.

sentry-5993638522

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
