### PR TITLE
[FIX] {,website_}sale_product_configurator: exclude duplicate optionals

### DIFF
--- a/addons/sale_product_configurator/controllers/main.py
+++ b/addons/sale_product_configurator/controllers/main.py
@@ -57,13 +57,32 @@ class ProductConfiguratorController(http.Controller):
             # They are kept in the context since they are not linked to this product variant
             parent_combination |= product.env.context.get('no_variant_attribute_values')
 
-        return request.env['ir.ui.view']._render_template("sale_product_configurator.optional_product_items", {
+        exclude_product_tmpl_ids = kw.get('exclude_product_tmpl_ids')
+        if exclude_product_tmpl_ids:
+            # Temporarily exclude products from being in `optional_product_ids`
+            # to avoid issues with mutually recursive/cyclic optional products
+            optional_products = product.optional_product_ids
+            exclude_products = request.env['product.template'].browse(exclude_product_tmpl_ids)
+            request.env.cache.update(
+                product,
+                product._fields['optional_product_ids'],
+                [(optional_products - exclude_products).ids],
+            )
+        res = request.env['ir.ui.view']._render_template("sale_product_configurator.optional_product_items", {
             'product': product,
             'parent_name': product.name,
             'parent_combination': parent_combination,
             'pricelist': pricelist,
             'add_qty': add_qty,
         })
+        if exclude_product_tmpl_ids:
+            # Re-add the excluded products after rendering the configurator template
+            request.env.cache.update(
+                product,
+                product._fields['optional_product_ids'],
+                [optional_products.ids],
+            )
+        return res
 
     def _show_advanced_configurator(self, product_id, variant_values, pricelist, handle_stock, **kw):
         product = request.env['product.product'].browse(int(product_id))

--- a/addons/sale_product_configurator/static/src/js/product_configurator_modal.js
+++ b/addons/sale_product_configurator/static/src/js/product_configurator_modal.js
@@ -377,9 +377,14 @@ export const OptionalProductsModal = Dialog.extend(ServicesMixin, VariantMixin, 
         ).then(function (productId) {
             $parent.find('.product_id').val(productId);
 
+            // Get currently displayed items to exclude them from being added again as options
+            const product_tmpl_ids = new Array(...$modal.find('input.product_template_id')).map(
+                (el) => parseInt(el.value)
+            );
             ajax.jsonRpc(self._getUri("/sale_product_configurator/optional_product_items"), 'call', {
                 'product_id': productId,
                 'pricelist_id': self.pricelistId || false,
+                'exclude_product_tmpl_ids': product_tmpl_ids,
             }).then(function (addedItem) {
                 var $addedItem = $(addedItem);
                 $modal.find('tr:last').after($addedItem);

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_optional_products_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_optional_products_ui.js
@@ -31,10 +31,10 @@ tour.register('sale_product_configurator_optional_products_tour', {
 }, {
     trigger: 'tr:has(.td-product_name:contains("Conference Chair")) .fa-minus'
 }, {
-    trigger: 'tr:has(.td-product_name:contains("Chair floor protection")) .js_add',
+    trigger: 'tr:has(.td-product_name:contains("Chair floor protection")) .fa-plus',
 }, {
     content: 'Is below its parent 2',
-    trigger: 'tr:has(.td-product_name:contains("Conference Chair")) + tr:has(.td-product_name:contains("Chair floor protection"))'
+    trigger: 'tr:has(.td-product_name:contains("Conference Chair"))'
 }, {
     trigger: 'button span:contains(Confirm)',
     extra_trigger: '.oe_advanced_configurator_modal',
@@ -54,11 +54,7 @@ tour.register('sale_product_configurator_optional_products_tour', {
     extra_trigger: 'div[name="order_line"]',
     run: function () {}, // check added product
 }, {
-    trigger: 'tr:has(td.o_data_cell:contains("Chair floor protection")):nth(0) td.o_data_cell:contains("1.0")',
-    extra_trigger: 'div[name="order_line"]',
-    run: function () {}, // check added product
-}, {
-    trigger: 'tr:has(td.o_data_cell:contains("Chair floor protection")):nth(1) td.o_data_cell:contains("1.0")',
+    trigger: 'tr:has(td.o_data_cell:contains("Chair floor protection")):nth(0) td.o_data_cell:contains("2.0")',
     extra_trigger: 'div[name="order_line"]',
     run: function () {}, // check added product
 }, ...tour.stepUtils.discardForm()


### PR DESCRIPTION
Versions
--------
- 16.0 _(sale_product_configurator)_
- 17.0 _(website_sale_product_configurator)_
- 17.2 _(website_sale_product_configurator)_

Steps
-----
1. Have 2 products with variants;
2. for both, add the other as optional product;
3. in eCommerce, add one to the cart;
4. select the other in the product configurator.

Issue
-----
The attributes get messed up due to first product being listed twice in the wizard, once in the cart, and once as an option for the second product.

Solution
--------
### Front-end:
Get the IDs of the currently displayed product templates, and pass them to the controller when fetching additional variants.

### Back-end:
Before rendering the configurator template, update the cache to remove the currently displayed products from the added product's `optional_product_ids` field. Re-add them after rendering is done.

opw-4071002
opw-4189450