### PR TITLE
[FIX] im_livechat: blank chat window on reload

### DIFF
--- a/addons/im_livechat/static/src/public_models/public_livechat_global.js
+++ b/addons/im_livechat/static/src/public_models/public_livechat_global.js
@@ -50,7 +50,7 @@ registerModel({
             const strCookie = decodeURIComponent(getCookie('im_livechat_session'));
             let isSessionCookieAvailable = Boolean(strCookie);
             let cookie = JSON.parse(strCookie || '{}');
-            if (isSessionCookieAvailable && cookie.visitor_uid !== session.user_id) {
+            if (isSessionCookieAvailable && (cookie.visitor_uid !== session.user_id || !cookie.id)) {
                 this.leaveSession();
                 isSessionCookieAvailable = false;
                 cookie = {};
@@ -66,8 +66,6 @@ registerModel({
                     message.body = Markup(message.body);
                 }
                 this.update({ isAvailableForMe: true });
-            } else if (isSessionCookieAvailable) {
-                this.update({ history: [], isAvailableForMe: true });
             } else {
                 const result = await this.messaging.rpc({
                     route: '/im_livechat/init',
@@ -92,7 +90,6 @@ registerModel({
          *   method overrides ('sendWelcomeMessage', 'sendMessage', ...)
          *
          * - If the chat has been started before, but the user did not interact with the bot
-         *   The default behavior is to open an empty chat window, without any messages.
          *   In addition, we fetch the configuration (with a '/init' call), to see if we have a bot
          *   configured.
          *   Indeed we want to trigger the bot script on every page where the associated rule is matched.


### PR DESCRIPTION
Since the introduction of live chat, an arbitrary decision to open a blank chat window when reloading/navigating away from the page when the user didn't interract with it was made.

However, this is disturbing, especially in the chat bot case where the empty chat window still has the chat bot name as its title.

Moreover, this chat bot chat window won't trigger the bot answers if the user interract with it.

This PR removes this blank window behavior and displays the live chat button instead.

opw-4214093

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
