### PR TITLE
[FIX] calendar: X-named params without RRULE prefix

### DIFF
--- a/addons/calendar/models/calendar_recurrence.py
+++ b/addons/calendar/models/calendar_recurrence.py
@@ -368,7 +368,8 @@ class RecurrenceRule(models.Model):
         # Optional parameters starts with X- and they can be placed anywhere in the RRULE string.
         # RRULE:FREQ=MONTHLY;INTERVAL=3;X-RELATIVE=1
         # RRULE;X-EVOLUTION-ENDDATE=20200120:FREQ=WEEKLY;COUNT=3;BYDAY=MO
-        rule_str = re.sub(r';?X-[-\w]+=[^;:]*', '', rule_str).replace(":;", ":")
+        # X-EVOLUTION-ENDDATE=20200120:FREQ=WEEKLY;COUNT=3;BYDAY=MO
+        rule_str = re.sub(r';?X-[-\w]+=[^;:]*', '', rule_str).replace(":;", ":").lstrip(":;")
 
         if 'Z' in rule_str and date_start and not date_start.tzinfo:
             date_start = pytz.utc.localize(date_start)

--- a/addons/calendar/tests/test_event_recurrence.py
+++ b/addons/calendar/tests/test_event_recurrence.py
@@ -474,6 +474,13 @@ class TestUpdateRecurrentEvents(TestRecurrentEvents):
         self.assertFalse(self.recurrence.tue)
         self.assertTrue(self.recurrence.wed)
 
+    def test_rrule_x_params_no_rrule_prefix(self):
+        self.recurrence.rrule = 'X-EVOLUTION-ENDDATE=20371102T114500Z:FREQ=WEEKLY;COUNT=720;BYDAY=MO'
+        self.assertFalse(self.recurrence.tue)
+        self.assertTrue(self.recurrence.mon)
+        self.assertEqual(self.recurrence.count, 720)
+        self.assertEqual(self.recurrence.rrule_type, 'weekly')
+
     def test_shift_all_base_inactive(self):
         self.recurrence.base_event_id.active = False
         event = self.events[1]


### PR DESCRIPTION
This completes https://github.com/odoo/odoo/pull/171784 by adding support for the same kind of rrule string, but without the `RRULE;` prefix.

Based on Real World™️ evidence.


Description of the issue/feature this PR addresses:

<details>

```
odoo-1  | 2024-10-24 11:20:18,785 42 ERROR odoo odoo.addons.google_calendar.models.res_users: [res.users(2,)] Calendar Synchro - Exception : unsupported property:  !
odoo-1  | Traceback (most recent call last):
odoo-1  |   File "/opt/odoo/auto/addons/google_calendar/models/﻿[﻿res_users.py﻿](https://res_users.py/)﻿", line 100, in _sync_all_google_calendar
odoo-1  |     user.with_user(user).sudo()._sync_google_calendar(google)
odoo-1  |   File "/opt/odoo/auto/addons/google_calendar/models/﻿[﻿res_users.py﻿](https://res_users.py/)﻿", line 78, in _sync_google_calendar
odoo-1  |     synced_recurrences = self.env['calendar.recurrence'].with_context(write_dates=recurrences_write_dates)._sync_google2odoo(recurrences)
odoo-1  |   File "/opt/odoo/auto/addons/google_calendar/models/﻿[﻿google_sync.py﻿](https://google_sync.py/)﻿", line 202, in _sync_google2odoo
odoo-1  |     odoo_record.with_context(dont_notify=True)._write_from_google(gevent, vals)
odoo-1  |   File "/opt/odoo/auto/addons/google_calendar/models/﻿[﻿calendar_recurrence_rule.py﻿](https://calendar_recurrence_rule.py/)﻿", line 86, in _write_from_google
odoo-1  |     current_parsed_rrule = self._rrule_parse(current_rrule, self.dtstart)
odoo-1  |   File "/opt/odoo/auto/addons/calendar/models/﻿[﻿calendar_recurrence.py﻿](https://calendar_recurrence.py/)﻿", line 375, in _rrule_parse
odoo-1  |     rule = rrule.rrulestr(rule_str, dtstart=date_start)
odoo-1  |   File "/usr/local/lib/python3.10/site-packages/dateutil/﻿[﻿rrule.py﻿](https://rrule.py/)﻿", line 1730, in __call__
odoo-1  |     return self._parse_rfc(s, **kwargs)
odoo-1  |   File "/usr/local/lib/python3.10/site-packages/dateutil/﻿[﻿rrule.py﻿](https://rrule.py/)﻿", line 1698, in _parse_rfc
odoo-1  |     raise ValueError("unsupported property: "+name)
odoo-1  | ValueError: unsupported property:
```

</details>

Current behavior before PR: Odoo stops sync of users calendars as long as they have one event with an RRULE like this.

Desired behavior after PR is merged: Odoo keeps working.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
@moduon MT-7215
