### PR TITLE
[FIX] hr: Prevent traceback error

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -419,7 +419,7 @@ class HolidaysAllocation(models.Model):
                 [self.employee_id.id]['hours']
         else:
             planned_worked = worked
-        left = self.employee_id.sudo()._get_leave_days_data_batch(start_dt, end_dt,
+        left = self.employee_id.sudo()._get_leave_days_data_batch(start_dt, end_dt, calendar=self.employee_id._get_calendar(start_dt),
             domain=[('time_type', '=', 'leave')])[self.employee_id.id]['hours']
         if level.frequency == 'hourly':
             if level.accrual_plan_id.is_based_on_worked_time:

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -2314,3 +2314,37 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             data = self.leave_type.get_allocation_data(self.employee_emp, date(2025, 1, 15))
             remaining_future = data[self.employee_emp][0][1]["remaining_leaves"]
             self.assertEqual(remaining_future, 21)
+
+    def test_accrual_allocation_without_working_hours(self):
+        """
+        check that creating an accrual allocation for an employee without working hours doesn't raise a traceback error
+        """
+        with freeze_time("2017-12-5"):
+            employee_without_calendar = self.env['hr.employee'].create({
+                'name': 'employee without calendar',
+                'resource_calendar_id': False,
+            })
+            accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
+                'name': 'accrual plan',
+                'is_based_on_worked_time': True,
+                'level_ids': [(0, 0, {
+                    'start_count': 1,
+                    'start_type': 'day',
+                    'added_value': 1,
+                    'added_value_type': 'hour',
+                    'frequency': 'hourly',
+                })],
+            })
+            past_date = datetime.date.today() - relativedelta(days=1)
+            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
+                'name': 'accrual allocation for employee without calendar',
+                'accrual_plan_id': accrual_plan.id,
+                'employee_id': employee_without_calendar.id,
+                'holiday_status_id': self.leave_type.id,
+                'number_of_days': 0,
+                'allocation_type': 'accrual',
+                'date_from': past_date,
+                'holiday_type': 'employee'
+            })
+            future_date = datetime.date.today() + relativedelta(days=1)
+            allocation._process_accrual_plans(date_to=future_date)


### PR DESCRIPTION
A traceback error occurs when creating an employee without working hours, setting up an accrual allocation for that employee, and choosing a start date before yesterday.

**Steps to reproduce the issue:**

1- Create a new employee in the Employees module with an empty "Working Hours" field.
2- Create an accrual plan:

- 	Go to Time Off > Configurations > Accrual Plans > New.
- 	Create a new milestone for X amount of days hourly, source: Calendar. 

3- Create an accrual allocation for that employee:

- 	Go to Time Off > Management > Allocations > New.
- 	Select the accrual plan created earlier.

If you choose any start date before yesterday, a traceback error occurs (see screenshots attached)
<img src="https://github.com/user-attachments/assets/03198eb8-5e9a-4633-a87f-b0c07aec600d" alt="traceback_error" width="400"/>

The PO (GMF) confirmed that there should always be a fallback for "Working Hours" in this order: Working hours from Contract > Working Hours from Employee > Working Hours from company

opw-4281311
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
