### PR TITLE
[FIX] website_slides: Error message Youtube preview with no API key

### DIFF
--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -1053,6 +1053,9 @@ class Slide(models.Model):
 
         self.ensure_one()
         google_app_key = self.env['website'].get_current_website().sudo().website_slide_google_app_key
+        if not google_app_key:
+            return {}, _(
+                'Please enter a Google Drive API key in your website\'s settings to have a preview.')
         error_message = False
         try:
             response = requests.get(


### PR DESCRIPTION
Steps to reproduce:

Install website_slides
Have 2 websites
Create a course for the second website
Go on the course on the website
Add a video content and put any Youtube link

Current behavior before PR:

Error message no clear due to an empty API Key
"Could not fetch data from url. Document or access right not available: badRequest"

Desired behavior after PR is merged:

Having a clear message to make the user set up a key.

task-3861625