### PR TITLE
[FIX] POS: Add Product and Quantity in Reversal Entries and Refund Lines

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -818,6 +818,8 @@ class PosOrder(models.Model):
             balance = company_currency.round(amount_currency * rate)
             aml_vals_list_per_nature['product'].append({
                 'name': order_line.full_product_name,
+                'product_id': order_line.product_id.id,
+                'quantity': order_line.qty * sign,
                 'account_id': base_line_vals['account_id'].id,
                 'partner_id': base_line_vals['partner_id'].id,
                 'currency_id': base_line_vals['currency_id'].id,

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1384,7 +1384,7 @@ class PosSession(models.Model):
             'balance': amount_converted,
         }
         if partial_vals.get('product_id'):
-            partial_vals['quantity'] = sale_vals.get('quantity') or 1
+            partial_vals['quantity'] = sale_vals.get('quantity', 1.00) * sign
         return partial_vals
 
     def _get_tax_vals(self, key, amount, amount_converted, base_amount_converted):


### PR DESCRIPTION
This PR resolves issues with POS order reversals by:

- **Including Product Details and Quantity**: Reversal entries now capture `product_id`, `product_uom_id` and accurate `quantity`, matching the original order.

- **Adjust Quantity Sign Based on Refund Status in POS Closing Entry**: The quantity for refund lines is now set to negative, accurately reflecting the refund status in the entry.
