### PR TITLE
[FIX] sale_project: set default value of allow_billable to true.

### DIFF
--- a/addons/sale_project/views/sale_order_views.xml
+++ b/addons/sale_project/views/sale_order_views.xml
@@ -30,7 +30,7 @@
                 </button>
             </xpath>
             <field name="journal_id" position="before">
-                <field name="project_id" groups="project.group_project_user"/>
+                <field name="project_id" groups="project.group_project_user" context="{'default_allow_billable': True}"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Steps to Reproduce:
- Go to the Sales app 
- Create a new sales order
- On the other info tab try to add a project:

issue:
the project created is non-billable by default

sol:
-make the project billable by default when it is created through sale order
task-4207347
