### PR TITLE
[FIX] website_sale: fix discount display

### DIFF
--- a/addons/website_sale/models/sale_order_line.py
+++ b/addons/website_sale/models/sale_order_line.py
@@ -48,11 +48,16 @@ class SaleOrderLine(models.Model):
         return warn
 
     def _get_displayed_unit_price(self):
+        # Remove me in master
+        return 0.0
+
+    def _get_price_before_discount(self):
         show_tax = self.order_id.website_id.show_line_subtotals_tax_selection
         tax_display = 'total_excluded' if show_tax == 'tax_excluded' else 'total_included'
+        price_before_discount = self._get_pricelist_price_before_discount()
 
         return self.tax_id.compute_all(
-            self.price_unit, self.currency_id, 1, self.product_id, self.order_partner_id,
+            price_before_discount, self.currency_id, self.product_uom_qty, self.product_id, self.order_partner_id,
         )[tax_display]
 
     def _get_displayed_quantity(self):

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1606,18 +1606,23 @@
                             </t>
                         </div>
                         <div class="mb-0 h6 fw-bold text-end" name="website_sale_cart_line_price">
-                            <t t-if="line.discount">
+                            <t
+                                t-if="website.show_line_subtotals_tax_selection == 'tax_excluded'"
+                                t-set='product_price'
+                                t-value='line.price_subtotal'
+                            />
+                            <t
+                                t-else=""
+                                t-set='product_price'
+                                t-value='line.price_total'
+                            />
+                            <t t-set="price_before_discount" t-value="line._get_price_before_discount()"/>
+                            <t t-if="product_price != price_before_discount">
                                 <del t-attf-class="#{'text-danger mr8'}"
                                      style="white-space: nowrap;"
-                                     t-out="line._get_displayed_unit_price() * line.product_uom_qty"
+                                     t-out="price_before_discount"
                                      t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
                             </t>
-                            <t t-if="website.show_line_subtotals_tax_selection == 'tax_excluded'"
-                               t-set='product_price'
-                               t-value='line.price_subtotal'/>
-                            <t t-else=""
-                               t-set='product_price'
-                               t-value='line.price_total'/>
                             <span t-out="product_price" style="white-space: nowrap;"
                                   t-options="{'widget': 'monetary', 'display_currency': website_sale_order.currency_id}"/>
                             <small t-if="not line._is_not_sellable_line() and line.product_id.base_unit_price"


### PR DESCRIPTION
Steps:
- Install Ecom.
- Add a product in pricelist with fomula type.
- Go to Ecom.
- Product old and new price displaying with old in strike out.
- Go to check out.

Issue:
- Only new product price is displaying as formula and fixed type rule directly change value of product on SOL and discount type add discount on SOL.

Cause:
- Only checked discount on SOL to display old price.

Fix:
- Check price before discount and after discount to display old price if both are not same.

opw-4277128
