### PR TITLE
[IMP] base, project_(*), sale_(#): project update generic changes

### DIFF
--- a/addons/project/models/project_update.py
+++ b/addons/project/models/project_update.py
@@ -121,7 +121,7 @@ class ProjectUpdate(models.Model):
             'show_activities': milestones['show_section'],
             'milestones': milestones,
             'format_lang': lambda value, digits: formatLang(self.env, value, digits=digits),
-            'format_monetary': lambda value: format_amount(self.env, value, project.currency_id),
+            'format_monetary': lambda value: format_amount(self.env, value, project.currency_id, trailing_zeroes=False),
         }
 
     @api.model

--- a/addons/project/static/src/components/project_right_side_panel/components/project_right_side_panel_section.xml
+++ b/addons/project/static/src/components/project_right_side_panel/components/project_right_side_panel_section.xml
@@ -4,7 +4,7 @@
     <t t-name="project.ProjectRightSidePanelSection">
         <div class="o_rightpanel_section py-0" t-att-name="props.name" t-if="props.show">
             <div class="o_rightpanel_header d-flex align-items-center justify-content-between py-2 border-bottom" t-att-class="props.headerClassName" t-if="props.header">
-                <div class="o_rightpanel_title me-auto" t-if="props.slots.title">
+                <div class="o_rightpanel_title me-auto" t-if="props.slots.title" t-attf-class="{{ env.isSmall ? 'd-flex flex-row-reverse align-items-center' : '' }}">
                     <h3 class="m-0 lh-lg ps-1"><t t-slot="title"/></h3>
                 </div>
                 <t t-slot="header"/>

--- a/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.xml
+++ b/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.xml
@@ -83,6 +83,7 @@
             <ProjectRightSidePanelSection
                 name="'profitability'"
                 show="state.data.show_project_profitability_helper"
+                dataClassName="'my-3'"
             >
                 <t t-set-slot="title">
                     Profitability

--- a/addons/project_account/views/project_project_views.xml
+++ b/addons/project_account/views/project_project_views.xml
@@ -34,4 +34,14 @@
         <field name="domain">[('account_id', '!=', False)]</field>
     </record>
 
+    <record id="project_embedded_action_analytic_items_dashboard" model="ir.embedded.actions">
+        <field name="parent_res_model">project.project</field>
+        <field name="sequence">105</field>
+        <field name="name">Analytic Items</field>
+        <field name="parent_action_id" ref="project.project_update_all_action"/>
+        <field name="python_method">action_open_analytic_items</field>
+        <field name="context">{"from_embedded_action": true}</field>
+        <field name="groups_ids" eval="[(4, ref('analytic.group_analytic_accounting'))]" />
+        <field name="domain">[('account_id', '!=', False)]</field>
+    </record>
 </odoo>

--- a/addons/project_hr_expense/views/project_project_views.xml
+++ b/addons/project_hr_expense/views/project_project_views.xml
@@ -9,4 +9,14 @@
         <field name="context">{"from_embedded_action": true}</field>
         <field name="groups_ids" eval="[(4, ref('hr_expense.group_hr_expense_user'))]"/>
     </record>
+
+    <record id="project_embedded_action_hr_expenses_dashbord" model="ir.embedded.actions">
+        <field name="parent_res_model">project.project</field>
+        <field name="sequence">77</field>
+        <field name="name">Expenses</field>
+        <field name="parent_action_id" ref="project.project_update_all_action"/>
+        <field name="python_method">action_open_project_expenses</field>
+        <field name="context">{"from_embedded_action": true}</field>
+        <field name="groups_ids" eval="[(4, ref('hr_expense.group_hr_expense_user'))]"/>
+    </record>
 </odoo>

--- a/addons/project_mrp/views/project_project_views.xml
+++ b/addons/project_mrp/views/project_project_views.xml
@@ -10,11 +10,31 @@
         <field name="groups_ids" eval="[(4, ref('mrp.group_mrp_user'))]"/>
     </record>
 
