### PR TITLE
[FIX] mrp: click in the subcontracting line without raise an error

### DIFF
--- a/addons/mrp/static/src/components/bom_overview_special_line/mrp_bom_overview_special_line.xml
+++ b/addons/mrp/static/src/components/bom_overview_special_line/mrp_bom_overview_special_line.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <tr t-name="mrp.BomOverviewSpecialLine" t-on-click="hasFoldButton? props.toggleFolded : false" >
+    <tr t-name="mrp.BomOverviewSpecialLine" t-on-click="props.toggleFolded" >
         <td name="td_mrp_bom">
             <span t-attf-style="margin-left: {{ data.level * 20 }}px"/>
             <span t-if="hasFoldButton" t-attf-class="o_mrp_bom_{{ props.isFolded ? 'unfoldable' : 'foldable' }} btn btn-light ps-0 py-0" t-attf-aria-label="{{ props.isFolded ? 'Unfold' : 'Fold' }}" t-attf-title="{{ props.isFolded ? 'Unfold' : 'Fold' }}">


### PR DESCRIPTION
When the user clicks on a subcontracting line in the BOM overview, an error is raised. This occurs because we are passing false when subcontracting lines are not folded, but a function is expected. The solution is to pass a function, which should be a void function when toggleFolded is false.

Steps to Reproduce:
1. Go to the Manufacturing app.
2. Enable the Subcontracting feature in the Settings tab.
3. Navigate to the BoM overview in the Products tab.
4. Open a BoM that includes subcontracting.
5. Click to expand the subcontracting line.

Previous Behaviour: An error pop-up appears.
Current Behaviour: Opens without any error.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
