### PR TITLE
[REF] mail, various: have email-like explicit external recipients

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4790,7 +4790,9 @@ class MailThread(models.AbstractModel):
                     ['model', '=', self._name], ['res_id', '=', thread.id]
                 ]))
             if request_list and "suggestedRecipients" in request_list:
-                res["suggestedRecipients"] = thread._message_get_suggested_recipients()
+                res["suggestedRecipients"] = thread._message_get_suggested_recipients(
+                    reply_discussion=True, no_create=True,
+                )
             if res:
                 store.add(thread, res, as_thread=True)
 

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2420,13 +2420,15 @@ class MailThread(models.AbstractModel):
 
         # subscribe author(s) so that they receive answers; do it only when it is
         # a manual post by the author (aka not a system notification, not a message
-        # posted 'in behalf of', and if still active).
+        # posted 'in behalf of'). Limit to active and internal partners, as external
+        # customers should be proposed through suggested recipients.
         author_subscribe = (
             not self._context.get('mail_post_autofollow_author_skip')
             and msg_values['message_type'] not in ('notification', 'user_notification', 'auto_comment')
         )
         if author_subscribe:
-            if real_author := self._message_compute_real_author(msg_values['author_id']):
+            real_author = self._message_compute_real_author(msg_values['author_id'])
+            if real_author and not real_author.partner_share:
                 self._message_subscribe(partner_ids=[real_author.id])
 
         self._message_post_after_hook(new_message, msg_values)

--- a/addons/mail/models/mail_thread_cc.py
+++ b/addons/mail/models/mail_thread_cc.py
@@ -43,9 +43,8 @@ class MailThreadCc(models.AbstractModel):
         cc_values.update(update_vals)
         return super().message_update(msg_dict, cc_values)
 
-    def _message_get_suggested_recipients(self):
-        recipients = super()._message_get_suggested_recipients()
+    def _message_add_suggested_recipients(self):
+        email_to_lst, partners = super()._message_add_suggested_recipients()
         if self.email_cc:
-            for email in tools.mail.email_split_and_format(self.email_cc):
-                self._message_add_suggested_recipient(recipients, email=email, reason=_('CC Email'))
-        return recipients
+            email_to_lst.append(self.email_cc)
+        return email_to_lst, partners

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -61,10 +61,10 @@ class ResPartner(models.Model):
     def _mail_get_partners(self, introspect_fields=False):
         return dict((partner.id, partner) for partner in self)
 
-    def _message_get_suggested_recipients(self):
-        recipients = super()._message_get_suggested_recipients()
-        self._message_add_suggested_recipient(recipients, partner=self, reason=_('Partner Profile'))
-        return recipients
+    def _message_add_suggested_recipients(self):
+        email_to_lst, partners = super()._message_add_suggested_recipients()
+        partners += self
+        return email_to_lst, partners
 
     def _message_get_default_recipients(self):
         return {

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -901,7 +901,7 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
     # ------------------------------------------------------------
 
     def assertNoPushNotification(self):
-        """ Asserts a single push notification """
+        """ Asserts no push notification """
         self.push_to_end_point_mocked.assert_not_called()
         self.assertEqual(self.env['mail.push'].search_count([]), 0)
 
@@ -909,7 +909,7 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
                                endpoint=None, keys=None,
                                title=None, title_content=None, body=None, body_content=None,
                                options=None):
-        """ Asserts a single push notification """
+        """ Asserts a single push notification (not really batch enabled currently) """
         self.push_to_end_point_mocked.assert_called_once()
         self.assertEqual(self.env['mail.push'].search_count([]), mail_push_count)
         if endpoint:

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -590,7 +590,22 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
             with self.subTest(fname=fname, expected_fvalue=expected_fvalue):
                 if fname == 'headers':
                     fvalue = literal_eval(mail[fname])
-                    self.assertDictEqual(fvalue, expected_fvalue)
+                    # specific use case for X-Msg-To-Add: it is a comma-separated list of
+                    # email addresses, order is not important
+                    if 'X-Msg-To-Add' in fvalue and 'X-Msg-To-Add' in expected_fvalue:
+                        msg_to_add = fvalue['X-Msg-To-Add']
+                        exp_msg_to_add = expected_fvalue['X-Msg-To-Add']
+                        self.assertEqual(
+                            sorted(email_split_and_format_normalize(msg_to_add)),
+                            sorted(email_split_and_format_normalize(exp_msg_to_add))
+                        )
+                        fvalue = dict(fvalue)
+                        fvalue.pop('X-Msg-To-Add')
+                        expected_fvalue = dict(expected_fvalue)
+                        expected_fvalue.pop('X-Msg-To-Add')
+                        self.assertDictEqual(fvalue, expected_fvalue)
+                    else:
+                        self.assertDictEqual(fvalue, expected_fvalue)
                 elif fname == 'attachments_info':
                     for attachment_info in expected_fvalue:
                         attachment = next((attach for attach in mail.attachment_ids if attach.name == attachment_info['name']), False)
