### PR TITLE
[17.0] [IMP] Sale: Distribute fixed discount amount proportionally by tax group

### DIFF
--- a/addons/sale/wizard/sale_order_discount.py
+++ b/addons/sale/wizard/sale_order_discount.py
@@ -91,26 +91,34 @@ class SaleOrderDiscount(models.TransientModel):
         self.ensure_one()
         discount_product = self._get_discount_product()
 
+        total_price_per_tax_groups = defaultdict(float)
+        for line in self.sale_order_id.order_line:
+            if not line.product_uom_qty or not line.price_unit:
+                continue
+
+            total_price_per_tax_groups[line.tax_id] += (line.price_unit * line.product_uom_qty)
+
+        if not total_price_per_tax_groups:
+            # No valid lines on which the discount can be applied
+            return
+
         if self.discount_type == 'amount':
+            total_ht = sum(total_price_per_tax_groups.values())
             vals_list = [
                 self._prepare_discount_line_values(
                     product=discount_product,
-                    amount=self.discount_amount,
-                    taxes=self.env['account.tax'],
-                )
+                    amount=self.discount_amount * (subtotal / total_ht), 
+                    taxes=taxes,
+                    description=_(
+                        "Discount: Proportional amount on products with the following taxes %(taxes)s",
+                        taxes=", ".join(taxes.mapped('name')) 
+                    ),
+                ) for taxes, subtotal in total_price_per_tax_groups.items()
             ]
+    
         else: # so_discount
-            total_price_per_tax_groups = defaultdict(float)
-            for line in self.sale_order_id.order_line:
-                if not line.product_uom_qty or not line.price_unit:
-                    continue
 
-                total_price_per_tax_groups[line.tax_id] += (line.price_unit * line.product_uom_qty)
-
-            if not total_price_per_tax_groups:
-                # No valid lines on which the discount can be applied
-                return
-            elif len(total_price_per_tax_groups) == 1:
+            if len(total_price_per_tax_groups) == 1:
                 # No taxes, or all lines have the exact same taxes
                 taxes = next(iter(total_price_per_tax_groups.keys()))
                 subtotal = total_price_per_tax_groups[taxes]

--- a/doc/cla/individual/rpinset.md
+++ b/doc/cla/individual/rpinset.md
@@ -6,4 +6,4 @@ I declare that I am authorized and able to make this agreement and sign this dec
 
 Signed,
 
-Romaric PINSET LEPRETRE 81656154+romaric-oci@users.noreply.github.com https://github.com/romaric-oci
+Romaric PINSET LEPRETRE 12782314+rpinset@users.noreply.github.com https://github.com/rpinset


### PR DESCRIPTION
summary :
Refactored discount line creation to allocate `discount_amount` proportionally across tax groups based on their pre-tax totals in the sale order. This ensures that each tax group receives a proportional share of the total discount when `discount_type` is set to '`amount`'.

---

Description of the issue/feature this PR addresses: When discount_type is set to 'amount', the fixed discount amount is not distributed proportionally across different tax groups on sale orders.

Current behavior before PR: The fixed discount amount is applied uniformly, resulting in a single discount line, regardless of the presence of multiple tax groups on the sale order.

Desired behavior after PR is merged: The fixed discount amount is split proportionally across tax groups based on their pre-tax totals. Each tax group receives a discount line reflecting its proportional share of the total discount, ensuring accuracy when multiple tax groups are present on a sale order.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
