### PR TITLE
[FIX] website: properly pause auto-cycling on carousel drag and drop

### DIFF
--- a/addons/website/static/src/js/content/snippets.animation.js
+++ b/addons/website/static/src/js/content/snippets.animation.js
@@ -639,7 +639,8 @@ publicWidget.registry.CarouselBootstrapUpgradeFix = publicWidget.Widget.extend({
             // we remove the bsRide.
             delete this.el.dataset.bsRide;
             await this._destroyCarouselInstance();
-            window.Carousel.getOrCreateInstance(this.el);
+            const options = this.editableMode ? {ride: false, pause: true} : undefined;
+            window.Carousel.getOrCreateInstance(this.el, options);
         } else if (hasInterval && !this.el.dataset.bsRide) {
             // Re-add bsRide on carousels that don't have it but still have
             // a bsInterval. E.g. s_image_gallery must auto-slide on load,
@@ -652,7 +653,8 @@ publicWidget.registry.CarouselBootstrapUpgradeFix = publicWidget.Widget.extend({
             const snippetName = this.el.closest("[data-snippet]").dataset.snippet;
             this.el.dataset.bsRide = this.OLD_AUTO_SLIDING_SNIPPETS.includes(snippetName) ? "carousel" : "true";
             await this._destroyCarouselInstance();
-            window.Carousel.getOrCreateInstance(this.el);
+            const options = this.editableMode ? {ride: false, pause: true} : undefined;
+            window.Carousel.getOrCreateInstance(this.el, options);
         }
     },
     /**

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -2022,7 +2022,6 @@ options.registry.Carousel = options.registry.CarouselHandler.extend({
      * @override
      */
     start: function () {
-        this.$bsTarget.carousel('pause');
         this.$indicators = this.$target.find('.carousel-indicators');
         this.$controls = this.$target.find('.carousel-control-prev, .carousel-control-next, .carousel-indicators');
 


### PR DESCRIPTION
Follow-up of [1] which was not enough to fully fix the issue.

Indeed, there was a remaining call to `.carousel("pause")` in an editor
option `start` that funnily enough actually unpaused the carousel.
Indeed, it created the carousel bootstrap instance, paused... but meant
to restart on first mouseleave.

The `slider` public widget is in charge of pausing the carousel in edit
mode. And it does so by preventing it to cycle for the whole edit mode
duration. But because of that editor option code, it happened too late.

[1]: https://github.com/odoo/odoo/commit/9eff9ae1904e0583f5dc60c6d925c52b48b208ec