### PR TITLE
[FIX] mail: inconsistent sidebar and banner unread counter

### DIFF
--- a/addons/mail/static/src/core/common/channel_member_model.js
+++ b/addons/mail/static/src/core/common/channel_member_model.js
@@ -121,6 +121,14 @@ export class ChannelMember extends Record {
               })
             : undefined;
     }
+
+    get totalUnreadMessageCounter() {
+        let counter = this.message_unread_counter;
+        if (!this.unreadSynced) {
+            counter += this.localMessageUnreadCounter;
+        }
+        return counter;
+    }
 }
 
 ChannelMember.register();

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -52,8 +52,8 @@
                 <t t-call="mail.ChatWindow.headerContent"/>
             </t>
             <div class="flex-grow-1"/>
-            <div t-if="thread and thread.needactionCounter > 0" class="o-mail-ChatWindow-counter mx-1 my-0 badge rounded-pill fw-bold o-discuss-badge" t-ref="needactionCounter">
-                <t t-out="thread.needactionCounter"/>
+            <div t-if="thread and thread.importantCounter > 0" class="o-mail-ChatWindow-counter mx-1 my-0 badge rounded-pill fw-bold o-discuss-badge" t-ref="needactionCounter">
+                <t t-out="thread.importantCounter"/>
             </div>
             <t t-if="threadActions.actions.length > 1" t-call="mail.ChatWindow.dropdownAction">
                 <t t-set="action" t-value="threadActions.actions[0]"/>

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -453,8 +453,8 @@ export class Thread extends Component {
     }
 
     get newMessageBannerText() {
-        if (this.props.thread.selfMember?.localMessageUnreadCounter > 1) {
-            return _t("%s new messages", this.props.thread.selfMember.localMessageUnreadCounter);
+        if (this.props.thread.selfMember?.totalUnreadMessageCounter > 1) {
+            return _t("%s new messages", this.props.thread.selfMember.totalUnreadMessageCounter);
         }
         return _t("1 new message");
     }

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -181,8 +181,8 @@ export class Thread extends Record {
         if (this.model === "mail.box") {
             return this.counter;
         }
-        if (this.isChatChannel) {
-            return this.selfMember?.message_unread_counter || this.message_needaction_counter;
+        if (this.isChatChannel && this.selfMember?.message_unread_counter) {
+            return this.selfMember.totalUnreadMessageCounter;
         }
         return this.message_needaction_counter;
     }

--- a/addons/mail/static/tests/thread/unread_messages_banner.test.js
+++ b/addons/mail/static/tests/thread/unread_messages_banner.test.js
@@ -14,12 +14,14 @@ import { Thread } from "@mail/core/common/thread";
 import { describe, test } from "@odoo/hoot";
 import { tick } from "@odoo/hoot-mock";
 import {
+    Command,
     getService,
     onRpc,
     patchWithCleanup,
     serverState,
     withUser,
 } from "@web/../tests/web_test_helpers";
+import { rpc } from "@web/core/network/rpc";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -222,4 +224,50 @@ test("keep banner after mark as unread when scrolling to bottom", async () => {
     await click(".o-mail-Message-moreMenu [title='Mark as Unread']");
     await scroll(".o-mail-Thread", "bottom");
     await contains(".o-mail-Thread-banner", { text: "30 new messages" });
+});
+
+test("sidebar and banner counters display same value", async () => {
+    const pyEnv = await startServer();
+    const bobPatnerId = pyEnv["res.partner"].create({ name: "Bob" });
+    const bobUserId = pyEnv["res.users"].create({ name: "Bob", partner_id: bobPatnerId });
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_type: "chat",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: bobPatnerId }),
+        ],
+    });
+    for (let i = 0; i < 30; ++i) {
+        pyEnv["mail.message"].create({
+            author_id: serverState.partnerId,
+            body: `message ${i}`,
+            model: "discuss.channel",
+            res_id: channelId,
+        });
+    }
+    await start();
+    await openDiscuss();
+    await contains(".o-mail-DiscussSidebar-badge", {
+        text: "30",
+        parent: [".o-mail-DiscussSidebarChannel", { text: "Bob" }],
+    });
+    await click(".o-mail-DiscussSidebarChannel", { text: "Bob" });
+    await contains(".o-mail-Thread-banner", { text: "30 new messages" });
+    await contains(".o-mail-DiscussSidebar-badge", { text: "30", count: 0 });
+    await withUser(bobUserId, () =>
+        rpc("/mail/message/post", {
+            post_data: {
+                body: "Hello!",
+                message_type: "comment",
+                subtype_xmlid: "mail.mt_comment",
+            },
+            thread_id: channelId,
+            thread_model: "discuss.channel",
+        })
+    );
+    await contains(".o-mail-Thread-banner", { text: "31 new messages" });
+    await contains(".o-mail-DiscussSidebar-badge", {
+        text: "31",
+        parent: [".o-mail-DiscussSidebarChannel", { text: "Bob" }],
+    });
 });


### PR DESCRIPTION
Discuss displays an unread counter for the user to keep track of unread messages. This counter is notably shown in the sidebar and in the unread messages banner. However, these counters sometimes have different values, which is inconsistent.

Steps to reproduce:
- Open two browsers (admin/demo).
- Send enough messages from demo to admin to get a scrollbar.
- Scroll to the top with admin, mark the first message as unread.
- Focus the composer: only the banner remains.
- Send another message from demo.
- The sidebar displays 1 unread message while the banner still shows the same value.

To better indicate unread messages, the banner/indicator remains until the user returns to the thread. As a result, server and local values can sometimes become desynced.

This PR ensures both counters account for this desync, adding the local counter to the server one when necessary.