### PR TITLE
[FIX] auth_password_policy_signup: minlength in form

### DIFF
--- a/addons/auth_password_policy_signup/views/signup_templates.xml
+++ b/addons/auth_password_policy_signup/views/signup_templates.xml
@@ -4,5 +4,8 @@
         <xpath expr="//input[@name='password']" position="after">
             <owl-component name="password_meter" props='{"selector": "input[name=password]"}'/>
         </xpath>
+        <xpath expr="//input[@name='password']" position="attributes">
+            <attribute name="t-att-minlength">password_minimum_length</attribute>
+        </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
When trying to sign in (for a new user) after making a purchase (existing token), we can choose a password of less than the minimum length allowed in the configuration. 
The _check_password_policy method prevents the save of the password to the user but arrives too late in the flow as the initiation of the user creation is half done leading to an Invalid token issue at the next attempt (no partner found for the existing token with _signup_retrieve_partner). 

By adding the minlength attribute in the form of the sign up, we force the respect of the password policy minimum length in the front end and minimize the risk to encounter the issue. 

opw-4182543