### PR TITLE
[FIX] mail: prevent error when use an icon in email template

### DIFF
--- a/addons/mail/static/src/views/web/fields/html_mail_field/html_mail_field.js
+++ b/addons/mail/static/src/views/web/fields/html_mail_field/html_mail_field.js
@@ -16,8 +16,11 @@ export class HtmlMailField extends HtmlField {
             cssRulesByElement.set(editor.editable, getCSSRules(editor.document));
         }
         const cssRules = cssRulesByElement.get(editor.editable);
+        // Insert the cloned element inside an DOM so we can get its computed style.
+        document.body.append(el);
         el.classList.remove("odoo-editor-editable");
         await toInline(el, cssRules);
+        el.remove();
     }
 
     async getEditorContent() {

--- a/addons/mail/static/tests/inline/html_mail_field.test.js
+++ b/addons/mail/static/tests/inline/html_mail_field.test.js
@@ -54,7 +54,7 @@ beforeEach(() => {
 test("HtmlMail save inline html", async function () {
     onRpc("web_save", ({ args }) => {
         expect(args[1].body.replace(/font-size: (\d+(\.\d+)?)px/, "font-size: []px")).toBe(
-            `<h1 style="margin: 0px 0px 8px; box-sizing: border-box; font-size: []px; line-height: 1.2; font-weight: 500; font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Ubuntu, 'Noto Sans', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';">first</h1>`
+            `<h1 style="margin: 0px 0px 8px; box-sizing: border-box; font-size: []px; color: #111827; line-height: 1.2; font-weight: 500; font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Ubuntu, 'Noto Sans', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';">first</h1>`
         );
         expect.step("web_save");
     });
@@ -94,4 +94,31 @@ test("HtmlMail don't have access to column commands", async function () {
     await insertText(htmlEditor, "column");
     await animationFrame();
     expect(".o-we-powerbox").toHaveCount(0);
+});
+
+test("HtmlMail add icon and save inline html", async function () {
+    onRpc("web_save", ({ args }) => {
+        expect(args[1].body.replace(/font-size: (\d+(\.\d+)?)px/, "font-size: []px")).toBe(
+            `<p style="margin:0px 0 16px 0;box-sizing:border-box;"><span style="display: inline-block; width: 14px; height: 14px; vertical-align: text-bottom;" class="oe_unbreakable "><img width="14" height="14" src="/web_editor/font_to_img/61440/rgb(55%2C65%2C81)/rgb(249%2C250%2C251)/14x14" data-class="fa fa-glass" data-style="null" style="box-sizing: border-box; line-height: 14px; width: 14px; height: 14px; vertical-align: unset; margin: 0px;"></span>first</p>`
+        );
+        expect.step("web_save");
+    });
+    await mountView({
+        type: "form",
+        resId: 1,
+        resModel: "custom.message",
+        arch: `
+        <form>
+            <field name="body" widget="html_mail"/>
+        </form>`,
+    });
+    setSelectionInHtmlField();
+    await insertText(htmlEditor, "/image");
+    await press("enter");
+
+    await contains("a.nav-link:contains('Icons')").click();
+    await contains("span.fa-glass").click();
+
+    await contains(".o_form_button_save").click();
+    expect.verifySteps(["web_save"]);
 });


### PR DESCRIPTION
Currently, an error occurs when using an image icon in the email template.

Step to produce:

- Install the ```mail``` module.
- Go to Settings / Technical / Email / Email Templates, and open any templates.
- Insert any image icon, and save the record.

ValueError: `unknown color specifier: '1x1'`

An error occurred when attempting to retrieve computed styles for the element
during inlining converting. Specifically, when the system tries to fetch the
color code and other CSS properties, it returns empty values because
`getComputedStyle` fails to properly access the full set of styles from the
cloned element. This is because `getComputedStyle` cannot retrieve styles from
an element when it is detached from DOM (a cloned element not in a DOM).

To resolve this issue, The cloned element is temporarily added to the DOM,So `getComputedStyle` access the required style properties.

Ref:- https://drafts.csswg.org/cssom/#dom-window-getcomputedstyle


Sentry-5747299019