### PR TITLE
[IMP] event: remove 96x134mm badge format

### DIFF
--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -241,7 +241,6 @@ class EventEvent(models.Model):
             ('A6', 'A6'),
             ('four_per_sheet', '4 per sheet'),
             ('96x82', '96x82mm (Badge Printer)'),
-            ('96x134', '96x134mm (Badge Printer)')
         ], default='A6', required=True)
     badge_image = fields.Image('Badge Background', max_width=1024, max_height=1024)
     ticket_instructions = fields.Html('Ticket Instructions', translate=True,

--- a/addons/event/report/event_event_reports.xml
+++ b/addons/event/report/event_event_reports.xml
@@ -84,17 +84,6 @@
         <field name="binding_type">report</field>
     </record>
 
-    <record id="action_report_event_registration_badge_96x134" model="ir.actions.report">
-        <field name="name">Badge (96x134mm)</field>
-        <field name="model">event.registration</field>
-        <field name="groups_id" eval="[Command.link(ref('base.group_no_one'))]"/>
-        <field name="report_type">qweb-text</field>
-        <field name="report_name">event.event_report_template_esc_label_96x134_badge</field>
-        <field name="report_file">event.event_report_template_esc_label_96x134_badge</field>
-        <field name="binding_model_id" ref="model_event_registration"/>
-        <field name="binding_type">report</field>
-    </record>
-
     <record id="action_report_event_event_badge" model="ir.actions.report">
         <field name="name">Badge Example</field>
         <field name="model">event.event</field>

--- a/addons/event/report/event_event_templates.xml
+++ b/addons/event/report/event_event_templates.xml
@@ -113,12 +113,6 @@
     </t>
 </template>
 
-<!-- EVENT ESC/LABEL 96x134mm -->
-
-<template id="event_report_template_esc_label_96x134_badge">
-    <t t-esc="docs._generate_esc_label_badges(is_small_badge=False)"/>
-</template>
-
 <!-- EVENT ESC/LABEL 96x82mm -->
 
 <template id="event_report_template_esc_label_96x82_badge">

--- a/addons/event/static/src/client_action/event_registration_summary_dialog.js
+++ b/addons/event/static/src/client_action/event_registration_summary_dialog.js
@@ -180,9 +180,14 @@ export class EventRegistrationSummaryDialog extends Component {
     async printWithBadgePrinter() {
         const reportName = `event.event_report_template_esc_label_${this.registration.badge_format}_badge`;
         const [{ id: reportId }] = await this.orm.searchRead("ir.actions.report", [["report_name", "=", reportName]], ["id"]);
+        const ticket_type = this.registration.ticket_name ? this.registration.ticket_name : '';
 
         this.notification.add(
-            _t("'%(name)s' badge sent to printer '%(printer)s'", { name: this.registration.name, printer: this.selectedPrinter.name }),
+            _t("'%(name)s' %(type)s badge sent to printer '%(printer)s'", {
+                name: this.registration.name,
+                type: ticket_type,
+                printer: this.selectedPrinter.name,
+            }),
             { type: "info" }
         );
         if (await this.isIotBoxReachable()) {

--- a/addons/event/tools/esc_label_tools.py
+++ b/addons/event/tools/esc_label_tools.py
@@ -537,33 +537,3 @@ layout_96x82 = {
     "secondary_text_color": "#374151",
     "secondary_text_alpha": 200
 }
-
-
-layout_96x134 = {
-    "print_width": 2340,
-    "print_height": 3225,
-    "print_offset_left": -30,
-    "print_offset_top": 36,
-    "double_sided": True,
-    "label_gap": 80,
-    "text_margin": 160,
-    "logo_width": 800,
-    "logo_height": 300,
-    "ticket_bg_height": 275,
-    "event_name_font_size": 150,
-    "details_font_size": 80,
-    "attendee_name_font_size": 130,
-    "company_font_size": 100,
-    "ticket_font_size": 110,
-    "event_name_y_pos": 450,
-    "date_y_pos": 650,
-    "address_y_pos": 770,
-    "attendee_name_y_pos": 1025,
-    "company_y_pos": 1200,
-    "answers_y_pos": 1350,
-    "logo_y_pos": 2380,
-    "ticket_text_y_pos": 3040,
-    "custom_text_y_pos": 2750,
-    "secondary_text_color": "#374151",
-    "secondary_text_alpha": 200
-}


### PR DESCRIPTION
in this [PR](https://github.com/odoo/odoo/pull/179903) configured two badge formats for the EPSON C4000e printer:
- 96x82mm,
- 96x134mm.

As we don't have a dedicated proper template for the 96x134mm format, we remove it.

In addition, we added the badge type (e.g. VIP, Standard, ...) in the notification displayed once a badge is printed.

Tasks: 4231455, 4229143
