### PR TITLE
[FIX] hr_holidays: approval of allocation requests that require 2 approvers

### DIFF
--- a/addons/hr_holidays/data/hr_holidays_demo.xml
+++ b/addons/hr_holidays/data/hr_holidays_demo.xml
@@ -100,7 +100,7 @@
         <field name="date_from" eval="time.strftime('%Y-1-1')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
     </record>
-    <function model="hr.leave.allocation" name="action_validate">
+    <function model="hr.leave.allocation" name="action_approve">
         <value eval="[ref('hr_holidays_allocation_cl'), ref('hr_holidays_int_tour'), ref('hr_holidays_cl_allocation')]"/>
     </function>
 
@@ -173,7 +173,7 @@
         <field name="date_from" eval="time.strftime('%Y-1-1')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
     </record>
-    <function model="hr.leave.allocation" name="action_validate">
+    <function model="hr.leave.allocation" name="action_approve">
         <value eval="[ref('hr_holidays_allocation_cl_al'), ref('hr_holidays_allocation_pl_al'), ref('hr_holidays_vc_al')]"/>
     </function>
 
@@ -212,7 +212,7 @@
         <field name="date_from" eval="time.strftime('%Y-1-1')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
     </record>
-    <function model="hr.leave.allocation" name="action_validate">
+    <function model="hr.leave.allocation" name="action_approve">
         <value eval="[ref('hr_holidays_allocation_cl_mit')]"/>
     </function>
 
@@ -271,7 +271,7 @@
         <field name="date_from" eval="time.strftime('%Y-1-1')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
     </record>
-    <function model="hr.leave.allocation" name="action_validate">
+    <function model="hr.leave.allocation" name="action_approve">
         <value eval="[ref('hr_holidays.hr_holidays_allocation_cl_qdp'), ref('hr_holidays.hr_holidays_vc_qdp')]"/>
     </function>
 
@@ -311,7 +311,7 @@
         <field name="date_from" eval="time.strftime('%Y-1-1')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
     </record>
-    <function model="hr.leave.allocation" name="action_validate">
+    <function model="hr.leave.allocation" name="action_approve">
         <value eval="[ref('hr_holidays.hr_holidays_allocation_cl_fpi')]"/>
     </function>
 
@@ -346,7 +346,7 @@
         <field name="date_from" eval="time.strftime('%Y-1-1')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
     </record>
-    <function model="hr.leave.allocation" name="action_validate">
+    <function model="hr.leave.allocation" name="action_approve">
         <value eval="[ref('hr_holidays.hr_holidays_allocation_cl_vad'), ref('hr_holidays.hr_holidays_vc_vad')]"/>
     </function>
 

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -686,7 +686,7 @@ class HrLeaveAllocation(models.Model):
             if not self._context.get('import_file'):
                 allocation.activity_update()
             if allocation.validation_type == 'no_validation' and allocation.state == 'confirm':
-                allocation.action_validate()
+                allocation.action_approve()
         return allocations
 
     def write(self, values):
@@ -751,26 +751,6 @@ class HrLeaveAllocation(models.Model):
     # Business methods
     ####################################################
 
-    def action_validate(self):
-        if any(allocation.state not in ['confirm', 'validate1'] and allocation.validation_type != 'no_validation' for allocation in self):
-            raise UserError(_('Allocation must be "To Approve" or "Second Approval" in order to validate it.'))
-
-        to_validate = self.filtered(lambda alloc: alloc.state == 'confirm' and alloc.validation_type != 'both')
-        to_second_validate = self.filtered(lambda alloc: alloc.state == 'validate1' and alloc.validation_type == 'both')
-        if to_validate:
-            to_validate.write({
-                'state': 'validate',
-                'approver_id': self.env.user.employee_id.id
-            })
-            to_validate.activity_update()
-        if to_second_validate:
-            to_second_validate.write({
-                'state': 'validate',
-                'second_approver_id': self.env.user.employee_id.id
-            })
-            to_second_validate.activity_update()
-        return True
-
     def action_set_to_confirm(self):
         if any(allocation.state != 'refuse' for allocation in self):
             raise UserError(_('Allocation state must be "Refused" in order to be reset to "To Approve".'))
@@ -783,17 +763,21 @@ class HrLeaveAllocation(models.Model):
         return True
 
     def action_approve(self):
-        # if allocation_validation_type == 'both': this method is the first approval
-        # if allocation_validation_type != 'both': this method calls action_validate() below
 
-        if any(allocation.validation_type != 'no_validation' and allocation.state != 'confirm' for allocation in self):
-            raise UserError(_('Allocation must be confirmed ("To Approve") in order to approve it.'))
+        if any(allocation.state not in ['confirm', 'validate1'] and allocation.validation_type != 'no_validation' for allocation in self):
+            raise UserError(_('Allocation must be "To Approve" or "Second Approval" in order to approve it.'))
 
         current_employee = self.env.user.employee_id
-        self.filtered(lambda alloc: alloc.validation_type == 'both').write({'state': 'validate1', 'approver_id': current_employee.id})
+        single_validate_allocs = self.filtered(lambda alloc: alloc.state == 'confirm' and alloc.validation_type != 'both')
+        first_validate_allocs = self.filtered(lambda alloc: alloc.state == 'confirm' and alloc.validation_type == 'both')
+        second_validate_allocs = self.filtered(lambda alloc: alloc.state == 'validate1' and alloc.validation_type == 'both')
 
