### PR TITLE
[FIX] project_todo: fixes the issue of chatter

### DIFF
--- a/addons/project_todo/static/src/components/todo_chatter_panel/todo_chatter_panel.js
+++ b/addons/project_todo/static/src/components/todo_chatter_panel/todo_chatter_panel.js
@@ -23,12 +23,13 @@ export class TodoChatterPanel extends Component {
 
     toggleChatter(ev) {
         this.state.displayChatter = ev.detail.displayChatter;
+        this.rootRef.el?.parentElement?.classList.toggle('d-none', !this.state.displayChatter);
     }
 }
 
 export const todoChatterPanel = {
     component: TodoChatterPanel,
-    additionalClasses: ["o_todo_chatter", "position-relative", "p-0", "overflow-y-auto"],
+    additionalClasses: ["o_todo_chatter", "d-none", "position-relative", "p-0", "overflow-y-auto"],
 };
 
 registry.category("view_widgets").add("todo_chatter_panel", todoChatterPanel);

--- a/addons/project_todo/static/src/components/todo_chatter_panel/todo_chatter_panel.xml
+++ b/addons/project_todo/static/src/components/todo_chatter_panel/todo_chatter_panel.xml
@@ -2,7 +2,7 @@
 
 <templates xml:space="preserve">
 
-    <t t-name="project_todo.TodoChatterPanel">
+    <div t-name="project_todo.TodoChatterPanel" t-ref="root">
         <chatter t-if="state.displayChatter" class="o_FormRenderer_chatterContainer">
             <Chatter
                 threadModel="'project.task'"
@@ -14,6 +14,6 @@
                 saveRecord="props.record.save.bind(props.record, { reload: false })"
             />
         </chatter>
-    </t>
+    </div>
 
 </templates>

--- a/addons/project_todo/static/src/scss/todo.scss
+++ b/addons/project_todo/static/src/scss/todo.scss
@@ -13,6 +13,16 @@
     .o_task_state_widget {
         font-size: large;
     }
+    @include media-breakpoint-up(xxl) {
+        .o_widget_todo_chatter_panel {
+            width: 35%;
+        }
+    }
+    @include media-breakpoint-down(xxl, $o-extra-grid-breakpoints) {
+        .o_widget_todo_chatter_panel {
+            min-width: 100%;
+        }
+    }
 }
 
 .o_todo_hide_avatar .o_avatar {


### PR DESCRIPTION
Steps to Reproduce:
- Open the To-Do app and click on the chatter icon.
- Create an activity with a long description.
- As the description increases, the chatter expands beyond its intended area.

Issue:
- The chatter did not have a fixed length, causing it to expand with long descriptions .

After PR:
- The chatter section now maintains a consistent fixed size.

task-4256985




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
