### PR TITLE
[IMP] mail: enable add attachment button in chatter

### DIFF
--- a/addons/mail/static/src/chatter/web/chatter.xml
+++ b/addons/mail/static/src/chatter/web/chatter.xml
@@ -180,7 +180,7 @@
 </t>
 
 <t t-name="mail.Chatter.attachFiles">
-    <button class="o-mail-Chatter-attachFiles btn btn-link text-action px-1 d-flex align-items-center" aria-label="Attach files" t-att-class="{ 'my-2': !props.compactHeight }" t-on-click="onClickAddAttachments" t-att-disabled="state.isSearchOpen">
+    <button class="o-mail-Chatter-attachFiles btn btn-link text-action px-1 d-flex align-items-center" aria-label="Attach files" t-att-class="{ 'my-2': !props.compactHeight }" t-on-click="onClickAddAttachments">
         <i class="fa fa-paperclip fa-lg me-1"/>
         <sup t-if="attachments.length > 0" t-esc="attachments.length"/>
         <i t-if="!state.thread.areAttachmentsLoaded and state.thread.isLoadingAttachments and state.showAttachmentLoading" class="fa fa-circle-o-notch fa-spin" aria-label="Attachment counter loading..."/>

--- a/addons/mail/static/src/chatter/web/chatter_patch.js
+++ b/addons/mail/static/src/chatter/web/chatter_patch.js
@@ -257,7 +257,9 @@ patch(Chatter.prototype, {
         if (this.attachments.length === 0) {
             return;
         }
-        this.state.isAttachmentBoxOpened = !this.state.isAttachmentBoxOpened;
+        this.state.isAttachmentBoxOpened =
+            this.state.isSearchOpen || !this.state.isAttachmentBoxOpened;
+        this.state.isSearchOpen = false;
         if (this.state.isAttachmentBoxOpened) {
             this.rootRef.el.scrollTop = 0;
             this.state.thread.scrollTop = "bottom";
@@ -265,6 +267,9 @@ patch(Chatter.prototype, {
     },
 
     async onClickAttachFile(ev) {
+        if (this.attachments.length === 0 && this.state.isSearchOpen) {
+            this.state.isSearchOpen = false;
+        }
         if (this.state.thread.id) {
             return;
         }


### PR DESCRIPTION
**Current behavior before PR:**

currently attachment button is disable while search is open in chatter. because it was disabled by opening search action.

**Desired behavior after PR is merged:**

improved logic to enable attachment button while search action is open in chatter.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
