### PR TITLE
[FIX] *: rework tests to work without demo data

### DIFF
--- a/addons/auth_totp/tests/test_totp.py
+++ b/addons/auth_totp/tests/test_totp.py
@@ -9,7 +9,7 @@ from odoo import http
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 from odoo.exceptions import AccessDenied
 from odoo.service import common as auth, model
-from odoo.tests import tagged, get_db_name, loaded_demo_data
+from odoo.tests import tagged, get_db_name
 from odoo.tools import mute_logger
 
 from ..controllers.home import Home
@@ -17,8 +17,7 @@ from ..controllers.home import Home
 _logger = logging.getLogger(__name__)
 
 
-@tagged('post_install', '-at_install')
-class TestTOTP(HttpCaseWithUserDemo):
+class TestTOTPCommon:
     def setUp(self):
         super().setUp()
         totp = None
@@ -47,11 +46,11 @@ class TestTOTP(HttpCaseWithUserDemo):
             del Home.totp_hook
             self.env['ir.http']._clear_routing_map()
 
+
+@tagged('post_install', '-at_install')
+class TestTOTP(TestTOTPCommon, HttpCaseWithUserDemo):
+
     def test_totp(self):
-        # TODO: Make this work if no demo data + hr installed
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
         # 1. Enable 2FA
         self.start_tour('/web', 'totp_tour_setup', login='demo')
 
@@ -91,11 +90,12 @@ class TestTOTP(HttpCaseWithUserDemo):
 
 
     def test_totp_administration(self):
-        # TODO: Make this work if no demo data + hr installed
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
         self.start_tour('/web', 'totp_tour_setup', login='demo')
+        # If not enabled (like in demo data), landing on res.config will try
+        # to disable module_sale_quotation_builder and raise an issue
+        group_order_template = self.env.ref('sale_management.group_sale_order_template', raise_if_not_found=False)
+        if group_order_template:
+            self.env.ref('base.group_user').write({"implied_ids": [(4, group_order_template.id)]})
         self.start_tour('/web', 'totp_admin_disables', login='admin')
         self.start_tour('/', 'totp_login_disabled', login=None)
 
@@ -105,11 +105,6 @@ class TestTOTP(HttpCaseWithUserDemo):
         Ensure we don't leak the session info from an half-logged-in
         user.
         """
-        # TODO: Make this work if no demo data + hr installed
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
-
         self.start_tour('/web', 'totp_tour_setup', login='demo')
         self.url_open('/web/session/logout')
 

--- a/addons/auth_totp_mail/tests/test_totp.py
+++ b/addons/auth_totp_mail/tests/test_totp.py
@@ -3,19 +3,21 @@
 
 import logging
 
-from odoo.tests import tagged, loaded_demo_data
-from odoo.addons.auth_totp.tests.test_totp import TestTOTP
+from odoo.tests import tagged
+from odoo.addons.base.tests.common import HttpCaseWithUserDemo
+from odoo.addons.auth_totp.tests.test_totp import TestTOTPCommon
 
 _logger = logging.getLogger(__name__)
 
 
 @tagged('post_install', '-at_install')
-class TestTOTPInvite(TestTOTP):
+class TestTOTPInvite(TestTOTPCommon, HttpCaseWithUserDemo):
 
     def test_totp_administration(self):
-        # TODO: Make this work if no demo data + hr installed
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
+        # If not enabled (like in demo data), landing on res.config will try
+        # to disable module_sale_quotation_builder and raise an issue
+        group_order_template = self.env.ref('sale_management.group_sale_order_template', raise_if_not_found=False)
+        if group_order_template:
+            self.env.ref('base.group_user').write({"implied_ids": [(4, group_order_template.id)]})
         self.start_tour('/web', 'totp_admin_invite', login='admin')
         self.start_tour('/web', 'totp_admin_self_invite', login='admin')

--- a/addons/auth_totp_portal/tests/test_tour.py
+++ b/addons/auth_totp_portal/tests/test_tour.py
@@ -6,7 +6,7 @@ from passlib.totp import TOTP
 from odoo import http
 from odoo.addons.auth_totp.controllers.home import Home
 from odoo.addons.base.tests.common import HttpCaseWithUserPortal
-from odoo.tests import tagged, loaded_demo_data
+from odoo.tests import tagged
 
 _logger = logging.getLogger(__name__)
 
@@ -17,10 +17,6 @@ class TestTOTPortal(HttpCaseWithUserPortal):
     Largely replicates TestTOTP
     """
     def test_totp(self):
-        # TODO: Make this work if no demo data + hr installed
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
         totp = None
         # test endpoint as doing totp on the client side is not really an option
         # (needs sha1 and hmac + BE packing of 64b integers)

--- a/addons/lunch/static/tests/tours/order_lunch.js
+++ b/addons/lunch/static/tests/tours/order_lunch.js
@@ -41,10 +41,13 @@ tour.register('order_lunch_tour', {
     trigger: 'button[name="add_to_cart"]',
     content: _t("Add your order to the cart."),
     position: 'bottom',
-},
-{
+}, {
     trigger: 'button:contains("Order Now")',
     content: _t("Validate your order"),
     position: 'left',
     run: 'click',
+}, {
+    trigger: '.o_lunch_widget_lines .badge:contains("Ordered")',
+    content: 'Check that order is ordered',
+    run: () => {}
 }]);

--- a/addons/lunch/tests/test_ui.py
+++ b/addons/lunch/tests/test_ui.py
@@ -41,5 +41,11 @@ class TestUi(HttpCase):
             'supplier_id': self.supplier_pizza_inn.id,
         })
 
+        user_admin = self.env.ref('base.user_admin')
+        self.env['lunch.cashmove'].create({
+            'user_id': user_admin.id,
+            'amount': 10,
+        })
+
         with freeze_time("2022-04-19 10:00"):
             self.start_tour("/", 'order_lunch_tour', login='admin', timeout=180)

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -1630,6 +1630,11 @@ class TestBoM(TestMrpCommon):
         This test checks the behaviour of updating the BoM associated with a routing workcenter,
         It verifies that the link between the BOM lines and the operation is correctly deleted.
         """
+        resource_calendar_std_id = self.env.ref('resource.resource_calendar_std').id
+        mrp_workcenter_1 = self.env['mrp.workcenter'].create({
+            'name': 'Drill Station 1',
+            'resource_calendar_id': resource_calendar_std_id,
+        })
         p1, c1, c2, byproduct = self.make_prods(4)
         bom = self.env['mrp.bom'].create({
             'product_tmpl_id': p1.product_tmpl_id.id,
@@ -1646,12 +1651,12 @@ class TestBoM(TestMrpCommon):
         operation_1, operation_2 = self.env['mrp.routing.workcenter'].create([
             {
                 'name': 'Operation 1',
-                'workcenter_id': self.env.ref('mrp.mrp_workcenter_1').id,
+                'workcenter_id': mrp_workcenter_1.id,
                 'bom_id': bom.id,
             },
             {
                 'name': 'Operation 2',
-                'workcenter_id': self.env.ref('mrp.mrp_workcenter_1').id,
+                'workcenter_id': mrp_workcenter_1.id,
                 'bom_id': bom.id,
             }
         ])

--- a/addons/mrp_repair/tests/test_tracability.py
+++ b/addons/mrp_repair/tests/test_tracability.py
@@ -267,7 +267,6 @@ class TestRepairTraceability(TestMrpCommon):
         """
         stock_location = self.env.ref('stock.stock_location_stock')
         scrap_location = self.env['stock.location'].search([('company_id', '=', self.env.company.id), ('scrap_location', '=', True)], limit=1)
