### PR TITLE
[FIX] sale_{project,timesheet}: unharcode domain methods of fields

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -26,13 +26,13 @@ class Project(models.Model):
                 '|', ('company_id', '=', False), ('company_id', '=', unquote("company_id")),
             ],
         ])
-        return str(domain)
+        return domain
 
     allow_billable = fields.Boolean("Billable")
     sale_line_id = fields.Many2one(
         'sale.order.line', 'Sales Order Item', copy=False,
         compute="_compute_sale_line_id", store=True, readonly=False, index='btree_not_null',
-        domain=_domain_sale_line_id,
+        domain=lambda self: str(self._domain_sale_line_id()),
         help="Sales order item that will be selected by default on the tasks and timesheets of this project,"
             " except if the employee set on the timesheets is explicitely linked to another sales order item on the project.\n"
             "It can be modified on each task and timesheet entry individually if necessary.")
@@ -631,14 +631,14 @@ class ProjectTask(models.Model):
                 ('is_service', '=', True), ('is_expense', '=', False), ('state', 'in', ['sale', 'done']),
             ],
         ])
-        return str(domain)
+        return domain
 
     sale_order_id = fields.Many2one('sale.order', 'Sales Order', compute='_compute_sale_order_id', store=True, help="Sales order to which the task is linked.")
     sale_line_id = fields.Many2one(
         'sale.order.line', 'Sales Order Item',
         copy=True, tracking=True, index='btree_not_null', recursive=True,
         compute='_compute_sale_line', store=True, readonly=False,
-        domain=_domain_sale_line_id,
+        domain=lambda self: str(self._domain_sale_line_id()),
         help="Sales Order Item to which the time spent on this task will be added in order to be invoiced to your customer.\n"
              "By default the sales order item set on the project will be selected. In the absence of one, the last prepaid sales order item that has time remaining will be used.\n"
              "Remove the sales order item in order to make this task non billable. You can also change or remove the sales order item of each timesheet entry individually.")

--- a/addons/sale_timesheet/models/project_sale_line_employee_map.py
+++ b/addons/sale_timesheet/models/project_sale_line_employee_map.py
@@ -21,14 +21,14 @@ class ProjectProductEmployeeMap(models.Model):
                 '|', ('company_id', '=', False), ('company_id', '=', unquote('company_id')),
             ],
         ])
-        return str(domain)
+        return domain
 
     project_id = fields.Many2one('project.project', "Project", required=True)
     employee_id = fields.Many2one('hr.employee', "Employee", required=True)
     sale_line_id = fields.Many2one(
         'sale.order.line', "Sales Order Item",
         compute="_compute_sale_line_id", store=True, readonly=False,
-        domain=_domain_sale_line_id)
+        domain=lambda self: str(self._domain_sale_line_id()))
     company_id = fields.Many2one('res.company', string='Company', related='project_id.company_id')
     partner_id = fields.Many2one(related='project_id.partner_id')
     price_unit = fields.Float("Unit Price", compute='_compute_price_unit', store=True, readonly=True)


### PR DESCRIPTION
Since domain methods of fields are set using the actual class method instead of a lambda, it is not possible to inherit those methods when inheriting the model.

This issue is fixed by using a lambda function to call the domain method.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