@@ -889,7 +904,18 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
                 )
 
         if 'headers' in expected:
+            # specific use case for X-Msg-To-Add: it is a comma-separated list of
+            # email addresses, order is not important
+            if 'X-Msg-To-Add' in sent_mail['headers'] and 'X-Msg-To-Add' in expected['headers']:
+                msg_to_add = sent_mail['headers']['X-Msg-To-Add']
+                exp_msg_to_add = expected['headers']['X-Msg-To-Add']
+                self.assertEqual(
+                    sorted(email_split_and_format_normalize(msg_to_add)),
+                    sorted(email_split_and_format_normalize(exp_msg_to_add))
+                )
             for key, value in expected['headers'].items():
+                if key == 'X-Msg-To-Add':
+                    continue
                 self.assertTrue(key in sent_mail['headers'], f'Missing key {key}')
                 found = sent_mail['headers'][key]
                 self.assertEqual(found, value,
@@ -1224,6 +1250,7 @@ class MailCase(MockEmail):
               {
                 'check_send': whether outgoing stuff has to be checked;
                 'email': NOT SUPPORTED YET,
+                'email_to_recipients': propagated to 'assertMailMail';
                 'failure_reason': failure_reason on mail.notification;
                 'failure_type': 'failure_type' on mail.notification;
                 'is_read': 'is_read' on mail.notification;
@@ -1258,6 +1285,7 @@ class MailCase(MockEmail):
             # sanity check
             extra_keys = set(message_info.keys()) - {
                 'content',
+                'email_to_recipients',
                 'email_values',
                 'mail_mail_values',
                 'message_type',

--- a/addons/test_mail/models/mail_test_lead.py
+++ b/addons/test_mail/models/mail_test_lead.py
@@ -40,18 +40,6 @@ class MailTestTLead(models.Model):
             values['phone'] = values.get('phone') or lead.phone
         return email_normalized_to_values
 
-    def _message_get_suggested_recipients(self):
-        recipients = super()._message_get_suggested_recipients()
-        # check if that language is correctly installed (and active) before using it
-        lang_code = self.env['res.lang']._get_data(code=self.lang_code).code or None
-        if self.partner_id:
-            self._message_add_suggested_recipient(
-                recipients, partner=self.partner_id, reason=_('Customer'))
-        elif self.email_from:
-            self._message_add_suggested_recipient(
-                recipients, email=self.email_from, reason=_('Customer Email'))
-        return recipients
-
     def _message_post_after_hook(self, message, msg_vals):
         if self.email_from and not self.partner_id:
             # we consider that posting a message with a specified recipient (not a follower, a specific one)

--- a/addons/test_mail/models/test_mail_feature_models.py
+++ b/addons/test_mail/models/test_mail_feature_models.py
@@ -8,7 +8,7 @@ from odoo import api, fields, models
 class MailTestRecipients(models.Model):
     _name = 'mail.test.recipients'
     _description = "Test Recipients Computation"
-    _inherit = ['mail.thread']
+    _inherit = ['mail.thread.cc']
     _primary_email = 'customer_email'
 
     company_id = fields.Many2one('res.company')
@@ -16,7 +16,6 @@ class MailTestRecipients(models.Model):
     customer_id = fields.Many2one('res.partner')
     customer_email = fields.Char('Customer Email', compute='_compute_customer_email', readonly=False, store=True)
     customer_phone = fields.Char('Customer Phone', compute='_compute_customer_phone', readonly=False, store=True)
-    email_cc = fields.Char('Email CC')
     name = fields.Char()
 
     @api.depends('customer_id')
@@ -39,7 +38,6 @@ class MailTestThreadCustomer(models.Model):
     _inherit = ['mail.test.recipients']
     _mail_thread_customer = True
     _primary_email = 'customer_email'
-
 
 # ------------------------------------------------------------
 # PROPERTIES

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -2120,6 +2120,7 @@ class TestComposerResultsComment(TestMailComposer, CronMixinCase):
                 ):
                     message = record.message_ids[0]
                     for recipient in [self.partner_employee_2, new_partner, record.customer_id]:
+                        headers_recipients = f'{new_partner.email_formatted},{record.customer_id.email_formatted}'
                         self.assertMailMail(
                             recipient,
                             'sent',
@@ -2129,6 +2130,7 @@ class TestComposerResultsComment(TestMailComposer, CronMixinCase):
                                 'headers': {
                                     'Return-Path': f'{exp_alias_domain.bounce_email}',
                                     'X-Odoo-Objects': f'{record._name}-{record.id}',
+                                    'X-Msg-To-Add': headers_recipients,
                                 },
                                 'subject': f'TemplateSubject {record.name}',
                             },
@@ -2136,6 +2138,7 @@ class TestComposerResultsComment(TestMailComposer, CronMixinCase):
                                 'headers': {
                                     'Return-Path': f'{exp_alias_domain.bounce_email}',
                                     'X-Odoo-Objects': f'{record._name}-{record.id}',
+                                    'X-Msg-To-Add': headers_recipients,
                                 },
                                 'mail_server_id': self.env['ir.mail_server'],
                                 'record_alias_domain_id': exp_alias_domain,

--- a/addons/test_mail/tests/test_mail_flow.py
+++ b/addons/test_mail/tests/test_mail_flow.py
@@ -1,7 +1,8 @@
+from odoo import tools
 from odoo.addons.mail.tests.common import mail_new_test_user, MailCommon
 from odoo.addons.test_mail.data.test_mail_data import MAIL_TEMPLATE
 from odoo.addons.test_mail.tests.common import TestRecipients
-from odoo.tools.mail import email_normalize, formataddr
+from odoo.tools.mail import formataddr
 from odoo.tests import tagged
 
 
@@ -187,64 +188,59 @@ class TestMailFlow(MailCommon, TestRecipients):
         # uses Chatter: fetches suggested recipients, post a message
         # - checks all suggested: email_cc field, primary email
         # ------------------------------------------------------------
-        suggested_all = lead_as_emp._message_get_suggested_recipients()
-        expected_all = [
-            {  # first primary email
-                'create_values': {
-                    'lang': 'fr_FR',
-                    'mobile': False,
-                    'phone': '+32455001122',
-                },
-                'email': 'sylvie.lelitre@zboing.com',
-                'name': 'Sylvie Lelitre (Zboing)',
-                'partner_id': False,
-                'reason': 'Customer Email',
-            },
-            {  # mail.thread.cc: email_cc field
-                'create_values': {},
-                'email': 'pay@zboing.com',
-                'name': '',
-                'partner_id': False,
-                'reason': 'CC Email',
-            },
-            {  # mail.thread.cc: email_cc field (linked to partner)
-                'create_values': {},
-                'email': 'portal@zboing.com',
-                'name': 'Portal Zboing',
-                'reason': 'CC Email',
-                'partner_id': self.customer_portal_zboing.id,
-            },
-        ]
-        for suggested, expected in zip(suggested_all, expected_all):
-            self.assertDictEqual(suggested, expected)
-
-        # check recipients, which creates them (simulating discuss in a quick way)
-        lead_as_emp._partner_find_from_emails_single([sug['email'] for sug in suggested_all])
+        suggested_all = lead_as_emp._message_get_suggested_recipients(
+            reply_discussion=True, no_create=False,
+        )
         partner_sylvie = self.env['res.partner'].search(
             [('email_normalized', '=', 'sylvie.lelitre@zboing.com')]
         )
         partner_pay = self.env['res.partner'].search(
             [('email_normalized', '=', 'pay@zboing.com')]
         )
-        self.assertEqual(
-            len(partner_sylvie + partner_pay), 2,
-            'Mail: should have created partners for emails')
-        self.assertFalse(
-            self.env['res.partner'].search([('email_normalized', '=', 'accounting@zboing.com')]),
-            'Mail: currently other "To" in incoming emails are lost if not linked to existing partners'
+        partner_accounting = self.env['res.partner'].search(
+            [('email_normalized', '=', 'accounting@zboing.com')]
         )
+        expected_all = [
+            {  # existing partners come first
+                'create_values': {},
+                'email': 'portal@zboing.com',
+                'name': 'Portal Zboing',
+                'partner_id': self.customer_portal_zboing.id,
+            },
+            {  # primary email comes first
+                'create_values': {},
+                'email': 'sylvie.lelitre@zboing.com',
+                'name': 'Sylvie Lelitre (Zboing)',
+                'partner_id': partner_sylvie.id,
+            },
+            {  # mail.thread.cc: email_cc field
+                'create_values': {},
+                'email': 'pay@zboing.com',
+                'name': 'pay@zboing.com',
+                'partner_id': partner_pay.id,
+            },
+            {  # reply message
+                'create_values': {},
+                'email': 'accounting@zboing.com',
+                'name': 'Josiane Quichopoils',
+                'partner_id': partner_accounting.id,
+            },
+        ]
+        for suggested, expected in zip(suggested_all, expected_all):
+            self.assertDictEqual(suggested, expected)
+
         # finally post the message with recipients
         with self.mock_mail_gateway():
             responsible_answer = lead_as_emp.message_post(
                 body='<p>Well received !',
-                partner_ids=(partner_sylvie + partner_pay + self.customer_portal_zboing).ids,
+                partner_ids=(partner_sylvie + partner_pay + partner_accounting + self.customer_portal_zboing).ids,
                 message_type='comment',
                 subject=f'Re: {lead.name}',
                 subtype_id=self.env.ref('mail.mt_comment').id,
             )
         self.assertEqual(lead_as_emp.message_partner_ids, self.partner_employee + self.partner_employee_2 + self.partner_portal)
 
-        external_partners = partner_sylvie + partner_pay + self.customer_portal_zboing + self.partner_portal
+        external_partners = partner_sylvie + partner_pay + partner_accounting + self.customer_portal_zboing + self.partner_portal
         internal_partners = self.partner_employee + self.partner_employee_2
         expected_chatter_reply_to = formataddr(
             (f'{self.env.company.name} {lead.name}', f'{self.alias_catchall}@{self.alias_domain}')
@@ -268,13 +264,14 @@ class TestMailFlow(MailCommon, TestRecipients):
                         'notified_partner_ids': external_partners + self.partner_employee_2,
                         'parent_id': incoming_email,
                         # matches posted message
-                        'partner_ids': partner_sylvie + partner_pay + self.customer_portal_zboing,
+                        'partner_ids': partner_sylvie + partner_pay + partner_accounting + self.customer_portal_zboing,
                         'reply_to': expected_chatter_reply_to,
                         'subtype_id': self.env.ref('mail.mt_comment'),
                     },
                     'notif': [
                         {'partner': partner_sylvie, 'type': 'email'},
                         {'partner': partner_pay, 'type': 'email'},
+                        {'partner': partner_accounting, 'type': 'email'},
                         {'partner': self.customer_portal_zboing, 'type': 'email'},
                         {'partner': self.partner_employee_2, 'type': 'email'},
                         {'partner': self.partner_portal, 'type': 'email'},
@@ -302,14 +299,16 @@ class TestMailFlow(MailCommon, TestRecipients):
             MAIL_TEMPLATE, [partner_sylvie.email_normalized], reply_all=False,
             cc=f'{self.test_emails[3]}, {self.test_emails[4]}',  # used mainly for existing partners currently
         )
+        external_partners += self.customer_zboing  # added in CC just above
         self.assertEqual(len(lead.message_ids), 3, 'Incoming email + chatter reply + customer reply')
         self.assertEqual(
             lead.message_partner_ids,
             partner_sylvie + internal_partners + self.partner_portal,
             'Mail gateway: author (partner_sylvie) added in followers')
 
+        customer_reply = lead.message_ids[0]
         self.assertMailNotifications(
-            lead.message_ids[0],
+            customer_reply,
             [
                 {
                     'content': 'Please call me as soon as possible',
@@ -317,6 +316,7 @@ class TestMailFlow(MailCommon, TestRecipients):
                     'message_values': {
                         'author_id': partner_sylvie,
                         'email_from': partner_sylvie.email_formatted,
+                        # Cc: received email CC - an email still not partnerized (invoicing) and customer_zboing
                         'incoming_email_cc': f'{self.test_emails[3]}, {self.test_emails[4]}',
                         'incoming_email_to': expected_chatter_reply_to,  # reply_all not already implemented, hence just alias
                         'mail_server_id': self.env['ir.mail_server'],

--- a/addons/test_mail/tests/test_mail_flow.py
+++ b/addons/test_mail/tests/test_mail_flow.py
@@ -306,8 +306,8 @@ class TestMailFlow(MailCommon, TestRecipients):
         self.assertEqual(len(lead.message_ids), 3, 'Incoming email + chatter reply + customer reply')
         self.assertEqual(
             lead.message_partner_ids,
-            partner_sylvie + internal_partners + self.partner_portal,
-            'Mail gateway: author (partner_sylvie) added in followers')
+            internal_partners + self.partner_portal,
+            'Mail gateway: author (partner_sylvie) should not added in followers if external')
 
         customer_reply = lead.message_ids[0]
         self.assertMailNotifications(

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -495,9 +495,7 @@ class TestAPI(MailCommon, TestRecipients):
             }),
         ]:
             messages += test_record.with_user(user).message_post(**post_values)
-        self.assertEqual(test_record.message_partner_ids, self.user_employee.partner_id + self.user_portal.partner_id)
-        # to test author proposal, remove portal for some reason
-        test_record.message_unsubscribe(partner_ids=self.user_portal.partner_id.ids)
+        self.assertEqual(test_record.message_partner_ids, self.user_employee.partner_id)
 
         recipients = test_record._message_get_suggested_recipients(reply_message=messages[0], no_create=True)
         for recipient, expected in zip(recipients, [

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from unittest.mock import DEFAULT
 import base64
 
-from odoo import exceptions
+from odoo import exceptions, tools
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.addons.test_mail.models.test_mail_models import MailTestSimple
 from odoo.addons.test_mail.tests.common import TestRecipients
@@ -12,12 +12,13 @@ from odoo.tests import Form, tagged, users
 from odoo.tools import mute_logger
 
 
-@tagged('mail_thread', 'mail_tools')
+@tagged('mail_thread', 'mail_thread_api', 'mail_tools')
 class TestAPI(MailCommon, TestRecipients):
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.user_portal = cls._create_portal_user()
         cls.test_partner = cls.env['res.partner'].create({
             'email': '"Test External" <test.external@example.com>',
             'mobile': '+32455001122',
@@ -183,15 +184,15 @@ class TestAPI(MailCommon, TestRecipients):
                 'mobile': '+32455000001',
                 'phone': False,
             }]),
-            (self.env['res.partner'], [{}]),
+            (self.env['res.partner'], []),
             (self.test_partner, [{}]),
-            (self.env['res.partner'], [{}]),
+            (self.env['res.partner'], []),
         ]
         for ticket, (exp_partners, exp_values_list) in zip(tickets, expected_all):
             partners = res[ticket.id]
             with self.subTest(ticket_name=ticket.name):
                 self.assertEqual(partners, exp_partners, f'Found {partners.name} instead of {exp_partners.name}')
-                for partner, exp_values in zip(partners, exp_values_list):
+                for partner, exp_values in zip(partners, exp_values_list, strict=True):
                     for fname, fvalue in exp_values.items():
                         self.assertEqual(partners[fname], fvalue)
 
@@ -379,7 +380,7 @@ class TestAPI(MailCommon, TestRecipients):
             }, {  # public user should not be proposed
                 'email_cc': '', 'email_to': '', 'partner_ids': [],
             },
-        ]):
+        ], strict=True):
             with self.subTest(name=record.name):
                 self.assertEqual(defaults_withcc[record.id], expected)
                 self.assertEqual(defaults_withoutcc[record.id], dict(expected, email_cc=''))
