### PR TITLE
[IMP] pos_restaurant: auto-create floating order from quick table selector

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
@@ -1,7 +1,6 @@
 import { Navbar } from "@point_of_sale/app/navbar/navbar";
 import { patch } from "@web/core/utils/patch";
 import { _t } from "@web/core/l10n/translation";
-import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import {
     getButtons,
     EMPTY,
@@ -61,11 +60,11 @@ patch(Navbar.prototype, {
                     return this.setFloatingOrder(floating_order);
                 }
                 if (!table && !floating_order) {
-                    this.dialog.add(AlertDialog, {
-                        title: _t("Error"),
-                        body: _t("No table or floating order found with this number"),
-                    });
-                    return;
+                    this.pos.selectedTable = null;
+                    const newOrder = this.pos.add_new_order();
+                    newOrder.floating_order_name = table_number;
+                    newOrder.setBooked(true);
+                    return this.setFloatingOrder(newOrder);
                 }
             },
         });


### PR DESCRIPTION
Before this commit:
====================
If the number entered on the quick table selector numpad did not match any existing table or floating order, an error message ("No table or floating order found with this number") was displayed.

After this commit:
==================
When the entered number does not correspond to an existing table or floating order, a new floating order is automatically created using the inputted number.

task- 4274465

