### PR TITLE
[IMP] base: "--shell-file" option override for $PYTHONSTARTUP

### DIFF
--- a/odoo/addons/base/tests/config/cli
+++ b/odoo/addons/base/tests/config/cli
@@ -62,7 +62,6 @@
 --no-database-list
 
 --dev xml,reload
---shell-interface ipython
 --stop-after-init
 --osv-memory-count-limit 71
 --transient-age-limit 4

--- a/odoo/addons/base/tests/config/non_default.conf
+++ b/odoo/addons/base/tests/config/non_default.conf
@@ -85,7 +85,6 @@ list_db = False
 
 # advanced
 dev_mode = xml
-shell_interface = ipython
 stop_after_init = True
 osv_memory_count_limit = 71
 transient_age_limit = 4.0

--- a/odoo/addons/base/tests/shell_file.txt
+++ b/odoo/addons/base/tests/shell_file.txt
@@ -1,0 +1,1 @@
+message = 'Hello from Python!'

--- a/odoo/addons/base/tests/test_configmanager.py
+++ b/odoo/addons/base/tests/test_configmanager.py
@@ -148,7 +148,6 @@ class TestConfigManager(TransactionCase):
 
             # advanced
             'dev_mode': [],
-            'shell_interface': '',
             'stop_after_init': False,
             'osv_memory_count_limit': 0,
             'transient_age_limit': 1.0,
@@ -266,7 +265,6 @@ class TestConfigManager(TransactionCase):
 
             # advanced
             'dev_mode': ['xml'],  # blacklist for save, read from the config file
-            'shell_interface': 'ipython',  # blacklist for save, read from the config file
             'stop_after_init': True,  # blacklist for save, read from the config file
             'osv_memory_count_limit': 71,
             'transient_age_limit': 4.0,
@@ -379,7 +377,6 @@ class TestConfigManager(TransactionCase):
             'language': None,
             'publisher_warranty_url': 'http://services.odoo.com/publisher-warranty/',
             'save': False,
-            'shell_interface': '',
             'stop_after_init': False,
             'translate_in': '',
             'translate_out': '',
@@ -548,7 +545,6 @@ class TestConfigManager(TransactionCase):
 
             # advanced
             'dev_mode': ['xml', 'reload'],
-            'shell_interface': 'ipython',
             'stop_after_init': True,
             'osv_memory_count_limit': 71,
             'transient_age_limit': 4.0,

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -383,9 +383,6 @@ class configmanager:
                               "- reload: restart server on change in the source code  "
                               "- werkzeug: open a html debugger on http request error "
                               "- xml: read views from the source code, and not the db ")
-        group.add_option('--shell-interface', dest='shell_interface', my_default='', file_exportable=False,
-                         help="Specify a preferred REPL to use in shell mode. Supported REPLs are: "
-                              "[ipython|ptpython|bpython|python]")
         group.add_option("--stop-after-init", action="store_true", dest="stop_after_init", my_default=False, file_exportable=False,
                          help="stop the server after its initialization")
         group.add_option("--osv-memory-count-limit", dest="osv_memory_count_limit", my_default=0,


### PR DESCRIPTION
The `$PYTHONSTARTUP` env variable can contain a python script that is used by Python shell at the start of any interactive session.

- fix this feature from being broken in `python` and `ptpython`
- include a new `--shell-file=<filename>` shell parameter to override the env variable `$PYTHONSTARTUP`
- group the two shell parameters in a new options group
- remove custom python shells' banners from the start of the session
- shell options can now be saved in the configuration file.

Python docs: https://docs.python.org/3/using/cmdline.html#envvar-PYTHONSTARTUP

Old PR: https://github.com/odoo/odoo/pull/83227
Documentation PR: odoo/documentation#11334

Task [link](https://www.odoo.com/odoo/project/967/tasks/4306704)
task-4306704