### PR TITLE
[IMP] mail: expand searchbar in place in chatter

### DIFF
--- a/addons/mail/static/src/chatter/web/chatter.xml
+++ b/addons/mail/static/src/chatter/web/chatter.xml
@@ -5,70 +5,73 @@
     <div t-if="state.thread" class="o-mail-Chatter w-100 h-100 flex-grow-1 d-flex flex-column" t-att-class="{ 'overflow-auto': props.isChatterAside, 'o-chatter-disabled': props.threadId === false }" t-on-scroll="onScrollDebounced" t-ref="root">
         <div class="o-mail-Chatter-top d-print-none position-sticky top-0" t-att-class="{ 'shadow-sm': state.isTopStickyPinned }" t-ref="top">
             <div class="o-mail-Chatter-topbar d-flex flex-shrink-0 flex-grow-0 overflow-x-auto">
-                <button class="o-mail-Chatter-sendMessage btn text-nowrap me-1" t-att-class="{
-                    'btn-primary': state.composerType !== 'note',
-                    'btn-secondary': state.composerType === 'note',
-                    'active': state.composerType === 'message',
-                    'my-2': !props.compactHeight
-                }" t-att-disabled="!state.thread.hasWriteAccess and !(state.thread.hasReadAccess and state.thread.canPostOnReadonly) and props.threadId" data-hotkey="m" t-on-click="() => this.toggleComposer('message')">
-                    Send message
-                </button>
-                <button class="o-mail-Chatter-logNote btn text-nowrap me-1" t-att-class="{
-                    'btn-primary active': state.composerType === 'note',
-                    'btn-secondary': state.composerType !== 'note',
-                    'my-2': !props.compactHeight
-                }" data-hotkey="shift+m" t-on-click="() => this.toggleComposer('note')">
-                    Log note
-                </button>
-                <div class="flex-grow-1 d-flex">
+                <div t-if="state.isSearchOpen" class="flex-grow-1">
+                    <SearchMessageInput closeSearch.bind="closeSearch" messageSearch="messageSearch" thread="state.thread"/>
+                </div>
+                <t t-else="" name="chatter-topbar-left-buttons">
+                    <button class="o-mail-Chatter-sendMessage btn text-nowrap me-1" t-att-class="{
+                        'btn-primary': state.composerType !== 'note',
+                        'btn-secondary': state.composerType === 'note',
+                        'active': state.composerType === 'message',
+                        'my-2': !props.compactHeight
+                    }" t-att-disabled="!state.thread.hasWriteAccess and !(state.thread.hasReadAccess and state.thread.canPostOnReadonly) and props.threadId" data-hotkey="m" t-on-click="() => this.toggleComposer('message')">
+                        Send message
+                    </button>
+                    <button class="o-mail-Chatter-logNote btn text-nowrap me-1" t-att-class="{
+                        'btn-primary active': state.composerType === 'note',
+                        'btn-secondary': state.composerType !== 'note',
+                        'my-2': !props.compactHeight
+                    }" data-hotkey="shift+m" t-on-click="() => this.toggleComposer('note')">
+                        Log note
+                    </button>
                     <button t-if="props.has_activities" class="o-mail-Chatter-activity btn btn-secondary text-nowrap" t-att-class="{ 'my-2': !props.compactHeight }" data-hotkey="shift+a" t-on-click="scheduleActivity">
                         <span>Activities</span>
                     </button>
                     <span class="o-mail-Chatter-topbarGrow flex-grow-1 pe-2"/>
-                    <button class="btn btn-link text-action" t-att-class="{ 'o-active': state.isSearchOpen }" aria-label="Search Messages" title="Search Messages" t-on-click="onClickSearch">
+                    <button class="btn btn-link text-action" aria-label="Search Messages" title="Search Messages" t-on-click="onClickSearch">
                         <i class="oi oi-search" role="img"/>
                     </button>
