### PR TITLE
[FIX] microsoft_calendar: skip syncing old odoo events to prevent outlook spam

### DIFF
--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -278,7 +278,7 @@ class Meeting(models.Model):
         lower_bound = fields.Datetime.subtract(fields.Datetime.now(), days=day_range)
         upper_bound = fields.Datetime.add(fields.Datetime.now(), days=day_range)
         # Define 'custom_lower_bound_range' param for limiting old events updates in Odoo and avoid spam on Microsoft.
-        custom_lower_bound_range = ICP.get_param('microsoft_calendar.sync.lower_bound_range')
+        custom_lower_bound_range = ICP.get_param('microsoft_calendar.sync.lower_bound_range', 1)
         if custom_lower_bound_range:
             lower_bound = fields.Datetime.subtract(fields.Datetime.now(), days=int(custom_lower_bound_range))
         domain = [


### PR DESCRIPTION
Before this commit, When a customer starts synchronizing with Outlook, the full sync would create events in Outlook that are already in Odoo, leading to a large number of unwanted emails being sent to attendees.

After this commit, Events in Odoo that were created before the connector setup date will be skipped during synchronization with Outlook, preventing excessive email notifications to attendees.

Task-4263029
