### PR TITLE
[FIX] onboarding: prevent crash with multiple progress records

### DIFF
--- a/addons/onboarding/models/onboarding_onboarding.py
+++ b/addons/onboarding/models/onboarding_onboarding.py
@@ -57,7 +57,7 @@ class Onboarding(models.Model):
     def _compute_current_progress(self):
         for onboarding in self:
             current_progress_id = onboarding.progress_ids.filtered(
-                lambda progress: progress.company_id.id in {False, self.env.company.id})
+                lambda progress: progress.company_id.id in {False, self.env.company.id}).sorted('create_date', reverse=True)[:1]
             if current_progress_id:
                 onboarding.current_onboarding_state = current_progress_id.onboarding_state
                 onboarding.current_progress_id = current_progress_id

--- a/addons/onboarding/models/onboarding_onboarding_step.py
+++ b/addons/onboarding/models/onboarding_onboarding_step.py
@@ -55,7 +55,7 @@ class OnboardingStep(models.Model):
         for step in self:
             if step in existing_progress_steps.step_id:
                 current_progress_step_id = existing_progress_steps.filtered(
-                    lambda progress_step: progress_step.step_id == step)
+                    lambda progress_step: progress_step.step_id == step).sorted('create_date', reverse=True)[:1]
                 step.current_progress_step_id = current_progress_step_id
                 step.current_step_state = current_progress_step_id.step_state
             else:


### PR DESCRIPTION
Multiple progress records for the same onboarding and company_id (False) were allowed to be created in several databases which resulted in crashes.

As simple stable fix, we'll select only the latest onboarding_progress records created per onboarding when trying to compute the current_progress_id and similarly for progress steps.

The [fix](https://github.com/odoo/odoo/pull/108183) in this addresses the fix up to version forward bot 16.1. However, in my case starting the database from versions 16.4 and 17.0, this code is no longer present, as confirmed by TBG. As a result, the same issue reappears, which is why I prepared this fix.

tbg-1565
upg-2106731,2094548

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