-                    <button t-if="props.hasAttachmentPreview and state.thread.attachmentsInWebClientView.length" class="btn btn-link text-action" t-on-click="popoutAttachment">
-                        <i class="fa fa-window-restore" aria-hidden="Pop out Attachments" title="Pop out Attachments"/>
-                    </button>
-                    <FileUploader t-if="attachments.length === 0" fileUploadClass="'o-mail-Chatter-fileUploader'" multiUpload="true" onUploaded.bind="onUploaded" onClick="(ev) => this.onClickAttachFile(ev)">
-                        <t t-set-slot="toggler">
-                            <t t-call="mail.Chatter.attachFiles"/>
+                </t>
+                <button t-if="props.hasAttachmentPreview and state.thread.attachmentsInWebClientView.length" class="btn btn-link text-action" t-on-click="popoutAttachment">
+                    <i class="fa fa-window-restore" aria-hidden="Pop out Attachments" title="Pop out Attachments"/>
+                </button>
+                <FileUploader t-if="attachments.length === 0" fileUploadClass="'o-mail-Chatter-fileUploader'" multiUpload="true" onUploaded.bind="onUploaded" onClick="(ev) => this.onClickAttachFile(ev)">
+                    <t t-set-slot="toggler">
+                        <t t-call="mail.Chatter.attachFiles"/>
+                    </t>
+                </FileUploader>
+                <t t-else="" t-call="mail.Chatter.attachFiles"/>
+                <div class="o-mail-Followers d-flex me-1">
+                    <Dropdown position="'bottom-end'" menuClass="'o-mail-Followers-dropdown d-flex flex-column'" state="followerListDropdown">
+                        <button t-att-class="'o-mail-Followers-button btn btn-link d-flex align-items-center text-action px-1 ' + (props.compactHeight ? '' : 'my-2')" t-att-disabled="isDisabled" t-att-title="followerButtonLabel">
+                            <i class="fa fa-user-o me-1" role="img"/>
+                            <i t-if="state.thread.id and state.thread.followersCount === undefined" class="fa fa-circle-o-notch fa-spin"/>
+                            <sup t-else="" class="o-mail-Followers-counter" t-esc="state.thread.followersCount ?? 0"/>
+                        </button>
+                        <t t-set-slot="content">
+                            <FollowerList onAddFollowers.bind="onAddFollowers" onFollowerChanged.bind="onFollowerChanged" thread="state.thread" dropdown="followerListDropdown"/>
                         </t>
-                    </FileUploader>
-                    <t t-else="" t-call="mail.Chatter.attachFiles"/>
-                    <div class="o-mail-Followers d-flex me-1">
-                        <Dropdown position="'bottom-end'" menuClass="'o-mail-Followers-dropdown d-flex flex-column'" state="followerListDropdown">
-                            <button t-att-class="'o-mail-Followers-button btn btn-link d-flex align-items-center text-action px-1 ' + (props.compactHeight ? '' : 'my-2')" t-att-disabled="isDisabled" t-att-title="followerButtonLabel">
-                                <i class="fa fa-user-o me-1" role="img"/>
-                                <i t-if="state.thread.id and state.thread.followersCount === undefined" class="fa fa-circle-o-notch fa-spin"/>
-                                <sup t-else="" class="o-mail-Followers-counter" t-esc="state.thread.followersCount ?? 0"/>
-                            </button>
-                            <t t-set-slot="content">
-                                <FollowerList onAddFollowers.bind="onAddFollowers" onFollowerChanged.bind="onFollowerChanged" thread="state.thread" dropdown="followerListDropdown"/>
-                            </t>
-                        </Dropdown>
-                    </div>
-                    <button t-if="state.thread.selfFollower" class="btn px-0" t-att-class="{ 'text-success': !unfollowHover.isHover, 'text-warning': unfollowHover.isHover, 'my-2': !props.compactHeight }" t-att-disabled="!props.threadId" t-on-click="onClickUnfollow" t-ref="unfollow">
-                        <div class="position-relative">
-                            <!-- Hidden element used to set the button maximum size -->
-                            <span class="d-flex invisible text-nowrap">
-                                <t t-out="followingText.length > unfollowText.length ? followingText : unfollowText"/>
-                            </span>
-                            <span class="o-mail-Chatter-follow position-absolute end-0 top-0" t-out="unfollowHover.isHover ? unfollowText : followingText"/>
-                        </div>
-                    </button>
-                    <button t-if="!state.thread.selfFollower" class="o-mail-Chatter-follow btn btn-link  px-0 text-600" t-on-click="onClickFollow">
-                        <div class="position-relative">
-                            <span class="d-flex invisible text-nowrap">
-                                <t t-out="followingText.length > unfollowText.length ? followingText : unfollowText"/>
-                            </span>
-                            <span class="position-absolute end-0 top-0">
-                                Follow
-                            </span>
-                        </div>
-                    </button>
+                    </Dropdown>
                 </div>
