### PR TITLE
[FIX] pos_sale: add discount for products with non groupable uom

### DIFF
--- a/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js
+++ b/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js
@@ -238,6 +238,7 @@ odoo.define('pos_sale.SaleOrderManagementScreen', function (require) {
                         while (!utils.float_is_zero(remaining_quantity, 6)) {
                             let splitted_line = Orderline.create({}, line_values);
                             splitted_line.set_quantity(Math.min(remaining_quantity, 1.0), true);
+                            splitted_line.set_discount(line.discount);
                             remaining_quantity -= splitted_line.quantity;
                             this.env.pos.get_order().add_orderline(splitted_line);
                         }

--- a/addons/pos_sale/static/tests/tours/pos_sale_tours.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tours.js
@@ -118,9 +118,10 @@ odoo.define('pos_sale.tour', function (require) {
     ProductScreen.do.confirmOpeningPopup();
     ProductScreen.do.clickQuotationButton();
     ProductScreen.do.selectFirstOrder();
-    ProductScreen.check.totalAmountIs(32.2); // 3.5 * 8 * 1.15
-    ProductScreen.do.clickOrderline("Product A", 0.5);
+    ProductScreen.check.totalAmountIs(28.98); // 3.5 * 8 * 1.15 * 90%
+    ProductScreen.do.clickOrderline("Product A", '0.5');
     ProductScreen.check.checkOrderlinesNumber(4);
+    ProductScreen.check.selectedOrderlineHas('Product A', '0.5', '4.14');
 
     Tour.register('PosSettleOrderNotGroupable', { test: true, url: '/pos/ui' }, getSteps());
 

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -329,9 +329,10 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
                 'product_uom_qty': 3.5,
                 'product_uom': product_a.uom_id.id,
                 'price_unit': 8,  # manually set a different price than the lst_price
+                'discount': 10,
             })],
         })
-        self.assertEqual(sale_order.amount_total, 32.2)  # 3.5 * 8 * 1.15
+        self.assertEqual(sale_order.amount_total, 28.98)  # 3.5 * 8 * 1.15 * 90%
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosSettleOrderNotGroupable', login="accountman")
 


### PR DESCRIPTION
### Issue:
- When picking up a SO in POS, the discount on products sold with a non groupable UOM disappears.

### Steps to reproduce:
- Create a SO in the sales app.
- Include a product that has a UOM of which the uom category is not grouped in POS (g for example).
- Add a discount to the product.
- Pick up the order in POS.
- Notice that the discount is not applied.

### Solution:
 - In `_onClickSaleOrder` I set the discount on the `splitted_line` before adding it to the orderline.

opw-4133659

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
