### PR TITLE
[FIX] point_of_sale: ensure correct UID extraction from pos_reference

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1104,7 +1104,7 @@ class PosOrder(models.Model):
             'lines': [[0, 0, line] for line in order.lines.export_for_ui()],
             'statement_ids': [[0, 0, payment] for payment in order.payment_ids.export_for_ui()],
             'name': order.pos_reference,
-            'uid': re.search('([0-9-]){14}', order.pos_reference).group(0),
+            'uid': re.search('([0-9-]){14,}', order.pos_reference).group(0),
             'amount_paid': order.amount_paid,
             'amount_total': order.amount_total,
             'amount_tax': order.amount_tax,


### PR DESCRIPTION
The regex used to extract the UID from `pos_reference` was too restrictive, failing when the session number exceeded 99999. This fix allows the UID extraction to handle references with larger session numbers.

opw-4281163

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
