### PR TITLE
[FIX] web: close google slide in shopfloor

### DIFF
--- a/addons/web/static/src/core/utils/draggable_hook_builder.js
+++ b/addons/web/static/src/core/utils/draggable_hook_builder.js
@@ -668,7 +668,7 @@ export function makeDraggableHook(hookParams) {
                 safePrevent(ev);
                 let activeElement = document.activeElement;
                 while (activeElement?.nodeName === "IFRAME") {
-                    activeElement = activeElement.contentDocument.activeElement;
+                    activeElement = activeElement.contentDocument?.activeElement;
                 }
                 if (activeElement && !activeElement.contains(ev.target)) {
                     activeElement.blur();
@@ -798,7 +798,7 @@ export function makeDraggableHook(hookParams) {
                 let iframeOffsetX = 0;
                 let iframeOffsetY = 0;
                 const iframeEl = container.ownerDocument.defaultView.frameElement;
-                if (iframeEl && !iframeEl.contentDocument.contains(element)) {
+                if (iframeEl && !iframeEl.contentDocument?.contains(element)) {
                     const { x, y } = dom.getRect(iframeEl);
                     iframeOffsetX = x;
                     iframeOffsetY = y;


### PR DESCRIPTION
When an iFrame and its parent document are from different origins, contentDocument is null. See:
https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/contentDocument

This will cause an error when interacting with an iFrame that contains a Google Slide, which 
is from a different origin. Due to this, we need to check that there's a contentDocument
before trying to use its content.

opw-4240622

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
