### PR TITLE
[FIX] website_slides_survey: remove download button

### DIFF
--- a/addons/website_slides_survey/static/src/xml/website_slides_fullscreen.xml
+++ b/addons/website_slides_survey/static/src/xml/website_slides_fullscreen.xml
@@ -12,7 +12,7 @@
             </div>
             <div t-if="widget._slideValue.category === 'certification' &amp;&amp; widget._slideValue.completed">
                 <h4 class="mb-3 text-white">Congratulations, you passed the Certification!</h4>
-                <a role="button" class="btn btn-primary" t-att-href="'/survey/' + widget._slideValue.certificationId + '/get_certification'">
+                <a t-if="widget._slideValue.isCertification" role="button" class="btn btn-primary" t-att-href="'/survey/' + widget._slideValue.certificationId + '/get_certification'">
                     <i class="fa fa-fw fa-trophy" role="img" aria-label="Download certification" title="Download certification"/> Download certification
                 </a>
             </div>

--- a/addons/website_slides_survey/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides_survey/views/website_slides_templates_lesson.xml
@@ -16,7 +16,7 @@
                 </div>
                 <div t-if="slide.slide_category == 'certification' and channel_progress[slide.id].get('completed')" class="col mt32 mb8 text-center">
                     <h4 class="mb-3">Congratulations, you passed the Certification!</h4>
-                    <a role="button" class="btn btn-primary btn-lg" t-att-href="'/survey/%s/get_certification' % slide.survey_id.id">
+                    <a t-if="slide.survey_id.certification" role="button" class="btn btn-primary btn-lg" t-att-href="'/survey/%s/get_certification' % slide.survey_id.id">
                         <i class="fa fa-fw fa-trophy" role="img" aria-label="Download certification" title="Download certification"/> Download certification
                     </a>
                 </div>

--- a/addons/website_slides_survey/views/website_slides_templates_lesson_fullscreen.xml
+++ b/addons/website_slides_survey/views/website_slides_templates_lesson_fullscreen.xml
@@ -4,6 +4,7 @@
     <template id="slide_fullscreen_sidebar_category" inherit_id="website_slides.slide_fullscreen_sidebar_category">
         <xpath expr="//li[@t-att-data-id='slide.id']" position="attributes">
             <attribute name="t-att-data-certification-id">slide.survey_id.id</attribute>
+            <attribute name="t-att-data-is-certification">'true' if slide.survey_id.certification else 'false'</attribute>
             <attribute name="t-att-data-is-member">slide.channel_id.is_member</attribute>
             <attribute name="t-att-data-can-upload">channel.can_upload</attribute>
         </xpath>


### PR DESCRIPTION
Current behaviour:
---
When you want to download the certification of a course, if the checkbox "Is a certification"
has been unchecked on the survey, the download button redirects to the website root.

Expected behaviour:
---
No download button if "Is a Certification" is unchecked

Steps to reproduce:
---
1. Go to eLearning
2. Create a new course
3. Add content of type Certification
4. Create then add a certificate
5. In the certificate add a question
6. Question type "Multiple choice: only one answer"
7. Add two choices, one with Correct checked
8. In the certificate option, uncheck "Is a Certification"
9. In the course, click on "Go to website"
10. Click on the certification then "Begin certification"
11. Answer correctly as to validate the certification
12. Click on "Go back to course" then the certification
13. Button "Download certification" appears
14. If you click on it, it redirects you to the website

Fix:
---
If survey_id.certification is False, hide download button

opw-4122334

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
