### PR TITLE
[REV] account, point_of_sale: line sorting and deducting change from cash payment

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -2416,11 +2416,7 @@ class AccountMoveLine(models.Model):
                 raise UserError(_("Entries are not from the same account: %s != %s")
                                 % (account.display_name, line.account_id.display_name))
 
-        if self._context.get('reduced_line_sorting'):
-            sorting_f = lambda line: (line.date_maturity or line.date, line.currency_id)
-        else:
-            sorting_f = lambda line: (line.date_maturity or line.date, line.currency_id, line.amount_currency)
-        sorted_lines = self.sorted(key=sorting_f)
+        sorted_lines = self.sorted(key=lambda line: (line.date_maturity or line.date, line.currency_id))
 
         # ==== Collect all involved lines through the existing reconciliation ====
 

--- a/addons/point_of_sale/models/pos_payment.py
+++ b/addons/point_of_sale/models/pos_payment.py
@@ -65,14 +65,7 @@ class PosPayment(models.Model):
 
     def _create_payment_moves(self, is_reverse=False):
         result = self.env['account.move']
-        # Get the first cash payment or, if none, the first non-change payment
-        target_payment = self.filtered(lambda p: p.payment_method_id.type == 'cash' and not p.is_change)[:1]
-        if not target_payment:
-            target_payment = self.filtered(lambda p: not p.is_change)[:1]
-        change_payment = self.filtered(lambda p: p.is_change and p.payment_method_id.type == 'cash')
-        if target_payment and change_payment:
-            target_payment.amount += change_payment.amount
-        for payment in self.filtered(lambda p: not p.is_change):
+        for payment in self:
             payment_method = payment.payment_method_id
             if payment_method.type == 'pay_later' or float_is_zero(payment.amount, precision_rounding=payment.pos_order_id.currency_id.rounding):
                 continue


### PR DESCRIPTION
this commit reverts changes introduced in https://github.com/odoo/odoo/pull/119726/commits/8e2407ef10119ba989586183072fe068291cd2ad and https://github.com/odoo/odoo/commit/bb34dab0a33cca2f2e949c0a3e73682fd12dccd2

the changes in https://github.com/odoo/odoo/pull/119726/commits/8e2407ef10119ba989586183072fe068291cd2ad were initially implemented as a workaround for the line sorting by amount introduced in https://github.com/odoo/odoo/commit/5b2c1d243c0dd5b049ceae280dd270fc8a59f955 However, the bug that required sorting by amount is no longer reproducible, even without this sorting.

The sorting by amount now causes issues during reconciliation when two payment methods (cash and bank) are used at the same time. Specifically, the change amount is incorrectly deducted from the bank payment.

An attempt to resolve this issue was made in https://github.com/odoo/odoo/commit/bb34dab0a33cca2f2e949c0a3e73682fd12dccd2 but the solution introduced further complications with payment amounts. By creating a single account move, it attempted to deduct the change amount from the cash payment, which led to inaccurate payment amounts.

opw-4276421

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
