### PR TITLE
[FIX] account: Restore Payment Reference on Customer Invoices

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1346,6 +1346,10 @@
                                                context="{'default_partner_id': bank_partner_id, 'display_account_trust': True}"
                                                domain="[('partner_id.ref_company_ids', 'parent_of', company_id)]"
                                                readonly="state != 'draft'"/>
+                                        <field name="payment_reference"
+                                            invisible="move_type not in ('out_invoice', 'out_refund')"
+                                            readonly="inalterable_hash"
+                                            placeholder="Standard communication"/>
                                         <field name="qr_code_method"
                                                invisible="not display_qr_code"/>
                                         <field name="delivery_date" readonly="state != 'draft'"/>


### PR DESCRIPTION
We improved in 17.3/17.4 the Customer Invoice form view, and one of the changes where hiding the Payment Reference field.
See https://github.com/odoo/odoo/commit/112c68a07b817e5e9a6c01e34a0fe7238b2eaa07
The rationale was: as it's most often generated by Odoo, let's not clutter the interface with a field that is left open most of the time. While this is true, in some cases people need to manage them by hand, for example when they import invoices, or they use specific formats not yet handled by Odoo. This commit restores the field in the Other Info tab for those cases.

Task: 4276812