+                <button t-if="state.thread.selfFollower" class="btn px-0" t-att-class="{ 'text-success': !unfollowHover.isHover, 'text-warning': unfollowHover.isHover, 'my-2': !props.compactHeight }" t-att-disabled="!props.threadId" t-on-click="onClickUnfollow" t-ref="unfollow">
+                    <div class="position-relative">
+                        <!-- Hidden element used to set the button maximum size -->
+                        <span class="d-flex invisible text-nowrap">
+                            <t t-out="followingText.length > unfollowText.length ? followingText : unfollowText"/>
+                        </span>
+                        <span class="o-mail-Chatter-follow position-absolute end-0 top-0" t-out="unfollowHover.isHover ? unfollowText : followingText"/>
+                    </div>
+                </button>
+                <button t-if="!state.thread.selfFollower" class="o-mail-Chatter-follow btn btn-link  px-0 text-600" t-on-click="onClickFollow">
+                    <div class="position-relative">
+                        <span class="d-flex invisible text-nowrap">
+                            <t t-out="followingText.length > unfollowText.length ? followingText : unfollowText"/>
+                        </span>
+                        <span class="position-absolute end-0 top-0">
+                            Follow
+                        </span>
+                    </div>
+                </button>
                 <button t-if="props.close" class="o-mail-Chatter-close btn btn-secondary flex-shrink-0 ms-2" aria-label="Close" t-on-click="props.close">
                     <i class="oi oi-close"/>
                 </button>
@@ -97,18 +100,11 @@
             </t>
         </div>
         <div class="o-mail-Chatter-content d-flex flex-column flex-grow-1">
-            <div t-if="state.isSearchOpen" class="o-mail-Chatter-search">
-                <SearchMessagesPanel
-                    closeSearch.bind="closeSearch"
-                    thread="state.thread"
-                    onClickJump.bind="closeSearch"
-                />
-            </div>
-            <t t-else="">
-                <t t-if="props.has_activities and activities.length and !state.isSearchOpen">
+            <t>
+                <t t-if="props.has_activities and activities.length and !messageSearch.searching and !messageSearch.searched">
                     <t t-call="mail.ActivityList"/>
                 </t>
-                <t t-if="scheduledMessages.length and !state.isSearchOpen">
+                <t t-if="scheduledMessages.length">
                     <t t-call="mail.ScheduledMessagesList"/>
                 </t>
                 <div t-if="state.isAttachmentBoxOpened" class="o-mail-AttachmentBox position-relative">
@@ -135,7 +131,8 @@
                         </FileUploader>
                     </div>
                 </div>
-                <Thread t-if="!state.isSearchOpen" thread="state.thread" t-key="state.thread.localId" order="'desc'" scrollRef="rootRef" jumpPresent="state.jumpThreadPresent"/>
+                <SearchMessageResult t-if="messageSearch.searching or messageSearch.searched" thread="state.thread"  messageSearch="messageSearch" onClickJump.bind="closeSearch"/>
+                <Thread t-else="" thread="state.thread" t-key="state.thread.localId" order="'desc'" scrollRef="rootRef" jumpPresent="state.jumpThreadPresent"/>
             </t>
         </div>
     </div>

