### PR TITLE
[FIX] l10n_ug: fix account type

### DIFF
--- a/addons/l10n_ug/data/template/account.account-ug.csv
+++ b/addons/l10n_ug/data/template/account.account-ug.csv
@@ -98,7 +98,7 @@ id,name,code,account_type,tag_ids,reconcile
 352704,Swaps,352704,asset_prepayments,,False
 3528,Account Receivable,3528,asset_receivable,,True
 352802,Staff Advances,352802,asset_receivable,,True
-352804,Taxes Receivable,352804,asset_receivable,,True
+352804,Taxes Receivable,352804,asset_current,,True
 352805,Revenue receivable,352805,asset_receivable,,True
 352806,Trade debtors,352806,asset_receivable,,True
 352807,Sundry Debtors,352807,asset_receivable,,True


### PR DESCRIPTION
"Tax Receivable" account shouldn't be set as a receivable account, but as a current assets one, else it will appear in aged reports, which does not make sense.

Similar to the fix already made here for "Tax Payable": https://github.com/odoo/odoo/commit/2318e671c3a5535590fe6d95949835417856dce6
