### PR TITLE
[FIX] pos_self_order: fix product variant selection

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -124,7 +124,7 @@ export class ProductProduct extends Base {
     // product.pricelist.item records are loaded with a search_read
     // and were automatically sorted based on their _order by the
     // ORM. After that they are added in this order to the pricelists.
-    get_price(pricelist, quantity, price_extra = 0, recurring = false) {
+    get_price(pricelist, quantity, price_extra = 0, recurring = false, list_price = false) {
         // In case of nested pricelists, it is necessary that all pricelists are made available in
         // the POS. Display a basic alert to the user in the case where there is a pricelist item
         // but we can't load the base pricelist to get the price when calling this method again.
@@ -140,7 +140,7 @@ export class ProductProduct extends Base {
         }
 
         const rules = !pricelist ? [] : this.cachedPricelistRules[pricelist?.id] || [];
-        let price = this.lst_price + (price_extra || 0);
+        let price = (list_price || this.lst_price) + (price_extra || 0);
         const rule = rules.find((rule) => !rule.min_quantity || quantity >= rule.min_quantity);
         if (!rule) {
             return price;
@@ -148,7 +148,7 @@ export class ProductProduct extends Base {
 
         if (rule.base === "pricelist") {
             if (rule.base_pricelist_id) {
-                price = this.get_price(rule.base_pricelist_id, quantity, 0, true);
+                price = this.get_price(rule.base_pricelist_id, quantity, 0, true, list_price);
             }
         } else if (rule.base === "standard_price") {
             price = this.standard_price;

--- a/addons/pos_self_order/i18n/pos_self_order.pot
+++ b/addons/pos_self_order/i18n/pos_self_order.pot
@@ -1187,6 +1187,12 @@ msgstr ""
 
 #. module: pos_self_order
 #. odoo-javascript
+#: code:addons/pos_self_order/static/src/app/pages/product_page/product_page.xml:0
+msgid "This combination does not exist."
+msgstr ""
+
+#. module: pos_self_order
+#. odoo-javascript
 #: code:addons/pos_self_order/static/src/app/pages/cart_page/cart_page.xml:0
 #: code:addons/pos_self_order/static/src/app/pages/order_history_page/order_history_page.xml:0
 msgid "Total:"

--- a/addons/pos_self_order/models/product_product.py
+++ b/addons/pos_self_order/models/product_product.py
@@ -69,6 +69,8 @@ class ProductProduct(models.Model):
         product_objs = self.env['product.product'].browse(product_ids)
 
         product_map = {product.id: product for product in product_objs}
+        loaded_product_tmpl_ids = list({p['product_tmpl_id'] for p in products})
+        archived_combinations = self._get_archived_combinations_per_product_tmpl_id(loaded_product_tmpl_ids)
 
         for product in products:
             product_obj = product_map.get(product['id'])
@@ -76,6 +78,8 @@ class ProductProduct(models.Model):
                 product['lst_price'] = pricelist._get_product_price(
                     product_obj, 1.0, currency=config.currency_id
                 )
+            if archived_combinations.get(product['product_tmpl_id']):
+                product['_archived_combinations'] = archived_combinations[product['product_tmpl_id']]
 
     def _filter_applicable_attributes(self, attributes_by_ptal_id: Dict) -> List[Dict]:
         """

--- a/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.js
+++ b/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.js
@@ -88,12 +88,6 @@ export class AttributeSelection extends Component {
             : attribute.product_template_value_ids;
     }
 
-    availableAttributes() {
-        return this.props.product.attribute_line_ids.filter(
-            (a) => a.attribute_id.create_variant !== "always"
-        );
-    }
-
     initAttribute() {
         const initCustomValue = (value) => {
             const selectedValue = this.selfOrder.editedLine?.custom_attribute_value_ids.find(
@@ -115,7 +109,7 @@ export class AttributeSelection extends Component {
             return false;
         };
 
-        for (const attr of this.availableAttributes()) {
+        for (const attr of this.props.product.attribute_line_ids) {
             this.selectedValues[attr.id] = {};
 
             for (const value of attr.product_template_value_ids) {

--- a/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
+++ b/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
@@ -9,7 +9,7 @@
                         <div class="row g-2 g-md-3 g-xl-4 justify-content-between justify-content-md-start mb-5 row-cols-2 row-cols-sm-3 row-cols-md-4 row-cols-xl-5 row-cols-xxl-6"
                             t-ref="attribute_grid_{{attribute.id}}">
                             <t t-foreach="availableAttributeValue(attribute)" t-as="value" t-key="value.id">
-                                <div class="col">
+                                <div class="col" t-att-class="{'opacity-50' : value.excluded}">
                                     <label t-attf-for="{{ attribute.id }}_{{ value.id }}"
                                             t-attf-class="self_order_attribute_selection_option {{ this.isChecked(attribute, value) ? 'text-bg-primary border-primary active' : '' }}
                                             d-flex align-items-center justify-content-center h-100 rounded border ratio ratio-16x9"

--- a/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
+++ b/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
@@ -4,7 +4,7 @@
         <div class="self_order_attribute_selection d-flex flex-column flex-grow-1">
             <div class="attribute-selection-content align-items-center justify-content-start px-3 flex-grow-1">
                 <div class="d-flex flex-column">
-                    <div t-foreach="availableAttributes()" t-as="attribute" t-key="attribute.id" class="attribute-row">
+                    <div t-foreach="props.product.attribute_line_ids" t-as="attribute" t-key="attribute.id" class="attribute-row">
                         <h2 t-out="attribute.attribute_id.name"/>
                         <div class="row g-2 g-md-3 g-xl-4 justify-content-between justify-content-md-start mb-5 row-cols-2 row-cols-sm-3 row-cols-md-4 row-cols-xl-5 row-cols-xxl-6"
                             t-ref="attribute_grid_{{attribute.id}}">

--- a/addons/pos_self_order/static/src/app/components/combo_selection/combo_selection.js
+++ b/addons/pos_self_order/static/src/app/components/combo_selection/combo_selection.js
@@ -22,7 +22,10 @@ export class ComboSelection extends Component {
         }
 
         this.props.comboState.selectedProduct = productSelected;
-        if (productSelected.attribute_line_ids.length === 0) {
+        if (
+            productSelected.attribute_line_ids.length === 0 ||
+            productSelected.product_template_variant_value_ids.length !== 0
+        ) {
             this.props.next();
             return;
         }

--- a/addons/pos_self_order/static/src/app/components/product_card/product_card.js
+++ b/addons/pos_self_order/static/src/app/components/product_card/product_card.js
@@ -94,7 +94,7 @@ export class ProductCard extends Component {
 
         if (product.isCombo()) {
             this.router.navigate("combo_selection", { id: product.id });
-        } else if (product.needToConfigure()) {
+        } else if (product.isConfigurable()) {
             this.router.navigate("product", { id: product.id });
         } else {
             if (!this.selfOrder.ordering) {

--- a/addons/pos_self_order/static/src/app/components/product_card/product_card.xml
+++ b/addons/pos_self_order/static/src/app/components/product_card/product_card.xml
@@ -3,7 +3,7 @@
     <t t-name="pos_self_order.ProductCard">
         <article class="self_order_product_card d-flex flex-row-reverse flex-md-column align-items-start gap-2 user-select-none"
             role="button"
-            t-att-title="props.product.display_name"
+            t-att-title="props.product.name"
             t-on-click="() => this.selectProduct()"
             t-ref="selfProductCard">
             <div t-if="!this.isHtmlEmpty" class="product-information-tag" t-on-click.prevent.stop="showProductInfo">
@@ -16,7 +16,7 @@
                 }">
                 <div class="placeholder-glow o_self_order_item_card_no_image">
                     <div t-attf-class="{{ props.product.image_128 ? 'placeholder' : 'd-flex align-items-center justify-content-center h-100' }} bg-200 w-100 h-100 rounded">
-                        <span t-if="!props.product.image_128" t-esc="props.product.display_name" class="text-center text-white fs-2 fw-bold mb-1 mb-sm-2"/>
+                        <span t-if="!props.product.image_128" t-esc="props.product.name" class="text-center text-white fs-2 fw-bold mb-1 mb-sm-2"/>
                     </div>
                 </div>
                 <img
@@ -28,7 +28,7 @@
                     onerror="this.remove()"/>
             </div>
             <div class="product-infos d-flex flex-column justify-content-between text-start flex-grow-1 w-100 lh-1">
-                <span t-esc="props.product.display_name" class="fs-4 fw-bold mb-1 mb-sm-2"/>
+                <span t-esc="props.product.name" class="fs-4 fw-bold mb-1 mb-sm-2"/>
                 <div class="d-flex justify-content-between align-items-end gap-3">
                     <span t-esc="selfOrder.formatMonetary(selfOrder.getProductDisplayPrice(props.product))" class="o-so-tabular-nums fs-4 text-muted flex-grow-1" />
                     <div class="text-center ms-2 fs-lighter">

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.xml
@@ -15,7 +15,7 @@
                                     <span t-if="Object.keys(selfOrder.currentOrder.changes).length === 0"><t t-esc="line.qty" />x </span>
                                     <strong t-esc="line.product_id.display_name"/>
                                 </div>
-                                <div t-if="line.product_id?.attribute_line_ids.length > 0 || line.combo_line_ids.length > 0" class="d-flex align-items-start gap-2 gap-md-3 my-2">
+                                <div t-if="line.attribute_value_ids.length > 0 || line.combo_line_ids.length > 0" class="d-flex align-items-start gap-2 gap-md-3 my-2">
                                     <button
                                         t-if="Object.keys(selfOrder.currentOrder.changes).length === 0"
                                         type="button"

--- a/addons/pos_self_order/static/src/app/pages/product_page/product_page.js
+++ b/addons/pos_self_order/static/src/app/pages/product_page/product_page.js
@@ -88,4 +88,11 @@ export class ProductPage extends Component {
     isEveryValueSelected() {
         return Object.values(this.state.selectedValues).find((value) => !value) == false;
     }
+
+    isArchivedCombination() {
+        const variantAttributeValueIds = Object.values(this.state.selectedValues)
+            .filter((attr) => typeof attr !== "object")
+            .map((attr) => Number(attr));
+        return this.props.product._isArchivedCombination(variantAttributeValueIds);
+    }
 }

--- a/addons/pos_self_order/static/src/app/pages/product_page/product_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/product_page/product_page.xml
@@ -49,8 +49,18 @@
                 </div>
             </div>
 
-            <div t-if="showQtyButtons and !props.onValidate" class="page-buttons d-flex justify-content-end p-3 gap-3 bg-view border-top">
-                <button t-if="showQtyButtons and !props.onValidate and selfOrder.ordering" class="btn btn-primary btn-lg" t-att-class="{ 'disabled': this.isEveryValueSelected() }" t-on-click="addToCart">Add to cart</button>
+            <div t-if="showQtyButtons and !props.onValidate" class="page-buttons d-flex p-3 gap-3 bg-view border-top"
+                t-att-class="(isArchivedCombination() ? 'justify-content-between': 'justify-content-end')">
+                <div t-if="isArchivedCombination() and !this.isEveryValueSelected()" class="alert alert-warning m-0">
+                    This combination does not exist.
+                </div>
+                <button
+                    t-if="showQtyButtons and !props.onValidate and selfOrder.ordering"
+                    class="btn btn-primary btn-lg"
+                    t-att-disabled="this.isEveryValueSelected() or isArchivedCombination()"
+                    t-on-click="addToCart">
+                    Add to cart
+                </button>
             </div>
         </div>
     </t>

--- a/addons/pos_self_order/static/src/app/pages/product_page/product_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/product_page/product_page.xml
@@ -6,7 +6,7 @@
                 <button class="btn btn-secondary btn-lg px-3 text-nowrap" t-on-click="() => router.back()">
                     <i class="oi oi-chevron-left" aria-hidden="true"/><span class="ms-2 d-none d-md-inline">Discard</span>
                 </button>
-                <h1 class="mb-0 text-nowrap"><strong t-esc="product.display_name"/> options</h1>
+                <h1 class="mb-0 text-nowrap"><strong t-esc="product.name"/> options</h1>
                 <span class="d-none d-md-inline px-5"/> <!-- Spacer -->
             </div>
 
@@ -24,7 +24,7 @@
                             onerror="this.remove()"/>
                     </div>
                     <div class="o-so-product-details-description">
-                        <h2 t-esc="product.display_name"/>
+                        <h2 t-esc="product.name"/>
                         <small t-if="product.description_self_order"
                             class="o_self_order_main_desc d-block mb-3 text-muted"
                             t-out="product.description_self_order"

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -215,6 +215,21 @@ export class SelfOrder extends Reactive {
         };
 
         if (Object.entries(selectedValues).length > 0) {
+            const productVariant = this.models["product.product"].find(
+                (prd) =>
+                    prd.raw.product_tmpl_id === product.raw.product_tmpl_id &&
+                    prd.product_template_variant_value_ids.every((ptav) => {
+                        return Object.values(selectedValues).some((value) => ptav.id == value);
+                    })
+            );
+            if (productVariant) {
+                Object.assign(values, {
+                    product_id: productVariant,
+                    price_unit: productVariant.lst_price,
+                    tax_ids: productVariant.taxes_id.map((tax) => ["link", tax]),
+                });
+            }
+
             values.attribute_value_ids = Object.values(selectedValues)
                 .map((a) => {
                     if (typeof a === "object") {
@@ -229,8 +244,11 @@ export class SelfOrder extends Reactive {
                         }, []);
                     } else {
                         const attrVal = this.models["product.template.attribute.value"].get(a);
-                        values.price_extra += attrVal.price_extra;
-                        return [["link", attrVal]];
+                        if (attrVal.attribute_id.create_variant !== "always") {
+                            values.price_extra += attrVal.price_extra;
+                            return [["link", attrVal]];
+                        }
+                        return [];
                     }
                 })
                 .flat();
@@ -422,8 +440,16 @@ export class SelfOrder extends Reactive {
         this.productByCategIds = this.models["product.product"].getAllBy("pos_categ_ids");
         const isSpecialProduct = (p) => this.config._pos_special_products_ids.includes(p.id);
         for (const category_id in this.productByCategIds) {
+            const productTmplIds = new Set();
             this.productByCategIds[category_id] = this.productByCategIds[category_id].filter(
-                (p) => !isSpecialProduct(p)
+                (p) => {
+                    if (!isSpecialProduct(p) && !productTmplIds.has(p.raw.product_tmpl_id)) {
+                        productTmplIds.add(p.raw.product_tmpl_id);
+                        p.available_in_pos = false;
+                        return true;
+                    }
+                    return false;
+                }
             );
         }
         const productWoCat = this.models["product.product"].filter(
@@ -797,7 +823,7 @@ export class SelfOrder extends Reactive {
 
     getProductDisplayPrice(product) {
         const pricelist = this.config.pricelist_id;
-        const price = product.get_price(pricelist, 1);
+        const price = product.get_price(pricelist, 1, 0, false, product.list_price);
 
         let taxes = product.taxes_id;
 

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -218,9 +218,9 @@ export class SelfOrder extends Reactive {
             const productVariant = this.models["product.product"].find(
                 (prd) =>
                     prd.raw.product_tmpl_id === product.raw.product_tmpl_id &&
-                    prd.product_template_variant_value_ids.every((ptav) => {
-                        return Object.values(selectedValues).some((value) => ptav.id == value);
-                    })
+                    prd.product_template_variant_value_ids.every((ptav) =>
+                        Object.values(selectedValues).some((value) => ptav.id == value)
+                    )
             );
             if (productVariant) {
                 Object.assign(values, {

--- a/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
@@ -54,3 +54,25 @@ registry.category("web_tour.tours").add("self_multi_attribute_selector", {
         ProductPage.verifyIsCheckedAttribute("Attribute 1", ["Attribute Val 1", "Attribute Val 2"]),
     ],
 });
+
+registry.category("web_tour.tours").add("selfAlwaysAttributeVariants", {
+    test: true,
+    steps: () => [
+        Utils.clickBtn("Order Now"),
+        ProductPage.clickProduct("Chair"),
+        ...ProductPage.setupAttribute([{ name: "Color", value: "White" }]),
+        Utils.clickBtn("Order"),
+        CartPage.checkProduct("Chair (White)", "10", "1"),
+        CartPage.clickBack(),
+        ProductPage.clickProduct("Chair"),
+        ...ProductPage.setupAttribute([{ name: "Color", value: "Red" }]),
+        Utils.clickBtn("Order"),
+        CartPage.checkProduct("Chair (Red)", "15", "1"),
+        Utils.clickBtn("Pay"),
+        Utils.clickBtn("Ok"),
+        Utils.clickBtn("My Order"),
+        Utils.clickBtn("Pay"),
+        Utils.clickBtn("Ok"),
+        Utils.checkIsNoBtn("Order Now"),
+    ],
+});

--- a/addons/pos_self_order/tests/test_self_order_attribute.py
+++ b/addons/pos_self_order/tests/test_self_order_attribute.py
@@ -72,3 +72,41 @@ class TestSelfOrderAttribute(SelfOrderCommonTest):
         self_route = self.pos_config._get_self_order_route()
 
         self.start_tour(self_route, "self_multi_attribute_selector")
+
+    def test_self_order_always_attribute(self):
+        self.pos_config.write({
+            'self_ordering_default_user_id': self.pos_admin.id,
+            'self_ordering_takeaway': False,
+            'self_ordering_mode': 'mobile',
+            'self_ordering_pay_after': 'each',
+            'self_ordering_service_mode': 'counter',
+        })
+        pos_categ_chairs = self.env['pos.category'].create({
+            'name': 'Chairs',
+        })
+        color_attribute = self.env['product.attribute'].create({
+            'name': 'Color',
+            'create_variant': 'always',
+            'value_ids': [(0, 0, {'name': 'White'}), (0, 0, {'name': 'Red', 'default_extra_price': 5})],
+        })
+        chair_product_tmpl = self.env['product.template'].create({
+            'name': 'Chair',
+            'list_price': 10,
+            'taxes_id': False,
+            'available_in_pos': True,
+            'pos_categ_ids': [(4, pos_categ_chairs.id)],
+            'attribute_line_ids': [(0, 0, {
+                'attribute_id': color_attribute.id,
+                'value_ids': [(6, 0, color_attribute.value_ids.ids)]
+            })],
+        })
+
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self_route = self.pos_config._get_self_order_route()
+        self.start_tour(self_route, "selfAlwaysAttributeVariants")
+
+        order = self.pos_config.current_session_id.order_ids[0]
+        self.assertEqual(order.lines[0].product_id.id, chair_product_tmpl.product_variant_ids[0].id)
+        self.assertEqual(order.lines[0].price_unit, 10.0)
+        self.assertEqual(order.lines[1].product_id.id, chair_product_tmpl.product_variant_ids[1].id)
+        self.assertEqual(order.lines[1].price_unit, 15.0)

--- a/addons/pos_self_order_sale/static/src/app/pages/cart_page/cart_page.js
+++ b/addons/pos_self_order_sale/static/src/app/pages/cart_page/cart_page.js
@@ -15,8 +15,8 @@ patch(CartPage.prototype, {
             (line) => line.product_id.raw.optional_product_ids
         );
 
-        const products = this.selfOrder.models["product.product"].filter((p) =>
-            optionalProductIds.includes(p.raw.product_tmpl_id)
+        const products = this.selfOrder.models["product.product"].filter(
+            (p) => optionalProductIds.includes(p.raw.product_tmpl_id) && p.available_in_pos
         );
 
         return products;


### PR DESCRIPTION
before this commit:
==============
- Products with attributes in instant mode appeared duplicated in the product list for each combination.

![image](https://github.com/user-attachments/assets/d7b48807-825e-4205-8384-ee929dbc8314)

after this commit:
==============
- The product list now shows only the main product for variants, similar to POS. 
  Clicking on the product opens the configuration page.
- Disabled attribute values associated with archived combinations are on the product configuration page.

![imgonline-com-ua-twotoone-b37DSqUu8rGbB](https://github.com/user-attachments/assets/e6c23bd4-03df-4970-9a28-bd0716166ea6)


Task-4269189