### PR TITLE
[FIX] mail: error when pressing enter on new channel dialog

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
@@ -22,7 +22,6 @@ class CreateChatDialog extends Component {
 
     setup() {
         super.setup();
-        this.state = useState({ name: this.props.name });
         this.store = useState(useService("mail.store"));
         this.invitePeopleState = useState({
             selectablePartners: [],
@@ -55,7 +54,7 @@ class CreateChannelDialog extends Component {
         super.setup();
         this.store = useState(useService("mail.store"));
         this.orm = useService("orm");
-        this.state = useState({ name: this.props.name });
+        this.state = useState({ name: this.props.name || "", isInvalid: false });
     }
 
     /** @param {KeyboardEvent} ev */
@@ -64,12 +63,15 @@ class CreateChannelDialog extends Component {
             case "Enter":
                 this.onClickConfirm();
                 break;
+            default:
+                this.state.isInvalid = false;
         }
     }
 
     async onClickConfirm() {
         const name = this.state.name.trim();
         if (!name) {
+            this.state.isInvalid = true;
             return;
         }
         await makeNewChannel(name, this.orm, this.store);

--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.xml
@@ -28,7 +28,8 @@
         <Dialog size="'sm'" title.translate="New Channel">
             <div class="d-flex flex-column" t-on-keydown="onKeydown">
                 <span class="ms-1 text-uppercase text-muted o-xsmaller opacity-75"><i class="fa fa-hashtag"/> Channel name</span>
-                <input type="text" class="form-control lh-1" placeholder="Channel name" t-model="state.name" tabindex="1"/>
+                <input type="text" class="form-control lh-1" t-att-class="{ 'is-invalid': state.isInvalid }" placeholder="Channel name" t-model="state.name" tabindex="1"/>
+                <div class="invalid-feedback">Channel must have a name.</div>
             </div>
             <t t-set-slot="footer">
                 <button class="btn btn-primary me-2" t-att-disabled="!state.name or state.name.trim().length === 0" t-on-click="onClickConfirm">Create Channel</button>

--- a/addons/mail/static/tests/discuss/core/web/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/web/discuss.test.js
@@ -11,6 +11,7 @@ import {
     start,
     startServer,
     step,
+    triggerHotkey,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, test } from "@odoo/hoot";
 import { Command, onRpc, serverState } from "@web/../tests/web_test_helpers";
@@ -245,4 +246,14 @@ test("Preserve letter case and accents when creating channel from sidebar", asyn
     await insertText("input[placeholder='Search a conversation']", "Crème brûlée Fan Club");
     await click("a", { text: "Create Channel" });
     await contains(".o-mail-Discuss-threadName", { value: "Crème brûlée Fan Club" });
+});
+
+test("Create channel must have a name", async () => {
+    await start();
+    await openDiscuss();
+    await click("input[placeholder='Find or start a conversation']");
+    await click("a", { text: "Create Channel" });
+    await click("input[placeholder='Channel name']");
+    await triggerHotkey("Enter");
+    await contains(".invalid-feedback", { text: "Channel must have a name." });
 });


### PR DESCRIPTION
Before this commit, pressing enter on the empty input in the new channel dialog resulted in a traceback.
1. Open Discuss app
2. Click on "Find or start a conversation"
3. Click on "Create Channel"
4. Press Enter

This happens because the trim function gets called on the name property of state while it is undefined.
This commit fixes the issue by assigning a default value to the name property when it is not provided by props.

This commit also removes the unused name property of the CreateChatDialog component.