-        internal_type = self.env.ref('stock.picking_type_internal')
 
         finished = self.bom_4.product_id
         component = self.bom_4.bom_line_ids.product_id
@@ -313,7 +312,6 @@ class TestRepairTraceability(TestMrpCommon):
             'product_id': component.id,
             'product_uom_qty': 1,
             'product_uom': component.uom_id.id,
-            'picking_id': internal_type.id,
             'location_id': scrap_location.id,
             'location_dest_id': stock_location.id,
         })

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -6,7 +6,7 @@ from odoo import Command
 
 from odoo.api import Environment
 from odoo.tools import DEFAULT_SERVER_DATE_FORMAT
-from odoo.tests import loaded_demo_data, tagged
+from odoo.tests import tagged
 from odoo.addons.account.tests.common import AccountTestInvoicingHttpCommon
 from datetime import date, timedelta
 
@@ -54,6 +54,14 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
             'name': 'Deco Addict',
         })
 
+        env['res.partner'].create([{
+            'name': 'Nicole Ford'
+        }, {
+            'name': 'Brandon Freeman'
+        }, {
+            'name': 'Colleen Diaz'
+        }])
+
         cash_journal = journal_obj.create({
             'name': 'Cash Test',
             'type': 'cash',
@@ -71,12 +79,12 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
         # In DESKS categ: Desk Pad
         pos_categ_desks = env.ref('point_of_sale.pos_category_desks', raise_if_not_found=False)
         if not pos_categ_desks:
-            pos_categ_desks = cls.env['pos.category'].create({'name': 'Desk'})
+            pos_categ_desks = cls.env['pos.category'].create({'name': 'Desks'})
 
         # In DESKS categ: Whiteboard Pen
         pos_categ_misc = env.ref('point_of_sale.pos_category_miscellaneous', raise_if_not_found=False)
         if not pos_categ_misc:
-            pos_categ_misc = cls.env['pos.category'].create({'name': 'Misc'})
+            pos_categ_misc = cls.env['pos.category'].create({'name': 'Miscellaneous'})
 
         # In CHAIR categ: Letter Tray
         pos_categ_chairs = env.ref('point_of_sale.pos_category_chairs', raise_if_not_found=False)
@@ -489,9 +497,6 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
 @tagged('post_install', '-at_install')
 class TestUi(TestPointOfSaleHttpCommon):
     def test_01_pos_basic_order(self):
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
 
         self.main_pos_config.write({
             'iface_tipproduct': True,
@@ -521,9 +526,6 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.assertEqual(email_count, 1)
 
     def test_02_pos_with_invoiced(self):
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'ChromeTour', login="accountman")
         n_invoiced = self.env['pos.order'].search_count([('state', '=', 'invoiced')])
@@ -544,9 +546,6 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config, 'InactiveAttributeValueTour', login="accountman")
 
     def test_05_ticket_screen(self):
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'TicketScreenTour', login="accountman")
 

--- a/addons/point_of_sale/tests/test_js.py
+++ b/addons/point_of_sale/tests/test_js.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from odoo.tests import tagged, HttpCase, loaded_demo_data
+from odoo.tests import tagged, HttpCase
 
 _logger = logging.getLogger(__name__)
 
@@ -19,10 +19,6 @@ class WebSuite(HttpCase):
 
     def test_pos_js(self):
         # open a session, the /pos/ui controller will redirect to it
-        # TODO: Adapt to work without demo data
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
         self.main_pos_config.open_ui()
         self.main_pos_config.current_session_id.set_cashbox_pos(0, None)
 

--- a/addons/repair/tests/test_repair.py
+++ b/addons/repair/tests/test_repair.py
@@ -495,6 +495,9 @@ class TestRepair(AccountTestInvoicingCommon):
         """
         Check that the lot_id field is cleared after updating the product in the repair order.
         """
+        self.env.ref('base.group_user').implied_ids += (
+            self.env.ref('stock.group_production_lot')
+        )
         self.product_a.tracking = 'serial'
         sn_1 = self.env['stock.lot'].create({'name': 'sn_1', 'product_id': self.product_a.id})
         ro_form = Form(self.env['repair.order'])

--- a/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
+++ b/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
@@ -176,6 +176,7 @@ tour.register('sale_timesheet_tour', {
 }, {
     trigger: '[name=sale_line_id] ul.ui-autocomplete > li:first-child > a:not(:has(i.fa))',
     content: 'Select the first Sales Order Item in the autocomplete dropdown.',
+    run: 'click'
 }, {
     trigger: 'h1 > div[name="name"] > input',
     content: 'Set Project name',

--- a/addons/sale_timesheet/tests/test_sale_timesheet_ui.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet_ui.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from odoo.tests import HttpCase, tagged, loaded_demo_data
+from odoo.tests import HttpCase, tagged
 
 _logger = logging.getLogger(__name__)
 
@@ -38,8 +38,8 @@ class TestUi(HttpCase):
             .create({'group_project_milestone': True}) \
             .execute()
 
+        admin = cls.env.ref('base.user_admin')
+        admin.employee_id.hourly_cost = 75
+
     def test_ui(self):
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
         self.start_tour('/web', 'sale_timesheet_tour', login='admin', timeout=100)

--- a/addons/test_sale_product_configurators/tests/test_sale_product_matrix.py
+++ b/addons/test_sale_product_configurators/tests/test_sale_product_matrix.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from odoo.tests import tagged, loaded_demo_data
+from odoo.tests import tagged
 
 from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.product_matrix.tests.common import TestMatrixCommon
@@ -35,10 +35,9 @@ class TestSaleMatrixUi(TestMatrixCommon):
         cls.currency.action_unarchive()
 
     def test_sale_matrix_ui(self):
-        # TODO: Adapt to work without demo data
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
+        self.env.ref('base.group_user').implied_ids += (
+            self.env.ref('sale_management.group_sale_order_template')
+        )
 
         # Set the template as configurable by matrix.
         self.matrix_template.product_add_mode = "matrix"

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -4,6 +4,7 @@ odoo.define("website.tour_utils", function (require) {
 const {_t} = require("web.core");
 const {Markup} = require('web.utils');
 var tour = require("web_tour.tour");
+const { getCookie } = require('web.utils.cookies');
 
 function addMedia(position = "right") {
     return {
@@ -454,7 +455,7 @@ function switchWebsite(websiteId, websiteName) {
     }, {
         content: `Switch to website '${websiteName}'`,
         extra_trigger: `iframe html:not([data-website-id="${websiteId}"])`,
-        trigger: `.o_website_switcher_container .dropdown-item:contains("${websiteName}")`,
+        trigger: `.o_website_switcher_container .dropdown-item[data-website-id=${websiteId}]:contains("${websiteName}")`,
     }, {
         content: "Wait for the iframe to be loaded",
         // The page reload generates assets for the new website, it may take
@@ -463,6 +464,20 @@ function switchWebsite(websiteId, websiteName) {
         trigger: `iframe html[data-website-id="${websiteId}"]`,
         isCheck: true,
     }];
+}
+
+/**
+ * Switches to a different website by clicking on the website switcher.
+ * This function can only be used during test tours as it requires
+ * specific cookies to properly function.
+ *
+ * @param {string} websiteName - The name of the website to switch to.
+ * @returns {Array} - The steps required to perform the website switch.
+ */
+function testSwitchWebsite(websiteName) {
+    const websiteIdMapping = JSON.parse(getCookie('websiteIdMapping') || '{}');
+    const websiteId = websiteIdMapping[websiteName];
+    return switchWebsite(websiteId, websiteName)
 }
 
 return {
@@ -496,5 +511,6 @@ return {
     selectNested,
     selectSnippetColumn,
     switchWebsite,
+    testSwitchWebsite
 };
 });

--- a/addons/website/static/src/systray_items/website_switcher.xml
+++ b/addons/website/static/src/systray_items/website_switcher.xml
@@ -16,7 +16,7 @@
             <DropdownItem
                 onSelected="element.callback"
                 class="element.class"
-                dataset="!element.domain ? {'tooltip': tooltipValue, 'tooltipPosition': 'left'} : undefined">
+                dataset="!element.domain ? {'tooltip': tooltipValue, 'tooltipPosition': 'left', websiteId: element.id} : {websiteId: element.id}">
                 <t t-if="!element.domain">
                     <span class="fa fa-warning me-2 text-warning"/>
                 </t>

--- a/addons/website/static/tests/tours/page_manager.js
+++ b/addons/website/static/tests/tours/page_manager.js
@@ -34,16 +34,16 @@ const checkWebsiteFilter = [{
     content: "Click on My Website",
     trigger: "button.dropdown-toggle:contains('My Website')",
 }, {
-    content: "Select My Website 2",
-    trigger: ".dropdown-menu.show > .dropdown-item:contains('My Website 2')",
+    content: "Select Test Website",
+    trigger: ".dropdown-menu.show > .dropdown-item:contains('Test Website')",
 }, {
-    content: "Check that the homepage is now the one of My Website 2",
+    content: "Check that the homepage is now the one of Test Website",
     trigger: ".o_list_table .o_data_row .o_data_cell[name=name]:contains('Home') " +
-             "~ .o_data_cell[name=website_id]:contains('My Website 2')",
+             "~ .o_data_cell[name=website_id]:contains('Test Website')",
     run: () => null, // it's a check
 }, {
-    content: "Click on My Website 2",
-    trigger: "button.dropdown-toggle:contains('My Website 2')",
+    content: "Click on Test Website",
+    trigger: "button.dropdown-toggle:contains('Test Website')",
 }, {
     content: "Go back to My Website",
     trigger: ".dropdown-menu.show > .dropdown-item:contains('My Website')",
@@ -116,20 +116,20 @@ wTourUtils.registerWebsitePreviewTour('website_page_manager', {
 wTourUtils.registerWebsitePreviewTour('website_page_manager_session_forced', {
     test: true,
     url: '/',
-}, [...wTourUtils.switchWebsite(2, 'My Website 2'), {
+}, [...wTourUtils.testSwitchWebsite('Test Website'), {
     content: "Click on Site",
     trigger: 'button.dropdown-toggle[data-menu-xmlid="website.menu_site"]',
 }, {
     content: "Click on Pages",
     trigger: 'a.dropdown-item[data-menu-xmlid="website.menu_website_pages_list"]',
 }, {
-    content: "Check that the homepage is the one of My Website 2",
+    content: "Check that the homepage is the one of Test Website",
     trigger: ".o_list_table .o_data_row .o_data_cell[name=name]:contains('Home') " +
-             "~ .o_data_cell[name=website_id]:contains('My Website 2')",
+             "~ .o_data_cell[name=website_id]:contains('Test Website')",
     run: () => null, // it's a check
 }, {
-    content: "Check that the selected website is My Website 2",
-    trigger: ".o_search_options .dropdown-toggle:contains('My Website 2')",
+    content: "Check that the selected website is Test Website",
+    trigger: ".o_search_options .dropdown-toggle:contains('Test Website')",
     run: () => null, // it's a check
 }]);
 
@@ -137,12 +137,12 @@ tour.register('website_page_manager_direct_access', {
     test: true,
     url: '/web#action=website.action_website_pages_list',
 }, [{
-    content: "Check that the homepage is the one of My Website 2",
+    content: "Check that the homepage is the one of Test Website",
     trigger: ".o_list_table .o_data_row .o_data_cell[name=name]:contains('Home') " +
-             "~ .o_data_cell[name=website_id]:contains('My Website 2')",
+             "~ .o_data_cell[name=website_id]:contains('Test Website')",
     run: () => null, // it's a check
 }, {
-    content: "Check that the selected website is My Website 2",
-    trigger: ".o_search_options .dropdown-toggle:contains('My Website 2')",
+    content: "Check that the selected website is Test Website",
+    trigger: ".o_search_options .dropdown-toggle:contains('Test Website')",
     run: () => null, // it's a check
 }]);

--- a/addons/website/static/tests/tours/snippet_cache_across_websites.js
+++ b/addons/website/static/tests/tours/snippet_cache_across_websites.js
@@ -14,7 +14,7 @@ wTourUtils.registerWebsitePreviewTour('snippet_cache_across_websites', {
     },
     // There's no need to save, but canceling might or might not show a popup...
     ...wTourUtils.clickOnSave(),
-    ...wTourUtils.switchWebsite(2, 'My Website 2'),
+    ...wTourUtils.testSwitchWebsite('Test Website'),
     ...wTourUtils.clickOnEditAndWaitEditMode(),
     {
         content: "Check that the custom snippet is not here",

--- a/addons/website/tests/test_page_manager.py
+++ b/addons/website/tests/test_page_manager.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import json
+
 import odoo.tests
 
 from odoo.tests.common import HOST
@@ -11,16 +13,16 @@ from odoo.tools import config
 class TestWebsitePageManager(odoo.tests.HttpCase):
 
     def test_01_page_manager(self):
-        if self.env['website'].search_count([]) == 1:
-            self.env['website'].create({
-                'name': 'My Website 2',
-                'domain': '',
-                'sequence': 20,
-            })
+        website = self.env['website'].create({
+            'name': 'Test Website',
+            'domain': '',
+            'sequence': 20
+        })
         url = self.env['website'].get_client_action_url('/')
         self.start_tour(url, 'website_page_manager', login="admin")
-        self.start_tour(url, 'website_page_manager_session_forced', login="admin")
+        self.start_tour(url, 'website_page_manager_session_forced', login="admin", cookies={
+            'websiteIdMapping': json.dumps({'Test Website': website.id})
+        })
 
-        alternate_website = self.env['website'].search([('name', '=', 'My Website 2')], limit=1)
-        alternate_website.domain = f'http://{HOST}:{config["http_port"]}'
+        website.domain = f'http://{HOST}:{config["http_port"]}'
         self.start_tour('/web#action=website.action_website_pages_list', 'website_page_manager_direct_access', login='admin')

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import base64
+import json
 
 from werkzeug.urls import url_encode
 
@@ -459,12 +460,11 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_24_snippet_cache_across_websites(self):
         default_website = self.env.ref('website.default_website')
-        if self.env['website'].search_count([]) == 1:
-            self.env['website'].create({
-                'name': 'My Website 2',
-                'domain': '',
-                'sequence': 20,
-            })
+        website = self.env['website'].create({
+            'name': 'Test Website',
+            'domain': '',
+            'sequence': 20
+        })
         self.env['ir.ui.view'].with_context(website_id=default_website.id).save_snippet(
             name='custom_snippet_test',
             arch="""
@@ -475,7 +475,9 @@ class TestUi(odoo.tests.HttpCase):
             thumbnail_url='/website/static/src/img/snippets_thumbs/s_text_block.svg',
             snippet_key='s_text_block',
             template_key='website.snippets')
-        self.start_tour('/@/', 'snippet_cache_across_websites', login='admin')
+        self.start_tour('/@/', 'snippet_cache_across_websites', login='admin', cookies={
+            'websiteIdMapping': json.dumps({'Test Website': website.id})
+        })
 
     def test_25_website_edit_discard(self):
         self.start_tour('/web', 'homepage_edit_discard', login='admin')

--- a/addons/website_forum/static/tests/tours/website_forum_question.js
+++ b/addons/website_forum/static/tests/tours/website_forum_question.js
@@ -37,7 +37,7 @@ odoo.define('website_forum.tour_forum_question', function (require) {
         trigger: ".modal-header button.btn-close",
     }, {
         content: "Check that the code still exists as it was written.",
-        trigger: 'div[data-oe-field="content"]:contains("First Question <p>code here</p>")',
+        trigger: 'div.o_wforum_post_content:contains("First Question <p>code here</p>")',
     }, {
         content: "Open dropdown to edit the post",
         trigger: 'div.dropdown a#dropdownMenuLink',

--- a/addons/website_payment/tests/test_snippets.py
+++ b/addons/website_payment/tests/test_snippets.py
@@ -15,8 +15,5 @@ class TestSnippets(odoo.tests.HttpCase):
 
         demo_provider = self.env['payment.provider'].search([('code', '=', "demo")])
         demo_provider.write({'state': 'test'})
-
-        if not odoo.tests.loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
+        self.env.ref('base.user_admin').partner_id.country_id = self.env.ref('base.be')
         self.start_tour("/?enable_editor=1", "donation_snippet_edition", login='admin')

--- a/addons/website_profile/static/tests/tours/tour_website_profile_description.js
+++ b/addons/website_profile/static/tests/tours/tour_website_profile_description.js
@@ -8,7 +8,7 @@ odoo.define('website_profile.tour_website_profile_description', function (requir
             url: "/profile/users",
         }, [{
             content: "Click on one user profile card",
-            trigger: "div[onclick]",
+            trigger: "div[onclick]:contains(\"test_user\")",
         },{
             content: "Edit profile",
             trigger: "a:contains('EDIT PROFILE')",

--- a/addons/website_profile/tests/test_website_profile.py
+++ b/addons/website_profile/tests/test_website_profile.py
@@ -7,4 +7,8 @@ from odoo.addons.gamification.tests.common import HttpCaseGamification
 @odoo.tests.tagged('post_install', '-at_install')
 class TestWebsiteProfile(HttpCaseGamification):
     def test_save_change_description(self):
+        odoo.tests.new_test_user(
+            self.env, 'test_user',
+            karma=100, website_published=True
+        )
         self.start_tour("/", 'website_profile_description', login="admin")

--- a/addons/website_sale/data/product_snippet_template_data.xml
+++ b/addons/website_sale/data/product_snippet_template_data.xml
@@ -236,9 +236,7 @@
                                 <div class="card-title h1" t-field="record.display_name"/>
                                 <div class="d-flex align-items-center my-4">
                                     <div class="h4 mb-0 me-3">
-                                        <span>
-                                            <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
-                                        </span>
+                                        <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
                                     </div>
                                     <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
                                         <t t-set="rating_avg" t-value="record.rating_avg"/>

--- a/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
@@ -20,7 +20,7 @@ wTourUtils.registerWebsitePreviewTour('add_to_cart_snippet_tour', {
 
         // Basic product with no variants
         wTourUtils.clickOnSnippet({id: 's_add_to_cart'}),
-        ...wTourUtils.selectElementInWeSelectWidget('product_template_picker_opt', 'Acoustic Bloc Screens', true),
+        ...wTourUtils.selectElementInWeSelectWidget('product_template_picker_opt', 'Product No Variant', true),
         ...wTourUtils.clickOnSave(),
         wTourUtils.clickOnElement('add to cart button', 'iframe .s_add_to_cart_btn'),
         {
@@ -29,7 +29,7 @@ wTourUtils.registerWebsitePreviewTour('add_to_cart_snippet_tour', {
         },
         // Product with 2 variants with visitor choice (will open modal)
         ...editAddToCartSnippet(),
-        ...wTourUtils.selectElementInWeSelectWidget('product_template_picker_opt', 'Conference Chair', true),
+        ...wTourUtils.selectElementInWeSelectWidget('product_template_picker_opt', 'Product Yes Variant 1', true),
         ...wTourUtils.clickOnSave(),
         wTourUtils.clickOnElement('add to cart button', 'iframe .s_add_to_cart_btn'),
         wTourUtils.clickOnElement('continue shopping', 'iframe span:contains(Continue Shopping)'),
@@ -44,13 +44,13 @@ wTourUtils.registerWebsitePreviewTour('add_to_cart_snippet_tour', {
 
         // Product with 2 variants with a variant selected
         ...editAddToCartSnippet(),
-        ...wTourUtils.selectElementInWeSelectWidget('product_template_picker_opt', 'Conference Chair', true),
+        ...wTourUtils.selectElementInWeSelectWidget('product_template_picker_opt', 'Product Yes Variant 2', true),
         {
             run: () => null,
             trigger:
                 `we-select[data-name=product_variant_picker_opt] we-toggler:contains("Visitor's Choice")`,
         },
-        ...wTourUtils.selectElementInWeSelectWidget('product_variant_picker_opt', 'Conference Chair (Aluminium)'),
+        ...wTourUtils.selectElementInWeSelectWidget('product_variant_picker_opt', 'Product Yes Variant 2 (Pink)'),
         ...wTourUtils.clickOnSave(),
         wTourUtils.clickOnElement('add to cart button', 'iframe .s_add_to_cart_btn'),
         {
@@ -60,7 +60,7 @@ wTourUtils.registerWebsitePreviewTour('add_to_cart_snippet_tour', {
 
         // Basic product with no variants and action=buy now
         ...editAddToCartSnippet(),
-        ...wTourUtils.selectElementInWeSelectWidget('product_template_picker_opt', 'Acoustic Bloc Screens', true),
+        ...wTourUtils.selectElementInWeSelectWidget('product_template_picker_opt', 'Product No Variant', true),
         {
             run: () => null,
             trigger:
@@ -72,14 +72,14 @@ wTourUtils.registerWebsitePreviewTour('add_to_cart_snippet_tour', {
         {
             // wait for the page to load, as the next check was sometimes too fast
             content: "Wait for the redirection to the payment page",
-            trigger: "div:contains(Choose a delivery method)",
+            trigger: "div#oe_structure_website_sale_payment_1",
             run: () => null,
         },
         wTourUtils.assertPathName('/shop/payment', 'button[name=o_payment_submit_button]'),
 
         wsTourUtils.goToCart({quantity: 4, backend: false}),
-        wsTourUtils.assertCartContains({productName: 'Acoustic Bloc Screens'}),
-        wsTourUtils.assertCartContains({productName: 'Conference Chair (Steel)'}),
-        wsTourUtils.assertCartContains({productName: 'Conference Chair (Aluminium)'}),
+        wsTourUtils.assertCartContains({productName: 'Product No Variant'}),
+        wsTourUtils.assertCartContains({productName: 'Product Yes Variant 1 (Red)'}),
+        wsTourUtils.assertCartContains({productName: 'Product Yes Variant 2 (Pink)'}),
     ],
 );

--- a/addons/website_sale/static/tests/tours/website_sale_category_page_and_products_snippet.js
+++ b/addons/website_sale/static/tests/tours/website_sale_category_page_and_products_snippet.js
@@ -3,13 +3,16 @@
 import tour from 'web_tour.tour';
 import wTourUtils from 'website.tour_utils';
 
-const PRODUCT_CATEGORY_ID = 2;
 
-wTourUtils.registerWebsitePreviewTour('category_page_and_products_snippet_edition', {
+tour.register('category_page_and_products_snippet_edition', {
     test: true,
-    url: `/shop/category/${PRODUCT_CATEGORY_ID}`,
-    edition: true,
+    url: wTourUtils.getClientActionUrl('/shop'),
 }, [
+    {
+        content: "Navigate to category",
+        trigger: 'iframe .o_wsale_filmstip > li:contains("Test Category")',
+    },
+    wTourUtils.clickOnEdit(),
     Object.assign(wTourUtils.dragNDrop({id: 's_dynamic_snippet_products', name: 'Products'}), {
         content: "Drag and drop the product snippet inside the category area",
         run: 'drag_and_drop iframe #category_header',
@@ -31,18 +34,21 @@ wTourUtils.registerWebsitePreviewTour('category_page_and_products_snippet_editio
 
 tour.register('category_page_and_products_snippet_use', {
     test: true,
-    url: `/shop/category/${PRODUCT_CATEGORY_ID}`,
+    url: `/shop`,
 }, [
+    {
+        content: "Navigate to category",
+        trigger: '.o_wsale_filmstip > li:contains("Test Category")',
+    },
     {
         content: "Check that the snippet displays the right products",
         // Wait for at least one shown product
         trigger: '#category_header .s_dynamic_snippet_products:has(.o_carousel_product_img_link)',
-        run: function (actions) {
-            // Note: this could be more robust to not rely on demo data and
-            // make sure that the newest products are not by chance all of
-            // the second category (used for the test) and ... but should be ok.
+        run: function () {
+            // Fetch the category's id from the url.
+            const productCategoryId = window.location.href.match('/shop/category/test-category-(\\d+)')[1]
             const productGridEl = this.$anchor[0].closest('#products_grid');
-            const regex = new RegExp(`^/shop/[\\w-/]+-(\\d+)\\?category=${PRODUCT_CATEGORY_ID}$`);
+            const regex = new RegExp(`^/shop/[\\w-/]+-(\\d+)\\?category=${productCategoryId}$`);
             const allPageProductIDs = [...productGridEl.querySelectorAll('.oe_product_image_link')]
                 .map(el => el.getAttribute('href').match(regex)[1]);
 

--- a/addons/website_sale/static/tests/tours/website_sale_google_analytics.js
+++ b/addons/website_sale/static/tests/tours/website_sale_google_analytics.js
@@ -18,12 +18,12 @@ websiteSaleTracking.include({
 
 tour.register('google_analytics_view_item', {
     test: true,
-    url: '/shop?search=Customizable Desk',
+    url: '/shop?search=Colored T-Shirt',
 },
 [
     {
-        content: "select customizable desk",
-        trigger: '.oe_product_cart a:contains("Customizable Desk")',
+        content: "select Colored T-Shirt",
+        trigger: '.oe_product_cart a:contains("Colored T-Shirt")',
     },
     {
         content: "wait until `_getCombinationInfo()` rpc is done",
@@ -51,12 +51,12 @@ tour.register('google_analytics_view_item', {
 
 tour.register('google_analytics_add_to_cart', {
     test: true,
-    url: '/shop?search=Acoustic Bloc Screens',
+    url: '/shop?search=Basic Shirt',
 },
 [
     {
-        content: "select Acoustic Bloc Screens",
-        trigger: '.oe_product_cart a:contains("Acoustic Bloc Screens")',
+        content: "select Basic Shirt",
+        trigger: '.oe_product_cart a:contains("Basic Shirt")',
     },
     {
         content: "click add to cart button on product page",

--- a/addons/website_sale/static/tests/tours/website_sale_shop_pricelist_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_pricelist_tour.js
@@ -9,7 +9,7 @@ odoo.define('website_sale_tour.website_sale_shop_pricelist_tour', function (requ
     }, [
     {
         content: "Check pricelist",
-        trigger: ".o_pricelist_dropdown:contains('Public Pricelist')",
+        trigger: ".o_pricelist_dropdown:contains('Public Pricelist 1')",
         run: function() {} // Check
     },
     {

--- a/addons/website_sale/tests/test_sale_process.py
+++ b/addons/website_sale/tests/test_sale_process.py
@@ -137,11 +137,42 @@ class TestUi(HttpCaseWithUserDemo):
         self.start_tour("/", 'website_sale_tour_2', login="admin")
 
     def test_05_google_analytics_tracking(self):
-        if not odoo.tests.loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
+        # Data for google_analytics_view_item
+        attribute = self.env['product.attribute'].create({
+            'name': 'Color',
+            'sequence': 10,
+            'display_type': 'color',
+            'value_ids': [
+                Command.create({
+                    'name': 'Red',
+                }),
+                Command.create({
+                    'name': 'Pink',
+                }),
+            ]
+        })
+        self.env['product.template'].create({
+            'name': 'Colored T-Shirt',
+            'standard_price': 500,
+            'list_price': 750,
+            'detailed_type': 'consu',
+            'website_published': True,
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': attribute.id,
+                    'value_ids': attribute.value_ids,
+                })
+            ]
+        })
         self.env['website'].browse(1).write({'google_analytics_key': 'G-XXXXXXXXXXX'})
         self.start_tour("/shop", 'google_analytics_view_item')
+        # Data for google_analytics_add_to_cart
+        self.env['product.template'].create({
+            'name': 'Basic Shirt',
+            'standard_price': 500,
+            'detailed_type': 'consu',
+            'website_published': True
+        })
         self.start_tour("/shop", 'google_analytics_add_to_cart')
 
 

--- a/addons/website_sale/tests/test_website_editor.py
+++ b/addons/website_sale/tests/test_website_editor.py
@@ -7,7 +7,7 @@ from odoo import Command
 from odoo.addons.website_sale.controllers.main import WebsiteSale
 from odoo.addons.website.tools import MockRequest
 from odoo.exceptions import ValidationError
-from odoo.tests import HttpCase, tagged, loaded_demo_data
+from odoo.tests import HttpCase, tagged
 
 _logger = logging.getLogger(__name__)
 
@@ -240,15 +240,27 @@ class TestWebsiteSaleEditor(HttpCase):
         })
 
     def test_category_page_and_products_snippet(self):
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
-        SHOP_CATEGORY_ID = 2
-        self.start_tour(self.env['website'].get_client_action_url(f'/shop/category/{SHOP_CATEGORY_ID}'), 'category_page_and_products_snippet_edition', login='restricted')
-        self.start_tour(f'/shop/category/{SHOP_CATEGORY_ID}', 'category_page_and_products_snippet_use', login=None)
+        category = self.env['product.public.category'].create({
+            'name': 'Test Category',
+        })
+        self.env['product.template'].create({
+            'name': 'Test Product',
+            'website_published': True,
+            'public_categ_ids': [
+                Command.link(category.id)
+            ]
+        })
+        self.env['product.template'].create({
+            'name': 'Test Product Outside Category',
+            'website_published': True,
+        })
+        self.start_tour(self.env['website'].get_client_action_url('/shop'), 'category_page_and_products_snippet_edition', login='restricted')
+        self.start_tour('/shop', 'category_page_and_products_snippet_use', login=None)
 
     def test_website_sale_restricted_editor_ui(self):
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
+        self.env['product.template'].create({
+            'name': 'Test Product',
+            'website_sequence': 0,
+            'website_published': True,
+        })
         self.start_tour(self.env['website'].get_client_action_url('/shop'), 'website_sale_restricted_editor_ui', login='restricted')

--- a/addons/website_sale/tests/test_website_sale_add_to_cart_snippet.py
+++ b/addons/website_sale/tests/test_website_sale_add_to_cart_snippet.py
@@ -2,7 +2,8 @@
 
 import logging
 
-from odoo.tests import HttpCase, tagged, loaded_demo_data
+from odoo import Command
+from odoo.tests import HttpCase, tagged
 
 _logger = logging.getLogger(__name__)
 
@@ -37,7 +38,46 @@ class TestAddToCartSnippet(HttpCase):
     def test_configure_product(self):
         # Reset the company country id, which ensure that no country dependant fields are blocking the address form.
         self.env.company.country_id = self.env.ref('base.us')
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
+        attribute = self.env['product.attribute'].create({
+            'name': 'Color',
+            'value_ids': [
+                Command.create({
+                    'name': 'Red'
+                }),
+                Command.create({
+                    'name': 'Pink'
+                })
+            ]
+        })
+        self.env['product.template'].create([{
+            'name': 'Product No Variant',
+            'website_published': True
+        }, {
+            'name': 'Product Yes Variant 1',
+            'website_published': True,
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': attribute.id,
+                    'value_ids': attribute.value_ids
+                })
+            ]
+        }, {
+            'name': 'Product Yes Variant 2',
+            'website_published': True,
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': attribute.id,
+                    'value_ids': attribute.value_ids
+                })
+            ]
+        }])
+        admin_partner = self.env.ref('base.user_admin').partner_id
+        admin_partner.write({
+            'street': "rue des Bourlottes, 9",
+            'street2': "",
+            'city': "Ramillies",
+            'zip': 1367,
+            'country_id': self.env.ref('base.be')
+        })
+        self.env.ref('base.user_admin').country_id = self.env.ref('base.be')
         self.start_tour("/", 'add_to_cart_snippet_tour', login="admin")

--- a/addons/website_sale/tests/test_website_sale_pricelist.py
+++ b/addons/website_sale/tests/test_website_sale_pricelist.py
@@ -6,7 +6,7 @@ import logging
 from unittest.mock import patch
 
 from odoo.fields import Command
-from odoo.tests import tagged, TransactionCase, loaded_demo_data
+from odoo.tests import tagged, TransactionCase
 
 from odoo.addons.base.tests.common import TransactionCaseWithUserDemo, HttpCaseWithUserPortal
 from odoo.addons.website.tools import MockRequest
@@ -656,15 +656,20 @@ class TestWebsiteSaleSession(HttpCaseWithUserPortal):
             The objective is to verify that the pricelist
             changes correctly according to the user.
         """
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
         website = self.env.ref('website.default_website')
         test_user = self.env['res.users'].create({
             'name': 'Toto',
             'login': 'toto',
             'password': 'long_enough_password',
         })
+        # We need at least two selectable pricelists to display the dropdown
+        self.env['product.pricelist'].create([{
+            'name': 'Public Pricelist 1',
+            'selectable': True
+        }, {
+            'name': 'Public Pricelist 2',
+            'selectable': True
+        }])
         user_pricelist = self.env['product.pricelist'].create({
             'name': 'User Pricelist',
             'website_id': website.id,

--- a/addons/website_sale/tests/test_website_sale_snippets.py
+++ b/addons/website_sale/tests/test_website_sale_snippets.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from odoo.tests import HttpCase, tagged, loaded_demo_data
+from odoo.tests import HttpCase, tagged
 from odoo.addons.website.tools import MockRequest
 
 _logger = logging.getLogger(__name__)
@@ -13,12 +13,30 @@ _logger = logging.getLogger(__name__)
 class TestSnippets(HttpCase):
 
     def test_01_snippet_products_edition(self):
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
-        if self.env.company.account_fiscal_country_id.code == 'IT':
-            # tour breaks when company is italian. Deactivated the tour for it
-            return
+        self.env['product.product'].create({
+            'name': 'Test Product',
+            'website_published': True,
+            'sale_ok': True,
+            'list_price': 500,
+        })
+        self.env['product.product'].create({
+            'name': 'Test Product 2',
+            'website_published': True,
+            'sale_ok': True,
+            'list_price': 500,
+        })
+        self.env['product.product'].create({
+            'name': 'Test Product 3',
+            'website_published': True,
+            'sale_ok': True,
+            'list_price': 500,
+        })
+        self.env['product.product'].create({
+            'name': 'Test Product 4',
+            'website_published': True,
+            'sale_ok': True,
+            'list_price': 500,
+        })
         self.start_tour('/', 'website_sale.snippet_products', login='admin')
 
     def test_02_snippet_products_remove(self):

--- a/addons/website_sale_comparison/static/tests/tours/website_sale_comparison.js
+++ b/addons/website_sale_comparison/static/tests/tours/website_sale_comparison.js
@@ -10,8 +10,8 @@ odoo.define('website_sale_comparison.tour_comparison', function (require) {
     }, [
     // test from shop page
     {
-        content: "add first product 'Warranty' in a comparison list",
-        trigger: '.oe_product_cart:contains("Warranty") .o_add_compare',
+        content: "add first product 'Color T-Shirt' in a comparison list",
+        trigger: '.oe_product_cart:contains("Color T-Shirt") .o_add_compare',
     },
     {
         content: "check compare button contains one product",
@@ -24,8 +24,8 @@ odoo.define('website_sale_comparison.tour_comparison', function (require) {
         run: function () {},
     },
     {
-        content: "add second product 'Conference Chair' in a comparison list",
-        trigger: '.oe_product_cart:contains("Conference Chair") .o_add_compare',
+        content: "add second product 'Color Pants' in a comparison list",
+        trigger: '.oe_product_cart:contains("Color Pants") .o_add_compare',
     },
     {
         content: "check popover is now open and compare button contains two products",
@@ -35,14 +35,14 @@ odoo.define('website_sale_comparison.tour_comparison', function (require) {
     },
     {
         content: "check products name are correct in the comparelist",
-        extra_trigger: '.o_product_row:contains("Warranty")',
-        trigger: '.o_product_row:contains("Conference Chair")',
+        extra_trigger: '.o_product_row:contains("Color T-Shirt")',
+        trigger: '.o_product_row:contains("Color Pants")',
         run: function () {},
     },
     // test form product page
     {
-        content: "go to product page of customizable desk(with variants)",
-        trigger: '.oe_product_cart a:contains("Customizable Desk")',
+        content: "go to product page of Color Shoes (with variants)",
+        trigger: '.oe_product_cart a:contains("Color Shoes")',
     },
     {
         content: "check compare button is still there and contains 2 products",
@@ -62,12 +62,12 @@ odoo.define('website_sale_comparison.tour_comparison', function (require) {
     {
         content: "check the comparelist is now open and contains 3rd product with correct variant",
         extra_trigger: '.comparator-popover',
-        trigger: '.o_product_row:contains("Customizable Desk (Steel, White)")',
+        trigger: '.o_product_row:contains("Color Shoes (Red)")',
         run: function () {},
     },
     {
-        content: "select 2nd variant(Black Color)",
-        trigger: '.variant_attribute[data-attribute_name="Color"] input[data-value_name="Black"]',
+        content: "select 2nd variant(Pink Color)",
+        trigger: '.variant_attribute[data-attribute_name="Color"] input[data-value_name="Pink"]',
         run: function (actions) {
           $('img[class*="product_detail_img"]').attr('data-image-to-change', 1);
           actions.click();
@@ -81,7 +81,7 @@ odoo.define('website_sale_comparison.tour_comparison', function (require) {
     {
         content: "comparelist contains 4th product with correct variant",
         extra_trigger: '.o_product_circle:contains(4)',
-        trigger: '.o_product_row:contains("Customizable Desk (Steel, Black)")',
+        trigger: '.o_product_row:contains("Color Shoes (Red)")',
         run: function () {},
     },
     {
@@ -90,8 +90,8 @@ odoo.define('website_sale_comparison.tour_comparison', function (require) {
         run: function () {},
     },
     {
-        content: "select 3nd variant(Custom)",
-        trigger: '.variant_attribute[data-attribute_name="Legs"] input[data-value_name="Custom"]',
+        content: "select 3rd variant(Blue)",
+        trigger: '.variant_attribute[data-attribute_name="Color"] input[data-value_name="Blue"]',
     },
     {
         content: "click on compare button to add in comparison list when variant changed",
@@ -110,59 +110,59 @@ odoo.define('website_sale_comparison.tour_comparison', function (require) {
     // test on compare page
     {
         content: "check 1st product contains correct variant",
-        trigger: '.o_product_comparison_table:contains("Conference Chair (Steel)")',
+        trigger: '.o_product_comparison_table:contains("Color Pants (Red)")',
         run: function () {},
     },
     {
         content: "check 2nd product contains correct variant",
-        trigger: '.o_product_comparison_table:contains("Customizable Desk (Steel, White)")',
+        trigger: '.o_product_comparison_table:contains("Color Shoes (Pink)")',
         run: function () {},
     },
     {
         content: "check 3rd product is correctly added",
-        trigger: '.o_product_comparison_table:contains("Customizable Desk (Steel, Black)")',
+        trigger: '.o_product_comparison_table:contains("Color Shoes (Red)")',
         run: function () {},
     },
     {
         content: "check 4th product is correctly added",
-        trigger: '.o_product_comparison_table:contains("Warranty")',
+        trigger: '.o_product_comparison_table:contains("Color T-Shirt")',
         run: function () {},
     },
     {
-        content: "remove Customizable Desk (Steel, Black) from compare table",
+        content: "remove Color Shoes (Pink) from compare table",
         trigger: '#o_comparelist_table .o_comparelist_remove:eq(2)',
     },
     {
-        content: "check customizable table with black variant is removed",
-        trigger: '#o_comparelist_table:not(:contains("Customizable Desk (Steel, Black)"))',
+        content: "check color shoes pink variant is removed",
+        trigger: '#o_comparelist_table:not(:contains("Color Shoes (Pink)"))',
         run: function () {},
     },
     {
         content: "open compare menu",
-        extra_trigger: 'body:has(.o_product_row:contains("Warranty") .o_remove)',
+        extra_trigger: 'body:has(.o_product_row:contains("Color T-Shirt") .o_remove)',
         trigger: '.o_product_panel_header',
     },
     {
         content: "remove product",
-        trigger: '.o_product_row:contains("Warranty") .o_remove',
+        trigger: '.o_product_row:contains("Color T-Shirt") .o_remove',
     },
     {
         content: "click on compare button to reload",
         trigger: '.o_comparelist_button a',
     },
     {
-        content: "check product 'Warranty' is removed",
-        trigger: '#o_comparelist_table:not(:contains("Warranty"))',
+        content: "check product 'Color T-Shirt' is removed",
+        trigger: '#o_comparelist_table:not(:contains("Color T-Shirt"))',
         run: function () {},
     },
     {
-        content: "add product 'Conference Chair' to cart",
-        trigger: '.product_summary:contains("Conference Chair") .a-submit:contains("Add to Cart")',
+        content: "add product 'Color Pants' to cart",
+        trigger: '.product_summary:contains("Color Pants") .a-submit:contains("Add to Cart")',
     },
         tourUtils.goToCart(),
     {
         content: "check product correctly added to cart",
-        trigger: '#cart_products:contains("Conference Chair") .js_quantity[value="1"]',
+        trigger: '#cart_products:contains("Color Pants") .js_quantity[value="1"]',
         run: function () {},
     },
     ]);

--- a/addons/website_sale_comparison/tests/test_website_sale_comparison.py
+++ b/addons/website_sale_comparison/tests/test_website_sale_comparison.py
@@ -5,7 +5,7 @@ import logging
 
 from collections import OrderedDict
 from lxml import etree
-from odoo import tools
+from odoo import Command
 
 import odoo.tests
 
@@ -115,10 +115,62 @@ class TestUi(odoo.tests.HttpCase):
             variant.product_template_attribute_value_ids.filtered(lambda ptav: ptav.attribute_id == self.attribute_vintage).price_extra = price
 
     def test_01_admin_tour_product_comparison(self):
-        # YTI FIXME: Adapt to work without demo data
-        if not odoo.tests.loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
+        attribute = self.env['product.attribute'].create({
+            'name': 'Color',
+            'sequence': 10,
+            'display_type': 'color',
+            'value_ids': [
+                Command.create({
+                    'name': 'Red',
+                }),
+                Command.create({
+                    'name': 'Pink',
+                }),
+                Command.create({
+                    'name': 'Blue'
+                })
+            ]
+        })
+        self.env['product.template'].create([{
+            'name': 'Color T-Shirt',
+            'list_price': 20.0,
+            'website_sequence': 1,
+            'is_published': True,
+            'type': 'service',
+            'invoice_policy': 'delivery',
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': attribute.id,
+                    'value_ids': attribute.value_ids,
+                })
+            ]
+        }, {
+            'name': 'Color Pants',
+            'list_price': 20.0,
+            'website_sequence': 1,
+            'is_published': True,
+            'type': 'service',
+            'invoice_policy': 'delivery',
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': attribute.id,
+                    'value_ids': attribute.value_ids,
+                })
+            ]
+        }, {
+            'name': 'Color Shoes',
+            'list_price': 20.0,
+            'website_sequence': 1,
+            'is_published': True,
+            'type': 'service',
+            'invoice_policy': 'delivery',
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': attribute.id,
+                    'value_ids': attribute.value_ids,
+                })
+            ]
+        }])
         self.start_tour("/", 'product_comparison', login='admin')
 
     def test_02_attribute_multiple_lines(self):

--- a/addons/website_sale_comparison/tests/test_website_sale_comparison.py
+++ b/addons/website_sale_comparison/tests/test_website_sale_comparison.py
@@ -22,13 +22,6 @@ class TestWebsiteSaleComparison(odoo.tests.TransactionCase):
         `_remove_copied_views`. The problematic view that has to be removed is
         `product_attributes_body` because it has a reference to `add_to_compare`.
         """
-        # YTI TODO: Adapt this tour without demo data
-        # I still didn't figure why, but this test freezes on runbot
-        # without the demo data
-        if not odoo.tests.loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
-
         Website0 = self.env['website'].with_context(website_id=None)
         Website1 = self.env['website'].with_context(website_id=1)
 

--- a/addons/website_sale_picking/static/tests/tours/onsite_payment_tour.js
+++ b/addons/website_sale_picking/static/tests/tours/onsite_payment_tour.js
@@ -9,7 +9,7 @@ tour.register('onsite_payment_tour', {
         url: '/web',
     },
     [
-        ...wsTourUtils.addToCart({productName: 'Chair floor protection'}),
+        ...wsTourUtils.addToCart({productName: 'Product Consumable'}),
         wsTourUtils.goToCart(),
         wTourUtils.clickOnElement('Proceed to checkout', 'a:contains(Process Checkout)'),
         ...wsTourUtils.fillAdressForm(),
@@ -21,8 +21,8 @@ tour.register('onsite_payment_tour', {
         },
 
         // Test multi products (Either physical or not)
-        ...wsTourUtils.addToCart({productName: 'Customizable Desk', productHasVariants: true}),
-        ...wsTourUtils.addToCart({productName: 'Warranty'}),
+        ...wsTourUtils.addToCart({productName: 'Product Consumable'}),
+        ...wsTourUtils.addToCart({productName: 'Product Service'}),
         wsTourUtils.goToCart({quantity: 2}),
         wTourUtils.clickOnElement('Go to payment page', 'a:contains("Process Checkout")'),
         ...wsTourUtils.fillAdressForm(),
@@ -34,7 +34,7 @@ tour.register('onsite_payment_tour', {
         },
 
         // Test without any physical product (option pay on site should not appear)
-        ...wsTourUtils.addToCart({productName: 'Warranty'}),
+        ...wsTourUtils.addToCart({productName: 'Product Service'}),
         wsTourUtils.goToCart(),
         wTourUtils.clickOnElement('Go to payment page', 'a:contains("Process Checkout")'),
         ...wsTourUtils.fillAdressForm(),

--- a/addons/website_sale_picking/tests/test_ui.py
+++ b/addons/website_sale_picking/tests/test_ui.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from odoo.tests import HttpCase, tagged, loaded_demo_data
+from odoo.tests import HttpCase, tagged
 
 _logger = logging.getLogger(__name__)
 
@@ -12,34 +12,19 @@ _logger = logging.getLogger(__name__)
 class TestUi(HttpCase):
     def setUp(self):
         super(TestUi, self).setUp()
-        # create a Chair floor protection product
-        self.env['product.product'].create({
-            'name': 'Chair floor protection',
+        self.env['product.product'].create([{
+            'name': 'Product Consumable',
             'type': 'consu',
             'website_published': True,
             'list_price': 1000,
-        })
-        # create a Customizable Desk product
-        self.env['product.product'].create({
-            'name': 'Customizable Desk',
-            'type': 'consu',
-            'website_published': True,
-            'list_price': 1000,
-        })
-        # create a Warranty product
-        self.env['product.product'].create({
-            'name': 'Warranty',
+        }, {
+            'name': 'Product Service',
             'type': 'service',
             'website_published': True,
             'list_price': 20,
-        })
+        }])
 
     def test_onsite_payment_tour(self):
-        # Make sure at least one onsite payment option exists.
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
-
         self.env['delivery.carrier'].create({
             'delivery_type': 'onsite',
             'is_published': True,

--- a/odoo/addons/base/tests/common.py
+++ b/odoo/addons/base/tests/common.py
@@ -121,6 +121,7 @@ class HttpCaseWithUserDemo(HttpCase):
             cls.partner_demo = cls.env['res.partner'].create({
                 'name': 'Marc Demo',
                 'email': 'mark.brown23@example.com',
+                'tz': 'UTC'
             })
             cls.user_demo = cls.env['res.users'].create({
                 'login': 'demo',

--- a/odoo/addons/test_apikeys/tests/test_flow.py
+++ b/odoo/addons/test_apikeys/tests/test_flow.py
@@ -2,7 +2,7 @@ import logging
 import json
 
 from odoo import api
-from odoo.tests import tagged, get_db_name, loaded_demo_data
+from odoo.tests import tagged, get_db_name
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 
 _logger = logging.getLogger(__name__)
@@ -23,10 +23,6 @@ class TestAPIKeys(HttpCaseWithUserDemo):
             del self.registry['ir.logging'].send_key
 
     def test_addremove(self):
-        # TODO: Make this work if no demo data + hr installed
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
         db = get_db_name()
         self.start_tour('/web', 'apikeys_tour_setup', login='demo')
         demo_user = self.env['res.users'].search([('login', '=', 'demo')])

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -572,7 +572,7 @@ tour.stepUtils.autoExpandMoreButtons('.o_form_saved'),
     run: () => {}, // check
 }, {
     mobile: false,
-    trigger: 'label:contains("Untaxed Amount")',
+    trigger: 'body',
     // click somewhere else to exit cell focus
 }, {
     mobile: true,

--- a/odoo/addons/test_main_flows/tests/test_flow.py
+++ b/odoo/addons/test_main_flows/tests/test_flow.py
@@ -15,6 +15,11 @@ class BaseTestUi(odoo.tests.HttpCase):
         self.env.ref('stock.route_warehouse0_mto').active = True
 
         # Define minimal accounting data to run without CoA
+        a_suspense = self.env['account.account'].create({
+            'code': 'X2220',
+            'name': 'Suspense - Test',
+            'account_type': 'asset_current'
+        })
         a_expense = self.env['account.account'].create({
             'code': 'X2120',
             'name': 'Expenses - (test)',
@@ -60,14 +65,24 @@ class BaseTestUi(odoo.tests.HttpCase):
             'name': 'Bank - Test',
             'code': 'TBNK',
             'type': 'bank',
+            'suspense_account_id': a_suspense.id,
             'default_account_id': bnk.id,
         })
+        self.bank_journal.outbound_payment_method_line_ids.payment_account_id = a_expense
+        self.bank_journal.inbound_payment_method_line_ids.payment_account_id = a_sale
+
         self.sales_journal = self.env['account.journal'].create({
             'name': 'Customer Invoices - Test',
             'code': 'TINV',
             'type': 'sale',
             'default_account_id': a_sale.id,
             'refund_sequence': True,
+        })
+        self.general_journal = self.env['account.journal'].create({
+            'name': 'General - Test',
+            'code': 'GNRL',
+            'type': 'general',
+            'default_account_id': bnk.id,
         })
 
         self.start_tour("/web", 'main_flow_tour', login="admin", timeout=180)
@@ -76,10 +91,6 @@ class BaseTestUi(odoo.tests.HttpCase):
 class TestUi(BaseTestUi):
 
     def test_01_main_flow_tour(self):
-        # TODO: Adapt to work without demo data
-        if not odoo.tests.loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
         self.main_flow_tour()
 
 @odoo.tests.tagged('post_install', '-at_install')
@@ -89,8 +100,4 @@ class TestUiMobile(BaseTestUi):
     touch_enabled = True
 
     def test_01_main_flow_tour_mobile(self):
-        # TODO: Adapt to work without demo data
-        if not odoo.tests.loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
         self.main_flow_tour()


### PR DESCRIPTION
A part of the nightly is testing odoo without demo data and is expected to work. It has been red for a while and this pr will fix all the existing errors. 

This is also part of the work to make it green in master in order to change the demo data default behavior. 

