### PR TITLE
[FIX] website_sale, _*: fix Discount Price Color on Product Page

### DIFF
--- a/addons/website/static/src/snippets/s_searchbar/000.xml
+++ b/addons/website/static/src/snippets/s_searchbar/000.xml
@@ -32,7 +32,7 @@
             </div>
             <div t-if="parts['detail'] and widget.displayDetail" class="flex-shrink-0 ms-auto">
                 <t t-if="result['detail_strike']">
-                    <span class="text-danger text-nowrap" style="text-decoration: line-through;">
+                    <span class="text-muted text-nowrap" style="text-decoration: line-through;">
                         <t t-out="result['detail_strike']"/>
                     </span>
                     <br/>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2734,7 +2734,7 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
             </div>
             <div class="flex-shrink-0">
                 <t t-if="result.get('detail_strike')">
-                    <span class="text-danger text-nowrap" style="text-decoration: line-through;">
+                    <span class="text-muted text-nowrap" style="text-decoration: line-through;">
                         <t t-out="result.get('detail_strike')"/>
                     </span>
                     <br/>

--- a/addons/website_sale/static/src/js/product/product.xml
+++ b/addons/website_sale/static/src/js/product/product.xml
@@ -49,7 +49,7 @@
     <t t-name="website_sale.not_for_sale">
         <div
             t-if="!this.props.can_be_sold"
-            class="text-danger fw-bold"
+            class="text-muted fst-italic"
         >
             <i class="fa fa-times me-1"/>
             Not available for sale
@@ -58,7 +58,7 @@
 
     <t t-name="website_sale.strikethrough_product_price">
         <h5
-            class="oe_striked_price text-danger small"
+            class="oe_striked_price text-muted small"
             t-if="this.props.strikethrough_price"
             t-out="formattedStrikethroughPrice"
         />

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1325,7 +1325,7 @@
                       t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
                 <span itemprop="price" style="display:none;" t-out="combination_info['price']"/>
                 <span itemprop="priceCurrency" style="display:none;" t-esc="website.currency_id.name"/>
-                <span t-attf-class="text-danger oe_default_price ms-1 h5 {{'' if combination_info['has_discounted_price'] and not combination_info['compare_list_price'] else 'd-none'}}"
+                <span t-attf-class="text-muted oe_default_price ms-1 h5 {{'' if combination_info['has_discounted_price'] and not combination_info['compare_list_price'] else 'd-none'}}"
                       style="text-decoration: line-through; white-space: nowrap;"
                       t-esc="combination_info['list_price']"
                       t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
@@ -1333,7 +1333,7 @@
                 />
                 <t t-if="is_view_active('website_sale.tax_indication')" t-call="website_sale.tax_indication"/>
                 <del t-if="combination_info['compare_list_price'] and (combination_info['compare_list_price'] &gt; combination_info['price'])"
-                    class="text-danger ms-1 h5 oe_compare_list_price">
+                    class="text-muted ms-1 h5 oe_compare_list_price">
                     <bdi dir="inherit">
                     <span t-esc="combination_info['compare_list_price']"
                           groups="website_sale.group_product_price_comparison"
@@ -1607,7 +1607,7 @@
                         </div>
                         <div class="mb-0 h6 fw-bold text-end" name="website_sale_cart_line_price">
                             <t t-if="line.discount">
-                                <del t-attf-class="#{'text-danger mr8'}"
+                                <del t-attf-class="#{'text-muted mr8'}"
                                      style="white-space: nowrap;"
                                      t-out="line._get_displayed_unit_price() * line.product_uom_qty"
                                      t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
@@ -1713,7 +1713,7 @@
                              name="website_sale_suggested_product_price">
                             <t t-set="combination_info"
                                t-value="product._get_combination_info_variant()"/>
-                            <del t-attf-class="text-danger mr8 {{'' if combination_info['has_discounted_price'] else 'd-none'}}"
+                            <del t-attf-class="text-muted mr8 {{'' if combination_info['has_discounted_price'] else 'd-none'}}"
                                  t-esc="combination_info['list_price']"
                                  t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
                                  style="white-space: nowrap;"/>

--- a/addons/website_sale_comparison/views/website_sale_comparison_template.xml
+++ b/addons/website_sale_comparison/views/website_sale_comparison_template.xml
@@ -136,12 +136,12 @@
                                                 <span t-out="combination_info['price']"
                                                       t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
                                                 <del t-if="combination_info['compare_list_price'] and (combination_info['compare_list_price'] &gt; combination_info['price'])"
-                                                     t-attf-class="text-danger mr8"
+                                                     t-attf-class="text-muted mr8"
                                                      style="white-space: nowrap;"
                                                      t-esc="combination_info['compare_list_price']"
                                                      t-options="{'widget': 'monetary', 'display_currency': website.currency_id}" />
                                                 <del t-else=""
-                                                     t-attf-class="text-danger mr8 {{'' if combination_info['has_discounted_price'] else 'd-none'}}"
+                                                     t-attf-class="text-muted mr8 {{'' if combination_info['has_discounted_price'] else 'd-none'}}"
                                                      style="white-space: nowrap;"
                                                      t-out="combination_info['list_price']"
                                                      t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>


### PR DESCRIPTION
Version:
- saas 17.4

Steps to reproduce:
- Install the website_sale module.
- Open the pricelist and apply a discount to a product.

Issue:
- The discount price on the product page appears in a red "danger" color.

Solution:
- Changed the text class from "text-danger" to "text-muted" to fix the issue.

opw-4277128
