### PR TITLE
[FIX] l10n_cl: display consistent currency rate on printed invoice

### DIFF
--- a/addons/l10n_cl/models/account_move_line.py
+++ b/addons/l10n_cl/models/account_move_line.py
@@ -65,7 +65,7 @@ class AccountMoveLine(models.Model):
             second_currency_field = 'price_subtotal'
             second_currency = self.currency_id
             main_currency_rate = 1
-            second_currency_rate = abs(self.balance) / self.price_subtotal if domestic_invoice_other_currency else False
+            second_currency_rate = abs(self.move_id.amount_total_signed) / self.move_id.amount_total if self.move_id.amount_total else 1
             inverse_rate = second_currency_rate if domestic_invoice_other_currency else main_currency_rate
         else:
             # This is to manage case 5 (export docs)
@@ -73,7 +73,7 @@ class AccountMoveLine(models.Model):
             second_currency = self.move_id.company_id.currency_id
             main_currency_field = 'price_subtotal'
             second_currency_field = 'balance'
-            inverse_rate = abs(self.balance) / self.price_subtotal
+            inverse_rate = abs(self.move_id.amount_total_signed) / self.move_id.amount_total if self.move_id.amount_total else 1
         price_subtotal = abs(self[main_currency_field]) * line_sign
         if self.quantity and self.discount != 100.0:
             price_unit = (price_subtotal / abs(self.quantity)) / (1 - self.discount / 100)


### PR DESCRIPTION
**Steps to reproduce:**
- Install l10n_cl
- Switch to a Chilean company (e.g. CL Company)
- Activate a foreign currency (e.g. USD)
- Make sure that the rate of the foreign currency is not 1 For example:
  * Unit per CLP: 0.001057876419
  * CLP per Unit:945.29
- Create an invoice in USD with 2 lines having different amount:
  * 15.80
  * 15.00
- Save the invoice
- Print the invoice

**Issue:**
On the printed invoice, a slightly different currency rate is displayed for each invoice line.

**Cause:**
The currency rate to display is computed for each invoice line, based on the following formula:
`abs(self.balance) / self.price_subtotal`
However, the value of balance is rounded to the unit because of the CLP currency and therefore it generates a different rate when trying to compute it.

**Solution:**
Compute the rate from the total values instead of the subtotal of each line.
The real rate configured on the currency cannot be used because it can be modified after the creation of the invoice.

opw-4242448


Linked enterprise PR: https://github.com/odoo/enterprise/pull/73035

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
