### PR TITLE
[IMP] mail: improved video calling behavior

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -1337,8 +1337,11 @@ export class Rtc extends Record {
         if (activeRtcSession.isMainVideoStreamActive) {
             if (videoType === session.mainVideoStreamType) {
                 if (videoType === "screen") {
-                    this.state.channel.activeRtcSession = undefined;
-                } else {
+                    session.mainVideoStreamType = "camera";
+                } else if (
+                    this.actionsStack.includes("camera-on") &&
+                    this.actionsStack.includes("share-screen")
+                ) {
                     session.mainVideoStreamType = "screen";
                 }
             }

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -237,6 +237,50 @@ test("can share user camera", async () => {
     await contains("video", { count: 0 });
 });
 
+test("Card should remain in focus after Share Screen is toggled", async () => {
+    mockGetMedia();
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    await start();
+    await openDiscuss(channelId);
+    await click("[title='Start a Call']");
+    await contains(".o-discuss-Call.o-minimized"); // minimized = no card focused
+    await click(".o-discuss-CallParticipantCard-avatar");
+    await contains(
+        ".o-discuss-Call:not(.o-minimized) .o-discuss-CallParticipantCard:not(.o-inset) img" // inset = aside, not inset = center
+    );
+    await click("[title='Share Screen']");
+    await contains(".o-discuss-CallParticipantCard.o-inset img");
+    await contains(
+        ".o-discuss-Call:not(.o-minimized) .o-discuss-CallParticipantCard:not(.o-inset) video[type='screen']"
+    );
+    await click("[title='Stop Sharing Screen']");
+    await contains(".o-discuss-CallParticipantCard.o-inset", { count: 0 });
+    await contains(
+        ".o-discuss-Call:not(.o-minimized) .o-discuss-CallParticipantCard:not(.o-inset) img"
+    );
+});
+
+test("Camera video stream stays in focus when on/off", async () => {
+    mockGetMedia();
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    await start();
+    await openDiscuss(channelId);
+    await click("[title='Start a Call']");
+    await click(".o-discuss-CallParticipantCard-avatar");
+    await click("[title='Turn camera on']");
+    await click("[title='Stop camera']");
+    await click("[title='Turn camera on']");
+    await contains("video[type='camera']:not(.o-inset)");
+    // test screen sharing then camera on to check camera aside
+    await click("[title='Stop camera']");
+    await click("[title='Share Screen']");
+    await click("[title='Turn camera on']");
+    await contains("video[type='screen']:not(.o-inset)");
+    await contains("video[type='camera'].o-inset");
+});
+
 test("Create a direct message channel when clicking on start a meeting", async () => {
     mockGetMedia();
     await start();


### PR DESCRIPTION
**Current behavior before PR:**

When a participant turned on their video while they're focused in a call,
their video appeared in the corner, while their profile card
remained visible in the center.

**Desired behavior after PR is merged:**

1. When a participant is in focus and screen sharing begins, their video
   will be in focus even after screen sharing ends.

2. When a participant turns on their video while they're focused in a call:

    _Screen Sharing Off:_
    The participant's video will replace the profile card,
    appearing in the center of the screen, while the profile card will be hidden.

    _Screen Sharing On:_
    The shared screen will remain focused in the center, and the participant's
    video  will stay in the corner, maintaining existing behavior.


task-[4195731](https://www.odoo.com/odoo/all-tasks/4195731)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
