### PR TITLE
[FIX] point_of_sale: broken combo selection

### DIFF
--- a/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.js
@@ -55,7 +55,7 @@ export class ComboConfiguratorPopup extends AbstractAwaitablePopup {
                 this.state.configuration[combo_line.id] = payload;
             } else {
                 // Do not select the product if configuration popup is cancelled.
-                this.state.combo[combo_line.id] = 0;
+                this.state.combo[combo_line.combo_id[0]] = 0;
             }
         }
     }

--- a/addons/point_of_sale/static/tests/tours/PosComboTour.js
+++ b/addons/point_of_sale/static/tests/tours/PosComboTour.js
@@ -5,6 +5,7 @@ import * as PaymentScreen from "@point_of_sale/../tests/tours/helpers/PaymentScr
 import * as ReceiptScreen from "@point_of_sale/../tests/tours/helpers/ReceiptScreenTourMethods";
 import * as combo from "@point_of_sale/../tests/tours/helpers/ComboPopupMethods";
 import * as Order from "@point_of_sale/../tests/tours/helpers/generic_components/OrderWidgetMethods";
+import * as ProductConfigurator from "@point_of_sale/../tests/tours/helpers/ProductConfiguratorTourMethods";
 import { inLeftSide } from "@point_of_sale/../tests/tours/helpers/utils";
 import { registry } from "@web/core/registry";
 
@@ -16,6 +17,9 @@ registry.category("web_tour.tours").add("PosComboPriceTaxIncludedTour", {
         ...ProductScreen.clickDisplayedProduct("Office Combo"),
         combo.isPopupShown(),
         combo.select("Combo Product 3"),
+        combo.select("Combo Product 9"),
+        ...ProductConfigurator.isShown(),
+        ...ProductConfigurator.cancelAttributes(),
         {
             content: "check that amount is not displayed if zero",
             trigger: `article.product .product-content:not(:has(.price-tag:contains("0")))`,

--- a/addons/point_of_sale/static/tests/tours/helpers/ComboPopupMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/ComboPopupMethods.js
@@ -2,7 +2,7 @@
 
 const popup = ".popup.combo-configurator-popup";
 const productTrigger = (productName) =>
-    `label.combo-line:has(article.product .product-name:contains("${productName}"))`;
+    `label.combo-line article.product:has( .product-name:contains("${productName}"))`;
 const isNot = (trigger) => `body:not(:has(${trigger}))`;
 const isComboSelectedTrigger = (productName) => `input:checked ~ ${productTrigger(productName)}`;
 const confirmationButtonTrigger = `${popup} footer button.confirm`;

--- a/addons/point_of_sale/tests/common_setup_methods.py
+++ b/addons/point_of_sale/tests/common_setup_methods.py
@@ -167,6 +167,37 @@ def setup_pos_combo_items(self):
         }
     )
 
+    combo_product_9 = self.env["product.product"].create(
+        {
+            "name": "Combo Product 9",
+            "type": "product",
+            "available_in_pos": True,
+            "list_price": 50,
+            "taxes_id": [(6, 0, [tax20in.id])],
+        }
+    )
+
+    chair_color_attribute = self.env['product.attribute'].create({
+        'name': 'Color',
+        'display_type': 'color',
+        'create_variant': 'no_variant',
+    })
+    chair_color_red = self.env['product.attribute.value'].create({
+        'name': 'Red',
+        'attribute_id': chair_color_attribute.id,
+        'html_color': '#ff0000',
+    })
+    chair_color_blue = self.env['product.attribute.value'].create({
+        'name': 'Blue',
+        'attribute_id': chair_color_attribute.id,
+        'html_color': '#0000ff',
+    })
+    self.env['product.template.attribute.line'].create({
+        'product_tmpl_id': combo_product_9.product_tmpl_id.id,
+        'attribute_id': chair_color_attribute.id,
+        'value_ids': [(6, 0, [chair_color_red.id, chair_color_blue.id])]
+    })
+
     product_6_combo_line = self.env["pos.combo.line"].create(
         {
             "product_id": combo_product_6.id,
@@ -188,6 +219,13 @@ def setup_pos_combo_items(self):
         }
     )
 
+    product_9_combo_line = self.env["pos.combo.line"].create(
+        {
+            "product_id": combo_product_9.id,
+            "combo_price": 5,
+        }
+    )
+
     self.chairs_combo = self.env["pos.combo"].create(
         {
             "name": "Chairs Combo",
@@ -199,6 +237,7 @@ def setup_pos_combo_items(self):
                         product_6_combo_line.id,
                         product_7_combo_line.id,
                         product_8_combo_line.id,
+                        product_9_combo_line.id,
                     ],
                 )
             ],


### PR DESCRIPTION
Steps:
- Open Terminal and click on the burger combo
- Select burger and click the cancel button
- Select the burger again and click OK with the default selection
- Select a drink

Issue:
- After selecting all components of the product, the `Add to Order` button remains disabled, preventing the combo from being added to the cart.

Cause:
- The combo state is not being reset when discarding or closing the product configuration popup.

Fix:
- Implemented a proper reset of the combo state upon closing the configuration popup.

task-4285981

