### PR TITLE
[IMP] point_of_sale: Add 'SALES RECEIPT' title to POS receipts

### DIFF
--- a/addons/point_of_sale/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
@@ -44,6 +44,11 @@
             </div>
             <br /><br />
 
+            <div class="pos-receipt-title">
+                SALES RECEIPT
+            </div>
+            <br /><br />
+
             <!-- Orderlines -->
 
             <div class="orderlines">


### PR DESCRIPTION
The current POS receipt only displays the company address without a clear title, making it difficult for users to identify the type of document. This PR proposes an enhancement by adding a 'SALES RECEIPT' title at the top of each POS receipt, making it easier for users to recognize the document as a sales receipt.

Current behavior before PR:
![Screenshot from 2024-10-25 08-27-55](https://github.com/user-attachments/assets/7b386730-e46a-4f1a-a8c8-80b96325441f)

Desired behavior after PR is merged:
![Screenshot from 2024-10-25 08-30-49](https://github.com/user-attachments/assets/4b5fd2ec-ae0c-4621-a62c-4d8964f9e741)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
