### PR TITLE
[IMP] website_payment: add razorpay to website payments

### DIFF
--- a/addons/website_payment/data/ir_actions_server_data.xml
+++ b/addons/website_payment/data/ir_actions_server_data.xml
@@ -12,4 +12,15 @@ action = env.company._run_payment_onboarding_step(menu_id=menu_id)
         </field>
     </record>
 
+    <record id="action_activate_razorpay" model="ir.actions.server">
+        <field name="name">Activate Razorpay</field>
+        <field name="model_id" ref="website_payment.model_payment_provider"/>
+        <field name="state">code</field>
+        <field name="code">
+menu = env.ref('website.menu_website_website_settings', raise_if_not_found=False)
+menu_id = menu and menu.id
+action = env.company._run_payment_onboarding_step(menu_id=menu_id)
+        </field>
+    </record>
+
 </odoo>

--- a/addons/website_payment/models/__init__.py
+++ b/addons/website_payment/models/__init__.py
@@ -6,3 +6,4 @@ from . import payment_provider
 from . import payment_transaction
 from . import res_config_settings
 from . import res_country
+from . import res_company

--- a/addons/website_payment/models/res_company.py
+++ b/addons/website_payment/models/res_company.py
@@ -1,0 +1,24 @@
+from odoo import api, fields, models
+from odoo.addons.payment_razorpay.const import SUPPORTED_CURRENCIES as RAZORPAY_SUPPORTED_CURRENCIES
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    razorpay_display_connect_button = fields.Boolean(compute='_compute_razorpay_display_connect_button')
+
+    @api.depends('currency_id')
+    def _compute_razorpay_display_connect_button(self):
+        has_razorpay_support_per_company = {
+            company.id: bool(count)
+            for company,count in self.env['payment.provider'].read_group(
+                [
+                    *self.env['payment.provider']._check_company_domain(self),
+                    ('code', '=', 'razorpay'),
+                    ('currency_id.name', 'in', RAZORPAY_SUPPORTED_CURRENCIES),
+                ],
+                ['company_id'],
+                ['__count'],
+        )}
+        for company in self:
+            company.razorpay_display_connect_button = has_razorpay_support_per_company.get(company.id, False)

--- a/addons/website_payment/models/res_config_settings.py
+++ b/addons/website_payment/models/res_config_settings.py
@@ -18,6 +18,8 @@ class ResConfigSettings(models.TransientModel):
         compute='_compute_providers_state')
     is_stripe_supported_country = fields.Boolean(
         related='company_id.country_id.is_stripe_supported_country')
+    is_razorpay_supported_currency = fields.Boolean(
+        related='company_id.currency_id.is_razorpay_supported_currency')
 
     def _get_activated_providers(self):
         self.ensure_one()
@@ -66,3 +68,14 @@ class ResConfigSettings(models.TransientModel):
             'views': [[False, 'form']],
             'res_id': stripe.id if stripe in providers else providers[0].id,
         }
+
+    def action_activate_razorpay(self):
+        self.ensure_one()
+        razorpay = self.env['payment.provider'].search([
+            *self.env['payment.provider']._check_company_domain(self.env.company),
+            ('code', '=', 'razorpay')
+        ], limit=1)
+
+        if not self.is_stripe_supported_country:
+            return False
+        return self.env['ir.actions.actions']._for_xml_id('website_payment.action_activate_razorpay')

--- a/addons/website_payment/views/res_config_settings_views.xml
+++ b/addons/website_payment/views/res_config_settings_views.xml
@@ -13,6 +13,7 @@
                             <div class="row" invisible="providers_state == 'other_than_paypal'">
                                 <field name="providers_state" invisible="1"/>
                                 <field name="is_stripe_supported_country" invisible="1"/>
+                                <field name="is_razorpay_supported_currency" invisible="1"/>
                                 <div class="oe_inline"
                                      invisible="not is_stripe_supported_country">
                                     <button string="Activate Stripe" name="action_activate_stripe" type="object" class="btn-primary"/>
@@ -21,6 +22,19 @@
                                      title="Stripe Connect is not available in your country, please use another payment provider."
                                      invisible="is_stripe_supported_country">
                                     <button string="Activate Stripe" class="btn-primary" disabled=""/>
+                                </div>
+                                <div class="oe_inline"
+                                     invisible="not is_razorpay_supported_currency">
+                                    <button string="Connect Razorpay"
+                                            name="action_activate_razorpay"
+                                            type="object"
+                                            class="btn-primary"/>
+                                </div>
+                                <div class="oe_inline"
+                                     title="Razorpay is not available in your country, please use another payment provider."
+                                     invisible="is_razorpay_supported_currency">
+                                    <button string="Connect Razorpay"
+                                            class="btn-primary"/>
                                 </div>
                                 <button type="action"
                                         name="%(payment.action_payment_provider)d"


### PR DESCRIPTION
Before this PR, users couldn't pay directly on the website.

With this PR, Razorpay is added as a payment provider, allowing users to
make payments directly on the website.