--- a/addons/mail/static/src/chatter/web/chatter_patch.js
+++ b/addons/mail/static/src/chatter/web/chatter_patch.js
@@ -6,10 +6,11 @@ import { Chatter } from "@mail/chatter/web_portal/chatter";
 import { SuggestedRecipientsList } from "@mail/core/web/suggested_recipient_list";
 import { FollowerList } from "@mail/core/web/follower_list";
 import { isDragSourceExternalFile } from "@mail/utils/common/misc";
-import { SearchMessagesPanel } from "@mail/core/common/search_messages_panel";
 import { useAttachmentUploader } from "@mail/core/common/attachment_uploader_hook";
 import { useDropzone } from "@web/core/dropzone/dropzone_hook";
 import { useHover, useMessageHighlight } from "@mail/utils/common/hooks";
+import { SearchMessageInput } from "@mail/core/common/search_message_input";
+import { SearchMessageResult } from "@mail/core/common/search_message_result";
 
 import { useEffect } from "@odoo/owl";
 
@@ -20,6 +21,7 @@ import { FileUploader } from "@web/views/fields/file_handler";
 import { patch } from "@web/core/utils/patch";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
 import { useService } from "@web/core/utils/hooks";
+import { useMessageSearch } from "@mail/core/common/message_search_hook";
 
 export const DELAY_FOR_SPINNER = 1000;
 
@@ -31,7 +33,8 @@ Object.assign(Chatter.components, {
     FileUploader,
     FollowerList,
     ScheduledMessage,
-    SearchMessagesPanel,
+    SearchMessageInput,
+    SearchMessageResult,
     SuggestedRecipientsList,
 });
 
@@ -82,6 +85,7 @@ patch(Chatter.prototype, {
             showAttachmentLoading: false,
             showScheduledMessages: true,
         });
+        this.messageSearch = useMessageSearch();
         this.attachmentUploader = useAttachmentUploader(
             this.store.Thread.insert({ model: this.props.threadModel, id: this.props.threadId })
         );
@@ -227,11 +231,13 @@ patch(Chatter.prototype, {
         } else {
             this.onThreadCreated?.(this.state.thread);
             this.onThreadCreated = null;
+            this.messageSearch.thread = this.state.thread;
             this.closeSearch();
         }
     },
 
     closeSearch() {
+        this.messageSearch.clear();
         this.state.isSearchOpen = false;
     },
 

--- a/addons/mail/static/src/chatter/web_portal/chatter.scss
+++ b/addons/mail/static/src/chatter/web_portal/chatter.scss
@@ -49,7 +49,3 @@
 .btn.o-mail-Chatter-follow:hover {
     color: $black !important;
 }
-
-.o-mail-Chatter button.o-active {
-    color: $o-action !important;
-}

--- a/addons/mail/static/src/core/common/search_message_input.js
+++ b/addons/mail/static/src/core/common/search_message_input.js
@@ -1,0 +1,54 @@
+import { Component, useExternalListener, useState } from "@odoo/owl";
+import { browser } from "@web/core/browser/browser";
+import { useAutofocus } from "@web/core/utils/hooks";
+
+/**
+ * @typedef {Object} Props
+ * @property {import("@mail/core/common/thread_model").Thread} thread
+ * @property {function} [closeSearch]
+ */
+
+export class SearchMessageInput extends Component {
+    static template = "mail.SearchMessageInput";
+    static props = ["closeSearch?", "messageSearch", "thread"];
+
+    setup() {
+        super.setup();
+        this.state = useState({ searchTerm: "", searchedTerm: "" });
+        useAutofocus();
+        useExternalListener(
+            browser,
+            "keydown",
+            (ev) => {
+                if (ev.key === "Escape") {
+                    this.props.closeSearch?.();
+                }
+            },
+            { capture: true }
+        );
+    }
+
+    search() {
+        this.props.messageSearch.searchTerm = this.state.searchTerm;
+        this.props.messageSearch.search();
+        this.state.searchedTerm = this.state.searchTerm;
+    }
+
+    clear() {
+        this.state.searchTerm = "";
+        this.state.searchedTerm = this.state.searchTerm;
+        this.props.messageSearch.clear();
+        this.props.closeSearch?.();
+    }
+
+    onKeydownSearch(ev) {
+        if (ev.key !== "Enter") {
+            return;
+        }
+        if (!this.state.searchTerm) {
+            this.clear();
+        } else {
+            this.search();
+        }
+    }
+}