-        self.filtered(lambda alloc: alloc.validation_type != 'both').action_validate()
+        single_validate_allocs.write({'state': 'validate', 'approver_id': current_employee.id})
+        first_validate_allocs.write({'state': 'validate1', 'approver_id': current_employee.id})
+        second_validate_allocs.write({'state': 'validate', 'second_approver_id': current_employee.id})
+
         self.activity_update()
+
         return True
 
     def action_refuse(self):

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -119,7 +119,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'number_of_days': 0,
                 'allocation_type': 'accrual',
             })
-            allocation.action_validate()
+            allocation.action_approve()
             self.assertFalse(allocation.nextcall, 'There should be no nextcall set on the allocation.')
             self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
             allocation._update_accrual()
@@ -157,7 +157,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'number_of_days': 0,
                 'allocation_type': 'accrual',
             })
-            allocation.action_validate()
+            allocation.action_approve()
             self.assertFalse(allocation.nextcall, 'There should be no nextcall set on the allocation.')
             self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
             allocation._update_accrual()
@@ -212,7 +212,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'number_of_days': 0,
                 'allocation_type': 'accrual',
             })
-            allocation.action_validate()
+            allocation.action_approve()
             self.assertFalse(allocation.nextcall, 'There should be no nextcall set on the allocation.')
             self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
             allocation._update_accrual()
@@ -251,7 +251,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'date_from': '2021-09-03',
             })
             with freeze_time(datetime.date.today() + relativedelta(days=2)):
-                allocation.action_validate()
+                allocation.action_approve()
                 self.assertFalse(allocation.nextcall, 'There should be no nextcall set on the allocation.')
                 self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
                 allocation._update_accrual()
@@ -297,7 +297,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'date_from': '2021-09-03',
             })
             self.setAllocationCreateDate(allocation.id, '2021-09-01 00:00:00')
-            allocation.action_validate()
+            allocation.action_approve()
             self.assertFalse(allocation.nextcall, 'There should be no nextcall set on the allocation.')
             self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
             allocation._update_accrual()
@@ -340,7 +340,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'date_from': '2021-08-31',
             })
             self.setAllocationCreateDate(allocation.id, '2021-09-01 00:00:00')
-            allocation.action_validate()
+            allocation.action_approve()
             self.assertFalse(allocation.nextcall, 'There should be no nextcall set on the allocation.')
             self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
             allocation._update_accrual()
@@ -378,7 +378,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'allocation_type': 'accrual',
             })
             self.setAllocationCreateDate(allocation.id, '2021-09-01 00:00:00')
-            allocation.action_validate()
+            allocation.action_approve()
             self.assertFalse(allocation.nextcall, 'There should be no nextcall set on the allocation.')
             self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
             allocation._update_accrual()
@@ -421,7 +421,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'allocation_type': 'accrual',
             })
             self.setAllocationCreateDate(allocation.id, '2021-09-01 00:00:00')
-            allocation.action_validate()
+            allocation.action_approve()
             self.assertFalse(allocation.nextcall, 'There should be no nextcall set on the allocation.')
             self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
             allocation._update_accrual()
@@ -515,7 +515,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'allocation_type': 'accrual',
                 'state': 'confirm',
             })
-            (allocation_not_worked_time | allocation_worked_time).action_validate()
+            (allocation_not_worked_time | allocation_worked_time).action_approve()
             self.setAllocationCreateDate(allocation_not_worked_time.id, '2021-08-01 00:00:00')
             self.setAllocationCreateDate(allocation_worked_time.id, '2021-08-01 00:00:00')
             leave_type = self.env['hr.leave.type'].create({
@@ -580,7 +580,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'number_of_days': 0,
                 'allocation_type': 'accrual',
             })
-            allocation.action_validate()
+            allocation.action_approve()
             allocation._update_accrual()
             tomorrow = datetime.date.today() + relativedelta(days=2)
             self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet. The accrual starts tomorrow.')
@@ -620,7 +620,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'number_of_days': 0,
                 'allocation_type': 'accrual',
             })
-            allocation.action_validate()
+            allocation.action_approve()
             allocation._update_accrual()
             tomorrow = datetime.date.today() + relativedelta(days=2)
             self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet. The accrual starts tomorrow.')
@@ -669,7 +669,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'number_of_days': 0,
                 'allocation_type': 'accrual',
             })
-            allocation.action_validate()
+            allocation.action_approve()
             next_date = datetime.date.today() + relativedelta(days=11)
             second_level = self.env['hr.leave.accrual.level'].search([('accrual_plan_id', '=', accrual_plan.id), ('start_count', '=', 10)])
             self.assertEqual(allocation._get_current_accrual_plan_level_id(next_date)[0], second_level, 'The second level should be selected')
@@ -705,7 +705,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'number_of_days': 0,
                 'allocation_type': 'accrual',
             })
-            allocation.action_validate()
+            allocation.action_approve()
             next_date = datetime.date.today() + relativedelta(days=11)
             second_level = self.env['hr.leave.accrual.level'].search([('accrual_plan_id', '=', accrual_plan.id), ('start_count', '=', 10)])
             self.assertEqual(allocation._get_current_accrual_plan_level_id(next_date)[0], second_level, 'The second level should be selected')
