### PR TITLE
[FIX] l10n_*: remove single module warnings

### DIFF
--- a/addons/l10n_cy/demo/demo_company.xml
+++ b/addons/l10n_cy/demo/demo_company.xml
@@ -36,5 +36,6 @@
         <value eval="[]"/>
         <value>cy</value>
         <value model="res.company" eval="obj().env.ref('l10n_cy.demo_company_cy')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_iq/demo/demo_company.xml
+++ b/addons/l10n_iq/demo/demo_company.xml
@@ -30,6 +30,7 @@
             <value eval="[]" />
             <value>iq</value>
             <value model="res.company" eval="obj().env.ref('l10n_iq.demo_company_iq')" />
+            <value name="install_demo" eval="True"/>
         </function>
     </data>
 </odoo>

--- a/addons/l10n_mt/demo/demo_company.xml
+++ b/addons/l10n_mt/demo/demo_company.xml
@@ -36,5 +36,6 @@
         <value eval="[]"/>
         <value>mt</value>
         <value model="res.company" eval="obj().env.ref('l10n_mt.demo_company_mt')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_qa/demo/demo_company.xml
+++ b/addons/l10n_qa/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>qa</value>
         <value model="res.company" eval="obj().env.ref('l10n_qa.demo_company_qa')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_tz_account/demo/demo_company.xml
+++ b/addons/l10n_tz_account/demo/demo_company.xml
@@ -36,5 +36,6 @@
         <value eval="[]"/>
         <value>tz</value>
         <value model="res.company" eval="obj().env.ref('l10n_tz_account.demo_company_tz')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>


### PR DESCRIPTION
Correctly set the flag `install_demo` in demo data for some localisation, they were triggering some warnings otherwise.

RunbotError: 103691
