### PR TITLE
[FIX] website_sale_loyalty: prevent endless loop on checkout

### DIFF
--- a/addons/website_sale_loyalty/static/src/js/checkout.js
+++ b/addons/website_sale_loyalty/static/src/js/checkout.js
@@ -19,6 +19,12 @@ websiteSaleCheckout.include({
             const cart_summary_discount_rewards = document.querySelectorAll(
                 '[data-reward-type=discount]'
             );
+            if (!cart_summary_discount_rewards.length) {
+                // return in case the current XML template hasn't been adjusted yet to
+                // add data-reward-type attributes when displaying prices tax-included,
+                // leading to an endless refresh cycle
+                return;
+            }
             if (cart_summary_discount_rewards.length !== result.discount_reward_amounts.length) {
                 // refresh cart summary to sync number of discount items
                 location.reload();

--- a/addons/website_sale_loyalty/views/website_sale_templates.xml
+++ b/addons/website_sale_loyalty/views/website_sale_templates.xml
@@ -170,7 +170,12 @@
     </template>
 
     <template id="cart_summary" name="Payment" inherit_id="website_sale.checkout_layout">
-        <xpath expr="//td[@name='website_sale_cart_summary_line_price']/child::*" position="attributes">
+        <!-- `tax_excluded` line price -->
+        <xpath expr="//td[@name='website_sale_cart_summary_line_price']/*[1]" position="attributes">
+            <attribute name="t-att-data-reward-type">line.reward_id.reward_type</attribute>
+        </xpath>
+        <!-- `tax_included` line price -->
+        <xpath expr="//td[@name='website_sale_cart_summary_line_price']/*[2]" position="attributes">
             <attribute name="t-att-data-reward-type">line.reward_id.reward_type</attribute>
         </xpath>
     </template>


### PR DESCRIPTION
Versions
--------
- saas-17.4+

Steps
-----
1. Set website to display prices tax included;
2. have a discount code program (e.g. '10pc' on runbot);
3. add a deliverable product to cart;
4. apply discount code;
5. proceed to delivery options page.

Issue
-----
Endless refresh loop.

Cause
-----
Commit 5ba6723578af fixed an issue with updating the cart summary after a discount reward change. Part of this process is reloading the page if the rewards are no longer in sync. For this to work, it relies on the `data-reward-type` attribute being present in the summary, which isn't the case when prices are set to display tax included.

The reason for this is `xpath` only adding the attribute to the first child[^1] of `website_sale_cart_summary_line_price`, which is the `price_subtotal`[^2], but misses the second element displaying the `price_total`, hence it lacks the `data-reward-type` attribute.

Solution
--------
Add an `xpath` node to add the attribute on the second element as well.

Also update the JavaScript added in 5ba6723578af to not reload if no `[data-reward-type=discount]` elements were found, to prevent an endless refresh cycle for clients who haven't updated their templates yet.

opw-4284046

[^1]: https://github.com/odoo/odoo/blob/72addc749879/addons/website_sale_loyalty/views/website_sale_templates.xml#L172-L176
[^2]: https://github.com/odoo/odoo/blob/72addc749879/addons/website_sale/views/templates.xml#L2341-L2349