### PR TITLE
[FIX] purchase: remove HTML tags from tax description in PO report

### DIFF
--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -88,7 +88,7 @@
                                     <span class="text-align-bottom"><span t-field="line.discount"/>%</span>
                                 </td>
                                 <td class="text-end">
-                                    <span t-esc="', '.join(map(lambda x: x.description or x.name, line.taxes_id))"/>
+                                    <span t-esc="', '.join([(tax.invoice_label or tax.name) for tax in line.taxes_id])"/>
                                 </td>
                                 <td class="text-end">
                                     <span t-field="line.price_subtotal"


### PR DESCRIPTION
When printing the purchase order, the tax values were displayed with HTML tags because the field is an HTML field, and it was passed to the `join` function, which treated it as plain text.
```<span t-esc="', '.join(map(lambda x: x.description or x.name, line.taxes_id))"/>```
To fix this, the tax values are now converted to plain text before being passed to the `join` function.

Steps to reproduce:
1. Create a purchase order PDF using taxes from a localization (e.g., Belgium).
2. Print the purchase order and observe the tax values displaying with HTML tags.

opw-4260595


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
