### PR TITLE
[FIX] mail: make image action usable on small images

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -602,6 +602,14 @@ msgid "Action Window View"
 msgstr ""
 
 #. module: mail
+#. odoo-javascript
+#: code:addons/mail/static/src/core/common/attachment_list.xml:0
+#: code:addons/mail/static/src/core/common/attachment_list.xml:0
+#, python-format
+msgid "Actions"
+msgstr ""
+
+#. module: mail
 #: model:ir.model.fields,help:mail.field_mail_activity__activity_category
 #: model:ir.model.fields,help:mail.field_mail_activity_schedule__activity_category
 #: model:ir.model.fields,help:mail.field_mail_activity_type__category
@@ -2967,7 +2975,7 @@ msgstr ""
 
 #. module: mail
 #. odoo-javascript
-#: code:addons/mail/static/src/core/common/attachment_list.xml:0
+#: code:addons/mail/static/src/core/common/attachment_list.js:0
 #: code:addons/mail/static/src/core/common/attachment_list.xml:0
 #: code:addons/mail/static/src/core/common/attachment_list.xml:0
 #: model_terms:ir.ui.view,arch_db:mail.view_document_file_kanban
@@ -7419,8 +7427,7 @@ msgstr ""
 
 #. module: mail
 #. odoo-javascript
-#: code:addons/mail/static/src/core/common/attachment_list.xml:0
-#: code:addons/mail/static/src/core/common/attachment_list.xml:0
+#: code:addons/mail/static/src/core/common/attachment_list.js:0
 #: code:addons/mail/static/src/core/common/attachment_list.xml:0
 #: code:addons/mail/static/src/core/common/attachment_list.xml:0
 #: code:addons/mail/static/src/core/common/link_preview.xml:0
@@ -9864,13 +9871,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:mail.field_ir_actions_act_window_view__view_mode
 #: model:ir.model.fields,field_description:mail.field_ir_ui_view__type
 msgid "View Type"
-msgstr ""
-
-#. module: mail
-#. odoo-javascript
-#: code:addons/mail/static/src/core/common/attachment_list.xml:0
-#, python-format
-msgid "View image"
 msgstr ""
 
 #. module: mail

--- a/addons/mail/static/src/core/common/attachment_list.js
+++ b/addons/mail/static/src/core/common/attachment_list.js
@@ -1,12 +1,33 @@
 /* @odoo-module */
 
 import { Component, useState } from "@odoo/owl";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { useFileViewer } from "@web/core/file_viewer/file_viewer_hook";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { url } from "@web/core/utils/urls";
