### PR TITLE
[FIX] spreadsheet: fix handcrafted json

### DIFF
--- a/addons/spreadsheet/tests/__init__.py
+++ b/addons/spreadsheet/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_currency_rate
 from . import test_display_names
 from . import test_locale
 from . import test_session_info
+from . import test_utils

--- a/addons/spreadsheet/tests/test_utils.py
+++ b/addons/spreadsheet/tests/test_utils.py
@@ -1,0 +1,39 @@
+from odoo.tests.common import TransactionCase
+
+from odoo.addons.spreadsheet.utils.json import extend_serialized_json
+
+
+class TestSpreadsheetUtils(TransactionCase):
+
+    def test_extend_serialized_json(self):
+        self.assertEqual(extend_serialized_json('{}', []), '{}')
+        self.assertEqual(extend_serialized_json('{}', [('key', '{}')]), '{"key":{}}')
+        self.assertEqual(extend_serialized_json('{}', [('key', '[]')]), '{"key":[]}')
+        self.assertEqual(
+            extend_serialized_json('{}', [('key', '"value"')]),
+            '{"key":"value"}'
+        )
+        self.assertEqual(
+            extend_serialized_json('{"a": 1}', [('key', '"value"')]),
+            '{"a": 1,"key":"value"}'
+        )
+        self.assertEqual(
+            extend_serialized_json('{"a": 1}', [('key', '{"b": 2}')]),
+            '{"a": 1,"key":{"b": 2}}'
+        )
+        self.assertEqual(
+            extend_serialized_json('{"a": {}}', [('key', '{"b": 2}')]),
+            '{"a": {},"key":{"b": 2}}'
+        )
+        self.assertEqual(
+            extend_serialized_json('{"a": 1}', [('key', '[]')]),
+            '{"a": 1,"key":[]}'
+        )
+        self.assertEqual(
+            extend_serialized_json('{"a": []}', [('key', '[]')]),
+            '{"a": [],"key":[]}'
+        )
+        self.assertEqual(
+            extend_serialized_json('{}', [('key1', '1'), ('key2', '2')]),
+            '{"key1":1,"key2":2}'
+        )

--- a/addons/spreadsheet/utils/json.py
+++ b/addons/spreadsheet/utils/json.py
@@ -6,7 +6,7 @@ def extend_serialized_json(json: str, key_value_pairs: list) -> str:
     value should be already serialized.
     """
     # avoid copying strings as much as possible for performance reasons
-    parts = [json.rstrip('}')]
+    parts = [json.removesuffix('}')]
     if json != '{}':
         parts.append(',')
     for i, (key, value) in enumerate(key_value_pairs):


### PR DESCRIPTION
If a spreadsheet json ends with two closing curly brackets `}}` `extend_serialized_json` would remove both `}` leading to an invalid serialized json.

Bug introduced by c39f305491a1ced451d8fd0ecd67de94c88c2604

Task: 4282874


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
