### PR TITLE
[FIX] product: pricelist import duplication issue

### DIFF
--- a/addons/product/models/product_pricelist_item.py
+++ b/addons/product/models/product_pricelist_item.py
@@ -273,17 +273,24 @@ class PricelistItem(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         for values in vals_list:
-            if values.get('applied_on', False):
-                # Ensure item consistency for later searches.
-                applied_on = values['applied_on']
-                if applied_on == '3_global':
-                    values.update(dict(product_id=None, product_tmpl_id=None, categ_id=None))
-                elif applied_on == '2_product_category':
-                    values.update(dict(product_id=None, product_tmpl_id=None))
-                elif applied_on == '1_product':
-                    values.update(dict(product_id=None, categ_id=None))
-                elif applied_on == '0_product_variant':
-                    values.update(dict(categ_id=None))
+            if not values.get('applied_on'):
+                values['applied_on'] = (
+                    '0_product_variant' if values.get('product_id') else
+                    '1_product' if values.get('product_tmpl_id') else
+                    '2_product_category' if values.get('categ_id') else
+                    '3_global'
+                )
+
+            # Ensure item consistency for later searches.
+            applied_on = values['applied_on']
+            if applied_on == '3_global':
+                values.update(dict(product_id=None, product_tmpl_id=None, categ_id=None))
+            elif applied_on == '2_product_category':
+                values.update(dict(product_id=None, product_tmpl_id=None))
+            elif applied_on == '1_product':
+                values.update(dict(product_id=None, categ_id=None))
+            elif applied_on == '0_product_variant':
+                values.update(dict(categ_id=None))
         return super().create(vals_list)
 
     def write(self, values):


### PR DESCRIPTION
Steps to reproduce:
1. Navigate to Pricelists.
2. Import a CSV or XLSX file that contains at least one product or product variant.
3. Duplicate the newly created pricelist.

Issue:
- When duplicating an imported pricelist, the duplicated record does not retain
  the product or product variant information.

Cause:
- If the applied_on field is not provided during the creation of the pricelist
  item, the default value of 3_global is applied.
- As a result, when duplicating the pricelist, the product_tmpl_id and
  product_id fields are set to None.

Fix:
- When the applied_on field is missing during the creation of a new pricelist
  item, set it based on the presence of the relevant fields (such as product or
  product variant).

opw-4170242

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
