### PR TITLE
[FIX] l10n_cl: display the document type border correctly

### DIFF
--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -44,7 +44,7 @@
                 <div name="right-upper-side" class="col-4">
                     <div class="row">
                         <div name="right-upper-side" class="col-12">
-                            <div class="row border border-4 border-dark">
+                            <div class="row border border-4 border-dark" style="max-width: 100%;">
                                 <div class="col-12 text-center">
                                     <h6 style="color: black;">
                                         <strong>


### PR DESCRIPTION
[FIX] l10n_cl: display the document type border correctly

Steps to reproduce:
1 - In the chilean localization create an invoice (with a long text document type). 
2 - Preview

The observed behaviour:
- The right side of the border of the document type would go out of the view.

This Fix would just make the maximum width of the said border to never exceed its container.

opw-4278374

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
