### PR TITLE
[FIX] web: prevent infinite recursion in doActionButton

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1462,7 +1462,7 @@ export function makeActionManager(env, router = _router) {
             }
             throw new InvalidButtonParamsError("Missing type for doActionButton request");
         }
-        if (action.embedded_action_ids && !this.currentController?.config.currentEmbeddedActionId) {
+        if (!isEmbeddedAction && action.embedded_action_ids?.length) {
             const embeddedActionsOrder = JSON.parse(
                 browser.localStorage.getItem(
                     `orderEmbedded${action.id}+${params.resId || ""}+${user.userId}`

--- a/addons/web/static/tests/webclient/actions/embedded_action.test.js
+++ b/addons/web/static/tests/webclient/actions/embedded_action.test.js
@@ -137,6 +137,18 @@ defineActions([
             [false, "form"],
         ],
     },
+    {
+        id: 4,
+        xml_id: "action_4",
+        name: "Ponies",
+        res_model: "pony",
+        type: "ir.actions.act_window",
+        views: [
+            [false, "list"],
+            [false, "kanban"],
+            [false, "form"],
+        ],
+    },
 ]);
 
 defineEmbeddedActions([
@@ -156,6 +168,14 @@ defineEmbeddedActions([
         type: "ir.embedded.actions",
         parent_action_id: 1,
         python_method: "do_python_method",
+    },
+    {
+        id: 4,
+        name: "Custom Embedded Action 4",
+        type: "ir.embedded.actions",
+        user_id: user.userId,
+        parent_action_id: 4,
+        action_id: 4,
     },
 ]);
 
@@ -480,4 +500,27 @@ test("execute a regular action from an embedded action", async () => {
 
     await contains(".o_form_view button[type=action]").click();
     expect(".o_control_panel .o_embedded_actions").toHaveCount(0);
+});
+
+test("custom embedded action loaded first", async () => {
+    await mountWithCleanup(WebClient);
+    browser.localStorage.setItem(`orderEmbedded4++${user.userId}`, JSON.stringify([4, false])); // set embedded action 4 in first
+    await getService("action").doActionButton({
+        name: 4,
+        type: "action",
+    });
+    expect(".o_list_view").toHaveCount(1);
+    await contains(".o_control_panel_navigation > button > i.fa-sliders").click();
+    expect(".o_embedded_actions > button:first-child").toHaveClass("active", {
+        message: "First embedded action in order should have the 'active' class",
+    });
+    expect(".o_embedded_actions > button:first-child > span").toHaveText(
+        "Custom Embedded Action 4",
+        {
+            message: "First embedded action in order should be 'Embedded Action 4'",
+        }
+    );
+    expect(".o_last_breadcrumb_item > span").toHaveText("Ponies", {
+        message: "'Favorite Ponies' view should be loaded",
+    });
 });


### PR DESCRIPTION
Before this commit, when the current user goes to an action with
embedded actions and create a custom embedded action to load the main
one with custom filters, for instance, and then sorts the embedded
actions displayed in the top bar to first load his own embedded action
instead of the main one. When the user will try to load the main action
to load his custom one by default, the UI will be blocked because of a
infinite recursion.

This is because the condition "action.embedded_actions_ids &&
!this.currentController?.config.currentEmbeddedActionId" is wrong, since
this.currentController is the same object between recursions ; this can
cause an infinite recursive call in some cases.

To fix this, the condition was changed to use flag recently introduced
to know when it is embedded actions calling `doActionButton` to make
sure we will no longer have any infinite recursions inside that function.

Steps to reproduce the issue:
============================

1. Install project app (with demo data)
2. Go to project app
3. Select `Office design` project to see the tasks linked to that
   project.
4. Click on the button to see the top bar containing the embedded
   actions.
5. Remove the `Open tasks` filter and create a custom embedded action.
6. Sort the embedded actions inside the top bar to have the custom one
   first.
7. Go back to the project dashboard.
8. Select again `Office design` project.

Expected behavior:
-----------------

The custom embedded action should be loaded instead of the main one
without any issues.

Current Behavior:
-----------------

The UI completely freezes because of an infinite recursions in the JS
code.

task-4283994