### PR TITLE
[FIX] point_of_sale: deduct change from cash payment

### DIFF
--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -1957,3 +1957,57 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
 
         moves = self.env['account.move'].search([('ref', '=', f'pos_order_{order.id}')])
         self.assertEqual(len(moves), 2)
+
+    def test_change_is_deducted_from_cash(self):
+        self.pos_config.open_ui()
+        pos_session = self.pos_config.current_session_id
+        product_order = {'data':
+          {'amount_paid': 450,
+           'amount_return': 50,
+           'amount_tax': 0,
+           'amount_total': 450,
+           'creation_date': fields.Datetime.to_string(fields.Datetime.now()),
+           'fiscal_position_id': False,
+           'pricelist_id': self.pos_config.available_pricelist_ids[0].id,
+           'lines': [[0, 0, {
+                'discount': 0,
+                'id': 42,
+                'pack_lot_ids': [],
+                'price_unit': 450.0,
+                'product_id': self.product3.id,
+                'price_subtotal': 450.0,
+                'price_subtotal_incl': 450.0,
+                'tax_ids': [[6, False, []]],
+                'qty': 1,
+            }]],
+           'name': 'Order 12346-123-1234',
+           'partner_id': self.partner1.id,
+           'pos_session_id': pos_session.id,
+           'sequence_number': 2,
+           'statement_ids': [[0, 0, {
+                'amount': 400,
+                'name': fields.Datetime.now(),
+                'payment_method_id': self.bank_payment_method.id
+            }], [0, 0, {
+                'amount': 100,
+                'name': fields.Datetime.now(),
+                'payment_method_id': self.cash_payment_method.id
+            }]],
+           'uid': '12346-123-1234',
+           'user_id': self.env.uid,
+           'to_invoice': True
+            }
+        }
+
+        pos_order_id = self.PosOrder.create_from_ui([product_order])[0]['id']
+        pos_order = self.PosOrder.search([('id', '=', pos_order_id)])
+        payments = pos_order.payment_ids
+        self.assertRecordValues(payments.sorted(), [
+            {'amount': -50, 'payment_method_id': self.cash_payment_method.id, 'is_change': True},
+            {'amount': 100, 'payment_method_id': self.cash_payment_method.id, 'is_change': False},
+            {'amount': 400, 'payment_method_id': self.bank_payment_method.id, 'is_change': False},
+        ])
+
+        account_moves = self.env['account.move'].search([('pos_payment_ids', 'in', pos_order.payment_ids.ids)])
+        self.assertEqual(sum(account_moves.mapped('amount_total')), pos_order.amount_total)
+


### PR DESCRIPTION
Issue:

when making a payment using 2 different payment methods (cash and bank), the change gets deducted from the bank payment not the cash payment in the invoice.

Steps To Reproduce:

On POS, for an order totaling $120.
    - Add a customer and ensure the "Invoice" box is checked.
    - pay using two payments methods bank 100$ Cash 50$
    - the change is $30, everything looks fine on the ticket on the pos.
    - Notice on the invoice on the db backend the $30 change is incorrectly deducted from the bank payment. As a result, the invoice displays: bank : $70 cash: $50

Soltution:

    - In the _create_payment_moves method, ensure that cash payment method creates an `account.move` including the change amount.

opw-4076246

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
