### PR TITLE
[FIX] l10n_de: apply fp account mapping

### DIFF
--- a/addons/l10n_de/models/datev.py
+++ b/addons/l10n_de/models/datev.py
@@ -28,11 +28,13 @@ class ProductTemplate(models.Model):
             if not self.property_account_income_id:
                 taxes = self.taxes_id.filtered(lambda t: t.company_id == company)
                 if not result['income'] or (result['income'].tax_ids and taxes and taxes[0] not in result['income'].tax_ids):
-                    result['income'] = self.env['account.account'].search([('internal_group', '=', 'income'), ('deprecated', '=', False),
+                    result_income = self.env['account.account'].search([('internal_group', '=', 'income'), ('deprecated', '=', False),
                                                                    ('tax_ids', 'in', taxes.ids)], limit=1)
+                    result['income'] = result_income or result['income']
             if not self.property_account_expense_id:
                 supplier_taxes = self.supplier_taxes_id.filtered(lambda t: t.company_id == company)
                 if not result['expense'] or (result['expense'].tax_ids and supplier_taxes and supplier_taxes[0] not in result['expense'].tax_ids):
-                    result['expense'] = self.env['account.account'].search([('internal_group', '=', 'expense'), ('deprecated', '=', False),
+                    result_expense = self.env['account.account'].search([('internal_group', '=', 'expense'), ('deprecated', '=', False),
                                                                    ('tax_ids', 'in', supplier_taxes.ids)], limit=1)
+                    result['expense'] = result_expense or result['expense']
         return result


### PR DESCRIPTION
When having a tax with a specific tax as source account in the
tax mapping of a fiscal position. The mapping does not apply
if the product has a different tax from the tax of the account
and no income/expense account set.

This is because we extend `_get_product_accounts` in `datev`
and replace the default income/expense account by an account
that have the product tax.

With this fix, we replace defualt income/expense accounts only
if we find an account.

Steps:

- Have a FP with an account mapping: 8400 -> 2315
- Have a product P with a different tax from the one set on 8400
  account, and that is not set on any other account
- Create an invoice, set the FP, select the product P
-> Account on the aml is 8400 instead of 2315

opw-4075846
