### PR TITLE
[FIX] web: handle undefined results from load_breadcrumbs

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -270,11 +270,11 @@ export function makeActionManager(env, router = _router) {
         const results = await Promise.all(keys.map((k) => breadcrumbCache[k]));
         const controllersToRemove = [];
         for (const [controller, res] of zip(controllers, results)) {
-            if ("display_name" in res) {
+            if (res && "display_name" in res) {
                 controller.displayName = res.display_name;
             } else {
                 controllersToRemove.push(controller);
-                if ("error" in res) {
+                if (res && "error" in res) {
                     console.warn(
                         "The following element was removed from the breadcrumb and from the url.\n",
                         controller.state,


### PR DESCRIPTION
When a breadcrumb contains a client action without a multi-record view, load_breadcrumbs skips this action, returning nothing for that key. However, on the frontend, we are not removing these controllers and attempt to access display_name each time the user reloads the page. This PR resolves this issue. If the backend result is undefined for a key stored in a breadcrumb cache, we remove it.

Steps to test:
We can open any sub-view from the BoM overview, as it is an action without a multi-record view.

1. Activate the Subcontracting feature in the settings tab.
2. Go to the Manufacturing app.
3. Click on the Product tab.
4. Select the Bills of Materials
5. Select Office Lamp BoM, for example
6. Click on BoM Overview
7. Click on Subcontracting
8. Refresh the page

An error should appear, indicating an attempt to access display_name on an undefined object.

Related Commit: https://github.com/odoo/odoo/commit/5047d1b3f4b2bd8061a15457350a0250bf93145f


https://github.com/user-attachments/assets/57633318-cc24-4e0d-acb2-0f27f7ccd847


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
