### PR TITLE
[FIX] web: restore `o_form_sheet_bg` `padding-top` if no statusbar

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -250,6 +250,10 @@
         width: 100%;
         max-width: $o-form-view-sheet-max-width;
         margin-right: auto; // Always align to le left
+
+        &:not(:has(.o_form_statusbar)) {
+            padding-top: map-get($spacers, 2);
+        }
     }
 
     // Sheet


### PR DESCRIPTION
This PR fixes an issue introduced in Commit[1]. With Commit[1], the statusbar of our form views is now sticky. To achieve the right visual result, the top padding defined on `.o_form_sheet_bg` had to be removed to avoid a weird gap.

While this changed unlocked the desired visual result, it introduced an issue on form views without statusbar, making the form sheet stick to the control panel, as it it the case in `Contacts` for instance.

To prevent this behaviour, we use a conditional approach to handle the `padding`.

Commit[1]: a3c63413825cf3492a10ade77a2c571c4eeb33a6

task-4286105
related to task-3419566

| Master | This PR |
|--------|--------|
| <img width="1134" alt="image" src="https://github.com/user-attachments/assets/3b84a5c6-d03a-4760-b948-6129786ace72"> | <img width="1128" alt="image" src="https://github.com/user-attachments/assets/2bf38725-233b-4f25-a27b-f45fde8dc7b8"> | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
