### PR TITLE
[PERF] l10n_in_witholding: index on `l10n_in_withholding_ref_move_id`

### DIFF
--- a/addons/l10n_in_withholding/models/account_move.py
+++ b/addons/l10n_in_withholding/models/account_move.py
@@ -15,6 +15,7 @@ class AccountMove(models.Model):
         comodel_name='account.move',
         string="Indian TDS Ref Move",
         readonly=True,
+        index='btree_not_null',
         copy=False,
         help="Reference move for withholding entry",
     )


### PR DESCRIPTION
## Description
Opening of the form view for invoices is slow on large databases. It's due to the presence of the `l10n_in_withhold_move_ids` in the form view. It's inverse `l10n_in_withholding_ref_move_id` isn't indexed, defaulting to a Seq.Scan on `account.move`.

## Benchmark
On next.odoo.com, opening an invoice form view

| web_read > read | Before | After  |
|-----------------|--------|--------|
| Timings         | 3.35s  | 0.02ms |

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
