### PR TITLE
[FIX] link_tracker: required tracked url on create

### DIFF
--- a/addons/link_tracker/views/link_tracker_views.xml
+++ b/addons/link_tracker/views/link_tracker_views.xml
@@ -45,10 +45,10 @@
                                 <field name="title"/>
                                 <field name="label"/>
                                 <field name="url"/>
-                                <label for="short_url_host" string="Tracked URL" class="opacity-100 fw-bold text-900"/>
+                                <label for="code" string="Tracked URL"/>
                                 <div>
                                     <field name="short_url_host" nolabel="1" readonly="1" class="me-1 oe_inline"/>
-                                    <field name="code" nolabel="1" required="1" class="oe_inline o_input"/>
+                                    <field name="code" nolabel="1" readonly="not code" class="oe_inline o_input"/>
                                 </div>
                             </group>
                             <group name="utm" string="UTM">


### PR DESCRIPTION
#### Purpose

We should not ask users to provide a tracked URL,
it's supposed to be something you change afterwards if you want an extension that looks good.

#### After this PR

Removed required attribute, so it will not asked user a Tracked URL on record creation.

Task-4279725

