### PR TITLE
[IMP] mail: add leave action in thread actions for mobile devices

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -121,7 +121,7 @@
 <t t-name="mail.ChatWindow.dropdownAction">
     <DropdownItem class="'o-mail-ChatWindow-command btn rounded-0 d-flex align-items-center px-2 py-2 m-0'" onSelected="() => action.onSelect()">
         <i t-att-class="action.icon"/>
-        <span class="mx-2" t-out="action.name"/>
+        <span class="mx-2" t-att-class="action.nameClass" t-out="action.name"/>
     </DropdownItem>
 </t>
 

--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -130,6 +130,12 @@ function transformAction(component, id, action) {
             const res = this.isActive && action.nameActive ? action.nameActive : action.name;
             return typeof res === "function" ? res(component) : res;
         },
+        /** ClassName on name of this action */
+        get nameClass() {
+            return typeof action.nameClass === "function"
+                ? action.nameClass(component)
+                : action.nameClass;
+        },
         /**
          * Action to execute when this action is selected (on or off).
          *

--- a/addons/mail/static/src/core/public_web/@types/models.d.ts
+++ b/addons/mail/static/src/core/public_web/@types/models.d.ts
@@ -16,6 +16,8 @@ declare module "models" {
         discussAppCategory: DiscussAppCategory,
         setAsDiscussThread: (pushState: boolean) => void,
         unpin: () => Promise<void>,
+        askLeaveConfirmation: (body: string) => void,
+        leaveChannel: () => Promise<void>,
     }
 
     export interface Models {

--- a/addons/mail/static/src/core/public_web/thread_actions.js
+++ b/addons/mail/static/src/core/public_web/thread_actions.js
@@ -1,0 +1,20 @@
+import { threadActionsRegistry } from "@mail/core/common/thread_actions";
+import { useComponent, useState } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
+import { useService } from "@web/core/utils/hooks";
+
+threadActionsRegistry.add("leave", {
+    condition: (component) =>
+        component.ui.isSmall && (component.thread?.canLeave || component.thread?.canUnpin),
+    icon: "fa fa-fw fa-sign-out text-danger",
+    name: (component) => (component.thread.canLeave ? _t("Leave") : _t("Unpin")),
+    nameClass: "text-danger",
+    open: (component) =>
+        component.thread.canLeave ? component.thread.leaveChannel() : component.thread.unpin(),
+    sequence: 10,
+    sequenceGroup: 40,
+    setup() {
+        const component = useComponent();
+        component.ui = useState(useService("ui"));
+    },
+});

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
@@ -6,7 +6,6 @@ import { useHover } from "@mail/utils/common/hooks";
 
 import { Component, useState, useSubEnv } from "@odoo/owl";
 
-import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
 import { _t } from "@web/core/l10n/translation";
@@ -71,7 +70,6 @@ export class DiscussSidebarChannel extends Component {
     setup() {
         super.setup();
         this.store = useState(useService("mail.store"));
-        this.dialogService = useService("dialog");
         this.hover = useHover(["root", "floating*"], {
             onHover: () => (this.floating.isOpen = true),
             onAway: () => (this.floating.isOpen = false),
@@ -114,7 +112,7 @@ export class DiscussSidebarChannel extends Component {
         const commands = [];
         if (this.thread.canLeave) {
             commands.push({
-                onSelect: () => this.leaveChannel(),
+                onSelect: () => this.thread.leaveChannel(),
                 label: _t("Leave Channel"),
                 icon: "oi oi-close",
                 sequence: 20,
@@ -140,34 +138,6 @@ export class DiscussSidebarChannel extends Component {
     /** @returns {import("models").Thread} */
     get thread() {
         return this.props.thread;
-    }
-
-    askConfirmation(body) {
-        return new Promise((resolve) => {
-            this.dialogService.add(ConfirmationDialog, {
-                body: body,
-                confirmLabel: _t("Leave Conversation"),
-                confirm: resolve,
-                cancel: () => {},
-            });
-        });
-    }
-
-    async leaveChannel() {
-        const thread = this.thread;
-        if (thread.channel_type !== "group" && thread.create_uid === thread.store.self.userId) {
-            await this.askConfirmation(
-                _t("You are the administrator of this channel. Are you sure you want to leave?")
-            );
-        }
-        if (thread.channel_type === "group") {
-            await this.askConfirmation(
-                _t(
-                    "You are about to leave this group conversation and will no longer have access to it unless you are invited again. Are you sure you want to continue?"
-                )
-            );
-        }
-        thread.leave();
     }
 
     /** @param {MouseEvent} ev */

--- a/addons/mail/static/tests/mobile/mobile.test.js
+++ b/addons/mail/static/tests/mobile/mobile.test.js
@@ -52,3 +52,13 @@ test("show loading on initial opening", async () => {
     await contains(".o-mail-MessagingMenu .fa.fa-circle-o-notch.fa-spin", { count: 0 });
     await contains(".o-mail-NotificationItem", { text: "General" });
 });
+
+test("can leave channel in mobile", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    patchUiSize({ size: SIZES.SM });
+    await start();
+    await openDiscuss(channelId);
+    await click(".o-mail-ChatWindow-command", { text: "General" });
+    await contains(".o-dropdown-item", { text: "Leave" });
+});


### PR DESCRIPTION
Prior to this commit, it wasn't possible to leave a channel from a mobile device, as the `swipe` action could only remove read chats.

This commit introduces a new thread action, allowing users to leave a channel or unpin a chat directly from the mobile interface.

![Screenshot 2024-10-25 at 15 53 17](https://github.com/user-attachments/assets/2a7aa538-850d-42d2-9548-338f1f85fb96)
