### PR TITLE
[FIX] account: bill creation from other company user email

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4742,7 +4742,13 @@ class AccountMove(models.Model):
             'invoice_source_email': from_mail_addresses[0],
             'partner_id': partners and partners[0].id or False,
         }
-        move_ctx = self.with_context(default_move_type=custom_values['move_type'], default_journal_id=custom_values['journal_id'])
+        ctx = {
+            'default_move_type': custom_values['move_type'],
+            'default_journal_id': custom_values['journal_id'],
+        }
+        if custom_values.get('company_id'):
+            ctx['default_company_id'] = custom_values['company_id']
+        move_ctx = self.with_context(**ctx)
         move = super(AccountMove, move_ctx).message_new(msg_dict, custom_values=values)
         move._compute_name()  # because the name is given, we need to recompute in case it is the first invoice of the journal
 


### PR DESCRIPTION
Issue can be reproduced on a trial/SaaS db:
- Have an alias [alias] set up for vendor bills journal
- Create another company [company2]
- Add user [user] that can only access [company2]
- Add email [mail] as login/mail of that user
- Now from [mail] send a message, with pdf attachment, to [alias]

Issue: Mail will bounce back with an error
```
odoo.exceptions.UserError: Incompatible companies on records:
- “Draft Bill ” belongs to company “False” and “Journal” (journal_id: \'Vendor Bills\') belongs to another company.
```
This does not occur if [MAIL] is not associated with an user of company2

When the email is processed, the system recognizes the user email and
we have a minimal context.
Then, during move creation, `_compute_company_id` is called to assign
the company to the first accessible company.
However no accessible company is found because:
- current company would be the vendor bill journal's company ([company1])
  https://github.com/odoo/odoo/blame/0aa729fd6492139869bab299d1091a54fd443c54/odoo/addons/base/models/res_company.py#L390
- because of the lack of `accessible_companies` in environment,
  accessible companies is [user]'s company, [company2]
  https://github.com/odoo/odoo/blame/0aa729fd6492139869bab299d1091a54fd443c54/odoo/api.py#L682

As result, no company is assigned to the newly created move and it
raises an error when inconsistencies are checked

A solution is to force the company whenever we detect the move is
created from an alias

[1] Full traceback
```
  File "/home/odoo/src/odoo/18.0/addons/mail/models/mail_thread.py", line 1389, in message_process
    thread_id = self._message_route_process(message, msg_dict, routes)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/18.0/addons/mail/models/mail_thread.py", line 1282, in _message_route_process
    thread = ModelCtx.message_new(message_dict, custom_values)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/18.0/addons/account/models/account_move.py", line 5894, in message_new
    move = super(AccountMove, move_ctx).message_new(msg_dict, custom_values=values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/18.0/addons/mail/models/mail_thread.py", line 1424, in message_new
    return self.create(data)
           ^^^^^^^^^^^^^^^^^
  File "<decorator-gen-67>", line 2, in create
  File "/home/odoo/src/odoo/18.0/odoo/api.py", line 479, in _model_create_multi
    return create(self, [arg])
           ^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/18.0/addons/account/models/account_move.py", line 3125, in create
    moves = super().create(vals_list)
            ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<decorator-gen-40>", line 2, in create
  File "/home/odoo/src/odoo/18.0/odoo/api.py", line 480, in _model_create_multi
    return create(self, arg)
           ^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/18.0/addons/mail/models/mail_thread.py", line 267, in create
    threads = super(MailThread, self).create(vals_list)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<decorator-gen-0>", line 2, in create
  File "/home/odoo/src/odoo/18.0/odoo/api.py", line 480, in _model_create_multi
    return create(self, arg)
           ^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/18.0/odoo/models.py", line 5018, in create
    records._check_company()
  File "/home/odoo/src/odoo/18.0/odoo/models.py", line 4368, in _check_company
    raise UserError("\
".join(lines))
odoo.exceptions.UserError: Incompatible companies on records:
- “Draft Bill ” belongs to company “False” and “Journal” (journal_id: \'Vendor Bills\') belongs to another company.
```

opw-4232030
