### PR TITLE
[FIX] base: prevent selection of invalid home actions

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -27954,6 +27954,13 @@ msgid "The \"App Switcher\" action cannot be selected as home action."
 msgstr ""
 
 #. module: base
+#. odoo-python
+#: code:addons/base/models/res_users.py:0
+#, python-format
+msgid "The action \"%s\" cannot be set as the home action because it requires a record to be selected beforehand."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_res_country__code
 #: model:ir.model.fields,help:base.field_res_partner__country_code
 #: model:ir.model.fields,help:base.field_res_users__country_code

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -555,13 +555,23 @@ class Users(models.Model):
         action_open_website = self.env.ref('base.action_open_website', raise_if_not_found=False)
         if action_open_website and any(user.action_id.id == action_open_website.id for user in self):
             raise ValidationError(_('The "App Switcher" action cannot be selected as home action.'))
-        # Prevent using reload actions.
         # We use sudo() because  "Access rights" admins can't read action models
         for user in self.sudo():
             if user.action_id.type == "ir.actions.client":
+                # Prevent using reload actions.
                 action = self.env["ir.actions.client"].browse(user.action_id.id)  # magic
                 if action.tag == "reload":
                     raise ValidationError(_('The "%s" action cannot be selected as home action.', action.name))
+
+            elif user.action_id.type == "ir.actions.act_window":
+                # Restrict actions that include 'active_id' in their context.
+                action = self.env["ir.actions.act_window"].browse(user.action_id.id)  # magic
+                if not action.context:
+                    continue
+                if "active_id" in action.context:
+                    raise ValidationError(
+                        _('The action "%s" cannot be set as the home action because it requires a record to be selected beforehand.', action.name)
+                    )
 
 
     @api.constrains('groups_id')


### PR DESCRIPTION
Problem:
Certain `ir.actions.act_window` actions contain a context with `active_id`, which causes issues when set as home actions, as `active_id` will not be defined in that context.

Solution:
Prevent the selection of actions that include `active_id` in their context from being set as home actions.

Steps to reproduce:
1. Enable debug mode.
2. Navigate to `Settings / Users & Companies / Users`.
3. Select the current user from the list.
4. Under Preferences / Menus Customization set "Home Action" to "Quotations and Sales."
5. After that: each time you go to backend homepage (/) you get a traceback error instead of the app dashboard

opw-4283156

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