@@ -402,14 +403,13 @@ class TestAPI(MailCommon, TestRecipients):
         """ Test default creation values returned for suggested recipient. """
         ticket = self.ticket_record.with_user(self.env.user)
         ticket.message_unsubscribe(ticket.user_id.partner_id.ids)
-        suggestions = ticket._message_get_suggested_recipients()
+        suggestions = ticket._message_get_suggested_recipients(no_create=True)
         self.assertEqual(len(suggestions), 2)
         for suggestion, expected in zip(suggestions, [{
             'create_values': {},
             'email': self.user_employee.email_normalized,
             'name': self.user_employee.name,
             'partner_id': self.partner_employee.id,
-            'reason': 'Responsible',
         }, {
             'create_values': {
                 'company_id': self.env.user.company_id.id,
@@ -419,8 +419,7 @@ class TestAPI(MailCommon, TestRecipients):
             'email': 'paulette@test.example.com',
             'name': 'Paulette Vachette',
             'partner_id': False,
-            'reason': 'Customer Email',
-        }]):
+        }], strict=True):
             self.assertDictEqual(suggestion, expected)
 
         # existing partner not linked -> should propose it
@@ -437,7 +436,7 @@ class TestAPI(MailCommon, TestRecipients):
         })
         for ticket in ticket_partner_email + ticket_partner:
             with self.subTest(ticket=ticket.name):