@@ -755,7 +755,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'number_of_days': 10,
                 'allocation_type': 'accrual',
             })
-            allocation.action_validate()
+            allocation.action_approve()
 
         # Reset the cron's lastcall
         accrual_cron = self.env['ir.cron'].sudo().env.ref('hr_holidays.hr_leave_allocation_cron_accrual')
@@ -790,7 +790,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'number_of_days': 10,
                 'allocation_type': 'accrual',
             })
-            allocation.action_validate()
+            allocation.action_approve()
 
         # Reset the cron's lastcall
         accrual_cron = self.env['ir.cron'].sudo().env.ref('hr_holidays.hr_leave_allocation_cron_accrual')
@@ -823,7 +823,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'number_of_days': 0,
                 'allocation_type': 'accrual',
             })
-            allocation.action_validate()
+            allocation.action_approve()
 
         # Reset the cron's lastcall
         accrual_cron = self.env['ir.cron'].sudo().env.ref('hr_holidays.hr_leave_allocation_cron_accrual')
@@ -883,7 +883,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'number_of_days': 10,
                 'allocation_type': 'accrual',
             })
-            allocation.action_validate()
+            allocation.action_approve()
 
         # Reset the cron's lastcall
         accrual_cron = self.env['ir.cron'].sudo().env.ref('hr_holidays.hr_leave_allocation_cron_accrual')
@@ -937,7 +937,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'number_of_days': 0,
                 'allocation_type': 'accrual',
             })
-            allocation.action_validate()
+            allocation.action_approve()
 
         # Reset the cron's lastcall
         accrual_cron = self.env['ir.cron'].sudo().env.ref('hr_holidays.hr_leave_allocation_cron_accrual')
@@ -981,7 +981,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'allocation_type': 'accrual',
                 'date_from': datetime.date(2020, 8, 16),
             })
-            allocation.action_validate()
+            allocation.action_approve()
         with freeze_time('2022-1-10'):
             allocation._update_accrual()
         self.assertAlmostEqual(allocation.number_of_days, 30.82, 2, "Invalid number of days")
@@ -1029,7 +1029,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'allocation_type': 'accrual',
                 'date_from': datetime.date(2022, 1, 31),
             })
-            allocation.action_validate()
+            allocation.action_approve()
         with freeze_time('2022-7-20'):
             allocation._update_accrual()
         # The first level gives 3 days
@@ -1100,7 +1100,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'allocation_type': 'accrual',
                 'date_from': datetime.date(2021, 1, 1),
             })
-            allocation.action_validate()
+            allocation.action_approve()
         with freeze_time('2022-4-4'):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 4, "Invalid number of days")
@@ -1153,7 +1153,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'allocation_type': 'accrual',
                 'date_from': datetime.date(2019, 1, 1),
             })
-            allocation.action_validate()
+            allocation.action_approve()
 
         with freeze_time('2022-4-1'):
             allocation._update_accrual()
@@ -1184,7 +1184,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             })
 
         with freeze_time("2021-10-3"):
-            allocation.action_validate()
+            allocation.action_approve()
             allocation._update_accrual()
 
             self.assertEqual(allocation.number_of_days, 5, "Should accrue maximum 5 days")
@@ -1213,7 +1213,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             })
 
         with freeze_time("2021-10-3"):
-            allocation.action_validate()
+            allocation.action_approve()
             allocation._update_accrual()
 
             self.assertEqual(allocation.number_of_days, 29, "No limits for accrued days")
@@ -1242,7 +1242,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'allocation_type': 'accrual',
                 'date_from': '2022-01-01',
             })
-            allocation.action_validate()
+            allocation.action_approve()
 
         with freeze_time("2022-3-2"):
             allocation._update_accrual()
@@ -1286,7 +1286,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'allocation_type': 'accrual',
                 'date_from': '2022-01-01',
             })
-            allocation.action_validate()
+            allocation.action_approve()
 
         with freeze_time(datetime.date(2022, 4, 1)):
             allocation._update_accrual()
@@ -1450,7 +1450,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'allocation_type': 'accrual',
                 'date_from': '2023-04-24',
             })
-            allocation.action_validate()
+            allocation.action_approve()
 
             allocation._update_accrual()
 
@@ -1467,7 +1467,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'allocation_type': 'accrual',
                 'date_from': '2023-04-24',
             })
-            allocation.action_validate()
+            allocation.action_approve()
 
             allocation._update_accrual()
 
@@ -1498,7 +1498,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'allocation_type': 'accrual',
                 'date_from': '2023-04-13',
             })
-            allocation.action_validate()
+            allocation.action_approve()
             allocation._update_accrual()
 
         self.assertAlmostEqual(allocation.number_of_days, 1.5, 2)
@@ -1544,7 +1544,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'allocation_type': 'accrual',
                 'date_from': '2023-04-26',
             })
-            allocation.action_validate()
+            allocation.action_approve()
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 1, "Should accrue 1 day, at the start of the period.")
 
@@ -1583,7 +1583,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'allocation_type': 'accrual',
                 'date_from': '2023-04-26',
             })
