### PR TITLE
[FIX] website_sale: fix font-family issue

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -860,12 +860,19 @@
             <label t-attf-class="m-0 h6 o_products_attributes_title {{_classes_title}}">
                 <b>Price Range</b>
             </label>
-            <input type="range" multiple="multiple"
-                   t-attf-class="form-range range-with-input {{_classes_input}}"
-                   t-att-data-currency="pricelist.currency_id.symbol"
-                   t-att-data-currency-position="pricelist.currency_id.position"
-                   t-att-step="pricelist.currency_id.rounding" t-att-min="'%f' % (available_min_price)"
-                   t-att-max="'%f' % (available_max_price)" t-att-value="'%f,%f' % (min_price, max_price)"/>
+            <span style="font-family:none;">
+                <input
+                    type="range"
+                    multiple="multiple"
+                    t-attf-class="form-range range-with-input {{_classes_input}}"
+                    t-att-data-currency="pricelist.currency_id.symbol"
+                    t-att-data-currency-position="pricelist.currency_id.position"
+                    t-att-step="pricelist.currency_id.rounding"
+                    t-att-min="'%f' % (available_min_price)"
+                    t-att-max="'%f' % (available_max_price)"
+                    t-att-value="'%f,%f' % (min_price, max_price)"
+                />
+            </span>
         </div>
     </template>
 


### PR DESCRIPTION
Step:
- Install Ecom app with theames.
- Go to website and edit website
- Update theme to Legal theme.

Issue:
- Currency symbol for INR in not right.

Cause:
- Issue with google font for INR currency symbol https://github.com/google/fonts/issues/2406

Fix:
- Apply none font family for input range.

opw-4149453