### PR TITLE
[FIX] mail: fixed handling of deleted messages and notifications

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4331,6 +4331,12 @@ class MailThread(models.AbstractModel):
         empty_messages = message.sudo()._filter_empty()
         empty_messages._cleanup_side_records()
         empty_messages.write({'pinned_at': None})
+        if empty_messages:
+            self.env['bus.bus']._sendone(
+                empty_messages._bus_notification_target(),
+                'mail.message/delete',
+                {'message_ids': empty_messages.ids}
+            )
         payload = {
             'Message': {
                 'id': message.id,

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -111,9 +111,14 @@ export class DiscussCoreCommon {
                         .filter(({ type }) => type === "discuss.channel/leave")
                         .map(({ payload }) => payload.id)
                 );
+                const deletedMessagesIds = notifications
+                    .filter(({ type }) => type === "mail.message/delete")
+                    .flatMap(({ payload }) => payload.message_ids);
                 for (const notif of notifications.filter(
                     ({ payload, type }) =>
-                        type === "discuss.channel/new_message" && !channelsLeft.has(payload.id)
+                        type === "discuss.channel/new_message" &&
+                        !channelsLeft.has(payload.id) &&
+                        !deletedMessagesIds.includes(payload.message.id)
                 )) {
                     this._handleNotificationNewMessage(notif);
                 }


### PR DESCRIPTION
Before this commit:
1. Deleted messages were counted in the unread messages count.
2. Fetched deleted messages upon opening Discuss would produce a notification.

Steps to reproduce:
1. Open Discuss with user A
2. Send message as user A to user B
3. Delete said message
4. Open Discuss with user B
5. Observe as user B the unread message counter and the notification

The notification happens because the client is not informed specifically of a deleted message, but just of the empty body.
The inaccurate unread message counter happens because deleted messages (i.e. empty body) are not excluded from the count.
This commit fixes the issue by:
- Sending a bus notification to notify the client of deleted messages.
- Excluding deleted messages in the count of unread messages.

task-2746505