### PR TITLE
[FIX] account: Move `_ref_vat` to account

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -11,7 +11,7 @@ from odoo.tools import format_list, SQL
 from odoo.tools.mail import is_html_empty
 from odoo.tools.misc import format_date
 from odoo.addons.account.models.account_move import MAX_HASH_VERSION
-from odoo.addons.base_vat.models.res_partner import _ref_vat
+from odoo.addons.account.models.partner import _ref_vat
 
 
 MONTH_SELECTION = [

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -10,11 +10,70 @@ from psycopg2 import errors as pgerrors
 
 from odoo import api, fields, models, _
 from odoo.osv import expression
-from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT, mute_logger
+from odoo.tools import mute_logger, LazyTranslate
 from odoo.exceptions import ValidationError, UserError
 from odoo.addons.base.models.res_partner import WARNING_MESSAGE, WARNING_HELP
 from odoo.tools import SQL, unique
-from odoo.addons.base_vat.models.res_partner import _ref_vat
+
+_lt = LazyTranslate(__name__)
+
+_ref_vat = {
+    'al': 'ALJ91402501L',
+    'ar': _lt('AR200-5536168-2 or 20055361682'),
+    'at': 'ATU12345675',
+    'au': '83 914 571 673',
+    'be': 'BE0477472701',
+    'bg': 'BG1234567892',
+    'br': _lt('either 11 digits for CPF or 14 digits for CNPJ'),
+    'cr': _lt('3101012009'),
+    'ch': _lt('CHE-123.456.788 TVA or CHE-123.456.788 MWST or CHE-123.456.788 IVA'),  # Swiss by Yannick Vaucher @ Camptocamp
+    'cl': 'CL76086428-5',
+    'co': _lt('CO213123432-1 or CO213.123.432-1'),
+    'cy': 'CY10259033P',
+    'cz': 'CZ12345679',
+    'de': _lt('DE123456788 or 12/345/67890'),
+    'dk': 'DK12345674',
+    'do': _lt('DO1-01-85004-3 or 101850043'),
+    'ec': _lt('1792060346001 or 1792060346'),
+    'ee': 'EE123456780',
+    'es': 'ESA12345674',
+    'fi': 'FI12345671',
+    'fr': 'FR23334175221',
+    'gb': _lt('GB123456782 or XI123456782'),
+    'gr': 'EL123456783',
+    'hu': _lt('HU12345676 or 12345678-1-11 or 8071592153'),
+    'hr': 'HR01234567896',  # Croatia, contributed by Milan Tribuson
+    'ie': 'IE1234567FA',
+    'il': _lt('XXXXXXXXX [9 digits] and it should respect the Luhn algorithm checksum'),
+    'in': "12AAAAA1234AAZA",
+    'is': 'IS062199',
+    'it': 'IT12345670017',
+    'lt': 'LT123456715',
+    'lu': 'LU12345613',
+    'lv': 'LV41234567891',
+    'mc': 'FR53000004605',
+    'mt': 'MT12345634',
+    'mx': _lt('MXGODE561231GR8 or GODE561231GR8'),
+    'nl': 'NL123456782B90',
+    'no': 'NO123456785',
+    'nz': _lt('49-098-576 or 49098576'),
+    'pe': _lt('10XXXXXXXXY or 20XXXXXXXXY or 15XXXXXXXXY or 16XXXXXXXXY or 17XXXXXXXXY'),
+    'ph': '123-456-789-123',
+    'pl': 'PL1234567883',
+    'pt': 'PT123456789',
+    'ro': 'RO1234567897 or 8001011234567 or 9000123456789',
+    'rs': 'RS101134702',
+    'ru': 'RU123456789047',
+    'se': 'SE123456789701',
+    'si': 'SI12345679',
+    'sk': 'SK2022749619',
+    'sm': 'SM24165',
+    'tr': _lt('TR1234567890 (VERGINO) or TR17291716060 (TCKIMLIKNO)'),  # Levent Karakas @ Eska Yazilim A.S.
+    'uy': _lt("'219999830019' (should be 12 digits)"),
+    've': 'V-12345678-1, V123456781, V-12.345.678-1',
+    'xi': 'XI123456782',
+    'sa': _lt('310175397400003 [Fifteen digits, first and last digits should be "3"]')
+}
 
 _logger = logging.getLogger(__name__)
 

--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -10,10 +10,10 @@ from stdnum import luhn
 import logging
 
 from odoo import api, models, fields
-from odoo.tools import _, zeep, LazyTranslate
+from odoo.tools import _, zeep
 from odoo.exceptions import ValidationError
+from odoo.addons.account.models.partner import _ref_vat
 
-_lt = LazyTranslate(__name__)
 _logger = logging.getLogger(__name__)
 
 _eu_country_vat = {
@@ -21,64 +21,6 @@ _eu_country_vat = {
 }
 
 _eu_country_vat_inverse = {v: k for k, v in _eu_country_vat.items()}
-
-_ref_vat = {
-    'al': 'ALJ91402501L',
-    'ar': _lt('AR200-5536168-2 or 20055361682'),
-    'at': 'ATU12345675',
-    'au': '83 914 571 673',
-    'be': 'BE0477472701',
-    'bg': 'BG1234567892',
-    'br': _lt('either 11 digits for CPF or 14 digits for CNPJ'),
-    'cr': _lt('3101012009'),
-    'ch': _lt('CHE-123.456.788 TVA or CHE-123.456.788 MWST or CHE-123.456.788 IVA'),  # Swiss by Yannick Vaucher @ Camptocamp
-    'cl': 'CL76086428-5',
-    'co': _lt('CO213123432-1 or CO213.123.432-1'),
-    'cy': 'CY10259033P',
-    'cz': 'CZ12345679',
-    'de': _lt('DE123456788 or 12/345/67890'),
-    'dk': 'DK12345674',
-    'do': _lt('DO1-01-85004-3 or 101850043'),
-    'ec': _lt('1792060346001 or 1792060346'),
-    'ee': 'EE123456780',
-    'es': 'ESA12345674',
-    'fi': 'FI12345671',
-    'fr': 'FR23334175221',
-    'gb': _lt('GB123456782 or XI123456782'),
-    'gr': 'EL123456783',
-    'hu': _lt('HU12345676 or 12345678-1-11 or 8071592153'),
-    'hr': 'HR01234567896',  # Croatia, contributed by Milan Tribuson
-    'ie': 'IE1234567FA',
-    'il': _lt('XXXXXXXXX [9 digits] and it should respect the Luhn algorithm checksum'),
-    'in': "12AAAAA1234AAZA",
-    'is': 'IS062199',
-    'it': 'IT12345670017',
-    'lt': 'LT123456715',
-    'lu': 'LU12345613',
-    'lv': 'LV41234567891',
-    'mc': 'FR53000004605',
-    'mt': 'MT12345634',
-    'mx': _lt('MXGODE561231GR8 or GODE561231GR8'),
-    'nl': 'NL123456782B90',
-    'no': 'NO123456785',
-    'nz': _lt('49-098-576 or 49098576'),
-    'pe': _lt('10XXXXXXXXY or 20XXXXXXXXY or 15XXXXXXXXY or 16XXXXXXXXY or 17XXXXXXXXY'),
-    'ph': '123-456-789-123',
-    'pl': 'PL1234567883',
-    'pt': 'PT123456789',
-    'ro': 'RO1234567897 or 8001011234567 or 9000123456789',
-    'rs': 'RS101134702',
-    'ru': 'RU123456789047',
-    'se': 'SE123456789701',
-    'si': 'SI12345679',
-    'sk': 'SK2022749619',
-    'sm': 'SM24165',
-    'tr': _lt('TR1234567890 (VERGINO) or TR17291716060 (TCKIMLIKNO)'),  # Levent Karakas @ Eska Yazilim A.S.
-    'uy': _lt("'219999830019' (should be 12 digits)"),
-    've': 'V-12345678-1, V123456781, V-12.345.678-1',
-    'xi': 'XI123456782',
-    'sa': _lt('310175397400003 [Fifteen digits, first and last digits should be "3"]')
-}
 
 _region_specific_vat_codes = {
     'xi',


### PR DESCRIPTION
In #180744, we used the `_ref_vat` dictionary in the `account` module in order to provide a placeholder for the company and partner VAT.

However, `_ref_vat` was defined only in `base_vat` which depends on `account`, not the other way around.

As such, some users might want to use `account` without `base_vat`.

We therefore move `_ref_vat` to `account` to allow this.

task-none