+    <record id="project_embedded_action_bills_of_materials_dashboard" model="ir.embedded.actions">
+        <field name="parent_res_model">project.project</field>
+        <field name="sequence">95</field>
+        <field name="name">Bills of Materials</field>
+        <field name="parent_action_id" ref="project.project_update_all_action"/>
+        <field name="python_method">action_view_mrp_bom</field>
+        <field name="context">{"from_embedded_action": true}</field>
+        <field name="groups_ids" eval="[(4, ref('mrp.group_mrp_user'))]"/>
+    </record>
+
     <record id="project_embedded_action_manufacturing_orders" model="ir.embedded.actions">
         <field name="parent_res_model">project.project</field>
         <field name="sequence">100</field>
         <field name="name">Manufacturing Orders</field>
         <field name="parent_action_id" ref="project.act_project_project_2_project_task_all"/>
+        <field name="python_method">action_view_mrp_production</field>
+        <field name="context">{"from_embedded_action": true}</field>
+        <field name="groups_ids" eval="[(4, ref('mrp.group_mrp_user'))]"/>
+    </record>
+
+    <record id="project_embedded_action_manufacturing_orders_dashboard" model="ir.embedded.actions">
+        <field name="parent_res_model">project.project</field>
+        <field name="sequence">100</field>
+        <field name="name">Manufacturing Orders</field>
+        <field name="parent_action_id" ref="project.project_update_all_action"/>
         <field name="python_method">action_view_mrp_production</field>
         <field name="context">{"from_embedded_action": true}</field>
         <field name="groups_ids" eval="[(4, ref('mrp.group_mrp_user'))]"/>

--- a/addons/project_purchase/views/project_project.xml
+++ b/addons/project_purchase/views/project_project.xml
@@ -9,4 +9,14 @@
         <field name="context">{"from_embedded_action": true}</field>
         <field name="groups_ids" eval="[(4, ref('purchase.group_purchase_user'))]"/>
     </record>
+
+    <record id="project_embedded_action_purchase_orders_dashboard" model="ir.embedded.actions">
+        <field name="parent_res_model">project.project</field>
+        <field name="sequence">70</field>
+        <field name="name">Purchase Orders</field>
+        <field name="parent_action_id" ref="project.project_update_all_action"/>
+        <field name="python_method">action_open_project_purchase_orders</field>
+        <field name="context">{"from_embedded_action": true}</field>
+        <field name="groups_ids" eval="[(4, ref('purchase.group_purchase_user'))]"/>
+    </record>
 </odoo>

--- a/addons/project_stock/views/project_project_views.xml
+++ b/addons/project_stock/views/project_project_views.xml
@@ -9,6 +9,15 @@
         <field name="groups_ids" eval="[(4, ref('stock.group_stock_user'))]"/>
     </record>
 
+    <record id="project_embedded_action_from_wh_dashboard" model="ir.embedded.actions">
+        <field name="parent_res_model">project.project</field>
+        <field name="sequence">80</field>
+        <field name="name">From WH</field>
+        <field name="parent_action_id" ref="project.project_update_all_action"/>
+        <field name="python_method">action_open_deliveries</field>
+        <field name="groups_ids" eval="[(4, ref('stock.group_stock_user'))]"/>
+    </record>
+
     <record id="project_embedded_action_to_wh" model="ir.embedded.actions">
         <field name="parent_res_model">project.project</field>
         <field name="sequence">90</field>
@@ -18,11 +27,29 @@
         <field name="groups_ids" eval="[(4, ref('stock.group_stock_user'))]"/>
     </record>
 
