### PR TITLE
[FIX] html_editor: display table picker in firefox

### DIFF
--- a/addons/html_editor/static/src/main/table/table_ui_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_ui_plugin.js
@@ -42,11 +42,7 @@ export class TableUIPlugin extends Plugin {
                     if (this.config.direction === "rtl") {
                         // position from the right instead of the left as it is needed
                         // to ensure the expand animation is properly done
-                        if (left < 0) {
-                            picker.style.right = `${-popperRect.width - left}px`;
-                        } else {
-                            picker.style.right = `${window.innerWidth - left - popperRect.width}px`;
-                        }
+                        picker.style.right = `${window.innerWidth - left - popperRect.width}px`;
                         picker.style.removeProperty("left");
                     }
                 },


### PR DESCRIPTION
Issue:
======
Table picker doesn't appear in rtl language in firefox

Steps to reproduce the issue:
=============================
- Make sure you use rtl lang
- Create a new todo
- Try to add table
- Table picker doesn't appear

Origin of the issue:
====================

The case of `left < 0` was handled wrong. They can both be handled by the sane formule.

When left > 0 it will be like this:

`|---left---||---width---||---right---|`
`|-----------------window-------------|`

So here `right = window-left-width`

And when left < 0 it will be like this

`|---width-----||---right------------------------ |`
`|---left---|                                     |`
`           |-----------------window--------------|`

And here `right = window - left - width` (left here is < 0)

task-4282549

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
