### PR TITLE
[IMP] base_vat: Add VAT validations for CR

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -30,6 +30,7 @@ _ref_vat = {
     'be': 'BE0477472701',
     'bg': 'BG1234567892',
     'br': _('either 11 digits for CPF or 14 digits for CNPJ'),
+    'cr': _('3101012009'),
     'ch': _('CHE-123.456.788 TVA or CHE-123.456.788 MWST or CHE-123.456.788 IVA'),  # Swiss by Yannick Vaucher @ Camptocamp
     'cl': 'CL76086428-5',
     'co': _('CO213123432-1 or CO213.123.432-1'),
@@ -782,6 +783,16 @@ class ResPartner(models.Model):
             len(vat_clean) == 14 and _is_valid_cnpj(vat_clean)
             or len(vat_clean) == 11 and _is_valid_cpf(vat_clean)
         )
+
+    __check_vat_cr_re = re.compile(r'^(?:[1-9]\d{8}|\d{10}|[1-9]\d{10,11})$')
+
+    def check_vat_cr(self, vat):
+        # CÉDULA FÍSICA: 9 digits
+        # CÉDULA JURÍDICA: 10 digits
+        # CÉDULA DIMEX: 11 or 12 digits
+        # CÉDULA NITE: 10 digits
+
+        return self.__check_vat_cr_re.match(vat) or False
 
     def format_vat_eu(self, vat):
         # Foreign companies that trade with non-enterprises in the EU


### PR DESCRIPTION
VAT validations for Costa Rica identification types according to:

- CÉDULA FÍSICA: 9 digits
- CÉDULA JURÍDICA: 10 digits
- CÉDULA DIMEX: 11 or 12 digits
- CÉDULA NITE: 10 digits

Legal info on page 4:
https://atv.hacienda.go.cr/ATV/ComprobanteElectronico/docs/esquemas/2016/v4/ANEXOS%20Y%20ESTRUCTURAS.pdf

**This is a backport of commit:**
https://github.com/odoo/odoo/commit/b37dadc5d05645cad4483fba7849b4b35f0d20f2

opw-4183698




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
