### PR TITLE
[IMP] point_of_sale: unify order & order line notes

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -251,7 +251,11 @@ class PosOrder(models.Model):
                     'name': line.customer_note,
                     'display_type': 'line_note',
                 }))
-
+        if self.general_customer_note:
+            invoice_lines.append((0, None, {
+                'name': self.general_customer_note,
+                'display_type': 'line_note',
+            }))
         return invoice_lines
 
     def _get_pos_anglo_saxon_price_unit(self, product, partner_id, quantity):
@@ -306,7 +310,8 @@ class PosOrder(models.Model):
     procurement_group_id = fields.Many2one('procurement.group', 'Procurement Group', copy=False)
 
     floating_order_name = fields.Char(string='Order Name')
-    general_note = fields.Text(string='General Note')
+    general_customer_note = fields.Text(string='General Customer Note')
+    internal_note = fields.Text(string='Internal Note')
     nb_print = fields.Integer(string='Number of Print', readonly=True, copy=False, default=0)
     pos_reference = fields.Char(string='Receipt Number', readonly=True, copy=False, index=True, help="""
         Human readable reference for this order.

--- a/addons/point_of_sale/static/src/app/generic_components/order_widget/order_widget.js
+++ b/addons/point_of_sale/static/src/app/generic_components/order_widget/order_widget.js
@@ -12,7 +12,8 @@ export class OrderWidget extends Component {
         tax: { type: String, optional: true },
         style: { type: String, optional: true },
         class: { type: String, optional: true },
-        generalNote: { type: String, optional: true },
+        generalCustomerNote: { type: String, optional: true },
+        internalNote: { type: String, optional: true },
         screenName: { type: String, optional: true },
     };
     static defaultProps = {

--- a/addons/point_of_sale/static/src/app/generic_components/order_widget/order_widget.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/order_widget/order_widget.xml
@@ -8,10 +8,30 @@
                         <t t-if="props.slots?.default" t-slot="default" line="line"/>
                         <Orderline t-else="" line="line" />
                     </t>
-                    <div class="mt-1 bg-opacity-75" t-attf-class="{{ props.screenName == 'ReceiptScreen' ? 'p-0' : 'p-2 border-bottom border-top border-opacity-75'}}" t-if="props.generalNote">
-                        <b class="fw-bolder">General Note</b>
-                        <t t-foreach="props.generalNote.split('\n')" t-as="subNote" t-key="subNote_index">
-                            <br/>• <t t-esc="subNote"/>
+                    <div t-if="props.generalCustomerNote"
+                        t-attf-class="{{ props.screenName == 'ReceiptScreen' ? 'mt-1 bg-opacity-75 p-0' : 'customer-note w-100 p-2 mt-2 rounded text-break text-bg-warning bg-opacity-25 mt-0'}}">
+                        <div class="row flex-wrap w-100 m-0"> <!-- Add w-100 and remove margins -->
+                            <div class="col-auto px-1">
+                                <i class="fa fa-sticky-note me-1 fa-lg" role="img"
+                                    aria-label="Customer Note" title="Customer Note"/>
+                            </div>
+                            <div class="col ps-0">
+                                <t t-foreach="props.generalCustomerNote.split('\n')" t-as="subNote"
+                                    t-key="subNote_index">
+                                    <div class="d-inline text-break">
+                                        <t t-esc="subNote"/><br/>
+                                    </div>
+                                </t>
+                            </div>
+                        </div>
+                    </div>
+                    <div t-if="props.internalNote"
+                        class="internal-note-container d-flex gap-2">
+                        <t t-foreach="props.internalNote?.split?.('\n') or []" t-as="note"
+                            t-key="note_index">
+                            <li t-if="note.trim() !== ''" t-esc="note"
+                                class="internal-note badge mt-1 p-2 rounded-pill bg-info text-info bg-opacity-25"
+                                style="font-size: 0.85rem;"/>
                         </t>
                     </div>
                 </div>

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -32,9 +32,11 @@ export class PosOrder extends Base {
             ? JSON.parse(vals.last_order_preparation_change)
             : {
                   lines: {},
-                  generalNote: "",
+                  general_customer_note: "",
+                  internal_note: "",
               };
-        this.general_note = vals.general_note || "";
+        this.general_customer_note = vals.general_customer_note || "";
+        this.internal_note = vals.internal_note || "";
         if (!vals.lines) {
             this.lines = [];
         }
@@ -108,7 +110,7 @@ export class PosOrder extends Base {
             tax_details: this.get_tax_details(),
             change: this.amount_return,
             name: this.pos_reference,
-            generalNote: this.general_note || "",
+            general_customer_note: this.general_customer_note || "",
             invoice_id: null, //TODO
             cashier: this.getCashierName(),
             date: formatDateTime(parseUTCString(this.date_order)),
@@ -259,7 +261,8 @@ export class PosOrder extends Base {
                 delete this.last_order_preparation_change.lines[key];
             }
         }
-        this.last_order_preparation_change.generalNote = this.general_note;
+        this.last_order_preparation_change.general_customer_note = this.general_customer_note;
+        this.last_order_preparation_change.internal_note = this.internal_note;
     }
 
     hasSkippedChanges() {
@@ -431,7 +434,7 @@ export class PosOrder extends Base {
             }
         }
         if (!this.lines.length) {
-            this.general_note = ""; // reset general note on empty order
+            this.general_customer_note = ""; // reset general note on empty order
         }
         this.select_orderline(this.get_last_orderline());
         return true;
@@ -1043,7 +1046,7 @@ export class PosOrder extends Base {
                 amount: formatCurrency(pl.get_amount()),
             })),
             change: this.get_change() && formatCurrency(this.get_change()),
-            generalNote: this.general_note || "",
+            generalCustomerNote: this.general_customer_note || "",
         };
     }
     get floatingOrderName() {
@@ -1086,6 +1089,14 @@ export class PosOrder extends Base {
     }
     getName() {
         return this.floatingOrderName || "";
+    }
+    setGeneralCustomerNote(note) {
+        this.general_customer_note = note || "";
+        this.setDirty();
+    }
+    setInternalNote(note) {
+        this.internal_note = note || "";
+        this.setDirty();
     }
 }
 

--- a/addons/point_of_sale/static/src/app/models/utils/order_change.js
+++ b/addons/point_of_sale/static/src/app/models/utils/order_change.js
@@ -21,7 +21,11 @@ export const changesToOrder = (
         }
     }
 
-    return { new: toAdd, cancelled: toRemove, generalNote: orderChanges.generalNote };
+    return {
+        new: toAdd,
+        cancelled: toRemove,
+        general_customer_note: orderChanges.general_customer_note,
+    };
 };
 
 /**
@@ -110,10 +114,14 @@ export const getOrderChanges = (order, skipped = false, orderPreparationCategori
         count: changesCount,
     };
 
-    // if `generalNote` key is present, then there is a change in the generalNote
-    const lastGeneralNote = order.last_order_preparation_change.generalNote;
-    if (lastGeneralNote !== order.general_note) {
-        result.generalNote = order.general_note;
+    // if `generalCustomerNote` key is present, then there is a change in the generalCustomerNote
+    const lastGeneralCustomerNote = order.last_order_preparation_change.general_customer_note || "";
+    if (lastGeneralCustomerNote !== order.general_customer_note) {
+        result.general_customer_note = order.general_customer_note;
+    }
+    const lastInternalNote = order.last_order_preparation_change.internal_note || "";
+    if (lastInternalNote !== order.internal_note) {
+        result.internal_note = order.internal_note;
     }
     return result;
 };

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -2,7 +2,7 @@ import { Component, useState, xml } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 import { Dialog } from "@web/core/dialog/dialog";
 import { SelectionPopup } from "@point_of_sale/app/components/popups/selection_popup/selection_popup";
-import { OrderlineNoteButton } from "@point_of_sale/app/screens/product_screen/control_buttons/customer_note_button/customer_note_button";
+import { NoteButton } from "@point_of_sale/app/screens/product_screen/control_buttons/note_button/note_button";
 import { usePos } from "@point_of_sale/app/hooks/pos_hook";
 import { _t } from "@web/core/l10n/translation";
 import { makeAwaitable } from "@point_of_sale/app/store/make_awaitable_dialog";
@@ -10,7 +10,7 @@ import { SelectPartnerButton } from "@point_of_sale/app/screens/product_screen/c
 
 export class ControlButtons extends Component {
     static template = "point_of_sale.ControlButtons";
-    static components = { OrderlineNoteButton, SelectPartnerButton };
+    static components = { NoteButton, SelectPartnerButton };
     static props = {
         showRemainingButtons: { type: Boolean, optional: true },
         onClickMore: { type: Function, optional: true },
@@ -114,10 +114,7 @@ export class ControlButtons extends Component {
             },
         });
     }
-    internalNoteLabel(order) {
-        if (order) {
-            return _t("General Note");
-        }
+    internalNoteLabel() {
         return this.pos.config.module_pos_restaurant ? _t("Kitchen Note") : _t("Internal Note");
     }
 

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -4,11 +4,10 @@
         <!-- All buttons always displayed -->
         <SelectPartnerButton partner="partner" t-if="!props.showRemainingButtons"/>
         <t t-if="!props.showRemainingButtons || (ui.isSmall and props.showRemainingButtons)">
-            <OrderlineNoteButton
+            <NoteButton
                 label="internalNoteLabel()"
-                getter="(orderline) => orderline.getNote()"
-                class="buttonClass"
-                setter="(orderline, note) => orderline.setNote(note)" />
+                type="'internal'"
+                class="buttonClass"/>
         </t>
         <button class="btn btn-light btn-lg flex-shrink-0 ms-auto" t-if="!props.showRemainingButtons and !ui.isSmall and props.onClickMore" t-on-click="props.onClickMore">
             Actions
@@ -16,8 +15,11 @@
         <!-- All these buttons will only be displayed in a dialog -->
         <t t-if="props.showRemainingButtons">
             <div class="control-buttons control-buttons-modal d-grid gap-2 mt-2">
-                <OrderlineNoteButton class="buttonClass" label="internalNoteLabel(this.pos.get_order())"/>
-                <OrderlineNoteButton class="buttonClass" icon="'fa fa-sticky-note'"/>
+                <NoteButton
+                    label.translate="Customer Note"
+                    type="'customer'"
+                    class="buttonClass"
+                    icon="'fa fa-sticky-note'"/>
                 <button class="o_pricelist_button btn btn-secondary btn-lg py-5" t-on-click="() => this.clickPricelist()">
                     <i class="fa fa-th-list me-2" role="img" aria-label="Price list" title="Price list" />
                     <t t-if="currentOrder?.pricelist_id" t-esc="currentOrder.pricelist_id.display_name" />

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/note_button/note_button.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/note_button/note_button.js
@@ -5,35 +5,31 @@ import { TextInputPopup } from "@point_of_sale/app/components/popups/text_input_
 import { useService } from "@web/core/utils/hooks";
 import { makeAwaitable } from "@point_of_sale/app/store/make_awaitable_dialog";
 
-export class OrderlineNoteButton extends Component {
-    static template = "point_of_sale.OrderlineNoteButton";
+export class NoteButton extends Component {
+    static template = "point_of_sale.NoteButton";
     static props = {
         icon: { type: String, optional: true },
-        label: { type: String, optional: true },
-        getter: { type: Function, optional: true },
-        setter: { type: Function, optional: true },
+        label: { type: String, optional: false },
+        type: { type: String, optional: false },
         class: { type: String, optional: true },
-    };
-    static defaultProps = {
-        label: _t("Customer Note"),
-        getter: (orderline) => orderline.get_customer_note(),
-        setter: (orderline, note) => orderline.set_customer_note(note),
-        class: "",
     };
 
     setup() {
         this.pos = usePos();
         this.dialog = useService("dialog");
     }
+
     onClick() {
-        return this.props.label == _t("General Note") ? this.addGeneralNote() : this.addLineNotes();
+        return this.pos.get_order()?.get_selected_orderline()
+            ? this.addLineNote()
+            : this.addOrderNote();
     }
-    async addLineNotes() {
+
+    async addLineNote() {
         const selectedOrderline = this.pos.get_order().get_selected_orderline();
-        const selectedNote = this.props.getter(selectedOrderline);
+        const selectedNote = this.currentNote || "";
         const oldNote = selectedOrderline.getNote();
         const payload = await this.openTextInput(selectedNote);
-
         var quantity_with_note = 0;
         const changes = this.pos.getOrderChanges();
         for (const key in changes.orderlines) {
@@ -45,28 +41,30 @@ export class OrderlineNoteButton extends Component {
         const saved_quantity = selectedOrderline.qty - quantity_with_note;
         if (saved_quantity > 0 && quantity_with_note > 0) {
             await this.pos.addLineToCurrentOrder({
-                product_id: selectedOrderline.product_id,
                 product_tmpl_id: selectedOrderline.product_id.product_tmpl_id,
                 qty: quantity_with_note,
                 note: payload,
             });
             selectedOrderline.qty = saved_quantity;
         } else {
-            this.props.setter(selectedOrderline, payload);
+            this.setNote(payload);
         }
-
         return { confirmed: typeof payload === "string", inputNote: payload, oldNote };
     }
-    async addGeneralNote() {
-        const selectedOrder = this.pos.get_order();
-        const selectedNote = selectedOrder.general_note || "";
+
+    async addOrderNote() {
+        const selectedNote = this.currentNote || "";
         const payload = await this.openTextInput(selectedNote);
-        selectedOrder.general_note = payload;
+        this.setNote(payload);
         return { confirmed: typeof payload === "string", inputNote: payload };
     }
+
     async openTextInput(selectedNote) {
         let buttons = [];
-        if (this._isInternalNote() || this.props.label == _t("General Note")) {
+        if (
+            this.props.type === "internal" ||
+            this.pos.get_order()?.get_selected_orderline() === undefined
+        ) {
             buttons = this.pos.models["pos.note"].getAll().map((note) => ({
                 label: note.name,
                 isSelected: selectedNote.split("\n").includes(note.name), // Check if the note is already selected
@@ -79,10 +77,40 @@ export class OrderlineNoteButton extends Component {
             startingValue: selectedNote,
         });
     }
-    _isInternalNote() {
-        if (this.pos.config.module_pos_restaurant) {
-            return this.props.label == _t("Kitchen Note");
-        }
-        return this.props.label == _t("Internal Note");
+
+    get orderNote() {
+        const order = this.pos.get_order();
+        return this.props.type === "internal"
+            ? order.internal_note || ""
+            : order.general_customer_note || "";
+    }
+
+    get orderlineNote() {
+        const orderline = this.pos.get_order().get_selected_orderline();
+        return this.props.type === "internal" ? orderline.getNote() : orderline.get_customer_note();
+    }
+
+    get currentNote() {
+        return this.pos.get_order().get_selected_orderline() ? this.orderlineNote : this.orderNote;
+    }
+
+    setOrderNote(value) {
+        const order = this.pos.get_order();
+        return this.props.type === "internal"
+            ? order.setInternalNote(value)
+            : order.setGeneralCustomerNote(value);
+    }
+
+    setOrderlineNote(value) {
+        const orderline = this.pos.get_order().get_selected_orderline();
+        return this.props.type === "internal"
+            ? orderline.setNote(value)
+            : orderline.set_customer_note(value);
+    }
+
+    setNote(note) {
+        return this.pos.get_order().get_selected_orderline()
+            ? this.setOrderlineNote(note)
+            : this.setOrderNote(note);
     }
 }

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/note_button/note_button.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/note_button/note_button.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-
-    <t t-name="point_of_sale.OrderlineNoteButton">
+    <t t-name="point_of_sale.NoteButton">
         <button
             t-attf-class="{{this.props.class}} flex-shrink-0"
-            t-att-disabled="!pos.get_order()?.get_selected_orderline()" t-on-click="onClick">
+            t-att-disabled="pos.get_order()?.is_empty()" t-on-click="onClick">
             <t t-if="this.props.icon">
                 <i t-attf-class="{{this.props.icon}} me-1"/>
             </t>

--- a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.OrderSummary">
-      <OrderWidget lines="currentOrder.getSortedOrderlines()" t-slot-scope="scope" class="'bg-light'"
-          total="env.utils.formatCurrency(currentOrder.get_total_with_tax())"
-          tax="!env.utils.floatIsZero(currentOrder.get_total_tax()) and env.utils.formatCurrency(currentOrder.get_total_tax()) or ''"
-          generalNote="currentOrder.general_note or ''">
+    <OrderWidget lines="currentOrder.getSortedOrderlines()" t-slot-scope="scope" class="'bg-light'"
+      total="env.utils.formatCurrency(currentOrder.get_total_with_tax())"
+      tax="!env.utils.floatIsZero(currentOrder.get_total_tax()) and env.utils.formatCurrency(currentOrder.get_total_tax()) or ''"
+      generalCustomerNote="currentOrder.general_customer_note or ''"
+      internalNote="currentOrder.internal_note or ''">
           <t t-set="line" t-value="scope.line" />
           <Orderline line="line.getDisplayData()"
               t-on-click="(event) => this.clickLine(event, line)"

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -4,7 +4,9 @@
         <div class="pos-receipt p-2">
             <t t-set="showTaxGroupLabels" t-value="doesAnyOrderlineHaveTaxLabel()"/>
             <ReceiptHeader data="props.data.headerData" />
-            <OrderWidget t-if="props.data.orderlines?.length" lines="props.data.orderlines" t-slot-scope="scope" generalNote="props.data.generalNote or ''" screenName="props.data.screenName">
+            <OrderWidget lines="props.data.orderlines" t-slot-scope="scope"
+                generalCustomerNote="props.data.general_customer_note or ''"
+                internalNote="props.data.internalNote or ''" screenName="props.data.screenName">
                 <t t-set="line" t-value="scope.line"/>
                 <Orderline basic_receipt="props.basic_receipt" line="omit(scope.line, 'customerNote')" class="{ 'px-0': true }" showTaxGroupLabels="showTaxGroupLabels">
                     <li t-if="line.customerNote" class="customer-note w-100 p-2 my-1 rounded text-break">
@@ -36,7 +38,7 @@
                     </div>
                 </div>
 
-        <!-- Total -->
+                <!-- Total -->
                 <div class="text-center">--------------------------------</div>
                 <div class="pos-receipt-amount">
                     TOTAL

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -123,7 +123,8 @@
                         <OrderWidget lines="_selectedSyncedOrder.lines" t-slot-scope="scope"
                             total="env.utils.formatCurrency(_selectedSyncedOrder.get_total_with_tax())"
                             tax="!env.utils.floatIsZero(_selectedSyncedOrder.get_total_tax()) and env.utils.formatCurrency(_selectedSyncedOrder.get_total_tax()) or ''"
-                            generalNote="_selectedSyncedOrder?.general_note or ''">
+                            generalCustomerNote="_selectedSyncedOrder?.general_customer_note or ''"
+                            internalNote="_selectedSyncedOrder.internal_note or ''">
                             <t t-set="line" t-value="scope.line" />
                             <Orderline line="line.getDisplayData()"
                                 class="{'selected': line.id === getSelectedOrderlineId()}"

--- a/addons/point_of_sale/static/src/customer_display/customer_display.xml
+++ b/addons/point_of_sale/static/src/customer_display/customer_display.xml
@@ -10,7 +10,7 @@
                 <div class="position-absolute bottom-0 mb-4 d-none d-lg-flex align-items-center ps-3 pe-2 py-1 rounded-3 text-bg-dark small">Powered by <OdooLogo style="'width: 3rem;'" monochrome="true"/></div>
             </div>
             <div class="o_customer_display_main d-flex flex-column flex-grow-1 overflow-auto">
-                <OrderWidget t-if="!order.finalized" lines="order.lines" t-slot-scope="scope" class="'gap-0 p-0 mx-2 pb-3 bg-view'" style="'scroll-snap-type: y mandatory;'" generalNote="order.generalNote or ''">
+                <OrderWidget t-if="!order.finalized" lines="order.lines" t-slot-scope="scope" class="'gap-0 p-0 mx-2 pb-3 bg-view'" style="'scroll-snap-type: y mandatory;'" generalCustomerNote="order.generalCustomerNote or ''">
                     <Orderline line="scope.line" class="{
                             'o_customer_display_orderline bg-white fs-3 rounded-0': true,
                         }"

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -199,8 +199,8 @@
                             </group>
                         </group>
                     </page>
-                    <page string="General Notes" name="notes">
-                        <field name="general_note" readonly="1"/>
+                    <page string="Customer Note" name="notes">
+                        <field name="general_customer_note" readonly="1"/>
                     </page>
                 </notebook>
             </sheet>

--- a/addons/pos_discount/static/src/overrides/components/control_buttons/control_buttons.xml
+++ b/addons/pos_discount/static/src/overrides/components/control_buttons/control_buttons.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_discount.ControlButtons" t-inherit="point_of_sale.ControlButtons" t-inherit-mode="extension">
-        <xpath expr="//t[@t-if='props.showRemainingButtons']/div/OrderlineNoteButton" position="after">
+        <xpath
+            expr="//t[@t-if='props.showRemainingButtons']/div/button[hasclass('o_pricelist_button')]"
+            position="before">
             <button t-if="pos.config.module_pos_discount and pos.config.discount_product_id"
                 class="js_discount"
                 t-att-class="buttonClass"

--- a/addons/pos_loyalty/static/src/overrides/components/control_buttons/control_buttons.xml
+++ b/addons/pos_loyalty/static/src/overrides/components/control_buttons/control_buttons.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_loyalty.ControlButtons" t-inherit="point_of_sale.ControlButtons" t-inherit-mode="extension">
-        <xpath expr="//t[@t-if='props.showRemainingButtons']/div/OrderlineNoteButton" position="after">
+        <xpath
+            expr="//t[@t-if='props.showRemainingButtons']/div/button[hasclass('o_pricelist_button')]"
+            position="before">
             <t t-if="pos.models['loyalty.program'].some((p) => p.program_type == 'ewallet')">
                 <t t-set="_orderTotal" t-value="pos.get_order().get_total_with_tax()" />
                 <t t-set="_eWalletPrograms" t-value="_getEWalletPrograms()" />
@@ -30,7 +32,7 @@
                 </button>
             </t>
         </xpath>
-        <xpath expr="//t[@t-if='props.showRemainingButtons']/div/OrderlineNoteButton" position="after">
+        <xpath expr="//t[@t-if='props.showRemainingButtons']/div/button[hasclass('o_pricelist_button')]" position="before">
             <t t-if="pos.models['loyalty.program'].some((p) => ['coupons', 'promotion'].includes(p.program_type))">
                 <button class="btn btn-secondary btn-lg py-5" t-att-class="{'disabled': !pos.get_order().isProgramsResettable()}"
                     t-on-click="() => this.pos.resetPrograms()">

--- a/addons/pos_restaurant/models/pos_session.py
+++ b/addons/pos_restaurant/models/pos_session.py
@@ -21,7 +21,7 @@ class PosSession(models.Model):
             order = self.env['pos.order'].browse(order_id)
             last_order_preparation_change = {
                 'lines': {},
-                'generalNote': '',
+                'generalCustomerNote': '',
             }
             for orderline in order['lines']:
                 last_order_preparation_change['lines'][orderline.uuid + " - "] = {

--- a/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.xml
+++ b/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_restaurant.ControlButtons" t-inherit="point_of_sale.ControlButtons" t-inherit-mode="extension">
-        <xpath expr="//t[@t-if='props.showRemainingButtons']/div/OrderlineNoteButton" position="after">
+        <xpath
+            expr="//t[@t-if='props.showRemainingButtons']/div/button[hasclass('o_pricelist_button')]"
+            position="before">
             <t t-if="pos.config.module_pos_restaurant">
                 <!-- All buttons always displayed -->
                 <button t-att-class="buttonClass"
@@ -15,7 +17,9 @@
                 </button>
             </t>
         </xpath>
-        <xpath expr="//t[@t-if='props.showRemainingButtons']/div/OrderlineNoteButton" position="after">
+        <xpath
+            expr="//t[@t-if='props.showRemainingButtons']/div/button[hasclass('o_pricelist_button')]"
+            position="before">
             <!-- All these buttons will only be displayed in a dialog -->
             <t t-if="pos.config.module_pos_restaurant">
                 <button class="btn btn-secondary btn-lg py-5"

--- a/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.xml
+++ b/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.xml
@@ -15,7 +15,9 @@
 
                 <div class="main d-flex flex-column flex-lg-row flex-grow-1 gap-2 p-2 overflow-hidden">
                     <div class="flex-grow-1 w-100 w-lg-50 me-0 me-lg-2 rounded-3 bg-view overflow-auto">
-                        <OrderWidget lines="orderlines" t-slot-scope="scope" generalNote="currentOrder.general_note or ''">
+                        <OrderWidget lines="orderlines" t-slot-scope="scope"
+                            generalCustomerNote="currentOrder.general_customer_note or ''"
+                            internalNote="currentOrder.internal_note or ''">
                             <t t-set="line" t-value="scope.line" />
                             <Orderline line="getLineData(line)"
                                 t-on-click="() => this.onClickLine(line)"

--- a/addons/pos_restaurant/static/src/overrides/components/product_screen/actionpad_widget/actionpad_widget.js
+++ b/addons/pos_restaurant/static/src/overrides/components/product_screen/actionpad_widget/actionpad_widget.js
@@ -20,9 +20,9 @@ patch(ActionpadWidget.prototype, {
     get hasChangesToPrint() {
         let hasChange = this.pos.getOrderChanges();
         hasChange =
-            hasChange.generalNote == ""
+            hasChange.generalCustomerNote == ""
                 ? true // for the case when removed all general note
-                : hasChange.count || hasChange.generalNote;
+                : hasChange.count || hasChange.generalCustomerNote;
         return hasChange;
     },
     get swapButtonClasses() {

--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -78,10 +78,13 @@ patch(PosStore.prototype, {
 
             return acc;
         }, {});
-
+        const noteCount = ["general_customer_note", "internal_note"].reduce(
+            (count, note) => count + (note in orderChanges ? 1 : 0),
+            0
+        );
         return [
             ...Object.values(categories),
-            ...("generalNote" in orderChanges ? [{ count: 1, name: _t("General Note") }] : []),
+            ...(noteCount > 0 ? [{ count: noteCount, name: _t("Message") }] : []),
         ];
     },
     get selectedTable() {

--- a/addons/pos_sale/static/src/overrides/components/control_buttons/control_buttons.xml
+++ b/addons/pos_sale/static/src/overrides/components/control_buttons/control_buttons.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_sale.ControlButtons" t-inherit="point_of_sale.ControlButtons" t-inherit-mode="extension">
-        <xpath expr="//t[@t-if='props.showRemainingButtons']/div/OrderlineNoteButton" position="after">
+        <xpath
+            expr="//t[@t-if='props.showRemainingButtons']/div/button[hasclass('o_pricelist_button')]"
+            position="before">
             <button t-att-class="buttonClass" t-on-click="() => this.onClickQuotation()">
                 <i class="fa fa-link me-1" role="img" aria-label="Set Sale Order" title="Set Sale Order" /> Quotation/Order
             </button>


### PR DESCRIPTION
- Remove "General note" button and use it as a "Customer note" when no order line is selected:
	- For this, I've used the existing "general_note" field in PosOrder and rename it as "general_customer_note" for clarity.

 - Make "Internal note" active even if no order line is selected:
	- For this I've added a field "internal_note" in PosOrder. 
	- Refactor the previous "OrderLineNoteButton" that was previously used for "order.general_note", "orderline.customer_note" and "orderline.note" into a new "NoteButton" component that is now used for:
	  - Order notes:
		  - "general_customer_note" and "internal_note"
	  - Orderline notes:
		  - "customer_note" and "note"

task-ids: 4247230, 4167563

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
