### PR TITLE
[FIX] core: ignore un-fixable reportlab warning

### DIFF
--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -164,6 +164,8 @@ def init_logger():
     ]:
         warnings.filterwarnings('ignore', category=DeprecationWarning, module=module)
 
+    # reportlab<4.0.6 triggers this in Py3.10/3.11
+    warnings.filterwarnings('ignore', r'the load_module\(\) method is deprecated', category=DeprecationWarning, module='importlib._bootstrap')
     # the SVG guesser thing always compares str and bytes, ignore it
     warnings.filterwarnings('ignore', category=BytesWarning, module='odoo.tools.image')
     # reportlab does a bunch of bytes/str mixing in a hashmap


### PR DESCRIPTION
`importlib.load_module` has been deprecated in Py3.10 and removed in Py3.12. `reportlab` uses that function until 4.0.6.

Inside Ubuntu Jammy we have Py3.10 and reportlab 3.8, a deprecatation warning is emitted upon importing reportlab.

Inside Ubuntu Noble, we have Py3.12 and reportlab 4.1.0, reportlab doesn't use `load_module` anymore so no warning is emitted.

In the version that matters (Py3.12) the problem is solved so the deprecation warning is more noise than anything useful, ignore the warning until we drop support for py3.10/py3.11.

