### PR TITLE
[IMP] account, *: Use dynamic placeholder on account.move.form

### DIFF
--- a/addons/account/tests/test_account_incoming_supplier_invoice.py
+++ b/addons/account/tests/test_account_incoming_supplier_invoice.py
@@ -167,7 +167,7 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon):
 
         following_partners = invoice.message_follower_ids.mapped('partner_id')
         self.assertEqual(following_partners, self.env.user.partner_id)
-        self.assertRegex(invoice.name, r'BILL/\d{4}/\d{2}/0001')
+        self.assertRegex(invoice.name_placeholder, r'BILL/\d{4}/\d{2}/0001')
 
     def test_supplier_invoice_forwarded_by_internal_user_without_supplier(self):
         """ In this test, the bill was forwarded by an employee,

--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -950,14 +950,14 @@ class TestAccountMove(AccountTestInvoicingCommon):
         })
         move = self.env['account.move'].with_context(default_move_type='entry')
         with Form(move) as move_form:
-            self.assertEqual(move_form.name, 'MISC/2021/10/0001')
+            self.assertEqual(move_form.name_placeholder, 'MISC/2021/10/0001')
             move_form.journal_id, journal = journal, move_form.journal_id
-            self.assertEqual(move_form.name, 'AJ/2021/10/0001')
+            self.assertEqual(move_form.name_placeholder, 'AJ/2021/10/0001')
             # ensure we aren't burning any sequence by switching journal
             move_form.journal_id, journal = journal, move_form.journal_id
-            self.assertEqual(move_form.name, 'MISC/2021/10/0001')
+            self.assertEqual(move_form.name_placeholder, 'MISC/2021/10/0001')
             move_form.journal_id, journal = journal, move_form.journal_id
-            self.assertEqual(move_form.name, 'AJ/2021/10/0001')
+            self.assertEqual(move_form.name_placeholder, 'AJ/2021/10/0001')
 
     def test_change_journal_posted_before(self):
         """ Changes to a move posted before can only de done if move name is '/' or empty (False) """
@@ -975,6 +975,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
         # Once move name in draft is changed to '/', changing the journal is allowed
         self.test_move.name = '/'
         self.test_move.journal_id = journal
+        self.test_move.action_post()
         self.assertEqual(self.test_move.name, 'AJ/2016/01/0001')
         self.assertEqual(self.test_move.journal_id, journal)
 
@@ -995,7 +996,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
         with self.assertRaisesRegex(UserError, 'You cannot edit the journal of an account move with a sequence number assigned, unless the name is removed or set to "/". This might create a gap in the sequence.'):
             test_move_2.write({'journal_id': False})
         # Once move name in draft is changed to '/', changing the journal is allowed
-        test_move_2.write({'name': '/', 'journal_id': journal.id})
+        test_move_2.write({'name': False, 'journal_id': journal.id})
         test_move_2.action_post()
         # Sequence number is updated for the new journal
         self.assertEqual(test_move_2.sequence_number, 1)

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -1850,7 +1850,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         ], {
             **self.move_vals,
             'invoice_payment_term_id': None,
-            'name': 'RINV/2019/00001',
+            'name_placeholder': 'RINV/2019/00001',
             'date': move_reversal.date,
             'state': 'draft',
             'ref': 'Reversal of: %s, %s' % (self.invoice.name, move_reversal.reason),

--- a/addons/account/tests/test_audit_trail.py
+++ b/addons/account/tests/test_audit_trail.py
@@ -81,7 +81,7 @@ class TestAuditTrail(AccountTestInvoicingCommon):
         self.assertTrail(self.get_trail(self.move), messages)
 
         self.move.action_post()
-        messages.append("Updated\nFalse ⇨ True (Checked)\nDraft ⇨ Posted (Status)")
+        messages.append("Updated\nFalse ⇨ True (Checked)\nFalse ⇨ MISC/2021/04/0001 (Number)\nDraft ⇨ Posted (Status)")
         self.assertTrail(self.get_trail(self.move), messages)
 
         self.move.button_draft()

--- a/addons/account/tests/test_sequence_mixin.py
+++ b/addons/account/tests/test_sequence_mixin.py
@@ -40,6 +40,13 @@ class TestSequenceMixinCommon(AccountTestInvoicingCommon):
             move.action_post()
         return move
 
+    def assertMoveName(cls, move, expected_name):
+        if move.name_placeholder:
+            cls.assertFalse(move.name, f"This move is potentially the first of the sequence, it shouldn't have a name while it is not posted. Got '{move.name}'.")
+            cls.assertEqual(move.name_placeholder, expected_name, f"This move is potentially the first of the sequence, it doesn't have a name but a placeholder name which is currently '{move.name_placeholder}'. You expected '{expected_name}'.")
+        else:
+            cls.assertEqual(move.name, expected_name, f"Expected '{expected_name}' but got '{move.name}'.")
+
 
 @tagged('post_install', '-at_install')
 class TestSequenceMixin(TestSequenceMixinCommon):
@@ -56,23 +63,23 @@ class TestSequenceMixin(TestSequenceMixinCommon):
         """Change the sequence when we change the date iff it has never been posted."""
         # Check setup
         self.assertEqual(self.test_move.state, 'draft')
-        self.assertEqual(self.test_move.name, 'MISC/15-16/01/0001')
+        self.assertEqual(self.test_move.name_placeholder, 'MISC/15-16/01/0001')
         self.assertEqual(fields.Date.to_string(self.test_move.date), '2016-01-01')
 
         # Never posetd, the number must change if we change the date
         self.test_move.date = '2020-02-02'
-        self.assertEqual(self.test_move.name, 'MISC/19-20/02/0001')
+        self.assertMoveName(self.test_move, 'MISC/19-20/02/0001')
 
         # We don't recompute user's input when posting
         self.test_move.name = 'MyMISC/2020/0000001'
         self.test_move.action_post()
-        self.assertEqual(self.test_move.name, 'MyMISC/2020/0000001')
+        self.assertMoveName(self.test_move, 'MyMISC/2020/0000001')
 
         # Has been posted, and it doesn't change anymore
         self.test_move.button_draft()
         self.test_move.date = '2020-01-02'
         self.test_move.action_post()
-        self.assertEqual(self.test_move.name, 'MyMISC/2020/0000001')
+        self.assertMoveName(self.test_move, 'MyMISC/2020/0000001')
 
     def test_sequence_change_date_with_quick_edit_mode(self):
         """
