### PR TITLE
[FIX] hr_expense: fix validation for company and employee expense journals

### DIFF
--- a/addons/hr_expense/i18n/hr_expense.pot
+++ b/addons/hr_expense/i18n/hr_expense.pot
@@ -1771,6 +1771,13 @@ msgstr ""
 #. odoo-python
 #: code:addons/hr_expense/models/hr_expense.py:0
 #, python-format
+msgid "Please specify a bank journal in order to generate accounting entries."
+msgstr ""
+
+#. module: hr_expense
+#. odoo-python
+#: code:addons/hr_expense/models/hr_expense.py:0
+#, python-format
 msgid "Specify expense journal to generate accounting entries."
 msgstr ""
 

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1212,8 +1212,11 @@ class HrExpenseSheet(models.Model):
         if any(sheet.state != 'approve' for sheet in self):
             raise UserError(_("You can only generate accounting entry for approved expense(s)."))
 
-        if any(not sheet.journal_id for sheet in self):
+        if any(not sheet.journal_id for sheet in self if sheet.payment_mode == 'own_account'):
             raise UserError(_("Specify expense journal to generate accounting entries."))
+
+        if any(not sheet.bank_journal_id for sheet in self if sheet.payment_mode == 'company_account'):
+            raise UserError(_("Please specify a bank journal in order to generate accounting entries."))
 
         if not self.employee_id.sudo().address_home_id:
             raise UserError(_("The private address of the employee is required to post the expense report. Please add it on the employee form."))


### PR DESCRIPTION
Previously, an error would appear for both company and employee expenses if the expense journal was not configured.

The new behavior is as follows:
1. For company-paid expenses, an error will only be shown if the bank journal is not filled in.
2. For employee-paid expenses, an error will be shown if the expense journal is not filled in.

This change ensures that journal validation aligns with the type of expense being processed.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
