### PR TITLE
[IMP] project: make all fields read-only in task calendar popover

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -823,7 +823,7 @@
                     <field name="milestone_id" invisible="not allow_milestones or not milestone_id"/>
                     <field name="user_ids" widget="many2many_avatar_user" invisible="not user_ids"/>
                     <field name="partner_id" invisible="not partner_id"/>
-                    <field name="priority" widget="priority"/>
+                    <field name="priority" widget="priority" readonly="1"/>
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" invisible="not tag_ids"/>
                     <field name="stage_id" invisible="not project_id or not stage_id" widget="task_stage_with_state_selection"/>
                     <field name="personal_stage_id" string="Personal Stage" options="{'no_open': True}" invisible="project_id or not personal_stage_id"/>


### PR DESCRIPTION
According to the JS framework team, fields are not supposed to be editable in the calendar popover, nothing is done to manage their edition. To stay consistent, we then make the 'Priority' field of tasks read-only in the calendar popover.

task-4269542

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