@@ -94,17 +101,17 @@ class TestSequenceMixin(TestSequenceMixinCommon):
                 }),
             ]
         })
-        self.assertEqual(bill.name, 'BILL/15-16/01/0001')
+        self.assertMoveName(bill, 'BILL/15-16/01/0001')
         bill = bill.copy({'date': '2016-02-01'})
 
-        self.assertEqual(bill.name, 'BILL/15-16/02/0001')
+        self.assertMoveName(bill, 'BILL/15-16/02/0001')
         with Form(bill) as bill_form:
             bill_form.date = '2016-02-02'
-            self.assertEqual(bill_form.name, 'BILL/15-16/02/0001')
+            self.assertMoveName(bill_form, 'BILL/15-16/02/0001')
             bill_form.date = '2016-03-01'
-            self.assertEqual(bill_form.name, 'BILL/15-16/03/0001')
+            self.assertMoveName(bill_form, 'BILL/15-16/03/0001')
             bill_form.date = '2017-01-01'
-            self.assertEqual(bill_form.name, 'BILL/16-17/01/0001')
+            self.assertMoveName(bill_form, 'BILL/16-17/01/0001')
 
         invoice = self.env['account.move'].create({
             'partner_id': 1,
@@ -118,14 +125,14 @@ class TestSequenceMixin(TestSequenceMixinCommon):
             ]
         })
 
-        self.assertEqual(invoice.name, 'INV/15-16/0001')
+        self.assertMoveName(invoice, 'INV/15-16/0001')
         with Form(invoice) as invoice_form:
             invoice_form.date = '2016-01-02'
-            self.assertEqual(invoice_form.name, 'INV/15-16/0001')
+            self.assertMoveName(invoice_form, 'INV/15-16/0001')
             invoice_form.date = '2016-02-02'
-            self.assertEqual(invoice_form.name, 'INV/15-16/0001')
+            self.assertMoveName(invoice_form, 'INV/15-16/0001')
             invoice_form.date = '2017-01-01'
-            self.assertEqual(invoice_form.name, 'INV/16-17/0001')
+            self.assertMoveName(invoice_form, 'INV/16-17/0001')
 
     def test_sequence_empty_editable_with_quick_edit_mode(self):
         """ Ensure the names of all but the first moves in a period are empty and editable in quick edit mode """
@@ -135,6 +142,7 @@ class TestSequenceMixin(TestSequenceMixinCommon):
             'partner_id': 1,
             'move_type': 'in_invoice',
             'date': '2016-01-01',
+            'invoice_date': '2016-01-01',
             'line_ids': [
                 Command.create({
                     'name': 'line',
@@ -143,14 +151,14 @@ class TestSequenceMixin(TestSequenceMixinCommon):
             ]
         })
         # First move in a period gets a name
-        self.assertEqual(bill_1.name, 'BILL/15-16/01/0001')
+        self.assertMoveName(bill_1, 'BILL/15-16/01/0001')
 
         bill_2 = bill_1.copy({'date': '2016-01-02'})
         with Form(bill_2) as bill_2_form:
             # Subsequent moves in the same period get an empty editable name in draft mode
             self.assertFalse(bill_2_form.name)
-            bill_2_form.name = 'BILL/15-16/01/0002'
-            self.assertEqual(bill_2_form.name, 'BILL/15-16/01/0002')
+            bill_2.name = 'BILL/15-16/01/0002'
+            self.assertMoveName(bill_2_form, 'BILL/15-16/01/0001')
 
         bill_3 = bill_1.copy({'date': '2016-01-03'})
         bill_4 = bill_1.copy({'date': '2016-01-04'})
@@ -158,16 +166,16 @@ class TestSequenceMixin(TestSequenceMixinCommon):
 
         # Same works with updating multiple moves
         with Form(bill_3) as bill_3_form:
-            self.assertEqual(bill_3_form.name, 'BILL/15-16/02/0001')
+            self.assertMoveName(bill_3_form, 'BILL/15-16/02/0001')
 
         with Form(bill_4) as bill_4_form:
             self.assertFalse(bill_4_form.name)
-            bill_4_form.name = 'BILL/15-16/02/0002'
-            self.assertEqual(bill_4_form.name, 'BILL/15-16/02/0002')
+            bill_4.name = 'BILL/15-16/02/0002'
+            self.assertMoveName(bill_4_form, 'BILL/15-16/02/0001')
 
     def test_sequence_draft_change_date(self):
         # When a draft entry is added to an empty period, it should get a name.
-        # When a draft entry with a name is moved to a period already having entries, its name should be reset to '/'.
+        # When a draft entry with a name is moved to a period already having entries, its name should be reset to False.
 
         new_move = self.test_move.copy({'date': '2016-02-01'})
         new_multiple_move_1 = self.test_move.copy({'date': '2016-03-01'})
@@ -175,36 +183,37 @@ class TestSequenceMixin(TestSequenceMixinCommon):
         new_moves = new_multiple_move_1 + new_multiple_move_2
 
         # Empty period, so a name should be set
-        self.assertEqual(new_move.name, 'MISC/15-16/02/0001')
-        self.assertEqual(new_multiple_move_1.name, 'MISC/15-16/03/0001')
-        self.assertEqual(new_multiple_move_2.name, 'MISC/16-17/04/0001')
+        self.assertMoveName(new_move, 'MISC/15-16/02/0001')
+        self.assertMoveName(new_multiple_move_1, 'MISC/15-16/03/0001')
+        self.assertMoveName(new_multiple_move_2, 'MISC/16-17/04/0001')
 
-        # Move to an existing period with another move in it
+        # Move to an existing period with a posted move in it
+        self.test_move.action_post()
         new_move.date = fields.Date.to_date('2016-01-10')
         new_moves.date = fields.Date.to_date('2016-01-15')
 
