### PR TITLE
[FIX] product*: blacklist product service tracking upfront payment

### DIFF
--- a/addons/event_booth_sale/models/product_template.py
+++ b/addons/event_booth_sale/models/product_template.py
@@ -17,3 +17,6 @@ class ProductTemplate(models.Model):
     def _onchange_type_event_booth(self):
         if self.service_tracking == 'event_booth':
             self.invoice_policy = 'order'
+
+    def _service_tracking_blacklist(self):
+        return super()._service_tracking_blacklist() + ['event_booth']

--- a/addons/event_product/models/product_template.py
+++ b/addons/event_product/models/product_template.py
@@ -7,3 +7,6 @@ class ProductTemplate(models.Model):
     service_tracking = fields.Selection(selection_add=[
         ('event', 'Event Registration'),
     ], ondelete={'event': 'set default'})
+
+    def _service_tracking_blacklist(self):
+        return super()._service_tracking_blacklist() + ['event']

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -1476,3 +1476,11 @@ class ProductTemplate(models.Model):
         To be overridden in accounting module."""
         self.ensure_one()
         return price
+
+    @api.model
+    def _service_tracking_blacklist(self):
+        """ Service tracking field is used to distinguish some specific categories of products.
+        Those products shouldn't be displayed or used in unrelated applications.
+        This method returns a domain targeting all those specific products (events, courses, ...).
+        """
+        return []

--- a/addons/website_sale_slides/models/product_template.py
+++ b/addons/website_sale_slides/models/product_template.py
@@ -19,3 +19,6 @@ class ProductTemplate(models.Model):
     @api.model
     def _get_product_types_allow_zero_price(self):
         return super()._get_product_types_allow_zero_price() + ["course"]
+
+    def _service_tracking_blacklist(self):
+        return super()._service_tracking_blacklist() + ['course']


### PR DESCRIPTION
*product, event_product, event_booth_sale

In the Appointment app, when trying to select an "Up-front payment product," products configured to create a task in a project are not available in the dropdown list.

Cause of the issue:
In the `appointment_type` model definition within the `appointment_account_payment` module, a domain was applied on the `product_id` field, restricting the selectable products. The domain filtered out products with the `service_tracking` field set to values other than `"no"`. As a result, products that create tasks in projects (which have `service_tracking` set to `"task_global_project"`) were excluded. The commit https://github.com/odoo/enterprise/commit/ff54ff6cbdf79b1c24c468b5238d8eeb91e85cb9 aim was to prevent `event` and `event_booth` product to be selectable. This commit allows other product whose `service_tracking != 'no'` to be selectable while not allowing `event` and `event_booth`.

opw-4146731

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
