### PR TITLE
[PERF] sale_timesheet: improve compute_sale_line() perf

### DIFF
--- a/addons/sale_timesheet/models/project_task.py
+++ b/addons/sale_timesheet/models/project_task.py
@@ -25,6 +25,7 @@ class ProjectTask(models.Model):
     timesheet_product_id = fields.Many2one(related="project_id.timesheet_product_id")
     remaining_hours_so = fields.Float('Time Remaining on SO', compute='_compute_remaining_hours_so', search='_search_remaining_hours_so', compute_sudo=True)
     remaining_hours_available = fields.Boolean(related="sale_line_id.remaining_hours_available")
+    last_sol_of_customer = fields.Many2one('sale.order.line', compute='_compute_last_sol_of_customer')
 
     @property
     def SELF_READABLE_FIELDS(self):
@@ -57,18 +58,29 @@ class ProjectTask(models.Model):
     def _search_remaining_hours_so(self, operator, value):
         return [('sale_line_id.remaining_hours', operator, value)]
 
+    def _compute_last_sol_of_customer(self):
+        sol_per_domain = dict()
+        for task in self:
+            domain = tuple(task._get_last_sol_of_customer_domain())
+            if not domain:
+                task.last_sol_of_customer = False
+                continue
+            if domain not in sol_per_domain:
+                sol_per_domain[domain] = self.env['sale.order.line'].search(domain, limit=1)
+            task.last_sol_of_customer = sol_per_domain[domain]
+
     def _inverse_partner_id(self):
         super()._inverse_partner_id()
         for task in self:
             if task.allow_billable and not task.sale_line_id:
-                task.sale_line_id = task._get_last_sol_of_customer()
+                task.sale_line_id = task.last_sol_of_customer
 
     @api.depends('sale_line_id.order_partner_id', 'parent_id.sale_line_id', 'project_id.sale_line_id', 'allow_billable')
     def _compute_sale_line(self):
         super()._compute_sale_line()
         for task in self:
             if task.allow_billable and not task.sale_line_id:
-                task.sale_line_id = task._get_last_sol_of_customer()
+                task.sale_line_id = task.last_sol_of_customer
 
     @api.depends('project_id.sale_line_employee_ids')
     def _compute_is_project_map_empty(self):
@@ -80,11 +92,11 @@ class ProjectTask(models.Model):
         for task in self:
             task.has_multi_sol = task.timesheet_ids and task.timesheet_ids.so_line != task.sale_line_id
 
-    def _get_last_sol_of_customer(self):
-        # Get the last SOL made for the customer in the current task where we need to compute
+    def _get_last_sol_of_customer_domain(self):
+        # Get the domain of the last SOL made for the customer in the current task where we need to compute
         self.ensure_one()
         if not self.partner_id.commercial_partner_id or not self.allow_billable:
-            return False
+            return []
         SaleOrderLine = self.env['sale.order.line']
         domain = expression.AND([
             SaleOrderLine._domain_sale_line_service(),
@@ -95,8 +107,8 @@ class ProjectTask(models.Model):
             ],
         ])
         if self.project_id.pricing_type != 'task_rate' and self.project_sale_order_id and self.partner_id.commercial_partner_id == self.project_id.partner_id.commercial_partner_id:
-            domain = expression.AND([domain, [('order_id', '=?', self.project_sale_order_id.id)]])
-        return SaleOrderLine.search(domain, limit=1)
+            domain = expression.AND([domain, [('order_id', '=', self.project_sale_order_id.id)]])
+        return domain
 
     def _get_timesheet(self):
         # return not invoiced timesheet and timesheet without so_line or so_line linked to task

--- a/addons/sale_timesheet/tests/__init__.py
+++ b/addons/sale_timesheet/tests/__init__.py
@@ -18,3 +18,4 @@ from . import test_sale_timesheet_accrued_entries
 from . import test_sale_timesheet_report
 from . import test_sale_timesheet_dashboard
 from . import test_task_analysis
