### PR TITLE
[FIX] account: prevent error when removing currency from invoice

### DIFF
--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -4438,3 +4438,21 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
                 'credit': 0.0,
             },
         ])
+
+    def test_invoice_with_empty_currency(self):
+
+        move = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_line_ids': [
+                Command.create({
+                    'name': 'invoice_line',
+                    'quantity': 1.0,
+                    'price_unit': 100.0,
+                    'tax_ids': [Command.set(self.company_data['default_tax_sale'].ids)],
+                }),
+            ],
+        })
+        move_form = Form(move)
+        move_form.currency_id = self.env['res.currency']
+        self.assertTrue(move.currency_id)


### PR DESCRIPTION
When the user removes the currency from the invoice,
a traceback will appear.

Steps to reproduce the error:
- Enable multiple currencies
- Create a invoice > Add a line > Add any product > Remove currency

Traceback:
```
AssertionError: precision_rounding must be positive, got 0.0
  File "addons/account/models/account_move.py", line 1550, in _compute_tax_totals
    base_lines, _tax_lines = move._get_rounded_base_and_tax_lines()
  File "addons/account/models/account_move.py", line 1529, in _get_rounded_base_and_tax_lines
    AccountTax._add_tax_details_in_base_lines(base_lines, self.company_id)
  File "addons/account/models/account_tax.py", line 1354, in _add_tax_details_in_base_lines
    self._add_tax_details_in_base_line(base_line, company)
  File "addons/account/models/account_tax.py", line 1313, in _add_tax_details_in_base_line
    taxes_computation = base_line['tax_ids']._get_tax_details(
  File "addons/account/models/account_tax.py", line 1034, in _get_tax_details
    raw_base = float_round(raw_base, precision_rounding=precision_rounding)
  File "odoo/tools/float_utils.py", line 70, in float_round
    rounding_factor = _float_check_precision(precision_digits=precision_digits,
  File "odoo/tools/float_utils.py", line 35, in _float_check_precision
    assert precision_rounding > 0,\
```

https://github.com/odoo/odoo/blob/0bcc55685fd75f88214b7da1f5df9ec9a7aff784/addons/account/models/account_tax.py#L1041
When, the user removes the currency, ``precision_rounding`` will be 0.0
because at [1], ``base_line['currency_id']`` will be empty,
So, the rounding will be 0.0
So, It will lead to the above traceback.

[1]- https://github.com/odoo/odoo/blob/0bcc55685fd75f88214b7da1f5df9ec9a7aff784/addons/account/models/account_tax.py#L1324



When, the user removes the currency, precision_rounding will be 0.0
because at [2], currency will be empty,
[2]- https://github.com/odoo/odoo/blob/a2c9755e3924bc04e524f5ca0e5e17cd98be5b12/addons/account/models/account_tax.py#L985

When, the user removes the currency,
At [3] "singleton: res.currency()" error will be raised.
so, fallback value is added for that.
[3]- https://github.com/odoo/odoo/blob/a2c9755e3924bc04e524f5ca0e5e17cd98be5b12/addons/account/models/account_tax.py#L1433

When the customer and product are added to the invoice, then the user removes
the currency, At [4] "singleton: res.currency()" error will be raised.
so, fallback value is added for that at [5]
[4]- https://github.com/odoo/odoo/blob/a2c9755e3924bc04e524f5ca0e5e17cd98be5b12/addons/account/models/account_tax.py#L1640

[5]- https://github.com/odoo/odoo/blob/a2c9755e3924bc04e524f5ca0e5e17cd98be5b12/addons/account/models/account_tax.py#L1601

When the customer and product are added to the invoice, then the user removes
the currency, At [6] "singleton: res.currency()" error will be raised because
k['currency_id'] is False.
[6]- https://github.com/odoo/odoo/blob/a2c9755e3924bc04e524f5ca0e5e17cd98be5b12/addons/account/models/account_tax.py#L2173


sentry-6018518380

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
