### PR TITLE
[FIX] sale_pdf_quote_builder: fix multi-company behavior of quotation documents

### DIFF
--- a/addons/sale_pdf_quote_builder/__manifest__.py
+++ b/addons/sale_pdf_quote_builder/__manifest__.py
@@ -11,6 +11,7 @@
         'report/ir_actions_report.xml',
 
         'security/ir.model.access.csv',
+        'security/ir_rules.xml',
 
         'views/product_document_views.xml',
         'views/quotation_document_views.xml',

--- a/addons/sale_pdf_quote_builder/models/quotation_document.py
+++ b/addons/sale_pdf_quote_builder/models/quotation_document.py
@@ -15,6 +15,7 @@ class QuotationDocument(models.Model):
         'ir.attachment': 'ir_attachment_id',
     }
     _order = 'document_type desc, sequence, name'
+    _check_company_auto = True
 
     ir_attachment_id = fields.Many2one(
         string="Related attachment",
@@ -37,6 +38,7 @@ class QuotationDocument(models.Model):
         string="Quotation Templates",
         comodel_name='sale.order.template',
         relation='header_footer_quotation_template_rel',
+        check_company=True,
     )
     form_field_ids = fields.Many2many(
         string="Form Fields Included",

--- a/addons/sale_pdf_quote_builder/models/sale_order.py
+++ b/addons/sale_pdf_quote_builder/models/sale_order.py
@@ -20,6 +20,7 @@ class SaleOrder(models.Model):
         string="Headers/Footers",
         comodel_name='quotation.document',
         readonly=False,
+        check_company=True,
     )
     customizable_pdf_form_fields = fields.Json(
         string="Customizable PDF Form Fields",
@@ -32,7 +33,8 @@ class SaleOrder(models.Model):
     def _compute_available_product_document_ids(self):
         for order in self:
             order.available_product_document_ids = self.env['quotation.document'].search(
-                [], order='sequence'
+                self.env['quotation.document']._check_company_domain(self.company_id),
+                order='sequence',
             ).filtered(lambda doc:
                 self.sale_order_template_id in doc.quotation_template_ids
                 or not doc.quotation_template_ids

--- a/addons/sale_pdf_quote_builder/models/sale_order_template.py
+++ b/addons/sale_pdf_quote_builder/models/sale_order_template.py
@@ -5,9 +5,11 @@ from odoo import fields, models
 
 class SaleOrderTemplate(models.Model):
     _inherit = 'sale.order.template'
+    _check_company_auto = True
 
     quotation_document_ids = fields.Many2many(
         string="Headers and footers",
         comodel_name='quotation.document',
         relation='header_footer_quotation_template_rel',
+        check_company=True,
     )

--- a/addons/sale_pdf_quote_builder/security/ir_rules.xml
+++ b/addons/sale_pdf_quote_builder/security/ir_rules.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <!-- Multi-company rules -->
+    <record id="quotation_document_comp_rule" model="ir.rule">
+        <field name="name">Quotation document multi-company rule</field>
+        <field name="model_id" ref="model_quotation_document"/>
+        <field name="domain_force">
+            ['|', ('company_id', '=', False), ('company_id', 'parent_of', company_ids)]
+        </field>
+    </record>
+
+</odoo>

--- a/addons/sale_pdf_quote_builder/views/quotation_document_views.xml
+++ b/addons/sale_pdf_quote_builder/views/quotation_document_views.xml
@@ -39,14 +39,19 @@
                             />
                         </group>
                     </group>
-                    <group string="Attached To" groups="base.group_no_one">
+                    <group string="Attached To" groups="base.group_multi_company,base.group_no_one">
                         <field
                             name="company_id"
+                            placeholder="Visible to all"
                             groups="base.group_multi_company"
                             options="{'no_create': True}"
                             class="oe_inline"
                         />
-                        <field name="form_field_ids" widget="many2many_tags"/>
+                        <field
+                            name="form_field_ids"
+                            groups="base.group_no_one"
+                            widget="many2many_tags"
+                        />
                     </group>
                     <group string="History" groups="base.group_no_one" invisible="not create_date">
                         <label for="create_uid" string="Creation"/>


### PR DESCRIPTION
A quotation document can be linked either to a single company, or to all companies. However, this information was ignored, and all quotation documents were available in all companies, regardless of their linked companies.

This change enforces consistent multi-company behavior, i.e. quotation documents are only available in their linked companies.

opw-4087354