-            allocation.action_validate()
+            allocation.action_approve()
             allocation._update_accrual()
         self.assertAlmostEqual(allocation.number_of_days, 0.03, 2, "Should accrue 0.03 days, accrued_gain_time == start.")
 
@@ -1632,7 +1632,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'allocation_type': 'accrual',
                 'date_from': '2023-04-20',
             })
-            allocation.action_validate()
+            allocation.action_approve()
 
         with freeze_time("2024-04-20"):
             allocation._update_accrual()
@@ -1752,7 +1752,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'allocation_type': 'accrual',
                 'date_from': '2023-04-4',
             })
-            allocation.action_validate()
+            allocation.action_approve()
 
         with freeze_time("2026-08-01"):
             allocation._update_accrual()
@@ -1783,7 +1783,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             })
             # As the duration is set to a onchange, we need to force that onchange to run
             accrual_allocation._onchange_date_from()
-            accrual_allocation.action_validate()
+            accrual_allocation.action_approve()
             # The amount of days should be computed as if it was accrued since
             # the start date of the allocation.
             self.assertAlmostEqual(accrual_allocation.number_of_days, 34.0, places=0)
@@ -1825,7 +1825,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'number_of_days': 0.125,
                 'allocation_type': 'accrual',
             })
-            allocation.action_validate()
+            allocation.action_approve()
             allocation_data = leave_type.get_allocation_data(self.employee_emp, datetime.date(2024, 2, 1))
             self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 2)
 
@@ -1880,7 +1880,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             })
             # As the duration is set to a onchange, we need to force that onchange to run
             accrual_allocation._onchange_date_from()
-            accrual_allocation.action_validate()
+            accrual_allocation.action_approve()
             # The amount of days should be computed as if it was accrued since
             # the start date of the allocation.
             self.assertEqual(accrual_allocation.number_of_days, 31.0, "The allocation should have given 31 days")
@@ -1992,7 +1992,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 f.name = "Employee Allocation"
 
             accrual_allocation = f.record
-            accrual_allocation.action_validate()
+            accrual_allocation.action_approve()
             self.assertAlmostEqual(accrual_allocation.number_of_days, 3.0, places=0)
 
         with freeze_time('2024-04-01'):
@@ -2033,7 +2033,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'number_of_days': 3,
             }
         ])
-        allocations.action_validate()
+        allocations.action_approve()
         leave = self.env['hr.leave'].create({
                 'name': 'Leave',
                 'employee_id': self.employee_emp.id,
@@ -2158,7 +2158,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'number_of_days': 10,
                 'allocation_type': 'regular',
             })
-            allocation.action_validate()
+            allocation.action_approve()
 
             self.assertEqual(allocation.lastcall, False)
 
@@ -2207,7 +2207,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 f.name = "Accrual allocation for employee"
 
             allocation = f.record
-            allocation.action_validate()
+            allocation.action_approve()
 
             first_result = get_remaining_leaves(2024, 2, 21)
             self.assertEqual(get_remaining_leaves(2024, 2, 21), first_result, "Function return result should persist")
@@ -2249,7 +2249,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 f.name = "Accrual allocation for employee"
 
             allocation = f.record
-            allocation.action_validate()
+            allocation.action_approve()
             self.assertEqual(get_remaining_leaves(2024, 3, 1), 10, "The cap is reached, no more leaves should be accrued")
 
             leave = self.env['hr.leave'].create({
@@ -2285,7 +2285,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'allocation_type': 'regular',
         })
 
-        allocation.action_validate()
+        allocation.action_approve()
         with self.assertRaises(ValidationError):
             self.env['hr.leave'].create([{
                 'employee_id': self.employee_emp.id,
@@ -2435,7 +2435,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'accrual_plan_id': accrual_plan.id,
                 'date_from': datetime.date(2024, 1, 1)
             })
-            allocation.action_validate()
+            allocation.action_approve()
 
         with freeze_time('2025-1-01'):
             allocation._update_accrual()
@@ -2496,7 +2496,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'accrual_plan_id': accrual_plan.id,
                 'date_from': datetime.date(2024, 1, 1)
             })
-            allocation.action_validate()
+            allocation.action_approve()
 
         with freeze_time('2025-1-01'):
             allocation._update_accrual()
@@ -2567,7 +2567,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'accrual_plan_id': accrual_plan.id,
                 'date_from': datetime.date(2024, 1, 1)
             })
-            allocation.action_validate()
+            allocation.action_approve()
 
         with freeze_time('2025-1-01'):
             allocation._update_accrual()
@@ -2648,7 +2648,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'accrual_plan_id': accrual_plan.id,
                 'date_from': datetime.date(2024, 1, 1)
             })
-            allocation.action_validate()
+            allocation.action_approve()
 
         with freeze_time('2024-5-01'):
             allocation._update_accrual()
@@ -2738,7 +2738,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'accrual_plan_id': accrual_plan.id,
                 'date_from': datetime.date(2024, 1, 1)
             })
-            allocation.action_validate()
+            allocation.action_approve()
 
         with freeze_time('2024-1-01'):
             allocation._update_accrual()
@@ -2836,7 +2836,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'number_of_days': 0,
                 'allocation_type': 'accrual',
             })
