### PR TITLE
[FIX] website_sale: traceback in multiple delivery methods

### DIFF
--- a/addons/website_sale_collect/models/sale_order.py
+++ b/addons/website_sale_collect/models/sale_order.py
@@ -27,7 +27,10 @@ class SaleOrder(models.Model):
             return res
 
         self.pickup_location_data = json.loads(pickup_location_data)
-        self.warehouse_id = self.pickup_location_data['id']
+        if self.pickup_location_data:
+            self.warehouse_id = self.pickup_location_data['id']
+        else:
+            self._compute_warehouse_id()
 
     def _get_pickup_locations(self, zip_code=None, country=None, **kwargs):
         """ Override of `website_sale` to ensure that a country is provided when there is a zip


### PR DESCRIPTION
Steps:
- Activate multiple Delivery Methods
- Add a product to cart in /shop
- set delivery method to pickup in store and reload the page
- change delivery method to another method and then try changing it back to pickup in store

Issue:
- Traceback : object not subscriptable

Cause:
- `editPickupLocationButton.dataset.pickupLocationData` is set to "{}"  and `_showPickupLocation` calls `_setPickupLocation` with this object leading to traceback

Fix:
- Added a check for empty json object

opw-4282496

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
