### PR TITLE
[FIX] l10n_it_edi_ndd: use auto_init to avoid timeout

### DIFF
--- a/addons/l10n_it_edi_ndd/models/account_move.py
+++ b/addons/l10n_it_edi_ndd/models/account_move.py
@@ -1,5 +1,6 @@
-from odoo.addons.l10n_it_edi_ndd.models.account_payment_methode_line import L10N_IT_PAYMENT_METHOD_SELECTION
 from odoo import api, fields, models
+from odoo.tools.sql import column_exists, create_column
+from odoo.addons.l10n_it_edi_ndd.models.account_payment_methode_line import L10N_IT_PAYMENT_METHOD_SELECTION
 
 
 class AccountMove(models.Model):
@@ -18,6 +19,15 @@ class AccountMove(models.Model):
         store=True,
         readonly=False,
     )
+
+    def _auto_init(self):
+        # Create compute stored field l10n_it_document_type and l10n_it_payment_method
+        # here to avoid timeout error on large databases.
+        if not column_exists(self.env.cr, 'account_move', 'l10n_it_payment_method'):
+            create_column(self.env.cr, 'account_move', 'l10n_it_payment_method', 'varchar')
+        if not column_exists(self.env.cr, 'account_move', 'l10n_it_document_type'):
+            create_column(self.env.cr, 'account_move', 'l10n_it_document_type', 'integer')
+        return super()._auto_init()
 
     @api.depends('line_ids.matching_number', 'payment_state')
     def _compute_l10n_it_payment_method(self):


### PR DESCRIPTION
In large database, the compute of the field l10n_it_payment_method and
l10n_it_document_type can raise a timeout.

Step to reproduce:
- On a large database (tested with +10M account.move), try to install
  the module l10n_it_edi_ndd
- The installation will raise a timeout

New behavior:
The fields l10n_it_payment_method and l10n_it_document_type will no
longer be computed during module installation. This will avoid the
timeout.

opw-4273165
