### PR TITLE
[FIX] web: check validity of unset required fields while saving records

### DIFF
--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -989,13 +989,13 @@ export class Record extends DataPoint {
                 this.data[fieldName]._abandonRecords();
             }
         }
+        if (!this._checkValidity({ displayNotification: true })) {
+            return false;
+        }
         const changes = this._getChanges();
         delete changes.id; // id never changes, and should not be written
         if (!creation && !Object.keys(changes).length) {
             return true;
-        }
-        if (!this._checkValidity({ displayNotification: true })) {
-            return false;
         }
         if (this.model._urgentSave && this.model.useSendBeaconToSaveUrgently) {
             // We are trying to save urgently because the user is closing the page. To

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -2842,46 +2842,6 @@ QUnit.module("Views", (hooks) => {
         assert.verifySteps(["openRecord", "openRecord"]);
     });
 
-    QUnit.test("open invalid but unchanged record", async function (assert) {
-        const listView = registry.category("views").get("list");
-        class CustomListController extends listView.Controller {
-            openRecord(record) {
-                assert.step("openRecord");
-                assert.strictEqual(record.resId, 2);
-                return super.openRecord(record);
-            }
-        }
-        registry.category("views").add("custom_list", {
-            ...listView,
-            Controller: CustomListController,
-        });
-
-        const list = await makeView({
-            type: "list",
-            resModel: "foo",
-            serverData,
-            arch: `
-                <tree js_class="custom_list">
-                    <field name="foo"/>
-                    <field name="date" required="1"/>
-                </tree>`,
-        });
-
-        patchWithCleanup(list.env.services.notification, {
-            add: () => {
-                throw new Error("should not display a notification");
-            },
-        });
-
-        // second record is invalid as date is not set
-        assert.strictEqual(
-            target.querySelector(".o_data_row:nth-child(2) .o_data_cell[name=date]").innerText,
-            ""
-        );
-        await click(target.querySelector(".o_data_row:nth-child(2) .o_data_cell"));
-        assert.verifySteps(["openRecord"]);
-    });
-
     QUnit.test(
         "execute an action before and after each valid save in a list view",
         async function (assert) {


### PR DESCRIPTION
We revert Commit fe4208c1ed7f9f59736d36930ba77541c19ffaeb as it allows to perform button actions on records with invalid datas. Notably because of unset required fields.

### Steps to reproduce:

- In the settings enable sbcontracting
- Create 2 storable products tracked by SN: Final Product (FP) and COMP
- Create a subcontracting BOM for FP with COMP as component
- On COMP set the route Resupply Subcontractor on Order
- Register 3 SN of COMP in stock: SN01, SN02, SN03
- Create and confirm a PO for your subcontractor for 3 units of FP
- Validate the Resupply picking
- Go to the reciept and click "Record components"
- Record your first Final product SN: FP01 (required)
- Continue
- Dont register any SN on the second and third recording
#### > Since you will not be able to edit this required field later on, the registration of such a SN should be required on FP.
#### > This leads to a softlock as the field is readonly afterwards.

### Cause of the Issue:

Since Commit fe4208c1ed7f9f59736d36930ba77541c19ffaeb, the `_checkValidity` of the `_save` call do not happen if we are not at record creation or if no change has been applied on the record. However, in our case, we are not at creation of the record and we did not perfom any change on the record form so that  the `_save` call will return `true` rather than the `false` he would return if he performed a `_checkValidity` of the record. This is a drastic difference since the returned value of this `_save` is used by the `formController` when you click a button in order to determine if he should proceed with the action or cancel the call:
https://github.com/odoo/odoo/blob/9b5eed7e215b2601c25b9d81c42dfa1bc1d06fee/addons/web/static/src/views/form/form_controller.js#L497-L510
https://github.com/odoo/odoo/blob/9b5eed7e215b2601c25b9d81c42dfa1bc1d06fee/addons/web/static/src/views/view_button/view_button_hook.js#L49-L60
In particular, in our case, the action will be called even thought the "required onchange" (and associated "websave") was never called. What I mean by "required onchange" is that the "lot_producing_id" is a required field of our form:
https://github.com/odoo/odoo/blob/4d5d270e72fdec49ffc31269642683b68984adca/addons/mrp_subcontracting/views/mrp_production_views.xml#L24-L27
Hence it needs to be set and provoke an onchange that will it self provoke a `web_save` of the new record value in the `_save` before it proceeds with the button action.

### Additional note on Commit fe4208c1ed7f9f59736d36930ba77541c19ffaeb:

This commit was initially added to avoid displaying Invalid Field notifications when you open a record with invalid data as a `_save` is also called in the `openRecord` of the `ListController` for instance. To me even in that case, it is usefull even if unnecessary to know that some record data's are currently invalid.

opw-4267852
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
