### PR TITLE
[FIX] website_sale: change placeholder for website in pricelist

### DIFF
--- a/addons/website_sale/i18n/website_sale.pot
+++ b/addons/website_sale/i18n/website_sale.pot
@@ -639,7 +639,7 @@ msgstr ""
 
 #. module: website_sale
 #: model_terms:ir.ui.view,arch_db:website_sale.website_sale_pricelist_form_view
-msgid "All websites"
+msgid "Select a website"
 msgstr ""
 
 #. module: website_sale

--- a/addons/website_sale/views/product_pricelist_views.xml
+++ b/addons/website_sale/views/product_pricelist_views.xml
@@ -12,7 +12,7 @@
                         <field name="company_id" invisible="1"/>
                         <field name="website_id"
                             options="{'no_create': True}"
-                            placeholder="All websites"/>
+                            placeholder="Select a website"/>
                         <field name="selectable"/>
                         <field name="code"/>
                     </group>


### PR DESCRIPTION
**Prior to this commit:**
- While configuring a pricelist, if we don't select any website in the Website field, the placeholder let us think that it should be applied on 'All websites'.

**Post this commit:**
- The placeholder is renamed as 'Select a website' as the pricelist doesn't apply to any website when the field is empty.

**Affected version:** saas-17.4~master
**opw**-4256656