+from . import test_performance

--- a/addons/sale_timesheet/tests/test_performance.py
+++ b/addons/sale_timesheet/tests/test_performance.py
@@ -1,0 +1,42 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.sale_timesheet.tests.test_sale_timesheet import TestSaleTimesheet
+from odoo.tests import tagged
+from odoo.fields import Command
+
+
+@tagged('post_install', '-at_install')
+class TestPerformanceTimesheet(TestSaleTimesheet):
+
+    def test_performance_billable_project_change_customer(self):
+        """
+            Use case: change the partner of a billable project containing many tasks having no SOL, which should trigger _compute_sale_line_id() of all tasks.
+            We check if the number of queries does not increase proportionally to the number of tasks.
+        """
+        project = self.env['project.project'].create({
+            'name': 'Perf Project',
+            'task_ids': [Command.create({'name': f'Task {i}'}) for i in range(50)]
+        })
+        self.assertFalse(project.task_ids.sale_line_id)
+        self.env.invalidate_all()
+        with self.assertQueryCount(80):
+            project.write({
+                'allow_billable': True,
+                'partner_id': self.partner_b.id,
+            })
+        self.assertTrue(project.task_ids.sale_line_id)
+
+        # Reset all tasks's SOL to False, double the number of tasks and run it again
+        project.allow_billable = False
+        self.assertFalse(project.task_ids.sale_line_id)
+        self.env['project.task'].create([{
+            'name': f'Task {i}',
+            'project_id': project.id,
+        } for i in range(50, 100)])
+        self.env.invalidate_all()
+        with self.assertQueryCount(130):
+            project.write({
+                'allow_billable': True,
+                'partner_id': self.partner_b.id,
+            })
+        self.assertTrue(project.task_ids.sale_line_id)


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Install Project, Timesheets and Sales apps
2. Create a billable project with many tasks (e.g. 10k) with a customer set. For maximum effect, the created tasks should not have any SOL defined.
3. Change the customer of the project

Other way to reproduce:
1. Install Project, Timesheets and Sales apps
2. Create a billable project with many tasks with a customer set. For maximum effect, the created tasks should not have any SOL defined.
3. Go to the list view of tasks in that project
4. Update the customer in all those tasks

Fix:
-------------------
The idea is to batch the RPC (search) made by the method "_get_last_sol_of_customer()". It benefits to cases where we compute the sale_line_id of many tasks whose commercial partner is the same. Avoiding to do an RPC for each task, we can now re-use the computed SOLs as we store them in a dictionary. As sale_line_id has "recursive=True", its compute method is called one record at a time, preventing any batch optimization. To cope with that, we add a new technical computed non-stored field "last_sol_of_customer" that will be able to compute the last SOLs of customers in batch and store the results in a dictionary to avoid doing the same RPC call multiple times. This new field can then be used to set the sale_line_id of tasks if no SOL was set before.

Remarks:
-------------------
As previously said, the optimization may only benefit cases where we change the partner of a project containing many tasks not having already their SOL that is set. A typical example is when a non-billable project is set to billable and we set a partner to it. Modifying the partner of multiple tasks in batch should also benefit from that optimization (again, if the SOL was not set on the tasks already).

Other cases will not benefit that much from the changes (when the SOL of most of the tasks is already defined) but we cannot really do other improvements like getting rid of the "recursive=True" of sale_line_id, as it is needed for handling the task hierarchy. The notifications created in the chatter when changing the customer or the SOL also take a lot of time (almost 50% of the time actually if there were many updates), especially when having more than 10k tasks.

Benchmark:
-------------------
- Usecase: Create 10k tasks in a project, make it billable, give it a partner, then save.
- Parameters: In local, run with "--limit-memory-soft=8589934592", "--limit-memory-hard=8589934592".
- Results: 
    Without optimization: 72 seconds, 56 756 queries
    With optimization:    46 seconds, 24 284 queries

task-4255293

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
