### PR TITLE
[FIX] website: fix failing to load system fonts offline

### DIFF
--- a/addons/website/static/src/scss/website.wysiwyg.scss
+++ b/addons/website/static/src/scss/website.wysiwyg.scss
@@ -1,11 +1,13 @@
 
-@each $font-name, $font-config in $o-theme-font-configs {
-    $url: map-get($font-config, 'url');
-    @if $url {
+$seen-urls: ();
+@each $alias, $key in $o-font-aliases-to-keys {
+    $url: o-get-font-info($alias, 'url');
+    @if $url and index($seen-urls, $url) == null {
+        $seen-urls: append($seen-urls, $url);
         @import url("https://fonts.googleapis.com/css?family=#{unquote($url)}&display=swap");
     } @else {
-        $name: map-get($font-config, 'name');
-        $attachment: map-get($font-config, 'attachment');
+        $name: o-get-font-info($alias, 'name');
+        $attachment: o-get-font-info($alias, 'attachment');
         @if $attachment {
             @import url("/web/content/#{$attachment}/google-font-#{unquote($name)}");
         }


### PR DESCRIPTION
In Ubuntu 24.04 the client can not load the system fonts if there is no internet network.
This issue is present in versions descending to 14.0.
There is a bug report about it: [https://github.com/odoo/odoo/issues/177848](https://github.com/odoo/odoo/issues/177848)

I tried to solve the issue by importing a block of scss code from other file, the behavior succeeded in versions 16.0, and 17.0, but it failed in versions 15.0 and 14.0.

With this change, I can open the web editor in odoo when the server is online and offline too.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
