### PR TITLE
[FIX] pos_self_order: show product public description on self-order

### DIFF
--- a/addons/pos_self_order/models/product_product.py
+++ b/addons/pos_self_order/models/product_product.py
@@ -52,7 +52,7 @@ class ProductProduct(models.Model):
         config_id = data['pos.config']['data'][0]['id']
 
         # Add custom fields for 'formula' taxes.
-        fields = set(self._load_pos_data_fields(config_id))
+        fields = set(self._load_pos_self_data_fields(config_id))
         taxes = self.env['account.tax'].search(self.env['account.tax']._load_pos_data_domain(data))
         product_fields = taxes._eval_taxes_computation_prepare_product_fields()
         fields = list(fields.union(product_fields))

--- a/addons/pos_self_order/static/src/app/components/product_card/product_card.js
+++ b/addons/pos_self_order/static/src/app/components/product_card/product_card.js
@@ -118,7 +118,6 @@ export class ProductCard extends Component {
     showProductInfo() {
         this.dialog.add(ProductInfoPopup, {
             product: this.props.product,
-            title: this.props.product.display_name,
             addToCart: (qty) => {
                 this.selectProduct(qty);
             },

--- a/addons/pos_self_order/static/src/app/components/product_info_popup/product_info_popup.js
+++ b/addons/pos_self_order/static/src/app/components/product_info_popup/product_info_popup.js
@@ -2,7 +2,7 @@ import { Component, useExternalListener, useState } from "@odoo/owl";
 
 export class ProductInfoPopup extends Component {
     static template = "pos_self_order.ProductInfoPopup";
-    static props = ["product", "addToCart"];
+    static props = ["product", "addToCart", "close"];
 
     setup() {
         useExternalListener(window, "click", this.props.close);

--- a/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
@@ -74,3 +74,17 @@ registry.category("web_tour.tours").add("selfAlwaysAttributeVariants", {
         Utils.checkIsNoBtn("Order Now"),
     ],
 });
+
+registry.category("web_tour.tours").add("self_order_product_info", {
+    steps: () => [
+        Utils.clickBtn("Order Now"),
+        {
+            trigger: ".self_order_product_card .product-information-tag",
+            run: "click",
+        },
+        {
+            trigger: '.modal-body p:contains("Nice Product")',
+            run: () => {},
+        },
+    ],
+});

--- a/addons/pos_self_order/tests/test_self_order_attribute.py
+++ b/addons/pos_self_order/tests/test_self_order_attribute.py
@@ -112,3 +112,29 @@ class TestSelfOrderAttribute(SelfOrderCommonTest):
         self.assertEqual(order.lines[0].price_unit, 10.0)
         self.assertEqual(order.lines[1].product_id.id, chair_product_tmpl.product_variant_ids[1].id)
         self.assertEqual(order.lines[1].price_unit, 15.0)
+
+    def test_self_order_product_info(self):
+        self.pos_config.write({
+            'self_ordering_default_user_id': self.pos_admin.id,
+            'self_ordering_takeaway': False,
+            'self_ordering_mode': 'mobile',
+            'self_ordering_pay_after': 'each',
+            'self_ordering_service_mode': 'counter',
+        })
+
+        pos_categ_misc = self.env['pos.category'].create({
+            'name': 'Miscellaneous',
+        })
+
+        self.env['product.product'].create({
+            'name': 'Product Info Test',
+            'available_in_pos': True,
+            'list_price': 1,
+            'pos_categ_ids': [(4, pos_categ_misc.id)],
+            'public_description': 'Nice Product'
+        })
+
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self_route = self.pos_config._get_self_order_route()
+
+        self.start_tour(self_route, "self_order_product_info")


### PR DESCRIPTION
Problem:
The `public_description` field is not loaded in `_load_pos_data_fields`, which prevents the product information icon from appearing in the self-order interface, thus hiding the public description from users.

Solution:
Ensure the `public_description` field is loaded so that the product info icon is displayed, allowing users to view the product's public description.

Steps to reproduce:
- Add a Public description to a product.
- Open the Kiosk/Self-order interface.
- The info icon is not visible, and the product description cannot be viewed.

opw-4250442

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
