### PR TITLE
[FIX] {,website_}sale_product_configurator: shrink cart button 

### DIFF
--- a/addons/sale_product_configurator/i18n/sale_product_configurator.pot
+++ b/addons/sale_product_configurator/i18n/sale_product_configurator.pot
@@ -16,11 +16,6 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: sale_product_configurator
-#: model_terms:ir.ui.view,arch_db:sale_product_configurator.optional_product_items
-msgid "<i class=\"fa fa-shopping-cart add-optionnal-item\"/> Add to cart"
-msgstr ""
-
-#. module: sale_product_configurator
 #: model_terms:ir.ui.view,arch_db:sale_product_configurator.configure_optional_products
 msgid "<span class=\"label\">Price</span>"
 msgstr ""

--- a/addons/sale_product_configurator/views/templates.xml
+++ b/addons/sale_product_configurator/views/templates.xml
@@ -219,7 +219,9 @@
                         <span class="js_raw_price d-none" t-out="combination_info['price']" />
                         <p class="css_not_available_msg alert alert-warning">Option not available</p>
 
-                        <a role="button" href="#" class="js_add btn btn-primary btn-sm"><i class="fa fa-shopping-cart add-optionnal-item"></i> Add to cart</a>
+                        <a role="button" href="#" class="js_add btn btn-primary">
+                            <i class="fa fa-shopping-cart add-optionnal-item"/>
+                        </a>
                         <span class="js_remove d-none">
                             <a role="button" href="#" class="js_remove"><i class="fa fa-trash-o remove-optionnal-item"></i></a>
                         </span>


### PR DESCRIPTION
Versions
--------
- 16.0  _(sale_product_configurator)_
- 17.0+ _(website_sale_product_configurator)_

Steps
-----
1. Enable Dutch language;
2. go to eCommerce;
3. switch to mobile view;
4. go to a product which has optional products;
5. add to cart.

Issue
-----
There's not enough space in the configurator to properly display the "Toevoegen aan winkelmandje" button.

Cause
-----
The view isn't mobile-responsive.

Solution
--------
Replace the button with a simple cart icon to ensure consistency between localisations while keeping things simple.

opw-4198786