### PR TITLE
[18.0][FIX] microsoft_calendar: fix res user refresh token extra parameter

### DIFF
--- a/addons/microsoft_calendar/models/res_users.py
+++ b/addons/microsoft_calendar/models/res_users.py
@@ -38,7 +38,7 @@ class User(models.Model):
     def _is_microsoft_calendar_valid(self):
         return self.sudo().microsoft_calendar_token_validity and self.sudo().microsoft_calendar_token_validity >= (fields.Datetime.now() + timedelta(minutes=1))
 
-    def _refresh_microsoft_calendar_token(self, service):
+    def _refresh_microsoft_calendar_token(self, service='calendar'):
         self.ensure_one()
         ICP_sudo = self.env['ir.config_parameter'].sudo()
         client_id = self.env['microsoft.service']._get_microsoft_client_id('calendar')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
While getting a token for Microsoft Calendar, the `_refresh_microsoft_calendar_token` method has been called without service parameters.

Current behavior before PR:
Raising an error 
```
User._refresh_microsoft_calendar_token() missing 1 required positional argument.
```
IMO, the extra parameter `service` has been added so that dynamic service can be used. 
Fixing by making service as default argument None, and if no service passed, then it will use microsoft_service (current behaviour)

```
TypeError: User._refresh_microsoft_calendar_token() missing 1 required positional argument: 'service'
  File "odoo/http.py", line 2363, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1891, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1954, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 137, in retrying
    result = func()
  File "odoo/http.py", line 1921, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2168, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 329, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 727, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/microsoft_calendar/controllers/main.py", line 45, in microsoft_calendar_sync_data
    need_refresh = request.env.user.sudo().with_context(dont_notify=True)._sync_microsoft_calendar()
  File "addons/microsoft_calendar/models/res_users.py", line 105, in _sync_microsoft_calendar
    with microsoft_calendar_token(self) as token:
  File "contextlib.py", line 137, in __enter__
    return next(self.gen)
  File "addons/microsoft_calendar/models/microsoft_sync.py", line 52, in microsoft_calendar_token
    yield user._get_microsoft_calendar_token()
  File "addons/microsoft_calendar/models/res_users.py", line 35, in _get_microsoft_calendar_token
    self._refresh_microsoft_calendar_token()

```

sentry-6026445994
OPW: 4290260

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