-            allocation.action_validate()
+            allocation.action_approve()
 
         with freeze_time('2024-04-01'):
             allocation._update_accrual()
@@ -2904,7 +2904,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'number_of_days': 0,
                 'allocation_type': 'accrual',
             })
-            allocation.action_validate()
+            allocation.action_approve()
 
         with freeze_time('2024-04-01'):
             allocation._update_accrual()
@@ -2977,7 +2977,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'number_of_days': 0,
                 'allocation_type': 'accrual',
             })
-            allocation.action_validate()
+            allocation.action_approve()
 
         with freeze_time('2024-05-01'):
             allocation._update_accrual()
@@ -3037,7 +3037,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'number_of_days': 0,
                 'allocation_type': 'accrual',
             })
-            allocation.action_validate()
+            allocation.action_approve()
 
         with freeze_time('2024-05-01'):
             allocation._update_accrual()
@@ -3098,7 +3098,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'number_of_days': 0,
                 'allocation_type': 'accrual',
             })
-            allocation.action_validate()
+            allocation.action_approve()
 
         with freeze_time('2024-05-01'):
             allocation._update_accrual()
@@ -3160,7 +3160,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'number_of_days': 0,
                 'allocation_type': 'accrual',
             })
-            allocation.action_validate()
+            allocation.action_approve()
 
         with freeze_time('2025-01-01'):
             allocation._update_accrual()
@@ -3225,7 +3225,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'number_of_days': 0,
                 'allocation_type': 'accrual',
             })
-            allocation.action_validate()
+            allocation.action_approve()
 
         with freeze_time('2024-07-01'):
             allocation._update_accrual()
@@ -3305,7 +3305,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'number_of_days': 0,
                 'allocation_type': 'accrual',
             })
-            allocation.action_validate()
+            allocation.action_approve()
 
         with freeze_time('2024-01-01'):
             allocation._update_accrual()
@@ -3460,7 +3460,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'allocation_type': 'accrual',
             })
 
-            allocation.action_validate()
+            allocation.action_approve()
             allocation._update_accrual()
             self.assertAlmostEqual(allocation.number_of_days, 1.21, 2, 'Days for the current month should be granted immediately')
 
@@ -3507,7 +3507,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'number_of_days': 0,
                 'allocation_type': 'accrual',
             })
-            allocation.action_validate()
+            allocation.action_approve()
             allocation._update_accrual()
 
             leave = self.env['hr.leave'].create({

--- a/addons/hr_holidays/tests/test_allocation_access_rights.py
+++ b/addons/hr_holidays/tests/test_allocation_access_rights.py
@@ -57,7 +57,7 @@ class TestAccessRightsSimpleUser(TestAllocationRights):
         }
         allocation = self.request_allocation(self.user_employee.id, values)
         with self.assertRaises(UserError):
-            allocation.action_validate()
+            allocation.action_approve()
 
     def test_simple_user_request_allocation_no_validation(self):
         """ A simple user can request and automatically validate an allocation with no validation """
@@ -113,7 +113,7 @@ class TestAccessRightsEmployeeManager(TestAllocationRights):
             'holiday_status_id': self.lt_validation_manager.id,
         }
         allocation = self.request_allocation(self.user_employee.id, values)
-        allocation.action_validate()
+        allocation.action_approve()
         self.assertEqual(allocation.state, 'validate', "The allocation should be validated")
 
     def test_manager_refuse_request_allocation(self):
@@ -134,7 +134,7 @@ class TestAccessRightsEmployeeManager(TestAllocationRights):
         }
         allocation = self.request_allocation(self.user_employee.id, values)
         with self.assertRaises(UserError):
-            allocation.action_validate()
+            allocation.action_approve()
 
 class TestAccessRightsHolidayUser(TestAllocationRights):
 
@@ -145,7 +145,7 @@ class TestAccessRightsHolidayUser(TestAllocationRights):
             'holiday_status_id': self.lt_validation_manager.id,
         }
         allocation = self.request_allocation(self.user_hruser.id, values)
-        allocation.action_validate()
+        allocation.action_approve()
         self.assertEqual(allocation.state, 'validate', "It should have been validated")
 
     def test_holiday_user_cannot_approve_own(self):
@@ -156,7 +156,7 @@ class TestAccessRightsHolidayUser(TestAllocationRights):
         }
         allocation = self.request_allocation(self.user_hruser.id, values)
         with self.assertRaises(UserError):
-            allocation.action_validate()
+            allocation.action_approve()
 
 
 class TestAccessRightsHolidayManager(TestAllocationRights):
@@ -168,7 +168,7 @@ class TestAccessRightsHolidayManager(TestAllocationRights):
             'holiday_status_id': self.lt_validation_manager.id,
         }
         allocation = self.request_allocation(self.user_hrmanager.id, values)
-        allocation.action_validate()
+        allocation.action_approve()
         self.assertEqual(allocation.state, 'validate', "It should have been validated")
 
     def test_holiday_manager_refuse_validated(self):
@@ -178,7 +178,7 @@ class TestAccessRightsHolidayManager(TestAllocationRights):
             'holiday_status_id': self.lt_validation_manager.id,
         }
         allocation = self.request_allocation(self.user_hrmanager.id, values)