-        # Not an empty period, so names should be reset to '/' (draft)
-        self.assertEqual(new_move.name, '/')
-        self.assertEqual(new_multiple_move_1.name, '/')
-        self.assertEqual(new_multiple_move_2.name, '/')
+        # Not an empty period, so names should be reset to False (draft)
+        self.assertMoveName(new_move, False)
+        self.assertMoveName(new_multiple_move_1, False)
+        self.assertMoveName(new_multiple_move_2, False)
 
         # Move back to a period with no moves in it
         new_move.date = fields.Date.to_date('2016-02-01')
         new_moves.date = fields.Date.to_date('2016-03-01')
 
         # All moves in the previously empty periods should be given a name instead of `/`
-        self.assertEqual(new_move.name, 'MISC/15-16/02/0001')
-        self.assertEqual(new_multiple_move_1.name, 'MISC/15-16/03/0001')
-        # Since this is the second one in the same period, it should remain `/`
-        self.assertEqual(new_multiple_move_2.name, '/')
+        self.assertMoveName(new_move, 'MISC/15-16/02/0001')
+        self.assertMoveName(new_multiple_move_1, 'MISC/15-16/03/0001')
+        # Since this is the second one in the same period, both have the same pending name
+        self.assertMoveName(new_multiple_move_2, 'MISC/15-16/03/0001')
 
-        # Move both moves back to different periods, both with already moves in it.
+        # Move both moves back to different periods, both with already moves in it. One has a posted move in the sequence, the other not.
         new_multiple_move_1.date = fields.Date.to_date('2016-01-10')
         new_multiple_move_2.date = fields.Date.to_date('2016-02-10')
 
