### PR TITLE
[FIX] mail: emoji generator doesn't work with '<'

### DIFF
--- a/addons/mail/static/src/models/composer_view.js
+++ b/addons/mail/static/src/models/composer_view.js
@@ -754,7 +754,7 @@ registerModel({
         _generateEmojisOnHtml(htmlString) {
             for (const emoji of this.messaging.emojiRegistry.allEmojis) {
                 for (const source of emoji.sources) {
-                    const escapedSource = String(source).replace(
+                    const escapedSource = escape(String(source)).replace(
                         /([.*+?=^!:${}()|[\]/\\])/g,
                         '\\$1');
                     const regexp = new RegExp(


### PR DESCRIPTION
When typing '>:)' in the composer, it should be replaced by '😈'.

The problem is that the emoji generator doesn't work with '<', '>' because the text is escaped and the '<', '>'is replaced by '&lt;', '&gt;'. In this case, the regrex doesn't match.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