-        allocation.action_validate()
+        allocation.action_approve()
         self.assertEqual(allocation.state, 'validate', "It should have been validated")
         allocation.action_refuse()
         self.assertEqual(allocation.state, 'refuse', "It should have been refused")

--- a/addons/hr_holidays/tests/test_allocations.py
+++ b/addons/hr_holidays/tests/test_allocations.py
@@ -235,7 +235,7 @@ class TestAllocations(TestHrHolidaysCommon):
             'employee_id': self.employee.id,
             'date_from': date(2024, 1, 1),
         })
-        allocation.action_validate()
+        allocation.action_approve()
 
         leave_request = self.env['hr.leave'].create({
             'name': 'Leave Request',
@@ -261,7 +261,7 @@ class TestAllocations(TestHrHolidaysCommon):
             'date_from': date(2024, 1, 1),
             'date_to': date(2024, 1, 30),
         })
-        allocation_one.action_validate()
+        allocation_one.action_approve()
 
         # Creating the second overlapping allocation
         allocation_two = self.env['hr.leave.allocation'].create({
@@ -272,7 +272,7 @@ class TestAllocations(TestHrHolidaysCommon):
             'date_from': date(2024, 1, 20),
             'date_to': date(2024, 2, 20),
         })
-        allocation_two.action_validate()
+        allocation_two.action_approve()
 
         # Creating a leave request consuming days from both allocations
         leave_request = self.env['hr.leave'].create({
@@ -308,7 +308,7 @@ class TestAllocations(TestHrHolidaysCommon):
             'date_from': date(2024, 1, 1),
             'date_to': date(2024, 4, 30)
         })
-        allocation.action_validate()
+        allocation.action_approve()
 
         second_allocation = self.env['hr.leave.allocation'].sudo().create({
             'name': 'Alloc2',
@@ -319,7 +319,7 @@ class TestAllocations(TestHrHolidaysCommon):
             'date_from': date(2024, 5, 1),
             'date_to': date(2024, 12, 31)
         })
-        second_allocation.action_validate()
+        second_allocation.action_approve()
         result = self.env['hr.leave.type'].with_context(
             employee_id=self.employee.id,
             default_date_from='2024-08-18 06:00:00',

--- a/addons/hr_holidays/tests/test_holidays_flow.py
+++ b/addons/hr_holidays/tests/test_holidays_flow.py
@@ -109,7 +109,7 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
                     'state': 'confirm',
                     'date_from': time.strftime('%Y-%m-01'),
                 }
-            ]).action_validate()
+            ]).action_approve()
 
             def _check_holidays_status(holiday_status, employee, ml, lt, rl, vrl):
                 result = holiday_status.get_allocation_data(employee)[employee][0][1]
@@ -152,7 +152,7 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
             self.env.flush_all()
 
             # HrManager validates the second step
-            aloc1_user_group.with_user(self.user_hrmanager_id).action_validate()
+            aloc1_user_group.with_user(self.user_hrmanager_id).action_approve()
             # Checks Employee has effectively some days left
             hol_status_2_employee_group = self.holidays_status_limited.with_user(self.user_employee_id)
             _check_holidays_status(hol_status_2_employee_group, self.employee_emp, 2.0, 0.0, 2.0, 2.0)
@@ -251,7 +251,7 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
             'state': 'confirm',
             'date_from': time.strftime('%Y-%m-01'),
             'date_to': time.strftime('%Y-12-31'),
-        }).action_validate()
+        }).action_approve()
 
         leave_vals = {
             'name': 'Sick Time Off',

--- a/addons/hr_holidays/tests/test_holidays_mail.py
+++ b/addons/hr_holidays/tests/test_holidays_mail.py
@@ -39,7 +39,7 @@ class TestHolidaysMail(TestHrHolidaysCommon, MailCase):
                     'state': 'confirm',
                     'date_from': time.strftime('%Y-%m-01'),
                 }
-            ]).action_validate()
+            ]).action_approve()
 
             leave_vals = {
                 'name': 'Sick Time Off',

--- a/addons/hr_holidays/tests/test_hr_departure_wizard.py
+++ b/addons/hr_holidays/tests/test_hr_departure_wizard.py
@@ -82,7 +82,7 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
             'state': 'confirm',
             'date_from': self.departure_date + timedelta(days=-10),
             'date_to': self.departure_date,
-        }]).action_validate()
+        }]).action_approve()
         self._check_action_departure()
 
     def test_departure_allocation_after_departure_date(self):
@@ -94,7 +94,7 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
             'state': 'confirm',
             'date_from': self.departure_date + timedelta(days=1),
             'date_to': self.departure_date + timedelta(days=10),
-        }]).action_validate()
+        }]).action_approve()
         self._check_action_departure()
 
     def test_departure_allocation_with_departure_date(self):
@@ -107,7 +107,7 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
             'date_from': self.departure_date + timedelta(days=-10),
             'date_to': self.departure_date + timedelta(days=10),
         }])
