### PR TITLE
[FIX] mail: access to the left partner or guest avatar

### DIFF
--- a/addons/mail/models/__init__.py
+++ b/addons/mail/models/__init__.py
@@ -53,6 +53,7 @@ from . import bus_presence
 from . import ir_action_act_window
 from . import ir_actions_server
 from . import ir_attachment
+from . import ir_binary
 from . import ir_config_parameter
 from . import ir_cron
 from . import ir_http

--- a/addons/mail/models/ir_binary.py
+++ b/addons/mail/models/ir_binary.py
@@ -1,0 +1,18 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class IrBinary(models.AbstractModel):
+    _inherit = ["ir.binary"]
+
+    def _find_record_check_access(self, record, access_token, field):
+        if record._name in ["res.partner", "mail.guest"] and field == "avatar_128":
+            # access to the avatar is allowed if there is access to the messages
+            if record._name == "res.partner":
+                domain = [("author_id", "=", record.id)]
+            else:
+                domain = [("author_guest_id", "=", record.id)]
+            if self.env["mail.message"].search_count(domain, limit=1):
+                return record.sudo()
+        return super()._find_record_check_access(record, access_token, field)

--- a/addons/mail/tests/__init__.py
+++ b/addons/mail/tests/__init__.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_attachment_controller
+from . import test_binary_controller
 from . import test_controller_common
 from . import test_discuss_tools
 from . import test_ir_mail_server

--- a/addons/mail/tests/discuss/__init__.py
+++ b/addons/mail/tests/discuss/__init__.py
@@ -3,6 +3,7 @@
 from . import test_avatar_acl
 from . import test_bus_presence
 from . import test_discuss_attachment_controller
+from . import test_discuss_binary_controller
 from . import test_discuss_channel
 from . import test_discuss_channel_access
 from . import test_discuss_channel_as_guest

