### PR TITLE
[FIX] purchase: link downpayment lines instead of adding them

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -635,7 +635,10 @@ class PurchaseOrder(models.Model):
             for i, line_val in enumerate(line_vals, start=1)
         ]
         downpayment_lines = self.env['purchase.order.line'].create(vals)
-        self.order_line += downpayment_lines
+        self.order_line = [
+            Command.link(line_id)
+            for line_id in downpayment_lines.ids
+        ]  # a simple concatenation would cause all order_line to recompute, we do not want it to happen
         return downpayment_lines
 
     def action_create_invoice(self):


### PR DESCRIPTION
### Steps to reproduce the issue:

1. Create a Product and add a Vendor Price under the Purchase tab
2. Create a Request for Quotation from the Vendor with the Product, change the Unit Price
3. Confirm Order
4. Create a Vendor Bill from the Vendor with one Invoice Line, click on "Purchase Matching"
5. Select the Invoice Line and click on "Add to PO"
6. Select the PO previously created and Add Down Payment
7. On the PO, the Unit Price on the Product Line has reverted to the Vendor Price

### Explanation:

During `_create_downpayments`, `purchase.order.line` created from `account.move.line` are added to `purchase.order.order_line` through a concatenation operator (here a `+`, but `|` would have the same effect).
With this operation, `purchase.order.order_line` is flagged as a modified value and needs to be totally recomputed. In the triggered recomputation methods is `_compute_price_unit_and_date_planned_and_name`, which affects multiple values including `unit_price` and uses `product_product.seller_ids`. https://github.com/odoo/odoo/blob/d0e7be7832672d476f1b289af52d3a425990d719/addons/purchase/models/purchase_order_line.py#L313-L318 https://github.com/odoo/odoo/blob/d0e7be7832672d476f1b289af52d3a425990d719/addons/purchase/models/purchase_order_line.py#L351-L358

### Fix reasoning:

With `Command.link`, only the added lines are flagged as new values and `purchase.order.order_line` is not recomputed.

opw-4275163