-        allocation.action_validate()
+        allocation.action_approve()
         self._check_action_departure()
 
         allocation_msg = '<p>Validity End date has been updated because the employee will leave the company on %(departure_date)s.</p>' % {

--- a/addons/hr_holidays/tests/test_hr_leave_type.py
+++ b/addons/hr_holidays/tests/test_hr_leave_type.py
@@ -62,7 +62,7 @@ class TestHrLeaveType(TestHrHolidaysCommon):
             'employee_id': employee.id,
             'date_from': '2024-08-19',
             'date_to': '2024-08-20',
-        }).action_validate()
+        }).action_approve()
 
         leave_types = self.env['hr.leave.type'].with_context(
             default_date_from='2024-08-20 21:00:00',

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -123,7 +123,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
                 'date_to': time.strftime('%Y-12-31'),
             })
 
-            allocation.action_validate()
+            allocation.action_approve()
 
             # Employee cannot take a leave longer than the allocation
             with self.assertRaises(ValidationError):
@@ -162,7 +162,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
                 'date_from': time.strftime('%Y-1-1'),
                 'date_to': time.strftime('%Y-12-31'),
             })
-            allocation.action_validate()
+            allocation.action_approve()
 
             holiday_status = self.holidays_type_2.with_user(self.user_employee_id)
             self._check_holidays_status(holiday_status, self.employee_emp, 2.0, 0.0, 2.0, 2.0)
@@ -195,7 +195,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             'date_to': fields.Datetime.from_string('2017-06-01 00:00:00'),
             'number_of_days': 10,
         })
-        allocation.action_validate()
+        allocation.action_approve()
 
         self.env['hr.leave'].with_user(self.user_employee_id).create({
             'name': 'Valid time period',
@@ -490,7 +490,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             'date_from': '2020-01-01',
             'date_to': '2020-12-31',
         })
-        allocation.action_validate()
+        allocation.action_approve()
 
         with self.assertRaises(ValidationError):
             self.env['hr.leave'].with_user(self.user_employee_id).create({
@@ -519,7 +519,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             'date_from': '2020-01-01',
             'date_to': '2020-12-31',
         })
-        allocation_one.action_validate()
+        allocation_one.action_approve()
         allocation_two = self.env['hr.leave.allocation'].create({
             'name': 'Expired Allocation',
             'employee_id': self.employee_emp_id,
@@ -529,7 +529,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             'date_from': '2021-01-01',
             'date_to': '2021-12-31',
         })
-        allocation_two.action_validate()
+        allocation_two.action_approve()
         # Try creating a request that could be validated if allocation1 was still valid
         with self.assertRaises(ValidationError):
             self.env['hr.leave'].with_user(self.user_employee_id).create({
@@ -631,10 +631,10 @@ class TestLeaveRequests(TestHrHolidaysCommon):
 
             allocation_vals.update({'number_of_days': 4})
             allocation_4days = Allocation.create(allocation_vals)
-            allocation_4days.action_validate()
+            allocation_4days.action_approve()
             allocation_vals.update({'number_of_days': 1})
             allocation_1day = Allocation.create(allocation_vals)
-            allocation_1day.action_validate()
+            allocation_1day.action_approve()
             allocations = (allocation_4days + allocation_1day)
 
             leave_vals.update({
@@ -803,7 +803,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
                 'date_from': '2020-01-01',
                 'date_to': '2020-12-31',
             })
-            allocation.action_validate()
+            allocation.action_approve()
             self.env['hr.leave'].with_user(self.user_employee_id).create({
                 'name': 'Holiday Request',
                 'employee_id': self.employee_emp_id,
@@ -828,7 +828,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
                 'date_from': '2021-06-01',
                 'date_to': '2021-12-31',
             })
-            allocation_2021.action_validate()
+            allocation_2021.action_approve()
 
             allocation_2022 = self.env['hr.leave.allocation'].create({
                 'name': 'Annual Time Off 2022',
@@ -839,7 +839,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
                 'date_from': '2022-01-01',
                 'date_to': '2022-12-31',
             })
-            allocation_2022.action_validate()
+            allocation_2022.action_approve()
 
             # Leave taken in 2021
             leave_2021 = self.env['hr.leave'].with_user(self.user_employee_id).create({
@@ -961,7 +961,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             },
         ])
 
-        allocations.action_validate()
+        allocations.action_approve()
 
         trigger_error_leave = {
             'name': 'Holiday Request',
@@ -1132,7 +1132,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             'date_from': '2024-01-01',
             'date_to': '2024-12-31',
         })
-        allocation.action_validate()
+        allocation.action_approve()
         self.env['hr.leave'].with_user(self.user_employee_id).create({
             'name': 'Holiday Request',
             'employee_id': employee.id,
@@ -1174,7 +1174,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             'holiday_status_id': self.holidays_type_2.id,
             'allocation_type': 'regular'
         })
-        allocation.action_validate()
+        allocation.action_approve()
 
         self.assertEqual(allocation.state, 'validate')
 

--- a/addons/hr_holidays/tests/test_negative.py
+++ b/addons/hr_holidays/tests/test_negative.py
@@ -31,7 +31,7 @@ class TestNegative(TestHrHolidaysCommon):
             'date_to': '2022-12-31',
             'number_of_days': 1,
         })
-        cls.allocation_2022.action_validate()
+        cls.allocation_2022.action_approve()
 
         cls.allocation_2023 = cls.env['hr.leave.allocation'].create({
             'employee_id': cls.employee_emp_id,
@@ -39,7 +39,7 @@ class TestNegative(TestHrHolidaysCommon):
             'date_from': '2023-01-01',
             'number_of_days': 5,
         })
