### PR TITLE
[IMP] base: Allow not showing address type if contact name is empty

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -353,10 +353,13 @@ class Partner(models.Model):
 
         name = self.name or ''
         if self.company_name or self.parent_id:
-            if not name and self.type in displayed_types:
+            if not name and self.type in displayed_types and not self.env.context.get("no_address_type"):
                 name = type_description[self.type]
-            if not self.is_company:
-                name = f"{self.commercial_company_name or self.sudo().parent_id.name}, {name}"
+            company_name = self.commercial_company_name or self.sudo().parent_id.name
+            if not name:
+                name = company_name
+            elif not self.is_company:
+                name = f"{company_name}, {name}"
         return name.strip()
 
     @api.depends('is_company', 'name', 'parent_id.name', 'type', 'company_name', 'commercial_company_name')
@@ -853,8 +856,9 @@ class Partner(models.Model):
                 }
 
     @api.depends('complete_name', 'email', 'vat', 'state_id', 'country_id', 'commercial_company_name')
-    @api.depends_context('show_address', 'partner_show_db_id', 'address_inline', 'show_email', 'show_vat', 'lang')
+    @api.depends_context('show_address', 'partner_show_db_id', 'address_inline', 'show_email', 'show_vat', 'lang', 'no_address_type')
     def _compute_display_name(self):
+        breakpoint()
         for partner in self:
             name = partner.with_context(lang=self.env.lang)._get_complete_name()
             if partner._context.get('show_address'):

--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -736,6 +736,12 @@ class TestPartnerAddressCompany(TransactionCase):
         res_bhide = test_partner_bhide.with_context(show_address=1, address_inline=1).display_name
         self.assertEqual(res_bhide, "Atmaram Bhide", "name should contain only name if address is not available, without extra commas")
 
+        test_invoice_partner_no_name = self.env['res.partner'].create({'name': '', 'parent_id': test_partner_jetha.id, 'type': 'invoice'})
+        res_invoice_partner_no_name = test_invoice_partner_no_name.display_name
+        self.assertEqual(res_invoice_partner_no_name, "Jethala, Invoice Address", "name should contain parent name and address type")
+        res_invoice_partner_no_name = test_invoice_partner_no_name.with_context(no_address_type=1).display_name
+        self.assertEqual(res_invoice_partner_no_name, "Jethala", "name should contain only parent name and no address type")
+
     def test_accessibility_of_company_partner_from_branch(self):
         """ Check accessibility of company partner from branch. """
         company = self.env['res.company'].create({'name': 'company'})


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

In case a child contact (e.g. Invoicing or delivery address) does not require a dedicated name (but only a different address of the same company), we do not want to print "Company name, Address Type" but only "Company name".

Adding an extra context key allows to do such a customization.

Current behavior before PR:

Impossible not to display the address type if contact doesn't have name

Desired behavior after PR is merged:

Possible to not display the address type if contact doesn't have name


Forward port of https://github.com/odoo/odoo/pull/126451
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
