### PR TITLE
[FIX] web: load_breadcrumbs controller should always have a return

### DIFF
--- a/addons/web/controllers/action.py
+++ b/addons/web/controllers/action.py
@@ -76,6 +76,7 @@ class Action(Controller):
                         act['display_name'] = act['name']
                     # client actions don't have multi-record views, so we can't go further to the next controller
                     if act['type'] == 'ir.actions.client' and idx + 1 < len(actions) and action.get('action') == actions[idx + 1].get('action'):
+                        results.append({'error': 'Client actions don\'t have multi-record views'})
                         continue
                     if record_id:
                         # some actions may not have a res_model (e.g. a client action)


### PR DESCRIPTION
In the case of a client action with a record id on the breadcrumb part of the url (`myClient/22` for instance). The controller should return the display name for the combination action + record id. And for the action alone (a multi-record if it was the case of a window action), the controller should return an error, to be removed from the breadcrumb. This is because client actions don't have multi-records views.

Before this commit, the controller avoids returning anything, and an error raised.

Now, the controller returns correctly an error, and it's correctly removed from the breadcrumb.