--- a/addons/mail/static/src/core/common/search_message_input.xml
+++ b/addons/mail/static/src/core/common/search_message_input.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="mail.SearchMessageInput">
+        <div class="o-mail-SearchMessageInput d-flex py-2">
+            <div class="input-group">
+                <div class="o_searchview form-control d-flex align-items-center bg-view p-0" role="search" aria-autocomplete="list">
+                    <div class="o_searchview_input_container d-flex flex-grow-1 flex-wrap gap-1 h-100">
+                        <input type="text" class="o_searchview_input flex-grow-1 w-auto border-0 rounded-start px-2" accesskey="Q" placeholder="Search" t-model="state.searchTerm" t-on-keydown="onKeydownSearch" t-ref="autofocus" role="searchbox"/>
+                    </div>
+                </div>
+                <button class="btn" t-att-class="state.searchedTerm === state.searchTerm ? 'btn-outline-secondary' : 'btn-secondary'" t-on-click="() => this.search()" aria-label="Search button">
+                    <i t-if="!props.messageSearch.searching" class="o_searchview_icon oi oi-search" role="img" aria-label="Search Messages" title="Search Messages"/>
+                    <i t-else="" class="fa fa-spin fa-spinner" aria-label="Search in progress" title="Search in progress"/>
+                </button>
+            </div>
+            <button t-if="env.inChatter" class="btn btn-outline-secondary ms-3" t-on-click="() => this.clear()" aria-label="Close button">
+                <i class="o_searchview_icon oi oi-close cursor-pointer" role="img" aria-label="Close search" title="Close"/>
+            </button>
+        </div>
+    </t>
+</templates>

--- a/addons/mail/static/src/core/common/search_message_result.js
+++ b/addons/mail/static/src/core/common/search_message_result.js
@@ -1,0 +1,30 @@
+import { Component } from "@odoo/owl";
+import { MessageCardList } from "./message_card_list";
+import { _t } from "@web/core/l10n/translation";
+
+/**
+ * @typedef {Object} Props
+ * @property {import("@mail/core/common/thread_model").Thread} thread
+ * @property {Object} [messaageSearch]
+ * @property {function} [onClickJump]
+ * @property {function} [loadMore]
+ */
+export class SearchMessageResult extends Component {
+    static template = "mail.SearchMessageResult";
+    static components = { MessageCardList };
+    static props = ["thread", "messageSearch", "onClickJump?"];
+
+    get MESSAGE_FOUND() {
+        if (this.props.messageSearch.messages.length === 0) {
+            return false;
+        }
+        return _t("%s messages found", this.props.messageSearch.count);
+    }
+
+    onLoadMoreVisible() {
+        const before = this.props.messageSearch?.messages
+            ? Math.min(...this.props.messageSearch.messages.map((message) => message.id))
+            : false;
+        this.props.messageSearch.search(before);
+    }
+}

--- a/addons/mail/static/src/core/common/search_message_result.xml
+++ b/addons/mail/static/src/core/common/search_message_result.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="mail.SearchMessageResult">
+        <div class="o-mail-SearchMessageResult">
+            <p t-if="MESSAGE_FOUND" class="o-mail-SearchMessagesPanel-title py-1 mb-0 fw-bolder text-center text-uppercase text-muted">
+                <t t-out="MESSAGE_FOUND" />
+            </p>
+            <MessageCardList 
+                messages="props.messageSearch.messages" 
+                thread="props.thread" 
+                mode="'search'" 
+                messageSearch="props.messageSearch" 
+                showEmpty="props.messageSearch.messages.length === 0 and props.messageSearch.searched" 
+                onClickJump="() => this.props.onClickJump?.()" 
+                loadMore="props.messageSearch.loadMore" 
+                onLoadMoreVisible.bind="onLoadMoreVisible" 
+            />    
+        </div>
+    </t>
+</templates>