+
+class ImageActions extends Component {
+    static components = { Dropdown, DropdownItem };
+    static props = ["actions", "imagesHeight"];
+    static template = "mail.ImageActions";
+
+    setup() {
+        super.setup();
+        this.actionsMenuState = useState({
+            isOpen: false,
+        });
+        this.isMobileOS = isMobileOS;
+    }
+
+    async setActionsMenuState(state) {
+        this.actionsMenuState.isOpen = state.isOpen;
+    }
+}
 
 /**
  * @typedef {Object} Props
@@ -17,6 +38,7 @@ import { url } from "@web/core/utils/urls";
  * @extends {Component<Props, Env>}
  */
 export class AttachmentList extends Component {
+    static components = { ImageActions };
     static props = ["attachments", "unlinkAttachment", "imagesHeight", "messageSearch?"];
     static template = "mail.AttachmentList";
 
@@ -26,6 +48,7 @@ export class AttachmentList extends Component {
         this.imagesWidth = 1920;
         this.dialog = useService("dialog");
         this.fileViewer = useFileViewer();
+        this.isMobileOS = isMobileOS;
     }
 
     /**
@@ -107,6 +130,25 @@ export class AttachmentList extends Component {
 
     get isInChatWindowAndIsAlignedLeft() {
         return this.env.inChatWindow && !this.env.alignedRight;
+    }
+
+    getActions(attachment) {
+        const res = [];
+        if (this.showDelete) {
+            res.push({
+                label: _t("Remove"),
+                icon: "fa fa-trash",
+                onSelect: () => this.onClickUnlink(attachment),
+            });
+        }
+        if (this.canDownload(attachment)) {
+            res.push({
+                label: _t("Download"),
+                icon: "fa fa-download",
+                onSelect: () => this.onClickDownload(attachment),
+            });
+        }
+        return res;
     }
 
     get showDelete() {

--- a/addons/mail/static/src/core/common/attachment_list.scss
+++ b/addons/mail/static/src/core/common/attachment_list.scss
@@ -25,8 +25,9 @@
 }
 
 .o-mail-AttachmentImage {
-    min-width: 20px;
-    min-height: 20px;
+    min-width: 75px;
+    min-height: 75px;
+    background-color: $gray-200;
 
     img {
         object-fit: contain;

--- a/addons/mail/static/src/core/common/attachment_list.xml
+++ b/addons/mail/static/src/core/common/attachment_list.xml
@@ -12,19 +12,19 @@
         >
             <div class="d-flex flex-grow-1 flex-wrap mx-1" t-att-class="{
                 'justify-content-end': isInChatWindowAndIsAlignedRight and !env.inComposer,
-            }" role="menu">
-                <div t-foreach="imagesAttachments" t-as="attachment" t-key="attachment.id" t-att-aria-label="attachment.filename"
-                    class="o-mail-AttachmentImage d-flex position-relative flex-shrink-0 mw-100 mb-1 me-1"
-                    t-att-title="attachment.name"
-                    t-att-class="{ 'o-isUploading': attachment.uploading }"
-                    tabindex="0"
-                    aria-label="View image"
-                    role="menuitem"
-                    t-att-data-mimetype="attachment.mimetype"
-                    t-on-click="() => this.fileViewer.open(attachment, props.attachments)"
+                        }" role="menu" >
+                <div t-foreach="imagesAttachments" t-as="attachment" t-key="attachment.id"
+                     t-att-aria-label="attachment.filename"
+                     class="o-mail-AttachmentImage d-flex position-relative flex-shrink-0 mw-100 mb-1 me-1 rounded o-viewable"
+                     t-att-title="attachment.name"
+                     t-att-class="{ 'o-isUploading': attachment.uploading }"
+                     tabindex="0"
+                     t-att-data-mimetype="attachment.mimetype"
+                     t-on-click="() => this.fileViewer.open(attachment, props.attachments)"
+                     role="menuitem"
                 >
                     <img
-                        class="img img-fluid my-0 mx-auto o-viewable"
+                        class="img img-fluid my-0 mx-auto"
                         t-att-class="{ 'opacity-25': attachment.uploading }"
                         t-att-src="getImageUrl(attachment)"
                         t-att-alt="attachment.name"
@@ -34,16 +34,7 @@
                     <div t-if="attachment.uploading" class="position-absolute top-0 bottom-0 start-0 end-0 d-flex align-items-center justify-content-center" title="Uploading">
                         <i class="fa fa-spin fa-spinner"/>
                     </div>
-                    <div class="position-absolute top-0 bottom-0 start-0 end-0 p-2 text-white opacity-0 opacity-100-hover d-flex align-items-end flax-wrap flex-column">
-                        <div t-if="showDelete and !ui.isSmall"
-                            class="btn btn-sm btn-dark rounded opacity-75 opacity-100-hover"
-                            tabindex="0" aria-label="Remove" role="menuitem" t-on-click.stop="() => this.onClickUnlink(attachment)" title="Remove">
-                            <i class="fa fa-trash"/>
-                        </div>
-                        <div t-if="canDownload(attachment) and !ui.isSmall" class="btn btn-sm btn-dark rounded opacity-75 opacity-100-hover mt-auto" t-on-click.stop="() => this.onClickDownload(attachment)" title="Download">
-                            <i class="fa fa-download"/>
-                        </div>
-                    </div>
+                    <ImageActions actions="getActions(attachment)" imagesHeight="props.imagesHeight"/>
                 </div>
             </div>
             <div class="d-flex flex-grow-1 flex-wrap mt-1 mx-1" t-att-class="{
@@ -85,15 +76,34 @@
                             <i class="fa fa-trash" role="img" aria-label="Remove"/>
                         </button>
                         <!-- t-attf-class overridden in extensions -->
-                        <button t-if="canDownload(attachment)" class="btn d-flex justify-content-center align-items-center w-100 h-100 rounded-0"
-                            t-attf-class="bg-300"
-                            t-on-click.stop="() => this.onClickDownload(attachment)" title="Download"
+                        <button t-if="canDownload(attachment)" class="btn d-flex align-items-center justify-content-center w-100 h-100 rounded-0"
+                                t-attf-class="{{ bg-300 }}"
+                                t-on-click.stop="() => this.onClickDownload(attachment)" title="Download"
                         >
                             <i class="fa fa-download" role="img" aria-label="Download"/>
                         </button>
                     </div>
                 </div>
             </div>
+        </div>
+    </t>
+
+    <t t-name="mail.ImageActions">
+        <div class="o-mail-attachment-actions position-absolute top-0 bottom-0 start-0 end-0 p-1 text-white o-opacity-hoverable opacity-100-hover d-flex align-items-end flax-wrap flex-column" t-att-class="{ 'opacity-0': !actionsMenuState.isOpen }">
+            <button t-if="props.actions.length === 1 and props.imagesHeight gt 75" class="btn btn-sm btn-light rounded px-1 py-0" t-att-class="{ 'opacity-75 opacity-100-hover': !isMobileOS }" tabindex="0" t-att-aria-label="props.actions[0].label" t-att-title="props.actions[0].label" role="menuitem" t-on-click.stop="props.actions[0].onSelect">
+                <i t-att-class="props.actions[0].icon"/>
+            </button>
+            <Dropdown t-else="" onStateChanged="(state) => this.setActionsMenuState(state)" togglerClass="'btn btn-sm btn-light rounded px-1 py-0'" menuClass="'d-flex flex-column py-0' + (props.actions.length gt 1 ? ' py-0' : '')" position="'right-start'">
+                <t t-set-slot="toggler">
+                    <i class="oi oi-chevron-down" t-att-class="{ 'opacity-75 opacity-100-hover py-0': !isMobileOS }" tabindex="0" aria-label="Actions" title="Actions" role="menuitem"/>
+                </t>
+                <t t-set-slot="default">
+                    <DropdownItem t-foreach="props.actions" t-as="action" t-key="action_index" class="'px-2 py-1 d-flex align-items-center rounded-0'" onSelected="action.onSelect">
+                        <i class="fa-fw" t-att-class="action.icon"/>
+                        <span class="mx-2" t-esc="action.label"/>
+                    </DropdownItem>
+                </t>
+            </Dropdown>
         </div>
     </t>
 

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -96,7 +96,7 @@
                     t-if="allowUpload and props.composer.attachments.length > 0"
                     attachments="props.composer.attachments"
                     unlinkAttachment.bind="(...args) => attachmentUploader.unlink(...args)"
-                    imagesHeight="50"/>
+                    imagesHeight="75"/>
                 <Picker t-props="picker"/>
             </div>
         </div>

--- a/addons/mail/static/tests/message/message_tests.js
+++ b/addons/mail/static/tests/message/message_tests.js
@@ -1181,8 +1181,9 @@ QUnit.test("allow attachment delete on authored message", async () => {
         message_type: "comment",
     });
     const { openDiscuss } = await start();
-    openDiscuss(channelId);
-    await click(".o-mail-AttachmentImage div[title='Remove']");
+    await openDiscuss(channelId);
+    await click(".o-mail-AttachmentImage [title='Actions']");
+    await click(".dropdown-item", { text: "Remove" });
     await contains(".modal-dialog .modal-body", { text: 'Do you really want to delete "BLAH"?' });
     await click(".modal-footer .btn-primary");
     await contains(".o-mail-AttachmentCard", { count: 0 });
@@ -1227,8 +1228,9 @@ QUnit.test("allow attachment image download on message", async () => {
         res_id: channelId,
     });
     const { openDiscuss } = await start();
-    openDiscuss(channelId);
-    await contains(".o-mail-AttachmentImage .fa-download");
+    await openDiscuss(channelId);
+    await click(".o-mail-AttachmentImage [title='Actions']");
+    await contains(".dropdown-item", { text: "Download" });
 });
 
 QUnit.test("Can download all files of a message", async () => {

--- a/addons/mail/static/tests/thread/attachment_list_tests.js
+++ b/addons/mail/static/tests/thread/attachment_list_tests.js
@@ -312,7 +312,7 @@ QUnit.test(
         });
         const { openDiscuss } = await start();
         openDiscuss(channelId);
-        await contains(".o-mail-AttachmentImage[title='test.png'] img.o-viewable");
+        await contains(".o-mail-AttachmentImage[title='test.png'].o-viewable");
         await contains(".o-mail-AttachmentCard:not(.o-viewable)", { text: "test.odt" });
         await click(".o-mail-AttachmentCard", { text: "test.odt" });
         // weak test, no guarantee that we waited long enough for the potential file viewer to show


### PR DESCRIPTION
On small images, the actions to delete image is barely usable. In mobile, these actions are always shown, so they could even prevent clicking on attachment to view in dialog. Also on big a image the 2 actions are far away, which is can be exhausting.

This commit fixes the issue by using a dropdown when there is more than 1 action or when the image is considered very small. Images visual is at most 75px width and height, so smaller images now show a background, which ensures image actions and clicking on image for preview are both reachable with ease, also added the required changes accordingly.

task-3563828

Backport of: https://github.com/odoo/odoo/pull/180671