### PR TITLE
[IMP] html_editor: implement baseContainer

### DIFF
--- a/addons/hr_skills/static/tests/tours/skills_tour.js
+++ b/addons/hr_skills/static/tests/tours/skills_tour.js
@@ -45,7 +45,7 @@ registry.category("web_tour.tours").add("hr_skills_tour", {
         },
         {
             content: "Give some description",
-            trigger: ".modal:contains(new resume line) .o_field_html[name='description'] p",
+            trigger: `.modal:contains(new resume line) .o_field_html[name='description'] div.o-paragraph`,
             run: "editor Sang some songs and played some music",
         },
         {

--- a/addons/html_editor/static/src/core/base_container_plugin.js
+++ b/addons/html_editor/static/src/core/base_container_plugin.js
@@ -1,0 +1,170 @@
+import {
+    containsAnyNonPhrasingContent,
+    isMediaElement,
+    isProtected,
+    isProtecting,
+} from "@html_editor/utils/dom_info";
+import { Plugin } from "../plugin";
+import { fillEmpty } from "@html_editor/utils/dom";
+import {
+    BASE_CONTAINER_CLASS,
+    SUPPORTED_BASE_CONTAINER_NAMES,
+    baseContainerGlobalSelector,
+    createBaseContainer,
+} from "../utils/base_container";
+import { withSequence } from "@html_editor/utils/resource";
+import { selectElements } from "@html_editor/utils/dom_traversal";
+
+export class BaseContainerPlugin extends Plugin {
+    static id = "baseContainer";
+    static shared = ["createBaseContainer", "getDefaultNodeName", "isCandidateForBaseContainer"];
+    /**
+     * Register one of the predicates for `invalid_for_base_container_predicates`
+     * as a property for optimization, see variants of `isCandidateForBaseContainer`.
+     */
+    hasNonPhrasingContentPredicate = (element) => {
+        return element?.nodeType === Node.ELEMENT_NODE && containsAnyNonPhrasingContent(element);
+    };
+    /**
+     * The `unsplittable` predicate for `invalid_for_base_container_predicates`
+     * is defined in this file and not in split_plugin because it has to be removed
+     * in a specific case: see `isCandidateForBaseContainerAllowUnsplittable`.
+     */
+    isUnsplittablePredicate = (element) => {
+        return this.getResource("unsplittable_node_predicates").some((fn) => fn(element));
+    };
+    resources = {
+        clean_for_save_handlers: this.cleanForSave.bind(this),
+        // `baseContainer` normalization should occur after every other normalization
+        // because a `div` may only have the baseContainer identity if it does not
+        // already have another incompatible identity given by another plugin.
+        normalize_handlers: withSequence(Infinity, this.normalizeDivBaseContainers.bind(this)),
+        unsplittable_node_predicates: (node) => {
+            if (node.nodeName !== "DIV") {
+                return false;
+            }
+            return !this.isCandidateForBaseContainerAllowUnsplittable(node);
+        },
+        invalid_for_base_container_predicates: [
+            (node) =>
+                !node ||
+                node.nodeType !== Node.ELEMENT_NODE ||
+                !SUPPORTED_BASE_CONTAINER_NAMES.includes(node.tagName) ||
+                isProtected(node) ||
+                isProtecting(node) ||
+                isMediaElement(node),
+            this.isUnsplittablePredicate,
+            this.hasNonPhrasingContentPredicate,
+        ],
+        system_classes: [BASE_CONTAINER_CLASS],
+    };
+
+    createBaseContainer(nodeName = this.getDefaultNodeName()) {
+        return createBaseContainer(nodeName, this.document);
+    }
+
+    getDefaultNodeName() {
+        return this.config.baseContainer || "P";
+    }
+
+    /**
+     * Evaluate if an element is eligible to become a baseContainer (i.e. an
+     * unmarked div which could receive baseContainer attributes to inherit
+     * paragraph-like features).
+     *
+     * This function considers unsplittable and childNodes.
+     */
+    isCandidateForBaseContainer(element) {
+        return !this.getResource("invalid_for_base_container_predicates").some((fn) => fn(element));
+    }
+
+    /**
+     * Evaluate if an element would be eligible to become a baseContainer
+     * without considering unsplittable.
+     *
+     * This function is only meant to be used during `unsplittable_node_predicates` to
+     * avoid an infinite loop:
+     * Considering a `DIV`,
+     * - During `unsplittable_node_predicates`, one predicate should return true
+     *   if the `DIV` is NOT a baseContainer candidate (Odoo specification),
+     *   therefore `invalid_for_base_container_predicates` should be evaluated.
+     * - During `invalid_for_base_container_predicates`, one predicate should
+     *   return true if the `DIV` is unsplittable, because a node has to be
+     *   splittable to use the featureSet associated with paragraphs.
+     * Each resource has to call the other. To avoid the issue, during
+     * `unsplittable_node_predicates`, the baseContainer predicate will execute
+     * all predicates for `invalid_for_base_container_predicates` except
+     * the one using `unsplittable_node_predicates`, since it is already being
+     * evaluated.
+     *
+     * In simpler terms:
+     * A `DIV` is unsplittable by default;
+     * UNLESS it is eligible to be a baseContainer => it becomes one;
+     * UNLESS it has to be unsplittable for an explicit reason (i.e. has class
+     * oe_unbreakable) => it stays unsplittable.
+     */
+    isCandidateForBaseContainerAllowUnsplittable(element) {
+        const predicates = new Set(this.getResource("invalid_for_base_container_predicates"));
+        predicates.delete(this.isUnsplittablePredicate);
+        for (const predicate of predicates) {
+            if (predicate(element)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Evaluate if an element would be eligible to become a baseContainer
+     * without considering its childNodes.
+     *
+     * This function is only meant to be used internally, to avoid having to
+     * compute childNodes multiple times in more complex operations.
+     */
+    shallowIsCandidateForBaseContainer(element) {
+        const predicates = new Set(this.getResource("invalid_for_base_container_predicates"));
+        predicates.delete(this.hasNonPhrasingContentPredicate);
+        for (const predicate of predicates) {
+            if (predicate(element)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    cleanForSave({ root }) {
+        for (const baseContainer of selectElements(root, `.${BASE_CONTAINER_CLASS}`)) {
+            baseContainer.classList.remove(BASE_CONTAINER_CLASS);
+            if (baseContainer.classList.length === 0) {
+                baseContainer.removeAttribute("class");
+            }
+        }
+    }
+
+    normalizeDivBaseContainers(element = this.editable) {
+        const newBaseContainers = [];
+        const divSelector = `div:not(.${BASE_CONTAINER_CLASS})`;
+        const targets = [...element.querySelectorAll(divSelector)];
+        if (element.matches(divSelector)) {
+            targets.unshift(element);
+        }
+        for (const div of targets) {
+            if (
+                // Ensure that newly created `div` baseContainers are never themselves
+                // children of a baseContainer. BaseContainers should always only
+                // contain phrasing content (even `div`), because they could be
+                // converted to an element which can actually only contain phrasing
+                // content. In practice a div should never be a child of a
+                // baseContainer, since a baseContainer should only contain
+                // phrasingContent.
+                !div.parentElement?.matches(baseContainerGlobalSelector) &&
+                this.shallowIsCandidateForBaseContainer(div) &&
+                !containsAnyNonPhrasingContent(div)
+            ) {
+                div.classList.add(BASE_CONTAINER_CLASS);
+                newBaseContainers.push(div);
+                fillEmpty(div);
+            }
+        }
+    }
+}

--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -413,6 +413,8 @@ export class ClipboardPlugin extends Plugin {
                 const block = closestBlock(br);
                 if (
                     isParagraphRelatedElement(block) &&
+                    // TODO specific exception for "PRE" to keep everything inside one PRE.
+                    // Consider removing this if PRE is to be used as a paragraph.
                     block.nodeName !== "PRE" &&
                     !block.closest("li")
                 ) {

--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -131,7 +131,7 @@ export class ClipboardPlugin extends Plugin {
         // Repair the copied range.
         if (clonedContents.firstChild.nodeName === "LI") {
             const list = selection.commonAncestorContainer.cloneNode();
-            list.replaceChildren(...clonedContents.childNodes);
+            list.replaceChildren(...childNodes(clonedContents));
             clonedContents = list;
         }
         if (
@@ -198,7 +198,7 @@ export class ClipboardPlugin extends Plugin {
                 // related ones like headings etc.
                 if (!isBlock(ancestor) || paragraphRelatedElements.includes(ancestor.nodeName)) {
                     const clone = ancestor.cloneNode();
-                    clone.append(...clonedContents.childNodes);
+                    clone.append(...childNodes(clonedContents));
                     clonedContents.appendChild(clone);
                 }
             }
@@ -486,14 +486,14 @@ export class ClipboardPlugin extends Plugin {
                 }
             } else if (
                 ["S", "U"].includes(node.nodeName) &&
-                node.childNodes.length === 1 &&
+                childNodes(node).length === 1 &&
                 node.firstChild.nodeName === "FONT"
             ) {
                 // S and U tags sometimes contain FONT tags. We prefer the
                 // strike to adopt the style of the text, so we invert them.
                 const fontNode = node.firstChild;
                 node.before(fontNode);
-                node.replaceChildren(...fontNode.childNodes);
+                node.replaceChildren(...childNodes(fontNode));
                 fontNode.appendChild(node);
             } else if (
                 node.nodeName === "IMG" &&
@@ -534,7 +534,7 @@ export class ClipboardPlugin extends Plugin {
                     node.classList.remove(klass);
                 }
             }
-            for (const child of [...node.childNodes]) {
+            for (const child of childNodes(node)) {
                 this.cleanForPaste(child);
             }
         }

--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -223,11 +223,6 @@ export class ClipboardPlugin extends Plugin {
         if (!selection.anchorNode.isConnected) {
             return;
         }
-        // TODO ABD: TODO @phoenix: handle protected content
-        // if (sel.anchorNode && (isProtected(sel.anchorNode) || isProtecting(sel.anchorNode))) {
-        //     return;
-        // }
-
         ev.preventDefault();
 
         this.dependencies.history.stageSelection();

--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -1,16 +1,24 @@
 import { isTextNode, isParagraphRelatedElement } from "../utils/dom_info";
 import { Plugin } from "../plugin";
 import { closestBlock, isBlock } from "../utils/blocks";
-import { unwrapContents } from "../utils/dom";
+import { unwrapContents, wrapInlinesInBlocks } from "../utils/dom";
 import { ancestors, childNodes, closestElement } from "../utils/dom_traversal";
 import { parseHTML } from "../utils/html";
+import {
+    baseContainerGlobalSelector,
+    getBaseContainerSelector,
+} from "@html_editor/utils/base_container";
 
 /**
  * @typedef { import("./selection_plugin").EditorSelection } EditorSelection
  */
 
 const CLIPBOARD_BLACKLISTS = {
-    unwrap: [".Apple-interchange-newline", "DIV"], // These elements' children will be unwrapped.
+    unwrap: [
+        // These elements' children will be unwrapped.
+        ".Apple-interchange-newline",
+        "DIV", // DIV is unwrapped unless eligible to be a baseContainer, see cleanForPaste
+    ],
     remove: ["META", "STYLE", "SCRIPT"], // These elements will be removed along with their children.
 };
 export const CLIPBOARD_WHITELISTS = {
@@ -86,6 +94,7 @@ export const CLIPBOARD_WHITELISTS = {
 export class ClipboardPlugin extends Plugin {
     static id = "clipboard";
     static dependencies = [
+        "baseContainer",
         "dom",
         "selection",
         "sanitize",
@@ -327,16 +336,28 @@ export class ClipboardPlugin extends Plugin {
             if (textIndex < textFragments.length) {
                 // Break line by inserting new paragraph and
                 // remove current paragraph's bottom margin.
-                const p = closestElement(selection.anchorNode, "p");
+                const block = closestBlock(selection.anchorNode);
                 if (
-                    this.dependencies.split.isUnsplittable(closestBlock(selection.anchorNode)) ||
+                    this.dependencies.split.isUnsplittable(block) ||
                     closestElement(selection.anchorNode).tagName === "PRE"
                 ) {
                     this.dependencies.lineBreak.insertLineBreak();
                 } else {
-                    const [pBefore] = this.dependencies.split.splitBlock();
-                    if (p) {
-                        pBefore.style.marginBottom = "0px";
+                    const [blockBefore] = this.dependencies.split.splitBlock();
+                    if (
+                        block &&
+                        block.matches(baseContainerGlobalSelector) &&
+                        blockBefore &&
+                        !blockBefore.matches(getBaseContainerSelector("DIV"))
+                    ) {
+                        // Do something only if blockBefore is not a DIV (which is the no-margin option)
+                        // replace blockBefore by a DIV.
+                        const div = this.dependencies.baseContainer.createBaseContainer("DIV");
+                        const cursors = this.dependencies.selection.preserveSelection();
+                        blockBefore.before(div);
+                        div.replaceChildren(...childNodes(blockBefore));
+                        blockBefore.remove();
+                        cursors.remapNode(blockBefore, div).restore();
                     }
                     selection = this.dependencies.selection.getEditableSelection();
                 }
@@ -380,56 +401,52 @@ export class ClipboardPlugin extends Plugin {
                 }
             }
         }
-        for (const child of childNodes(container)) {
+        const childContent = childNodes(container);
+        for (const child of childContent) {
             this.cleanForPaste(child);
         }
-        // Force inline nodes at the root of the container into separate P
+        // Identify the closest baseContainer from the selection. This will
+        // determine which baseContainer will be used by default for the
+        // clipboard content if it has to be modified.
+        const selection = this.dependencies.selection.getEditableSelection();
+        const closestBaseContainer =
+            selection.anchorNode &&
+            closestElement(selection.anchorNode, baseContainerGlobalSelector);
+        // Force inline nodes at the root of the container into separate `baseContainers`
         // elements. This is a tradeoff to ensure some features that rely on
         // nodes having a parent (e.g. convert to list, title, etc.) can work
         // properly on such nodes without having to actually handle that
         // particular case in all of those functions. In fact, this case cannot
         // happen on a new document created using this editor, but will happen
         // instantly when editing a document that was created from Etherpad.
+        wrapInlinesInBlocks(container, {
+            baseContainerNodeName:
+                closestBaseContainer?.nodeName ||
+                this.dependencies.baseContainer.getDefaultNodeName(),
+        });
         const result = this.document.createDocumentFragment();
-        let p = this.document.createElement("p");
-        for (const child of childNodes(container)) {
-            if (isBlock(child)) {
-                if (p.hasChildNodes()) {
-                    result.appendChild(p);
-                    p = this.document.createElement("p");
-                }
-                result.appendChild(child);
-            } else {
-                p.appendChild(child);
-            }
+        result.replaceChildren(...childNodes(container));
 
-            if (p.hasChildNodes()) {
-                result.appendChild(p);
-            }
-
-            // Split elements containing <br> into seperate elements for each line.
-            const brs = result.querySelectorAll("br");
-            for (const br of brs) {
-                const block = closestBlock(br);
-                if (
-                    isParagraphRelatedElement(block) &&
-                    // TODO specific exception for "PRE" to keep everything inside one PRE.
-                    // Consider removing this if PRE is to be used as a paragraph.
-                    block.nodeName !== "PRE" &&
-                    !block.closest("li")
-                ) {
-                    // A linebreak at the beginning of a block is an empty line.
-                    const isEmptyLine = block.firstChild.nodeName === "BR";
-                    // Split blocks around it until only the BR remains in the
-                    // block.
-                    const remainingBrContainer = this.dependencies.split.splitAroundUntil(
-                        br,
-                        block
-                    );
-                    // Remove the container unless it represented an empty line.
-                    if (!isEmptyLine) {
-                        remainingBrContainer.remove();
-                    }
+        // Split elements containing <br> into separate elements for each line.
+        const brs = result.querySelectorAll("br");
+        for (const br of brs) {
+            const block = closestBlock(br);
+            if (
+                (isParagraphRelatedElement(block) ||
+                    this.dependencies.baseContainer.isCandidateForBaseContainer(block)) &&
+                // TODO specific exception for "PRE" to keep everything inside one PRE.
+                // Consider removing this if PRE is to be used as a paragraph.
+                block.nodeName !== "PRE" &&
+                !block.closest("li")
+            ) {
+                // A linebreak at the beginning of a block is an empty line.
+                const isEmptyLine = block.firstChild.nodeName === "BR";
+                // Split blocks around it until only the BR remains in the
+                // block.
+                const remainingBrContainer = this.dependencies.split.splitAroundUntil(br, block);
+                // Remove the container unless it represented an empty line.
+                if (!isEmptyLine) {
+                    remainingBrContainer.remove();
                 }
             }
         }
@@ -452,23 +469,18 @@ export class ClipboardPlugin extends Plugin {
             if (!node.matches || node.matches(CLIPBOARD_BLACKLISTS.remove.join(","))) {
                 node.remove();
             } else {
-                let childNodes;
-                if (node.nodeName === "DIV" && [...node.childNodes].every((n) => !isBlock(n))) {
-                    // Convert <div> to <p> to preserve the inline structure
-                    // while maintaining block-level behaviour.
-                    const dir = node.getAttribute("dir");
-                    const p = this.document.createElement("p");
-                    if (dir) {
-                        p.setAttribute("dir", dir);
+                let childrenNodes;
+                if (node.nodeName === "DIV") {
+                    if (this.dependencies.baseContainer.isCandidateForBaseContainer(node)) {
+                        childrenNodes = childNodes(node);
+                    } else {
+                        childrenNodes = unwrapContents(node);
                     }
-                    p.append(...node.childNodes);
-                    node.replaceWith(p);
-                    childNodes = p.childNodes;
                 } else {
                     // Unwrap the illegal node's contents.
-                    childNodes = unwrapContents(node);
+                    childrenNodes = unwrapContents(node);
                 }
-                for (const child of childNodes) {
+                for (const child of childrenNodes) {
                     this.cleanForPaste(child);
                 }
             }

--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -560,7 +560,7 @@ export class ClipboardPlugin extends Plugin {
                 okClass instanceof RegExp ? okClass.test(item) : okClass === item
             );
         } else {
-            return isTextNode(item) || item.matches?.(CLIPBOARD_WHITELISTS.nodes);
+            return isTextNode(item) || item.matches?.(CLIPBOARD_WHITELISTS.nodes.join(","));
         }
     }
     /**

--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -1,4 +1,4 @@
-import { isTextNode, paragraphRelatedElements } from "../utils/dom_info";
+import { isTextNode, isParagraphRelatedElement } from "../utils/dom_info";
 import { Plugin } from "../plugin";
 import { closestBlock, isBlock } from "../utils/blocks";
 import { unwrapContents } from "../utils/dom";
@@ -196,7 +196,7 @@ export class ClipboardPlugin extends Plugin {
             for (const ancestor of ancestorsList) {
                 // Keep the formatting by keeping inline ancestors and paragraph
                 // related ones like headings etc.
-                if (!isBlock(ancestor) || paragraphRelatedElements.includes(ancestor.nodeName)) {
+                if (!isBlock(ancestor) || isParagraphRelatedElement(ancestor)) {
                     const clone = ancestor.cloneNode();
                     clone.append(...childNodes(clonedContents));
                     clonedContents.appendChild(clone);
@@ -412,7 +412,8 @@ export class ClipboardPlugin extends Plugin {
             for (const br of brs) {
                 const block = closestBlock(br);
                 if (
-                    ["P", "H1", "H2", "H3", "H4", "H5", "H6"].includes(block.nodeName) &&
+                    isParagraphRelatedElement(block) &&
+                    block.nodeName !== "PRE" &&
                     !block.closest("li")
                 ) {
                     // A linebreak at the beginning of a block is an empty line.

--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -59,7 +59,7 @@ import { compareListTypes } from "@html_editor/main/list/utils";
  */
 
 export class DeletePlugin extends Plugin {
-    static dependencies = ["selection", "history", "input"];
+    static dependencies = ["baseContainer", "selection", "history", "input"];
     static id = "delete";
     static shared = ["deleteRange", "deleteSelection", "delete"];
     resources = {
@@ -100,6 +100,7 @@ export class DeletePlugin extends Plugin {
             // Monetary field
             (node) => node.matches?.("[data-oe-type='monetary'] > span"),
         ],
+        invalid_for_base_container_predicates: (node) => this.isUnremovable(node, this.editable),
     };
 
     setup() {
@@ -429,9 +430,9 @@ export class DeletePlugin extends Plugin {
                 !block.parentElement.isContentEditable
             ) {
                 // @todo: not sure we want this when allowInlineAtRoot is true
-                const p = this.document.createElement("p");
-                p.appendChild(this.document.createElement("br"));
-                block.appendChild(p);
+                const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+                baseContainer.appendChild(this.document.createElement("br"));
+                block.appendChild(baseContainer);
             } else {
                 block.appendChild(this.document.createElement("br"));
             }

--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -1200,7 +1200,11 @@ export class DeletePlugin extends Plugin {
             return;
         }
 
-        if (isEmpty(closestUnmergeable) && !this.isUnremovable(closestUnmergeable)) {
+        if (
+            (isEmpty(closestUnmergeable) ||
+                this.delegateTo("is_empty_predicates", closestUnmergeable)) &&
+            !this.isUnremovable(closestUnmergeable)
+        ) {
             closestUnmergeable.remove();
             this.dependencies.selection.setSelection({
                 anchorNode: destContainer,

--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -10,19 +10,43 @@ import {
     setTagName,
     splitTextNode,
     unwrapContents,
+    wrapInlinesInBlocks,
 } from "../utils/dom";
 import {
     allowsParagraphRelatedElements,
     getDeepestPosition,
+    isContentEditable,
+    isContentEditableAncestor,
     isEmptyBlock,
+    isProtecting,
+    isProtected,
     isSelfClosingElement,
     isShrunkBlock,
+    isTangible,
+    isUnprotecting,
     paragraphRelatedElements,
 } from "../utils/dom_info";
 import { closestElement, descendants, firstLeaf, lastLeaf } from "../utils/dom_traversal";
 import { FONT_SIZE_CLASSES, TEXT_STYLE_CLASSES } from "../utils/formatting";
 import { DIRECTIONS, childNodeIndex, nodeSize, rightPos } from "../utils/position";
+import { normalizeCursorPosition } from "@html_editor/utils/selection";
 import { convertList, getListMode } from "@html_editor/utils/list";
+
+/**
+ * Get distinct connected parents of nodes
+ *
+ * @param {Iterable} nodes
+ * @returns {Set}
+ */
+function getConnectedParents(nodes) {
+    const parents = new Set();
+    for (const node of nodes) {
+        if (node.isConnected && node.parentElement) {
+            parents.add(node.parentElement);
+        }
+    }
+    return parents;
+}
 
 /**
  * @typedef {Object} DomShared
@@ -65,7 +89,7 @@ export class DomPlugin extends Plugin {
     // Shared
 
     /**
-     * @param {string | DocumentFragment | null} content
+     * @param {string | DocumentFragment | Element | null} content
      */
     insert(content) {
         if (!content) {
@@ -91,11 +115,16 @@ export class DomPlugin extends Plugin {
         if (typeof content === "string") {
             container.textContent = content;
         } else {
-            for (const child of content.children) {
-                this.dispatchTo("normalize_handlers", child);
+            if (content.nodeType === Node.ELEMENT_NODE) {
+                this.dispatchTo("normalize_handlers", content);
+            } else {
+                for (const child of content.children) {
+                    this.dispatchTo("normalize_handlers", child);
+                }
             }
             container.replaceChildren(content);
         }
+        const allInsertedNodes = [];
 
         // In case the html inserted starts with a list and will be inserted within
         // a list, unwrap the list elements from the list.
@@ -118,12 +147,15 @@ export class DomPlugin extends Plugin {
 
         const shouldUnwrap = (node) =>
             [...paragraphRelatedElements, "LI"].includes(node.nodeName) &&
-            block.textContent !== "" &&
-            node.textContent !== "" &&
+            !isEmptyBlock(block) &&
+            !isEmptyBlock(node) &&
+            (isContentEditable(node) ||
+                (!node.isConnected && !closestElement(node, "[contenteditable]"))) &&
+            !this.dependencies.split.isUnsplittable(node) &&
             [node.nodeName, "DIV"].includes(block.nodeName) &&
             // If the selection anchorNode is the editable itself, the content
             // should not be unwrapped.
-            selection.anchorNode !== this.editable;
+            !this.isEditionBoundary(selection.anchorNode);
 
         // Empty block must contain a br element to allow cursor placement.
         if (
@@ -137,12 +169,7 @@ export class DomPlugin extends Plugin {
         // In case the html inserted is all contained in a single root <p> or <li>
         // tag, we take the all content of the <p> or <li> and avoid inserting the
         // <p> or <li>.
-        if (
-            container.childElementCount === 1 &&
-            (["P", "LI"].includes(container.firstChild.nodeName) ||
-                shouldUnwrap(container.firstChild)) &&
-            selection.anchorNode !== this.editable
-        ) {
+        if (container.childElementCount === 1 && shouldUnwrap(container.firstChild)) {
             const p = container.firstElementChild;
             container.replaceChildren(...p.childNodes);
         } else if (container.childElementCount > 1) {
@@ -186,6 +213,7 @@ export class DomPlugin extends Plugin {
                     startNode.prepend(textNode);
                 }
                 startNode = textNode;
+                allInsertedNodes.push(textNode);
             } else {
                 startNode = startNode.childNodes[selection.anchorOffset - 1];
             }
@@ -194,7 +222,6 @@ export class DomPlugin extends Plugin {
         // If we have isolated block content, first we split the current focus
         // element if it's a block then we insert the content in the right places.
         let currentNode = startNode;
-        let lastChildNode = false;
         const currentList = currentNode && closestElement(currentNode, "UL, OL");
         const mode = currentList && getListMode(currentList);
 
@@ -209,7 +236,7 @@ export class DomPlugin extends Plugin {
             const toInsert = [...containerLastChild.childNodes]; // Prevent mutation
             _insertAt(currentNode, [...toInsert], insertBefore);
             currentNode = insertBefore ? toInsert[0] : currentNode;
-            lastChildNode = toInsert[toInsert.length - 1];
+            toInsert[toInsert.length - 1];
         }
         const firstInsertedNodes = [...containerFirstChild.childNodes];
         if (containerFirstChild.hasChildNodes()) {
@@ -218,6 +245,7 @@ export class DomPlugin extends Plugin {
             currentNode = toInsert[toInsert.length - 1];
             insertBefore = false;
         }
+        allInsertedNodes.push(...firstInsertedNodes);
 
         // If all the Html have been isolated, We force a split of the parent element
         // to have the need new line in the final result
@@ -252,9 +280,9 @@ export class DomPlugin extends Plugin {
                             !this.dependencies.split.isUnsplittable(nodeToInsert)))
                 ) {
                     if (this.dependencies.split.isUnsplittable(currentNode.parentElement)) {
-                        // If we have to insert a table, we cannot afford to unwrap it
-                        // we need to search for a more suitable spot to put the table in
-                        if (nodeToInsert.nodeName === "TABLE") {
+                        // If we have to insert an unsplittable element, we cannot afford to
+                        // unwrap it we need to search for a more suitable spot to put it
+                        if (this.dependencies.split.isUnsplittable(nodeToInsert)) {
                             currentNode = currentNode.parentElement;
                             doesCurrentNodeAllowsP = allowsParagraphRelatedElements(currentNode);
                             continue;
@@ -283,15 +311,9 @@ export class DomPlugin extends Plugin {
                         } else if (isEmptyBlock(otherNode)) {
                             otherNode.remove();
                         }
-                        if (otherNode.nodeType === Node.ELEMENT_NODE) {
-                            cleanTrailingBR(otherNode);
-                        }
                     } else {
                         if (isBlock(currentNode)) {
                             fillShrunkPhrasingParent(currentNode);
-                        }
-                        if (currentNode.nodeType === Node.ELEMENT_NODE) {
-                            cleanTrailingBR(currentNode);
                         }
                         currentNode = currentNode.parentElement;
                     }
@@ -303,7 +325,9 @@ export class DomPlugin extends Plugin {
                     this.dependencies.split.isUnsplittable(nodeToInsert)
                 ) {
                     const br = document.createElement("br");
-                    currentNode[currentNode.textContent ? "after" : "before"](br);
+                    currentNode[
+                        isEmptyBlock(currentNode) || !isTangible(currentNode) ? "before" : "after"
+                    ](br);
                 }
             }
             // Ensure that all adjacent paragraph elements are converted to
@@ -312,7 +336,14 @@ export class DomPlugin extends Plugin {
                 block.nodeName === "LI" &&
                 paragraphRelatedElements.includes(nodeToInsert.nodeName)
             ) {
-                setTagName(nodeToInsert, "LI");
+                nodeToInsert = setTagName(nodeToInsert, "LI");
+            }
+            if (
+                currentList &&
+                ((nodeToInsert.nodeName === "LI" && nodeToInsert.classList.contains("oe-nested")) ||
+                    isList(nodeToInsert))
+            ) {
+                nodeToInsert = convertList(nodeToInsert, mode);
             }
             if (insertBefore) {
                 currentNode.before(nodeToInsert);
@@ -320,42 +351,61 @@ export class DomPlugin extends Plugin {
             } else {
                 currentNode.after(nodeToInsert);
             }
-            let convertedList;
-            if (
-                currentList &&
-                ((nodeToInsert.nodeName === "LI" && nodeToInsert.classList.contains("oe-nested")) ||
-                    isList(nodeToInsert))
-            ) {
-                convertedList = convertList(nodeToInsert, mode);
-            }
-            if (
-                (nodeToInsert.nodeType !== Node.ELEMENT_NODE ||
-                    nodeToInsert.tagName !== "BR" ||
-                    nodeToInsert.nextSibling) &&
-                !(isBlock(nodeToInsert) && this.dependencies.split.isUnsplittable(nodeToInsert))
-            ) {
-                // Avoid cleaning the trailing BR if it is nodeToInsert
-                cleanTrailingBR(currentNode.parentElement);
-            }
+            allInsertedNodes.push(nodeToInsert);
             if (currentNode.tagName !== "BR" && isShrunkBlock(currentNode)) {
                 currentNode.remove();
             }
-            currentNode = convertedList || nodeToInsert;
+            currentNode = nodeToInsert;
         }
-        const previousNode = currentNode.previousSibling;
-        if (
-            !(isBlock(currentNode) && this.dependencies.split.isUnsplittable(currentNode)) &&
-            cleanTrailingBR(currentNode.parentElement)
-        ) {
-            // Clean the last inserted trailing BR if any
-            currentNode = previousNode;
+        allInsertedNodes.push(...lastInsertedNodes);
+        let insertedNodesParents = getConnectedParents(allInsertedNodes);
+        for (const parent of insertedNodesParents) {
+            if (
+                !this.config.allowInlineAtRoot &&
+                this.isEditionBoundary(parent) &&
+                allowsParagraphRelatedElements(parent)
+            ) {
+                // Ensure that edition boundaries do not have inline content.
+                wrapInlinesInBlocks(parent);
+            }
         }
-        currentNode = lastChildNode || currentNode;
+        insertedNodesParents = getConnectedParents(allInsertedNodes);
+        for (const parent of insertedNodesParents) {
+            if (
+                !isProtecting(parent) &&
+                !(isProtected(parent) && !isUnprotecting(parent)) &&
+                parent.isContentEditable
+            ) {
+                cleanTrailingBR(parent, [
+                    (node) => {
+                        // Don't remove the last BR in cases where the
+                        // previous sibling is an unsplittable block
+                        // (i.e. a table, a non-editable div, ...)
+                        // to allow placing the cursor after that unsplittable
+                        // element. This can be removed when the cursor
+                        // is properly handled around these elements.
+                        const previousSibling = node.previousSibling;
+                        return (
+                            previousSibling &&
+                            isBlock(previousSibling) &&
+                            this.dependencies.split.isUnsplittable(previousSibling)
+                        );
+                    },
+                ]);
+            }
+        }
+        for (const insertedNode of allInsertedNodes.reverse()) {
+            if (insertedNode.isConnected) {
+                currentNode = insertedNode;
+                break;
+            }
+        }
         let lastPosition = [...paragraphRelatedElements, "LI", "OL", "UL"].includes(
             currentNode.nodeName
         )
             ? rightPos(lastLeaf(currentNode))
             : rightPos(currentNode);
+        lastPosition = normalizeCursorPosition(lastPosition[0], lastPosition[1], "right");
 
         if (!this.config.allowInlineAtRoot && this.isEditionBoundary(lastPosition[0])) {
             // Correct the position if it happens to be in the editable root.
@@ -369,10 +419,13 @@ export class DomPlugin extends Plugin {
     }
 
     isEditionBoundary(node) {
+        if (!node) {
+            return false;
+        }
         if (node === this.editable) {
             return true;
         }
-        return node.hasAttribute("contenteditable");
+        return isContentEditableAncestor(node);
     }
 
     /**

--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -157,12 +157,18 @@ export class DomPlugin extends Plugin {
         const block = closestBlock(selection.anchorNode);
 
         const shouldUnwrap = (node) =>
-            (isParagraphRelatedElement(node) || isListItemElement(node)) &&
+            (isParagraphRelatedElement(node) ||
+                isListItemElement(node) ||
+                // TODO remove: PRE should be a paragraphRelatedElement
+                node.nodeName === "PRE") &&
             !isEmptyBlock(block) &&
             !isEmptyBlock(node) &&
             (isContentEditable(node) ||
                 (!node.isConnected && !closestElement(node, "[contenteditable]"))) &&
             !this.dependencies.split.isUnsplittable(node) &&
+            // TODO add: when PRE is considered as a paragraphRelatedElement
+            // again, consider unwrapping in PRE by adding in the following
+            // Array.
             [node.nodeName, "DIV"].includes(block.nodeName) &&
             // If the selection anchorNode is the editable itself, the content
             // should not be unwrapped.
@@ -537,7 +543,11 @@ export class DomPlugin extends Plugin {
                 block.isContentEditable
         );
         for (const block of deepestSelectedBlocks) {
-            if (isParagraphRelatedElement(block) || isListItemElement(block)) {
+            if (
+                isParagraphRelatedElement(block) ||
+                block.nodeName === "PRE" || // TODO remove: PRE should be a paragraphRelatedElement
+                isListItemElement(block)
+            ) {
                 if (tagName === "P" && isListItemElement(block)) {
                     continue;
                 }

--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -26,7 +26,14 @@ import {
     isUnprotecting,
     paragraphRelatedElements,
 } from "../utils/dom_info";
-import { closestElement, descendants, firstLeaf, lastLeaf } from "../utils/dom_traversal";
+import {
+    childNodes,
+    children,
+    closestElement,
+    descendants,
+    firstLeaf,
+    lastLeaf,
+} from "../utils/dom_traversal";
 import { FONT_SIZE_CLASSES, TEXT_STYLE_CLASSES } from "../utils/formatting";
 import { DIRECTIONS, childNodeIndex, nodeSize, rightPos } from "../utils/position";
 import { normalizeCursorPosition } from "@html_editor/utils/selection";
@@ -118,7 +125,7 @@ export class DomPlugin extends Plugin {
             if (content.nodeType === Node.ELEMENT_NODE) {
                 this.dispatchTo("normalize_handlers", content);
             } else {
-                for (const child of content.children) {
+                for (const child of children(content)) {
                     this.dispatchTo("normalize_handlers", child);
                 }
             }
@@ -171,7 +178,7 @@ export class DomPlugin extends Plugin {
         // <p> or <li>.
         if (container.childElementCount === 1 && shouldUnwrap(container.firstChild)) {
             const p = container.firstElementChild;
-            container.replaceChildren(...p.childNodes);
+            container.replaceChildren(...childNodes(p));
         } else if (container.childElementCount > 1) {
             const isSelectionAtStart =
                 firstLeaf(block) === selection.anchorNode && selection.anchorOffset === 0;
@@ -185,9 +192,9 @@ export class DomPlugin extends Plugin {
                 if (container.firstChild.nodeName === "LI") {
                     const deepestBlock = closestBlock(firstLeaf(container.firstChild));
                     this.dependencies.split.splitAroundUntil(deepestBlock, container.firstChild);
-                    container.firstElementChild.replaceChildren(...deepestBlock.childNodes);
+                    container.firstElementChild.replaceChildren(...childNodes(deepestBlock));
                 }
-                containerFirstChild.replaceChildren(...container.firstElementChild.childNodes);
+                containerFirstChild.replaceChildren(...childNodes(container.firstElementChild));
                 container.firstElementChild.remove();
             }
             // Grab the content of the last child block and isolate it.
@@ -197,9 +204,9 @@ export class DomPlugin extends Plugin {
                 if (container.lastChild.nodeName === "LI") {
                     const deepestBlock = closestBlock(lastLeaf(container.lastChild));
                     this.dependencies.split.splitAroundUntil(deepestBlock, container.lastChild);
-                    container.lastElementChild.replaceChildren(...deepestBlock.childNodes);
+                    container.lastElementChild.replaceChildren(...childNodes(deepestBlock));
                 }
-                containerLastChild.replaceChildren(...container.lastElementChild.childNodes);
+                containerLastChild.replaceChildren(...childNodes(container.lastElementChild));
                 container.lastElementChild.remove();
             }
         }
@@ -215,7 +222,7 @@ export class DomPlugin extends Plugin {
                 startNode = textNode;
                 allInsertedNodes.push(textNode);
             } else {
-                startNode = startNode.childNodes[selection.anchorOffset - 1];
+                startNode = childNodes(startNode).at(selection.anchorOffset - 1);
             }
         }
 
@@ -231,16 +238,16 @@ export class DomPlugin extends Plugin {
                 reference = child;
             }
         };
-        const lastInsertedNodes = [...containerLastChild.childNodes];
+        const lastInsertedNodes = childNodes(containerLastChild);
         if (containerLastChild.hasChildNodes()) {
-            const toInsert = [...containerLastChild.childNodes]; // Prevent mutation
+            const toInsert = childNodes(containerLastChild); // Prevent mutation
             _insertAt(currentNode, [...toInsert], insertBefore);
             currentNode = insertBefore ? toInsert[0] : currentNode;
             toInsert[toInsert.length - 1];
         }
-        const firstInsertedNodes = [...containerFirstChild.childNodes];
+        const firstInsertedNodes = childNodes(containerFirstChild);
         if (containerFirstChild.hasChildNodes()) {
-            const toInsert = [...containerFirstChild.childNodes]; // Prevent mutation
+            const toInsert = childNodes(containerFirstChild); // Prevent mutation
             _insertAt(currentNode, [...toInsert], insertBefore);
             currentNode = toInsert[toInsert.length - 1];
             insertBefore = false;
@@ -258,7 +265,7 @@ export class DomPlugin extends Plugin {
             } else {
                 // If we arrive here, the o_enter index should always be 0.
                 const parent = currentNode.nextSibling.parentElement;
-                const index = [...parent.childNodes].indexOf(currentNode.nextSibling);
+                const index = childNodes(parent).indexOf(currentNode.nextSibling);
                 this.dependencies.split.splitBlockNode({
                     targetNode: parent,
                     targetOffset: index,
@@ -268,8 +275,8 @@ export class DomPlugin extends Plugin {
 
         let nodeToInsert;
         let doesCurrentNodeAllowsP = allowsParagraphRelatedElements(currentNode);
-        const insertedNodes = [...container.childNodes];
         const candidatesForRemoval = [];
+        const insertedNodes = childNodes(container);
         while ((nodeToInsert = container.firstChild)) {
             if (isBlock(nodeToInsert) && !doesCurrentNodeAllowsP) {
                 // Split blocks at the edges if inserting new blocks (preventing
@@ -289,7 +296,7 @@ export class DomPlugin extends Plugin {
                             continue;
                         } else {
                             makeContentsInline(container);
-                            nodeToInsert = container.childNodes[0];
+                            nodeToInsert = container.firstChild;
                             break;
                         }
                     }
@@ -518,7 +525,7 @@ export class DomPlugin extends Plugin {
                 // eg do not change a <div> into a h1: insert the h1
                 // into it instead.
                 const newBlock = this.document.createElement(tagName);
-                newBlock.append(...block.childNodes);
+                newBlock.append(...childNodes(block));
                 block.append(newBlock);
                 cursors.remapNode(block, newBlock);
             }

--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -360,6 +360,9 @@ export class FormatPlugin extends Plugin {
             this.dependencies.selection.setSelection(newSelection, { normalize: false });
             return true;
         }
+        if (selectedFieldNodes.size > 0) {
+            return true;
+        }
     }
 
     normalize(root) {

--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -530,12 +530,20 @@ export class HistoryPlugin extends Plugin {
 
         this.handleObserverRecords();
         const currentStep = this.currentStep;
-        if (!currentStep.mutations.length) {
+        const currentMutationsCount = currentStep.mutations.length;
+        if (currentMutationsCount === 0) {
             return false;
         }
         const stepCommonAncestor = this.getMutationsRoot(currentStep.mutations) || this.editable;
         this.dispatchTo("normalize_handlers", stepCommonAncestor);
         this.handleObserverRecords();
+        if (currentMutationsCount === currentStep.mutations.length) {
+            // If there was no registered mutation during the normalization step,
+            // force the dispatch of a content_updated to allow i.e. the hint
+            // plugin to react to non-observed changes (i.e. a div becoming
+            // a baseContainer).
+            this.dispatchContentUpdated();
+        }
 
         currentStep.previousStepId = this.steps.at(-1)?.id;
 

--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -1031,6 +1031,21 @@ export class HistoryPlugin extends Plugin {
     }
     /**
      * Unserialize a node and its children if the collaboration is true.
+     *
+     * TODO: find a solution so that the following issue can never happen:
+     *   If there is already another node in `nodeToIdMap` pointing to the
+     *   current id before executing `this.nodeToIdMap.set(node, id)` in this
+     *   function, there will be 2 different nodes pointing to the same id.
+     *
+     *   2 different nodes for the same id is pretty common:
+     *     Unserializing a text node in `_unserializeNode` always creates
+     *     another (new) node.
+     *
+     *   If mutations concerning both nodes are bundled in the same step, they
+     *   will all be erroneously serialized as if they concern the node which
+     *   had its id set the latest, which is likely to cause issues when
+     *   applying these mutations (undo/redo, collaboration).
+     *
      * @param { SerializedNode } node
      * @returns { Node }
      */

--- a/addons/html_editor/static/src/core/line_break_plugin.js
+++ b/addons/html_editor/static/src/core/line_break_plugin.js
@@ -3,6 +3,7 @@ import { Plugin } from "../plugin";
 import { CTGROUPS, CTYPES } from "../utils/content_types";
 import { getState, isFakeLineBreak, prepareUpdate } from "../utils/dom_state";
 import { DIRECTIONS, leftPos, rightPos } from "../utils/position";
+import { closestElement } from "@html_editor/utils/dom_traversal";
 
 /**
  * @typedef { Object } LineBreakShared
@@ -42,6 +43,10 @@ export class LineBreakPlugin extends Plugin {
      * @param {number} params.targetOffset
      */
     insertLineBreakNode({ targetNode, targetOffset }) {
+        const closestEl = closestElement(targetNode);
+        if (closestEl && !closestEl.isContentEditable) {
+            return;
+        }
         if (targetNode.nodeType === Node.TEXT_NODE) {
             targetOffset = splitTextNode(targetNode, targetOffset);
             targetNode = targetNode.parentElement;
@@ -60,6 +65,10 @@ export class LineBreakPlugin extends Plugin {
      * @param {number} params.targetOffset
      */
     insertLineBreakElement({ targetNode, targetOffset }) {
+        const closestEl = closestElement(targetNode);
+        if (closestEl && !closestEl.isContentEditable) {
+            return;
+        }
         const restore = prepareUpdate(targetNode, targetOffset);
 
         const brEl = this.document.createElement("br");

--- a/addons/html_editor/static/src/core/no_inline_root_plugin.js
+++ b/addons/html_editor/static/src/core/no_inline_root_plugin.js
@@ -5,7 +5,7 @@ import { nodeSize } from "@html_editor/utils/position";
 
 export class NoInlineRootPlugin extends Plugin {
     static id = "noInlineRoot";
-    static dependencies = ["selection", "history"];
+    static dependencies = ["baseContainer", "selection", "history"];
 
     resources = {
         ...(!this.config.allowInlineAtRoot && {
@@ -129,19 +129,19 @@ export class NoInlineRootPlugin extends Plugin {
             // used to prevent to fix twice from the same mouse event.
             this.preventNextPointerdownFix = true;
 
-            const p = this.document.createElement("p");
-            p.append(this.document.createElement("br"));
+            const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+            baseContainer.append(this.document.createElement("br"));
             if (!nodeAfterCursor) {
                 // Cursor is at the end of the editable.
-                this.editable.append(p);
+                this.editable.append(baseContainer);
             } else if (!nodeBeforeCursor) {
                 // Cursor is at the beginning of the editable.
-                this.editable.prepend(p);
+                this.editable.prepend(baseContainer);
             } else {
                 // Cursor is between two non-p blocks
-                nodeAfterCursor.before(p);
+                nodeAfterCursor.before(baseContainer);
             }
-            this.dependencies.selection.setCursorStart(p);
+            this.dependencies.selection.setCursorStart(baseContainer);
             this.dependencies.history.addStep();
             return true;
         }

--- a/addons/html_editor/static/src/core/no_inline_root_plugin.js
+++ b/addons/html_editor/static/src/core/no_inline_root_plugin.js
@@ -1,4 +1,4 @@
-import { getDeepestPosition, paragraphRelatedElements } from "@html_editor/utils/dom_info";
+import { getDeepestPosition, isParagraphRelatedElement } from "@html_editor/utils/dom_info";
 import { Plugin } from "../plugin";
 import { isNotAllowedContent } from "./selection_plugin";
 import { nodeSize } from "@html_editor/utils/position";
@@ -99,14 +99,11 @@ export class NoInlineRootPlugin extends Plugin {
      */
     fixSelectionOnEditableRootGeneric(nodeAfterCursor, nodeBeforeCursor) {
         // Handle arrow key presses.
-        if (nodeAfterCursor && paragraphRelatedElements.includes(nodeAfterCursor.nodeName)) {
+        if (nodeAfterCursor && isParagraphRelatedElement(nodeAfterCursor)) {
             // Cursor is right before a 'P'.
             this.dependencies.selection.setCursorStart(nodeAfterCursor);
             return true;
-        } else if (
-            nodeBeforeCursor &&
-            paragraphRelatedElements.includes(nodeBeforeCursor.nodeName)
-        ) {
+        } else if (nodeBeforeCursor && isParagraphRelatedElement(nodeBeforeCursor)) {
             // Cursor is right after a 'P'.
             this.dependencies.selection.setCursorEnd(nodeBeforeCursor);
             return true;

--- a/addons/html_editor/static/src/core/protected_node_plugin.js
+++ b/addons/html_editor/static/src/core/protected_node_plugin.js
@@ -1,5 +1,5 @@
 import { Plugin } from "../plugin";
-import { isProtecting } from "../utils/dom_info";
+import { isProtecting, isUnprotecting } from "../utils/dom_info";
 import { childNodes } from "../utils/dom_traversal";
 
 const PROTECTED_SELECTOR = `[data-oe-protected="true"],[data-oe-protected=""]`;
@@ -19,7 +19,10 @@ export class ProtectedNodePlugin extends Plugin {
         normalize_handlers: this.normalize.bind(this),
         before_filter_mutation_record_handlers: this.beforeFilteringMutationRecords.bind(this),
 
-        unsplittable_node_predicates: isProtecting, // avoid merge
+        unsplittable_node_predicates: [
+            isProtecting, // avoid merge
+            isUnprotecting,
+        ],
         savable_mutation_record_predicates: this.isMutationRecordSavable.bind(this),
         removable_descendants_providers: this.filterDescendantsToRemove.bind(this),
     };

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -431,14 +431,14 @@ export class SelectionPlugin extends Plugin {
         Object.defineProperty(selectionData, "documentSelectionIsProtecting", {
             get: function () {
                 return documentSelection?.anchorNode
-                    ? isProtected(documentSelection.anchorNode)
+                    ? isProtecting(documentSelection.anchorNode)
                     : false;
             }.bind(this),
         });
         Object.defineProperty(selectionData, "documentSelectionIsProtected", {
             get: function () {
                 return documentSelection?.anchorNode
-                    ? isProtecting(documentSelection.anchorNode)
+                    ? isProtected(documentSelection.anchorNode)
                     : false;
             }.bind(this),
         });

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -275,7 +275,15 @@ export class SelectionPlugin extends Plugin {
             if (anchorNode === focusNode && focusOffset < anchorOffset) {
                 direction = !direction;
             }
-
+            if (
+                this.activeSelection &&
+                (isProtecting(anchorNode) ||
+                    (isProtected(anchorNode) && !isUnprotecting(anchorNode)))
+            ) {
+                // Keep the previous activeSelection in case of user interactions
+                // inside a protected zone.
+                return this.activeSelection;
+            }
             [anchorNode, anchorOffset] = normalizeCursorPosition(
                 anchorNode,
                 anchorOffset,

--- a/addons/html_editor/static/src/core/split_plugin.js
+++ b/addons/html_editor/static/src/core/split_plugin.js
@@ -24,7 +24,7 @@ import { isProtected, isProtecting } from "@html_editor/utils/dom_info";
  */
 
 export class SplitPlugin extends Plugin {
-    static dependencies = ["selection", "history", "input", "delete", "lineBreak"];
+    static dependencies = ["baseContainer", "selection", "history", "input", "delete", "lineBreak"];
     static id = "split";
     static shared = [
         "splitBlock",
@@ -71,7 +71,7 @@ export class SplitPlugin extends Plugin {
                         isExplicitlyNotContentEditable(node.parentElement))
                 );
             },
-            (node) => ["DIV", "SECTION"].includes(node.nodeName),
+            (node) => node.nodeName === "SECTION",
         ],
     };
 

--- a/addons/html_editor/static/src/core/split_plugin.js
+++ b/addons/html_editor/static/src/core/split_plugin.js
@@ -1,7 +1,12 @@
 import { Plugin } from "../plugin";
 import { isBlock } from "../utils/blocks";
 import { fillEmpty, splitTextNode } from "../utils/dom";
-import { isTextNode, isVisible } from "../utils/dom_info";
+import {
+    isContentEditable,
+    isContentEditableAncestor,
+    isTextNode,
+    isVisible,
+} from "../utils/dom_info";
 import { prepareUpdate } from "../utils/dom_state";
 import { childNodes, closestElement, firstLeaf, lastLeaf } from "../utils/dom_traversal";
 import { DIRECTIONS, childNodeIndex, nodeSize } from "../utils/position";
@@ -46,6 +51,26 @@ export class SplitPlugin extends Plugin {
             // "Unbreakable" is a legacy term that means unsplittable and
             // unmergeable.
             (node) => node.classList?.contains("oe_unbreakable"),
+            (node) => {
+                const isExplicitlyNotContentEditable = (node) => {
+                    // In the `contenteditable` attribute consideration,
+                    // disconnected nodes can be unsplittable only if they are
+                    // explicitly set under a contenteditable="false" element.
+                    return (
+                        !isContentEditable(node) &&
+                        (node.isConnected || closestElement(node, "[contenteditable]"))
+                    );
+                };
+                return (
+                    isExplicitlyNotContentEditable(node) ||
+                    // If node sets contenteditable='true' and is inside a non-editable
+                    // context, it has to be unsplittable since splitting it would modify
+                    // the non-editable parent content.
+                    (node.parentElement &&
+                        isContentEditableAncestor(node) &&
+                        isExplicitlyNotContentEditable(node.parentElement))
+                );
+            },
             (node) => ["DIV", "SECTION"].includes(node.nodeName),
         ],
     };

--- a/addons/html_editor/static/src/editor.js
+++ b/addons/html_editor/static/src/editor.js
@@ -1,5 +1,6 @@
 import { MAIN_PLUGINS } from "./plugin_sets";
-import { removeClass } from "./utils/dom";
+import { createBaseContainer } from "./utils/base_container";
+import { fillShrunkPhrasingParent, removeClass } from "./utils/dom";
 import { isEmpty } from "./utils/dom_info";
 import { resourceSequenceSymbol, withSequence } from "./utils/resource";
 import { initElementForEdition } from "./utils/sanitize";
@@ -22,6 +23,7 @@ import { initElementForEdition } from "./utils/sanitize";
  * @typedef { Object } EditorConfig
  * @property { string } [content]
  * @property { boolean } [allowInlineAtRoot]
+ * @property { string } [baseContainer]
  * @property { PluginConstructor[] } [Plugins]
  * @property { boolean } [disableFloatingToolbar]
  * @property { string[] } [classList]
@@ -96,7 +98,9 @@ export class Editor {
         if (this.config.content) {
             editable.innerHTML = this.config.content;
             if (isEmpty(editable)) {
-                editable.innerHTML = "<p><br></p>";
+                const baseContainer = createBaseContainer(this.config.baseContainer, this.document);
+                fillShrunkPhrasingParent(baseContainer);
+                editable.replaceChildren(baseContainer);
             }
         }
         this.preparePlugins();

--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -236,6 +236,10 @@ export class HtmlField extends Component {
             ...this.props.editorConfig,
         };
 
+        if (!("baseContainer" in config)) {
+            config.baseContainer = "DIV";
+        }
+
         if (this.props.embeddedComponents) {
             // TODO @engagement: fill this array with default/base components
             config.resources.embedded_components = [...MAIN_EMBEDDINGS];
@@ -313,6 +317,9 @@ export const htmlField = {
         }
         if ("disableFile" in options) {
             editorConfig.disableFile = Boolean(options.disableFile);
+        }
+        if ("baseContainer" in options) {
+            editorConfig.baseContainer = options.baseContainer;
         }
         return {
             editorConfig,

--- a/addons/html_editor/static/src/main/banner_plugin.js
+++ b/addons/html_editor/static/src/main/banner_plugin.js
@@ -1,4 +1,5 @@
 import { Plugin } from "@html_editor/plugin";
+import { fillShrunkPhrasingParent } from "@html_editor/utils/dom";
 import { closestElement } from "@html_editor/utils/dom_traversal";
 import { parseHTML } from "@html_editor/utils/html";
 import { withSequence } from "@html_editor/utils/resource";
@@ -9,7 +10,7 @@ function isAvailable(selection) {
 }
 export class BannerPlugin extends Plugin {
     static id = "banner";
-    static dependencies = ["history", "dom", "emoji", "selection"];
+    static dependencies = ["baseContainer", "history", "dom", "emoji", "selection"];
     resources = {
         user_commands: [
             {
@@ -85,12 +86,15 @@ export class BannerPlugin extends Plugin {
     }
 
     insertBanner(title, emoji, alertClass) {
+        const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+        fillShrunkPhrasingParent(baseContainer);
+        const baseContainerHtml = baseContainer.outerHTML;
         const bannerElement = parseHTML(
             this.document,
             `<div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-${alertClass} pb-0 pt-3" role="status" contenteditable="false">
                 <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="${title}">${emoji}</i>
                 <div class="w-100 px-3" contenteditable="true">
-                    <p><br></p>
+                    ${baseContainerHtml}
                 </div>
             </div`
         ).childNodes[0];

--- a/addons/html_editor/static/src/main/chatgpt/chatgpt_alternatives_dialog.js
+++ b/addons/html_editor/static/src/main/chatgpt/chatgpt_alternatives_dialog.js
@@ -23,6 +23,7 @@ export class ChatGPTAlternativesDialog extends ChatGPTDialog {
         numberOfAlternatives: { type: Number, optional: true },
     };
     static defaultProps = {
+        ...super.defaultProps,
         alternativesModes: DEFAULT_ALTERNATIVES_MODES,
         numberOfAlternatives: 3,
     };

--- a/addons/html_editor/static/src/main/chatgpt/chatgpt_plugin.js
+++ b/addons/html_editor/static/src/main/chatgpt/chatgpt_plugin.js
@@ -10,7 +10,7 @@ import { user } from "@web/core/user";
 
 export class ChatGPTPlugin extends Plugin {
     static id = "chatgpt";
-    static dependencies = ["selection", "history", "dom", "sanitize", "dialog"];
+    static dependencies = ["baseContainer", "selection", "history", "dom", "sanitize", "dialog"];
     resources = {
         user_commands: [
             {
@@ -103,6 +103,7 @@ export class ChatGPTPlugin extends Plugin {
             },
             ...params,
         };
+        dialogParams.baseContainer = this.dependencies.baseContainer.getDefaultNodeName();
         // collapse to end
         const sanitize = this.dependencies.sanitize.sanitize;
         if (selection.isCollapsed) {

--- a/addons/html_editor/static/src/main/chatgpt/chatgpt_prompt_dialog.js
+++ b/addons/html_editor/static/src/main/chatgpt/chatgpt_prompt_dialog.js
@@ -12,6 +12,7 @@ export class ChatGPTPromptDialog extends ChatGPTDialog {
         initialPrompt: { type: String, optional: true },
     };
     static defaultProps = {
+        ...super.defaultProps,
         initialPrompt: "",
     };
 

--- a/addons/html_editor/static/src/main/column_plugin.js
+++ b/addons/html_editor/static/src/main/column_plugin.js
@@ -29,7 +29,7 @@ function columnIsAvailable(numberOfColumns) {
 
 export class ColumnPlugin extends Plugin {
     static id = "column";
-    static dependencies = ["selection", "history"];
+    static dependencies = ["baseContainer", "selection", "history"];
     resources = {
         user_commands: [
             {
@@ -141,14 +141,14 @@ export class ColumnPlugin extends Plugin {
         block.before(container);
         columns.shift().append(block);
         for (const column of columns) {
-            const p = this.document.createElement("p");
-            p.append(this.document.createElement("br"));
-            column.append(p);
+            const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+            baseContainer.append(this.document.createElement("br"));
+            column.append(baseContainer);
         }
         if (addParagraphAfter) {
-            const p = this.document.createElement("p");
-            p.append(this.document.createElement("br"));
-            container.after(p);
+            const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+            baseContainer.append(this.document.createElement("br"));
+            container.after(baseContainer);
         }
     }
 
@@ -172,9 +172,9 @@ export class ColumnPlugin extends Plugin {
             for (let i = 0; i < diff; i++) {
                 const column = this.document.createElement("div");
                 column.classList.add(`col-${columnSize}`);
-                const p = this.document.createElement("p");
-                p.append(this.document.createElement("br"));
-                column.append(p);
+                const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+                baseContainer.append(this.document.createElement("br"));
+                column.append(baseContainer);
                 lastColumn.after(column);
                 lastColumn = column;
             }

--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -17,6 +17,7 @@ import {
 import { DIRECTIONS } from "@html_editor/utils/position";
 import { _t } from "@web/core/l10n/translation";
 import { FontSelector } from "./font_selector";
+import { getBaseContainerSelector } from "@html_editor/utils/base_container";
 import { withSequence } from "@html_editor/utils/resource";
 import { reactive } from "@odoo/owl";
 
@@ -51,9 +52,16 @@ export const fontItems = [
     { name: _t("Header 5"), tagName: "h5" },
     { name: _t("Header 6"), tagName: "h6" },
 
-    { name: _t("Normal"), tagName: "p" },
+    {
+        name: _t("Normal"),
+        tagName: "div",
+        // for the FontSelector component
+        selector: getBaseContainerSelector("DIV"),
+    },
+    { name: _t("Paragraph"), tagName: "p" },
 
     // TODO @phoenix use them if showExtendedTextStylesOptions is true
+    // consider baseContainer if enabling them
     // {
     //     name: _t("Light"),
     //     tagName: "p",
@@ -99,7 +107,7 @@ const handledElemSelector = [...headingTags, "PRE", "BLOCKQUOTE"].join(", ");
 
 export class FontPlugin extends Plugin {
     static id = "font";
-    static dependencies = ["input", "split", "selection", "dom", "format"];
+    static dependencies = ["baseContainer", "input", "split", "selection", "dom", "format"];
     resources = {
         user_commands: [
             {
@@ -128,7 +136,11 @@ export class FontPlugin extends Plugin {
                 title: _t("Text"),
                 description: _t("Paragraph block"),
                 icon: "fa-paragraph",
-                run: () => this.dependencies.dom.setTag({ tagName: "P" }),
+                run: () => {
+                    this.dependencies.dom.setTag({
+                        tagName: this.dependencies.baseContainer.getDefaultNodeName(),
+                    });
+                },
             },
             {
                 id: "setTagQuote",
@@ -258,7 +270,7 @@ export class FontPlugin extends Plugin {
         const tagName = block.tagName.toLowerCase();
 
         const matchingItems = fontItems.filter((item) => {
-            return item.tagName === tagName;
+            return item.selector ? block.matches(item.selector) : item.tagName === tagName;
         });
 
         const matchingItemsWitoutExtraClass = matchingItems.filter((item) => !item.extraClass);
@@ -327,10 +339,10 @@ export class FontPlugin extends Plugin {
             if (closestBlockNode.nodeName !== "PRE") {
                 closestBlockNode.remove();
             }
-            const p = this.document.createElement("p");
-            closestPre.after(p);
-            fillEmpty(p);
-            this.dependencies.selection.setCursorStart(p);
+            const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+            closestPre.after(baseContainer);
+            fillEmpty(baseContainer);
+            this.dependencies.selection.setCursorStart(baseContainer);
         } else {
             const lineBreak = this.document.createElement("br");
             targetNode.insertBefore(lineBreak, targetNode.childNodes[targetOffset]);
@@ -364,10 +376,10 @@ export class FontPlugin extends Plugin {
             if (closestBlockNode.nodeName !== "BLOCKQUOTE") {
                 closestBlockNode.remove();
             }
-            const p = this.document.createElement("p");
-            closestQuote.after(p);
-            fillEmpty(p);
-            this.dependencies.selection.setCursorStart(p);
+            const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+            closestQuote.after(baseContainer);
+            fillEmpty(baseContainer);
+            this.dependencies.selection.setCursorStart(baseContainer);
             return true;
         }
     }
@@ -392,10 +404,10 @@ export class FontPlugin extends Plugin {
                 headingTags.includes(newElement.tagName) &&
                 !descendants(newElement).some(isVisibleTextNode)
             ) {
-                const p = this.document.createElement("P");
-                newElement.replaceWith(p);
-                p.replaceChildren(this.document.createElement("br"));
-                this.dependencies.selection.setCursorStart(p);
+                const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+                newElement.replaceWith(baseContainer);
+                baseContainer.replaceChildren(this.document.createElement("br"));
+                this.dependencies.selection.setCursorStart(baseContainer);
             }
             return true;
         }
@@ -420,11 +432,11 @@ export class FontPlugin extends Plugin {
         if (this.getResource("unremovable_node_predicates").some((p) => p(closestHandledElement))) {
             return;
         }
-        const p = this.document.createElement("p");
-        p.append(...closestHandledElement.childNodes);
-        closestHandledElement.after(p);
+        const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+        baseContainer.append(...closestHandledElement.childNodes);
+        closestHandledElement.after(baseContainer);
         closestHandledElement.remove();
-        this.dependencies.selection.setCursorStart(p);
+        this.dependencies.selection.setCursorStart(baseContainer);
         return true;
     }
 

--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -264,7 +264,7 @@ export class FontPlugin extends Plugin {
         const matchingItemsWitoutExtraClass = matchingItems.filter((item) => !item.extraClass);
 
         if (!matchingItems.length) {
-            return "Normal";
+            return _t("Normal");
         }
 
         return (

--- a/addons/html_editor/static/src/main/hint_plugin.js
+++ b/addons/html_editor/static/src/main/hint_plugin.js
@@ -1,25 +1,12 @@
 import { Plugin } from "@html_editor/plugin";
 import { isEmptyBlock, isProtected } from "@html_editor/utils/dom_info";
 import { removeClass } from "@html_editor/utils/dom";
-import { selectElements } from "@html_editor/utils/dom_traversal";
+import { childNodes, selectElements } from "@html_editor/utils/dom_traversal";
 import { closestBlock } from "../utils/blocks";
+import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
 
 function isMutationRecordSavable(record) {
     return !(record.type === "attributes" && record.attributeName === "placeholder");
-}
-
-/**
- * @param {SelectionData} selectionData
- * @param {HTMLElement} editable
- */
-function target(selectionData, editable) {
-    if (selectionData.documentSelectionIsInEditable || editable.childNodes.length !== 1) {
-        return;
-    }
-    const el = editable.firstChild;
-    if (el.tagName === "P" && isEmptyBlock(el)) {
-        return el;
-    }
 }
 
 export class HintPlugin extends Plugin {
@@ -39,7 +26,23 @@ export class HintPlugin extends Plugin {
         savable_mutation_record_predicates: isMutationRecordSavable,
         system_classes: ["o-we-hint"],
         ...(this.config.placeholder && {
-            hints: { text: this.config.placeholder, target },
+            hints: [
+                {
+                    text: this.config.placeholder,
+                    target: (selectionData, editable) => {
+                        if (
+                            selectionData.documentSelectionIsInEditable ||
+                            childNodes(editable).length !== 1
+                        ) {
+                            return;
+                        }
+                        const el = editable.firstChild;
+                        if (isEmptyBlock(el) && el.matches(baseContainerGlobalSelector)) {
+                            return el;
+                        }
+                    },
+                },
+            ],
         }),
     };
 

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -4,9 +4,12 @@ import { removeClass, toggleClass, wrapInlinesInBlocks } from "@html_editor/util
 import {
     getDeepestPosition,
     isEmptyBlock,
+    isListElement,
+    isListItemElement,
+    isParagraphRelatedElement,
     isProtected,
     isProtecting,
-    paragraphRelatedElements,
+    listElementSelector,
 } from "@html_editor/utils/dom_info";
 import {
     closestElement,
@@ -666,20 +669,17 @@ export class ListPlugin extends Plugin {
     // --------------------------------------------------------------------------
 
     processNodeToInsert({ nodeToInsert, container }) {
-        if (
-            container.nodeName === "LI" &&
-            paragraphRelatedElements.includes(nodeToInsert.nodeName)
-        ) {
+        if (isListItemElement(container) && isParagraphRelatedElement(nodeToInsert)) {
             nodeToInsert = this.dependencies.dom.setTagName(nodeToInsert, "LI");
         }
-        const listEl = container && closestElement(container, "UL, OL");
+        const listEl = container && closestElement(container, listElementSelector);
         if (!listEl) {
             return nodeToInsert;
         }
         const mode = container && this.getListMode(listEl);
         if (
-            (nodeToInsert.nodeName === "LI" && nodeToInsert.classList.contains("oe-nested")) ||
-            ["UL", "OL"].includes(nodeToInsert.nodeName)
+            (isListItemElement(nodeToInsert) && nodeToInsert.classList.contains("oe-nested")) ||
+            isListElement(nodeToInsert)
         ) {
             return this.convertList(nodeToInsert, mode);
         }
@@ -692,7 +692,7 @@ export class ListPlugin extends Plugin {
         if (closestLI) {
             const block = closestBlock(selection.anchorNode);
             const isLiContainsUnSpittable =
-                paragraphRelatedElements.includes(block.nodeName) &&
+                isParagraphRelatedElement(block) &&
                 ancestors(block, closestLI).find((node) =>
                     this.dependencies.split.isUnsplittable(node)
                 );
@@ -716,7 +716,7 @@ export class ListPlugin extends Plugin {
         if (closestLI) {
             const block = closestBlock(selection.anchorNode);
             const isLiContainsUnSpittable =
-                paragraphRelatedElements.includes(block.nodeName) &&
+                isParagraphRelatedElement(block) &&
                 ancestors(block, closestLI).find((node) =>
                     this.dependencies.split.isUnsplittable(node)
                 );

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -25,10 +25,20 @@ import { _t } from "@web/core/l10n/translation";
 import { compareListTypes, createList, insertListAfter, isListItem } from "./utils";
 import { callbacksForCursorUpdate } from "@html_editor/utils/selection";
 import { withSequence } from "@html_editor/utils/resource";
+import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
 
 export class ListPlugin extends Plugin {
     static id = "list";
-    static dependencies = ["tabulation", "history", "input", "split", "selection", "delete", "dom"];
+    static dependencies = [
+        "baseContainer",
+        "tabulation",
+        "history",
+        "input",
+        "split",
+        "selection",
+        "delete",
+        "dom",
+    ];
     resources = {
         user_commands: [
             {
@@ -276,8 +286,8 @@ export class ListPlugin extends Plugin {
      * @param {"UL"|"OL"|"CL"} mode
      */
     blockToList(element, mode) {
-        if (element.tagName === "P") {
-            return this.pToList(element, mode);
+        if (element.matches(baseContainerGlobalSelector)) {
+            return this.baseContainerToList(element, mode);
         }
         // @todo @phoenix: check for callbacks registered as resources instead?
         if (element.matches("td, th, li.nav-item")) {
@@ -314,15 +324,18 @@ export class ListPlugin extends Plugin {
     }
 
     /**
-     * @param {HTMLParagraphElement} p
+     * @param {HTMLElement} baseContainer baseContainer Element (can be a div with the
+     *        necessary classes/attributes).
      * @param {"UL"|"OL"|"CL"} mode
      */
-    pToList(p, mode) {
+    baseContainerToList(baseContainer, mode) {
         const cursors = this.dependencies.selection.preserveSelection();
-        const list = insertListAfter(this.document, p, mode, [[...p.childNodes]]);
-        this.dependencies.dom.copyAttributes(p, list);
-        p.remove();
-        cursors.remapNode(p, list.firstChild).restore();
+        const list = insertListAfter(this.document, baseContainer, mode, [
+            childNodes(baseContainer),
+        ]);
+        this.dependencies.dom.copyAttributes(baseContainer, list);
+        baseContainer.remove();
+        cursors.remapNode(baseContainer, list.firstChild).restore();
         return list;
     }
 
@@ -427,7 +440,7 @@ export class ListPlugin extends Plugin {
             return;
         }
         // Transform <li> into <p> if they are not in a <ul> / <ol>.
-        const paragraph = this.document.createElement("p");
+        const paragraph = this.dependencies.baseContainer.createBaseContainer();
         element.replaceWith(paragraph);
         paragraph.replaceChildren(...element.childNodes);
     }
@@ -467,7 +480,10 @@ export class ListPlugin extends Plugin {
             )
         ) {
             const cursors = this.dependencies.selection.preserveSelection();
-            wrapInlinesInBlocks(element, cursors);
+            wrapInlinesInBlocks(element, {
+                baseContainerNodeName: this.dependencies.baseContainer.getDefaultNodeName(),
+                cursors,
+            });
             cursors.restore();
         }
     }
@@ -602,13 +618,16 @@ export class ListPlugin extends Plugin {
         const ul = li.parentNode;
         const dir = ul.getAttribute("dir");
         const textAlign = ul.style.getPropertyValue("text-align");
-        wrapInlinesInBlocks(li, cursors);
+        wrapInlinesInBlocks(li, {
+            baseContainerNodeName: this.dependencies.baseContainer.getDefaultNodeName(),
+            cursors,
+        });
         if (!li.hasChildNodes()) {
-            // Outdenting an empty LI produces an empty P
-            const p = this.document.createElement("p");
-            p.append(this.document.createElement("br"));
-            li.append(p);
-            cursors.remapNode(li, p);
+            // Outdenting an empty LI produces an empty baseContainer
+            const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+            baseContainer.append(this.document.createElement("br"));
+            li.append(baseContainer);
+            cursors.remapNode(li, baseContainer);
         }
         // Move LI's children to after UL
         for (const block of childNodes(li).reverse()) {

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -21,15 +21,7 @@ import { leftLeafOnlyNotBlockPath } from "@html_editor/utils/dom_state";
 import { _t } from "@web/core/l10n/translation";
 import { compareListTypes, createList, insertListAfter, isListItem } from "./utils";
 import { callbacksForCursorUpdate } from "@html_editor/utils/selection";
-import { getListMode, switchListMode } from "@html_editor/utils/list";
 import { withSequence } from "@html_editor/utils/resource";
-
-function isListActive(listMode) {
-    return (selection) => {
-        const block = closestBlock(selection.anchorNode);
-        return block?.tagName === "LI" && getListMode(block.parentNode) === listMode;
-    };
-}
 
 export class ListPlugin extends Plugin {
     static id = "list";
@@ -68,19 +60,19 @@ export class ListPlugin extends Plugin {
                 id: "bulleted_list",
                 groupId: "list",
                 commandId: "toggleListUL",
-                isActive: isListActive("UL"),
+                isActive: this.isListActive("UL"),
             },
             {
                 id: "numbered_list",
                 groupId: "list",
                 commandId: "toggleListOL",
-                isActive: isListActive("OL"),
+                isActive: this.isListActive("OL"),
             },
             {
                 id: "checklist",
                 groupId: "list",
                 commandId: "toggleListCL",
-                isActive: isListActive("CL"),
+                isActive: this.isListActive("CL"),
             },
         ],
         powerbox_items: [
@@ -115,6 +107,7 @@ export class ListPlugin extends Plugin {
         tab_overrides: this.handleTab.bind(this),
         shift_tab_overrides: this.handleShiftTab.bind(this),
         split_element_block_overrides: this.handleSplitBlock.bind(this),
+        node_to_insert_processors: this.processNodeToInsert.bind(this),
     };
 
     setup() {
@@ -221,7 +214,7 @@ export class ListPlugin extends Plugin {
             }
             const li = closestElement(block, isListItem);
             if (li) {
-                if (getListMode(li.parentElement) === mode) {
+                if (this.getListMode(li.parentElement) === mode) {
                     sameModeListItems.add(li);
                 } else {
                     listsToSwitch.add(li.parentElement);
@@ -235,7 +228,7 @@ export class ListPlugin extends Plugin {
         if (listsToSwitch.size || nonListBlocks.size) {
             for (const list of listsToSwitch) {
                 const cursors = this.dependencies.selection.preserveSelection();
-                const newList = switchListMode(list, mode);
+                const newList = this.switchListMode(list, mode);
                 cursors.remapNode(list, newList).restore();
             }
             for (const block of nonListBlocks) {
@@ -338,6 +331,79 @@ export class ListPlugin extends Plugin {
     }
 
     /**
+     * Converts a list element and its nested elements to the given list mode.
+     *
+     * @see switchListMode
+     * @param {HTMLUListElement|HTMLOListElement|HTMLLIElement} node - HTML element
+     * representing a list or list item.
+     * @param {string} newMode - Target list mode
+     * @param {Object} options
+     * @returns {HTMLUListElement|HTMLOListElement|HTMLLIElement} node - Modified
+     * list element after conversion.
+     */
+    convertList(node, newMode) {
+        if (!["UL", "OL", "LI"].includes(node.tagName)) {
+            return;
+        }
+        const listMode = this.getListMode(node);
+        if (listMode && newMode !== listMode) {
+            node = this.switchListMode(node, newMode);
+        }
+        for (const child of node.children) {
+            this.convertList(child, newMode);
+        }
+        return node;
+    }
+
+    getListMode(listContainerEl) {
+        if (!["UL", "OL"].includes(listContainerEl.tagName)) {
+            return;
+        }
+        if (listContainerEl.tagName === "OL") {
+            return "OL";
+        }
+        return listContainerEl.classList.contains("o_checklist") ? "CL" : "UL";
+    }
+
+    isListActive(listMode) {
+        return (selection) => {
+            const block = closestBlock(selection.anchorNode);
+            return block?.tagName === "LI" && this.getListMode(block.parentNode) === listMode;
+        };
+    }
+
+    /**
+     * Switches the list mode of the given list element.
+     *
+     * @param {HTMLOListElement|HTMLUListElement} list - The list element to switch the mode of.
+     * @param {"UL"|"OL"|"CL"} newMode - The new mode to switch to.
+     * @param {Object} options
+     * @returns {HTMLOListElement|HTMLUListElement} The modified list element.
+     */
+    switchListMode(list, newMode) {
+        if (this.getListMode(list) === newMode) {
+            return;
+        }
+        const newTag = newMode === "CL" ? "UL" : newMode;
+        const newList = this.dependencies.dom.setTagName(list, newTag);
+        // Clear list style (@todo @phoenix - why??)
+        newList.style.removeProperty("list-style");
+        for (const li of newList.children) {
+            if (li.style.listStyle !== "none") {
+                li.style.listStyle = null;
+                if (!li.style.all) {
+                    li.removeAttribute("style");
+                }
+            }
+        }
+        removeClass(newList, "o_checklist");
+        if (newMode === "CL") {
+            newList.classList.add("o_checklist");
+        }
+        return newList;
+    }
+
+    /**
      * Unwraps LI's content into blocks. Equivalent to fully outdenting the LI.
      *
      * @param {HTMLLIElement} li
@@ -433,7 +499,7 @@ export class ListPlugin extends Plugin {
             li.nextElementSibling?.querySelector("ol, ul") ||
             li.closest("ol, ul");
 
-        const ul = createList(this.document, getListMode(destul));
+        const ul = createList(this.document, this.getListMode(destul));
         lip.append(ul);
 
         const cursors = this.dependencies.selection.preserveSelection();
@@ -599,6 +665,27 @@ export class ListPlugin extends Plugin {
     // Handlers of other plugins commands
     // --------------------------------------------------------------------------
 
+    processNodeToInsert({ nodeToInsert, container }) {
+        if (
+            container.nodeName === "LI" &&
+            paragraphRelatedElements.includes(nodeToInsert.nodeName)
+        ) {
+            nodeToInsert = this.dependencies.dom.setTagName(nodeToInsert, "LI");
+        }
+        const listEl = container && closestElement(container, "UL, OL");
+        if (!listEl) {
+            return nodeToInsert;
+        }
+        const mode = container && this.getListMode(listEl);
+        if (
+            (nodeToInsert.nodeName === "LI" && nodeToInsert.classList.contains("oe-nested")) ||
+            ["UL", "OL"].includes(nodeToInsert.nodeName)
+        ) {
+            return this.convertList(nodeToInsert, mode);
+        }
+        return nodeToInsert;
+    }
+
     handleTab() {
         const selection = this.dependencies.selection.getEditableSelection();
         const closestLI = closestElement(selection.anchorNode, "LI");
@@ -736,7 +823,8 @@ export class ListPlugin extends Plugin {
      */
     onPointerdown(ev) {
         const node = ev.target;
-        const isChecklistItem = node.tagName == "LI" && getListMode(node.parentElement) == "CL";
+        const isChecklistItem =
+            node.tagName == "LI" && this.getListMode(node.parentElement) == "CL";
         if (!isChecklistItem) {
             return;
         }

--- a/addons/html_editor/static/src/main/power_buttons_plugin.js
+++ b/addons/html_editor/static/src/main/power_buttons_plugin.js
@@ -1,4 +1,5 @@
 import { Plugin } from "@html_editor/plugin";
+import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
 import { closestBlock } from "@html_editor/utils/blocks";
 import { isEmptyBlock } from "@html_editor/utils/dom_info";
 import { closestElement } from "@html_editor/utils/dom_traversal";
@@ -41,7 +42,14 @@ import { omit, pick } from "@web/core/utils/objects";
 
 export class PowerButtonsPlugin extends Plugin {
     static id = "powerButtons";
-    static dependencies = ["selection", "position", "localOverlay", "powerbox", "userCommand"];
+    static dependencies = [
+        "baseContainer",
+        "selection",
+        "position",
+        "localOverlay",
+        "powerbox",
+        "userCommand",
+    ];
     resources = {
         layout_geometry_change_handlers: this.updatePowerButtons.bind(this),
         selectionchange_handlers: this.updatePowerButtons.bind(this),
@@ -95,7 +103,7 @@ export class PowerButtonsPlugin extends Plugin {
         const element = closestElement(editableSelection.anchorNode);
         if (
             editableSelection.isCollapsed &&
-            element?.tagName === "P" &&
+            element?.matches(baseContainerGlobalSelector) &&
             isEmptyBlock(block) &&
             !this.services.ui.isSmall &&
             !closestElement(editableSelection.anchorNode, "td") &&

--- a/addons/html_editor/static/src/main/powerbox/powerbox_plugin.js
+++ b/addons/html_editor/static/src/main/powerbox/powerbox_plugin.js
@@ -6,6 +6,7 @@ import { rotate } from "@web/core/utils/arrays";
 import { Powerbox } from "./powerbox";
 import { withSequence } from "@html_editor/utils/resource";
 import { omit, pick } from "@web/core/utils/objects";
+import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
 
 /** @typedef { import("@html_editor/core/selection_plugin").EditorSelection } EditorSelection */
 /** @typedef { import("@html_editor/core/user_command_plugin").UserCommand } UserCommand */
@@ -84,7 +85,7 @@ function target(selectionData) {
     const el = node.nodeType === Node.ELEMENT_NODE ? node : node.parentElement;
     if (
         selectionData.documentSelectionIsInEditable &&
-        (el.tagName === "DIV" || el.tagName === "P") &&
+        el.matches(baseContainerGlobalSelector) &&
         isEmptyBlock(el)
     ) {
         return el;

--- a/addons/html_editor/static/src/main/signature.xml
+++ b/addons/html_editor/static/src/main/signature.xml
@@ -1,0 +1,5 @@
+<templates>
+    <t t-name="html_editor.Signature">
+        <div t-att-class="signatureClass" t-out="signature"/>
+    </t>
+</templates>

--- a/addons/html_editor/static/src/main/signature_plugin.js
+++ b/addons/html_editor/static/src/main/signature_plugin.js
@@ -3,10 +3,16 @@ import { _t } from "@web/core/l10n/translation";
 import { parseHTML } from "@html_editor/utils/html";
 import { user } from "@web/core/user";
 import { withSequence } from "@html_editor/utils/resource";
+import { renderToString } from "@web/core/utils/render";
+import { markup } from "@odoo/owl";
+import { isEmptyBlock, paragraphRelatedElementsSelector } from "@html_editor/utils/dom_info";
+
+export const SIGNATURE_CLASS = "o-signature-container";
 
 export class SignaturePlugin extends Plugin {
     static id = "signature";
-    static dependencies = ["dom", "history"];
+    static dependencies = ["dom", "history", "selection"];
+    static shared = ["cleanSignatures"];
     resources = {
         user_commands: [
             {
@@ -24,7 +30,16 @@ export class SignaturePlugin extends Plugin {
                 commandId: "insertSignature",
             },
         ],
+        is_empty_predicates: this.isEmpty.bind(this),
+        unsplittable_node_predicates: (host) =>
+            host.nodeType === Node.ELEMENT_NODE && host.matches(`.${SIGNATURE_CLASS}`),
     };
+
+    cleanSignatures({ rootClone }) {
+        for (const el of rootClone.querySelectorAll(`.${SIGNATURE_CLASS}`)) {
+            el.remove();
+        }
+    }
 
     async insertSignature() {
         const [currentUser] = await this.services.orm.read(
@@ -33,8 +48,37 @@ export class SignaturePlugin extends Plugin {
             ["signature"]
         );
         if (currentUser && currentUser.signature) {
-            this.dependencies.dom.insert(parseHTML(this.document, currentUser.signature));
+            // User signature is sanitized in backend.
+            const signatureFragment = parseHTML(
+                this.document,
+                renderToString("html_editor.Signature", {
+                    signature: markup(currentUser.signature),
+                    signatureClass: SIGNATURE_CLASS,
+                })
+            );
+            const signatureBlock = signatureFragment.firstElementChild;
+            this.dependencies.dom.insert(signatureFragment);
+            if (signatureBlock) {
+                const lastPhrasingElement = [
+                    ...signatureBlock.querySelectorAll(paragraphRelatedElementsSelector),
+                ].at(-1);
+                if (lastPhrasingElement) {
+                    this.dependencies.selection.setCursorEnd(lastPhrasingElement);
+                } else {
+                    this.dependencies.selection.setCursorEnd(signatureBlock);
+                }
+            }
             this.dependencies.history.addStep();
+        }
+    }
+
+    isEmpty(element) {
+        if (
+            element.nodeType === Node.ELEMENT_NODE &&
+            element.matches(`.${SIGNATURE_CLASS}`) &&
+            isEmptyBlock(element)
+        ) {
+            return true;
         }
     }
 }

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -1,6 +1,7 @@
 import { Plugin } from "@html_editor/plugin";
+import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
 import { isBlock } from "@html_editor/utils/blocks";
-import { removeClass, splitTextNode } from "@html_editor/utils/dom";
+import { fillShrunkPhrasingParent, removeClass, splitTextNode } from "@html_editor/utils/dom";
 import {
     getDeepestPosition,
     isProtected,
@@ -46,7 +47,15 @@ function isUnremovableTableComponent(node, root) {
  */
 export class TablePlugin extends Plugin {
     static id = "table";
-    static dependencies = ["dom", "history", "selection", "delete", "split", "color"];
+    static dependencies = [
+        "baseContainer",
+        "dom",
+        "history",
+        "selection",
+        "delete",
+        "split",
+        "color",
+    ];
     static shared = [
         "insertTable",
         "addColumn",
@@ -119,7 +128,10 @@ export class TablePlugin extends Plugin {
     }
 
     createTable({ rows = 2, cols = 2 } = {}) {
-        const tdsHtml = new Array(cols).fill("<td><p><br></p></td>").join("");
+        const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+        fillShrunkPhrasingParent(baseContainer);
+        const baseContainerHtml = baseContainer.outerHTML;
+        const tdsHtml = new Array(cols).fill(`<td>${baseContainerHtml}</td>`).join("");
         const trsHtml = new Array(rows).fill(`<tr>${tdsHtml}</tr>`).join("");
         const tableHtml = `<table class="table table-bordered o_table"><tbody>${trsHtml}</tbody></table>`;
         return parseHTML(this.document, tableHtml);
@@ -148,7 +160,9 @@ export class TablePlugin extends Plugin {
     }
     insertTable({ rows = 2, cols = 2 } = {}) {
         const table = this._insertTable({ rows, cols });
-        this.dependencies.selection.setCursorStart(table.querySelector("p"));
+        this.dependencies.selection.setCursorStart(
+            table.querySelector(baseContainerGlobalSelector)
+        );
         this.dependencies.history.addStep();
     }
     /**
@@ -185,9 +199,9 @@ export class TablePlugin extends Plugin {
         }
         referenceColumn.forEach((cell, rowIndex) => {
             const newCell = this.document.createElement("td");
-            const p = this.document.createElement("p");
-            p.append(this.document.createElement("br"));
-            newCell.append(p);
+            const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+            baseContainer.append(this.document.createElement("br"));
+            newCell.append(baseContainer);
             cell[position](newCell);
             if (rowIndex === 0 && tableWidth) {
                 newCell.style.width = cell.style.width;
@@ -221,9 +235,9 @@ export class TablePlugin extends Plugin {
         newRow.append(
             ...Array.from(Array(cells.length)).map(() => {
                 const td = this.document.createElement("td");
-                const p = this.document.createElement("p");
-                p.append(this.document.createElement("br"));
-                td.append(p);
+                const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+                baseContainer.append(this.document.createElement("br"));
+                td.append(baseContainer);
                 return td;
             })
         );
@@ -338,11 +352,11 @@ export class TablePlugin extends Plugin {
         if (!table) {
             return;
         }
-        const p = this.document.createElement("p");
-        p.appendChild(this.document.createElement("br"));
-        table.before(p);
+        const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+        baseContainer.appendChild(this.document.createElement("br"));
+        table.before(baseContainer);
         table.remove();
-        this.dependencies.selection.setCursorStart(p);
+        this.dependencies.selection.setCursorStart(baseContainer);
     }
 
     // @todo @phoenix: handle deleteBackward on table cells

--- a/addons/html_editor/static/src/others/collaboration/collaboration_odoo_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_odoo_plugin.js
@@ -43,7 +43,7 @@ let ICE_SERVERS = null;
 
 export class CollaborationOdooPlugin extends Plugin {
     static id = "collaborationOdoo";
-    static dependencies = ["history", "collaboration", "selection"];
+    static dependencies = ["baseContainer", "history", "collaboration", "selection"];
     static shared = ["getPeerMetadata"];
     resources = {
         selectionchange_handlers: debounce(() => {
@@ -580,7 +580,8 @@ export class CollaborationOdooPlugin extends Plugin {
             return;
         }
 
-        let content = record[this.config.collaboration.collaborationChannel.collaborationFieldName];
+        const content =
+            record[this.config.collaboration.collaborationChannel.collaborationFieldName];
         const lastHistoryId = content && this.getLastHistoryStepId(content);
         // If a change was made in the document while retrieving it, the
         // lastHistoryId will be different if the odoo bus did not have time to
@@ -593,9 +594,12 @@ export class CollaborationOdooPlugin extends Plugin {
         }
 
         this.isDocumentStale = false;
-        content = content || "<p><br></p>";
-        // content here is trusted
-        this.editable.innerHTML = content;
+        if (content) {
+            // content here is trusted
+            this.editable.innerHTML = content;
+        } else {
+            this.editable.replaceChildren(this.dependencies.baseContainer.createBaseContainer());
+        }
         stripHistoryIds(this.editable);
         this.dispatchTo("normalize_handlers", this.editable);
 

--- a/addons/html_editor/static/src/others/qweb_plugin.js
+++ b/addons/html_editor/static/src/others/qweb_plugin.js
@@ -19,17 +19,20 @@ const isUnsplittableQWebElement = (node) =>
             "t-raw",
         ].some((attr) => node.getAttribute(attr)));
 
+const PROTECTED_QWEB_SELECTOR = "[t-esc], [t-raw], [t-out], [t-field]";
+
 export class QWebPlugin extends Plugin {
     static id = "qweb";
-    static dependencies = ["overlay", "selection"];
+    static dependencies = ["overlay", "protectedNode", "selection"];
     resources = {
         /** Handlers */
         selectionchange_handlers: this.onSelectionChange.bind(this),
         clean_handlers: this.clearDataAttributes.bind(this),
         clean_for_save_handlers: ({ root }) => {
             this.clearDataAttributes(root);
-            for (const element of root.querySelectorAll("[t-esc], [t-raw], [t-out], [t-field]")) {
+            for (const element of root.querySelectorAll(PROTECTED_QWEB_SELECTOR)) {
                 element.removeAttribute("contenteditable");
+                delete element.dataset.oeProtected;
             }
         },
         normalize_handlers: this.normalize.bind(this),
@@ -64,6 +67,18 @@ export class QWebPlugin extends Plugin {
         return true;
     }
 
+    isValidTargetForDomListener(ev) {
+        if (
+            ev.type === "click" &&
+            ev.target &&
+            closestElement(ev.target, PROTECTED_QWEB_SELECTOR)
+        ) {
+            // Allow clicking on a protected QWEB node to open the custom toolbar.
+            return true;
+        }
+        return super.isValidTargetForDomListener(ev);
+    }
+
     /**
      * @param { SelectionData } selectionData
      */
@@ -89,8 +104,8 @@ export class QWebPlugin extends Plugin {
     normalize(root) {
         this.normalizeInline(root);
 
-        for (const element of selectElements(root, "[t-esc], [t-raw], [t-out], [t-field]")) {
-            element.setAttribute("contenteditable", "false");
+        for (const element of selectElements(root, PROTECTED_QWEB_SELECTOR)) {
+            this.dependencies.protectedNode.setProtectingNode(element, true);
         }
         this.applyGroupQwebBranching(root);
     }

--- a/addons/html_editor/static/src/plugin.js
+++ b/addons/html_editor/static/src/plugin.js
@@ -37,12 +37,13 @@ export class Plugin {
 
     setup() {}
 
-    addDomListener(target, eventName, fn, capture) {
+    isValidTargetForDomListener(ev) {
+        return !isProtecting(ev.target) && (!isProtected(ev.target) || isUnprotecting(ev.target));
+    }
+
+    addDomListener(target, eventName, fn, capture = false) {
         const handler = (ev) => {
-            if (
-                !isProtecting(ev.target) &&
-                (!isProtected(ev.target) || isUnprotecting(ev.target))
-            ) {
+            if (this.isValidTargetForDomListener(ev)) {
                 fn?.call(this, ev);
             }
         };

--- a/addons/html_editor/static/src/plugin_sets.js
+++ b/addons/html_editor/static/src/plugin_sets.js
@@ -1,3 +1,4 @@
+import { BaseContainerPlugin } from "./core/base_container_plugin";
 import { ClipboardPlugin } from "./core/clipboard_plugin";
 import { CommentPlugin } from "./core/comment_plugin";
 import { DeletePlugin } from "./core/delete_plugin";
@@ -99,6 +100,7 @@ import { QWebPlugin } from "./others/qweb_plugin";
  */
 
 export const CORE_PLUGINS = [
+    BaseContainerPlugin,
     ClipboardPlugin,
     CommentPlugin,
     DeletePlugin,

--- a/addons/html_editor/static/src/utils/base_container.js
+++ b/addons/html_editor/static/src/utils/base_container.js
@@ -1,0 +1,46 @@
+export const BASE_CONTAINER_CLASS = "o-paragraph";
+
+export const SUPPORTED_BASE_CONTAINER_NAMES = ["P", "DIV"];
+
+/**
+ * @param {string} [nodeName] @see SUPPORTED_BASE_CONTAINER_NAMES
+ *                 will return the global selector if nodeName is not specified.
+ * @returns {string} selector for baseContainers.
+ */
+export function getBaseContainerSelector(nodeName) {
+    if (!nodeName) {
+        return baseContainerGlobalSelector;
+    }
+    nodeName = SUPPORTED_BASE_CONTAINER_NAMES.includes(nodeName) ? nodeName : "P";
+    let suffix = "";
+    if (nodeName !== "P") {
+        suffix = `.${BASE_CONTAINER_CLASS}`;
+    }
+    return `${nodeName}${suffix}`;
+}
+
+export const baseContainerGlobalSelector = SUPPORTED_BASE_CONTAINER_NAMES.map((name) =>
+    getBaseContainerSelector(name)
+).join(",");
+
+/**
+ * Create a new baseContainer element.
+ *
+ * @param {string} nodeName @see SUPPORTED_BASE_CONTAINER_NAMES
+ * @param {Document} [document] Used to create new baseContainer elements.
+ *                   For iframes, preferably use the iframe document.
+ *                   Fallbacks to the window document if possible and unspecified.
+ *                   Has to be specified otherwise.
+ * @returns {HTMLElement}
+ */
+export function createBaseContainer(nodeName, document) {
+    if (!document && window) {
+        document = window.document;
+    }
+    nodeName = nodeName && SUPPORTED_BASE_CONTAINER_NAMES.includes(nodeName) ? nodeName : "P";
+    const el = document.createElement(nodeName);
+    if (nodeName !== "P") {
+        el.className = BASE_CONTAINER_CLASS;
+    }
+    return el;
+}

--- a/addons/html_editor/static/src/utils/dom.js
+++ b/addons/html_editor/static/src/utils/dom.js
@@ -4,6 +4,10 @@ import { callbacksForCursorUpdate } from "./selection";
 import { isEmptyBlock, isPhrasingContent } from "../utils/dom_info";
 import { childNodes } from "./dom_traversal";
 import { childNodeIndex, DIRECTIONS } from "./position";
+import {
+    baseContainerGlobalSelector,
+    createBaseContainer,
+} from "@html_editor/utils/base_container";
 
 /** @typedef {import("@html_editor/core/selection_plugin").Cursors} Cursors */
 
@@ -40,11 +44,14 @@ export function makeContentsInline(node) {
  * @param {HTMLElement} element - block element
  * @param {Cursors} [cursors]
  */
-export function wrapInlinesInBlocks(element, cursors = { update: () => {} }) {
+export function wrapInlinesInBlocks(
+    element,
+    { baseContainerNodeName = "P", cursors = { update: () => {} } } = {}
+) {
     // Helpers to manipulate preserving selection.
     const wrapInBlock = (node, cursors) => {
         const block = isPhrasingContent(node)
-            ? node.ownerDocument.createElement("P")
+            ? createBaseContainer(baseContainerNodeName, node.ownerDocument)
             : node.ownerDocument.createElement("DIV");
         cursors.update(callbacksForCursorUpdate.append(block, node));
         cursors.update(callbacksForCursorUpdate.before(node, block));
@@ -61,8 +68,8 @@ export function wrapInlinesInBlocks(element, cursors = { update: () => {} }) {
         return block;
     };
     const appendToCurrentBlock = (currentBlock, node, cursors) => {
-        if (currentBlock.tagName === "P" && !isPhrasingContent(node)) {
-            const block = document.createElement("DIV");
+        if (currentBlock.matches(baseContainerGlobalSelector) && !isPhrasingContent(node)) {
+            const block = currentBlock.ownerDocument.createElement("DIV");
             cursors.update(callbacksForCursorUpdate.before(currentBlock, block));
             currentBlock.before(block);
             for (const child of childNodes(currentBlock)) {

--- a/addons/html_editor/static/src/utils/dom.js
+++ b/addons/html_editor/static/src/utils/dom.js
@@ -208,14 +208,16 @@ export function fillShrunkPhrasingParent(el) {
  * is not a BR, remove the BR.
  *
  * @param {HTMLElement} el
+ * @param {Array} predicates exceptions where a trailing BR should not be removed
  * @returns {HTMLElement|undefined} the removed br, if any
  */
-export function cleanTrailingBR(el) {
+export function cleanTrailingBR(el, predicates = []) {
     const candidate = el?.lastChild;
     if (
         candidate?.nodeName === "BR" &&
         candidate.previousSibling?.nodeName !== "BR" &&
-        !isEmptyBlock(el)
+        !isEmptyBlock(el) &&
+        !predicates.some((predicate) => predicate(candidate))
     ) {
         candidate.remove();
         return candidate;

--- a/addons/html_editor/static/src/utils/dom.js
+++ b/addons/html_editor/static/src/utils/dom.js
@@ -123,6 +123,7 @@ export function unwrapContents(node) {
 // This utils seem to handle a particular case of LI element.
 // If only relevant to the list plugin, a specific util should be created
 // that plugin instead.
+// TODO: deprecated, use the DomPlugin shared function instead.
 export function setTagName(el, newTagName) {
     const document = el.ownerDocument;
     if (el.tagName === newTagName) {

--- a/addons/html_editor/static/src/utils/dom.js
+++ b/addons/html_editor/static/src/utils/dom.js
@@ -1,5 +1,5 @@
 import { closestBlock, isBlock } from "./blocks";
-import { isShrunkBlock, isVisible, paragraphRelatedElements } from "./dom_info";
+import { isParagraphRelatedElement, isShrunkBlock, isVisible } from "./dom_info";
 import { callbacksForCursorUpdate } from "./selection";
 import { isEmptyBlock, isPhrasingContent } from "../utils/dom_info";
 import { childNodes } from "./dom_traversal";
@@ -19,7 +19,7 @@ export function makeContentsInline(node) {
     let childIndex = 0;
     for (const child of node.childNodes) {
         if (isBlock(child)) {
-            if (childIndex && paragraphRelatedElements.includes(child.nodeName)) {
+            if (childIndex && isParagraphRelatedElement(child)) {
                 child.before(document.createElement("br"));
             }
             for (const grandChild of child.childNodes) {

--- a/addons/html_editor/static/src/utils/dom.js
+++ b/addons/html_editor/static/src/utils/dom.js
@@ -46,9 +46,17 @@ export function wrapInlinesInBlocks(element, cursors = { update: () => {} }) {
         const block = isPhrasingContent(node)
             ? node.ownerDocument.createElement("P")
             : node.ownerDocument.createElement("DIV");
-        cursors.update(callbacksForCursorUpdate.before(node, block));
-        node.before(block);
         cursors.update(callbacksForCursorUpdate.append(block, node));
+        cursors.update(callbacksForCursorUpdate.before(node, block));
+        if (node.nextSibling) {
+            const sibling = node.nextSibling;
+            node.remove();
+            sibling.before(block);
+        } else {
+            const parent = node.parentElement;
+            node.remove();
+            parent.append(block);
+        }
         block.append(node);
         return block;
     };

--- a/addons/html_editor/static/src/utils/dom.js
+++ b/addons/html_editor/static/src/utils/dom.js
@@ -65,7 +65,7 @@ export function wrapInlinesInBlocks(element, cursors = { update: () => {} }) {
             const block = document.createElement("DIV");
             cursors.update(callbacksForCursorUpdate.before(currentBlock, block));
             currentBlock.before(block);
-            for (const child of [...currentBlock.childNodes]) {
+            for (const child of childNodes(currentBlock)) {
                 cursors.update(callbacksForCursorUpdate.append(block, child));
                 block.append(child);
             }

--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -1,3 +1,4 @@
+import { baseContainerGlobalSelector } from "./base_container";
 import { closestBlock, isBlock } from "./blocks";
 import { childNodes, closestElement, firstLeaf, lastLeaf } from "./dom_traversal";
 import { DIRECTIONS, nodeSize } from "./position";
@@ -390,6 +391,37 @@ export function isPhrasingContent(node) {
     return false;
 }
 
+export function containsAnyInline(element) {
+    if (!element) {
+        return false;
+    }
+    let child = element.firstChild;
+    while (child) {
+        if (
+            (!isBlock(child) && child.nodeType === Node.ELEMENT_NODE) ||
+            (child.nodeType === Node.TEXT_NODE && child.textContent.trim() !== "")
+        ) {
+            return true;
+        }
+        child = child.nextSibling;
+    }
+    return false;
+}
+
+export function containsAnyNonPhrasingContent(element) {
+    if (!element) {
+        return false;
+    }
+    let child = element.firstChild;
+    while (child) {
+        if (!isPhrasingContent(child)) {
+            return true;
+        }
+        child = child.nextSibling;
+    }
+    return false;
+}
+
 /**
  * A "protected" node will have its mutations filtered and not be registered
  * in an history step. Some editor features like selection handling, command
@@ -439,7 +471,8 @@ export function isUnprotecting(node) {
 }
 
 // This is a list of "paragraph-related elements", defined as elements that
-// behave like paragraphs.
+// behave like paragraphs. It is non-exhaustive and should not be used as a
+// standalone. @see isParagraphRelatedElement
 // TODO add: this list should contain PRE, but the spec currently is to
 // paste flow content inside the PRE, so it is removed temporarily.
 export const paragraphRelatedElements = ["P", "H1", "H2", "H3", "H4", "H5", "H6"];
@@ -483,10 +516,16 @@ export function isParagraphRelatedElement(node) {
     if (!node) {
         return false;
     }
-    return paragraphRelatedElements.includes(node.nodeName);
+    return (
+        paragraphRelatedElements.includes(node.nodeName) ||
+        (node.nodeType === Node.ELEMENT_NODE && node.matches(baseContainerGlobalSelector))
+    );
 }
 
-export const paragraphRelatedElementsSelector = paragraphRelatedElements.join(",");
+export const paragraphRelatedElementsSelector = [
+    ...paragraphRelatedElements,
+    baseContainerGlobalSelector,
+].join(",");
 
 export function isListItemElement(node) {
     return [...listItem].includes(node.nodeName);
@@ -506,11 +545,15 @@ export const listElementSelector = [...listContainers].join(",");
  * @returns {boolean}
  */
 export function isAllowedContent(parentBlock, nodes) {
-    const allowedContentSet = allowedContent[parentBlock.nodeName];
+    let allowedContentSet = allowedContent[parentBlock.nodeName];
     if (!allowedContentSet) {
         // Spec: a block not listed in allowedContent allows anything.
         // See "custom-block" in tests.
         return true;
+    }
+    if (parentBlock.matches(baseContainerGlobalSelector)) {
+        // A baseContainer DIV can only have phrasingContent, as a P would.
+        allowedContentSet = phrasingContent;
     }
     return nodes.every((node) => allowedContentSet.has(node.nodeName));
 }

--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -440,7 +440,9 @@ export function isUnprotecting(node) {
 
 // This is a list of "paragraph-related elements", defined as elements that
 // behave like paragraphs.
-export const paragraphRelatedElements = ["P", "H1", "H2", "H3", "H4", "H5", "H6", "PRE"];
+// TODO add: this list should contain PRE, but the spec currently is to
+// paste flow content inside the PRE, so it is removed temporarily.
+export const paragraphRelatedElements = ["P", "H1", "H2", "H3", "H4", "H5", "H6"];
 
 /**
  * Return true if the given node allows "paragraph-related elements".
@@ -472,7 +474,7 @@ const allowedContent = {
     OL: listItem,
     UL: listItem,
     P: phrasingContent,
-    PRE: phrasingContent,
+    PRE: flowContent, // HTML spec: phrasing content
     TD: flowContent,
     TR: new Set(["TD"]),
 };

--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -1,5 +1,5 @@
 import { closestBlock, isBlock } from "./blocks";
-import { closestElement, firstLeaf, lastLeaf } from "./dom_traversal";
+import { childNodes, closestElement, firstLeaf, lastLeaf } from "./dom_traversal";
 import { DIRECTIONS, nodeSize } from "./position";
 
 export function isEmpty(el) {
@@ -259,7 +259,7 @@ export function isVisible(node) {
     );
 }
 export function hasVisibleContent(node) {
-    return [...(node?.childNodes || [])].some((n) => isVisible(n));
+    return (node ? childNodes(node) : []).some((n) => isVisible(n));
 }
 
 export function isZwnbsp(node) {
@@ -271,7 +271,7 @@ export function isTangible(node) {
 }
 
 export function hasTangibleContent(node) {
-    return [...(node?.childNodes || [])].some((n) => isTangible(n));
+    return (node ? childNodes(node) : []).some((n) => isTangible(n));
 }
 
 export const isNotEditableNode = (node) =>
@@ -562,8 +562,9 @@ export function getDeepestPosition(node, offset) {
                 [node, offset] = [next, direction ? 0 : nodeSize(next)];
             }
             // First switch direction to left if offset is at the end.
-            direction = offset < node.childNodes.length;
-            next = node.childNodes[direction ? offset : offset - 1];
+            const childrenNodes = childNodes(node);
+            direction = offset < childrenNodes.length;
+            next = childrenNodes[direction ? offset : offset - 1];
         } else if (direction && next.nextSibling && closestBlock(node).contains(next.nextSibling)) {
             // Invalid node: skip to next sibling (without crossing blocks).
             next = next.nextSibling;

--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -440,17 +440,7 @@ export function isUnprotecting(node) {
 
 // This is a list of "paragraph-related elements", defined as elements that
 // behave like paragraphs.
-export const paragraphRelatedElements = [
-    "P",
-    "H1",
-    "H2",
-    "H3",
-    "H4",
-    "H5",
-    "H6",
-    "PRE",
-    "BLOCKQUOTE",
-];
+export const paragraphRelatedElements = ["P", "H1", "H2", "H3", "H4", "H5", "H6", "PRE"];
 
 /**
  * Return true if the given node allows "paragraph-related elements".
@@ -460,15 +450,16 @@ export const paragraphRelatedElements = [
  * @returns {boolean}
  */
 export function allowsParagraphRelatedElements(node) {
-    return isBlock(node) && !["P", "H1", "H2", "H3", "H4", "H5", "H6"].includes(node.nodeName);
+    return isBlock(node) && !isParagraphRelatedElement(node);
 }
 
 export const phrasingContent = new Set(["#text", ...phrasingTagNames]);
 const flowContent = new Set([...phrasingContent, ...paragraphRelatedElements, "DIV", "HR"]);
 export const listItem = new Set(["LI"]);
+const listContainers = new Set(["UL", "OL"]);
 
 const allowedContent = {
-    BLOCKQUOTE: phrasingContent, // HTML spec: flow content
+    BLOCKQUOTE: flowContent,
     DIV: flowContent,
     H1: phrasingContent,
     H2: phrasingContent,
@@ -485,6 +476,27 @@ const allowedContent = {
     TD: flowContent,
     TR: new Set(["TD"]),
 };
+
+export function isParagraphRelatedElement(node) {
+    if (!node) {
+        return false;
+    }
+    return paragraphRelatedElements.includes(node.nodeName);
+}
+
+export const paragraphRelatedElementsSelector = paragraphRelatedElements.join(",");
+
+export function isListItemElement(node) {
+    return [...listItem].includes(node.nodeName);
+}
+
+export const listItemElementSelector = [...listItem].join(",");
+
+export function isListElement(node) {
+    return [...listContainers].includes(node.nodeName);
+}
+
+export const listElementSelector = [...listContainers].join(",");
 
 /**
  * @param {Element} parentBlock

--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -664,5 +664,12 @@ export function isElement(node) {
 
 export function isContentEditable(node) {
     const element = isTextNode(node) ? node.parentElement : node;
-    return element.isContentEditable;
+    return element && element.isContentEditable;
+}
+
+export function isContentEditableAncestor(node) {
+    if (node.nodeType !== Node.ELEMENT_NODE) {
+        return false;
+    }
+    return node.isContentEditable && node.matches("[contenteditable]");
 }

--- a/addons/html_editor/static/src/utils/list.js
+++ b/addons/html_editor/static/src/utils/list.js
@@ -1,5 +1,6 @@
 import { removeClass, setTagName } from "./dom";
 
+// Deprecated, use the ListPlugin shared function instead.
 export function getListMode(pnode) {
     if (!["UL", "OL"].includes(pnode.tagName)) {
         return;
@@ -11,10 +12,13 @@ export function getListMode(pnode) {
 }
 
 /**
+ * Deprecated, use the ListPlugin shared function instead.
+ *
  * Switches the list mode of the given list element.
  *
  * @param {HTMLOListElement|HTMLUListElement} list - The list element to switch the mode of.
  * @param {"UL"|"OL"|"CL"} newMode - The new mode to switch to.
+ * @param {Object} options
  * @returns {HTMLOListElement|HTMLUListElement} The modified list element.
  */
 export function switchListMode(list, newMode) {
@@ -41,12 +45,15 @@ export function switchListMode(list, newMode) {
 }
 
 /**
+ * Deprecated, use the ListPlugin shared function instead.
+ *
  * Converts a list element and its nested elements to the given list mode.
  *
  * @see switchListMode
  * @param {HTMLUListElement|HTMLOListElement|HTMLLIElement} node - HTML element
  * representing a list or list item.
  * @param {string} newMode - Target list mode
+ * @param {Object} options
  * @returns {HTMLUListElement|HTMLOListElement|HTMLLIElement} node - Modified
  * list element after conversion.
  */

--- a/addons/html_editor/static/src/utils/position.js
+++ b/addons/html_editor/static/src/utils/position.js
@@ -73,5 +73,10 @@ export function childNodeIndex(node) {
  */
 export function nodeSize(node) {
     const isTextNode = node.nodeType === Node.TEXT_NODE;
-    return isTextNode ? node.length : node.childNodes.length;
+    if (isTextNode) {
+        return node.length;
+    } else {
+        const child = node.lastChild;
+        return child ? childNodeIndex(child) + 1 : 0;
+    }
 }

--- a/addons/html_editor/static/src/utils/sanitize.js
+++ b/addons/html_editor/static/src/utils/sanitize.js
@@ -1,60 +1,18 @@
-import { isBlock } from "./blocks";
-import { isPhrasingContent } from "../utils/dom_info";
-
-// @todo @phoenix: consider using the wrapInlinesInBlocks utils instead.
+import { containsAnyInline } from "./dom_info";
+import { wrapInlinesInBlocks } from "./dom";
 
 export function initElementForEdition(element, options = {}) {
-    const document = element.ownerDocument;
-    // Detect if the editable base element contain orphan inline nodes. If
-    // so we transform the base element HTML to put those orphans inside
-    // `<p>` containers.
-    const orphanInlineChildNodes = [...element.childNodes].find(
-        (n) => !isBlock(n) && (n.nodeType === Node.ELEMENT_NODE || n.textContent.trim() !== "")
-    );
-    if (orphanInlineChildNodes && !options.allowInlineAtRoot) {
-        const childNodes = [...element.childNodes];
-        const blockMap = new WeakMap();
-        for (const node of childNodes) {
-            blockMap.set(node, isBlock(node));
-        }
-        const newChildren = [];
-        let currentBlock = document.createElement("DIV");
-        let hasOnlyPhrasingContent = true;
-        currentBlock.style.marginBottom = "0";
-        for (let i = 0; i < childNodes.length; i++) {
-            const node = childNodes[i];
-            const nodeIsBlock = blockMap.get(node);
-            const nodeIsBR = node.nodeName === "BR";
-            // Append to the P unless child is block or an unneeded BR.
-            if (!(nodeIsBlock || (nodeIsBR && currentBlock.hasChildNodes()))) {
-                currentBlock.append(node);
-                if (!isPhrasingContent(node)) {
-                    hasOnlyPhrasingContent = false;
-                }
-            }
-            // Break paragraphs on blocks and BR.
-            if (nodeIsBlock || nodeIsBR || childNodes.length === i + 1) {
-                if (hasOnlyPhrasingContent) {
-                    const block = document.createElement("P");
-                    block.style.marginBottom = "0";
-                    block.replaceChildren(...currentBlock.childNodes);
-                    currentBlock = block;
-                }
-                // Ensure we don't add an empty P or a P containing only
-                // formating spaces that should not be visible.
-                if (currentBlock.hasChildNodes() && currentBlock.innerHTML.trim() !== "") {
-                    newChildren.push(currentBlock);
-                }
-                currentBlock = document.createElement("DIV");
-                currentBlock.style.marginBottom = "0";
-                hasOnlyPhrasingContent = true;
-                // Append block children directly to the template.
-                if (nodeIsBlock) {
-                    newChildren.push(node);
-                }
-            }
-        }
-        element.replaceChildren(...newChildren);
+    if (
+        element?.nodeType === Node.ELEMENT_NODE &&
+        containsAnyInline(element) &&
+        !options.allowInlineAtRoot
+    ) {
+        // No matter the inline content, it will be wrapped in a DIV to try
+        // and match the current style of the content as much as possible.
+        // (P has a margin-bottom, DIV does not).
+        wrapInlinesInBlocks(element, {
+            baseContainerNodeName: "DIV",
+        });
     }
 }
 

--- a/addons/html_editor/static/tests/banner.test.js
+++ b/addons/html_editor/static/tests/banner.test.js
@@ -6,6 +6,7 @@ import { getContent, setSelection } from "./_helpers/selection";
 import { insertText } from "./_helpers/user_actions";
 import { loader } from "@web/core/emoji_picker/emoji_picker";
 import { execCommand } from "./_helpers/userCommands";
+import { unformat } from "./_helpers/format";
 
 test("should insert a banner with focus inside followed by a paragraph", async () => {
     const { el, editor } = await setupEditor("<p>Test[]</p>");
@@ -14,13 +15,15 @@ test("should insert a banner with focus inside followed by a paragraph", async (
     expect(".active .o-we-command-name").toHaveText("Banner Info");
 
     await press("enter");
-    expect(getContent(el)).toBe(
-        `<p>Test</p><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
-                <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
-                <div class="w-100 px-3" contenteditable="true">
-                    <p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>
-                </div>
-            </div><p><br></p>`
+    expect(unformat(getContent(el))).toBe(
+        unformat(
+            `<p>Test</p><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
+                    <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
+                    <div class="w-100 px-3" contenteditable="true">
+                        <p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>
+                    </div>
+                </div><p><br></p>`
+        )
     );
 
     await insertText(editor, "/");
@@ -44,13 +47,15 @@ test("press 'ctrl+a' inside a banner should select all the banner content", asyn
     });
     await insertText(editor, "Test2");
     await press(["ctrl", "a"]);
-    expect(getContent(el)).toBe(
-        `<p>Test</p><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
-                <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
-                <div class="w-100 px-3" contenteditable="true">[
-                    <p>Test1</p><p>Test2<br></p>
-                ]</div>
-            </div><p><br></p>`
+    expect(unformat(getContent(el))).toBe(
+        unformat(
+            `<p>Test</p><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
+                    <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
+                    <div class="w-100 px-3" contenteditable="true">[
+                        <p>Test1</p><p>Test2<br></p>
+                    ]</div>
+                </div><p><br></p>`
+        )
     );
 });
 
@@ -64,21 +69,25 @@ test("remove all content should preserves the first paragraph tag inside the ban
     });
     await insertText(editor, "Test2");
     await press(["ctrl", "a"]);
-    expect(getContent(el)).toBe(
-        `<p>Test</p><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
-                <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
-                <div class="w-100 px-3" contenteditable="true">[
-                    <p>Test1</p><p>Test2<br></p>
-                ]</div>
-            </div><p><br></p>`
+    expect(unformat(getContent(el))).toBe(
+        unformat(
+            `<p>Test</p><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
+                    <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
+                    <div class="w-100 px-3" contenteditable="true">[
+                        <p>Test1</p><p>Test2<br></p>
+                    ]</div>
+                </div><p><br></p>`
+        )
     );
 
     await press("Backspace");
-    expect(getContent(el)).toBe(
-        `<p>Test</p><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
-                <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
-                <div class="w-100 px-3" contenteditable="true"><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p></div>
-            </div><p><br></p>`
+    expect(unformat(getContent(el))).toBe(
+        unformat(
+            `<p>Test</p><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
+                    <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
+                    <div class="w-100 px-3" contenteditable="true"><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p></div>
+                </div><p><br></p>`
+        )
     );
 });
 
@@ -94,13 +103,15 @@ test("Everything gets selected with ctrl+a, including a contenteditable=false as
     });
     await insertText(editor, "Test2");
     await press(["ctrl", "a"]);
-    expect(getContent(el)).toBe(
-        `[\u200b<div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
-                <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
-                <div class="w-100 px-3" contenteditable="true">
-                    <p><br></p>
-                </div>
-            </div><p>Test1</p><p>Test2<br></p>]`,
+    expect(unformat(getContent(el))).toBe(
+        unformat(
+            `[\u200b<div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
+                    <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
+                    <div class="w-100 px-3" contenteditable="true">
+                        <p><br></p>
+                    </div>
+                </div><p>Test1</p><p>Test2<br></p>]`
+        ),
         { message: "should select everything" }
     );
 
@@ -146,13 +157,15 @@ test("add banner inside empty list", async () => {
     const { el, editor } = await setupEditor("<ul><li>[]<br></li></ul>");
     await insertText(editor, "/bannerinfo");
     await press("enter");
-    expect(getContent(el)).toBe(
-        `<ul><li><br><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
-                <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
-                <div class="w-100 px-3" contenteditable="true">
-                    <p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>
-                </div>
-            </div><br></li></ul>`
+    expect(unformat(getContent(el))).toBe(
+        unformat(
+            `<ul><li><br><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
+                    <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
+                    <div class="w-100 px-3" contenteditable="true">
+                        <p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>
+                    </div>
+                </div><br></li></ul>`
+        )
     );
 });
 
@@ -160,12 +173,14 @@ test("add banner inside non-empty list", async () => {
     const { el, editor } = await setupEditor("<ul><li>Test[]</li></ul>");
     await insertText(editor, "/bannerinfo");
     await press("enter");
-    expect(getContent(el)).toBe(
-        `<ul><li>Test<div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
-                <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
-                <div class="w-100 px-3" contenteditable="true">
-                    <p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>
-                </div>
-            </div><br></li></ul>`
+    expect(unformat(getContent(el))).toBe(
+        unformat(
+            `<ul><li>Test<div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
+                    <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
+                    <div class="w-100 px-3" contenteditable="true">
+                        <p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>
+                    </div>
+                </div><br></li></ul>`
+        )
     );
 });

--- a/addons/html_editor/static/tests/collaboration.test.js
+++ b/addons/html_editor/static/tests/collaboration.test.js
@@ -470,7 +470,9 @@ describe("sanitize", () => {
                     peerInfos.c1.historyPlugin.steps[2],
                 ]);
                 execCommand(peerInfos.c2.editor, "historyUndo");
-                expect(peerInfos.c2.editor.editable).toHaveInnerHTML("<p>a</p><div><i>b</i></div>");
+                expect(peerInfos.c2.editor.editable).toHaveInnerHTML(
+                    `<p>a</p><div class="o-paragraph"><i>b</i></div>`
+                );
             },
         });
     });
@@ -512,7 +514,7 @@ describe("sanitize", () => {
                 execCommand(editor, "historyRedo");
             },
             contentAfter:
-                '<div contenteditable="true" placeholder="Type &quot;/&quot; for commands" class="o-we-hint">[c1}{c1]<br></div>',
+                '<div contenteditable="true" class="o-paragraph o-we-hint" placeholder="Type &quot;/&quot; for commands">[c1}{c1]<br></div>',
         });
     });
     test("should not sanitize the content of an element recursively when sanitizing an attribute", async () => {
@@ -749,7 +751,7 @@ describe("serialize/unserialize", () => {
         });
         mergePeersSteps(peerInfos);
         validateSameHistory(peerInfos);
-        validateContent(peerInfos, "<p>x</p><div>b<div>a</div></div>");
+        validateContent(peerInfos, `<p>x</p><div>b<div class="o-paragraph">a</div></div>`);
     });
 });
 
@@ -1229,7 +1231,7 @@ describe("Collaboration with embedded components", () => {
         test("A peer change to the embedded state is properly applied for every other collaborator", async () => {
             const peerInfos = await setupMultiEditor({
                 peerIds: ["c1", "c2"],
-                contentBefore: `<div>a[c1}{c1][c2}{c2]<span data-embedded="counter" data-embedded-props='{"value":1}'></span></div>`,
+                contentBefore: `<p>a[c1}{c1][c2}{c2]<span data-embedded="counter" data-embedded-props='{"value":1}'></span></p>`,
                 Plugins: [EmbeddedComponentPlugin],
                 resources: {
                     embedded_components: [savedCounter],
@@ -1242,20 +1244,20 @@ describe("Collaboration with embedded components", () => {
             const counter2 = [...peerInfos.c2.plugins.get("embeddedComponents").components][0].root
                 .node.component;
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":1}' data-oe-protected="true"><span class="counter">Counter:1</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":1}' data-oe-protected="true"><span class="counter">Counter:1</span></span></p>`
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":1}' data-oe-protected="true"><span class="counter">Counter:1</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":1}' data-oe-protected="true"><span class="counter">Counter:1</span></span></p>`
             );
             counter1.embeddedState.value = 3;
             await animationFrame();
             mergePeersSteps(peerInfos);
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":3}' data-embedded-state='{"stateChangeId":1,"previous":{"value":1},"next":{"value":3}}' data-oe-protected="true"><span class="counter">Counter:3</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":3}' data-embedded-state='{"stateChangeId":1,"previous":{"value":1},"next":{"value":3}}' data-oe-protected="true"><span class="counter">Counter:3</span></span></p>`
             );
             await animationFrame();
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":3}' data-embedded-state='{"stateChangeId":1,"previous":{"value":1},"next":{"value":3}}' data-oe-protected="true"><span class="counter">Counter:3</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":3}' data-embedded-state='{"stateChangeId":1,"previous":{"value":1},"next":{"value":3}}' data-oe-protected="true"><span class="counter">Counter:3</span></span></p>`
             );
             expect(counter2.embeddedState).toEqual({
                 value: 3,
@@ -1264,11 +1266,11 @@ describe("Collaboration with embedded components", () => {
             await animationFrame();
             mergePeersSteps(peerInfos);
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":5}' data-embedded-state='{"stateChangeId":2,"previous":{"value":3},"next":{"value":5}}' data-oe-protected="true"><span class="counter">Counter:5</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":5}' data-embedded-state='{"stateChangeId":2,"previous":{"value":3},"next":{"value":5}}' data-oe-protected="true"><span class="counter">Counter:5</span></span></p>`
             );
             await animationFrame();
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":5}' data-embedded-state='{"stateChangeId":2,"previous":{"value":3},"next":{"value":5}}' data-oe-protected="true"><span class="counter">Counter:5</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":5}' data-embedded-state='{"stateChangeId":2,"previous":{"value":3},"next":{"value":5}}' data-oe-protected="true"><span class="counter">Counter:5</span></span></p>`
             );
             expect(counter1.embeddedState).toEqual({
                 value: 5,
@@ -1285,7 +1287,7 @@ describe("Collaboration with embedded components", () => {
             // to the state before his own last undo.
             const peerInfos = await setupMultiEditor({
                 peerIds: ["c1", "c2"],
-                contentBefore: `<div>a[c1}{c1][c2}{c2]<span data-embedded="counter" data-embedded-props='{"value":1}'></span></div>`,
+                contentBefore: `<p>a[c1}{c1][c2}{c2]<span data-embedded="counter" data-embedded-props='{"value":1}'></span></p>`,
                 Plugins: [EmbeddedComponentPlugin],
                 resources: {
                     embedded_components: [savedCounter],
@@ -1306,10 +1308,10 @@ describe("Collaboration with embedded components", () => {
             mergePeersSteps(peerInfos);
             await animationFrame();
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":3}' data-embedded-state='{"stateChangeId":2,"previous":{"value":2},"next":{"value":3}}' data-oe-protected="true"><span class="counter">Counter:3</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":3}' data-embedded-state='{"stateChangeId":2,"previous":{"value":2},"next":{"value":3}}' data-oe-protected="true"><span class="counter">Counter:3</span></span></p>`
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":3}' data-embedded-state='{"stateChangeId":2,"previous":{"value":2},"next":{"value":3}}' data-oe-protected="true"><span class="counter">Counter:3</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":3}' data-embedded-state='{"stateChangeId":2,"previous":{"value":2},"next":{"value":3}}' data-oe-protected="true"><span class="counter">Counter:3</span></span></p>`
             );
             // e2 last step was to go from 1 to 2. e2 can not undo step from e1
             // therefore undo does 3 -> 1
@@ -1318,10 +1320,10 @@ describe("Collaboration with embedded components", () => {
             mergePeersSteps(peerInfos);
             await animationFrame();
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":1}' data-embedded-state='{"stateChangeId":3,"previous":{"value":3},"next":{"value":1}}' data-oe-protected="true"><span class="counter">Counter:1</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":1}' data-embedded-state='{"stateChangeId":3,"previous":{"value":3},"next":{"value":1}}' data-oe-protected="true"><span class="counter">Counter:1</span></span></p>`
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":1}' data-embedded-state='{"stateChangeId":3,"previous":{"value":3},"next":{"value":1}}' data-oe-protected="true"><span class="counter">Counter:1</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":1}' data-embedded-state='{"stateChangeId":3,"previous":{"value":3},"next":{"value":1}}' data-oe-protected="true"><span class="counter">Counter:1</span></span></p>`
             );
             // e1 last step was to go from 2 to 3. e1 can not undo step from e2
             // therefore undo does 1 -> 2
@@ -1330,10 +1332,10 @@ describe("Collaboration with embedded components", () => {
             mergePeersSteps(peerInfos);
             await animationFrame();
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":2}' data-embedded-state='{"stateChangeId":4,"previous":{"value":1},"next":{"value":2}}' data-oe-protected="true"><span class="counter">Counter:2</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":2}' data-embedded-state='{"stateChangeId":4,"previous":{"value":1},"next":{"value":2}}' data-oe-protected="true"><span class="counter">Counter:2</span></span></p>`
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":2}' data-embedded-state='{"stateChangeId":4,"previous":{"value":1},"next":{"value":2}}' data-oe-protected="true"><span class="counter">Counter:2</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":2}' data-embedded-state='{"stateChangeId":4,"previous":{"value":1},"next":{"value":2}}' data-oe-protected="true"><span class="counter">Counter:2</span></span></p>`
             );
             // e2 last undo was to go from 3 -> 1. e2 can not redo step from e1
             // therefore redo does 2 -> 3
@@ -1342,10 +1344,10 @@ describe("Collaboration with embedded components", () => {
             mergePeersSteps(peerInfos);
             await animationFrame();
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":3}' data-embedded-state='{"stateChangeId":5,"previous":{"value":2},"next":{"value":3}}' data-oe-protected="true"><span class="counter">Counter:3</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":3}' data-embedded-state='{"stateChangeId":5,"previous":{"value":2},"next":{"value":3}}' data-oe-protected="true"><span class="counter">Counter:3</span></span></p>`
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":3}' data-embedded-state='{"stateChangeId":5,"previous":{"value":2},"next":{"value":3}}' data-oe-protected="true"><span class="counter">Counter:3</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":3}' data-embedded-state='{"stateChangeId":5,"previous":{"value":2},"next":{"value":3}}' data-oe-protected="true"><span class="counter">Counter:3</span></span></p>`
             );
             // e1 last undo was to go from 1 -> 2. redo does 3 -> 1.
             redo(e1);
@@ -1353,10 +1355,10 @@ describe("Collaboration with embedded components", () => {
             mergePeersSteps(peerInfos);
             await animationFrame();
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":1}' data-embedded-state='{"stateChangeId":6,"previous":{"value":3},"next":{"value":1}}' data-oe-protected="true"><span class="counter">Counter:1</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":1}' data-embedded-state='{"stateChangeId":6,"previous":{"value":3},"next":{"value":1}}' data-oe-protected="true"><span class="counter">Counter:1</span></span></p>`
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":1}' data-embedded-state='{"stateChangeId":6,"previous":{"value":3},"next":{"value":1}}' data-oe-protected="true"><span class="counter">Counter:1</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":1}' data-embedded-state='{"stateChangeId":6,"previous":{"value":3},"next":{"value":1}}' data-oe-protected="true"><span class="counter">Counter:1</span></span></p>`
             );
         });
 
@@ -1440,7 +1442,7 @@ describe("Collaboration with embedded components", () => {
         test("New component with an embedded state received from a collaborator can have its state when it hasn't finished being mounted", async () => {
             const peerInfos = await setupMultiEditor({
                 peerIds: ["c1", "c2"],
-                contentBefore: `<div>a[c1}{c1][c2}{c2]</div>`,
+                contentBefore: `<p>a[c1}{c1][c2}{c2]</p>`,
                 Plugins: [EmbeddedComponentPlugin],
                 resources: {
                     embedded_components: [savedCounter],
@@ -1461,20 +1463,20 @@ describe("Collaboration with embedded components", () => {
             counter2.embeddedState.value = 3;
             await animationFrame();
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<div>a<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":3}' data-embedded-state='{"stateChangeId":1,"previous":{"value":1},"next":{"value":3}}' data-oe-protected="true"><span class="counter">Counter:3</span></span>[]</div>`
+                `<p>a<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":3}' data-embedded-state='{"stateChangeId":1,"previous":{"value":1},"next":{"value":3}}' data-oe-protected="true"><span class="counter">Counter:3</span></span>[]</p>`
             );
             insert(e1, "bc");
-            expect(getContent(e1.editable, { sortAttrs: true })).toBe(`<div>abc[]</div>`);
+            expect(getContent(e1.editable, { sortAttrs: true })).toBe(`<p>abc[]</p>`);
             mergePeersSteps(peerInfos);
             await animationFrame();
             // TODO @phoenix: selection should be at the end of the span for e2,
             // but it was not correctly updated after external steps. To update
             // when the selection is properly handled in collaboration.
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<div>abc[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":3}' data-embedded-state='{"stateChangeId":1,"previous":{"value":1},"next":{"value":3}}' data-oe-protected="true"><span class="counter">Counter:3</span></span></div>`
+                `<p>abc[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":3}' data-embedded-state='{"stateChangeId":1,"previous":{"value":1},"next":{"value":3}}' data-oe-protected="true"><span class="counter">Counter:3</span></span></p>`
             );
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<div>abc[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":3}' data-embedded-state='{"stateChangeId":1,"previous":{"value":1},"next":{"value":3}}' data-oe-protected="true"><span class="counter">Counter:3</span></span></div>`
+                `<p>abc[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":3}' data-embedded-state='{"stateChangeId":1,"previous":{"value":1},"next":{"value":3}}' data-oe-protected="true"><span class="counter">Counter:3</span></span></p>`
             );
         });
 
@@ -1555,7 +1557,7 @@ describe("Collaboration with embedded components", () => {
         test("Collaborative state changes can be applied while a current change is still pending", async () => {
             const peerInfos = await setupMultiEditor({
                 peerIds: ["c1", "c2"],
-                contentBefore: `<div>a[c1}{c1][c2}{c2]<span data-embedded="counter" data-embedded-props='{"value":1}'></span></div>`,
+                contentBefore: `<p>a[c1}{c1][c2}{c2]<span data-embedded="counter" data-embedded-props='{"value":1}'></span></p>`,
                 Plugins: [EmbeddedComponentPlugin],
                 resources: {
                     embedded_components: [savedCounter],
@@ -1574,16 +1576,16 @@ describe("Collaboration with embedded components", () => {
             await animationFrame();
             // c1 change was not yet shared with c2 since it was pending
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":2}' data-embedded-state='{"stateChangeId":1,"previous":{"value":1},"next":{"value":2}}' data-oe-protected="true"><span class="counter">Counter:2</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":2}' data-embedded-state='{"stateChangeId":1,"previous":{"value":1},"next":{"value":2}}' data-oe-protected="true"><span class="counter">Counter:2</span></span></p>`
             );
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":3}' data-embedded-state='{"stateChangeId":2,"previous":{"value":2},"next":{"value":3}}' data-oe-protected="true"><span class="counter">Counter:3</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":3}' data-embedded-state='{"stateChangeId":2,"previous":{"value":2},"next":{"value":3}}' data-oe-protected="true"><span class="counter">Counter:3</span></span></p>`
             );
             // share the missing step with c2
             mergePeersSteps(peerInfos);
             await animationFrame();
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":3}' data-embedded-state='{"stateChangeId":2,"previous":{"value":2},"next":{"value":3}}' data-oe-protected="true"><span class="counter">Counter:3</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":3}' data-embedded-state='{"stateChangeId":2,"previous":{"value":2},"next":{"value":3}}' data-oe-protected="true"><span class="counter">Counter:3</span></span></p>`
             );
         });
 
@@ -1598,7 +1600,7 @@ describe("Collaboration with embedded components", () => {
             };
             const peerInfos = await setupMultiEditor({
                 peerIds: ["c1", "c2"],
-                contentBefore: `<div>a[c1}{c1][c2}{c2]<span data-embedded="counter" data-embedded-props='{"name":"unnamed","value":1}'></span></div>`,
+                contentBefore: `<p>a[c1}{c1][c2}{c2]<span data-embedded="counter" data-embedded-props='{"name":"unnamed","value":1}'></span></p>`,
                 Plugins: [EmbeddedComponentPlugin],
                 resources: {
                     embedded_components: [namedCounter],
@@ -1613,28 +1615,28 @@ describe("Collaboration with embedded components", () => {
             counter1.embeddedState.name = "newName";
             await animationFrame();
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"name":"newName","value":1}' data-embedded-state='{"stateChangeId":1,"previous":{"name":"unnamed","value":1},"next":{"name":"newName","value":1}}' data-oe-protected="true"><span class="counter">newName:1</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"name":"newName","value":1}' data-embedded-state='{"stateChangeId":1,"previous":{"name":"unnamed","value":1},"next":{"name":"newName","value":1}}' data-oe-protected="true"><span class="counter">newName:1</span></span></p>`
             );
             counter2.embeddedState.value = 2;
             mergePeersSteps(peerInfos);
             await animationFrame();
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"name":"newName","value":1}' data-embedded-state='{"stateChangeId":1,"previous":{"name":"unnamed","value":1},"next":{"name":"newName","value":1}}' data-oe-protected="true"><span class="counter">newName:1</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"name":"newName","value":1}' data-embedded-state='{"stateChangeId":1,"previous":{"name":"unnamed","value":1},"next":{"name":"newName","value":1}}' data-oe-protected="true"><span class="counter">newName:1</span></span></p>`
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"name":"newName","value":2}' data-embedded-state='{"stateChangeId":2,"previous":{"name":"newName","value":1},"next":{"name":"newName","value":2}}' data-oe-protected="true"><span class="counter">newName:2</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"name":"newName","value":2}' data-embedded-state='{"stateChangeId":2,"previous":{"name":"newName","value":1},"next":{"name":"newName","value":2}}' data-oe-protected="true"><span class="counter">newName:2</span></span></p>`
             );
             mergePeersSteps(peerInfos);
             await animationFrame();
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"name":"newName","value":2}' data-embedded-state='{"stateChangeId":2,"previous":{"name":"newName","value":1},"next":{"name":"newName","value":2}}' data-oe-protected="true"><span class="counter">newName:2</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"name":"newName","value":2}' data-embedded-state='{"stateChangeId":2,"previous":{"name":"newName","value":1},"next":{"name":"newName","value":2}}' data-oe-protected="true"><span class="counter">newName:2</span></span></p>`
             );
         });
 
         test("Collaborative state changes received late can be applied while a current change is still pending", async () => {
             const peerInfos = await setupMultiEditor({
                 peerIds: ["c1", "c2"],
-                contentBefore: `<div>a[c1}{c1][c2}{c2]<span data-embedded="counter" data-embedded-props='{"value":1}'></span></div>`,
+                contentBefore: `<p>a[c1}{c1][c2}{c2]<span data-embedded="counter" data-embedded-props='{"value":1}'></span></p>`,
                 Plugins: [EmbeddedComponentPlugin],
                 resources: {
                     embedded_components: [savedCounter],
@@ -1653,15 +1655,15 @@ describe("Collaboration with embedded components", () => {
             mergePeersSteps(peerInfos);
             await animationFrame();
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":2}' data-embedded-state='{"stateChangeId":1,"previous":{"value":1},"next":{"value":2}}' data-oe-protected="true"><span class="counter">Counter:2</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":2}' data-embedded-state='{"stateChangeId":1,"previous":{"value":1},"next":{"value":2}}' data-oe-protected="true"><span class="counter">Counter:2</span></span></p>`
             );
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":4}' data-embedded-state='{"stateChangeId":3,"previous":{"value":2},"next":{"value":4}}' data-oe-protected="true"><span class="counter">Counter:4</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":4}' data-embedded-state='{"stateChangeId":3,"previous":{"value":2},"next":{"value":4}}' data-oe-protected="true"><span class="counter">Counter:4</span></span></p>`
             );
             mergePeersSteps(peerInfos);
             await animationFrame();
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":4}' data-embedded-state='{"stateChangeId":3,"previous":{"value":2},"next":{"value":4}}' data-oe-protected="true"><span class="counter">Counter:4</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":4}' data-embedded-state='{"stateChangeId":3,"previous":{"value":2},"next":{"value":4}}' data-oe-protected="true"><span class="counter">Counter:4</span></span></p>`
             );
         });
 
@@ -1701,7 +1703,7 @@ describe("Collaboration with embedded components", () => {
         test("A change from a collaborator with the same values as the previous change done by the peer is properly applied", async () => {
             const peerInfos = await setupMultiEditor({
                 peerIds: ["c1", "c2"],
-                contentBefore: `<div>a[c1}{c1][c2}{c2]<span data-embedded="counter" data-embedded-props='{"baseValue":1}'></span></div>`,
+                contentBefore: `<p>a[c1}{c1][c2}{c2]<span data-embedded="counter" data-embedded-props='{"baseValue":1}'></span></p>`,
                 Plugins: [EmbeddedComponentPlugin],
                 resources: {
                     embedded_components: [offsetCounter],
@@ -1722,20 +1724,20 @@ describe("Collaboration with embedded components", () => {
             // between previous and next. So if both users made a change going
             // from 1 to 3, the resulting value should be 5.
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"baseValue":5}' data-embedded-state='{"stateChangeId":2,"previous":{"baseValue":1},"next":{"baseValue":3}}' data-oe-protected="true"><span class="counter">Counter:5</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"baseValue":5}' data-embedded-state='{"stateChangeId":2,"previous":{"baseValue":1},"next":{"baseValue":3}}' data-oe-protected="true"><span class="counter">Counter:5</span></span></p>`
             );
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"baseValue":5}' data-embedded-state='{"stateChangeId":2,"previous":{"baseValue":1},"next":{"baseValue":3}}' data-oe-protected="true"><span class="counter">Counter:5</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"baseValue":5}' data-embedded-state='{"stateChangeId":2,"previous":{"baseValue":1},"next":{"baseValue":3}}' data-oe-protected="true"><span class="counter">Counter:5</span></span></p>`
             );
             undo(e1);
             await animationFrame();
             mergePeersSteps(peerInfos);
             await animationFrame();
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"baseValue":3}' data-embedded-state='{"stateChangeId":3,"previous":{"baseValue":5},"next":{"baseValue":3}}' data-oe-protected="true"><span class="counter">Counter:3</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"baseValue":3}' data-embedded-state='{"stateChangeId":3,"previous":{"baseValue":5},"next":{"baseValue":3}}' data-oe-protected="true"><span class="counter">Counter:3</span></span></p>`
             );
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"baseValue":3}' data-embedded-state='{"stateChangeId":3,"previous":{"baseValue":5},"next":{"baseValue":3}}' data-oe-protected="true"><span class="counter">Counter:3</span></span></div>`
+                `<p>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"baseValue":3}' data-embedded-state='{"stateChangeId":3,"previous":{"baseValue":5},"next":{"baseValue":3}}' data-oe-protected="true"><span class="counter">Counter:3</span></span></p>`
             );
         });
 

--- a/addons/html_editor/static/tests/data-oe/protected.test.js
+++ b/addons/html_editor/static/tests/data-oe/protected.test.js
@@ -414,7 +414,7 @@ test("moving a protected node at an unprotected location, only remove should be 
                 <div class="b" data-oe-protected="false"></div>
             </div>
             <div data-oe-protected="true">
-                <div class="a"></div>
+                <p class="a"></p>
             </div>
         `)
     );
@@ -435,7 +435,7 @@ test("moving a protected node at an unprotected location, only remove should be 
         unformat(`
             <div data-oe-protected="true" contenteditable="false">
                 <div class="b" data-oe-protected="false" contenteditable="true">
-                    <div class="a"></div>
+                    <p class="a"></p>
                 </div>
             </div>
             <div data-oe-protected="true" contenteditable="false"></div>
@@ -448,7 +448,7 @@ test("moving an unprotected node at a protected location, only add should be ign
         unformat(`
             <div data-oe-protected="true">
                 <div data-oe-protected="false">
-                    <div class="a"></div>
+                    <p class="a">content</p>
                 </div>
             </div>
             <div class="b" data-oe-protected="true"></div>
@@ -473,7 +473,7 @@ test("moving an unprotected node at a protected location, only add should be ign
                 <div data-oe-protected="false" contenteditable="true"></div>
             </div>
             <div class="b" data-oe-protected="true" contenteditable="false">
-                <div class="a"></div>
+                <p class="a">content</p>
             </div>
         `)
     );

--- a/addons/html_editor/static/tests/data-oe/protected.test.js
+++ b/addons/html_editor/static/tests/data-oe/protected.test.js
@@ -53,6 +53,24 @@ test("should not ignore unprotected elements children mutations (false)", async 
     });
 });
 
+test("should not update activeSelection when clicking inside a protected node", async () => {
+    const { el, editor } = await setupEditor(`<p><span data-oe-protected="true"></span>[]</p>`);
+    const span = el.querySelector("span");
+    let editableSelection = editor.shared.selection.getEditableSelection();
+    const documentSelection = editor.document.getSelection();
+    documentSelection.removeAllRanges();
+    const range = editor.document.createRange();
+    range.selectNodeContents(span);
+    // Set document range inside the protected zone
+    documentSelection.addRange(range);
+    editableSelection = editor.shared.selection.getEditableSelection();
+    // Ensure that the editable selection stayed unchanged
+    setSelection(editableSelection);
+    expect(getContent(el)).toBe(
+        `<p><span data-oe-protected="true" contenteditable="false"></span>[]</p>`
+    );
+});
+
 test("should not normalize protected elements children (true)", async () => {
     await testEditor({
         contentBefore: unformat(`

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -122,27 +122,27 @@ describe("Selection collapsed", () => {
         });
         test("should keep inline block and then undo (1)", async () => {
             await testEditor({
-                contentBefore: "<div>ab<b>c[]</b>de</div>",
+                contentBefore: "<p>ab<b>c[]</b>de</p>",
                 stepFunction: async (editor) => {
                     deleteBackward(editor);
                     await insertText(editor, "x");
                     undo(editor);
                 },
-                contentAfterEdit: '<div>ab<b data-oe-zws-empty-inline="">[]\u200B</b>de</div>',
-                contentAfter: "<div>ab[]de</div>",
+                contentAfterEdit: '<p>ab<b data-oe-zws-empty-inline="">[]\u200B</b>de</p>',
+                contentAfter: "<p>ab[]de</p>",
             });
         });
         test("should keep inline block and then undo (2)", async () => {
             await testEditor({
-                contentBefore: "<div>ab<b>c[]</b>de</div>",
+                contentBefore: "<p>ab<b>c[]</b>de</p>",
                 stepFunction: async (editor) => {
                     deleteBackward(editor);
                     await insertText(editor, "x");
                     undo(editor);
                     undo(editor);
                 },
-                contentAfterEdit: "<div>ab<b>c[]</b>de</div>",
-                contentAfter: "<div>ab<b>c[]</b>de</div>",
+                contentAfterEdit: "<p>ab<b>c[]</b>de</p>",
+                contentAfter: "<p>ab<b>c[]</b>de</p>",
             });
         });
 
@@ -311,11 +311,11 @@ describe("Selection collapsed", () => {
 
         test('should remove contenteditable="false"', async () => {
             await testEditor({
-                contentBefore: `<div><span contenteditable="false">abc</span>[]def</div>`,
+                contentBefore: `<p><span contenteditable="false">abc</span>[]def</p>`,
                 stepFunction: async (editor) => {
                     deleteBackward(editor);
                 },
-                contentAfter: `<div>[]def</div>`,
+                contentAfter: `<p>[]def</p>`,
             });
         });
 

--- a/addons/html_editor/static/tests/delete/backward_line.test.js
+++ b/addons/html_editor/static/tests/delete/backward_line.test.js
@@ -76,11 +76,11 @@ test("should not remove an unremovable element on CTRL+SHIFT+BACKSPACE", async (
 test("should not merge an unbreakable element on CTRL+SHIFT+BACKSPACE", async () => {
     await testEditor({
         contentBefore: unformat(`
-            <div>abc</div>
+            <div class="oe_unbreakable">abc</div>
             <p>[]def</p>`),
         stepFunction: ctrlShiftBackspace,
         contentAfter: unformat(`
-            <div>abc</div>
+            <div class="oe_unbreakable">abc</div>
             <p>[]def</p>`),
     });
 });
@@ -89,10 +89,10 @@ test("should not merge an unbreakable element on CTRL+SHIFT+BACKSPACE (2)", asyn
     await testEditor({
         contentBefore: unformat(`
             <p>abc</p>
-            <div>[]def</div>`),
+            <div class="oe_unbreakable">[]def</div>`),
         stepFunction: ctrlShiftBackspace,
         contentAfter: unformat(`
             <p>abc</p>
-            <div>[]def</div>`),
+            <div class="oe_unbreakable">[]def</div>`),
     });
 });

--- a/addons/html_editor/static/tests/delete/backward_word.test.js
+++ b/addons/html_editor/static/tests/delete/backward_word.test.js
@@ -88,11 +88,11 @@ test("should not remove an unremovable element on CTRL+BACKSPACE (2)", async () 
 test("should not merge an unbreakable element on CTRL+BACKSPACE", async () => {
     await testEditor({
         contentBefore: unformat(`
-            <div>abc</div>
+            <div class="oe_unbreakable">abc</div>
             <p>[]def</p>`),
         stepFunction: () => press(["Ctrl", "Backspace"]),
         contentAfter: unformat(`
-            <div>abc</div>
+            <div class="oe_unbreakable">abc</div>
             <p>[]def</p>`),
     });
 });
@@ -101,10 +101,10 @@ test("should not merge an unbreakable element on CTRL+BACKSPACE (2)", async () =
     await testEditor({
         contentBefore: unformat(`
             <p>abc</p>
-            <div>[]def</div>`),
+            <div class="oe_unbreakable">[]def</div>`),
         stepFunction: () => press(["Ctrl", "Backspace"]),
         contentAfter: unformat(`
             <p>abc</p>
-            <div>[]def</div>`),
+            <div class="oe_unbreakable">[]def</div>`),
     });
 });

--- a/addons/html_editor/static/tests/delete/delete_range.test.js
+++ b/addons/html_editor/static/tests/delete/delete_range.test.js
@@ -309,9 +309,9 @@ describe("deleteSelection", () => {
     describe("Unmergeables", () => {
         test("should not merge paragraph with unmeargeble block", async () => {
             await testEditor({
-                contentBefore: "<p>ab[c</p><div>d]ef</div>",
+                contentBefore: `<p>ab[c</p><div class="oe_unbreakable">d]ef</div>`,
                 stepFunction: deleteSelection,
-                contentAfter: "<p>ab[]</p><div>ef</div>",
+                contentAfter: `<p>ab[]</p><div class="oe_unbreakable">ef</div>`,
             });
         });
 
@@ -319,7 +319,7 @@ describe("deleteSelection", () => {
             // `includeEndOrStartBlock` fully includes the right block.
             // <p>ab[c</p><div>def]</div> -> <p>ab[c</p><div>def</div>] -> deleteRange
             await testEditor({
-                contentBefore: "<p>ab[c</p><div>def]</div>",
+                contentBefore: `<p>ab[c</p><div class="oe_unbreakable">def]</div>`,
                 stepFunction: deleteSelection,
                 contentAfter: "<p>ab[]</p>",
             });

--- a/addons/html_editor/static/tests/delete/forward.test.js
+++ b/addons/html_editor/static/tests/delete/forward.test.js
@@ -202,11 +202,11 @@ describe("Selection collapsed", () => {
 
         test('should remove contenteditable="false"', async () => {
             await testEditor({
-                contentBefore: `<div>[]<span contenteditable="false">abc</span>def</div>`,
+                contentBefore: `<p>[]<span contenteditable="false">abc</span>def</p>`,
                 stepFunction: async (editor) => {
                     deleteForward(editor);
                 },
-                contentAfter: `<div>[]def</div>`,
+                contentAfter: `<p>[]def</p>`,
             });
         });
 

--- a/addons/html_editor/static/tests/delete/forward_line.test.js
+++ b/addons/html_editor/static/tests/delete/forward_line.test.js
@@ -75,11 +75,11 @@ test("should not remove an unremovable element on CTRL+SHIFT+DELETE", async () =
 test("should not merge an unbreakable element on CTRL+SHIFT+DELETE", async () => {
     await testEditor({
         contentBefore: unformat(`
-            <div>abc[]</div>
+            <div class="oe_unbreakable">abc[]</div>
             <p>def</p>`),
         stepFunction: ctrlShiftDelete,
         contentAfter: unformat(`
-            <div>abc[]</div>
+            <div class="oe_unbreakable">abc[]</div>
             <p>def</p>`),
     });
 });
@@ -88,10 +88,10 @@ test("should not merge an unbreakable element on CTRL+SHIFT+DELETE (2)", async (
     await testEditor({
         contentBefore: unformat(`
             <p>abc[]</p>
-            <div>def</div>`),
+            <div class="oe_unbreakable">def</div>`),
         stepFunction: ctrlShiftDelete,
         contentAfter: unformat(`
             <p>abc[]</p>
-            <div>def</div>`),
+            <div class="oe_unbreakable">def</div>`),
     });
 });

--- a/addons/html_editor/static/tests/delete/forward_word.test.js
+++ b/addons/html_editor/static/tests/delete/forward_word.test.js
@@ -18,11 +18,11 @@ test("should not remove an unremovable element on CTRL+DELETE", async () => {
 test("should not merge an unbreakable element on CTRL+DELETE", async () => {
     await testEditor({
         contentBefore: unformat(`
-            <div>abc[]</div>
+            <div class="oe_unbreakable">abc[]</div>
             <p>def</p>`),
         stepFunction: () => press(["Ctrl", "Delete"]),
         contentAfter: unformat(`
-            <div>abc[]</div>
+            <div class="oe_unbreakable">abc[]</div>
             <p>def</p>`),
     });
 });
@@ -31,10 +31,10 @@ test("should not merge an unbreakable element on CTRL+DELETE (2)", async () => {
     await testEditor({
         contentBefore: unformat(`
             <p>abc[]</p>
-            <div>def</div>`),
+            <div class="oe_unbreakable">def</div>`),
         stepFunction: () => press(["Ctrl", "Delete"]),
         contentAfter: unformat(`
             <p>abc[]</p>
-            <div>def</div>`),
+            <div class="oe_unbreakable">def</div>`),
     });
 });

--- a/addons/html_editor/static/tests/embedded_components.test.js
+++ b/addons/html_editor/static/tests/embedded_components.test.js
@@ -53,39 +53,39 @@ function getConfig(components) {
 
 describe("Mount and Destroy embedded components", () => {
     test("can mount a embedded component", async () => {
-        const { el } = await setupEditor(`<div><span data-embedded="counter"></span></div>`, {
+        const { el } = await setupEditor(`<p><span data-embedded="counter"></span></p>`, {
             config: getConfig([embedding("counter", Counter)]),
         });
         expect(getContent(el)).toBe(
-            `<div><span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span></div>`
+            `<p><span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span></p>`
         );
         await click(".counter");
         await animationFrame();
         expect(getContent(el)).toBe(
-            `<div><span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:1</span></span></div>`
+            `<p><span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:1</span></span></p>`
         );
     });
 
     test("can mount a embedded component from a step", async () => {
-        const { el, editor } = await setupEditor(`<div>a[]b</div>`, {
+        const { el, editor } = await setupEditor(`<p>a[]b</p>`, {
             config: getConfig([embedding("counter", Counter)]),
         });
-        expect(getContent(el)).toBe(`<div>a[]b</div>`);
+        expect(getContent(el)).toBe(`<p>a[]b</p>`);
         editor.shared.dom.insert(
             parseHTML(editor.document, `<span data-embedded="counter"></span>`)
         );
         editor.shared.history.addStep();
         expect(getContent(el)).toBe(
-            `<div>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"></span>[]b</div>`
+            `<p>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"></span>[]b</p>`
         );
         await animationFrame();
         expect(getContent(el)).toBe(
-            `<div>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span>[]b</div>`
+            `<p>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span>[]b</p>`
         );
         await click(".counter");
         await animationFrame();
         expect(getContent(el)).toBe(
-            `<div>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:1</span></span>[]b</div>`
+            `<p>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:1</span></span>[]b</p>`
         );
     });
 
@@ -104,18 +104,15 @@ describe("Mount and Destroy embedded components", () => {
                 onWillDestroy(() => steps.push("willdestroy"));
             }
         }
-        const { el, editor } = await setupEditor(
-            `<div><span data-embedded="counter"></span></div>`,
-            {
-                config: getConfig([embedding("counter", Test)]),
-            }
-        );
+        const { el, editor } = await setupEditor(`<p><span data-embedded="counter"></span></p>`, {
+            config: getConfig([embedding("counter", Test)]),
+        });
         expect(steps).toEqual(["mounted"]);
 
         editor.destroy();
         expect(steps).toEqual(["mounted", "willunmount", "willdestroy"]);
         expect(getContent(el)).toBe(
-            `<div><span data-embedded="counter" data-oe-protected="true" contenteditable="false"></span></div>`
+            `<p><span data-embedded="counter" data-oe-protected="true" contenteditable="false"></span></p>`
         );
     });
 
@@ -134,20 +131,20 @@ describe("Mount and Destroy embedded components", () => {
             }
         }
         const { el, editor } = await setupEditor(
-            `<div>a<span data-embedded="counter"></span>[]</div>`,
+            `<p>a<span data-embedded="counter"></span>[]</p>`,
             {
                 config: getConfig([embedding("counter", Test)]),
             }
         );
 
         expect(getContent(el)).toBe(
-            `<div>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span>[]</div>`
+            `<p>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span>[]</p>`
         );
         expect(steps).toEqual(["mounted"]);
 
         deleteBackward(editor);
         expect(steps).toEqual(["mounted", "willunmount"]);
-        expect(getContent(el)).toBe(`<div>a[]</div>`);
+        expect(getContent(el)).toBe(`<p>a[]</p>`);
     });
 
     test("undo and redo a component insertion", async () => {
@@ -163,7 +160,7 @@ describe("Mount and Destroy embedded components", () => {
                 });
             }
         }
-        const { el, editor } = await setupEditor(`<div>a[]</div>`, {
+        const { el, editor } = await setupEditor(`<p>a[]</p>`, {
             config: getConfig([embedding("counter", Test)]),
         });
         editor.shared.dom.insert(
@@ -173,16 +170,16 @@ describe("Mount and Destroy embedded components", () => {
         await animationFrame();
         expect.verifySteps(["mounted"]);
         expect(getContent(el)).toBe(
-            `<div>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span>[]</div>`
+            `<p>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span>[]</p>`
         );
         undo(editor);
         expect.verifySteps(["willunmount"]);
-        expect(getContent(el)).toBe(`<div>a[]</div>`);
+        expect(getContent(el)).toBe(`<p>a[]</p>`);
         redo(editor);
         await animationFrame();
         expect.verifySteps(["mounted"]);
         expect(getContent(el)).toBe(
-            `<div>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span>[]</div>`
+            `<p>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span>[]</p>`
         );
         editor.destroy();
         expect.verifySteps(["willunmount"]);
@@ -202,7 +199,7 @@ describe("Mount and Destroy embedded components", () => {
             }
         }
         const { el, editor } = await setupEditor(
-            `<div>a<span data-embedded="counter"></span>[]</div>`,
+            `<p>a<span data-embedded="counter"></span>[]</p>`,
             {
                 config: getConfig([embedding("counter", Test)]),
             }
@@ -211,32 +208,32 @@ describe("Mount and Destroy embedded components", () => {
         editor.shared.history.stageSelection();
 
         expect(getContent(el)).toBe(
-            `<div>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span>[]</div>`
+            `<p>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span>[]</p>`
         );
         expect.verifySteps(["mounted"]);
 
         deleteBackward(editor);
         expect.verifySteps(["willunmount"]);
-        expect(getContent(el)).toBe(`<div>a[]</div>`);
+        expect(getContent(el)).toBe(`<p>a[]</p>`);
 
         // now, we undo and check that component still works
         undo(editor);
         expect(getContent(el)).toBe(
-            `<div>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"></span>[]</div>`
+            `<p>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"></span>[]</p>`
         );
         await animationFrame();
         expect.verifySteps(["mounted"]);
         expect(getContent(el)).toBe(
-            `<div>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span>[]</div>`
+            `<p>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span>[]</p>`
         );
         await click(".counter");
         await animationFrame();
         expect(getContent(el)).toBe(
-            `<div>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:1</span></span>[]</div>`
+            `<p>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:1</span></span>[]</p>`
         );
         redo(editor);
         expect.verifySteps(["willunmount"]);
-        expect(getContent(el)).toBe(`<div>a[]</div>`);
+        expect(getContent(el)).toBe(`<p>a[]</p>`);
     });
 
     test("mount and destroy components after a savepoint", async () => {
@@ -251,20 +248,20 @@ describe("Mount and Destroy embedded components", () => {
             }
         }
         const { el, editor } = await setupEditor(
-            `<div>a<span data-embedded="counter"></span>[]</div>`,
+            `<p>a<span data-embedded="counter"></span>[]</p>`,
             {
                 config: getConfig([embedding("counter", Test)]),
             }
         );
         editor.shared.history.stageSelection();
         expect(getContent(el)).toBe(
-            `<div>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span>[]</div>`
+            `<p>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span>[]</p>`
         );
         expect.verifySteps(["mounted"]);
         const savepoint = editor.shared.history.makeSavePoint();
         deleteBackward(editor);
         expect.verifySteps(["willunmount"]);
-        expect(getContent(el)).toBe(`<div>a[]</div>`);
+        expect(getContent(el)).toBe(`<p>a[]</p>`);
         editor.shared.dom.insert(
             parseHTML(editor.document, `<span data-embedded="counter"></span>`)
         );
@@ -272,14 +269,14 @@ describe("Mount and Destroy embedded components", () => {
         await animationFrame();
         expect.verifySteps(["mounted"]);
         expect(getContent(el)).toBe(
-            `<div>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span>[]</div>`
+            `<p>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span>[]</p>`
         );
         savepoint();
         expect.verifySteps(["willunmount"]);
         await animationFrame();
         expect.verifySteps(["mounted"]);
         expect(getContent(el)).toBe(
-            `<div>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span>[]</div>`
+            `<p>a<span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span>[]</p>`
         );
         editor.destroy();
         expect.verifySteps(["willunmount"]);
@@ -299,12 +296,9 @@ describe("Mount and Destroy embedded components", () => {
                 });
             }
         }
-        const { editor } = await setupEditor(
-            `<div>a<span data-embedded="counter"></span>[]</div>`,
-            {
-                config: getConfig([embedding("counter", Test)]),
-            }
-        );
+        const { editor } = await setupEditor(`<p>a<span data-embedded="counter"></span>[]</p>`, {
+            config: getConfig([embedding("counter", Test)]),
+        });
         deleteBackward(editor);
         expect.verifySteps(["destroy from plugin", "willdestroy"]);
         editor.destroy();
@@ -343,7 +337,7 @@ describe("Mount and Destroy embedded components", () => {
             }
         }
         let index = 1;
-        const { el, editor, plugins } = await setupEditor(`<div class="target">[]</div>`, {
+        const { el, editor, plugins } = await setupEditor(`<p class="target">[]</p>`, {
             config: getConfig([
                 embedding("recursiveComponent", RecursiveComponent, (host) => {
                     const result = {
@@ -391,24 +385,22 @@ describe("Mount and Destroy embedded components", () => {
         expect.verifySteps(["mount 1", "mount 2", "mount 3"]);
         expect(getContent(el)).toBe(
             unformat(`
-                <div class="target">
-                    <div data-embedded="recursiveComponent" data-oe-protected="true" contenteditable="false">
-                        <div>
-                            <div class="click count-2">Count:2</div>
-                            <div class="innerEditable-2">
-                                <div data-prop-name="innerValue" data-oe-protected="false" contenteditable="true">
-                                    <div data-embedded="recursiveComponent" data-oe-protected="true" contenteditable="false">
-                                        <div>
-                                            <div class="click count-1">Count:1</div>
-                                            <div class="innerEditable-1">
-                                                <div data-prop-name="innerValue" data-oe-protected="false" contenteditable="true">
-                                                    <div data-embedded="recursiveComponent" data-oe-protected="true" contenteditable="false">
-                                                        <div>
-                                                            <div class="click count-3">Count:3</div>
-                                                            <div class="innerEditable-3">
-                                                                <div data-prop-name="innerValue" data-oe-protected="false" contenteditable="true">
-                                                                    <p>HELL</p>
-                                                                </div>
+                <div data-embedded="recursiveComponent" data-oe-protected="true" contenteditable="false">
+                    <div>
+                        <div class="click count-2">Count:2</div>
+                        <div class="innerEditable-2">
+                            <div data-prop-name="innerValue" data-oe-protected="false" contenteditable="true">
+                                <div data-embedded="recursiveComponent" data-oe-protected="true" contenteditable="false">
+                                    <div>
+                                        <div class="click count-1">Count:1</div>
+                                        <div class="innerEditable-1">
+                                            <div data-prop-name="innerValue" data-oe-protected="false" contenteditable="true">
+                                                <div data-embedded="recursiveComponent" data-oe-protected="true" contenteditable="false">
+                                                    <div>
+                                                        <div class="click count-3">Count:3</div>
+                                                        <div class="innerEditable-3">
+                                                            <div data-prop-name="innerValue" data-oe-protected="false" contenteditable="true">
+                                                                <p>HELL</p>
                                                             </div>
                                                         </div>
                                                     </div>
@@ -420,7 +412,8 @@ describe("Mount and Destroy embedded components", () => {
                             </div>
                         </div>
                     </div>
-                []</div>
+                </div>
+                <p class="target o-we-hint" placeholder='Type "/" for commands'>[]<br></p>
             `)
         );
         for (const index of indexOrder) {
@@ -445,9 +438,8 @@ describe("Mount and Destroy embedded components", () => {
         // outermost host.
         expect(getContent(el)).toBe(
             unformat(`
-                <div class="target">
-                    <div data-embedded="recursiveComponent" data-oe-protected="true" contenteditable="false"></div>
-                []</div>
+                <div data-embedded="recursiveComponent" data-oe-protected="true" contenteditable="false"></div>
+                <p class="target o-we-hint" placeholder='Type "/" for commands'>[]<br></p>
             `)
         );
         // Verify that there is no potential host outside of the editable,
@@ -470,7 +462,7 @@ describe("Mount and Destroy embedded components", () => {
             },
         });
         const { editor, el } = await setupEditor(
-            `<div><span data-embedded="counter"></span>ALONE</div>`,
+            `<p><span data-embedded="counter"></span>ALONE</p>`,
             {
                 config: getConfig([embedding("counter", Counter)]),
             }
@@ -501,7 +493,7 @@ describe("Mount and Destroy embedded components", () => {
             },
         });
         const { editor, el } = await setupEditor(
-            `<div><div class="parent"><span data-embedded="counter"></span></div>ALONE</div>`,
+            `<div><p class="parent"><span data-embedded="counter"></span></p>ALONE</div>`,
             {
                 config: getConfig([embedding("counter", Counter)]),
             }
@@ -646,12 +638,12 @@ describe("Mount processing", () => {
                 this.state.value = this.props.initialCount;
             }
         }
-        const { el } = await setupEditor(`<div><span data-embedded="counter"></span></div>`, {
+        const { el } = await setupEditor(`<p><span data-embedded="counter"></span></p>`, {
             config: getConfig([embedding("counter", Test, () => ({ initialCount: 10 }))]),
         });
 
         expect(getContent(el)).toBe(
-            `<div><span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:10</span></span></div>`
+            `<p><span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:10</span></span></p>`
         );
     });
 
@@ -664,7 +656,7 @@ describe("Mount processing", () => {
             }
         }
         const { el } = await setupEditor(
-            `<div><span data-embedded="counter" data-count="10"></span></div>`,
+            `<p><span data-embedded="counter" data-count="10"></span></p>`,
             {
                 config: getConfig([
                     embedding("counter", Test, (host) => ({
@@ -675,7 +667,7 @@ describe("Mount processing", () => {
         );
 
         expect(getContent(el)).toBe(
-            `<div><span data-embedded="counter" data-count="10" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:10</span></span></div>`
+            `<p><span data-embedded="counter" data-count="10" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:10</span></span></p>`
         );
     });
 
@@ -692,20 +684,20 @@ describe("Mount processing", () => {
             }
         }
         const { el } = await setupEditor(
-            `<div><span data-embedded="counter" data-count="10"></span></div>`,
+            `<p><span data-embedded="counter" data-count="10"></span></p>`,
             {
                 config: getConfig([embedding("counter", Test, (host) => ({ host }))]),
             }
         );
 
         expect(getContent(el)).toBe(
-            `<div><span data-embedded="counter" data-count="10" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:10</span></span></div>`
+            `<p><span data-embedded="counter" data-count="10" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:10</span></span></p>`
         );
 
         await click(".counter");
         await animationFrame();
         expect(getContent(el)).toBe(
-            `<div><span data-embedded="counter" data-count="11" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:11</span></span></div>`
+            `<p><span data-embedded="counter" data-count="11" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:11</span></span></p>`
         );
     });
 
@@ -719,7 +711,7 @@ describe("Mount processing", () => {
         }
 
         const rootEnv = await makeMockEnv();
-        await setupEditor(`<div><span data-embedded="counter"></span></div>`, {
+        await setupEditor(`<p><span data-embedded="counter"></span></p>`, {
             config: getConfig([embedding("counter", Test)]),
             env: Object.assign(rootEnv, { somevalue: 1 }),
         });
@@ -727,11 +719,11 @@ describe("Mount processing", () => {
     });
 
     test("Content within an embedded component host is removed when mounting", async () => {
-        const { el } = await setupEditor(`<div><span data-embedded="counter">hello</span></div>`, {
+        const { el } = await setupEditor(`<p><span data-embedded="counter">hello</span></p>`, {
             config: getConfig([embedding("counter", Counter)]),
         });
         expect(getContent(el)).toBe(
-            `<div><span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span></div>`
+            `<p><span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span></p>`
         );
     });
 
@@ -788,9 +780,9 @@ describe("Mount processing", () => {
             }
         }
         const { el } = await setupEditor(
-            `<div><span data-embedded="labeledCounter">
+            `<p><span data-embedded="labeledCounter">
                 <span data-prop-name="label">Counter</span>
-            </span>[]a</div>`,
+            </span>[]a</p>`,
             {
                 config: getConfig([
                     embedding("labeledCounter", LabeledCounter, (host) => ({
@@ -804,7 +796,7 @@ describe("Mount processing", () => {
         await animationFrame();
         expect(getContent(el)).toBe(
             unformat(`
-                <div>
+                <p>
                     <span data-embedded="labeledCounter" data-oe-protected="true" contenteditable="false">
                         <span class="counter">
                             <span>
@@ -814,7 +806,7 @@ describe("Mount processing", () => {
                         </span>
                     </span>
                     []a
-                </div>
+                </p>
             `)
         );
         expect.verifySteps([
@@ -885,7 +877,7 @@ describe("Mount processing", () => {
         }
         const config = getConfig([embedding("embeddedCounter", EmbeddedCounter)]);
         config.Plugins.push(SimplePlugin);
-        const { plugins } = await setupEditor(`<div>[]a</div>`, { config });
+        const { plugins } = await setupEditor(`<p>[]a</p>`, { config });
         const simplePlugin = plugins.get("simple");
         simplePlugin.insertElement("<div data-embedded='embeddedCounter'/>");
         await animationFrame();
@@ -1227,23 +1219,23 @@ describe("Embedded state", () => {
             },
         });
         const { el } = await setupEditor(
-            `<div><span data-embedded="counter" data-embedded-props='{"baseValue":0}'></span></div>`,
+            `<p><span data-embedded="counter" data-embedded-props='{"baseValue":0}'></span></p>`,
             { config: getConfig([offsetCounter]) }
         );
         expect(getContent(el)).toBe(
-            `<div><span data-embedded="counter" data-embedded-props='{"baseValue":0}' data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span></div>`
+            `<p><span data-embedded="counter" data-embedded-props='{"baseValue":0}' data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span></p>`
         );
 
         counter.embeddedState.baseValue = 2;
         await animationFrame();
         expect(getContent(el)).toBe(
-            `<div><span data-embedded="counter" data-embedded-props='{"baseValue":2}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":1,"previous":{"baseValue":0},"next":{"baseValue":2}}'><span class="counter">Counter:2</span></span></div>`
+            `<p><span data-embedded="counter" data-embedded-props='{"baseValue":2}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":1,"previous":{"baseValue":0},"next":{"baseValue":2}}'><span class="counter">Counter:2</span></span></p>`
         );
 
         await click(".counter");
         await animationFrame();
         expect(getContent(el)).toBe(
-            `<div><span data-embedded="counter" data-embedded-props='{"baseValue":2}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":1,"previous":{"baseValue":0},"next":{"baseValue":2}}'><span class="counter">Counter:3</span></span></div>`
+            `<p><span data-embedded="counter" data-embedded-props='{"baseValue":2}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":1,"previous":{"baseValue":0},"next":{"baseValue":2}}'><span class="counter">Counter:3</span></span></p>`
         );
         expect(counter.embeddedState).toEqual({
             baseValue: 2,
@@ -1261,24 +1253,23 @@ describe("Embedded state", () => {
                 counter = this;
             },
         });
-        const { el, editor } = await setupEditor(
-            `<div><span data-embedded="counter"></span></div>`,
-            { config: getConfig([savedCounter]) }
-        );
+        const { el, editor } = await setupEditor(`<p><span data-embedded="counter"></span></p>`, {
+            config: getConfig([savedCounter]),
+        });
         expect(getContent(el)).toBe(
-            `<div><span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span></div>`
+            `<p><span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span></p>`
         );
         await click(".counter");
         await animationFrame();
         expect(getContent(el)).toBe(
-            `<div><span data-embedded="counter" data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":1,"previous":{},"next":{"value":1}}' data-embedded-props='{"value":1}'><span class="counter">Counter:1</span></span></div>`
+            `<p><span data-embedded="counter" data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":1,"previous":{},"next":{"value":1}}' data-embedded-props='{"value":1}'><span class="counter">Counter:1</span></span></p>`
         );
         expect(counter.embeddedState).toEqual({
             value: 1,
         });
         // `data-embedded-state` should be removed from editor.getElContent result
         expect(getContent(editor.getElContent())).toBe(
-            `<div><span data-embedded="counter" data-embedded-props='{"value":1}'></span></div>`
+            `<p><span data-embedded="counter" data-embedded-props='{"value":1}'></span></p>`
         );
     });
 
@@ -1291,21 +1282,21 @@ describe("Embedded state", () => {
             },
         });
         const { el, editor } = await setupEditor(
-            `<div><span data-embedded="counter" data-embedded-props='{"value":1}'></span></div>`,
+            `<p><span data-embedded="counter" data-embedded-props='{"value":1}'></span></p>`,
             { config: getConfig([savedCounter]) }
         );
         expect(getContent(el)).toBe(
-            `<div><span data-embedded="counter" data-embedded-props='{"value":1}' data-oe-protected="true" contenteditable="false"><span class="counter">Counter:1</span></span></div>`
+            `<p><span data-embedded="counter" data-embedded-props='{"value":1}' data-oe-protected="true" contenteditable="false"><span class="counter">Counter:1</span></span></p>`
         );
         delete counter.embeddedState.value;
         await animationFrame();
         expect(getContent(el)).toBe(
-            `<div><span data-embedded="counter" data-embedded-props="{}" data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":1,"previous":{"value":1},"next":{}}'><span class="counter">Counter:0</span></span></div>`
+            `<p><span data-embedded="counter" data-embedded-props="{}" data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":1,"previous":{"value":1},"next":{}}'><span class="counter">Counter:0</span></span></p>`
         );
         expect(counter.embeddedState).toEqual({});
         // `data-embedded-state` should be removed from editor.getElContent result
         expect(getContent(editor.getElContent())).toBe(
-            `<div><span data-embedded="counter" data-embedded-props="{}"></span></div>`
+            `<p><span data-embedded="counter" data-embedded-props="{}"></span></p>`
         );
     });
 
@@ -1318,11 +1309,11 @@ describe("Embedded state", () => {
             },
         });
         const { editor, el } = await setupEditor(
-            `<div><span data-embedded="counter" data-embedded-props='{"baseValue":0}'></span></div>`,
+            `<p><span data-embedded="counter" data-embedded-props='{"baseValue":0}'></span></p>`,
             { config: getConfig([offsetCounter]) }
         );
         expect(getContent(el)).toBe(
-            `<div><span data-embedded="counter" data-embedded-props='{"baseValue":0}' data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span></div>`
+            `<p><span data-embedded="counter" data-embedded-props='{"baseValue":0}' data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span></p>`
         );
 
         counter.props.host.dataset.embeddedState = JSON.stringify({
@@ -1337,7 +1328,7 @@ describe("Embedded state", () => {
         editor.shared.history.addStep();
         await animationFrame();
         expect(getContent(el)).toBe(
-            `<div><span data-embedded="counter" data-embedded-props='{"baseValue":4}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":-1,"previous":{"baseValue":1},"next":{"baseValue":5}}'><span class="counter">Counter:4</span></span></div>`
+            `<p><span data-embedded="counter" data-embedded-props='{"baseValue":4}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":-1,"previous":{"baseValue":1},"next":{"baseValue":5}}'><span class="counter">Counter:4</span></span></p>`
         );
         expect(counter.embeddedState).toEqual({
             baseValue: 4,
@@ -1346,7 +1337,7 @@ describe("Embedded state", () => {
         await click(".counter");
         await animationFrame();
         expect(getContent(el)).toBe(
-            `<div><span data-embedded="counter" data-embedded-props='{"baseValue":4}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":-1,"previous":{"baseValue":1},"next":{"baseValue":5}}'><span class="counter">Counter:5</span></span></div>`
+            `<p><span data-embedded="counter" data-embedded-props='{"baseValue":4}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":-1,"previous":{"baseValue":1},"next":{"baseValue":5}}'><span class="counter">Counter:5</span></span></p>`
         );
         expect(counter.embeddedState).toEqual({
             baseValue: 4,
@@ -1367,16 +1358,16 @@ describe("Embedded state", () => {
                 });
             },
         });
-        const { el } = await setupEditor(`<div><span data-embedded="counter"></span></div>`, {
+        const { el } = await setupEditor(`<p><span data-embedded="counter"></span></p>`, {
             config: getConfig([savedCounter]),
         });
         expect(getContent(el)).toBe(
-            `<div><span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span></div>`
+            `<p><span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span></p>`
         );
         await click(".counter");
         await animationFrame();
         expect(getContent(el)).toBe(
-            `<div><span data-embedded="counter" data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":1,"previous":{},"next":{"value":1}}' data-embedded-props='{"value":1}'><span class="counter">Counter:1</span></span></div>`
+            `<p><span data-embedded="counter" data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":1,"previous":{},"next":{"value":1}}' data-embedded-props='{"value":1}'><span class="counter">Counter:1</span></span></p>`
         );
         expect.verifySteps(["patched"]);
         counter.props.host.dataset.embeddedState = JSON.stringify({
@@ -1388,7 +1379,7 @@ describe("Embedded state", () => {
         });
         await animationFrame();
         expect(getContent(el)).toBe(
-            `<div><span data-embedded="counter" data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":1,"previous":{},"next":{"value":1}}' data-embedded-props='{"value":1}'><span class="counter">Counter:1</span></span></div>`
+            `<p><span data-embedded="counter" data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":1,"previous":{},"next":{"value":1}}' data-embedded-props='{"value":1}'><span class="counter">Counter:1</span></span></p>`
         );
         expect.verifySteps([]);
     });
@@ -1404,73 +1395,73 @@ describe("Embedded state", () => {
                 });
             },
         });
-        const { el } = await setupEditor(`<div><span data-embedded="counter"></span></div>`, {
+        const { el } = await setupEditor(`<p><span data-embedded="counter"></span></p>`, {
             config: getConfig([savedCounter]),
         });
         expect(getContent(el)).toBe(
-            `<div><span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span></div>`
+            `<p><span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span></p>`
         );
         await click(".counter");
         await animationFrame();
         expect(getContent(el)).toBe(
-            `<div><span data-embedded="counter" data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":1,"previous":{},"next":{"value":1}}' data-embedded-props='{"value":1}'><span class="counter">Counter:1</span></span></div>`
+            `<p><span data-embedded="counter" data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":1,"previous":{},"next":{"value":1}}' data-embedded-props='{"value":1}'><span class="counter">Counter:1</span></span></p>`
         );
         expect.verifySteps(["patched"]);
         counter.embeddedState.value = 1;
         await animationFrame();
         expect(getContent(el)).toBe(
-            `<div><span data-embedded="counter" data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":1,"previous":{},"next":{"value":1}}' data-embedded-props='{"value":1}'><span class="counter">Counter:1</span></span></div>`
+            `<p><span data-embedded="counter" data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":1,"previous":{},"next":{"value":1}}' data-embedded-props='{"value":1}'><span class="counter">Counter:1</span></span></p>`
         );
         expect.verifySteps([]);
     });
 
     test("Embedded state evolves during undo and redo", async () => {
         const { el, editor } = await setupEditor(
-            `<div>a[]<span data-embedded="counter" data-embedded-props='{"value":1}'></span></div>`,
+            `<p>a[]<span data-embedded="counter" data-embedded-props='{"value":1}'></span></p>`,
             { config: getConfig([savedCounter]) }
         );
         expect(getContent(el)).toBe(
-            `<div>a[]<span data-embedded="counter" data-embedded-props='{"value":1}' data-oe-protected="true" contenteditable="false"><span class="counter">Counter:1</span></span></div>`
+            `<p>a[]<span data-embedded="counter" data-embedded-props='{"value":1}' data-oe-protected="true" contenteditable="false"><span class="counter">Counter:1</span></span></p>`
         );
         await click(".counter");
         await animationFrame();
         expect(getContent(el)).toBe(
-            `<div>a[]<span data-embedded="counter" data-embedded-props='{"value":2}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":1,"previous":{"value":1},"next":{"value":2}}'><span class="counter">Counter:2</span></span></div>`
+            `<p>a[]<span data-embedded="counter" data-embedded-props='{"value":2}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":1,"previous":{"value":1},"next":{"value":2}}'><span class="counter">Counter:2</span></span></p>`
         );
         undo(editor);
         await animationFrame();
         expect(getContent(el)).toBe(
-            `<div>a[]<span data-embedded="counter" data-embedded-props='{"value":1}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":2,"previous":{"value":2},"next":{"value":1}}'><span class="counter">Counter:1</span></span></div>`
+            `<p>a[]<span data-embedded="counter" data-embedded-props='{"value":1}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":2,"previous":{"value":2},"next":{"value":1}}'><span class="counter">Counter:1</span></span></p>`
         );
         redo(editor);
         await animationFrame();
         expect(getContent(el)).toBe(
-            `<div>a[]<span data-embedded="counter" data-embedded-props='{"value":2}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":3,"previous":{"value":1},"next":{"value":2}}'><span class="counter">Counter:2</span></span></div>`
+            `<p>a[]<span data-embedded="counter" data-embedded-props='{"value":2}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":3,"previous":{"value":1},"next":{"value":2}}'><span class="counter">Counter:2</span></span></p>`
         );
         await click(".counter");
         await animationFrame();
         expect(getContent(el)).toBe(
-            `<div>a[]<span data-embedded="counter" data-embedded-props='{"value":3}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":4,"previous":{"value":2},"next":{"value":3}}'><span class="counter">Counter:3</span></span></div>`
+            `<p>a[]<span data-embedded="counter" data-embedded-props='{"value":3}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":4,"previous":{"value":2},"next":{"value":3}}'><span class="counter">Counter:3</span></span></p>`
         );
         undo(editor);
         await animationFrame();
         expect(getContent(el)).toBe(
-            `<div>a[]<span data-embedded="counter" data-embedded-props='{"value":2}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":5,"previous":{"value":3},"next":{"value":2}}'><span class="counter">Counter:2</span></span></div>`
+            `<p>a[]<span data-embedded="counter" data-embedded-props='{"value":2}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":5,"previous":{"value":3},"next":{"value":2}}'><span class="counter">Counter:2</span></span></p>`
         );
         redo(editor);
         await animationFrame();
         expect(getContent(el)).toBe(
-            `<div>a[]<span data-embedded="counter" data-embedded-props='{"value":3}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":6,"previous":{"value":2},"next":{"value":3}}'><span class="counter">Counter:3</span></span></div>`
+            `<p>a[]<span data-embedded="counter" data-embedded-props='{"value":3}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":6,"previous":{"value":2},"next":{"value":3}}'><span class="counter">Counter:3</span></span></p>`
         );
     });
 
     test("Embedded state evolves during the restoration of a savePoint after makeSavePoint, even if the component was destroyed", async () => {
         const { el, editor } = await setupEditor(
-            `<div>a[]<span data-embedded="counter" data-embedded-props='{"value":1}'></span></div>`,
+            `<p>a[]<span data-embedded="counter" data-embedded-props='{"value":1}'></span></p>`,
             { config: getConfig([savedCounter]) }
         );
         expect(getContent(el)).toBe(
-            `<div>a[]<span data-embedded="counter" data-embedded-props='{"value":1}' data-oe-protected="true" contenteditable="false"><span class="counter">Counter:1</span></span></div>`
+            `<p>a[]<span data-embedded="counter" data-embedded-props='{"value":1}' data-oe-protected="true" contenteditable="false"><span class="counter">Counter:1</span></span></p>`
         );
         const savepoint1 = editor.shared.history.makeSavePoint();
         await click(".counter");
@@ -1479,14 +1470,14 @@ describe("Embedded state", () => {
         await click(".counter");
         await animationFrame();
         expect(getContent(el)).toBe(
-            `<div>a[]<span data-embedded="counter" data-embedded-props='{"value":3}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":2,"previous":{"value":2},"next":{"value":3}}'><span class="counter">Counter:3</span></span></div>`
+            `<p>a[]<span data-embedded="counter" data-embedded-props='{"value":3}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":2,"previous":{"value":2},"next":{"value":3}}'><span class="counter">Counter:3</span></span></p>`
         );
         deleteForward(editor);
-        expect(getContent(el)).toBe(`<div>a[]</div>`);
+        expect(getContent(el)).toBe(`<p>a[]</p>`);
         savepoint2();
         await animationFrame();
         expect(getContent(el)).toBe(
-            `<div>a[]<span data-embedded="counter" data-embedded-props='{"value":2}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":3,"previous":{"value":3},"next":{"value":2}}'><span class="counter">Counter:2</span></span></div>`
+            `<p>a[]<span data-embedded="counter" data-embedded-props='{"value":2}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":3,"previous":{"value":3},"next":{"value":2}}'><span class="counter">Counter:2</span></span></p>`
         );
         savepoint1();
         await animationFrame();
@@ -1496,31 +1487,31 @@ describe("Embedded state", () => {
         // 3 -> 2, revert mutations of the second click.
         // 2 -> 1, revert mutations of the first click.
         expect(getContent(el)).toBe(
-            `<div>a[]<span data-embedded="counter" data-embedded-props='{"value":1}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":6,"previous":{"value":2},"next":{"value":1}}'><span class="counter">Counter:1</span></span></div>`
+            `<p>a[]<span data-embedded="counter" data-embedded-props='{"value":1}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":6,"previous":{"value":2},"next":{"value":1}}'><span class="counter">Counter:1</span></span></p>`
         );
     });
 
     test("Embedded state changes are discarded if the component is destroyed before they are applied", async () => {
         const { el, editor } = await setupEditor(
-            `<div>a[]<span data-embedded="counter" data-embedded-props='{"value":1}'></span></div>`,
+            `<p>a[]<span data-embedded="counter" data-embedded-props='{"value":1}'></span></p>`,
             { config: getConfig([savedCounter]) }
         );
         expect(getContent(el)).toBe(
-            `<div>a[]<span data-embedded="counter" data-embedded-props='{"value":1}' data-oe-protected="true" contenteditable="false"><span class="counter">Counter:1</span></span></div>`
+            `<p>a[]<span data-embedded="counter" data-embedded-props='{"value":1}' data-oe-protected="true" contenteditable="false"><span class="counter">Counter:1</span></span></p>`
         );
         await click(".counter");
         await animationFrame();
         expect(getContent(el)).toBe(
-            `<div>a[]<span data-embedded="counter" data-embedded-props='{"value":2}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":1,"previous":{"value":1},"next":{"value":2}}'><span class="counter">Counter:2</span></span></div>`
+            `<p>a[]<span data-embedded="counter" data-embedded-props='{"value":2}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":1,"previous":{"value":1},"next":{"value":2}}'><span class="counter">Counter:2</span></span></p>`
         );
         // Launch click sequence without awaiting it
         click(queryFirst(".counter"));
         deleteForward(editor);
-        expect(getContent(el)).toBe(`<div>a[]</div>`);
+        expect(getContent(el)).toBe(`<p>a[]</p>`);
         undo(editor);
         await animationFrame();
         expect(getContent(el)).toBe(
-            `<div>a[]<span data-embedded="counter" data-embedded-props='{"value":2}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":1,"previous":{"value":1},"next":{"value":2}}'><span class="counter">Counter:2</span></span></div>`
+            `<p>a[]<span data-embedded="counter" data-embedded-props='{"value":2}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":1,"previous":{"value":1},"next":{"value":2}}'><span class="counter">Counter:2</span></span></p>`
         );
     });
 
@@ -1533,11 +1524,11 @@ describe("Embedded state", () => {
             },
         });
         const { el, editor } = await setupEditor(
-            `<div>a[]<span data-embedded="counter" data-embedded-props='{"name":"customName","value":1}'></span></div>`,
+            `<p>a[]<span data-embedded="counter" data-embedded-props='{"name":"customName","value":1}'></span></p>`,
             { config: getConfig([namedCounter]) }
         );
         expect(getContent(el)).toBe(
-            `<div>a[]<span data-embedded="counter" data-embedded-props='{"name":"customName","value":1}' data-oe-protected="true" contenteditable="false"><span class="counter">customName:4</span></span></div>`
+            `<p>a[]<span data-embedded="counter" data-embedded-props='{"name":"customName","value":1}' data-oe-protected="true" contenteditable="false"><span class="counter">customName:4</span></span></p>`
         );
         // Only consider props supposed to be extracted from `data-embedded-props`
         const props = {
@@ -1556,7 +1547,7 @@ describe("Embedded state", () => {
         counter.embeddedState.value = 2;
         await animationFrame();
         expect(getContent(el)).toBe(
-            `<div>a[]<span data-embedded="counter" data-embedded-props='{"name":"customName","value":2}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":1,"previous":{"baseValue":3,"value":1},"next":{"baseValue":5,"value":2}}'><span class="counter">customName:7</span></span></div>`
+            `<p>a[]<span data-embedded="counter" data-embedded-props='{"name":"customName","value":2}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":1,"previous":{"baseValue":3,"value":1},"next":{"baseValue":5,"value":2}}'><span class="counter">customName:7</span></span></p>`
         );
         deleteForward(editor);
         undo(editor);
@@ -1567,7 +1558,7 @@ describe("Embedded state", () => {
             value: 2, // recovered from the props
         });
         expect(getContent(el)).toBe(
-            `<div>a[]<span data-embedded="counter" data-embedded-props='{"name":"customName","value":2}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":1,"previous":{"baseValue":3,"value":1},"next":{"baseValue":5,"value":2}}'><span class="counter">customName:5</span></span></div>`
+            `<p>a[]<span data-embedded="counter" data-embedded-props='{"name":"customName","value":2}' data-oe-protected="true" contenteditable="false" data-embedded-state='{"stateChangeId":1,"previous":{"baseValue":3,"value":1},"next":{"baseValue":5,"value":2}}'><span class="counter">customName:5</span></span></p>`
         );
     });
 });

--- a/addons/html_editor/static/tests/font_awesome.test.js
+++ b/addons/html_editor/static/tests/font_awesome.test.js
@@ -307,17 +307,17 @@ describe("deleteForward", () => {
             test("should not delete a fontawesome after multiple deleteForward with spaces inside a <span>", async () => {
                 await testEditor({
                     contentBefore:
-                        '<div><span class="a">ab[]c </span><i class="fa fa-star"></i> def</div>',
+                        '<p><span class="a">ab[]c </span><i class="fa fa-star"></i> def</p>',
                     contentBeforeEdit:
-                        '<div><span class="a">ab[]c </span><i class="fa fa-star" contenteditable="false">\u200b</i> def</div>',
+                        '<p><span class="a">ab[]c </span><i class="fa fa-star" contenteditable="false">\u200b</i> def</p>',
                     stepFunction: async (editor) => {
                         deleteForward(editor);
                         deleteForward(editor);
                     },
                     contentAfterEdit:
-                        '<div><span class="a">ab[]</span><i class="fa fa-star" contenteditable="false">\u200b</i> def</div>',
+                        '<p><span class="a">ab[]</span><i class="fa fa-star" contenteditable="false">\u200b</i> def</p>',
                     contentAfter:
-                        '<div><span class="a">ab[]</span><i class="fa fa-star"></i> def</div>',
+                        '<p><span class="a">ab[]</span><i class="fa fa-star"></i> def</p>',
                 });
             });
         });

--- a/addons/html_editor/static/tests/format/bold.test.js
+++ b/addons/html_editor/static/tests/format/bold.test.js
@@ -197,8 +197,7 @@ test("should make a few characters bold inside table (bold)", async () => {
                         <td><p><br></p></td>
                     </tr>
                 </tbody>
-            </table>`
-        ),
+            </table>`),
         stepFunction: bold,
         contentAfterEdit: unformat(`
             <table class="table table-bordered o_table o_selected_table">
@@ -219,8 +218,7 @@ test("should make a few characters bold inside table (bold)", async () => {
                         <td><p><br></p></td>
                     </tr>
             </tbody>
-            </table>`
-        ),
+            </table>`),
     });
 });
 
@@ -302,7 +300,7 @@ describe("inside container or inline with class already bold", () => {
     test("should force the font-weight to normal with an inline with class", async () => {
         await testEditor({
             styleContent: styleContentBold,
-            contentBefore: `<div>a<span class="boldClass">[b]</span>c</div>`,
+            contentBefore: `<div class="o-paragraph">a<span class="boldClass">[b]</span>c</div>`,
             stepFunction: bold,
             contentAfter: `<div>a<span class="boldClass"><span style="font-weight: normal;">[b]</span></span>c</div>`,
         });
@@ -311,9 +309,9 @@ describe("inside container or inline with class already bold", () => {
     test("should force the font-weight to normal", async () => {
         await testEditor({
             styleContent: styleContentBold,
-            contentBefore: `<div class="boldClass">a[b]c</div>`,
+            contentBefore: `<p class="boldClass">a[b]c</p>`,
             stepFunction: bold,
-            contentAfter: `<div class="boldClass">a<span style="font-weight: normal;">[b]</span>c</div>`,
+            contentAfter: `<p class="boldClass">a<span style="font-weight: normal;">[b]</span>c</p>`,
         });
     });
 
@@ -321,9 +319,9 @@ describe("inside container or inline with class already bold", () => {
         for (const tag of BOLD_TAGS) {
             await testEditor({
                 styleContent: styleContentBold,
-                contentBefore: `<div class="boldClass">a${tag("[b]")}c</div>`,
+                contentBefore: `<p class="boldClass">a${tag("[b]")}c</p>`,
                 stepFunction: bold,
-                contentAfter: `<div class="boldClass">a<span style="font-weight: normal;">[b]</span>c</div>`,
+                contentAfter: `<p class="boldClass">a<span style="font-weight: normal;">[b]</span>c</p>`,
             });
         }
     });

--- a/addons/html_editor/static/tests/format/bold.test.js
+++ b/addons/html_editor/static/tests/format/bold.test.js
@@ -55,7 +55,7 @@ test("should make qweb tag bold", async () => {
     });
 });
 
-test("should make qweb tag bold even with partial selection", async () => {
+test("should make qweb tag bold and create a step even with partial selection inside contenteditable false", async () => {
     const { editor, el } = await setupEditor(
         `<div><p t-esc="'Test'" contenteditable="false">T[e]st</p></div>`
     );
@@ -64,6 +64,13 @@ test("should make qweb tag bold even with partial selection", async () => {
         `<div>[<p t-esc="'Test'" contenteditable="false" style="font-weight: bolder;">Test</p>]</div>`
     );
     expect(queryOne(`p[contenteditable="false"]`).childNodes.length).toBe(1);
+    const historySteps = editor.shared.history.getHistorySteps();
+    expect(historySteps.length).toBe(2);
+    const lastStep = historySteps.at(-1);
+    expect(lastStep.mutations.length).toBe(1);
+    expect(lastStep.mutations[0].type).toBe("attributes");
+    expect(lastStep.mutations[0].attributeName).toBe("style");
+    expect(lastStep.mutations[0].value).toBe("font-weight: bolder;");
 });
 
 test("should make a whole heading bold after a triple click", async () => {

--- a/addons/html_editor/static/tests/history.test.js
+++ b/addons/html_editor/static/tests/history.test.js
@@ -320,6 +320,14 @@ describe("prevent system classes to be set from history", () => {
 
         expect(getContent(el)).toBe(`<p class="y">a</p>`);
     });
+
+    test("should not copy system classes when changing a tag name", async () => {
+        const { el, editor } = await setupEditor(`<p class="x">a[]</p>`, { config: { Plugins } });
+        editor.shared.dom.setTag({
+            tagName: "h1",
+        });
+        expect(getContent(el)).toBe(`<h1>a[]</h1>`);
+    });
 });
 
 describe("makeSavePoint", () => {

--- a/addons/html_editor/static/tests/history.test.js
+++ b/addons/html_editor/static/tests/history.test.js
@@ -582,14 +582,18 @@ describe("destroy", () => {
             }
             destroy() {
                 this.dependencies.dom.insert(
-                    parseHTML(this.document, `<div class="test">destroyed</div>`)
+                    parseHTML(this.document, `<div class="test oe_unbreakable">destroyed</div>`)
                 );
             }
         }
         const Plugins = [...MAIN_PLUGINS, TestPlugin];
-        const { editor } = await setupEditor(`<div>a[]b</div>`, { config: { Plugins } });
+        const { editor } = await setupEditor(`<div class="oe_unbreakable">a[]b</div>`, {
+            config: { Plugins },
+        });
         // Ensure dispatch when plugins are alive.
-        editor.shared.dom.insert(parseHTML(editor.document, `<div class="test">destroyed</div>`));
+        editor.shared.dom.insert(
+            parseHTML(editor.document, `<div class="test oe_unbreakable">destroyed</div>`)
+        );
         await animationFrame();
         expect.verifySteps(["dispatch"]);
         editor.destroy();

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -405,13 +405,13 @@ test("edit a html field in new form view dialog and close the dialog with 'escap
             </form>`,
     });
     expect(".modal").toHaveCount(1);
-    expect(".odoo-editor-editable p").toHaveText("");
+    expect(".odoo-editor-editable div.o-paragraph").toHaveText("");
 
     await contains("[name='txt'] .odoo-editor-editable").focus();
-    setSelectionInHtmlField();
+    setSelectionInHtmlField("div.o-paragraph");
     await insertText(htmlEditor, "test");
     await animationFrame();
-    expect(".odoo-editor-editable p").toHaveText("test");
+    expect(".odoo-editor-editable div.o-paragraph").toHaveText("test");
     expect(".o_form_button_save").toBeVisible();
 
     await press("escape");
@@ -900,21 +900,21 @@ test("html field with a placeholder", async () => {
     });
 
     expect(`[name="txt"] .odoo-editor-editable`).toHaveInnerHTML(
-        '<p placeholder="test" class="o-we-hint"><br></p>',
+        '<div class="o-paragraph o-we-hint" placeholder="test"><br></div>',
         { type: "html" }
     );
 
-    setSelectionInHtmlField();
+    setSelectionInHtmlField("div.o-paragraph");
     await tick();
     expect(`[name="txt"] .odoo-editor-editable`).toHaveInnerHTML(
-        '<p placeholder="Type &quot;/&quot; for commands" class="o-we-hint"><br></p>',
+        '<div class="o-paragraph o-we-hint" placeholder="Type &quot;/&quot; for commands"><br></div>',
         { type: "html" }
     );
 
     moveSelectionOutsideEditor();
     await tick();
     expect(`[name="txt"] .odoo-editor-editable`).toHaveInnerHTML(
-        '<p placeholder="test" class="o-we-hint"><br></p>',
+        '<div class="o-paragraph o-we-hint" placeholder="test"><br></div>',
         { type: "html" }
     );
 });

--- a/addons/html_editor/static/tests/image.test.js
+++ b/addons/html_editor/static/tests/image.test.js
@@ -18,7 +18,7 @@ test("image can be selected", async () => {
     await waitFor(".o-we-toolbar");
     expect(".btn-group[name='image_shape']").toHaveCount(1);
     const selectionPlugin = plugins.get("selection");
-    expect(selectionPlugin.getSelectedNodes()[0].tagName).toBe("IMG");
+    expect(selectionPlugin.getSelectedNodes()[1].tagName).toBe("IMG");
 });
 
 test("can shape an image", async () => {
@@ -62,7 +62,7 @@ test("can shape an image", async () => {
 
 test("shape_circle and shape_rounded are mutually exclusive", async () => {
     await setupEditor(`
-        <img src="${base64Img}">
+        <p><img src="${base64Img}"></p>
     `);
     const img = queryOne("img");
     await click(img);
@@ -491,7 +491,7 @@ test("can undo adding link to image", async () => {
 
     undo(editor);
     await animationFrame();
-    expect(img.parentElement.tagName).toBe("P");
+    expect(img.parentElement.tagName).toBe("DIV");
 });
 
 test("can remove the link of an image", async () => {
@@ -504,7 +504,7 @@ test("can remove the link of an image", async () => {
     expect("button[name='unlink']").toHaveCount(1);
     await click("button[name='unlink']");
     await animationFrame();
-    expect(img.parentElement.tagName).toBe("P");
+    expect(img.parentElement.tagName).toBe("DIV");
     expect(".o-we-linkpopover").toHaveCount(0);
 });
 
@@ -517,7 +517,7 @@ test("can undo link removing of an image", async () => {
     await waitFor(".o-we-toolbar");
     await click("button[name='unlink']");
     await animationFrame();
-    expect(img.parentElement.tagName).toBe("P");
+    expect(img.parentElement.tagName).toBe("DIV");
 
     undo(editor);
     await animationFrame();

--- a/addons/html_editor/static/tests/initialization.test.js
+++ b/addons/html_editor/static/tests/initialization.test.js
@@ -6,41 +6,38 @@ import { testEditor } from "./_helpers/editor";
  */
 
 describe("No orphan inline elements compatibility mode", () => {
-    test("should wrap inline node inside a p", async () => {
+    test("should wrap inline node inside a div baseContainer", async () => {
         await testEditor({
             contentBefore: "<p>abc</p> <p>def</p> orphan node",
-            contentAfter: '<p>abc</p><p>def</p><p style="margin-bottom: 0px;"> orphan node</p>',
+            contentAfter: "<p>abc</p><p>def</p><div> orphan node</div>",
         });
     });
 
-    test("should wrap inline node inside a p (2)", async () => {
+    test("should wrap inline node inside a div baseContainer (2)", async () => {
         await testEditor({
             contentBefore: "<p>ab</p>cd<p>ef</p>",
-            contentAfter: '<p>ab</p><p style="margin-bottom: 0px;">cd</p><p>ef</p>',
+            contentAfter: "<p>ab</p><div>cd</div><p>ef</p>",
         });
     });
 
-    test("should transform root <br> into <p>", async () => {
+    test("should transform root <br> into a div baseContainer", async () => {
         await testEditor({
             contentBefore: "ab<br>c",
-            contentAfter:
-                '<p style="margin-bottom: 0px;">ab</p><p style="margin-bottom: 0px;">c</p>',
+            contentAfter: "<div>ab</div><div>c</div>",
         });
     });
 
     test("should keep <br> if necessary", async () => {
         await testEditor({
             contentBefore: "ab<br><br>c",
-            contentAfter:
-                '<p style="margin-bottom: 0px;">ab</p><p style="margin-bottom: 0px;"><br></p><p style="margin-bottom: 0px;">c</p>',
+            contentAfter: "<div>ab</div><div><br></div><div>c</div>",
         });
     });
 
     test("should keep multiple conecutive <br> if necessary", async () => {
         await testEditor({
             contentBefore: "ab<br><br><br><br>c",
-            contentAfter:
-                '<p style="margin-bottom: 0px;">ab</p><p style="margin-bottom: 0px;"><br></p><p style="margin-bottom: 0px;"><br></p><p style="margin-bottom: 0px;"><br></p><p style="margin-bottom: 0px;">c</p>',
+            contentAfter: "<div>ab</div><div><br></div><div><br></div><div><br></div><div>c</div>",
         });
     });
 
@@ -48,7 +45,7 @@ describe("No orphan inline elements compatibility mode", () => {
         await testEditor({
             contentBefore: 'ab<br>c<br>d<span class="keep">xxx</span>e<br>f',
             contentAfter:
-                '<p style="margin-bottom: 0px;">ab</p><p style="margin-bottom: 0px;">c</p><p style="margin-bottom: 0px;">d<span class="keep">xxx</span>e</p><p style="margin-bottom: 0px;">f</p>',
+                '<div>ab</div><div>c</div><div>d<span class="keep">xxx</span>e</div><div>f</div>',
         });
     });
 
@@ -56,7 +53,7 @@ describe("No orphan inline elements compatibility mode", () => {
         await testEditor({
             contentBefore: "ab<br>c<ul><li>d</li><li>e</li></ul> f<br>g",
             contentAfter:
-                '<p style="margin-bottom: 0px;">ab</p><p style="margin-bottom: 0px;">c</p><ul><li>d</li><li>e</li></ul><p style="margin-bottom: 0px;"> f</p><p style="margin-bottom: 0px;">g</p>',
+                "<div>ab</div><div>c</div><ul><li>d</li><li>e</li></ul><div> f</div><div>g</div>",
         });
     });
 
@@ -71,8 +68,7 @@ describe("No orphan inline elements compatibility mode", () => {
         });
         await testEditor({
             contentBefore: "xx<p>ab<br>c</p>d<br>yy",
-            contentAfter:
-                '<p style="margin-bottom: 0px;">xx</p><p>ab<br>c</p><p style="margin-bottom: 0px;">d</p><p style="margin-bottom: 0px;">yy</p>',
+            contentAfter: "<div>xx</div><p>ab<br>c</p><div>d</div><div>yy</div>",
         });
     });
 
@@ -90,8 +86,7 @@ describe("No orphan inline elements compatibility mode", () => {
     test("should transform root .fa", async () => {
         await testEditor({
             contentBefore: '<p>ab</p><i class="fa fa-beer"></i><p>c</p>',
-            contentAfter:
-                '<p>ab</p><p style="margin-bottom: 0px;"><i class="fa fa-beer"></i></p><p>c</p>',
+            contentAfter: '<p>ab</p><div><i class="fa fa-beer"></i></div><p>c</p>',
         });
     });
 
@@ -99,9 +94,8 @@ describe("No orphan inline elements compatibility mode", () => {
         await testEditor({
             contentBefore: '<p>abc</p><div class="o_image"></div><p>def</p>',
             contentBeforeEdit:
-                '<p>abc</p><div style="margin-bottom: 0px;"><div class="o_image" contenteditable="false"></div></div><p>def</p>',
-            contentAfter:
-                '<p>abc</p><div style="margin-bottom: 0px;"><div class="o_image"></div></div><p>def</p>',
+                '<p>abc</p><div><div class="o_image" contenteditable="false"></div></div><p>def</p>',
+            contentAfter: '<p>abc</p><div><div class="o_image"></div></div><p>def</p>',
         });
     });
 });
@@ -110,7 +104,7 @@ describe("allowInlineAtRoot options", () => {
     test("should wrap inline node inside a p by default", async () => {
         await testEditor({
             contentBefore: "abc",
-            contentAfter: '<p style="margin-bottom: 0px;">abc</p>',
+            contentAfter: "<div>abc</div>",
         });
     });
 
@@ -118,7 +112,7 @@ describe("allowInlineAtRoot options", () => {
         await testEditor(
             {
                 contentBefore: "abc",
-                contentAfter: '<p style="margin-bottom: 0px;">abc</p>',
+                contentAfter: "<div>abc</div>",
             },
             { allowInlineAtRoot: false }
         );

--- a/addons/html_editor/static/tests/insert/html.test.js
+++ b/addons/html_editor/static/tests/insert/html.test.js
@@ -212,6 +212,48 @@ describe("collapsed selection", () => {
         );
     });
 
+    test("Should ensure a paragraph after an inserted unbreakable (add)", async () => {
+        const { editor } = await setupEditor(`<p>cont[]</p>`, {});
+        editor.shared.dom.insert(parseHTML(editor.document, `<p class="oe_unbreakable">1</p>`));
+        expect(getContent(editor.editable)).toBe(
+            `<p>cont</p><p class="oe_unbreakable">1[]</p><p><br></p>`
+        );
+    });
+
+    test("Should ensure a paragraph after an inserted unbreakable (keep)", async () => {
+        const { editor } = await setupEditor(`<p>cont[]</p><p>+</p>`, {});
+        editor.shared.dom.insert(parseHTML(editor.document, `<p class="oe_unbreakable">1</p>`));
+        expect(getContent(editor.editable)).toBe(
+            `<p>cont</p><p class="oe_unbreakable">1[]</p><p>+</p>`
+        );
+    });
+
+    test("Should ensure a paragraph after inserting multiple unbreakables (add)", async () => {
+        const { editor } = await setupEditor(`<p>cont[]</p>`, {});
+        editor.shared.dom.insert(
+            parseHTML(
+                editor.document,
+                `<p class="oe_unbreakable">1</p><p class="oe_unbreakable">2</p>`
+            )
+        );
+        expect(getContent(editor.editable)).toBe(
+            `<p>cont</p><p class="oe_unbreakable">1</p><p class="oe_unbreakable">2[]</p><p><br></p>`
+        );
+    });
+
+    test("Should ensure a paragraph after inserting multiple unbreakables (keep)", async () => {
+        const { editor } = await setupEditor(`<p>cont[]</p><p>+</p>`, {});
+        editor.shared.dom.insert(
+            parseHTML(
+                editor.document,
+                `<p class="oe_unbreakable">1</p><p class="oe_unbreakable">2</p>`
+            )
+        );
+        expect(getContent(editor.editable)).toBe(
+            `<p>cont</p><p class="oe_unbreakable">1</p><p class="oe_unbreakable">2[]</p><p>+</p>`
+        );
+    });
+
     test("should unwrap a paragraphRelated element inside another", async () => {
         const { editor } = await setupEditor(`<p>cont[]ent</p>`, {});
         editor.shared.dom.insert(parseHTML(editor.document, `<p>in</p>`));

--- a/addons/html_editor/static/tests/insert/html.test.js
+++ b/addons/html_editor/static/tests/insert/html.test.js
@@ -200,7 +200,7 @@ describe("collapsed selection", () => {
         // This test is a bit odd and whitebox but this is because multiple
         // parameters of the use case are interacting
         const { editor } = await setupEditor(
-            `<div><p class="oe-unbreakable" contenteditable="true"><b class="oe_unbreakable">cont[]ent</b></p></div>`,
+            `<div><p class="oe_unbreakable" contenteditable="true"><b class="oe_unbreakable">cont[]ent</b></p></div>`,
             {}
         );
 
@@ -208,7 +208,7 @@ describe("collapsed selection", () => {
             parseHTML(editor.document, "<table><tbody><tr><td/></tr></tbody></table>")
         );
         expect(getContent(editor.editable)).toBe(
-            `<div><p class="oe-unbreakable" contenteditable="true"><b class="oe_unbreakable">content[]</b><table><tbody><tr><td></td></tr></tbody></table></p></div>`
+            `<div><p class="oe_unbreakable" contenteditable="true"><b class="oe_unbreakable">content[]</b><table><tbody><tr><td></td></tr></tbody></table></p></div>`
         );
     });
 
@@ -322,32 +322,32 @@ describe("collapsed selection", () => {
 
     test("insert block in empty paragraph", async () => {
         const { el, editor } = await setupEditor(`<p>[]<br></p>`);
-        editor.shared.dom.insert(parseHTML(editor.document, `<div class="a">a</div>`));
+        editor.shared.dom.insert(parseHTML(editor.document, `<div class="oe_unbreakable">a</div>`));
         editor.shared.history.addStep();
         dispatchClean(editor);
-        expect(getContent(el)).toBe(`<div class="a">a</div><p>[]<br></p>`);
+        expect(getContent(el)).toBe(`<div class="oe_unbreakable">a</div><p>[]<br></p>`);
     });
 
     test("insert block at the end of a paragraph", async () => {
         const { el, editor } = await setupEditor(`<p>b[]</p>`);
-        editor.shared.dom.insert(parseHTML(editor.document, `<div class="a">a</div>`));
+        editor.shared.dom.insert(parseHTML(editor.document, `<div class="oe_unbreakable">a</div>`));
         editor.shared.history.addStep();
         dispatchClean(editor);
-        expect(getContent(el)).toBe(`<p>b</p><div class="a">a</div><p>[]<br></p>`);
+        expect(getContent(el)).toBe(`<p>b</p><div class="oe_unbreakable">a</div><p>[]<br></p>`);
     });
 
     test("insert block at the start of a paragraph", async () => {
         const { el, editor } = await setupEditor(`<p>[]b</p>`);
-        editor.shared.dom.insert(parseHTML(editor.document, `<div class="a">a</div>`));
+        editor.shared.dom.insert(parseHTML(editor.document, `<div class="oe_unbreakable">a</div>`));
         editor.shared.history.addStep();
-        expect(getContent(el)).toBe(`<div class="a">a</div><p>[]b</p>`);
+        expect(getContent(el)).toBe(`<div class="oe_unbreakable">a</div><p>[]b</p>`);
     });
 
     test("insert block at the middle of a paragraph", async () => {
         const { el, editor } = await setupEditor(`<p>b[]c</p>`);
-        editor.shared.dom.insert(parseHTML(editor.document, `<div class="a">a</div>`));
+        editor.shared.dom.insert(parseHTML(editor.document, `<div class="oe_unbreakable">a</div>`));
         editor.shared.history.addStep();
-        expect(getContent(el)).toBe(`<p>b</p><div class="a">a</div><p>[]c</p>`);
+        expect(getContent(el)).toBe(`<p>b</p><div class="oe_unbreakable">a</div><p>[]c</p>`);
     });
 });
 

--- a/addons/html_editor/static/tests/insert/html.test.js
+++ b/addons/html_editor/static/tests/insert/html.test.js
@@ -212,6 +212,44 @@ describe("collapsed selection", () => {
         );
     });
 
+    test("should unwrap a paragraphRelated element inside another", async () => {
+        const { editor } = await setupEditor(`<p>cont[]ent</p>`, {});
+        editor.shared.dom.insert(parseHTML(editor.document, `<p>in</p>`));
+        expect(getContent(editor.editable)).toBe(`<p>contin[]ent</p>`);
+    });
+
+    test("should unwrap a contenteditable='true' ancestor which is not descendant of a contenteditable='false'", async () => {
+        const { editor } = await setupEditor(`<p>cont[]ent</p>`, {});
+        editor.shared.dom.insert(parseHTML(editor.document, `<p contenteditable="true">in</p>`));
+        expect(getContent(editor.editable)).toBe(`<p>contin[]ent</p>`);
+    });
+
+    test("should not unwrap a contenteditable='false'", async () => {
+        const { editor } = await setupEditor(`<p>cont[]ent</p>`, {});
+        editor.shared.dom.insert(parseHTML(editor.document, `<p contenteditable="false">in</p>`));
+        expect(getContent(editor.editable)).toBe(
+            `<p>cont</p><p contenteditable="false">in</p><p>[]ent</p>`
+        );
+    });
+
+    test("should not unwrap an unsplittable", async () => {
+        const { editor } = await setupEditor(`<p>cont[]ent</p>`, {});
+        editor.shared.dom.insert(parseHTML(editor.document, `<p class="oe_unbreakable">in</p>`));
+        expect(getContent(editor.editable)).toBe(
+            `<p>cont</p><p class="oe_unbreakable">in[]</p><p>ent</p>`
+        );
+    });
+
+    test("should normalize the parent when inserting a single element", async () => {
+        const { editor } = await setupEditor(`<p>[]<br></p>`, {});
+        editor.shared.dom.insert(
+            parseHTML(editor.document, `<p data-oe-protected="true">in</p>`).firstElementChild
+        );
+        expect(getContent(editor.editable, { sortAttrs: true })).toBe(
+            `<p contenteditable="false" data-oe-protected="true">in</p><p>[]<br></p>`
+        );
+    });
+
     test("insert inline in empty paragraph", async () => {
         const { el, editor } = await setupEditor(`<p>[]<br></p>`);
         editor.shared.dom.insert(parseHTML(editor.document, `<span class="a">a</span>`));

--- a/addons/html_editor/static/tests/insert/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/insert/paragraph_break.test.js
@@ -434,29 +434,29 @@ describe("Selection collapsed", () => {
         // see `anchor.nodeName === "A" && brEls.includes(anchor.firstChild)` in line_break_plugin.js
         test("should insert line breaks outside the edges of an anchor in unbreakable", async () => {
             await testEditor({
-                contentBefore: "<div>ab<a>[]cd</a></div>",
+                contentBefore: `<div class="oe_unbreakable">ab<a>[]cd</a></div>`,
                 stepFunction: splitBlockA,
-                contentAfter: "<div>ab<br><a>[]cd</a></div>",
+                contentAfter: `<div class="oe_unbreakable">ab<br><a>[]cd</a></div>`,
             });
             await testEditor({
-                contentBefore: "<div><a>a[]b</a></div>",
+                contentBefore: `<div class="oe_unbreakable"><a>a[]b</a></div>`,
                 stepFunction: splitBlockA,
-                contentAfter: "<div><a>a<br>[]b</a></div>",
+                contentAfter: `<div class="oe_unbreakable"><a>a<br>[]b</a></div>`,
             });
             await testEditor({
-                contentBefore: "<div><a>ab[]</a></div>",
+                contentBefore: `<div class="oe_unbreakable"><a>ab[]</a></div>`,
                 stepFunction: splitBlockA,
-                contentAfter: "<div><a>ab</a><br><br>[]</div>",
+                contentAfter: `<div class="oe_unbreakable"><a>ab</a><br><br>[]</div>`,
             });
             await testEditor({
-                contentBefore: "<div><a>ab[]</a>cd</div>",
+                contentBefore: `<div class="oe_unbreakable"><a>ab[]</a>cd</div>`,
                 stepFunction: splitBlockA,
-                contentAfter: "<div><a>ab</a><br>[]cd</div>",
+                contentAfter: `<div class="oe_unbreakable"><a>ab</a><br>[]cd</div>`,
             });
             await testEditor({
-                contentBefore: '<div><a style="display: block;">ab[]</a></div>',
+                contentBefore: `<div class="oe_unbreakable"><a style="display: block;">ab[]</a></div>`,
                 stepFunction: splitBlockA,
-                contentAfter: '<div><a style="display: block;">ab</a>[]<br></div>',
+                contentAfter: `<div class="oe_unbreakable"><a style="display: block;">ab</a>[]<br></div>`,
             });
         });
 

--- a/addons/html_editor/static/tests/misc.test.js
+++ b/addons/html_editor/static/tests/misc.test.js
@@ -13,7 +13,7 @@ test("can instantiate a Editor", async () => {
     expect(getContent(el)).toBe(`<p>hel[lo] world</p>`);
     setContent(el, "<div>a[dddb]</div>");
     execCommand(editor, "formatBold");
-    expect(getContent(el)).toBe(`<div>a<strong>[dddb]</strong></div>`);
+    expect(getContent(el)).toBe(`<div class="o-paragraph">a<strong>[dddb]</strong></div>`);
 });
 
 test("cannot reattach an editor", async () => {
@@ -38,29 +38,29 @@ test("can instantiate a Editor in an iframe", async () => {
     expect(getContent(el)).toBe(`<p>hel[lo] world</p>`);
     setContent(el, "<div>a[dddb]</div>");
     execCommand(editor, "formatBold");
-    expect(getContent(el)).toBe(`<div>a<strong>[dddb]</strong></div>`);
+    expect(getContent(el)).toBe(`<div class="o-paragraph">a<strong>[dddb]</strong></div>`);
 });
 
 test("with an empty selector", async () => {
     const { el } = await setupEditor("<div>[]</div>", {});
     expect(el.innerHTML).toBe(
-        `<div placeholder="Type &quot;/&quot; for commands" class="o-we-hint"></div>`
+        `<div class="o-paragraph o-we-hint" placeholder="Type &quot;/&quot; for commands"><br></div>`
     );
     expect(getContent(el)).toBe(
-        `<div placeholder='Type "/" for commands' class="o-we-hint">[]</div>`
+        `<div class="o-paragraph o-we-hint" placeholder='Type "/" for commands'>[]<br></div>`
     );
 });
 
 test("with a part of the selector in an empty HTMLElement", async () => {
     const { el } = await setupEditor("<div>a[bc<div>]</div></div>", {});
-    expect(el.innerHTML).toBe(`<div>abc<div></div></div>`);
-    expect(getContent(el)).toBe(`<div>a[bc<div>]</div></div>`);
+    expect(el.innerHTML).toBe(`<div>abc<div class="o-paragraph"><br></div></div>`);
+    expect(getContent(el)).toBe(`<div>a[bc<div class="o-paragraph">]<br></div></div>`);
 });
 
 test("inverse selection", async () => {
     const { el } = await setupEditor("<div>a]bc<div>[</div></div>", {});
-    expect(el.innerHTML).toBe(`<div>abc<div></div></div>`);
-    expect(getContent(el)).toBe(`<div>a]bc<div>[</div></div>`);
+    expect(el.innerHTML).toBe(`<div>abc<div class="o-paragraph"><br></div></div>`);
+    expect(getContent(el)).toBe(`<div>a]bc<div class="o-paragraph">[<br></div></div>`);
 });
 
 test("with an empty selector and a <br>", async () => {

--- a/addons/html_editor/static/tests/movenode.test.js
+++ b/addons/html_editor/static/tests/movenode.test.js
@@ -5,7 +5,7 @@ import { contains } from "@web/../tests/web_test_helpers";
 import { setupEditor } from "./_helpers/editor";
 import { getContent } from "./_helpers/selection";
 
-describe.current.tags("desktop")
+describe.current.tags("desktop");
 
 const styles = `
 .odoo-editor-editable {
@@ -38,8 +38,8 @@ test("should show the hook when hovering the second P", async () => {
     expect(elementRect.top).toBe(37);
     expect(elementRect.left).toBe(5);
 });
-test("should not show the hook when hovering a DIV", async () => {
-    const { el } = await setupEditor("<p>a[]</p><div><br></div><p>b</p>", {
+test("should not show the hook when hovering a DIV which is not a baseContainer", async () => {
+    const { el } = await setupEditor(`<p>a[]</p><div class="oe_unbreakable"><br></div><p>b</p>`, {
         styleContent: styles,
     });
     await hover(el.querySelector("div"));
@@ -48,9 +48,12 @@ test("should not show the hook when hovering a DIV", async () => {
 });
 describe("drag", () => {
     test("should drop at the same place before the same element", async () => {
-        const { el } = await setupEditor("<p>a[]</p><div><br></div><p>b</p><p>c</p>", {
-            styleContent: styles,
-        });
+        const { el } = await setupEditor(
+            `<p>a[]</p><div class="oe_unbreakable"><br></div><div>d</div><p>b</p><p>c</p>`,
+            {
+                styleContent: styles,
+            }
+        );
         await animationFrame();
         const firstP = el.querySelector("p");
         await hover(firstP);
@@ -60,15 +63,20 @@ describe("drag", () => {
         await tick();
         const handle = await contains(moveElement).drag();
         dropzones = [...document.querySelectorAll(".oe-dropzone-box-side")];
-        expect(dropzones).toHaveLength(6);
+        expect(dropzones).toHaveLength(8);
         await handle.moveTo(dropzones[0]);
         await handle.drop();
-        expect(getContent(el)).toBe(`<p>a[]</p><div><br></div><p>b</p><p>c</p>`);
+        expect(getContent(el)).toBe(
+            `<p>a[]</p><div class="oe_unbreakable"><br></div><div class="o-paragraph">d</div><p>b</p><p>c</p>`
+        );
     });
     test("should drop at the same place after the same element", async () => {
-        const { el } = await setupEditor("<p>a[]</p><div><br></div><p>b</p><p>c</p>", {
-            styleContent: styles,
-        });
+        const { el } = await setupEditor(
+            `<p>a[]</p><div class="oe_unbreakable"><br></div><div>d</div><p>b</p><p>c</p>`,
+            {
+                styleContent: styles,
+            }
+        );
         await animationFrame();
         const firstP = el.querySelector("p");
         await hover(firstP);
@@ -78,15 +86,20 @@ describe("drag", () => {
         await tick();
         const handle = await contains(moveElement).drag();
         dropzones = [...document.querySelectorAll(".oe-dropzone-box-side")];
-        expect(dropzones).toHaveLength(6);
+        expect(dropzones).toHaveLength(8);
         await handle.moveTo(dropzones[1]);
         await handle.drop();
-        expect(getContent(el)).toBe(`<p>a[]</p><div><br></div><p>b</p><p>c</p>`);
+        expect(getContent(el)).toBe(
+            `<p>a[]</p><div class="oe_unbreakable"><br></div><div class="o-paragraph">d</div><p>b</p><p>c</p>`
+        );
     });
-    test("should drop before the next P", async () => {
-        const { el } = await setupEditor("<p>a[]</p><div><br></div><p>b</p><p>c</p>", {
-            styleContent: styles,
-        });
+    test("should drop before the next baseContainer", async () => {
+        const { el } = await setupEditor(
+            `<p>a[]</p><div class="oe_unbreakable"><br></div><div>d</div><p>b</p><p>c</p>`,
+            {
+                styleContent: styles,
+            }
+        );
         await animationFrame();
         const firstP = el.querySelector("p");
         await hover(firstP);
@@ -96,15 +109,20 @@ describe("drag", () => {
         await tick();
         const handle = await contains(moveElement).drag();
         dropzones = [...document.querySelectorAll(".oe-dropzone-box-side")];
-        expect(dropzones).toHaveLength(6);
+        expect(dropzones).toHaveLength(8);
         await handle.moveTo(dropzones[2]);
         await handle.drop();
-        expect(getContent(el)).toBe(`<div><br></div><p>a[]</p><p>b</p><p>c</p>`);
+        expect(getContent(el)).toBe(
+            `<div class="oe_unbreakable"><br></div><p>a[]</p><div class="o-paragraph">d</div><p>b</p><p>c</p>`
+        );
     });
-    test("should drop after the next P", async () => {
-        const { el } = await setupEditor("<p>a[]</p><div><br></div><p>b</p><p>c</p>", {
-            styleContent: styles,
-        });
+    test("should drop after the next baseContainer", async () => {
+        const { el } = await setupEditor(
+            `<p>a[]</p><div class="oe_unbreakable"><br></div><div>d</div><p>b</p><p>c</p>`,
+            {
+                styleContent: styles,
+            }
+        );
         await animationFrame();
         const firstP = el.querySelector("p");
         await hover(firstP);
@@ -114,15 +132,20 @@ describe("drag", () => {
         await tick();
         const handle = await contains(moveElement).drag();
         dropzones = [...document.querySelectorAll(".oe-dropzone-box-side")];
-        expect(dropzones).toHaveLength(6);
+        expect(dropzones).toHaveLength(8);
         await handle.moveTo(dropzones[3]);
         await handle.drop();
-        expect(getContent(el)).toBe(`<div><br></div><p>b</p><p>a[]</p><p>c</p>`);
+        expect(getContent(el)).toBe(
+            `<div class="oe_unbreakable"><br></div><div class="o-paragraph">d</div><p>a[]</p><p>b</p><p>c</p>`
+        );
     });
     test("should do nothing when dropping outside the editable", async () => {
-        const { el } = await setupEditor("<p>a[]</p><div><br></div><p>b</p><p>c</p>", {
-            styleContent: styles,
-        });
+        const { el } = await setupEditor(
+            `<p>a[]</p><div class="oe_unbreakable"><br></div><div>d</div><p>b</p><p>c</p>`,
+            {
+                styleContent: styles,
+            }
+        );
         await animationFrame();
         const firstP = el.querySelector("p");
         await hover(firstP);
@@ -132,17 +155,22 @@ describe("drag", () => {
         await tick();
         const handle = await contains(moveElement).drag();
         dropzones = [...document.querySelectorAll(".oe-dropzone-box-side")];
-        expect(dropzones).toHaveLength(6);
+        expect(dropzones).toHaveLength(8);
         const outsideArea = document.createElement("div");
         getFixture().appendChild(outsideArea);
         await handle.moveTo(outsideArea);
         await handle.drop();
-        expect(getContent(el)).toBe(`<p>a[]</p><div><br></div><p>b</p><p>c</p>`);
+        expect(getContent(el)).toBe(
+            `<p>a[]</p><div class="oe_unbreakable"><br></div><div class="o-paragraph">d</div><p>b</p><p>c</p>`
+        );
     });
     test("should do nothing when dropping outside the editable and after hovering a hook", async () => {
-        const { el } = await setupEditor("<p>a[]</p><div><br></div><p>b</p><p>c</p>", {
-            styleContent: styles,
-        });
+        const { el } = await setupEditor(
+            `<p>a[]</p><div class="oe_unbreakable"><br></div><div>d</div><p>b</p><p>c</p>`,
+            {
+                styleContent: styles,
+            }
+        );
         await animationFrame();
         const firstP = el.querySelector("p");
         await hover(firstP);
@@ -152,12 +180,14 @@ describe("drag", () => {
         await tick();
         const handle = await contains(moveElement).drag();
         dropzones = [...document.querySelectorAll(".oe-dropzone-box-side")];
-        expect(dropzones).toHaveLength(6);
+        expect(dropzones).toHaveLength(8);
         handle.moveTo(dropzones[3]);
         const outsideArea = document.createElement("div");
         getFixture().appendChild(outsideArea);
         await handle.moveTo(outsideArea);
         await handle.drop();
-        expect(getContent(el)).toBe(`<p>a[]</p><div><br></div><p>b</p><p>c</p>`);
+        expect(getContent(el)).toBe(
+            `<p>a[]</p><div class="oe_unbreakable"><br></div><div class="o-paragraph">d</div><p>b</p><p>c</p>`
+        );
     });
 });

--- a/addons/html_editor/static/tests/normalize.test.js
+++ b/addons/html_editor/static/tests/normalize.test.js
@@ -5,6 +5,6 @@ test("should remove empty class attribute", async () => {
     // content after is compared after cleaning up DOM
     await testEditor({
         contentBefore: '<div class=""></div>',
-        contentAfter: "<div></div>",
+        contentAfter: "<div><br></div>",
     });
 });

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -7,27 +7,38 @@ import { setupEditor, testEditor } from "./_helpers/editor";
 import { cleanLinkArtifacts, unformat } from "./_helpers/format";
 import { getContent, setSelection } from "./_helpers/selection";
 import { pasteHtml, pasteOdooEditorHtml, pasteText, undo } from "./_helpers/user_actions";
+import { createBaseContainer } from "@html_editor/utils/base_container";
 
 function isInline(node) {
     return ["I", "B", "U", "S", "EM", "STRONG", "IMG", "BR", "A", "FONT"].includes(node);
 }
 
 function toIgnore(node) {
-    return ["TABLE", "THEAD", "TH", "TBODY", "TR", "TD", "IMG", "BR", "LI", ".fa"].includes(node);
+    return ["TABLE", "THEAD", "TH", "TBODY", "TR", "TD", "IMG", "BR", "LI", ".FA"].includes(node);
 }
 
 describe("Html Paste cleaning - whitelist", () => {
     test("should keep whitelisted Tags tag", async () => {
-        for (const node of CLIPBOARD_WHITELISTS.nodes) {
-            if (!toIgnore(node)) {
-                const html = isInline(node)
-                    ? `a<${node.toLowerCase()}>b</${node.toLowerCase()}>c`
-                    : `a</p><${node.toLowerCase()}>b</${node.toLowerCase()}><p>c`;
+        const baseContainer = createBaseContainer("DIV");
+        const baseContainerString = `${baseContainer.nodeName}`;
+        const agg = [baseContainerString];
+        const baseContainerClass = baseContainer.className;
+        if (baseContainerClass) {
+            agg.push(`class="${baseContainerClass}"`);
+        }
+        const baseContainerNode = agg.join(" ");
+        for (const node of [...CLIPBOARD_WHITELISTS.nodes, baseContainerNode]) {
+            const tagDescription = node.toLowerCase();
+            const tagName = node.split(" ")[0].toLowerCase();
+            if (!toIgnore(tagName.toUpperCase())) {
+                const html = isInline(tagName.toUpperCase())
+                    ? `a<${tagName}>b</${tagName}>c`
+                    : `a</p><${tagName}>b</${tagName}><p>c`;
 
                 await testEditor({
                     contentBefore: "<p>123[]4</p>",
                     stepFunction: async (editor) => {
-                        pasteHtml(editor, `a<${node.toLowerCase()}>b</${node.toLowerCase()}>c`);
+                        pasteHtml(editor, `a<${tagDescription}>b</${tagName}>c`);
                     },
                     contentAfter: "<p>123" + html + "[]4</p>",
                 });
@@ -205,11 +216,7 @@ describe("Simple text", () => {
                 stepFunction: async (editor) => {
                     pasteText(editor, "a\nb\nc\nd");
                 },
-                contentAfter:
-                    '<p style="margin-bottom: 0px;">a</p>' +
-                    '<p style="margin-bottom: 0px;">b</p>' +
-                    '<p style="margin-bottom: 0px;">c</p>' +
-                    "<p>d[]</p>",
+                contentAfter: "<div>a</div>" + "<div>b</div>" + "<div>c</div>" + "<p>d[]</p>",
             });
         });
 
@@ -220,31 +227,27 @@ describe("Simple text", () => {
                 stepFunction: async (editor) => {
                     pasteText(editor, "a\r\nb\r\nc\r\nd");
                 },
-                contentAfter:
-                    '<p style="margin-bottom: 0px;">a</p>' +
-                    '<p style="margin-bottom: 0px;">b</p>' +
-                    '<p style="margin-bottom: 0px;">c</p>' +
-                    "<p>d[]</p>",
+                contentAfter: "<div>a</div>" + "<div>b</div>" + "<div>c</div>" + "<p>d[]</p>",
             });
         });
 
         test("should paste text and understand \\n newlines within UNBREAKABLE node", async () => {
             await testEditor({
-                contentBefore: "<div>[]<br></div>",
+                contentBefore: `<div class="oe_unbreakable">[]<br></div>`,
                 stepFunction: async (editor) => {
                     pasteText(editor, "a\nb\nc\nd");
                 },
-                contentAfter: "<div>a<br>b<br>c<br>d[]</div>",
+                contentAfter: `<div class="oe_unbreakable">a<br>b<br>c<br>d[]</div>`,
             });
         });
 
         test("should paste text and understand \\n newlines within UNBREAKABLE node(2)", async () => {
             await testEditor({
-                contentBefore: '<div><span style="font-size: 9px;">a[]</span></div>',
+                contentBefore: `<div class="oe_unbreakable"><span style="font-size: 9px;">a[]</span></div>`,
                 stepFunction: async (editor) => {
                     pasteText(editor, "b\nc\nd");
                 },
-                contentAfter: '<div><span style="font-size: 9px;">ab<br>c<br>d[]</span></div>',
+                contentAfter: `<div class="oe_unbreakable"><span style="font-size: 9px;">ab<br>c<br>d[]</span></div>`,
             });
         });
 
@@ -744,7 +747,7 @@ describe("Simple html elements containing <br>", () => {
                 stepFunction: async (editor) => {
                     pasteHtml(editor, "<div>abc<br>def</div>");
                 },
-                contentAfter: "<p>abc</p><p>def[]</p>",
+                contentAfter: `<div>abc</div><div>def[]</div>`,
             });
         });
     });
@@ -1224,20 +1227,37 @@ describe("Complex html p", () => {
             });
         });
 
-        test("should paste a text when selection leave a span (5)", async () => {
+        test("should paste a text when selection leave a span (5) baseContainer", async () => {
             await testEditor({
                 contentBefore: '<div>1ab<span class="a">c[d</span>e]f</div>',
                 stepFunction: async (editor) => {
                     pasteHtml(editor, complexHtmlData);
                 },
-                contentAfter: '<div>1ab<span class="a">c12<br>34[]</span>f</div>',
+                contentAfter: `<div>1ab<span class="a">c12</span></div><div><span class="a">34[]</span>f</div>`,
             });
             await testEditor({
                 contentBefore: '<div>2a[b<span class="a">c]d</span>ef</div>',
                 stepFunction: async (editor) => {
                     pasteHtml(editor, complexHtmlData);
                 },
-                contentAfter: '<div>2a12<br>34[]<span class="a">d</span>ef</div>',
+                contentAfter: `<div>2a12</div><div>34[]<span class="a">d</span>ef</div>`,
+            });
+        });
+
+        test("should paste a text when selection leave a span (5) unbreakable", async () => {
+            await testEditor({
+                contentBefore: `<div class="oe_unbreakable">1ab<span class="a">c[d</span>e]f</div>`,
+                stepFunction: async (editor) => {
+                    pasteHtml(editor, complexHtmlData);
+                },
+                contentAfter: `<div class="oe_unbreakable">1ab<span class="a">c12<br>34[]</span>f</div>`,
+            });
+            await testEditor({
+                contentBefore: `<div class="oe_unbreakable">2a[b<span class="a">c]d</span>ef</div>`,
+                stepFunction: async (editor) => {
+                    pasteHtml(editor, complexHtmlData);
+                },
+                contentAfter: `<div class="oe_unbreakable">2a12<br>34[]<span class="a">d</span>ef</div>`,
             });
         });
 
@@ -1272,13 +1292,23 @@ describe("Complex html p", () => {
             });
         });
 
-        test("should paste a text when selection across two element (6)", async () => {
+        test("should paste a text when selection across two element (6) baseContainer", async () => {
             await testEditor({
                 contentBefore: '<div>2a<span class="a">b[c</span><p>d]e</p>f</div>',
                 stepFunction: async (editor) => {
                     pasteHtml(editor, complexHtmlData);
                 },
-                contentAfter: '<div>2a<span class="a">b12<br>34[]</span>e<br>f</div>',
+                contentAfter: `<div>2a<span class="a">b12</span></div><div><span class="a">34[]</span>e<br>f</div>`,
+            });
+        });
+
+        test("should paste a text when selection across two element (6) unbreakable", async () => {
+            await testEditor({
+                contentBefore: `<div class="oe_unbreakable">2a<span class="a">b[c</span><p>d]e</p>f</div>`,
+                stepFunction: async (editor) => {
+                    pasteHtml(editor, complexHtmlData);
+                },
+                contentAfter: `<div class="oe_unbreakable">2a<span class="a">b12<br>34[]</span>e<br>f</div>`,
             });
         });
     });
@@ -1383,14 +1413,14 @@ describe("Complex html 3 p", () => {
             });
         });
 
-        test("should paste a text when selection leave a span (7)", async () => {
+        test("should paste a text when selection leave a span (7) baseContainer", async () => {
             await testEditor({
                 contentBefore: '<div>1ab<span class="a">c[d</span>e]f</div>',
                 stepFunction: async (editor) => {
                     pasteHtml(editor, complexHtmlData);
                 },
                 contentAfter:
-                    '<div>1ab<span class="a">c1<i>X</i>2</span><p>3<i>X</i>4</p><span class="a">5<i>X</i>6[]</span>f</div>',
+                    '<div>1ab<span class="a">c1<i>X</i>2</span></div><p>3<i>X</i>4</p><div><span class="a">5<i>X</i>6[]</span>f</div>',
             });
             await testEditor({
                 contentBefore: '<div>2a[b<span class="a">c]d</span>ef</div>',
@@ -1398,7 +1428,26 @@ describe("Complex html 3 p", () => {
                     pasteHtml(editor, complexHtmlData);
                 },
                 contentAfter:
-                    '<div>2a1<i>X</i>2<p>3<i>X</i>4</p>5<i>X</i>6[]<span class="a">d</span>ef</div>',
+                    '<div>2a1<i>X</i>2</div><p>3<i>X</i>4</p><div>5<i>X</i>6[]<span class="a">d</span>ef</div>',
+            });
+        });
+
+        test("should paste a text when selection leave a span (7) unbreakable", async () => {
+            await testEditor({
+                contentBefore: '<div class="oe_unbreakable">1ab<span class="a">c[d</span>e]f</div>',
+                stepFunction: async (editor) => {
+                    pasteHtml(editor, complexHtmlData);
+                },
+                contentAfter:
+                    '<div class="oe_unbreakable">1ab<span class="a">c1<i>X</i>2</span><p>3<i>X</i>4</p><span class="a">5<i>X</i>6[]</span>f</div>',
+            });
+            await testEditor({
+                contentBefore: '<div class="oe_unbreakable">2a[b<span class="a">c]d</span>ef</div>',
+                stepFunction: async (editor) => {
+                    pasteHtml(editor, complexHtmlData);
+                },
+                contentAfter:
+                    '<div class="oe_unbreakable">2a1<i>X</i>2<p>3<i>X</i>4</p>5<i>X</i>6[]<span class="a">d</span>ef</div>',
             });
         });
 
@@ -1540,20 +1589,39 @@ describe("Complex html p+i", () => {
             });
         });
 
-        test("should paste a text when selection leave a span (9)", async () => {
+        test("should paste a text when selection leave a span (9) baseContainer", async () => {
             await testEditor({
                 contentBefore: '<div>1ab<span class="a">c[d</span>e]f</div>',
                 stepFunction: async (editor) => {
                     pasteHtml(editor, complexHtmlData);
                 },
-                contentAfter: '<div>1ab<span class="a">c12<i><br>ii</i>[]</span>f</div>',
+                contentAfter: `<div>1ab<span class="a">c12</span></div><div><span class="a"><i>ii</i>[]</span>f</div>`,
             });
             await testEditor({
                 contentBefore: '<div>2a[b<span class="a">c]d</span>ef</div>',
                 stepFunction: async (editor) => {
                     pasteHtml(editor, complexHtmlData);
                 },
-                contentAfter: '<div>2a12<i><br>ii</i>[]<span class="a">d</span>ef</div>',
+                contentAfter: `<div>2a12</div><div><i>ii</i>[]<span class="a">d</span>ef</div>`,
+            });
+        });
+
+        test("should paste a text when selection leave a span (9) unbreakable", async () => {
+            await testEditor({
+                contentBefore: '<div class="oe_unbreakable">1ab<span class="a">c[d</span>e]f</div>',
+                stepFunction: async (editor) => {
+                    pasteHtml(editor, complexHtmlData);
+                },
+                contentAfter:
+                    '<div class="oe_unbreakable">1ab<span class="a">c12<i><br>ii</i>[]</span>f</div>',
+            });
+            await testEditor({
+                contentBefore: '<div class="oe_unbreakable">2a[b<span class="a">c]d</span>ef</div>',
+                stepFunction: async (editor) => {
+                    pasteHtml(editor, complexHtmlData);
+                },
+                contentAfter:
+                    '<div class="oe_unbreakable">2a12<i><br>ii</i>[]<span class="a">d</span>ef</div>',
             });
         });
 
@@ -1585,13 +1653,23 @@ describe("Complex html p+i", () => {
             });
         });
 
-        test("should paste a text when selection across two element (10)", async () => {
+        test("should paste a text when selection across two element (10) baseContainer", async () => {
             await testEditor({
                 contentBefore: '<div>2a<span class="a">b[c</span><p>d]e</p>f</div>',
                 stepFunction: async (editor) => {
                     pasteHtml(editor, complexHtmlData);
                 },
-                contentAfter: '<div>2a<span class="a">b12<i><br>ii</i>[]</span>e<br>f</div>',
+                contentAfter: `<div>2a<span class="a">b12</span></div><div><span class="a"><i>ii</i>[]</span>e<br>f</div>`,
+            });
+        });
+
+        test("should paste a text when selection across two element (10) unbreakable", async () => {
+            await testEditor({
+                contentBefore: `<div class="oe_unbreakable">2a<span class="a">b[c</span><p>d]e</p>f</div>`,
+                stepFunction: async (editor) => {
+                    pasteHtml(editor, complexHtmlData);
+                },
+                contentAfter: `<div class="oe_unbreakable">2a<span class="a">b12<i><br>ii</i>[]</span>e<br>f</div>`,
             });
         });
     });
@@ -1691,22 +1769,39 @@ describe("Complex html 3p+b", () => {
             });
         });
 
-        test("should paste a text when selection leave a span (11)", async () => {
+        test("should paste a text when selection leave a span (11) baseContainer", async () => {
             await testEditor({
                 contentBefore: '<div>1ab<span class="a">c[d</span>e]f</div>',
                 stepFunction: async (editor) => {
                     pasteHtml(editor, complexHtmlData);
                 },
-                contentAfter:
-                    '<div>1ab<span class="a">c1<b>23</b></span><p>zzz</p><span class="a">45<b>6</b>7[]</span>f</div>',
+                contentAfter: `<div>1ab<span class="a">c1<b>23</b></span></div><p>zzz</p><div><span class="a">45<b>6</b>7[]</span>f</div>`,
             });
             await testEditor({
                 contentBefore: '<div>2a[b<span class="a">c]d</span>ef</div>',
                 stepFunction: async (editor) => {
                     pasteHtml(editor, complexHtmlData);
                 },
+                contentAfter: `<div>2a1<b>23</b></div><p>zzz</p><div>45<b>6</b>7[]<span class="a">d</span>ef</div>`,
+            });
+        });
+
+        test("should paste a text when selection leave a span (11) unbreakable", async () => {
+            await testEditor({
+                contentBefore: '<div class="oe_unbreakable">1ab<span class="a">c[d</span>e]f</div>',
+                stepFunction: async (editor) => {
+                    pasteHtml(editor, complexHtmlData);
+                },
                 contentAfter:
-                    '<div>2a1<b>23</b><p>zzz</p>45<b>6</b>7[]<span class="a">d</span>ef</div>',
+                    '<div class="oe_unbreakable">1ab<span class="a">c1<b>23</b></span><p>zzz</p><span class="a">45<b>6</b>7[]</span>f</div>',
+            });
+            await testEditor({
+                contentBefore: '<div class="oe_unbreakable">2a[b<span class="a">c]d</span>ef</div>',
+                stepFunction: async (editor) => {
+                    pasteHtml(editor, complexHtmlData);
+                },
+                contentAfter:
+                    '<div class="oe_unbreakable">2a1<b>23</b><p>zzz</p>45<b>6</b>7[]<span class="a">d</span>ef</div>',
             });
         });
 
@@ -1736,13 +1831,13 @@ describe("Complex html 3p+b", () => {
 
 describe("Complex html div", () => {
     const complexHtmlData = `<div><div><span style="color: #fb4934;">abc</span><span style="color: #ebdbb2;">def</span></div><div dir="rtl"><span style="color: #fb4934;">ghi</span><span style="color: #fe8019;">jkl</span></div><div><span style="color: #fb4934;">jkl</span><span style="color: #ebdbb2;">mno</span></div></div>`;
-    test("should convert div to p", async () => {
+    test("should convert div to a baseContainer", async () => {
         await testEditor({
             contentBefore: "<p>[]<br></p>",
             stepFunction: async (editor) => {
                 pasteHtml(editor, complexHtmlData);
             },
-            contentAfter: '<p>abcdef</p><p dir="rtl">ghijkl</p><p>jklmno[]</p>',
+            contentAfter: `<div>abcdef</div><div dir="rtl">ghijkl</div><div>jklmno[]</div>`,
         });
     });
 });
@@ -2424,7 +2519,7 @@ describe("link", () => {
                     pasteText(editor, "odoo.com\ngoogle.com");
                 },
                 contentAfter:
-                    '<p style="margin-bottom: 0px;"><a href="http://odoo.com">odoo.com</a></p>' +
+                    '<div><a href="http://odoo.com">odoo.com</a></div>' +
                     '<p><a href="http://google.com">google.com</a>[]</p>',
             });
         });
@@ -3102,9 +3197,9 @@ describe("Odoo editor own html", () => {
         await testEditor({
             contentBefore: "<p>a[]b</p>",
             stepFunction: async (editor) => {
-                pasteOdooEditorHtml(editor, '<div class="custom-paste">b</div>');
+                pasteOdooEditorHtml(editor, '<div class="custom-paste oe_unbreakable">b</div>');
             },
-            contentAfter: '<p>a</p><div class="custom-paste">b</div><p>[]b</p>',
+            contentAfter: '<p>a</p><div class="custom-paste oe_unbreakable">b</div><p>[]b</p>',
         });
     });
 
@@ -3362,11 +3457,7 @@ ${"            "}
                 <td>14pt MONO TEXT
                 </td>
             </tr>
-        </tbody></table><p>
-${"    "}
-
-${"    "}
-[]</p>`,
+        </tbody></table><p>[]<br></p>`,
         });
     });
 
@@ -3477,8 +3568,7 @@ ${"        "}
                 <td>14pt MONO TEXT</td>
             </tr>
         </tbody>
-    </table><p>
-[]</p>`,
+    </table><p>[]<br></p>`,
         });
     });
 
@@ -3607,10 +3697,7 @@ ${"        "}
                 14pt MONO TEXT
             </td>
         </tr>
-    </tbody></table><p>
-
-
-[]</p>`,
+    </tbody></table><p>[]<br></p>`,
         });
     });
 });

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -2439,7 +2439,7 @@ describe("link", () => {
                     );
                 },
                 contentAfter:
-                    '<p><a href="www.odoo.com">odoo.com</a></p><p><a href="www.google.com">google.com</a>[]</p>',
+                    '<p><a href="www.odoo.com">odoo.com</a></p><p><a href="https://google.com">google.com[]</a></p>',
             });
         });
 
@@ -2722,7 +2722,7 @@ describe("link", () => {
                     );
                 },
                 contentAfter:
-                    '<p><a href="www.odoo.com">odoo.com</a></p><p><a href="www.google.com">google.com</a>[]</p>',
+                    '<p><a href="www.odoo.com">odoo.com</a></p><p><a href="https://google.com">google.com[]</a></p>',
             });
         });
     });

--- a/addons/html_editor/static/tests/powerbox.test.js
+++ b/addons/html_editor/static/tests/powerbox.test.js
@@ -567,7 +567,7 @@ test("should restore state before /command insertion when command is executed (2
     expect(".o-we-powerbox").toHaveCount(1);
     expect(commandNames(el)).toEqual(["No-op"]);
     await press("Enter");
-    expect(getContent(el)).toBe(
+    expect(getContent(el, { sortAttrs: true })).toBe(
         `<p class="o-we-hint" placeholder='Type "/" for commands'>[]<br></p>`
     );
 });
@@ -602,7 +602,7 @@ test("should discard /command insertion from history when command is executed", 
     execCommand(editor, "historyUndo");
     expect(getContent(el)).toBe("<p>a[]</p>");
     execCommand(editor, "historyUndo");
-    expect(getContent(el)).toBe(
+    expect(getContent(el, { sortAttrs: true })).toBe(
         `<p class="o-we-hint" placeholder='Type "/" for commands'>[]<br></p>`
     );
 });

--- a/addons/html_editor/static/tests/qweb.test.js
+++ b/addons/html_editor/static/tests/qweb.test.js
@@ -223,14 +223,14 @@ test("select text inside t-out", async () => {
         config,
     });
     expect(getContent(el)).toBe(
-        `<div><t t-out="test" data-oe-t-inline="true" contenteditable="false">Hello</t></div>`
+        `<div><t t-out="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t></div>`
     );
 
     setSelection({ anchorNode: el.querySelector("t[t-out]").childNodes[0], anchorOffset: 1 });
 
     await tick();
     expect(getContent(el)).toBe(
-        `<div>[<t t-out="test" data-oe-t-inline="true" contenteditable="false">Hello</t>]</div>`
+        `<div>[<t t-out="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t>]</div>`
     );
 });
 
@@ -239,14 +239,14 @@ test("select text inside t-esc", async () => {
         config,
     });
     expect(getContent(el)).toBe(
-        `<div><t t-esc="test" data-oe-t-inline="true" contenteditable="false">Hello</t></div>`
+        `<div><t t-esc="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t></div>`
     );
 
     setSelection({ anchorNode: el.querySelector("t[t-esc]").childNodes[0], anchorOffset: 1 });
 
     await tick();
     expect(getContent(el)).toBe(
-        `<div>[<t t-esc="test" data-oe-t-inline="true" contenteditable="false">Hello</t>]</div>`
+        `<div>[<t t-esc="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t>]</div>`
     );
 });
 
@@ -255,14 +255,14 @@ test("select text inside t-field", async () => {
         config,
     });
     expect(getContent(el)).toBe(
-        `<div><t t-field="test" data-oe-t-inline="true" contenteditable="false">Hello</t></div>`
+        `<div><t t-field="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t></div>`
     );
 
     setSelection({ anchorNode: el.querySelector("t[t-field]").childNodes[0], anchorOffset: 1 });
 
     await tick();
     expect(getContent(el)).toBe(
-        `<div>[<t t-field="test" data-oe-t-inline="true" contenteditable="false">Hello</t>]</div>`
+        `<div>[<t t-field="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t>]</div>`
     );
 });
 
@@ -281,10 +281,10 @@ test("cleaning removes content editable", async () => {
     );
     expect(getContent(el)).toBe(`
         <div>
-            <t t-field="test" data-oe-t-inline="true" contenteditable="false">Hello</t>
-            <t t-out="test" data-oe-t-inline="true" contenteditable="false">Hello</t>
-            <t t-esc="test" data-oe-t-inline="true" contenteditable="false">Hello</t>
-            <t t-raw="test" data-oe-t-inline="true" contenteditable="false">Hello</t>
+            <t t-field="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t>
+            <t t-out="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t>
+            <t t-esc="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t>
+            <t t-raw="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t>
         </div>`);
 
     expect(editor.getContent()).toBe(`

--- a/addons/html_editor/static/tests/selection.test.js
+++ b/addons/html_editor/static/tests/selection.test.js
@@ -66,11 +66,11 @@ test("correct selection after triple click with bold", async () => {
 
 test("fix selection P in the beggining being a direct child of the editable p after selection", async () => {
     const { el } = await setupEditor("<div>a</div>[]<p>b</p>");
-    expect(getContent(el)).toBe(`<div>a</div><p>[]b</p>`);
+    expect(getContent(el)).toBe(`<div class="o-paragraph">a</div><p>[]b</p>`);
 });
-test("fix selection P in the beggining being a direct child of the editable p before selection", async () => {
+test("fix selection P in the beginning being a direct child of the editable p before selection", async () => {
     const { el } = await setupEditor("<p>a</p>[]<div>b</div>");
-    expect(getContent(el)).toBe(`<p>a[]</p><div>b</div>`);
+    expect(getContent(el)).toBe(`<p>a</p><div class="o-paragraph">[]b</div>`);
 });
 
 describe("documentSelectionIsInEditable", () => {

--- a/addons/html_editor/static/tests/signature.test.js
+++ b/addons/html_editor/static/tests/signature.test.js
@@ -26,7 +26,9 @@ test("apply 'Signature' command", async () => {
 
     await press("enter");
     await tick();
-    expect(getContent(el)).toBe("<p>ab</p><h1>Hello[]</h1><p>cd</p>");
+    expect(getContent(el)).toBe(
+        `<p>ab</p><div class="o-signature-container"><h1>Hello[]</h1></div><p>cd</p>`
+    );
 });
 
 test("undo a 'Signature' command", async () => {
@@ -35,7 +37,9 @@ test("undo a 'Signature' command", async () => {
     await insertText(editor, "/signature");
     await press("enter");
     await tick();
-    expect(getContent(el)).toBe("<p>abtest</p><h1>Hello[]</h1><p>cd</p>");
+    expect(getContent(el)).toBe(
+        `<p>abtest</p><div class="o-signature-container"><h1>Hello[]</h1></div><p>cd</p>`
+    );
 
     undo(editor);
     expect(getContent(el)).toBe("<p>abtest[]cd</p>");

--- a/addons/html_editor/static/tests/tags.test.js
+++ b/addons/html_editor/static/tests/tags.test.js
@@ -42,11 +42,19 @@ describe("to paragraph", () => {
         });
     });
 
-    test("should not turn a div into a paragraph", async () => {
+    test("should turn a div into a paragraph (if div is eligible for a baseContainer)", async () => {
         await testEditor({
-            contentBefore: "<div>[ab]</div>",
+            contentBefore: `<div>[ab]</div>`,
             stepFunction: setTag("p"),
-            contentAfter: "<div><p>[ab]</p></div>",
+            contentAfter: "<p>[ab]</p>",
+        });
+    });
+
+    test("should not turn an unbreakable div into a paragraph", async () => {
+        await testEditor({
+            contentBefore: `<div class="oe_unbreakable">[ab]</div>`,
+            stepFunction: setTag("p"),
+            contentAfter: `<div class="oe_unbreakable"><p>[ab]</p></div>`,
         });
     });
 
@@ -162,11 +170,11 @@ describe("to heading 1", () => {
         });
     });
 
-    test("should not turn a div into a heading 1", async () => {
+    test("should turn a div into a heading 1 (if div is eligible for a baseContainer)", async () => {
         await testEditor({
             contentBefore: "<div>[ab]</div>",
             stepFunction: setTag("h1"),
-            contentAfter: "<div><h1>[ab]</h1></div>",
+            contentAfter: "<h1>[ab]</h1>",
         });
     });
 
@@ -223,11 +231,11 @@ describe("to heading 2", () => {
         });
     });
 
-    test("should not turn a div into a heading 2", async () => {
+    test("should turn a div into a heading 2 (if div is eligible for a baseContainer)", async () => {
         await testEditor({
             contentBefore: "<div>[ab]</div>",
             stepFunction: setTag("h2"),
-            contentAfter: "<div><h2>[ab]</h2></div>",
+            contentAfter: "<h2>[ab]</h2>",
         });
     });
 
@@ -284,11 +292,11 @@ describe("to heading 3", () => {
         });
     });
 
-    test("should not turn a div into a heading 3", async () => {
+    test("should turn a div into a heading 3 (if div is eligible for a baseContainer)", async () => {
         await testEditor({
             contentBefore: "<div>[ab]</div>",
             stepFunction: setTag("h3"),
-            contentAfter: "<div><h3>[ab]</h3></div>",
+            contentAfter: "<h3>[ab]</h3>",
         });
     });
 
@@ -409,11 +417,11 @@ describe("to blockquote", () => {
         });
     });
 
-    test("should not turn a div into a blockquote", async () => {
+    test("should turn a div into a blockquote (if div is eligible for a baseContainer)", async () => {
         await testEditor({
             contentBefore: "<div>[ab]</div>",
             stepFunction: setTag("blockquote"),
-            contentAfter: "<div><blockquote>[ab]</blockquote></div>",
+            contentAfter: "<blockquote>[ab]</blockquote>",
         });
     });
 

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -208,7 +208,7 @@ test("toolbar works: can select font", async () => {
     expect(".o-we-toolbar").toHaveCount(0);
     setContent(el, "<p>[test]</p>");
     await waitFor(".o-we-toolbar");
-    expect(".o-we-toolbar [name='font']").toHaveText("Normal");
+    expect(".o-we-toolbar [name='font']").toHaveText("Paragraph");
 
     await contains(".o-we-toolbar [name='font'] .dropdown-toggle").click();
     await contains(".o_font_selector_menu .dropdown-item:contains('Header 2')").click();
@@ -219,12 +219,13 @@ test("toolbar works: can select font", async () => {
 test("toolbar works: show the right font name", async () => {
     await setupEditor("<p>[test]</p>");
     await waitFor(".o-we-toolbar");
-    for (const item of fontItems) {
+    const items = fontItems;
+    for (const item of items) {
         await contains(".o-we-toolbar [name='font'] .dropdown-toggle").click();
         await animationFrame();
         const name = item.name.toString();
         let selector = `.o_font_selector_menu .dropdown-item:contains('${name}')`;
-        for (const tempItem of fontItems) {
+        for (const tempItem of items) {
             // we need to exclude the font names which have the current name as a substring.
             if (tempItem === item) {
                 continue;
@@ -243,7 +244,7 @@ test("toolbar works: show the right font name", async () => {
 test("toolbar works: show the right font name after undo", async () => {
     const { el } = await setupEditor("<p>[test]</p>");
     await waitFor(".o-we-toolbar");
-    expect(".o-we-toolbar [name='font']").toHaveText("Normal");
+    expect(".o-we-toolbar [name='font']").toHaveText("Paragraph");
 
     await contains(".o-we-toolbar [name='font'] .dropdown-toggle").click();
     await contains(".o_font_selector_menu .dropdown-item:contains('Header 2')").click();
@@ -252,7 +253,7 @@ test("toolbar works: show the right font name after undo", async () => {
     await press(["ctrl", "z"]);
     await animationFrame();
     expect(getContent(el)).toBe("<p>[test]</p>");
-    expect(".o-we-toolbar [name='font']").toHaveText("Normal");
+    expect(".o-we-toolbar [name='font']").toHaveText("Paragraph");
     await press(["ctrl", "y"]);
     await animationFrame();
     expect(getContent(el)).toBe("<h2>[test]</h2>");

--- a/addons/html_editor/static/tests/unbreakable/delete.test.js
+++ b/addons/html_editor/static/tests/unbreakable/delete.test.js
@@ -8,16 +8,16 @@ describe("backward", () => {
         describe("start empty", () => {
             test("should delete empty p after an unbreakable (backward)", async () => {
                 await testEditor({
-                    contentBefore: `<div>a</div><p>[]<br></p>`,
+                    contentBefore: `<div class="oe_unbreakable">a</div><p>[]<br></p>`,
                     stepFunction: deleteBackward,
-                    contentAfter: `<div>a[]</div>`,
+                    contentAfter: `<div class="oe_unbreakable">a[]</div>`,
                 });
             });
             test("should delete empty p/br after an unbreakable (backward)", async () => {
                 await testEditor({
-                    contentBefore: `<div>a</div><p>[]<br></p>`,
+                    contentBefore: `<div class="oe_unbreakable">a</div><p>[]<br></p>`,
                     stepFunction: deleteBackward,
-                    contentAfter: `<div>a[]</div>`,
+                    contentAfter: `<div class="oe_unbreakable">a[]</div>`,
                 });
             });
             test("should delete empty unbreakable (backward)", async () => {
@@ -25,7 +25,7 @@ describe("backward", () => {
                     contentBefore: unformat(`
                     <div>
                         <div><p>a</p></div>
-                        <div>[]</div>
+                        <div class="oe_unbreakable">[]</div>
                     </div>`),
                     stepFunction: deleteBackward,
                     contentAfter: unformat(`
@@ -40,14 +40,14 @@ describe("backward", () => {
                 await testEditor({
                     contentBefore: unformat(`
                         <div>
-                            <div>[]<br></div>
-                            <div>a</div>
+                            <div class="oe_unbreakable">[]<br></div>
+                            <p>a</p>
                         </div>`),
                     stepFunction: deleteBackward,
                     contentAfter: unformat(`
                         <div>
-                            <div>[]<br></div>
-                            <div>a</div>
+                            <div class="oe_unbreakable">[]<br></div>
+                            <p>a</p>
                         </div>`),
                 });
             });
@@ -56,23 +56,23 @@ describe("backward", () => {
         describe("start text", () => {
             test("should not merge p with an unbreakable (backward)", async () => {
                 await testEditor({
-                    contentBefore: `<div>b</div><p>[]a</p>`,
+                    contentBefore: `<div class="oe_unbreakable">b</div><p>[]a</p>`,
                     stepFunction: deleteBackward,
-                    contentAfter: `<div>b</div><p>[]a</p>`,
+                    contentAfter: `<div class="oe_unbreakable">b</div><p>[]a</p>`,
                 });
             });
             test("should not merge unbreakable before an unbreakable (backward)", async () => {
                 await testEditor({
                     contentBefore: unformat(`
                         <div>
-                            <div>a</div>
-                            <div>[]b</div>
+                            <div class="oe_unbreakable">a</div>
+                            <div class="oe_unbreakable">[]b</div>
                         </div>`),
                     stepFunction: deleteBackward,
                     contentAfter: unformat(`
                         <div>
-                            <div>a</div>
-                            <div>[]b</div>
+                            <div class="oe_unbreakable">a</div>
+                            <div class="oe_unbreakable">[]b</div>
                         </div>`),
                 });
             });
@@ -81,13 +81,13 @@ describe("backward", () => {
                     contentBefore: unformat(`
                         <div>
                             <p>a</p>
-                            <div>[]b</div>
+                            <div class="oe_unbreakable">[]b</div>
                         </div>`),
                     stepFunction: deleteBackward,
                     contentAfter: unformat(`
                         <div>
                             <p>a</p>
-                            <div>[]b</div>
+                            <div class="oe_unbreakable">[]b</div>
                         </div>`),
                 });
             });
@@ -95,14 +95,14 @@ describe("backward", () => {
                 await testEditor({
                     contentBefore: unformat(`
                         <div>
-                            <div><br></div>
-                            <div>[]b</div>
+                            <div class="oe_unbreakable"><br></div>
+                            <div class="oe_unbreakable">[]b</div>
                         </div>`),
                     stepFunction: deleteBackward,
                     contentAfter: unformat(`
                         <div>
-                            <div><br></div>
-                            <div>[]b</div>
+                            <div class="oe_unbreakable"><br></div>
+                            <div class="oe_unbreakable">[]b</div>
                         </div>`),
                 });
             });
@@ -111,13 +111,13 @@ describe("backward", () => {
                     contentBefore: unformat(`
                         <div>
                             <p><br></p>
-                            <div>[]b</div>
+                            <div class="oe_unbreakable">[]b</div>
                         </div>`),
                     stepFunction: deleteBackward,
                     contentAfter: unformat(`
                         <div>
                             <p><br></p>
-                            <div>[]b</div>
+                            <div class="oe_unbreakable">[]b</div>
                         </div>`),
                 });
             });
@@ -130,14 +130,14 @@ describe("backward", () => {
                     await testEditor({
                         contentBefore: unformat(`
                             <div>
-                                <div>[ab</div>
-                                <div>cd</div>
-                                <div>ef]</div>
+                                <div class="oe_unbreakable">[ab</div>
+                                <div class="oe_unbreakable">cd</div>
+                                <div class="oe_unbreakable">ef]</div>
                             </div>`),
                         stepFunction: deleteBackward,
                         contentAfter: unformat(`
                             <div>
-                                <div>[]<br></div>
+                                <div class="oe_unbreakable">[]<br></div>
                             </div>`),
                     });
                 });
@@ -145,14 +145,14 @@ describe("backward", () => {
                     await testEditor({
                         contentBefore: unformat(`
                             <div>
-                                <div>[ab</div>
-                                <div>cd</div>
-                                <div>e]f</div>
+                                <div class="oe_unbreakable">[ab</div>
+                                <div class="oe_unbreakable">cd</div>
+                                <div class="oe_unbreakable">e]f</div>
                             </div>`),
                         stepFunction: deleteBackward,
                         contentAfter: unformat(`
                             <div>
-                                <div>[]f</div>
+                                <div class="oe_unbreakable">[]f</div>
                             </div>`),
                     });
                 });
@@ -163,15 +163,15 @@ describe("backward", () => {
                     await testEditor({
                         contentBefore: unformat(`
                             <div>
-                                <div>a[b</div>
-                                <div>cd</div>
-                                <div>e]f</div>
+                                <div class="oe_unbreakable">a[b</div>
+                                <div class="oe_unbreakable">cd</div>
+                                <div class="oe_unbreakable">e]f</div>
                             </div>`),
                         stepFunction: deleteBackward,
                         contentAfter: unformat(`
                             <div>
-                                <div>a[]</div>
-                                <div>f</div>
+                                <div class="oe_unbreakable">a[]</div>
+                                <div class="oe_unbreakable">f</div>
                             </div>`),
                     });
                 });
@@ -179,14 +179,14 @@ describe("backward", () => {
                     await testEditor({
                         contentBefore: unformat(`
                             <div>
-                                <div>a[b</div>
-                                <div>cd</div>
-                                <div>ef]</div>
+                                <div class="oe_unbreakable">a[b</div>
+                                <div class="oe_unbreakable">cd</div>
+                                <div class="oe_unbreakable">ef]</div>
                             </div>`),
                         stepFunction: deleteBackward,
                         contentAfter: unformat(`
                             <div>
-                                <div>a[]</div>
+                                <div class="oe_unbreakable">a[]</div>
                             </div>`),
                     });
                 });
@@ -199,19 +199,19 @@ describe("backward", () => {
                     await testEditor({
                         contentBefore: unformat(`
                             <div>
-                                <div>[ab</div>
-                                <div>cd</div>
-                                <div>ef</div>
+                                <div class="oe_unbreakable">[ab</div>
+                                <div class="oe_unbreakable">cd</div>
+                                <div class="oe_unbreakable">ef</div>
                             </div>
                             <div>
-                                <div>gh</div>
-                                <div>ij</div>
-                                <div>k]l</div>
+                                <div class="oe_unbreakable">gh</div>
+                                <div class="oe_unbreakable">ij</div>
+                                <div class="oe_unbreakable">k]l</div>
                             </div>`),
                         stepFunction: deleteBackward,
                         contentAfter: unformat(`
                             <div>
-                                <div>[]l</div>
+                                <div class="oe_unbreakable">[]l</div>
                             </div>`),
                     });
                 });
@@ -221,22 +221,22 @@ describe("backward", () => {
                     await testEditor({
                         contentBefore: unformat(`
                             <div>
-                                <div>a[b</div>
-                                <div>cd</div>
-                                <div>ef</div>
+                                <div class="oe_unbreakable">a[b</div>
+                                <div class="oe_unbreakable">cd</div>
+                                <div class="oe_unbreakable">ef</div>
                             </div>
                             <div>
-                                <div>gh</div>
-                                <div>ij</div>
-                                <div>k]l</div>
+                                <div class="oe_unbreakable">gh</div>
+                                <div class="oe_unbreakable">ij</div>
+                                <div class="oe_unbreakable">k]l</div>
                             </div>`),
                         stepFunction: deleteBackward,
                         contentAfter: unformat(`
                             <div>
-                                <div>a[]</div>
+                                <div class="oe_unbreakable">a[]</div>
                             </div>
                             <div>
-                                <div>l</div>
+                                <div class="oe_unbreakable">l</div>
                             </div>`),
                     });
                 });
@@ -244,19 +244,19 @@ describe("backward", () => {
                     await testEditor({
                         contentBefore: unformat(`
                             <div>
-                                <div>a[b</div>
-                                <div>cd</div>
-                                <div>ef</div>
+                                <div class="oe_unbreakable">a[b</div>
+                                <div class="oe_unbreakable">cd</div>
+                                <div class="oe_unbreakable">ef</div>
                             </div>
                             <div>
-                                <div>gh</div>
-                                <div>ij</div>
-                                <div>kl]</div>
+                                <div class="oe_unbreakable">gh</div>
+                                <div class="oe_unbreakable">ij</div>
+                                <div class="oe_unbreakable">kl]</div>
                             </div>`),
                         stepFunction: (editor) => deleteBackward(editor),
                         contentAfter: unformat(`
                             <div>
-                                <div>a[]</div>
+                                <div class="oe_unbreakable">a[]</div>
                             </div>`),
                     });
                 });
@@ -293,16 +293,16 @@ describe("forward", () => {
         describe("start empty", () => {
             test("should delete empty p just before an unbreakable (forward)", async () => {
                 await testEditor({
-                    contentBefore: `<p>[]</p><div>a</div>`,
+                    contentBefore: `<p>[]</p><div class="oe_unbreakable">a</div>`,
                     stepFunction: deleteForward,
-                    contentAfter: `<div>[]a</div>`,
+                    contentAfter: `<div class="oe_unbreakable">[]a</div>`,
                 });
             });
             test("should delete empty p/br just before an unbreakable (forward)", async () => {
                 await testEditor({
-                    contentBefore: `<p><br>[]</p><div>a</div>`,
+                    contentBefore: `<p><br>[]</p><div class="oe_unbreakable">a</div>`,
                     stepFunction: deleteForward,
-                    contentAfter: `<div>[]a</div>`,
+                    contentAfter: `<div class="oe_unbreakable">[]a</div>`,
                 });
             });
             test("should delete empty unbreakables (forward)", async () => {
@@ -323,14 +323,14 @@ describe("forward", () => {
                 await testEditor({
                     contentBefore: unformat(`
                         <div>
-                            <div>a</div>
-                            <div>[]<br></div>
+                            <p>a</p>
+                            <div class="oe_unbreakable">[]<br></div>
                         </div>`),
                     stepFunction: deleteForward,
                     contentAfter: unformat(`
                         <div>
-                            <div>a</div>
-                            <div>[]<br></div>
+                            <p>a</p>
+                            <div class="oe_unbreakable">[]<br></div>
                         </div>`),
                 });
             });
@@ -339,23 +339,23 @@ describe("forward", () => {
         describe("start text", () => {
             test("should not merge p with an unbreakable (forward)", async () => {
                 await testEditor({
-                    contentBefore: `<p>a[]</p><div>b</div>`,
+                    contentBefore: `<p>a[]</p><div class="oe_unbreakable">b</div>`,
                     stepFunction: deleteForward,
-                    contentAfter: `<p>a[]</p><div>b</div>`,
+                    contentAfter: `<p>a[]</p><div class="oe_unbreakable">b</div>`,
                 });
             });
             test("should not remove unbreakable after an unbreakable (forward)", async () => {
                 await testEditor({
                     contentBefore: unformat(`
                         <div>
-                            <div>b[]</div>
-                            <div>a</div>
+                            <div class="oe_unbreakable">b[]</div>
+                            <div class="oe_unbreakable">a</div>
                         </div>`),
                     stepFunction: deleteForward,
                     contentAfter: unformat(`
                         <div>
-                            <div>b[]</div>
-                            <div>a</div>
+                            <div class="oe_unbreakable">b[]</div>
+                            <div class="oe_unbreakable">a</div>
                         </div>`),
                 });
             });
@@ -363,13 +363,13 @@ describe("forward", () => {
                 await testEditor({
                     contentBefore: unformat(`
                         <div>
-                            <div>b[]</div>
+                            <div class="oe_unbreakable">b[]</div>
                             <p>a</p>
                         </div>`),
                     stepFunction: deleteForward,
                     contentAfter: unformat(`
                         <div>
-                            <div>b[]</div>
+                            <div class="oe_unbreakable">b[]</div>
                             <p>a</p>
                         </div>`),
                 });
@@ -378,14 +378,14 @@ describe("forward", () => {
                 await testEditor({
                     contentBefore: unformat(`
                         <div>
-                            <div>b[]</div>
-                            <div><br></div>
+                            <div class="oe_unbreakable">b[]</div>
+                            <div class="oe_unbreakable"><br></div>
                         </div>`),
                     stepFunction: deleteForward,
                     contentAfter: unformat(`
                         <div>
-                            <div>b[]</div>
-                            <div><br></div>
+                            <div class="oe_unbreakable">b[]</div>
+                            <div class="oe_unbreakable"><br></div>
                         </div>`),
                 });
             });
@@ -393,13 +393,13 @@ describe("forward", () => {
                 await testEditor({
                     contentBefore: unformat(`
                         <div>
-                            <div>b[]</div>
+                            <div class="oe_unbreakable">b[]</div>
                             <p><br></p>
                         </div>`),
                     stepFunction: deleteForward,
                     contentAfter: unformat(`
                         <div>
-                            <div>b[]</div>
+                            <div class="oe_unbreakable">b[]</div>
                             <p><br></p>
                         </div>`),
                 });
@@ -413,14 +413,14 @@ describe("forward", () => {
             await testEditor({
                 contentBefore: unformat(`
                         <div>
-                            <div>a[bc</div>
-                            <div>de]f</div>
+                            <div class="oe_unbreakable">a[bc</div>
+                            <div class="oe_unbreakable">de]f</div>
                         </div>`),
                 stepFunction: deleteForward,
                 contentAfter: unformat(`
                         <div>
-                            <div>a[]</div>
-                            <div>f</div>
+                            <div class="oe_unbreakable">a[]</div>
+                            <div class="oe_unbreakable">f</div>
                         </div>`),
             });
         });
@@ -568,7 +568,7 @@ describe("list", () => {
         test("shoud not merge list item in the previous unbreakable sibling (2)", async () => {
             await testEditor({
                 contentBefore: unformat(`
-                        <div>
+                        <div class="oe_unbreakable">
                             <p>a[bc</p>
                         </div>
                         <ol>
@@ -577,7 +577,7 @@ describe("list", () => {
                         </ol>`),
                 stepFunction: deleteBackward,
                 contentAfter: unformat(`
-                        <div>
+                        <div class="oe_unbreakable">
                             <p>a[]</p>
                         </div>
                         <ol>

--- a/addons/html_editor/static/tests/unbreakable/split_element_block.test.js
+++ b/addons/html_editor/static/tests/unbreakable/split_element_block.test.js
@@ -1,6 +1,7 @@
-import { test } from "@odoo/hoot";
-import { testEditor } from "../_helpers/editor";
+import { expect, test } from "@odoo/hoot";
+import { setupEditor, testEditor } from "../_helpers/editor";
 import { splitBlock } from "../_helpers/user_actions";
+import { getContent } from "../_helpers/selection";
 
 test("should replace splitElementBlock with insertLineBreak (selection start)", async () => {
     await testEditor({
@@ -21,5 +22,25 @@ test("should replace splitElementBlock with insertLineBreak (selection end)", as
         contentBefore: `<div>ab[]</div>`,
         stepFunction: splitBlock,
         contentAfter: `<div>ab<br>[]<br></div>`,
+    });
+});
+test("should not split a contenteditable='false'", async () => {
+    const { editor, el } = await setupEditor(`<p contenteditable="false">ab</p>`);
+    const p = el.querySelector("p");
+    editor.shared.split.splitBlockNode({ targetNode: p, targetOffset: 0 });
+    expect(getContent(el)).toBe(`<p contenteditable="false">ab</p>`);
+});
+test("should split an explicit contenteditable='true' if its ancestor isContentEditable", async () => {
+    await testEditor({
+        contentBefore: `<p contenteditable="true">ab[]</p>`,
+        stepFunction: splitBlock,
+        contentAfter: `<p contenteditable="true">ab</p><p contenteditable="true">[]<br></p>`,
+    });
+});
+test("should insert a newline instead of splitting an explicit contenteditable='true' if its ancestor is not contentEditable", async () => {
+    await testEditor({
+        contentBefore: `<div contenteditable="false"><p contenteditable="true">ab[]</p></div>`,
+        stepFunction: splitBlock,
+        contentAfter: `<div contenteditable="false"><p contenteditable="true">ab<br>[]<br></p></div>`,
     });
 });

--- a/addons/html_editor/static/tests/unbreakable/split_element_block.test.js
+++ b/addons/html_editor/static/tests/unbreakable/split_element_block.test.js
@@ -5,23 +5,23 @@ import { getContent } from "../_helpers/selection";
 
 test("should replace splitElementBlock with insertLineBreak (selection start)", async () => {
     await testEditor({
-        contentBefore: `<div>[]ab</div>`,
+        contentBefore: `<div class="oe_unbreakable">[]ab</div>`,
         stepFunction: splitBlock,
-        contentAfter: `<div><br>[]ab</div>`,
+        contentAfter: `<div class="oe_unbreakable"><br>[]ab</div>`,
     });
 });
 test("should replace splitElementBlock with insertLineBreak (selection between)", async () => {
     await testEditor({
-        contentBefore: `<div>a[]b</div>`,
+        contentBefore: `<div class="oe_unbreakable">a[]b</div>`,
         stepFunction: splitBlock,
-        contentAfter: `<div>a<br>[]b</div>`,
+        contentAfter: `<div class="oe_unbreakable">a<br>[]b</div>`,
     });
 });
 test("should replace splitElementBlock with insertLineBreak (selection end)", async () => {
     await testEditor({
-        contentBefore: `<div>ab[]</div>`,
+        contentBefore: `<div class="oe_unbreakable">ab[]</div>`,
         stepFunction: splitBlock,
-        contentAfter: `<div>ab<br>[]<br></div>`,
+        contentAfter: `<div class="oe_unbreakable">ab<br>[]<br></div>`,
     });
 });
 test("should not split a contenteditable='false'", async () => {

--- a/addons/html_editor/static/tests/utils/dom.test.js
+++ b/addons/html_editor/static/tests/utils/dom.test.js
@@ -244,6 +244,7 @@ describe("wrapInlinesInBlocks", () => {
                 <div>
                     <div contenteditable="false" style="display: inline;">inline</div><span class="a">span</span>[]
                 </div>
+                <p><br></p>
                 <div style="margin-bottom: 0px;">
                     text<div contenteditable="false" style="display: inline;">inline</div><span class="a">span</span>
                 </div>

--- a/addons/html_editor/static/tests/utils/dom.test.js
+++ b/addons/html_editor/static/tests/utils/dom.test.js
@@ -189,10 +189,10 @@ describe("wrapInlinesInBlocks", () => {
     test("wrap block with display style inline in div", async () => {
         // Second part should be wrapped automatically during initElementForEdition
         const { el, editor } = await setupEditor(
-            `<p><br></p><div contenteditable="false" style="display: inline;">inline</div>`
+            `<div><br></div><div contenteditable="false" style="display: inline;">inline</div>`
         );
-        const p = el.querySelector("p");
-        editor.shared.selection.setSelection({ anchorNode: p, anchorOffset: 0 });
+        const div = el.querySelector("div");
+        editor.shared.selection.setSelection({ anchorNode: div, anchorOffset: 0 });
         editor.shared.selection.focusEditable();
         // dom insert should take care not to insert inline content at the root
         // inline non-phrasing content should not be added in a paragraph-related
@@ -213,8 +213,8 @@ describe("wrapInlinesInBlocks", () => {
                 <div>
                     <div contenteditable="false" style="display: inline;">inline</div>[]
                 </div>
-                <p><br></p>
-                <div style="margin-bottom: 0px;">
+                <div class="o-paragraph"><br></div>
+                <div>
                     <div contenteditable="false" style="display: inline;">inline</div>
                 </div>
             `)
@@ -223,10 +223,10 @@ describe("wrapInlinesInBlocks", () => {
     test("wrap a mix of inline elements in div", async () => {
         // Second part should be wrapped automatically during initElementForEdition
         const { el, editor } = await setupEditor(
-            `<p><br></p>text<div contenteditable="false" style="display: inline;">inline</div><span class="a">span</span>`
+            `<div><br></div>text<div contenteditable="false" style="display: inline;">inline</div><span class="a">span</span>`
         );
-        const p = el.querySelector("p");
-        editor.shared.selection.setSelection({ anchorNode: p, anchorOffset: 0 });
+        const div = el.querySelector("div");
+        editor.shared.selection.setSelection({ anchorNode: div, anchorOffset: 0 });
         editor.shared.selection.focusEditable();
         // dom insert should take care not to insert inline content at the root
         // inline non-phrasing content should not be added in a paragraph-related
@@ -240,13 +240,15 @@ describe("wrapInlinesInBlocks", () => {
         editor.shared.history.addStep();
         expect(getContent(el)).toBe(
             unformat(`
-                <p>text</p>
+                <div class="o-paragraph">text</div>
                 <div>
                     <div contenteditable="false" style="display: inline;">inline</div><span class="a">span</span>[]
                 </div>
-                <p><br></p>
-                <div style="margin-bottom: 0px;">
-                    text<div contenteditable="false" style="display: inline;">inline</div><span class="a">span</span>
+                <div class="o-paragraph"><br></div>
+                <div>
+                    text
+                    <div contenteditable="false" style="display: inline;">inline</div>
+                    <span class="a">span</span>
                 </div>
             `)
         );
@@ -254,10 +256,10 @@ describe("wrapInlinesInBlocks", () => {
     test("wrap a mix of inline elements in div with br", async () => {
         // Second part should be wrapped automatically during initElementForEdition
         const { el, editor } = await setupEditor(
-            `<p>[]<br></p>text<br><div contenteditable="false" style="display: inline;">inline</div><br><span class="a">span</span>`
+            `<div>[]<br></div>text<br><div contenteditable="false" style="display: inline;">inline</div><br><span class="a">span</span>`
         );
-        const p = el.querySelector("p");
-        editor.shared.selection.setSelection({ anchorNode: p, anchorOffset: 0 });
+        const div = el.querySelector("div");
+        editor.shared.selection.setSelection({ anchorNode: div, anchorOffset: 0 });
         // dom insert should take care not to insert inline content at the root
         // inline non-phrasing content should not be added in a paragraph-related
         // element.
@@ -270,20 +272,20 @@ describe("wrapInlinesInBlocks", () => {
         editor.shared.history.addStep();
         expect(getContent(el)).toBe(
             unformat(`
-                <p>text</p>
+                <div class="o-paragraph">text</div>
                 <div>
                     <div contenteditable="false" style="display: inline;">inline</div>
                 </div>
                 <p>
                     <span class="a">span</span>[]
                 </p>
-                <p style="margin-bottom: 0px;">text</p>
-                <div style="margin-bottom: 0px;">
+                <div class="o-paragraph">text</div>
+                <div>
                     <div contenteditable="false" style="display: inline;">inline</div>
                 </div>
-                <p style="margin-bottom: 0px;">
+                <div class="o-paragraph">
                     <span class="a">span</span>
-                </p>
+                </div>
             `)
         );
     });

--- a/addons/html_editor/static/tests/utils/dom.test.js
+++ b/addons/html_editor/static/tests/utils/dom.test.js
@@ -200,8 +200,10 @@ describe("wrapInlinesInBlocks", () => {
                 `<div contenteditable="false" style="display: inline;">inline</div>`
             )
         );
+        const cursors = editor.shared.selection.preserveSelection();
         // First part (inserted content) is wrapped manually
-        wrapInlinesInBlocks(div);
+        wrapInlinesInBlocks(div, cursors);
+        cursors.restore();
         expect(getContent(el)).toBe(
             unformat(`
                     <div>
@@ -229,8 +231,10 @@ describe("wrapInlinesInBlocks", () => {
                 `text<div contenteditable="false" style="display: inline;">inline</div><span class="a">span</span>`
             )
         );
+        const cursors = editor.shared.selection.preserveSelection();
         // First part (inserted content) is wrapped manually
-        wrapInlinesInBlocks(div);
+        wrapInlinesInBlocks(div, cursors);
+        cursors.restore();
         expect(getContent(el)).toBe(
             unformat(`
                 <div>
@@ -257,8 +261,10 @@ describe("wrapInlinesInBlocks", () => {
                 `text<br><div contenteditable="false" style="display: inline;">inline</div><br><span class="a">span</span>`
             )
         );
+        const cursors = editor.shared.selection.preserveSelection();
         // First part (inserted content) is wrapped manually
-        wrapInlinesInBlocks(div);
+        wrapInlinesInBlocks(div, cursors);
+        cursors.restore();
         expect(getContent(el)).toBe(
             unformat(`
                 <div>

--- a/addons/mail/static/src/chatter/web/mail_composer_form.js
+++ b/addons/mail/static/src/chatter/web/mail_composer_form.js
@@ -1,15 +1,24 @@
 import { formView } from "@web/views/form/form_view";
 import { registry } from "@web/core/registry";
-import { toRaw, useEffect, useRef } from "@odoo/owl";
+import { EventBus, toRaw, useEffect, useRef, useSubEnv } from "@odoo/owl";
 import { useCustomDropzone } from "@web/core/dropzone/dropzone_hook";
 import { useService } from "@web/core/utils/hooks";
 import { useX2ManyCrud } from "@web/views/fields/relational_utils";
 import { MailAttachmentDropzone } from "@mail/core/common/mail_attachment_dropzone";
 
 export class MailComposerFormController extends formView.Controller {
+    static props = {
+        ...formView.Controller.props,
+        fullComposerBus: { type: EventBus, optional: true },
+    };
     setup() {
         super.setup();
         toRaw(this.env.dialogData).model = "mail.compose.message";
+        if (this.props.fullComposerBus) {
+            useSubEnv({
+                fullComposerBus: this.props.fullComposerBus,
+            });
+        }
     }
 }
 

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -332,7 +332,15 @@ export class Message extends Record {
         compute() {
             return (
                 !this.body ||
-                ["", "<p></p>", "<p><br></p>", "<p><br/></p>"].includes(
+                [
+                    "",
+                    "<p></p>",
+                    "<p><br></p>",
+                    "<p><br/></p>",
+                    "<div></div>",
+                    "<div><br></div>",
+                    "<div><br/></div>",
+                ].includes(
                     this.body
                         .replace('<span class="o-mail-Message-edited"></span>', "")
                         .replace(/\s/g, "")

--- a/addons/mail/static/src/core/web/composer_patch.js
+++ b/addons/mail/static/src/core/web/composer_patch.js
@@ -1,0 +1,34 @@
+import { SIGNATURE_CLASS } from "@html_editor/main/signature_plugin";
+import { wrapInlinesInBlocks } from "@html_editor/utils/dom";
+import { childNodes } from "@html_editor/utils/dom_traversal";
+import { parseHTML } from "@html_editor/utils/html";
+import { Composer } from "@mail/core/common/composer";
+import { patch } from "@web/core/utils/patch";
+import { renderToElement } from "@web/core/utils/render";
+
+patch(Composer.prototype, {
+    /**
+     * Construct an editor friendly html representation of the body.
+     *
+     * @param {string} defaultBody
+     * @param {Markup} signature
+     * @returns {string}
+     */
+    formatDefaultBodyForFullComposer(defaultBody, signature = "") {
+        const fragment = parseHTML(document, defaultBody);
+        if (!fragment.firstChild) {
+            fragment.append(document.createElement("BR"));
+        }
+        if (signature) {
+            const signatureEl = renderToElement("html_editor.Signature", {
+                signature,
+                signatureClass: SIGNATURE_CLASS,
+            });
+            fragment.append(signatureEl);
+        }
+        const container = document.createElement("DIV");
+        container.append(...childNodes(fragment));
+        wrapInlinesInBlocks(container, { baseContainerNodeName: "DIV" });
+        return container.innerHTML;
+    },
+});

--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.js
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.js
@@ -1,9 +1,35 @@
 import { DYNAMIC_PLACEHOLDER_PLUGINS } from "@html_editor/plugin_sets";
+import { isEmpty } from "@html_editor/utils/dom_info";
 import { registry } from "@web/core/registry";
+import { useBus } from "@web/core/utils/hooks";
 import { HtmlMailField, htmlMailField } from "../html_mail_field/html_mail_field";
 import { MentionPlugin } from "./mention_plugin";
+import { SIGNATURE_CLASS } from "@html_editor/main/signature_plugin";
 
 export class HtmlComposerMessageField extends HtmlMailField {
+    setup() {
+        super.setup();
+        if (this.env.fullComposerBus) {
+            useBus(this.env.fullComposerBus, "ACCIDENTAL_DISCARD", (ev) => {
+                const elContent = this.getNoSignatureElContent();
+                ev.detail.onAccidentalDiscard(isEmpty(elContent));
+            });
+            useBus(this.env.fullComposerBus, "SAVE_CONTENT", (ev) => {
+                const emailAddSignature = Boolean(
+                    this.editor.editable.querySelector(`.${SIGNATURE_CLASS}`)
+                );
+                const elContent = this.getNoSignatureElContent();
+                // Temporarily Put the content in the DOM to be able to extract innerText newLines.
+                this.editor.editable.after(elContent);
+                // TODO: the following legacy regex may not have the desired effect as it
+                // agglomerates multiple newLines together.
+                const textValue = elContent.innerText.replace(/(\t|\n)+/g, "\n");
+                elContent.remove();
+                ev.detail.onSaveContent(textValue, emailAddSignature);
+            });
+        }
+    }
+
     getConfig() {
         const config = super.getConfig(...arguments);
         config.Plugins = [...config.Plugins, MentionPlugin];
@@ -25,6 +51,12 @@ export class HtmlComposerMessageField extends HtmlMailField {
             this.props.record.data.attachment_ids.linkTo(attachment.id, attachment);
         };
         return config;
+    }
+
+    getNoSignatureElContent() {
+        const elContent = this.editor.getElContent();
+        this.editor.shared.signature.cleanSignatures({ rootClone: elContent });
+        return elContent;
     }
 }
 

--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.scss
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.scss
@@ -3,3 +3,28 @@
         min-height: 180px !important;
     }
 }
+
+.o_dialog {
+    // WIDGET_CONTAINER_WIDTH in movenode_plugin.js should be enforced
+    // to ensure enough space for the drag&drop feature of the editor.
+    $movenode-horizontal-padding: 25px;
+    .modal-content:has(.o_mail_composer_form_view) {
+        .modal-header {
+            padding-left: $movenode-horizontal-padding;
+            padding-right: $movenode-horizontal-padding;
+        }
+    } 
+    .o_mail_composer_form_view {
+        .o_form_renderer.o_form_nosheet.o_form_editable {
+            padding-left: $movenode-horizontal-padding;
+            padding-right: $movenode-horizontal-padding;
+            padding-top: var(--#{$prefix}modal-padding);
+        }
+        .o_field_html_composer_message {
+            .note-editable {
+                padding-left: 0;
+                padding-right: 0;
+            }
+        }
+    }
+}

--- a/addons/mail/static/tests/composer/html_composer_message_field.test.js
+++ b/addons/mail/static/tests/composer/html_composer_message_field.test.js
@@ -100,7 +100,7 @@ test("media dialog: upload", async function () {
         </form>`,
     });
 
-    const anchorNode = queryOne(".odoo-editor-editable p");
+    const anchorNode = queryOne(".odoo-editor-editable div.o-paragraph");
     setSelection({ anchorNode, anchorOffset: 0 });
 
     // Open media dialog
@@ -150,7 +150,7 @@ test("mention a partner", async () => {
         </form>`,
     });
 
-    const anchorNode = queryOne(`[name='body'] .odoo-editor-editable p`);
+    const anchorNode = queryOne(`[name='body'] .odoo-editor-editable div.o-paragraph`);
     setSelection({ anchorNode, anchorOffset: 0 });
     await insertText(htmlEditor, "@");
     await animationFrame();
@@ -166,11 +166,11 @@ test("mention a partner", async () => {
 
     await press("enter");
     expect("[name='body'] .odoo-editor-editable").toHaveInnerHTML(`
-    <p>
+    <div class="o-paragraph">
         <a target="_blank" data-oe-protected="true" contenteditable="false" href="https://www.hoot.test/odoo/res.partner/17" class="o_mail_redirect" data-oe-id="17" data-oe-model="res.partner">
             @Mitchell Admin
         </a>
-    </p>`);
+    </div>`);
 });
 
 test("mention a channel", async () => {
@@ -185,7 +185,7 @@ test("mention a channel", async () => {
             <field name="body" type="html" widget="html_composer_message"/>
         </form>`,
     });
-    const anchorNode = queryOne(`[name='body'] .odoo-editor-editable p`);
+    const anchorNode = queryOne(`[name='body'] .odoo-editor-editable div.o-paragraph`);
     setSelection({ anchorNode, anchorOffset: 0 });
     await insertText(htmlEditor, "#");
     await animationFrame();

--- a/addons/project/static/tests/tours/project_task_history.js
+++ b/addons/project/static/tests/tours/project_task_history.js
@@ -11,7 +11,7 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 const baseDescriptionContent = "Test project task history version";
-const descriptionField = "div.note-editable.odoo-editor-editable p";
+const descriptionField = `div.note-editable.odoo-editor-editable div.o-paragraph`;
 function changeDescriptionContentAndSave(newContent) {
     const newText = `${baseDescriptionContent} ${newContent}`;
     return [

--- a/addons/website_forum/controllers/website_forum.py
+++ b/addons/website_forum/controllers/website_forum.py
@@ -15,6 +15,7 @@ from odoo.addons.website_profile.controllers.main import WebsiteProfile
 from odoo.exceptions import AccessError, UserError
 from odoo.http import request
 from odoo.osv import expression
+from odoo.tools import is_html_empty
 
 _logger = logging.getLogger(__name__)
 
@@ -412,7 +413,7 @@ class WebsiteForum(WebsiteProfile):
                  '/forum/<model("forum.forum"):forum>/<model("forum.post"):post_parent>/reply'],
                 type='http', auth="user", methods=['POST'], website=True)
     def post_create(self, forum, post_parent=None, **post):
-        if post.get('content', '') == '<p><br></p>':
+        if is_html_empty(post.get('content', '')):
             return request.render('http_routing.http_error', {
                 'status_code': _('Bad Request'),
                 'status_message': post_parent and _('Reply should not be empty.') or _('Question should not be empty.')

--- a/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
+++ b/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
@@ -34,7 +34,7 @@ registerWebsitePreviewTour('course_publisher_standard', {
     run: "click",
 }, {
     content: 'eLearning: set description',
-    trigger: '.o_field_html[name="description"] .odoo-editor-editable p',
+    trigger: '.o_field_html[name="description"] .odoo-editor-editable div.o-paragraph',
     run: "editor Déboulonnate is very common at Fleurus",
 }, {
     content: 'eLearning: we want reviews',


### PR DESCRIPTION
This PR's purpose is to allow certain `div` elements to be handled by the
editor with the features commonly used inside `p` elements.
It is also comprised of a series of fixes and improvements related to
that change, see each commit for more details. Notable changes:
- Fix some behaviors of the DomPlugin `insert` function
- Update how Signature is handled in mail html fields
- Update how qweb fields are handled in the Report editor
- Introduce usage of `div` elements (baseContainer)

Eligible `div` elements will automatically inherit these features as soon as
they met the requirements during the `normalization` phase.

For the user, this means that there are now 2 options for the "base container",
the `div` which does not have a margin-bottom and the `p` which does have one.
`div` will be used as the default in most cases, and `p` will be used as the
default for `knowledge` (and probably `website` when it starts using the
html_editor).

The features around paragraphs are some of the most well defined in the
editor, and with this commit, there are now more ways to fall back on the "right
track" (meaning that user interactions will more likely result in something they
want, rather than not). Most notably, prior to this commit, adding new lines
with `enter` starting from a `div` with one line, then applying an editor
command, would result in the command applying on every line. Now, since the
`div` behaves like a paragraph, adding new lines will create a new editor
context for each line (another `div`), meaning that any command will only apply
to that context.

Technically, this commit introduces a generalization of the concept for
`baseContainer`, meaning that it will be easier to introduce new forms that will
inherit the related editor features.

There are still some limitations:
Some `div` elements will keep their `unsplittable` properties if they contain
HTML elements that are not compatible with a `p` (non-phrasing content), because
any `baseContainer` should be convertible between all equivalent forms.
To avoid such limitations, one solution could be to only work with `div`
elements (and never use paragraph related elements like `p`, `h1`, etc.), which
would be less explicit, but would allow more flexibility.

task-4260398
and
task-4294440