+    <record id="project_embedded_action_to_wh_dashboard" model="ir.embedded.actions">
+        <field name="parent_res_model">project.project</field>
+        <field name="sequence">90</field>
+        <field name="name">To WH</field>
+        <field name="parent_action_id" ref="project.project_update_all_action"/>
+        <field name="python_method">action_open_receipts</field>
+        <field name="groups_ids" eval="[(4, ref('stock.group_stock_user'))]"/>
+    </record>
+
     <record id="project_embedded_action_all_pickings" model="ir.embedded.actions">
         <field name="parent_res_model">project.project</field>
         <field name="sequence">92</field>
         <field name="name">Stock Moves</field>
         <field name="parent_action_id" ref="project.act_project_project_2_project_task_all"/>
+        <field name="python_method">action_open_all_pickings</field>
+        <field name="groups_ids" eval="[(4, ref('stock.group_stock_user'))]"/>
+    </record>
+
+    <record id="project_embedded_action_all_pickings_dashboard" model="ir.embedded.actions">
+        <field name="parent_res_model">project.project</field>
+        <field name="sequence">92</field>
+        <field name="name">Stock Moves</field>
+        <field name="parent_action_id" ref="project.project_update_all_action"/>
         <field name="python_method">action_open_all_pickings</field>
         <field name="groups_ids" eval="[(4, ref('stock.group_stock_user'))]"/>
     </record>

--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -464,7 +464,7 @@ class ProjectProject(models.Model):
             'sol_items': [{
                 **sol_read,
                 **get_action(sol_read['id']),
-            } for sol_read in all_sols.with_context(with_price_unit=True)._read_format(['name', 'product_uom_qty', 'qty_delivered', 'qty_invoiced', 'product_uom_id', 'product_id'])],
+            } for sol_read in all_sols.with_context(with_price_unit=True)._read_format(['display_name', 'product_uom_qty', 'qty_delivered', 'qty_invoiced', 'product_uom_id', 'product_id'])],
             'displayLoadMore': display_load_more,
         }
 

--- a/addons/sale_project/static/src/components/project_right_side_panel/components/project_profitability_section.xml
+++ b/addons/sale_project/static/src/components/project_right_side_panel/components/project_profitability_section.xml
@@ -35,9 +35,9 @@
                                 <t t-set="uom_name" t-value="sale_item.product_uom_id and sale_item.product_uom_id[1]"/>
                                 <td style="padding-left: 30px">
                                     <a t-if="sale_item.action" href="#" t-on-click="() => this.onSaleItemActionClick(sale_item.action)">
-                                        <t t-esc="sale_item.name"/>
+                                        <t t-esc="sale_item.display_name"/>
                                     </a>
-                                    <t t-else="" t-esc="sale_item.name"/>
+                                    <t t-else="" t-esc="sale_item.display_name"/>
                                 </td>
                                 <td class="text-end align-middle"><t t-esc="formatValue(sale_item.product_uom_qty, uom_name)"/> <t t-esc="uom_name"/></td>
                                 <td class="text-end align-middle"><t t-esc="formatValue(sale_item.qty_delivered, uom_name)"/> <t t-esc="uom_name"/></td>

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -196,7 +196,7 @@ class TestSaleProject(HttpCase, TestSaleProjectCommon):
         expected_sale_line_dict = {
             sol_read['id']: sol_read
             for sol_read in sale_order_lines._read_format(
-                ['name', 'product_uom_qty', 'qty_delivered', 'qty_invoiced', 'product_uom_id', 'product_id'])
+                ['display_name', 'product_uom_qty', 'qty_delivered', 'qty_invoiced', 'product_uom_id', 'product_id'])
         }
         actual_sol_ids = []
         for line in sale_items_data['sol_items']:

--- a/addons/sale_project/tests/test_sale_project_dashboard.py
+++ b/addons/sale_project/tests/test_sale_project_dashboard.py
@@ -79,13 +79,13 @@ class TestDashboardProject(TestProjectDashboardCommon):
                 'product_id': self.dashboard_product_delivery_service.id,
                 'product_uom_qty': 1,
         }])
