### PR TITLE
[FIX] *: redirect documentation url to correct version

### DIFF
--- a/addons/l10n_bd/__manifest__.py
+++ b/addons/l10n_bd/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Bangladesh - Accounting',
-    'website': 'https://www.odoo.com/documentation/17.0/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/18.0/applications/finance/fiscal_localizations.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['bd'],
     'version': '1.0',

--- a/addons/l10n_es_modelo130/__manifest__.py
+++ b/addons/l10n_es_modelo130/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Spain - Modelo 130 Tax report',
-    'website': 'https://www.odoo.com/documentation/17.0/applications/finance/fiscal_localizations/spain.html',
+    'website': 'https://www.odoo.com/documentation/18.0/applications/finance/fiscal_localizations/spain.html',
     'version': '1.0',
     'icon': '/account/static/description/l10n.png',
     'countries': ['es'],

--- a/addons/l10n_it_edi_doi/__manifest__.py
+++ b/addons/l10n_it_edi_doi/__manifest__.py
@@ -11,7 +11,7 @@
     Add support for the Declaration of Intent (Dichiarazione di Intento) to the Italian localization.
     """,
     'category': 'Accounting/Localizations',
-    'website': 'https://www.odoo.com/documentation/17.0/applications/finance/fiscal_localizations/italy.html',
+    'website': 'https://www.odoo.com/documentation/18.0/applications/finance/fiscal_localizations/italy.html',
     'data': [
         'security/ir.model.access.csv',
         'data/invoice_it_template.xml',

--- a/addons/l10n_it_edi_withholding/__manifest__.py
+++ b/addons/l10n_it_edi_withholding/__manifest__.py
@@ -19,7 +19,7 @@ Withholding and Pension Fund handling for the E-invoice implementation for Italy
     Please also update the Italian Accounting module (l10n_it) when you install this module.
     """,
     'category': 'Accounting/Localizations/EDI',
-    'website': 'https://www.odoo.com/documentation/17.0/applications/finance/accounting/fiscal_localizations/localizations/italy.html',
+    'website': 'https://www.odoo.com/documentation/18.0/applications/finance/accounting/fiscal_localizations/localizations/italy.html',
     'data': [
         'data/account_withholding_report_data.xml',
         'data/invoice_it_template.xml',

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -642,7 +642,7 @@ class ProductTemplate(models.Model):
                     %s
                 </p>
                 <p>
-                    <a class="oe_link" href="https://www.odoo.com/documentation/17.0/_downloads/5f0840ed187116c425fdac2ab4b592e1/pdfquotebuilderexamples.zip">
+                    <a class="oe_link" href="https://www.odoo.com/documentation/18.0/_downloads/5f0840ed187116c425fdac2ab4b592e1/pdfquotebuilderexamples.zip">
                     %s
                     </a>
                 </p>

--- a/addons/website_links/views/website_links_template.xml
+++ b/addons/website_links/views/website_links_template.xml
@@ -67,7 +67,7 @@
                         <div class="offset-md-1 col-md-4 d-none d-md-block">
                             <p class="text-muted text-justify">Share this page with a <strong>short link</strong> that includes <strong>analytics trackers</strong>.</p>
                             <p class="text-muted text-justify">Those trackers can be used in Google Analytics to track clicks and visitors, or in Odoo reports to track opportunities and related revenues.</p>
-                            <a target="_blank" href="https://www.odoo.com/documentation/17.0/applications/websites/website/reporting/link_tracker.html">Read More</a>
+                            <a target="_blank" href="https://www.odoo.com/documentation/18.0/applications/websites/website/reporting/link_tracker.html">Read More</a>
                         </div>
                     </div>
 


### PR DESCRIPTION
before this commit, many of the url is pointing to 17.0

after this commit, the url will point to 18.0
documentation link

Enterprise: https://github.com/odoo/enterprise/pull/72858

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
