### PR TITLE
[16.0][IMP] stock: Make packages and owner on stock move lines optional hide

### DIFF
--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -280,10 +280,10 @@
                     <field name="location_dest_id" invisible="1"/>
                     <field name="location_id" options="{'no_create': True}" attrs="{'column_invisible': [('parent.picking_type_code', '=', 'incoming')]}" groups="stock.group_stock_multi_locations" domain="[('id', 'child_of', parent.location_id), '|', ('company_id', '=', False), ('company_id', '=', company_id), ('usage', '!=', 'view')]"/>
                     <field name="location_dest_id" options="{'no_create': True}" attrs="{'column_invisible': [('parent.picking_type_code', '=', 'outgoing')]}" groups="stock.group_stock_multi_locations" domain="[('id', 'child_of', parent.location_dest_id), '|', ('company_id', '=', False), ('company_id', '=', company_id), ('usage', '!=', 'view')]"/>
-                    <field name="package_id" groups="stock.group_tracking_lot"/>
-                    <field name="result_package_id" groups="stock.group_tracking_lot"/>
+                    <field name="package_id" groups="stock.group_tracking_lot" optional="hide"/>
+                    <field name="result_package_id" groups="stock.group_tracking_lot" optional="hide"/>
                     <field name="lots_visible" invisible="1"/>
-                    <field name="owner_id" groups="stock.group_tracking_owner" attrs="{'column_invisible': [('parent.picking_type_code', '=', 'incoming')]}"/>
+                    <field name="owner_id" groups="stock.group_tracking_owner" attrs="{'column_invisible': [('parent.picking_type_code', '=', 'incoming')]}" optional="hide"/>
                     <field name="state" invisible="1"/>
                     <field name="lot_id" groups="stock.group_production_lot" attrs="{'column_invisible': [('parent.show_lots_text', '=', True)], 'invisible': [('lots_visible', '=', False)]}" context="{'default_product_id': product_id, 'default_company_id': company_id, 'active_picking_id': picking_id}" optional="show"/>
                     <field name="lot_name" groups="stock.group_production_lot" attrs="{'column_invisible': [('parent.show_lots_text', '=', False)], 'invisible': [('lots_visible', '=', False)]}" context="{'default_product_id': product_id}"/>


### PR DESCRIPTION
This commit aims to hide the fields package_id, result_package_id and owner_id by default, so that they are only displayed to users who explicitly choose to see these fields, thereby avoiding cluttering the view.


cc @Tecnativa TT51427

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