-                suggestions = ticket_partner_email._message_get_suggested_recipients()
+                suggestions = ticket_partner_email._message_get_suggested_recipients(no_create=True)
                 self.assertEqual(len(suggestions), 1)
                 self.assertDictEqual(
                     suggestions[0],
@@ -446,13 +445,157 @@ class TestAPI(MailCommon, TestRecipients):
                         'email': self.test_partner.email_normalized,
                         'name': self.test_partner.name,
                         'partner_id': self.test_partner.id,
-                        'reason': 'Customer Email',
                     }
                 )
 
         # do not propose public partners
         ticket_public = self.env['mail.test.ticket.mc'].create({'customer_id': self.user_public.partner_id.id})
-        self.assertFalse(ticket_public._message_get_suggested_recipients())
+        self.assertFalse(ticket_public._message_get_suggested_recipients(no_create=True))
+
+    @users("employee")
+    def test_message_get_suggested_recipients_conversation(self):
+        """ Test suggested recipients in a conversation based on discussion
+        history: email_{cc/to} of previous messages, ... """
+        test_cc_tuples = [
+            ('Test Record Cc', 'test.record.cc@test.example.com'),
+            ('Test Msg Cc', 'test.msg.cc@test.example.com'),
+            ('Test Msg Cc 2', 'test.msg.cc.2@test.example.com'),
+        ]
+        test_to_tuples = [
+            ('Test Msg To', 'test.msg.to@test.example.com'),
+            ('Test Msg To 2', 'test.msg.to.2@test.example.com'),
+        ]
+        test_emails = [x[1] for x in test_cc_tuples + test_to_tuples]
+        self.assertFalse(self.env['res.partner'].search([('email_normalized', 'in', test_emails)]))
+
+        test_record = self.env['mail.test.recipients'].create({
+            'email_cc': tools.mail.formataddr(test_cc_tuples[0]),
+            'name': 'Test Recipients',
+        })
+        messages = self.env['mail.message']
+        for user, post_values in [
+            (self.user_root, {
+                'author_id': self.user_portal.partner_id.id,
+                'body': 'First incoming email',
+                'email_from': self.user_portal.email_formatted,
+                'incoming_email_cc': tools.mail.formataddr(test_cc_tuples[1]),
+                'incoming_email_to': tools.mail.formataddr(test_to_tuples[0]),
+                'message_type': 'email',
+            }),
+            (self.user_root, {
+                'body': 'Some automated email',
+                'message_type': 'email_outgoing',
+                'partner_ids': self.user_portal.partner_id.ids,
+            }),
+            (self.user_employee, {
+                'body': 'Salesman reply by email',
+                'incoming_email_cc': tools.mail.formataddr(test_cc_tuples[2]),
+                'incoming_email_to': tools.mail.formataddr(test_to_tuples[1]),
+                'message_type': 'email',
+            }),
+        ]:
+            messages += test_record.with_user(user).message_post(**post_values)
+        self.assertEqual(test_record.message_partner_ids, self.user_employee.partner_id + self.user_portal.partner_id)
+        # to test author proposal, remove portal for some reason
+        test_record.message_unsubscribe(partner_ids=self.user_portal.partner_id.ids)
+
+        recipients = test_record._message_get_suggested_recipients(reply_message=messages[0], no_create=True)
+        for recipient, expected in zip(recipients, [
+            {  # partner first: author of message
+                'create_values': {},
+                'email': self.user_portal.email_normalized,
+                'name': self.user_portal.name,
+                'partner_id': self.user_portal.partner_id.id,
+            }, {  # override of model for email_cc
+                'create_values': {},
+                'email': test_cc_tuples[0][1],
+                'name': test_cc_tuples[0][0],
+                'partner_id': False,
+            }, {  # replying message to
+                'create_values': {},
+                'email': test_to_tuples[0][1],
+                'name': test_to_tuples[0][0],
+                'partner_id': False,
+            }, {  # replying message  cc
+                'create_values': {},
+                'email': test_cc_tuples[1][1],
+                'name': test_cc_tuples[1][0],
+                'partner_id': False,
+            },
+        ], strict=True):
+            with self.subTest():
+                self.assertDictEqual(recipient, expected)
+
+        recipients = test_record._message_get_suggested_recipients(reply_message=messages[1], no_create=True)
+        for recipient, expected in zip(recipients, [
+            {  # partner first: recipient of message
+                'create_values': {},
+                'email': self.user_portal.email_normalized,
+                'name': self.user_portal.name,
+                'partner_id': self.user_portal.partner_id.id,
+            }, {  # override of model for email_cc
+                'create_values': {},
+                'email': test_cc_tuples[0][1],
+                'name': test_cc_tuples[0][0],
+                'partner_id': False,
+            },  # and not author, as it is odoobot's email
+        ], strict=True):
+            with self.subTest():
+                self.assertDictEqual(recipient, expected)
+
+        # discussion: should be last message
+        recipients = test_record._message_get_suggested_recipients(reply_discussion=True, no_create=True)
+        for recipient, expected in zip(recipients, [
+            {  # override of model for email_cc
+                'create_values': {},
+                'email': test_cc_tuples[0][1],
+                'name': test_cc_tuples[0][0],
+                'partner_id': False,
+            }, {  # replying message to
+                'create_values': {},
+                'email': test_to_tuples[1][1],
+                'name': test_to_tuples[1][0],
+                'partner_id': False,
+            }, {  # replying message  cc
+                'create_values': {},
+                'email': test_cc_tuples[2][1],
+                'name': test_cc_tuples[2][0],
+                'partner_id': False,
+            },  # and not author as he is already follower
+        ], strict=True):
+            with self.subTest():
+                self.assertDictEqual(recipient, expected)
+
+        # check with partner creation
+        recipients = test_record._message_get_suggested_recipients(reply_message=messages[0], no_create=False)
+        new_partners = self.env['res.partner'].search([('email_normalized', 'in', test_emails)], order='id ASC')
+        self.assertEqual(len(new_partners), 3, 'Find or create should have created 3 partners, one / email')
+        new_to, new_cc_0, new_cc_1 = new_partners
+        for recipient, expected in zip(recipients, [
+            {  # partner first: author of message
+                'create_values': {},
+                'email': self.user_portal.email_normalized,
+                'name': self.user_portal.name,
+                'partner_id': self.user_portal.partner_id.id,
+            }, {  # override of model for email_cc
+                'email': test_cc_tuples[0][1],
+                'name': test_cc_tuples[0][0],
+                'partner_id': new_to.id,
+                'create_values': {},
+            }, {  # replying message to
+                'email': test_to_tuples[0][1],
+                'name': test_to_tuples[0][0],
+                'partner_id': new_cc_0.id,
+                'create_values': {},
+            }, {  # replying message  cc
+                'email': test_cc_tuples[1][1],
+                'name': test_cc_tuples[1][0],
+                'partner_id': new_cc_1.id,
+                'create_values': {},
+            },
+        ], strict=True):
+            with self.subTest():
+                self.assertDictEqual(recipient, expected)
 
     @mute_logger('openerp.addons.mail.models.mail_mail')
     @users('employee')
