### PR TITLE
[IMP] l10n_br: clean up fields on res.company

### DIFF
--- a/addons/l10n_br/models/res_company.py
+++ b/addons/l10n_br/models/res_company.py
@@ -8,9 +8,8 @@ class ResCompany(models.Model):
     _inherit = ["res.company"]
 
     # ==== Business fields ====
-    l10n_br_cpf_code = fields.Char(string="CPF", help="Natural Persons Register.")
-    l10n_br_ie_code = fields.Char(string="IE", help="State Tax Identification Number. Should contain 9-14 digits.") # each state has its own format. Not all of the validation rules can be easily found.
-    l10n_br_im_code = fields.Char(string="IM", help="Municipal Tax Identification Number") # each municipality has its own format. There is no information about validation anywhere.
+    l10n_br_ie_code = fields.Char(string="IE", related="partner_id.l10n_br_ie_code", readonly=False)  # each state has its own format. Not all of the validation rules can be easily found.
+    l10n_br_im_code = fields.Char(string="IM", related="partner_id.l10n_br_im_code", readonly=False)  # each municipality has its own format. There is no information about validation anywhere.
     l10n_br_nire_code = fields.Char(string="NIRE", help="State Commercial Identification Number. Should contain 11 digits.")
 
     def _localization_use_documents(self):

--- a/addons/l10n_br/views/res_company_views.xml
+++ b/addons/l10n_br/views/res_company_views.xml
@@ -6,7 +6,6 @@
         <field name="inherit_id" ref="base.view_company_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='vat']" position="after">
-                <field name="l10n_br_cpf_code" invisible="country_id != %(base.br)d"/>
                 <field name="l10n_br_ie_code" invisible="country_id != %(base.br)d"/>
                 <field name="l10n_br_im_code" invisible="country_id != %(base.br)d"/>
                 <field name="l10n_br_nire_code" invisible="country_id != %(base.br)d"/>


### PR DESCRIPTION
The l10n_br_i{e,m}_code fields are duplicated on res.partner. The ones on res.company are unused. Users set these fields and get confused when they don't have any effect. We fix it by turning them into related fields to the partner.

l10n_br_cpf_code is removed because a CPF code is a specific type of Tax ID. The right place to enter this is in the `vat` field. CPF can be chosen as the `l10n_latam_identification_type_id`. Furthermore, CPF is typically an individual ID, for a company you would normally specify a CNPJ. Again this field was unused, so users enter it and get confused when nothing changes.

task-4281683