-        expected_dict = [{'id': sol_service_3.id, 'name': 'Material', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom_id': (1, 'Units'), 'product_id': (self.material_product.id, 'Material')}]
+        expected_dict = sol_service_3._read_format(
+            ['display_name', 'product_uom_qty', 'qty_delivered', 'qty_invoiced', 'product_uom_id', 'product_id']
+        )
         sale_item_data = self.dashboard_project.get_sale_items_data(limit=5, with_action=False, section_id='materials')
         self.assertEqual(sale_item_data['sol_items'], expected_dict)
-        expected_dict = [
-             {'id': sol_service_1.id, 'name': '[SERV-ORDERED2] Service Milestone', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom_id': (4, 'Hours'), 'product_id': (self.product_milestone.id, '[SERV-ORDERED2] Service Milestone')},
-             {'id': sol_service_2.id, 'name': '[SERV-ORDERED2] Product prepaid', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom_id': (4, 'Hours'), 'product_id': (self.product_prepaid.id, '[SERV-ORDERED2] Product prepaid')},
-             {'id': sol_service_4.id, 'name': '[SERV-ORDERED2] Service Delivery', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom_id': (4, 'Hours'), 'product_id': (self.dashboard_product_delivery_service.id, '[SERV-ORDERED2] Service Delivery')},
-        ]
+        expected_dict = (sol_service_1 + sol_service_2 + sol_service_4)._read_format(
+            ['display_name', 'product_uom_qty', 'qty_delivered', 'qty_invoiced', 'product_uom_id', 'product_id']
+        )
         sale_item_data = self.dashboard_project.get_sale_items_data(limit=5, with_action=False, section_id='service_revenues')
         self.assertEqual(sale_item_data['sol_items'], expected_dict)

--- a/addons/sale_project/views/project_views.xml
+++ b/addons/sale_project/views/project_views.xml
@@ -44,7 +44,7 @@
 
     <record id="project_embedded_action_invoices_dashboard" model="ir.embedded.actions">
         <field name="parent_res_model">project.project</field>
-        <field name="sequence">70</field>
+        <field name="sequence">60</field>
         <field name="name">Invoices</field>
         <field name="parent_action_id" ref="project.project_update_all_action"/>
         <field name="python_method">action_open_project_invoices</field>
@@ -69,6 +69,17 @@
         <field name="sequence">75</field>
         <field name="name">Vendor Bills</field>
         <field name="parent_action_id" ref="project.act_project_project_2_project_task_all"/>
+        <field name="python_method">action_open_project_vendor_bills</field>
+        <field name="context">{"from_embedded_action": true}</field>
+        <field name="groups_ids" eval="[(4, ref('account.group_account_invoice')), (4, ref('sales_team.group_sale_salesman'))]"/>
+        <field name="domain">[('allow_billable', '=', True)]</field>
+    </record>
+
+    <record id="project_embedded_action_vendor_bills_dashboard" model="ir.embedded.actions">
+        <field name="parent_res_model">project.project</field>
+        <field name="sequence">75</field>
+        <field name="name">Vendor Bills</field>
+        <field name="parent_action_id" ref="project.project_update_all_action"/>
         <field name="python_method">action_open_project_vendor_bills</field>
         <field name="context">{"from_embedded_action": true}</field>
         <field name="groups_ids" eval="[(4, ref('account.group_account_invoice')), (4, ref('sales_team.group_sale_salesman'))]"/>

--- a/addons/sale_timesheet/data/sale_service_demo.xml
+++ b/addons/sale_timesheet/data/sale_service_demo.xml
@@ -175,6 +175,7 @@
             <field name="list_price">500</field>
             <field name="standard_price">420.00</field>
             <field name="type">service</field>
+            <field name="invoice_policy">delivery</field>
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="uom_po_id" ref="uom.product_uom_unit"/>
             <field name="service_type" model="product.product" eval="'milestones' if obj().env.user.has_group('project.group_project_milestone') else 'manual'" />

--- a/addons/sale_timesheet/tests/test_sale_timesheet_dashboard.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet_dashboard.py
@@ -28,7 +28,7 @@ class TestSaleTimesheetDashboard(Common):
     def test_get_sale_item_data_various_sol_with_timesheet_installed(self):
         """This test ensures that when the timesheet module is installed, the sols are computed and put into the new profitability sections."""
 
-        sol_service_1, sol_service_2, sol_service_3, sol_service_4, sol_service_5 = self.dashboardSaleOrderLine.create([{
+        sols = self.dashboardSaleOrderLine.create([{
             'product_id': self.product_milestone.id,
             'product_uom_qty': 1,
         }, {
@@ -44,28 +44,32 @@ class TestSaleTimesheetDashboard(Common):
             'product_id': self.dashboard_product_delivery_service.id,
             'product_uom_qty': 1,
         }])
+
         sale_item_data = self.dashboard_project.get_sale_items_data(with_action=False, limit=5, section_id='materials')
+        expected_dict = sols._read_format(
+            ['display_name', 'product_uom_qty', 'qty_delivered', 'qty_invoiced', 'product_uom_id', 'product_id']
+        )
         self.assertEqual(
-            sale_item_data['sol_items'],
-            [{'id': sol_service_3.id, 'name': 'Material', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom_id': (1, 'Units'), 'product_id': (self.material_product.id, 'Material')}]
+            sale_item_data['sol_items'][0],
+            expected_dict[2]
         )
         sale_item_data = self.dashboard_project.get_sale_items_data(with_action=False, limit=5, section_id='billable_fixed')
         self.assertEqual(
-            sale_item_data['sol_items'],
-            [{'id': sol_service_2.id, 'name': '[SERV-ORDERED2] Product prepaid', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom_id': (4, 'Hours'), 'product_id': (self.product_prepaid.id, '[SERV-ORDERED2] Product prepaid')}]
+            sale_item_data['sol_items'][0],
+            expected_dict[1]
         )
         sale_item_data = self.dashboard_project.get_sale_items_data(with_action=False, limit=5, section_id='billable_milestones')
         self.assertEqual(
-            sale_item_data['sol_items'],
-            [{'id': sol_service_1.id, 'name': '[SERV-ORDERED2] Service Milestone', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom_id': (4, 'Hours'), 'product_id': (self.product_milestone.id, '[SERV-ORDERED2] Service Milestone')}]
+            sale_item_data['sol_items'][0],
+            expected_dict[0]
         )
         sale_item_data = self.dashboard_project.get_sale_items_data(with_action=False, limit=5, section_id='billable_time')
         self.assertEqual(
-            sale_item_data['sol_items'],
-            [{'id': sol_service_4.id, 'name': '[SERV-DELI1] Service delivered', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom_id': (4, 'Hours'), 'product_id': (self.dashboard_product_delivery_timesheet.id, '[SERV-DELI1] Service delivered')}]
+            sale_item_data['sol_items'][0],
+            expected_dict[3]
         )
         sale_item_data = self.dashboard_project.get_sale_items_data(with_action=False, limit=5, section_id='billable_manual')
         self.assertEqual(
-            sale_item_data['sol_items'],
-            [{'id': sol_service_5.id, 'name': '[SERV-ORDERED2] Service Delivery', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom_id': (4, 'Hours'), 'product_id': (self.dashboard_product_delivery_service.id, '[SERV-ORDERED2] Service Delivery')}]
+            sale_item_data['sol_items'][0],
+            expected_dict[4]
         )

--- a/addons/sale_timesheet/views/project_update_templates.xml
+++ b/addons/sale_timesheet/views/project_update_templates.xml
@@ -27,7 +27,7 @@
 <td class="text-end" t-out="format_monetary(revenue['invoiced'])"/>
 </tr>
 <tfoot>
-<td class="fw-bolder text-end">Total</td>
+<td class="fw-bolder">Total Revenues</td>
 <td class="fw-bolder text-end" t-out="format_monetary(profitability['revenues']['total']['invoiced'] + profitability['revenues']['total']['to_invoice'])"/>
 <td class="fw-bolder text-end" t-out="format_monetary(profitability['revenues']['total']['to_invoice'])"/>
 <td class="fw-bolder text-end" t-out="format_monetary(profitability['revenues']['total']['invoiced'])"/>
@@ -52,7 +52,7 @@
 <td class="text-end" t-out="format_monetary(cost['billed'])"/>
 </tr>
 <tfoot>
-<td class="fw-bolder text-end">Total</td>
+<td class="fw-bolder">Total Costs</td>
 <td class="fw-bolder text-end" t-out="format_monetary(profitability['costs']['total']['billed'] + profitability['costs']['total']['to_bill'])"/>
 <td class="fw-bolder text-end" t-out="format_monetary(profitability['costs']['total']['to_bill'])"/>
 <td class="fw-bolder text-end" t-out="format_monetary(profitability['costs']['total']['billed'])"/>
@@ -62,7 +62,7 @@
 
 <table class="table table-sm mt-4">
 <tr>
-<td class="fw-bolder">Margin</td>
+<td class="fw-bolder">Total</td>
 <td t-attf-class="#{'text-danger' if profitability['total']['margin'] &lt; 0 else 'text-success'}" style="text-align: right; font-weight: bolder">
 <t t-out="format_monetary(profitability['total']['margin'])"/><br/>
     <t t-if="profitability['expected_percentage']">

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -1608,12 +1608,15 @@ def format_decimalized_amount(amount: float, currency=None) -> str:
     return "%s %s" % (formated_amount, currency.symbol or '')
 
 
-def format_amount(env: Environment, amount: float, currency, lang_code: str | None = None) -> str:
+def format_amount(env: Environment, amount: float, currency, lang_code: str | None = None, trailing_zeroes: bool = True) -> str:
     fmt = "%.{0}f".format(currency.decimal_places)
     lang = env['res.lang'].browse(get_lang(env, lang_code).id)
 
     formatted_amount = lang.format(fmt, currency.round(amount), grouping=True)\
         .replace(r' ', u'\N{NO-BREAK SPACE}').replace(r'-', u'-\N{ZERO WIDTH NO-BREAK SPACE}')
+
+    if not trailing_zeroes:
+        formatted_amount = re.sub(fr'{re.escape(lang.decimal_point)}?0+$', '', formatted_amount)
 
     pre = post = u''
     if currency.position == 'before':


### PR DESCRIPTION
*= mrp, purchase, stock
#= project, timesheet

---
`[IMP] project, sale_(*): generic changes to project rightside panel`

- Applied changes in alignment and text changes in project update description
table.

-Fixed the tooltip of Profitability of Project Right Side Panel not being aligned

- Fixed the demo data issue as Timesheets(Billed on Milestones) doesnt have clickable
link. This is due to the problem that the revenues section is fetched based on the
timesheet_invoice_type but it is only changed when product on so line changes, but
the product service policy changes it is not changed.

---
`[IMP] base, project: adding an option to remove trailing zeroes in format_amount`

- Before this commit format_amount util tool didn't have any option to remove
trailing zeroes in the float part.

- After this commit we can supply a parameter trailing_zeroes to format_amount to
format the generated string without trailing_zeroes in fractional part.

---
`[IMP] project, sale_(*): Added back the SOL display in rightside panel to use display_name`

- After this commit SOL name in project update revenues will use display_name
instead of name because of differentiating between the SOL's.Fixup of all
test cases related

---
`[IMP] project_(*): synchronizing the embedded actions of task and dashboard`

- After this commit, task view and dashboard will have same embedded actions.

---
`[FIX] project: added back css affecting the right side panel caret in mobile`

- The caret is coming down to section text being displayed.

- Regression introduced in PR: https://github.com/odoo/odoo/pull/126827

---

task-4190761
