### PR TITLE
[FIX] website_sale_loyalty: backport `data-reward-type` attr for taxinc

### DIFF
--- a/addons/website_sale_loyalty/views/website_sale_templates.xml
+++ b/addons/website_sale_loyalty/views/website_sale_templates.xml
@@ -140,7 +140,12 @@
     </template>
 
     <template id="cart_summary" name="Payment" inherit_id="website_sale.cart_summary">
+        <!-- `tax_excluded` line price -->
         <xpath expr="//table[@id='cart_products']/tbody/tr/td[hasclass('td-price')]/child::*" position="attributes">
+            <attribute name="t-att-data-reward-type">line.reward_id.reward_type</attribute>
+        </xpath>
+        <!-- `tax_included` line price -->
+        <xpath expr="//table[@id='cart_products']/tbody/tr/td[hasclass('td-price')]/*[2]" position="attributes">
             <attribute name="t-att-data-reward-type">line.reward_id.reward_type</attribute>
         </xpath>
     </template>


### PR DESCRIPTION
Versions
--------
- 16.0
- 17.0
- saas-17.2

Backport of https://github.com/odoo/odoo/pull/185169, which fixed this in saas-17.4.

Steps
-----
1. Set eCommerce prices to display tax included;
2. have a discount code program;
3. add a deliverable product to cart;
4. apply discount code;
5. click "Proceed to Checkout";
6. open web inspector on the discount amount in the cart summary.

Issue
-----
The `span` element doesn't have the `data-reward-type="discount"` attribute.

Cause
-----
The template adding the attribute, only adds it to the first child element, which displays the price tax excluded.

Solution
--------
Add an `xpath` template to also add it to the second one.

opw-4284046