### PR TITLE
[18.0] [IMP] Sale: Distribute fixed discount amount proportionally by tax group

### DIFF
--- a/addons/sale/wizard/sale_order_discount.py
+++ b/addons/sale/wizard/sale_order_discount.py
@@ -98,12 +98,27 @@ class SaleOrderDiscount(models.TransientModel):
         discount_product = self._get_discount_product()
 
         if self.discount_type == 'amount':
+            total_price_per_tax_groups = defaultdict(float)
+            for line in self.sale_order_id.order_line:
+                if not line.product_uom_qty or not line.price_unit:
+                    continue
+                total_price_per_tax_groups[line.tax_id] += (line.price_unit * line.product_uom_qty)
+
+            if not total_price_per_tax_groups:
+                # No valid lines on which the discount can be applied
+                return
+            
+            total_ht = sum(total_price_per_tax_groups.values())
             vals_list = [
                 self._prepare_discount_line_values(
                     product=discount_product,
-                    amount=self.discount_amount,
-                    taxes=self.tax_ids,
-                )
+                    amount=self.discount_amount * (subtotal / total_ht),  # Proportionnel à chaque montant HT
+                    taxes=taxes,
+                    description=_(
+                        "Discount: Proportional amount on products with the following taxes %(taxes)s",
+                        taxes=", ".join(taxes.mapped('name'))  # "Remise : Montant proportionnel sur les produits avec les taxes suivantes %(taxes)s"
+                    ),
+                ) for taxes, subtotal in total_price_per_tax_groups.items()
             ]
         else: # so_discount
             total_price_per_tax_groups = defaultdict(float)


### PR DESCRIPTION
Summary :
Refactored discount line creation to allocate `discount_amount` proportionally across tax groups based on their pre-tax totals in the sale order. This ensures that each tax group receives a proportional share of the total discount when `discount_type` is set to 'amount'.
Issue : https://github.com/odoo/odoo/issues/185348

---

Description of the issue/feature this PR addresses: When discount_type is set to 'amount', the fixed discount amount is not distributed proportionally across different tax groups on sale orders.

Current behavior before PR: The fixed discount amount is applied uniformly, resulting in a single discount line, regardless of the presence of multiple tax groups on the sale order.

Desired behavior after PR is merged: The fixed discount amount is split proportionally across tax groups based on their pre-tax totals. Each tax group receives a discount line reflecting its proportional share of the total discount, ensuring accuracy when multiple tax groups are present on a sale order.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