@@ -955,7 +1098,7 @@ class TestNoThread(MailCommon, TestRecipients):
             _, messages = composer._action_send_mail()
 
         self.assertEqual(len(messages), 2)
-        for record, message in zip(test_records, messages):
+        for record, message in zip(test_records, messages, strict=True):
             self.assertEqual(
                 sorted(message.mapped('attachment_ids.name')),
                 sorted(['AttFileName_00.txt', 'AttFileName_01.txt',

--- a/addons/test_mail/tests/test_mail_thread_mixins.py
+++ b/addons/test_mail/tests/test_mail_thread_mixins.py
@@ -90,17 +90,17 @@ class TestMailThreadCC(MailCommon):
         record = self.env['mail.test.cc'].create({
             'email_cc': 'cc1@example.com, cc2@example.com, cc3 <cc3@example.com>',
         })
-        suggestions = record._message_get_suggested_recipients()
+        suggestions = record._message_get_suggested_recipients(no_create=True)
         expected_list = [
             {
                 'name': '', 'email': 'cc1@example.com',
-                'reason': 'CC Email', 'partner_id': False, 'create_values': {},
+                'partner_id': False, 'create_values': {},
             }, {
                 'name': '', 'email': 'cc2@example.com',
-                'reason': 'CC Email', 'partner_id': False, 'create_values': {},
+                'partner_id': False, 'create_values': {},
             }, {
                 'name': 'cc3', 'email': 'cc3@example.com',
-                'reason': 'CC Email', 'partner_id': False, 'create_values': {},
+                'partner_id': False, 'create_values': {},
             }]
         self.assertEqual(len(suggestions), len(expected_list))
         for suggestion, expected in zip(suggestions, expected_list):

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -480,15 +480,15 @@ class EventTrack(models.Model):
             } for track in self
         }
 
-    def _message_get_suggested_recipients(self):
-        recipients = super()._message_get_suggested_recipients()
+    def _message_add_suggested_recipients(self):
+        email_to_lst, partners = super()._message_add_suggested_recipients()
         if not self.partner_id:
             #  Priority: contact information then speaker information
-            if self.contact_email and self.contact_email != self.partner_id.email:
-                self._message_add_suggested_recipient(recipients, email=self.contact_email, reason=_('Contact Email'))
-            if not self.contact_email and self.partner_email and self.partner_email != self.partner_id.email:
-                self._message_add_suggested_recipient(recipients, email=self.partner_email, reason=_('Speaker Email'))
-        return recipients
+            if self.contact_email:
+                email_to_lst.append(self.contact_email)
+            elif self.partner_email:
+                email_to_lst.append(self.partner_email)
+        return email_to_lst, partners
 
     def _message_post_after_hook(self, message, msg_vals):
         #  OVERRIDE

--- a/odoo/addons/base/tests/common.py
+++ b/odoo/addons/base/tests/common.py
@@ -480,8 +480,8 @@ class MockSmtplibCase:
         :param from_filter: from_filter of the <ir.mail_server> used to send the
           email. False means 'match everything';'
         :param emails_count: the number of emails which should match the condition
-        :param msg_cc: optional check msg_cc value of email;
-        :param msg_to: optional check msg_to value of email;
+        :param msg_cc_lst: optional check msg_cc value of email;
+        :param msg_to_lst: optional check msg_to value of email;
 
         :return: True if at least one email has been found with those parameters
         """


### PR DESCRIPTION
Rationale

When having external recipients (customers, portal users), discussions
they receive from Odoo is not always clear. Indeed email is sent
directly to them, and they reply to a generic catchall without really
knowing who is behind that catchall except 'Odoo'.

Same issue arises for internal users working by email: when replying
in a discussion, it is unclear which external people are going to
receive the email: is the customer correctly included, is it going
to leak internal information to external people, ...

We decided to move towards a flow more looking like email providers.
External customers are put in recipients of emails. It means that
when replying to all, people reply to Odoo and external people. This
makes the recipients more explicit. Odoo Chatter also proposed more
suggested recipients, notably based on current discussion.

Suggested recipients

Rewrite '_message_get_suggested_recipients' so that it is more
optimized and fetches more recipients by default. It now supports
fetching suggestions in previous discussions, as well as directly
creating new partners based on unknown emails, in order to handle
partners.

It also allows to continue cleaning mail.thread overrides as some
code is now useless. Discussions options come thanks to [1] and are
 * reply to the discussion: reply to the last comment or email, hence
   add To/Cc of that message as suggested recipients;
 * reply to a specific message: once UI is updated it will be possible
   to reply to a specific message. Cc/To of that message are therefore
   suggested;

Note: UI is still not updated, as it is part of another branch that
is going to land soon. This commit is mainly about preparing ground
for the UI that needs some fine tuning.

Recipients in outgoing emails

When posting a message on a thread, emails are split for recipients.
When sending emails to recipients, tune the Msg['To'] envelope of
outgoing emails so that they look like being sent to 'all external
people'. This can be done thanks to [2].

This does not change the SMTP To, hence the email is still sent only
to the specific recipient. But then the recipient can 'Reply All'
and reply to all customers + Odoo. Indeed Reply-All includes 'Reply-to'
in addition to original 'To'.

Mail gateway note

When receiving an email from the mailgateway, be sure to not notify
people already in 'To'. Indeed it means they have already received
the email, hence Odoo should not send them another one.

[1] see https://github.com/odoo/odoo/pull/191213 previously merged
[2] see https://github.com/odoo/odoo/pull/184824 previously merged

This PR belongs to a group of PRs tailored for having an email-like
discussion flow in documents
 * odoo/odoo#184824
 * odoo/odoo#187024
 * odoo/odoo#191213
 * odoo/odoo#185240
 * odoo/odoo#191358
 * odoo/odoo#186875
 * odoo/odoo#188642 : Final branch

Task-4422660: [mail] Use external suggested recipients
Prepares Task-4273479: [mail] Email-like recipients