### PR TITLE
[FIX] account: Replace QR code in invoice document preview

### DIFF
--- a/addons/account/views/report_templates.xml
+++ b/addons/account/views/report_templates.xml
@@ -7,7 +7,7 @@
     </template>
 
     <template id="report_invoice_document_preview" inherit_id="account.report_invoice_document" primary="True">
-        <xpath expr="//div[@id='qrcode']" position="after">
+        <xpath expr="//div[@id='qrcode']" position="replace">
             <div t-if="qr_code" class="d-flex mb-3 avoid-page-break-inside">
                 <div class="qrcode me-3" id="qrcode_image">
                     <p class="position-relative mb-0">


### PR DESCRIPTION
Version: 18.0

Issue:
With a valid SEPA bank account enabled, 2 QR codes are generated on the report invoice preview document. This is because we are xpathing to the `qr_code` element and adding a dummy qr code after for the preview.

Purpose of this PR:
To replace the generated QR code with the preview, dummy QR code for the preview wizard.

Steps to Reproduce on Runbot:
install a new company
enable QR code in the settings
set up a valid SEPA bank account for the bank journal 
create an invoice and click 'print & send' to trigger the Configure Document Layout wizard 
view 2 QR codes in the preview

opw-4267407

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