-        cls.allocation_2023.action_validate()
+        cls.allocation_2023.action_approve()
 
     def test_negative_time_off(self):
         with freeze_time('2022-10-02'):

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -188,7 +188,7 @@
             <field name="state" position="before">
                 <button string="Approve" name="action_approve"
                     invisible="not can_approve or state != 'confirm' or not active_employee" type="object" class="oe_highlight"/>
-                <button string="Validate" name="action_validate"
+                <button string="Validate" name="action_approve"
                     invisible="state != 'validate1' or not active_employee" type="object" class="oe_highlight"/>
                 <button string="Refuse" name="action_refuse" type="object"
                     invisible="not can_approve or state not in ('confirm', 'validate1','validate') or not active_employee"/>
@@ -290,7 +290,7 @@
                     icon="fa-thumbs-up"
                     invisible="state != 'confirm'"
                     groups="hr_holidays.group_hr_holidays_responsible"/>
-                <button string="Validate" name="action_validate" type="object"
+                <button string="Validate" name="action_approve" type="object"
                     icon="fa-check"
                     invisible="state != 'validate1'"
                     groups="hr_holidays.group_hr_holidays_responsible"/>
@@ -316,7 +316,7 @@
             <xpath expr="//field[@name='department_id']" position="attributes">
                 <attribute name="column_invisible">1</attribute>
             </xpath>
-            <xpath expr="//button[@name='action_validate']" position="attributes">
+            <xpath expr="//button[@name='action_approve']" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
             <xpath expr="//button[@name='action_refuse']" position="attributes">
@@ -398,7 +398,7 @@
                                 <span t-attf-class="badge rounded-pill {{ classname }}"><field name="state"/></span>
                             </div>
                             <div t-if="record.can_approve.raw_value and record.state.raw_value === 'confirm'">
-                                <button name="action_validate" type="object" class="btn btn-link btn-sm ps-0">
+                                <button name="action_approve" type="object" class="btn btn-link btn-sm ps-0">
                                     <i class="fa fa-check"/> Validate
                                 </button>
                                 <button name="action_refuse" type="object" class="btn btn-link btn-sm ps-0">
@@ -502,7 +502,7 @@
         <field name="state">code</field>
         <field name="code">
             if records:
-                records.action_validate()
+                records.action_approve()
         </field>
     </record>
 </odoo>

--- a/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard.py
+++ b/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard.py
@@ -94,7 +94,7 @@ class HrLeaveAllocationGenerateMultiWizard(models.TransientModel):
                 mail_notify_force_send=False,
                 mail_activity_automation_skip=True
             ).create(vals_list)
-            allocations.filtered(lambda c: c.validation_type != 'no_validation').action_validate()
+            allocations.filtered(lambda c: c.validation_type != 'no_validation').action_approve()
 
             return {
                 'type': 'ir.actions.act_window',

--- a/addons/hr_holidays_attendance/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays_attendance/tests/test_accrual_allocations.py
@@ -47,7 +47,7 @@ class TestAccrualAllocationsAttendance(TestHrHolidaysCommon):
                 'number_of_days': 0,
                 'allocation_type': 'accrual',
             })
-            allocation.action_validate()
+            allocation.action_approve()
             self.assertFalse(allocation.nextcall, 'There should be no nextcall set on the allocation.')
             self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
             allocation._update_accrual()

--- a/addons/hr_holidays_contract/tests/test_multi_contract.py
+++ b/addons/hr_holidays_contract/tests/test_multi_contract.py
@@ -201,7 +201,7 @@ class TestHolidaysMultiContract(TestHolidayContract):
             'date_from': datetime.strptime('2023-01-01', '%Y-%m-%d').date(),
             'date_to': datetime.strptime('2023-12-31', '%Y-%m-%d').date(),
         })
-        allocation.action_validate()
+        allocation.action_approve()
         leave_during_full_time, leave_during_partial_time = self.env['hr.leave'].create([
             {
                 'employee_id': employee.id,

--- a/addons/l10n_fr_hr_holidays/data/l10n_fr_hr_holidays_demo.xml
+++ b/addons/l10n_fr_hr_holidays/data/l10n_fr_hr_holidays_demo.xml
@@ -65,7 +65,7 @@
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
         <field name="employee_id" ref="l10n_fr_part_time_employee"/>
     </record>
-    <function model="hr.leave.allocation" name="action_validate">
+    <function model="hr.leave.allocation" name="action_approve">
         <value eval="[ref('l10n_fr_hr_holidays_allocation')]"/>
     </function>
 


### PR DESCRIPTION
Steps to reproduce the bug:
1. Create a new time off type and set `approval` to
   By employee's approver and time off officer.
2. Create a new allocation:
  * Use the time off type created above.
  * Set the number of days to 20.
3. Save the created allocation.
4. Go to `Management -> Allocations`.
5. Select the created allocation and press on the
   actions cog.
6. Press on `Approve Allocations`.
7. The allocation state doesn't change to `second approval`.

The action `Approve Allocations` doesn't take into account the allocations that are in the first stage of approval.

To fix the issue, `Approve Allocations` action is updated to take these allocations into account. Also, `action_validate` and
`action_approve` are both now being combined into `action_approve`.

task-4207884