### PR TITLE
[FIX] l10n_in_ewaybill_stock: reset name while reseting state to pending

### DIFF
--- a/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
@@ -249,6 +249,7 @@ class Ewaybill(models.Model):
         if self.state not in ('cancel', 'challan'):
             raise UserError(_("Only Delivery Challan and Cancelled E-waybill can be reset to pending."))
         self.write({
+            'name': False,
             'state': 'pending',
             'cancel_reason': False,
             'cancel_remarks': False,


### PR DESCRIPTION
Once the ewaybill is generated, cancelled and resetted to pending the name is not resetted

After this commit:
we reset ewaybill name once it's been reset to pending

task-4285220

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