--- a/addons/mail/tests/discuss/test_discuss_binary_controller.py
+++ b/addons/mail/tests/discuss/test_discuss_binary_controller.py
@@ -1,0 +1,411 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo
+from odoo.addons.mail.tests.test_binary_controller import TestBinaryControllerCommon
+
+
+@odoo.tests.tagged("-at_install", "post_install")
+class TestDiscussBinaryControllerCommon(TestBinaryControllerCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.private_channel = cls.env["discuss.channel"].create(
+            {"name": "Private Channel", "channel_type": "group"}
+        )
+        cls.public_channel = cls.env["discuss.channel"].channel_create(
+            name="Public Channel", group_id=None
+        )
+        cls.partner_ids = (
+            cls.user_public + cls.user_portal + cls.user_employee + cls.user_demo + cls.user_admin
+        ).partner_id.ids
+
+
+@odoo.tests.tagged("-at_install", "post_install")
+class TestDiscussBinaryController(TestDiscussBinaryControllerCommon):
+    def test_open_guest_avatar(self):
+        """Test access to open the avatar of a guest.
+        There is no common channel or any interaction from the guest."""
+        self._execute_subtests(
+            self.guest_2,
+            (
+                (self.user_public, False),
+                (self.guest, False),
+                (self.user_portal, False),
+                (self.user_employee, True),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )
+
+    def test_01_guest_avatar_private_channel(self):
+        """Test access to open the avatar:
+        - target type: guest
+        - channel type: group
+        - target joins the channel: True
+        - other users join the channel: True
+        - target sends a message: False"""
+        self.private_channel.add_members(self.partner_ids, (self.guest + self.guest_2).ids)
+        self._execute_subtests(
+            self.guest_2,
+            (
+                (self.user_public, False),
+                (self.guest, True),
+                (self.user_portal, True),
+                (self.user_employee, True),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )
+
+    def test_01_partner_avatar_private_channel(self):
+        """Test access to open the avatar:
+        - target type: partner
+        - channel type: group
+        - target joins the channel: True
+        - other users join the channel: True
+        - target sends a message: False"""
+        self.private_channel.add_members(
+            self.partner_ids + [self.user_test.partner_id.id], self.guest.id
+        )
+        self._execute_subtests(
+            self.user_test,
+            (
+                (self.user_public, False),
+                (self.guest, True),
+                (self.user_portal, True),
+                (self.user_employee, True),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )
+
+    def test_02_guest_avatar_private_channel(self):
+        """Test access to open the avatar:
+        - target type: guest
+        - channel type: group
+        - target joins the channel: True
+        - other users join the channel: True
+        - target sends a message: True"""
+        self.private_channel.add_members(self.partner_ids, (self.guest + self.guest_2).ids)
+        self._send_message(self.guest_2, self.private_channel._name, self.private_channel.id)
+        self._execute_subtests(
+            self.guest_2,
+            (
+                (self.user_public, False),
+                (self.guest, True),
+                (self.user_portal, True),
+                (self.user_employee, True),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )
+
+    def test_02_partner_avatar_private_channel(self):
+        """Test access to open the avatar:
+        - target type: partner
+        - channel type: group
+        - target joins the channel: True
+        - other users join the channel: True
+        - target sends a message: True"""
+        self.private_channel.add_members(
+            self.partner_ids + [self.user_test.partner_id.id], self.guest.id
+        )
+        self._send_message(self.user_test, self.private_channel._name, self.private_channel.id)
+        self._execute_subtests(
+            self.user_test,
+            (
+                (self.user_public, False),
+                (self.guest, True),
+                (self.user_portal, True),
+                (self.user_employee, True),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )
+
+    def test_03_guest_avatar_private_channel(self):
+        """Test access to open the avatar:
+        - target type: guest
+        - channel type: group
+        - target joins the channel: True
+        - other users join the channel: True
+        - target sends a message: False
+        - target leaves the channel: True"""
+        self.private_channel.add_members(self.partner_ids, (self.guest + self.guest_2).ids)
+        self.env["discuss.channel.member"].search(
+            [("guest_id", "=", self.guest_2.id), ("channel_id", "=", self.private_channel.id)]
+        ).unlink()
+        self._execute_subtests(
+            self.guest_2,
+            (
+                (self.user_public, False),
+                (self.guest, False),
+                (self.user_portal, False),
+                (self.user_employee, True),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )
+
+    def test_03_partner_avatar_private_channel(self):
+        """Test access to open the avatar:
+        - target type: partner
+        - channel type: group
+        - target joins the channel: True
+        - other users join the channel: True
+        - target sends a message: False
+        - target leaves the channel: True"""
+        self.private_channel.add_members(
+            self.partner_ids + [self.user_test.partner_id.id], self.guest.id
+        )
+        self.env["discuss.channel.member"].search(
+            [
+                ("partner_id", "=", self.user_test.partner_id.id),
+                ("channel_id", "=", self.private_channel.id),
+            ]
+        ).unlink()
+        self._execute_subtests(
+            self.user_test,
+            (
+                (self.user_public, False),
+                (self.guest, False),
+                (self.user_portal, False),
+                (self.user_employee, True),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )
+
+    def test_04_guest_avatar_private_channel(self):
+        """Test access to open the avatar:
+        - target type: guest
+        - channel type: group
+        - target joins the channel: True
+        - other users join the channel: True
+        - target sends a message: True
+        - target leaves the channel: True"""
+        self.private_channel.add_members(self.partner_ids, (self.guest + self.guest_2).ids)
+        self._send_message(self.guest_2, self.private_channel._name, self.private_channel.id)
+        self.env["discuss.channel.member"].search(
+            [("guest_id", "=", self.guest_2.id), ("channel_id", "=", self.private_channel.id)]
+        ).unlink()
+        self._execute_subtests(
+            self.guest_2,
+            (
+                (self.user_public, False),
+                (self.guest, True),
+                (self.user_portal, True),
+                (self.user_employee, True),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )
+
+    def test_04_partner_avatar_private_channel(self):
+        """Test access to open the avatar:
+        - target type: partner
+        - channel type: group
+        - target joins the channel: True
+        - other users join the channel: True
+        - target sends a message: True
+        - target leaves the channel: True"""
+        self.private_channel.add_members(
+            self.partner_ids + [self.user_test.partner_id.id], self.guest.id
+        )
+        self._send_message(self.user_test, self.private_channel._name, self.private_channel.id)
+        self.env["discuss.channel.member"].search(
+            [
+                ("partner_id", "=", self.user_test.partner_id.id),
+                ("channel_id", "=", self.private_channel.id),
+            ]
+        ).unlink()
+        self._execute_subtests(
+            self.user_test,
+            (
+                (self.user_public, False),
+                (self.guest, True),
+                (self.user_portal, True),
+                (self.user_employee, True),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )
+
+    def test_05_guest_avatar_private_channel(self):
+        """Test access to open the avatar:
+        - target type: guest
+        - channel type: group
+        - target joins the channel: False
+        - other users join the channel: False
+        - target sends a message: True"""
+        self.private_channel.with_user(self.user_public).with_context(
+            guest=self.guest_2
+        ).sudo().message_post(body="Test", subtype_xmlid="mail.mt_comment", message_type="comment")
+        self._execute_subtests(
+            self.guest_2,
+            (
+                (self.user_public, False),
+                (self.guest, False),
+                (self.user_portal, False),
+                (self.user_employee, True),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )
+
+    def test_05_partner_avatar_private_channel(self):
+        """Test access to open the avatar:
+        - target type: partner
+        - channel type: group
+        - target joins the channel: False
+        - other users join the channel: False
+        - target sends a message: True"""
+        self.private_channel.message_post(
+            body="Test",
+            subtype_xmlid="mail.mt_comment",
+            message_type="comment",
+            author_id=self.user_test.partner_id.id,
+        )
+        self._execute_subtests(
+            self.user_test,
+            (
+                (self.user_public, False),
+                (self.guest, False),
+                (self.user_portal, False),
+                (self.user_employee, True),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )
+
+    def test_01_guest_avatar_public_channel(self):
+        """Test access to open the avatar:
+        - target type: guest
+        - channel type: public
+        - target joins the channel: False
+        - other users join the channel: False
+        - target sends a message: True"""
+        self.public_channel.with_user(self.user_public).with_context(
+            guest=self.guest_2
+        ).sudo().message_post(body="Test", subtype_xmlid="mail.mt_comment", message_type="comment")
+        self._execute_subtests(
+            self.guest_2,
+            (
+                (self.user_public, True),
+                (self.guest, True),
+                (self.user_portal, True),
+                (self.user_employee, True),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )
+
+    def test_01_partner_avatar_public_channel(self):
+        """Test access to open the avatar:
+        - target type: guest
+        - channel type: public
+        - target joins the channel: False
+        - other users join the channel: False
+        - target sends a message: True"""
+        self._send_message(self.user_test, self.public_channel._name, self.public_channel.id)
+        self._execute_subtests(
+            self.user_test,
+            (
+                (self.user_public, True),
+                (self.guest, True),
+                (self.user_portal, True),
+                (self.user_employee, True),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )
+
+    def test_02_guest_avatar_public_channel(self):
+        """Test access to open the avatar:
+        - target type: guest
+        - channel type: public
+        - target joins the channel: True
+        - other users join the channel: False
+        - target sends a message: False
+        - target leaves the channel: True"""
+        target_member = self.public_channel.add_members(guest_ids=self.guest_2.id)
+        target_member.unlink()
+        self._execute_subtests(
+            self.guest_2,
+            (
+                (self.user_public, False),
+                (self.guest, False),
+                (self.user_portal, False),
+                (self.user_employee, True),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )
+
+    def test_02_partner_avatar_public_channel(self):
+        """Test access to open the avatar:
+        - target type: partner
+        - channel type: public
+        - target joins the channel: True
+        - other users join the channel: False
+        - target sends a message: False
+        - target leaves the channel: True"""
+        target_member = self.public_channel.add_members(self.user_test.partner_id.id)
+        target_member.unlink()
+        self._execute_subtests(
+            self.user_test,
+            (
+                (self.user_public, False),
+                (self.guest, False),
+                (self.user_portal, False),
+                (self.user_employee, True),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )
+
+    def test_03_guest_avatar_public_channel(self):
+        """Test access to open the avatar:
+        - target type: guest
+        - channel type: public
+        - target joins the channel: True
+        - other users join the channel: False
+        - target sends a message: True
+        - target leaves the channel: True"""
+        target_member = self.public_channel.add_members(guest_ids=self.guest_2.id)
+        self._send_message(self.guest_2, self.public_channel._name, self.public_channel.id)
+        target_member.unlink()
+        self._execute_subtests(
+            self.guest_2,
+            (
+                (self.user_public, True),
+                (self.guest, True),
+                (self.user_portal, True),
+                (self.user_employee, True),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )
+
+    def test_03_partner_avatar_public_channel(self):
+        """Test access to open the avatar:
+        - target type: partner
+        - channel type: public
+        - target joins the channel: True
+        - other users join the channel: False
+        - target sends a message: True
+        - target leaves the channel: True"""
+        target_member = self.public_channel.add_members(self.user_test.partner_id.id)
+        self._send_message(self.user_test, self.public_channel._name, self.public_channel.id)
+        target_member.unlink()
+        self._execute_subtests(
+            self.user_test,
+            (
+                (self.user_public, True),
+                (self.guest, True),
+                (self.user_portal, True),
+                (self.user_employee, True),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )

--- a/addons/mail/tests/test_binary_controller.py
+++ b/addons/mail/tests/test_binary_controller.py
@@ -1,0 +1,91 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo
+from odoo.addons.mail.tests.test_controller_common import TestControllerCommon
+
+
+@odoo.tests.tagged("-at_install", "post_install")
+class TestBinaryControllerCommon(TestControllerCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user_test = cls.env["res.users"].create(
+            {
+                "email": "testuser@testuser.com",
+                "name": "Test User",
+                "login": "test_user",
+                "password": "test_user",
+            }
+        )
+        cls.guest_2 = cls.env["mail.guest"].create({"name": "Guest 2"})
+
+    def _execute_subtests(self, record, subtests):
+        for data_user, allowed in subtests:
+            user = data_user if data_user._name == "res.users" else self.user_public
+            guest = data_user if data_user._name == "mail.guest" else self.env["mail.guest"]
+            self._authenticate_user(user=user, guest=guest)
+            with self.subTest(user=user.name, guest=guest.name, record=record):
+                guest_or_partner = record if record._name == "mail.guest" else record.partner_id
+                if allowed:
+                    self.assertEqual(
+                        self._get_avatar_url(guest_or_partner).headers["Content-Disposition"],
+                        f'inline; filename="{guest_or_partner.name}.svg"',
+                    )
+                else:
+                    self.assertEqual(
+                        self._get_avatar_url(guest_or_partner).headers["Content-Disposition"],
+                        "inline; filename=placeholder.png",
+                    )
+
+    def _get_avatar_url(self, record):
+        url = f"/web/image?field=avatar_128&id={record.id}&model={record._name}&unique={odoo.fields.Datetime.to_string(record.write_date)}"
+        return self.url_open(url)
+
+    def _send_message(self, author, thread_model, thread_id):
+        user = author if author._name == "res.users" else self.user_public
+        guest = author if author._name == "mail.guest" else self.env["mail.guest"]
+        self._authenticate_user(user=user, guest=guest)
+        self.make_jsonrpc_request(
+            route="/mail/message/post",
+            params={
+                "thread_model": thread_model,
+                "thread_id": thread_id,
+                "post_data": {
+                    "body": "Test",
+                    "message_type": "comment",
+                    "subtype_xmlid": "mail.mt_comment",
+                },
+            },
+        )
+
+
+@odoo.tests.tagged("-at_install", "post_install")
+class TestBinaryController(TestBinaryControllerCommon):
+    def test_open_partner_avatar(self):
+        """Test access to open the partner avatar."""
+        self._execute_subtests(
+            self.user_test,
+            (
+                (self.user_public, False),
+                (self.guest, False),
+                (self.user_portal, False),
+                (self.user_employee, True),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )
+
+    def test_open_partner_avatar_has_message(self):
+        """Test access to open a partner avatar who has sent a message on a private record."""
+        self._send_message(self.user_test, "res.partner", self.user_test.partner_id.id)
+        self._execute_subtests(
+            self.user_test,
+            (
+                (self.user_public, False),
+                (self.guest, False),
+                (self.user_portal, False),
+                (self.user_employee, True),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )

--- a/addons/test_mail/models/test_mail_models.py
+++ b/addons/test_mail/models/test_mail_models.py
@@ -470,3 +470,14 @@ class MailTestMailTrackingDuration(models.Model):
 
     def _mail_get_partner_fields(self, introspect_fields=False):
         return ['customer_id']
+
+
+class MailTestPublicThread(models.Model):
+    """A model inheriting from mail.thread with public read and write access
+    to test some public and guest interactions."""
+
+    _description = "Portal Public Thread"
+    _name = "mail.test.public"
+    _inherit = ["mail.thread"]
+
+    name = fields.Char("Name")

--- a/addons/test_mail/security/ir.model.access.csv
+++ b/addons/test_mail/security/ir.model.access.csv
@@ -57,3 +57,5 @@ access_mail_test_track_selection_portal,mail.test.track.selection.portal,model_m
 access_mail_test_track_selection_user,mail.test.track.selection.user,model_mail_test_track_selection,base.group_user,1,1,1,1
 access_mail_test_properties_user,mail.test.properties.user,model_mail_test_properties,base.group_user,1,1,1,1
 access_mail_test_mail_tracking_duration,mail.test.mail.tracking.duration,model_mail_test_mail_tracking_duration,base.group_user,1,1,1,1
+access_mail_test_public_user,mail.test.public.user,model_mail_test_public,base.group_user,1,1,1,1
+access_mail_test_public_public,mail.test.public.public,model_mail_test_public,base.group_public,1,1,0,0

--- a/addons/test_mail/tests/__init__.py
+++ b/addons/test_mail/tests/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_invite
 from . import test_ir_actions
@@ -25,3 +25,4 @@ from . import test_message_management
 from . import test_message_post
 from . import test_message_track
 from . import test_performance
+from . import test_public_binary_controller

--- a/addons/test_mail/tests/test_public_binary_controller.py
+++ b/addons/test_mail/tests/test_public_binary_controller.py
@@ -1,0 +1,69 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo
+from odoo.addons.mail.tests.test_binary_controller import TestBinaryControllerCommon
+
+
+@odoo.tests.tagged("-at_install", "post_install")
+class TestPublicBinaryController(TestBinaryControllerCommon):
+    def test_01_guest_avatar_public_record(self):
+        """Test access to open a guest avatar who hasn't sent a message on a public record."""
+        self.env["mail.test.public"].create({"name": "Test"})
+        self._execute_subtests(
+            self.guest_2,
+            (
+                (self.user_public, False),
+                (self.guest, False),
+                (self.user_portal, False),
+                (self.user_employee, True),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )
+
+    def test_02_guest_avatar_public_record(self):
+        """Test access to open a guest avatar who has sent a message on a public record."""
+        thread = self.env["mail.test.public"].create({"name": "Test"})
+        self._send_message(self.guest_2, "mail.test.public", thread.id)
+        self._execute_subtests(
+            self.guest_2,
+            (
+                (self.user_public, True),
+                (self.guest, True),
+                (self.user_portal, False),
+                (self.user_employee, True),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )
+
+    def test_01_partner_avatar_public_record(self):
+        """Test access to open a partner avatar who hasn't sent a message on a public record."""
+        self.env["mail.test.public"].create({"name": "Test"})
+        self._execute_subtests(
+            self.user_test,
+            (
+                (self.user_public, False),
+                (self.guest, False),
+                (self.user_portal, False),
+                (self.user_employee, True),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )
+
+    def test_02_partner_avatar_public_record(self):
+        """Test access to open a partner avatar who has sent a message on a public record."""
+        thread = self.env["mail.test.public"].create({"name": "Test"})
+        self._send_message(self.user_test, "mail.test.public", thread.id)
+        self._execute_subtests(
+            self.user_test,
+            (
+                (self.user_public, True),
+                (self.guest, True),
+                (self.user_portal, False),
+                (self.user_employee, True),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )


### PR DESCRIPTION
Steps to reproduce:
- Create a public channel
- Add a non website_published user as a new member
- Log in as that new member and send a message then leave the channel
- Open the channel as a guest
- The author avatar of the message is not there
