### PR TITLE
[FIX] account: error on payment receipt download

### DIFF
--- a/addons/account/views/report_payment_receipt_templates.xml
+++ b/addons/account/views/report_payment_receipt_templates.xml
@@ -75,7 +75,7 @@
                                     <t t-set="payment" t-value="par[2]"/>
                                     <td><span t-field="payment.move_id.date">2023-01-05</span></td>
                                     <td><span t-field="payment.move_id.name">PAY001</span></td>
-                                    <td><span t-field="payment.move_id.memo">Payment Ref</span></td>
+                                    <td><span t-field="payment.payment_id.memo">Payment Ref</span></td>
                                     <t t-set="amountPayment" t-value="-par[0].amount"/>
                                     <t t-set="amountInvoice" t-value="-par[1]"/>
                                     <t t-set="currencyPayment" t-value="payment.currency_id"/>


### PR DESCRIPTION
1. Create a new Account called "Outstanding Payment".
2. Create a new Bank Journal and adde the new account in the Outgoing Payment tab.
3. Create a Vendor Bill, add partner details, product, date and confirm.
4. Process the payment using the newly created Bank Journal.
5. Opened the payment record.
6. Attempted to download the payment receipt.

Traceback will raise
```
odoo.addons.base.models.ir_qweb.QWebException: Error while render the template
KeyError: 'memo'
Template: account.report_payment_receipt_document
Path: /t/t/div[1]/table/tbody/t/t/tr[2]/td[3]/span
Node: <span t-field="payment.move_id.memo"/>
```
It occurs because the field `memo` is defined on the payment and not on the move

opw-4280508
