### PR TITLE
[FIX] l10n_cl: add company in context when fetching tax groups

### DIFF
--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -272,8 +272,8 @@ class AccountMove(models.Model):
                 'tax_percent': abs(line.tax_line_id.amount),
                 'tax_amount_currency': self.currency_id.round(abs(line.amount_currency)),
                 'tax_amount': self.currency_id.round(abs(line.balance))} for line in self.line_ids.filtered(
-            lambda x: x.tax_group_id.id in [self.env['account.chart.template'].ref('tax_group_ila').id,
-                                            self.env['account.chart.template'].ref('tax_group_retenciones').id])]
+            lambda x: x.tax_group_id.id in [self.env['account.chart.template'].with_company(self.company_id).ref('tax_group_ila').id,
+                                            self.env['account.chart.template'].with_company(self.company_id).ref('tax_group_retenciones').id])]
         return tax
 
     def _float_repr_float_round(self, value, decimal_places):


### PR DESCRIPTION
This is a complement of previous fix:
https://github.com/odoo/odoo/commit/792773296fce27340bf866fef8a6f6e8969b682e

Add the company of the move in the context as it is possible that the company of the move and the current company are different.

opw-4227241

Related enterprise PR: https://github.com/odoo/enterprise/pull/71725




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
