### PR TITLE
[IMP] account_edi: always allow to download edi content

### DIFF
--- a/addons/account_edi/models/account_edi_document.py
+++ b/addons/account_edi/models/account_edi_document.py
@@ -51,15 +51,14 @@ class AccountEdiDocument(models.Model):
     def _compute_edi_content(self):
         for doc in self:
             res = b''
-            if doc.state in ('to_send', 'to_cancel'):
-                move = doc.move_id
-                config_errors = doc.edi_format_id._check_move_configuration(move)
-                if config_errors:
-                    res = base64.b64encode('\n'.join(config_errors).encode('UTF-8'))
-                else:
-                    move_applicability = doc.edi_format_id._get_move_applicability(move)
-                    if move_applicability and move_applicability.get('edi_content'):
-                        res = base64.b64encode(move_applicability['edi_content'](move))
+            move = doc.move_id
+            config_errors = doc.edi_format_id._check_move_configuration(move)
+            if config_errors:
+                res = base64.b64encode('\n'.join(config_errors).encode('UTF-8'))
+            else:
+                move_applicability = doc.edi_format_id._get_move_applicability(move)
+                if move_applicability and move_applicability.get('edi_content'):
+                    res = base64.b64encode(move_applicability['edi_content'](move))
             doc.edi_content = res
 
     def action_export_xml(self):

--- a/addons/account_edi/views/account_move_views.xml
+++ b/addons/account_edi/views/account_move_views.xml
@@ -142,8 +142,7 @@
                                         type="object"
                                         class="oe_link oe_inline"
                                         string="Download"
-                                        groups="base.group_no_one"
-                                        invisible="not error or blocking_level == 'info'"/>
+                                        groups="base.group_no_one"/>
                             </tree>
                         </field>
                     </page>


### PR DESCRIPTION
* Problem: when successfully issue einvoice but because of some reason the issue invoice is not correct as we want it to be, for example: wrong value of amount or wrong text display or wrong negative/positive amount with out refund invoice, so the developer need to view the edi content (json data maybe) in order to troubleshoot by himself or to give the edi content to the provider (edi provider) in order to check also
* This commit always ensure technical person can download edi content unlike before can only download when has error

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