--- a/addons/mail/static/src/core/common/search_messages_panel.js
+++ b/addons/mail/static/src/core/common/search_messages_panel.js
@@ -1,41 +1,24 @@
-import { Component, onWillUpdateProps, useExternalListener, useState } from "@odoo/owl";
-import { useAutofocus } from "@web/core/utils/hooks";
-import { useMessageSearch } from "@mail/core/common/message_search_hook";
-import { browser } from "@web/core/browser/browser";
+import { Component, useState, onWillUpdateProps } from "@odoo/owl";
 import { ActionPanel } from "@mail/discuss/core/common/action_panel";
-import { MessageCardList } from "./message_card_list";
 import { _t } from "@web/core/l10n/translation";
+import { useService } from "@web/core/utils/hooks";
+import { SearchMessageInput } from "@mail/core/common/search_message_input";
+import { SearchMessageResult } from "@mail/core/common/search_message_result";
+import { useMessageSearch } from "./message_search_hook";
 
 /**
  * @typedef {Object} Props
  * @property {import("@mail/core/common/thread_model").Thread} thread
- * @property {funtion} [closeSearch]
- * @property {funtion} [onClickJump]
- * @extends {Component<Props, Env>}
  */
 export class SearchMessagesPanel extends Component {
-    static components = {
-        MessageCardList,
-        ActionPanel,
-    };
-    static props = ["thread", "closeSearch?", "onClickJump?"];
     static template = "mail.SearchMessagesPanel";
+    static components = { ActionPanel, SearchMessageInput, SearchMessageResult };
+    static props = ["thread"];
 
     setup() {
         super.setup();
-        this.state = useState({ searchTerm: "", searchedTerm: "" });
+        this.store = useState(useService("mail.store"));
         this.messageSearch = useMessageSearch(this.props.thread);
-        useAutofocus();
-        useExternalListener(
-            browser,
-            "keydown",
-            (ev) => {
-                if (ev.key === "Escape") {
-                    this.props.closeSearch?.();
-                }
-            },
-            { capture: true }
-        );
         onWillUpdateProps((nextProps) => {
             if (this.props.thread.notEq(nextProps.thread)) {
                 this.env.searchMenu?.close();
@@ -44,45 +27,6 @@ export class SearchMessagesPanel extends Component {
     }
 
     get title() {
-        return _t("Search messages");
-    }
-
-    get MESSAGES_FOUND() {
-        if (this.messageSearch.messages.length === 0) {
-            return false;
-        }
-        return _t("%s messages found", this.messageSearch.count);
-    }
-
-    search() {
-        this.messageSearch.searchTerm = this.state.searchTerm;
-        this.messageSearch.search();
-        this.state.searchedTerm = this.state.searchTerm;
-    }
-
-    clear() {
-        this.state.searchTerm = "";
-        this.state.searchedTerm = this.state.searchTerm;
-        this.messageSearch.clear();
-        this.props.closeSearch?.();
-    }
-
-    /** @param {KeyboardEvent} ev */
-    onKeydownSearch(ev) {
-        if (ev.key !== "Enter") {
-            return;
-        }
-        if (!this.state.searchTerm) {
-            this.clear();
-        } else {
-            this.search();
-        }
-    }
-
-    onLoadMoreVisible() {
-        const before = this.messageSearch.messages
-            ? Math.min(...this.messageSearch.messages.map((message) => message.id))
-            : false;
-        this.messageSearch.search(before);
+        return _t("Search Message");
     }
 }

--- a/addons/mail/static/src/core/common/search_messages_panel.xml
+++ b/addons/mail/static/src/core/common/search_messages_panel.xml
@@ -1,28 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.SearchMessagesPanel">
-        <ActionPanel title="env.inChatter ? undefined : title" minWidth="200" initialWidth="400" icon="env.inChatter ? false : 'oi oi-search'">
-            <div class="d-flex py-2">
-                <div class="input-group">
-                    <div class="o_searchview form-control d-flex align-items-center bg-view p-0" role="search" aria-autocomplete="list">
-                        <div class="o_searchview_input_container d-flex flex-grow-1 flex-wrap gap-1 h-100">
-                            <input type="text" class="o_searchview_input flex-grow-1 w-auto border-0 rounded-start px-2" accesskey="Q" placeholder="Search" t-model="state.searchTerm" t-on-keydown="onKeydownSearch" t-ref="autofocus" role="searchbox"/>
-                        </div>
-                    </div>
-                    <button class="btn" t-att-class="state.searchedTerm === state.searchTerm ? 'btn-outline-secondary' : 'btn-secondary'" t-on-click="() => this.search()" aria-label="Search button">
-                        <i t-if="!messageSearch.searching" class="o_searchview_icon oi oi-search" role="img" aria-label="Search Messages" title="Search Messages"/>
-                        <i t-else="" class="fa fa-spin fa-spinner" aria-label="Search in progress" title="Search in progress"/>
-                    </button>
-                </div>
-                <button t-if="env.inChatter" class="btn btn-outline-secondary ms-3" t-on-click="() => this.clear()" aria-label="Close button">
-                    <i class="o_searchview_icon oi oi-close cursor-pointer" role="img" aria-label="Close search" title="close"/>
-                </button>
-            </div>
-            <p t-if="MESSAGES_FOUND" class="o-mail-SearchMessagesPanel-title py-1 mb-0 fw-bolder text-center text-uppercase text-muted">
-                <t t-out="MESSAGES_FOUND"/>
-            </p>
-            <MessageCardList messages="messageSearch.messages" thread="props.thread" mode="'search'" messageSearch="messageSearch" showEmpty="messageSearch.messages.length === 0 and messageSearch.searched" onClickJump="() => this.props.onClickJump?.()" loadMore="messageSearch.loadMore" onLoadMoreVisible="onLoadMoreVisible"/>
+        <ActionPanel
+            title="title"
+            minWidth="200"
+            initialWidth="400"
+            icon="'oi oi-serch'"
+        >
+            <SearchMessageInput closeSearch="props.closeSearch" messageSearch="messageSearch" thread="props.thread"/>
+            <SearchMessageResult thread="props.thread" messageSearch="messageSearch"/>
         </ActionPanel>
     </t>
-
 </templates>

--- a/addons/mail/static/tests/chatter/web/chatter_search.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter_search.test.js
@@ -39,24 +39,6 @@ test("Click on the search icon should open the search form", async () => {
     await contains(".o_searchview_input");
 });
 
-test("Click again on the search icon should close the search form", async () => {
-    patchUiSize({ size: SIZES.XXL });
-    const pyEnv = await startServer();
-    const partnerId = pyEnv["res.partner"].create({ name: "John Doe" });
-    pyEnv["mail.message"].create({
-        body: "not empty",
-        model: "res.partner",
-        res_id: partnerId,
-    });
-    await start();
-    await openFormView("res.partner", partnerId);
-    await click(".o-mail-Chatter-topbar [title='Search Messages']");
-    await contains(".o_searchview");
-    await click(".o-mail-Chatter-topbar [title='Search Messages']");
-    await contains(".o_searchview", { count: 0 });
-    await contains(".o_searchview_input", { count: 0 });
-});
-
 test("Search in chatter", async () => {
     patchUiSize({ size: SIZES.XXL });
     const pyEnv = await startServer();
@@ -71,7 +53,7 @@ test("Search in chatter", async () => {
     await click("[title='Search Messages']");
     await insertText(".o_searchview_input", "empty");
     triggerHotkey("Enter");
-    await contains(".o-mail-Chatter-search .o-mail-Message");
+    await contains(".o-mail-SearchMessageResult .o-mail-Message");
     await click(".o-mail-MessageCard-jump");
     await contains(".o-mail-Message.o-highlighted .o-mail-Message-content", { text: "not empty" });
 });
@@ -90,9 +72,9 @@ test("Close button should close the search panel", async () => {
     await click(".o-mail-Chatter-topbar [title='Search Messages']");
     await insertText(".o_searchview_input", "empty");
     triggerHotkey("Enter");
-    await contains(".o-mail-Chatter-search .o-mail-Message");
-    await click(".o-mail-Chatter-topbar [title='Search Messages']");
-    await contains(".o-mail-Chatter-search", { count: 0 });
+    await contains(".o-mail-SearchMessageResult .o-mail-Message");
+    await click(".o-mail-SearchMessageInput [title='Close']");
+    await contains(".o-mail-SearchMessageInput", { count: 0 });
 });
 
 test("Search in chatter should be hightligted", async () => {
@@ -109,7 +91,7 @@ test("Search in chatter should be hightligted", async () => {
     await click("[title='Search Messages']");
     await insertText(".o_searchview_input", "empty");
     triggerHotkey("Enter");
-    await contains(`.o-mail-Chatter-search .o-mail-Message .${HIGHLIGHT_CLASS}`);
+    await contains(`.o-mail-SearchMessageResult .o-mail-Message .${HIGHLIGHT_CLASS}`);
 });
 
 test("Scrolling bottom in non-aside chatter should load more searched message", async () => {
@@ -131,7 +113,7 @@ test("Scrolling bottom in non-aside chatter should load more searched message", 
     await click("[title='Search Messages']");
     await insertText(".o_searchview_input", "message");
     triggerHotkey("Enter");
-    await contains(".o-mail-Chatter-search .o-mail-Message", { count: 30 });
+    await contains(".o-mail-SearchMessageResult .o-mail-Message", { count: 30 });
     await scroll(".o_content", "bottom");
-    await contains(".o-mail-Chatter-search .o-mail-Message", { count: 60 });
+    await contains(".o-mail-SearchMessageResult .o-mail-Message", { count: 60 });
 });

--- a/addons/mail/static/tests/core/search_highlight.test.js
+++ b/addons/mail/static/tests/core/search_highlight.test.js
@@ -122,7 +122,7 @@ test("Display highligthed search in chatter", async () => {
     await click("[title='Search Messages']");
     await insertText(".o_searchview_input", "empty");
     triggerHotkey("Enter");
-    await contains(`.o-mail-Chatter-search .o-mail-Message span.${HIGHLIGHT_CLASS}`);
+    await contains(`.o-mail-SearchMessageResult .o-mail-Message span.${HIGHLIGHT_CLASS}`);
 });
 
 test("Display multiple highligthed search in chatter", async () => {
@@ -139,7 +139,9 @@ test("Display multiple highligthed search in chatter", async () => {
     await click("[title='Search Messages']");
     await insertText(".o_searchview_input", "not empty");
     triggerHotkey("Enter");
-    await contains(`.o-mail-Chatter-search .o-mail-Message span.${HIGHLIGHT_CLASS}`, { count: 2 });
+    await contains(`.o-mail-SearchMessageResult .o-mail-Message span.${HIGHLIGHT_CLASS}`, {
+        count: 2,
+    });
 });
 
 test("Display highligthed search in Discuss", async () => {
@@ -196,6 +198,8 @@ test("Display highligthed with escaped character must ignore them", async () => 
     await click("[title='Search Messages']");
     await insertText(".o_searchview_input", "test hello");
     triggerHotkey("Enter");
-    await contains(`.o-mail-Chatter-search .o-mail-Message span.${HIGHLIGHT_CLASS}`, { count: 2 });
+    await contains(`.o-mail-SearchMessageResult .o-mail-Message span.${HIGHLIGHT_CLASS}`, {
+        count: 2,
+    });
     await contains(`.o-mail-Message-body`, { text: "<strong>test</strong> hello" });
 });


### PR DESCRIPTION
Purpose of this commit:
Previously, to search for a message in the chatter, users needed to click
the search icon, which would open the search panel and hide the thread.
With this update, clicking the search icon now opens only the search input,
keeping the thread visible until the user actively begins a search

Before:
https://www.loom.com/share/d9f1fa3a5eb14ac19d378a221003cb03?sid=f3114044-343d-4b46-ae3e-2501aa198ee5

After:
https://www.loom.com/share/6f5ea998cf8349d089c72b802ea93f7f?sid=54cccea4-4c1f-468d-af10-d98b37d12644

taskid-4260440