### PR TITLE
[ADD] base: add ir.rule for res.users on portal

### DIFF
--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -116,8 +116,8 @@ class TestStandardPerformance(UtilPerf):
         # not published user, get the not found image placeholder
         self.assertEqual(self.env['res.users'].sudo().browse(2).website_published, False)
         url = '/web/image/res.users/2/image_256'
-        self.assertEqual(self._get_url_hot_query(url), 8)
-        self.assertEqual(self._get_url_hot_query(url, cache=False), 8)
+        self.assertEqual(self._get_url_hot_query(url), 7)
+        self.assertEqual(self._get_url_hot_query(url, cache=False), 7)
 
     @mute_logger('odoo.http')
     def test_11_perf_sql_img_controller(self):

--- a/odoo/addons/base/security/base_security.xml
+++ b/odoo/addons/base/security/base_security.xml
@@ -152,6 +152,13 @@
             <field name="domain_force">['|', ('share', '=', False), ('company_ids', 'in', company_ids)]</field>
         </record>
 
+        <record id="res_users_rule" model="ir.rule">
+            <field name="name">portal user access</field>
+            <field name="model_id" ref="model_res_users"/>
+            <field name="groups" eval="[Command.set([ref('base.group_portal')])]"/>
+            <field name="domain_force">[('commercial_partner_id', '=', user.commercial_partner_id.id)]</field>
+        </record>
+
         <record id="change_password_own_rule" model="ir.rule">
             <field name="name">change own password</field>
             <field name="model_id" ref="model_change_password_own"/>


### PR DESCRIPTION
At the moment, the access to res.users is limited thanks to the rule on res.partner.
Add a rule on res.users for double security.

Task-id: 2967638