### PR TITLE
[FIX] account_edi_ubl_cii: missing node for early payment disc in Bis 3

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -212,8 +212,21 @@ class AccountEdiXmlUBL20(models.AbstractModel):
                 tax_totals_vals['tax_subtotal_vals'].append(subtotal)
 
         if epd_tax_to_discount:
-            # early payment discounts: hence, need to recompute the total tax amount
+            # early payment discounts: hence, need to recompute the total tax amount...
             tax_totals_vals['tax_amount'] = sum([subtot['tax_amount'] for subtot in tax_totals_vals['tax_subtotal_vals']])
+            # ... and add a subtotal section
+            tax_totals_vals['tax_subtotal_vals'].append({
+                'currency': invoice.currency_id,
+                'currency_dp': invoice.currency_id.decimal_places,
+                'taxable_amount': sum(epd_tax_to_discount.values()),
+                'tax_amount': 0.0,
+                'tax_category_vals': {
+                    'id': 'E',
+                    'percent': 0.0,
+                    'tax_scheme_id': "VAT",
+                    'tax_exemption_reason': "Exempt from tax",
+                },
+            })
         return [tax_totals_vals]
 
     def _get_invoice_line_item_vals(self, line, taxes_vals):
@@ -262,7 +275,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
                         'tax_scheme_id': 'VAT',
                     }],
                 })
-            # ne global Charge (VAT exempted)
+            # One global Charge (VAT exempted)
             vals_list.append({
                 'charge_indicator': 'true',
                 'allowance_charge_reason_code': 'ZZZ',

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_pay_term.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_pay_term.xml
@@ -146,6 +146,18 @@
                 </cac:TaxScheme>
             </cac:TaxCategory>
         </cac:TaxSubtotal>
+        <cac:TaxSubtotal>
+            <cbc:TaxableAmount currencyID="USD">52.00</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="USD">0.00</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <cbc:ID>E</cbc:ID>
+                <cbc:Percent>0.0</cbc:Percent>
+                <cbc:TaxExemptionReason>Exempt from tax</cbc:TaxExemptionReason>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
     </cac:TaxTotal>
     <cac:LegalMonetaryTotal>
         <cbc:LineExtensionAmount currencyID="USD">2600.00</cbc:LineExtensionAmount>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_pay_term_ecotax.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_pay_term_ecotax.xml
@@ -122,6 +122,18 @@
                 </cac:TaxScheme>
             </cac:TaxCategory>
         </cac:TaxSubtotal>
+        <cac:TaxSubtotal>
+            <cbc:TaxableAmount currencyID="USD">1.98</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="USD">0.00</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <cbc:ID>E</cbc:ID>
+                <cbc:Percent>0.0</cbc:Percent>
+                <cbc:TaxExemptionReason>Exempt from tax</cbc:TaxExemptionReason>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
     </cac:TaxTotal>
     <cac:LegalMonetaryTotal>
         <cbc:LineExtensionAmount currencyID="USD">100.00</cbc:LineExtensionAmount>


### PR DESCRIPTION
Currently, sending a Bis 3 xml on Peppol raises errors if an early payment discount is set on the invoice (the Belgian one: "Always (upon invoice)", for instance: "2/7 Net 30"). An example xml can be found in the attachments. It raises the error:

```
[BR-E-01]-An Invoice that contains an Invoice line (BG-25), a
Document level allowance (BG-20) or a Document level charge (BG-21)
where the VAT category code (BT-151, BT-95 or BT-102) is "Exempt from
VAT" shall contain exactly one VAT breakdown (BG-23) with the VAT
category code (BT-118) equal to "Exempt from VAT"
```

Looking at the documentation on [1], we realize we lack an additional VAT breakdown in the xml.

[1] https://einvoice.belgium.be/en/article/business-expert-group-overview

task-4283933