### PR TITLE
[FIX] stock: add name to mobile kanban create view

### DIFF
--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -96,6 +96,7 @@
             <field name="priority">10</field>
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile">
+                    <field name="name" invisible="1"/>
                     <field name="product_qty" readonly="1" force_save="0"/>
                     <field name="is_inventory"/>
                     <templates>


### PR DESCRIPTION
Since the `name` field is set via onchange, we need it here. Currently on mobile, a user may be prevented altogether from creating a stock move record in some situations.

opw-4278098