### PR TITLE
[FIX] website: avoid scroll bar flicker when resizing

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -4253,38 +4253,6 @@ options.registry.MegaMenuNoDelete = options.Class.extend({
 });
 
 options.registry.sizing.include({
-    /**
-     * @override
-     */
-    start() {
-        const defs = this._super(...arguments);
-        const self = this;
-        this.$handles.on('mousedown', function (ev) {
-            // Since website is edited in an iframe, a div that goes over the
-            // iframe is necessary to catch mousemove and mouseup events,
-            // otherwise the iframe absorbs them.
-            const $body = $(this.ownerDocument.body);
-            if (!self.divEl) {
-                self.divEl = document.createElement('div');
-                self.divEl.style.position = 'absolute';
-                self.divEl.style.height = '100%';
-                self.divEl.style.width = '100%';
-                self.divEl.setAttribute('id', 'iframeEventOverlay');
-                $body.append(self.divEl);
-            }
-            const documentMouseUp = () => {
-                // Multiple mouseup can occur if mouse goes out of the window
-                // while moving.
-                if (self.divEl) {
-                    self.divEl.remove();
-                    self.divEl = undefined;
-                }
-                $body.off('mouseup', documentMouseUp);
-            };
-            $body.on('mouseup', documentMouseUp);
-        });
-        return defs;
-    },
 
     //--------------------------------------------------------------------------
     // Public


### PR DESCRIPTION
Since commit [1], which moved the scroll out of the `#wrapwrap`, when we resize an element, the size of the scroll bar increases suddenly for no apparent reason, creating a flicker effect.

This happens because when we start resizing, a `div` is added at the end of the body, with a `height` set at `100%`. It was added in commit [2], when the website was moved in an iframe, in order for the mouse events to not be absorbed by it.

The scroll bar flicker is therefore due to the addition of this `div` in the body, which makes the page bigger.

Before commit [1], the body had its `overflow` property set to `hidden`, which is why adding the `div` had no visual effect, since it was hidden. (Note that the body has a fixed size, which is the size of the viewport with no overflow.) But with commit [1], this property has been removed, making the `div` appear at the bottom of the page.

To fix this issue, we could simply set this `div` height to `0px` or its `top` position to 0, so it would never overflow the body. But in fact, it appears that this `div` is simply not necessary anymore since commit [3], which restored the overlay computation.

This commit therefore removes the handler in charge of adding this `div` when we start resizing, as it is not needed anymore.

[1]: https://github.com/odoo/odoo/commit/189a7c96e6e26825dc05c0c6466576fe63aa091e
[2]: https://github.com/odoo/odoo/commit/03c552690b15cbf2e7d6b7812386ac64042219af
[3]: https://github.com/odoo/odoo/commit/2ae4e6434112a676c1cfa100e88fd756fe17f000

task-4190506
