### PR TITLE
[FIX] account: prevent tax lock date in changing periods

### DIFF
--- a/addons/account/tests/test_transfer_wizard.py
+++ b/addons/account/tests/test_transfer_wizard.py
@@ -428,6 +428,54 @@ class TestTransferWizard(AccountTestInvoicingCommon):
         adjustment_move = created_moves[1]  # There are 2 created moves; the adjustment move is the second one.
         self.assertRecordValues(adjustment_move, [{'date': fields.Date.to_date('2019-03-31')}])
 
+    def test_period_change_tax_lock_date(self):
+        """ If there is only a tax lock date, we should be able to proceed with the flow"""
+        move = self.env['account.move'].create({
+            'journal_id': self.company_data['default_journal_sale'].id,
+            'date': '2019-01-01',
+            'line_ids': [
+                # Base Tax line
+                Command.create({
+                    'debit': 0.0,
+                    'credit': 100.0,
+                    'account_id': self.company_data['default_account_revenue'].id,
+                    'tax_ids': [(6, 0, self.tax_sale_a.ids)],
+                }),
+
+                # Tax line
+                Command.create({
+                    'debit': 0.0,
+                    'credit': 15.0,
+                    'account_id': self.accounts[0].id,
+                }),
+
+                # Receivable line
+                Command.create({
+                    'debit': 115,
+                    'credit': 0.0,
+                    'account_id': self.receivable_account.id,
+                }),
+            ]
+        })
+        move.action_post()
+
+        # Set the tax lock date
+        move.company_id.write({'tax_lock_date': '2019-02-28'})
+
+        # Open the transfer wizard at a date after the lock date
+        wizard = self.env['account.automatic.entry.wizard'] \
+            .with_context(active_model='account.move.line', active_ids=move.line_ids[0].ids) \
+                .create({
+                'action': 'change_period',
+                'date': '2019-05-01',
+                'journal_id': self.company_data['default_journal_misc'].id,
+            })
+
+        # Check that there is no lock message
+        self.assertRecordValues(wizard, [{
+            'lock_date_message': False,
+        }])
+
     def test_transfer_wizard_amount_currency_is_zero(self):
         """ Tests that the transfer wizard create a transfer move when the amount_currency is zero.
         """

--- a/addons/account/wizard/account_automatic_entry_wizard.py
+++ b/addons/account/wizard/account_automatic_entry_wizard.py
@@ -108,7 +108,7 @@ class AutomaticEntryWizard(models.TransientModel):
             record.lock_date_message = False
             if record.action == 'change_period':
                 for aml in record.move_line_ids:
-                    lock_date_message = aml.move_id._get_lock_date_message(aml.date, aml.move_id._affect_tax_report())
+                    lock_date_message = aml.move_id._get_lock_date_message(aml.date, False)
                     if lock_date_message:
                         record.lock_date_message = lock_date_message
                         break
@@ -297,7 +297,7 @@ class AutomaticEntryWizard(models.TransientModel):
 
         def get_lock_safe_date(aml):
             # Use a reference move in the correct journal because _get_accounting_date depends on the journal sequence.
-            return reference_move._get_accounting_date(aml.date, aml.move_id._affect_tax_report())
+            return reference_move._get_accounting_date(aml.date, False)
 
         # set the change_period account on the selected journal items
 
@@ -388,7 +388,7 @@ class AutomaticEntryWizard(models.TransientModel):
         accrual_move_offsets = defaultdict(int)
         for move in self.move_line_ids.move_id:
             amount = sum((self.move_line_ids._origin & move.line_ids).mapped('balance'))
-            accrual_move = created_moves[1:].filtered(lambda m: m.date == m._get_accounting_date(move.date, move._affect_tax_report()))
+            accrual_move = created_moves[1:].filtered(lambda m: m.date == m._get_accounting_date(move.date, False))
 
             if accrual_account.reconcile and accrual_move.state == 'posted' and destination_move.state == 'posted':
                 destination_move_lines = destination_move.mapped('line_ids').filtered(lambda line: line.account_id == accrual_account)[destination_move_offset:destination_move_offset+2]


### PR DESCRIPTION
Steps to reproduce:
- Create and confirm an invoice at 2024/10/01 with a line containeing a tax_id
- In journal items, try to "cut-off"

Issue:
You won't be able to do so because of the tax lock date

Cause:
We need the correct accounting date to find back the reference move but before the fix, a side effect was to check for tax lock date which does not make sense in this flow. We create move line without tax_ids/tag_grid and so it does not impact the tax report: https://github.com/odoo/odoo/blob/16.0/addons/account/wizard/account_automatic_entry_wizard.py#L242-L271

Solution:
we set the `has_tax` to False to byapss the check. The user, if he wishes, could excatly the same flow by creating an entry "a la mano" <->  We don't need to block this flow

opw-4191527
