### PR TITLE
[FIX] mrp: unlink archived operations from byproducts

### DIFF
--- a/addons/mrp/models/mrp_routing.py
+++ b/addons/mrp/models/mrp_routing.py
@@ -109,6 +109,8 @@ class MrpRoutingWorkcenter(models.Model):
         res = super().action_archive()
         bom_lines = self.env['mrp.bom.line'].search([('operation_id', 'in', self.ids)])
         bom_lines.write({'operation_id': False})
+        byproduct_lines = self.env['mrp.bom.byproduct'].search([('operation_id', 'in', self.ids)])
+        byproduct_lines.write({'operation_id': False})
         return res
 
     def copy_to_bom(self):


### PR DESCRIPTION
When archiving an operation in a bom, currently it will unlink if from bom lines that had it set as their `Consumed in Operation`.

However, it's not the case for byproducts, meaning that the byproducts lines will still display the now archived operation.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