-        # Moves are not in empty periods, so names should be set to '/' (draft)
-        self.assertEqual(new_multiple_move_1.name, '/')
-        self.assertEqual(new_multiple_move_2.name, '/')
+        # Moves are not in empty periods, but only the first hsa a posted move. So the first draft should be False and the second should get a name.
+        self.assertMoveName(new_multiple_move_1, False)
+        self.assertMoveName(new_multiple_move_2, 'MISC/15-16/02/0001')
 
         # Change the journal of the last two moves (empty)
         journal = self.env['account.journal'].create({
@@ -215,13 +224,13 @@ class TestSequenceMixin(TestSequenceMixinCommon):
         new_moves.journal_id = journal
 
         # Both moves should be assigned a name, since no moves are in the journal and they are in different periods.
-        self.assertEqual(new_multiple_move_1.name, 'AJ/15-16/01/0001')
-        self.assertEqual(new_multiple_move_2.name, 'AJ/15-16/02/0001')
+        self.assertMoveName(new_multiple_move_1, 'AJ/15-16/01/0001')
+        self.assertMoveName(new_multiple_move_2, 'AJ/15-16/02/0001')
 
         # When the date is removed in the form view, the name should not recompute
         with Form(new_multiple_move_1) as move_form:
-            move_form.date = False
-            self.assertEqual(new_multiple_move_1.name, 'AJ/15-16/01/0001')
+            move_form.date = fields.Date.to_date('2016-01-11')
+            self.assertMoveName(new_multiple_move_1, 'AJ/15-16/01/0001')
             move_form.date = fields.Date.to_date('2016-01-10')
 
     def test_sequence_draft_first_of_period(self):
@@ -234,75 +243,69 @@ class TestSequenceMixin(TestSequenceMixinCommon):
         | 4    | `A`  | Cancel      | 2023-02-01 | `2023/02/0001` | -> Assert
         """
         move_a = self.test_move.copy({'date': '2023-02-01'})
-        self.assertEqual(move_a.name, 'MISC/22-23/02/0001')
+        self.assertMoveName(move_a, 'MISC/22-23/02/0001')
 
         move_b = self.test_move.copy({'date': '2023-02-02'})
-        self.assertEqual(move_b.name, '/')
+        self.assertMoveName(move_b, 'MISC/22-23/02/0001')
 
         move_b.action_post()
-        self.assertEqual(move_b.name, 'MISC/22-23/02/0002')
+        self.assertMoveName(move_b, 'MISC/22-23/02/0001')
 
+        # The first sequence slot is now taken by move_b, move_a's name and placeholder should be False.
         move_a.button_cancel()
-        self.assertEqual(move_a.name, 'MISC/22-23/02/0001')
+        self.assertMoveName(move_a, False)
 
     def test_journal_sequence(self):
-        self.assertEqual(self.test_move.name, 'MISC/15-16/01/0001')
+        self.assertMoveName(self.test_move, 'MISC/15-16/01/0001')
         self.test_move.action_post()
-        self.assertEqual(self.test_move.name, 'MISC/15-16/01/0001')
+        self.assertMoveName(self.test_move, 'MISC/15-16/01/0001')
 
         copy1 = self.create_move(date=self.test_move.date)
-        self.assertEqual(copy1.name, '/')
+        self.assertMoveName(copy1, False)
         copy1.action_post()
-        self.assertEqual(copy1.name, 'MISC/15-16/01/0002')
+        self.assertMoveName(copy1, 'MISC/15-16/01/0002')
 
         copy2 = self.create_move(date=self.test_move.date)
         new_journal = self.test_move.journal_id.copy()
         new_journal.code = "MISC2"
         copy2.journal_id = new_journal
-        self.assertEqual(copy2.name, 'MISC2/15-16/01/0001')
-
+        self.assertMoveName(copy2, 'MISC2/15-16/01/0001')
+        copy2.action_post()
+        copy2.button_draft()
         with Form(copy2) as move_form:  # It is editable in the form
             with self.assertLogs('odoo.tests.form') as cm:
                 move_form.name = 'MyMISC/2016/0001'
-            self.assertTrue(cm.output[0].startswith('WARNING:odoo.tests.form.onchange:'))
-            self.assertIn('The sequence will restart at 1 at the start of every year', cm.output[0])
+                self.assertTrue(cm.output[0].startswith('WARNING:odoo.tests.form.onchange:'))
+                self.assertIn('The sequence will restart at 1 at the start of every year', cm.output[0])
 
-            move_form.journal_id = self.test_move.journal_id
-            self.assertEqual(move_form.name, '/')
+        copy2.name = False  # Can't modify journal_id if name is set
+        copy2.journal_id = self.test_move.journal_id
+        self.assertMoveName(copy2, False)
+        copy2.journal_id = new_journal
+        self.assertMoveName(copy2, 'MISC2/15-16/01/0001')
 
-            move_form.journal_id = new_journal
-            self.assertEqual(move_form.name, 'MISC2/15-16/01/0001')
-
-            with self.assertLogs('odoo.tests.form') as cm:
-                move_form.name = 'MyMISC/2016/0001'
-            self.assertTrue(cm.output[0].startswith('WARNING:odoo.tests.form.onchange:'))
-            self.assertIn('The sequence will restart at 1 at the start of every year', cm.output[0])
-
+        copy2.name = 'MyMISC/2016/0001'
         copy2.action_post()
-        self.assertEqual(copy2.name, 'MyMISC/2016/0001')
+        self.assertMoveName(copy2, 'MyMISC/2016/0001')
 
         copy3 = self.create_move(date=copy2.date, journal=new_journal)
-        self.assertEqual(copy3.name, '/')
-        with self.assertRaises(AssertionError):
-            with Form(copy2) as move_form:  # It is not editable in the form
-                move_form.name = 'MyMISC/2016/0002'
-        copy3.action_post()
-        self.assertEqual(copy3.name, 'MyMISC/2016/0002')
+        self.assertMoveName(copy3, False)
         copy3.name = 'MISC2/2016/00002'
+        copy3.action_post()
 
         copy4 = self.create_move(date=copy2.date, journal=new_journal)
         copy4.action_post()
-        self.assertEqual(copy4.name, 'MISC2/2016/00003')
+        self.assertMoveName(copy4, 'MISC2/2016/00003')
 
         copy5 = self.create_move(date=copy2.date, journal=new_journal)
         copy5.date = '2021-02-02'
         copy5.action_post()
-        self.assertEqual(copy5.name, 'MISC2/2021/00001')
+        self.assertMoveName(copy5, 'MISC2/2021/00001')
         copy5.name = 'N\'importe quoi?'
 
         copy6 = self.create_move(date=copy5.date, journal=new_journal)
         copy6.action_post()
-        self.assertEqual(copy6.name, 'N\'importe quoi?1')
+        self.assertMoveName(copy6, 'N\'importe quoi?1')
 
     def test_journal_sequence_format(self):
         """Test different format of sequences and what it becomes on another period"""
@@ -343,9 +346,9 @@ class TestSequenceMixin(TestSequenceMixinCommon):
         self.test_move.name = f"{prefix}1"
         for c in range(2, 25):
             copy = self.create_move(date=self.test_move.date)
-            copy.name = "/"
+            copy.name = False
             copy.action_post()
-            self.assertEqual(copy.name, f"{prefix}{c}")
+            self.assertMoveName(copy, f"{prefix}{c}")
 
     def test_journal_sequence_multiple_type(self):
         """Domain is computed accordingly to different types."""
@@ -363,8 +366,8 @@ class TestSequenceMixin(TestSequenceMixinCommon):
         all_moves = (entry + entry2 + invoice + invoice2 + refund + refund2)
         all_moves.name = False
         all_moves.action_post()
-        self.assertEqual(entry.name, 'MISC/15-16/01/0002')
-        self.assertEqual(entry2.name, 'MISC/15-16/01/0003')
+        self.assertEqual(entry.name, 'MISC/15-16/01/0001')
+        self.assertEqual(entry2.name, 'MISC/15-16/01/0002')
         self.assertEqual(invoice.name, 'INV/15-16/0001')
         self.assertEqual(invoice2.name, 'INV/15-16/0002')
         self.assertEqual(refund.name, 'RINV/15-16/0001')
@@ -421,20 +424,20 @@ class TestSequenceMixin(TestSequenceMixinCommon):
         self.create_move(date='2020-01-01', name='00000876-G 0002/2020')
         next_move = self.create_move(date='2020-01-01')
         next_move.action_post()
-        self.assertEqual(next_move.name, '00000876-G 0002/2021')  # Wait, I didn't want this!
+        self.assertMoveName(next_move, '00000876-G 0002/2021')  # Wait, I didn't want this!
 
         next_move.button_draft()
         next_move.name = False
         next_move.journal_id.sequence_override_regex = r'^(?P<seq>\d*)(?P<suffix1>.*?)(?P<year>(\d{4})?)(?P<suffix2>)$'
         next_move.action_post()
-        self.assertEqual(next_move.name, '00000877-G 0002/2020')  # Pfew, better!
+        self.assertMoveName(next_move, '00000877-G 0002/2020')  # Pfew, better!
         next_move = self.create_move(date='2020-01-01')
         next_move.action_post()
-        self.assertEqual(next_move.name, '00000878-G 0002/2020')
+        self.assertMoveName(next_move, '00000878-G 0002/2020')
 
         next_move = self.create_move(date='2017-05-02')
         next_move.action_post()
-        self.assertEqual(next_move.name, '00000001-G 0002/2017')
+        self.assertMoveName(next_move, '00000001-G 0002/2017')
 
     def test_journal_sequence_ordering(self):
         """Entries are correctly sorted when posting multiple at once."""
@@ -451,17 +454,17 @@ class TestSequenceMixin(TestSequenceMixinCommon):
         copies[4].date = '2019-03-05'
         copies[5].date = '2019-03-05'
         # that entry is actualy the first one of the period, so it already has a name
-        # set it to '/' so that it is recomputed at post to be ordered correctly.
-        copies[0].name = '/'
+        # set it to False so that it is recomputed at post to be ordered correctly.
+        copies[0].name = False
         copies.action_post()
 
         # Ordered by date
-        self.assertEqual(copies[0].name, 'XMISC/2019/00002')
-        self.assertEqual(copies[1].name, 'XMISC/2019/00005')
-        self.assertEqual(copies[2].name, 'XMISC/2019/00006')
-        self.assertEqual(copies[3].name, 'XMISC/2019/00001')
-        self.assertEqual(copies[4].name, 'XMISC/2019/00003')
-        self.assertEqual(copies[5].name, 'XMISC/2019/00004')
+        self.assertMoveName(copies[0], 'XMISC/2019/00002')
+        self.assertMoveName(copies[1], 'XMISC/2019/00005')
+        self.assertMoveName(copies[2], 'XMISC/2019/00006')
+        self.assertMoveName(copies[3], 'XMISC/2019/00001')
+        self.assertMoveName(copies[4], 'XMISC/2019/00003')
+        self.assertMoveName(copies[5], 'XMISC/2019/00004')
 
         # Can't have twice the same name
         with self.assertRaises(psycopg2.DatabaseError), mute_logger('odoo.sql_db'), self.env.cr.savepoint():
@@ -503,7 +506,7 @@ class TestSequenceMixin(TestSequenceMixinCommon):
         wizard.save().resequence()
 
         self.assertEqual(copies[3].state, 'posted')
-        self.assertEqual(copies[5].name, 'XMISC/2019/10005')
+        self.assertMoveName(copies[5], 'XMISC/2019/10005')
         self.assertEqual(copies[5].state, 'draft')
 
     def test_journal_resequence_in_between_2_years_pattern(self):
@@ -565,20 +568,20 @@ class TestSequenceMixin(TestSequenceMixinCommon):
                 }),
             ]
         })
-        self.assertEqual(bill.name, 'BILL/24-25/04/0001')
+        self.assertMoveName(bill, 'BILL/24-25/04/0001')
         # First bill in first half of first month of the fiscal year, which is
         # the end of the fiscal year
         bill_copy = bill.copy({'date': '2024-04-10', 'invoice_date': '2024-04-10'})
         bill_copy.action_post()
-        self.assertEqual(bill_copy.name, 'BILL/23-24/04/0001')
+        self.assertMoveName(bill_copy, 'BILL/23-24/04/0001')
         # Second bill in first half of first month
         bill_copy_2 = bill.copy({'date': '2024-04-11', 'invoice_date': '2024-04-11'})
         bill_copy_2.action_post()
-        self.assertEqual(bill_copy_2.name, 'BILL/23-24/04/0002')
+        self.assertMoveName(bill_copy_2, 'BILL/23-24/04/0002')
         # Second bill in second half of first month
         bill_copy_3 = bill.copy({'date': '2024-04-18', 'invoice_date': '2024-04-18'})
         bill_copy_3.action_post()
-        self.assertEqual(bill_copy_3.name, 'BILL/24-25/04/0002')
+        self.assertMoveName(bill_copy_3, 'BILL/24-25/04/0001')
 
     def test_sequence_get_more_specific(self):
         """There is the ability to change the format (i.e. from yearly to montlhy)."""
@@ -645,10 +648,10 @@ class TestSequenceMixin(TestSequenceMixinCommon):
             'code': 'AJ',
         })
         move = self.env['account.move'].create({})
-        self.assertEqual(move.name, 'MISC/21-22/10/0001')
+        self.assertMoveName(move, 'MISC/21-22/10/0001')
         with Form(move) as move_form:
             move_form.journal_id = journal
-        self.assertEqual(move.name, 'AJ/21-22/10/0001')
+        self.assertMoveName(move, 'AJ/21-22/10/0001')
 
     def test_sequence_move_name_related_field_well_computed(self):
         AccountMove = type(self.env['account.move'])
@@ -833,9 +836,9 @@ class TestSequenceMixinConcurrency(TransactionCase):
                 'date': fields.Date.from_string('2016-01-01'),
                 'line_ids': [(0, 0, {'name': 'name', 'account_id': account.id})]
             }] * 3)
-            moves.name = '/'
+            moves.name = False
             moves[0].action_post()
-            self.assertEqual(moves.mapped('name'), ['CT/2016/01/0001', '/', '/'])
+            self.assertEqual(moves.mapped('name'), ['CT/2016/01/0001', False, False])
             env.cr.commit()
         self.data = {
             'move_ids': moves.ids,
@@ -904,4 +907,4 @@ class TestSequenceMixinConcurrency(TransactionCase):
 
         # check the values
         moves = env0['account.move'].browse(self.data['move_ids'])
-        self.assertEqual(moves.mapped('name'), ['CT/2016/01/0001', '/', 'CT/2016/01/0002'])
+        self.assertEqual(moves.mapped('name'), ['CT/2016/01/0001', False, 'CT/2016/01/0002'])

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -515,7 +515,7 @@
                             invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund', 'out_receipt', 'in_invoice', 'in_refund','in_receipt')"/>
                     </header>
                     <field name="made_sequence_gap" column_invisible="True"/>
-                    <field name="name" decoration-bf="1" decoration-danger="made_sequence_gap and state == 'posted'"/>
+                    <field name="name" decoration-bf="1" decoration-danger="made_sequence_gap and state == 'posted'" widget="char_with_placeholder_field" placeholder="/"/>
                     <field name="invoice_partner_display_name" column_invisible="context.get('default_move_type') not in ('in_invoice', 'in_refund', 'in_receipt')" groups="base.group_user" string="Vendor" />
                     <field name="invoice_partner_display_name" column_invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund', 'out_receipt')" groups="base.group_user" string="Customer" />
                     <field name="invoice_date" optional="show" column_invisible="context.get('default_move_type') not in ('in_invoice', 'in_refund', 'in_receipt')" readonly="state != 'draft'" string="Bill Date" decoration-warning="abnormal_date_warning"/>
@@ -578,7 +578,7 @@
                 <xpath expr="//field[@name='name']" position="after">
                     <!-- For draft moves, name only displays '/'. Since there may be moves of differenty types,
                          it is better to use display_name indicating what move it refers to when in draft-->
-                    <field name="display_name" decoration-bf="1" string="Number" context="{'name_with_move_type': True}"/>
+                    <field name="display_name" decoration-bf="1" string="Number" context="{'name_with_move_type': True}" widget="char_with_placeholder_field" placeholder="/"/>
                 </xpath>
             </field>
         </record>
@@ -946,9 +946,9 @@
                             <div class="text-warning" invisible="not show_name_warning">The current highest number is <field class="oe_inline" name="highest_name"/>. You might want to put a higher number here.</div>
 
                             <h1>
-                                <field name="name" invisible="name == '/' and not posted_before and not quick_edit_mode" readonly="state != 'draft'" placeholder="Draft"/>
+                                <field name="name" invisible="not (name or name_placeholder or quick_edit_mode)" readonly="state != 'draft'" options="{'placeholder_field': 'name_placeholder'}"/>
 
-                                <span invisible="state != 'draft' or name != '/' or posted_before or quick_edit_mode">Draft</span>
+                                <span invisible="name or name_placeholder or quick_edit_mode">Draft</span>
                             </h1>
                         </div>
                         <group>

--- a/addons/account/wizard/account_resequence.py
+++ b/addons/account/wizard/account_resequence.py
@@ -158,7 +158,7 @@ class ReSequenceWizard(models.TransientModel):
             if self.ordering == 'date':
                 raise UserError(_('You can not reorder sequence by date when the journal is locked with a hash.'))
         moves_to_rename = self.env['account.move'].browse(int(k) for k in new_values.keys())
-        moves_to_rename.name = '/'
+        moves_to_rename.name = False
         moves_to_rename.flush_recordset(["name"])
         # If the db is not forcibly updated, the temporary renaming could only happen in cache and still trigger the constraint
 

--- a/addons/account_payment/models/payment_transaction.py
+++ b/addons/account_payment/models/payment_transaction.py
@@ -88,7 +88,7 @@ class PaymentTransaction(models.Model):
             invoice_ids = self._fields['invoice_ids'].convert_to_cache(command_list, self)
             invoices = self.env['account.move'].browse(invoice_ids).exists()
             if len(invoices) == len(invoice_ids):  # All ids are valid
-                prefix = separator.join(invoices.mapped('name'))
+                prefix = separator.join(invoices.filtered(lambda inv: inv.name).mapped('name'))
                 if name := values.get('name_next_installment'):
                     prefix = name
                 return prefix

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -932,18 +932,20 @@ class TestExpenses(TestExpenseCommon):
         expense_sheet.action_approve_expense_sheets()
         expense_sheet.action_sheet_move_post()
 
-        self.assertRecordValues(expense_sheet.account_move_ids[0].attachment_ids, [{
+        expense_move = expense_sheet.account_move_ids.filtered(lambda am: am.invoice_line_ids[0].ref == 'Company expense')
+        expense_2_move = expense_sheet.account_move_ids.filtered(lambda am: am.invoice_line_ids[0].ref == 'Company expense 2')
+        self.assertRecordValues(expense_move.attachment_ids, [{
             'raw': b"R0lGODdhAQABAIAAAP///////ywAAAAAAQABAAACAkQBADs=",
             'name': 'file1.png',
             'res_model': 'account.move',
-            'res_id': expense_sheet.account_move_ids[0].id
+            'res_id': expense_move.id
         }])
 
-        self.assertRecordValues(expense_sheet.account_move_ids[1].attachment_ids, [{
+        self.assertRecordValues(expense_2_move.attachment_ids, [{
             'raw': b"R0lGODdhAQABAIAAAP///////ywAAAAAAQABAAACAkQBADs=",
             'name': 'file2.png',
             'res_model': 'account.move',
-            'res_id': expense_sheet.account_move_ids[1].id
+            'res_id': expense_2_move.id
         }])
 
     def test_expense_payment_method(self):

--- a/addons/l10n_ar/tests/test_manual.py
+++ b/addons/l10n_ar/tests/test_manual.py
@@ -27,7 +27,7 @@ class TestManual(common.TestAr):
         self.assertEqual(invoice.l10n_latam_document_type_id, self.document_type['invoice_a'], 'selected document type should be Factura A')
         self._post(invoice)
         self.assertEqual(invoice.state, 'posted', 'invoice has not been validate in Odoo')
-        self.assertEqual(invoice.name, 'FA-A %05d-00000002' % self.journal.l10n_ar_afip_pos_number, 'Invoice number is wrong')
+        self.assertEqual(invoice.name, 'FA-A %05d-00000001' % self.journal.l10n_ar_afip_pos_number, 'Invoice number is wrong')
 
     def test_02_fiscal_position(self):
         # ADHOC SA > IVA Responsable Inscripto > Without Fiscal Positon

--- a/addons/l10n_cl/views/account_move_view.xml
+++ b/addons/l10n_cl/views/account_move_view.xml
@@ -17,9 +17,9 @@
         <field name="inherit_id" ref="l10n_latam_invoice_document.view_move_form"/>
         <field name="arch" type="xml">
             <field name="l10n_latam_document_number" position="attributes">
-                <attribute name="invisible">(not l10n_latam_use_documents or not l10n_latam_manual_document_number) and (not l10n_latam_use_documents or highest_name or state != 'draft') and (not l10n_latam_use_documents or not posted_before or state != 'draft' or country_code != 'CL')</attribute>
+                <attribute name="invisible">not l10n_latam_use_documents or (not l10n_latam_manual_document_number and state != "draft" and (not posted_before or country_code != "CL"))</attribute>
                 <attribute name="readonly">posted_before and state != 'draft'</attribute>
-                <attribute name="required">l10n_latam_manual_document_number or not highest_name</attribute>
+                <attribute name="required">l10n_latam_manual_document_number</attribute>
             </field>
         </field>
     </record>

--- a/addons/l10n_in_edi/tests/test_edi_json.py
+++ b/addons/l10n_in_edi/tests/test_edi_json.py
@@ -157,7 +157,7 @@ class TestEdiJson(L10nInTestInvoicingCommon):
         expected = {
             "Version": "1.1",
             "TranDtls": {"TaxSch": "GST", "SupTyp": "B2B", "RegRev": "N", "IgstOnIntra": "N"},
-            "DocDtls": {"Typ": "INV", "No": "INV/18-19/0002", "Dt": "01/01/2019"},
+            "DocDtls": {"Typ": "INV", "No": "INV/18-19/0001", "Dt": "01/01/2019"},
             "SellerDtls": {
                 "Addr1": "Khodiyar Chowk",
                 "Loc": "Amreli",
@@ -201,7 +201,7 @@ class TestEdiJson(L10nInTestInvoicingCommon):
         #=================================== Full discount test =====================================
         json_value = self.env["account.edi.format"]._l10n_in_edi_generate_invoice_json(self.invoice_full_discount)
         expected.update({
-            "DocDtls": {"Typ": "INV", "No": "INV/18-19/0003", "Dt": "01/01/2019"},
+            "DocDtls": {"Typ": "INV", "No": "INV/18-19/0002", "Dt": "01/01/2019"},
             "ItemList": [{
                 "SlNo": "1", "PrdDesc": "product_a", "IsServc": "N", "HsnCd": "111111", "Qty": 1.0,
                 "Unit": "UNT", "UnitPrice": 1000.0, "TotAmt": 1000.0, "Discount": 1000.0, "AssAmt": 0.0,
@@ -216,7 +216,7 @@ class TestEdiJson(L10nInTestInvoicingCommon):
         #=================================== Zero quantity test =============================================
         json_value = self.env["account.edi.format"]._l10n_in_edi_generate_invoice_json(self.invoice_zero_qty)
         expected.update({
-            "DocDtls": {"Typ": "INV", "No": "INV/18-19/0004", "Dt": "01/01/2019"},
+            "DocDtls": {"Typ": "INV", "No": "INV/18-19/0003", "Dt": "01/01/2019"},
             "ItemList": [{
                 "SlNo": "1", "PrdDesc": "product_a", "IsServc": "N", "HsnCd": "111111", "Qty": 0.0,
                 "Unit": "UNT", "UnitPrice": 1000.0, "TotAmt": 0.0, "Discount": 0.0, "AssAmt": 0.0,
@@ -229,7 +229,7 @@ class TestEdiJson(L10nInTestInvoicingCommon):
         #=================================== Negative unit price test =============================================
         json_value = self.env["account.edi.format"]._l10n_in_edi_generate_invoice_json(self.invoice_negative_unit_price)
         expected.update({
-            "DocDtls": {"Typ": "INV", "No": "INV/18-19/0005", "Dt": "01/01/2019"},
+            "DocDtls": {"Typ": "INV", "No": "INV/18-19/0004", "Dt": "01/01/2019"},
             "ItemList": [
                 {
                     "SlNo": "1", "PrdDesc": "product_a", "IsServc": "N", "HsnCd": "111111", "Qty": 1.0,
@@ -253,16 +253,16 @@ class TestEdiJson(L10nInTestInvoicingCommon):
         })
         self.assertDictEqual(json_value, expected, "Indian EDI with negative unit price sent json value is not matched")
 
-        expected.update({"DocDtls": {"Typ": "INV", "No": "INV/18-19/0006", "Dt": "01/01/2019"}})
+        expected.update({"DocDtls": {"Typ": "INV", "No": "INV/18-19/0005", "Dt": "01/01/2019"}})
         json_value = self.env["account.edi.format"]._l10n_in_edi_generate_invoice_json(self.invoice_negative_qty)
         self.assertDictEqual(json_value, expected, "Indian EDI with negative quantity sent json value is not matched")
 
-        expected.update({"DocDtls": {"Typ": "INV", "No": "INV/18-19/0007", "Dt": "01/01/2019"}})
+        expected.update({"DocDtls": {"Typ": "INV", "No": "INV/18-19/0006", "Dt": "01/01/2019"}})
         json_value = self.env["account.edi.format"]._l10n_in_edi_generate_invoice_json(self.invoice_negative_unit_price_and_qty)
         self.assertDictEqual(json_value, expected, "Indian EDI with negative unit price and quantity sent json value is not matched")
 
         expected.update({
-            "DocDtls": {"Typ": "INV", "No": "INV/18-19/0008", "Dt": "01/01/2019"},
+            "DocDtls": {"Typ": "INV", "No": "INV/18-19/0007", "Dt": "01/01/2019"},
             "ItemList": [{
                 "SlNo": "1", "PrdDesc": "product_a", "IsServc": "N", "HsnCd": "111111", "Qty": 1.0,
                 "Unit": "UNT", "UnitPrice": 2000.0, "TotAmt": 2000.0, "Discount": 1400.0, "AssAmt": 600.0,
@@ -279,7 +279,7 @@ class TestEdiJson(L10nInTestInvoicingCommon):
         self.assertDictEqual(json_value, expected, "Indian EDI with negative unit price and quantity sent json value is not matched")
 
         expected.update({
-            "DocDtls": {"Typ": "INV", "No": "INV/18-19/0009", "Dt": "01/01/2019"},
+            "DocDtls": {"Typ": "INV", "No": "INV/18-19/0008", "Dt": "01/01/2019"},
             "ItemList": [{
                 "SlNo": "1", "PrdDesc": "product_a", "IsServc": "N", "HsnCd": "111111", "Qty": 1.0,
                 "Unit": "UNT", "UnitPrice": 2000.0, "TotAmt": 2000.0, "Discount": 2000.0, "AssAmt": 0.0,
@@ -304,7 +304,7 @@ class TestEdiJson(L10nInTestInvoicingCommon):
 
         json_value = self.env["account.edi.format"]._l10n_in_edi_generate_invoice_json(self.invoice_cash_rounding)
         expected_copy_rounding.update({
-            "DocDtls": {"Typ": "INV", "No": "INV/18-19/0010", "Dt": "01/01/2019"},
+            "DocDtls": {"Typ": "INV", "No": "INV/18-19/0009", "Dt": "01/01/2019"},
             "ValDtls": {
                 "AssVal": 1800.0, "CgstVal": 79.3, "SgstVal": 79.3, "IgstVal": 0.0, "CesVal": 46.59,
                 "StCesVal": 0.0, "Discount": 0.0, "RndOffAmt": -0.19, "TotInvVal": 2005.00
@@ -315,7 +315,7 @@ class TestEdiJson(L10nInTestInvoicingCommon):
         expected_with_intra_igst = {
             'Version': '1.1',
             'TranDtls': {'TaxSch': 'GST', 'SupTyp': 'SEZWP', 'RegRev': 'N', 'IgstOnIntra': 'Y'},
-            'DocDtls': {'Typ': 'INV', 'No': 'INV/18-19/0011', 'Dt': '01/01/2019'},
+            'DocDtls': {'Typ': 'INV', 'No': 'INV/18-19/0010', 'Dt': '01/01/2019'},
             'SellerDtls': expected['SellerDtls'],
             'BuyerDtls': {
                 'Addr1': 'Block no. 402',
@@ -380,7 +380,7 @@ class TestEdiJson(L10nInTestInvoicingCommon):
                 'LglNm': 'Overseas',
                 'GSTIN': 'URP'
             },
-            'DocDtls': {'Dt': '01/01/2019', 'No': 'INV/18-19/0012', 'Typ': 'INV'},
+            'DocDtls': {'Dt': '01/01/2019', 'No': 'INV/18-19/0011', 'Typ': 'INV'},
             'ExpDtls': {'CntCode': 'US', 'ForCur': 'INR', 'RefClm': 'Y'}
         })
         self.assertDictEqual(

--- a/addons/l10n_in_edi_ewaybill/tests/test_edi_ewaybill_json.py
+++ b/addons/l10n_in_edi_ewaybill/tests/test_edi_ewaybill_json.py
@@ -24,7 +24,7 @@ class TestEdiEwaybillJson(TestEdiJson):
             "transMode": "1",
             "vehicleNo": "GJ11AA1234",
             "vehicleType": "R",
-            "docNo": "INV/18-19/0002",
+            "docNo": "INV/18-19/0001",
             "docDate": "01/01/2019",
             "fromGstin": "24AAGCC7144L6ZE",
             "fromTrdName": "Default Company",
@@ -79,7 +79,7 @@ class TestEdiEwaybillJson(TestEdiJson):
         #=================================== Full discount test =====================================
         json_value = self.env["account.edi.format"]._l10n_in_edi_ewaybill_generate_json(self.invoice_full_discount)
         expected.update({
-            "docNo": "INV/18-19/0003",
+            "docNo": "INV/18-19/0002",
             "itemList": [{
                 "productName": "product_a", "hsnCode": "111111", "productDesc": "product_a", "quantity": 1.0,
                 "qtyUnit": "UNT", "taxableAmount": 0.0, "cgstRate": 0.0, "sgstRate": 0.0, 'igstRate': 0.0,
@@ -98,7 +98,7 @@ class TestEdiEwaybillJson(TestEdiJson):
         #=================================== Zero quantity test =============================================
         json_value = self.env["account.edi.format"]._l10n_in_edi_ewaybill_generate_json(self.invoice_zero_qty)
         expected.update({
-            "docNo": "INV/18-19/0004",
+            "docNo": "INV/18-19/0003",
             "itemList": [{
                 "productName": "product_a", "hsnCode": "111111", "productDesc": "product_a", "quantity": 0.0,
                 "qtyUnit": "UNT", "taxableAmount": 0.0, "cgstRate": 0.0, "sgstRate": 0.0, 'igstRate': 0.0,

--- a/addons/l10n_latam_invoice_document/views/account_move_view.xml
+++ b/addons/l10n_latam_invoice_document/views/account_move_view.xml
@@ -49,12 +49,11 @@
                 <field name="l10n_latam_document_number"
                     invisible="(not l10n_latam_use_documents or not l10n_latam_manual_document_number) and (not l10n_latam_use_documents or highest_name or state != 'draft')"
                     readonly="posted_before and state != 'draft'"
-                    required="partner_id and l10n_latam_use_documents and (l10n_latam_manual_document_number or not highest_name)"/>
+                    required="partner_id and l10n_latam_use_documents and l10n_latam_manual_document_number"/>
             </xpath>
 
             <!-- on latam_documents we use document_number to set name -->
             <field name="name" position="attributes">
-                <attribute name="invisible">name == '/' and not posted_before and not quick_edit_mode</attribute>
                 <attribute name="readonly">state != 'draft' or l10n_latam_use_documents</attribute>
                 <attribute name="force_save">1</attribute>
             </field>

--- a/addons/membership/tests/test_membership.py
+++ b/addons/membership/tests/test_membership.py
@@ -30,7 +30,7 @@ class TestMembership(TestMembershipCommon):
             'membership_date_to': datetime.date.today() + relativedelta(years=-1),
         })
 
-        self.partner_1.create_membership_invoice(self.membership_1, 75.0)
+        invoice = self.partner_1.create_membership_invoice(self.membership_1, 75.0)
         self.assertEqual(
             self.partner_1.membership_state, 'none',
             'membership: outdated non paid subscription should keep in non-member state')
@@ -39,7 +39,6 @@ class TestMembership(TestMembershipCommon):
         self.partner_1.create_membership_invoice(self.membership_1, 75.0)
 
         # checks for invoices
-        invoice = self.env['account.move'].search([('partner_id', '=', self.partner_1.id)], limit=1)
         self.assertEqual(
             invoice.state, 'draft',
             'membership: new subscription should create a draft invoice')

--- a/addons/payment_asiapay/tests/test_payment_transaction.py
+++ b/addons/payment_asiapay/tests/test_payment_transaction.py
@@ -27,7 +27,17 @@ class TestPaymentTransaction(AsiaPayCommon, PaymentHttpCommon):
         """ Test the computation of reference prefixes based on the provided invoice. """
         self._skip_if_account_payment_is_not_installed()
 
-        invoice = self.env['account.move'].create({})
+        invoice = self.env['account.move'].create({
+            'move_type': 'entry',
+            'date': '2011-11-02',
+            'line_ids': [
+                Command.create({
+                    'name': 'line',
+                    'account_id': self.company_data['default_account_revenue'].id,
+                }),
+            ]
+        })
+        invoice.action_post()
         reference = self.env['payment.transaction']._compute_reference(
             self.asiapay.code, invoice_ids=[Command.set([invoice.id])]
         )


### PR DESCRIPTION
*: account_payments, l10n_ar, l10n_cl, l10n_in_edi, l10n_in_edi_ewaybill, l10n_it_edi, l10n_latam_invoice_document, payment_asiapay

---

Description of the issue this commit addresses:

When there is no move in the current sequence, the moves you create take a slot in the sequence while being drafts, this means that if you do not confirm moves in the order they were created, the second move to be confirmed has a lower sequence number than the first which breaks continuity.

---

Desired behavior after this commit is merged:

This commit makes it so that no sequence number is ever assigned while the move stays in draft. A dynamic placeholder shows the user what the name will be with the sequence "template" but it is only used once the move is confirmed.

For subsequent moves, meaning when a first sequence number has been consumed, the old behavior of showing "Draft" as a name stands but there is still no sequence number consumed.

---

Enterprise PR: https://github.com/odoo/enterprise/pull/73837
task-4241510

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
