### PR TITLE
[FIX] stock_account: locations without company should not be valued

### DIFF
--- a/addons/stock_account/models/stock_location.py
+++ b/addons/stock_account/models/stock_location.py
@@ -27,6 +27,4 @@ class StockLocation(models.Model):
         be considered when valuating the stock of a company.
         """
         self.ensure_one()
-        if self.usage == 'internal' or (self.usage == 'transit' and self.company_id):
-            return True
-        return False
+        return bool(self.company_id) and self.usage in ['internal', 'transit']


### PR DESCRIPTION
A stock location without a company was a valued location. However, if there is no company to a location, it is accessible to all companies. This means that if you add stock while in company A, and remove while in company B, you create a permanent discrepancy in the valuation for both companies.

With this fix, a location is only valued if it is an 'internal' or 'transit' location, and belongs to a company.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
