### PR TITLE
[FIX] mail: close attachment box when empty

### DIFF
--- a/addons/mail/static/src/core/web/chatter.js
+++ b/addons/mail/static/src/core/web/chatter.js
@@ -194,11 +194,15 @@ export class Chatter extends Component {
                 } else {
                     this.state.showAttachmentLoading = false;
                     this.state.isAttachmentBoxOpened =
-                        this.props.isAttachmentBoxVisibleInitially && this.attachments.length > 0;
+                        this.state.isAttachmentBoxOpened && this.attachments.length > 0;
                 }
                 return () => browser.clearTimeout(this.loadingAttachmentTimeout);
             },
-            () => [this.state.thread, this.state.thread?.isLoadingAttachments]
+            () => [
+                this.state.thread,
+                this.state.thread?.isLoadingAttachments,
+                this.attachments.length,
+            ]
         );
     }
 


### PR DESCRIPTION
**Current behavior before PR:**

The attachment box in chatter remains visible even after all attachments have been removed.

**Desired behavior after PR is merged:**

The attachment box automatically closes when the last attachment is removed.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
