### PR TITLE
[IMP] point_of_sale: number buffer qty sign change when pressing +/-

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -61,6 +61,17 @@ export class OrderSummary extends Component {
     async updateSelectedOrderline({ buffer, key }) {
         const order = this.pos.get_order();
         const selectedLine = order.get_selected_orderline();
+        // Handling negation of value on first input
+        if (buffer === "-0" && key == "-") {
+            if (this.pos.numpadMode === "quantity" && !selectedLine.refunded_orderline_id) {
+                buffer = selectedLine.get_quantity() * -1;
+            } else if (this.pos.numpadMode === "discount") {
+                buffer = selectedLine.get_discount() * -1;
+            } else if (this.pos.numpadMode === "price") {
+                buffer = selectedLine.get_unit_price() * -1;
+            }
+            this.numberBuffer.state.buffer = buffer.toString();
+        }
         // This validation must not be affected by `disallowLineQuantityChange`
         if (selectedLine && selectedLine.isTipLine() && this.pos.numpadMode !== "price") {
             /**

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -17,7 +17,8 @@ import {
     BACKSPACE,
     Numpad,
     getButtons,
-    DEFAULT_LAST_ROW,
+    ZERO,
+    DECIMAL,
 } from "@point_of_sale/app/generic_components/numpad/numpad";
 import { PosOrderLineRefund } from "@point_of_sale/app/models/pos_order_line_refund";
 import { fuzzyLookup } from "@web/core/utils/search";
@@ -93,12 +94,15 @@ export class TicketScreen extends Component {
         }
     }
     getNumpadButtons() {
-        return getButtons(DEFAULT_LAST_ROW, [
-            { value: "quantity", text: _t("Qty"), class: "active border-primary" },
-            { value: "discount", text: _t("% Disc"), disabled: true },
-            { value: "price", text: _t("Price"), disabled: true },
-            BACKSPACE,
-        ]);
+        return getButtons(
+            [{ value: "-", text: "+/-", disabled: true }, ZERO, DECIMAL],
+            [
+                { value: "quantity", text: _t("Qty"), class: "active border-primary" },
+                { value: "discount", text: _t("% Disc"), disabled: true },
+                { value: "price", text: _t("Price"), disabled: true },
+                BACKSPACE,
+            ]
+        );
     }
     async onSearch(search) {
         this.state.search = search;

--- a/addons/point_of_sale/static/tests/tours/fixed_price_negative_qty_tour.js
+++ b/addons/point_of_sale/static/tests/tours/fixed_price_negative_qty_tour.js
@@ -18,7 +18,7 @@ registry.category("web_tour.tours").add("FixedTaxNegativeQty", {
                     ...ProductScreen.clickLine("Zero Amount Product", "1.0")[0],
                     isActive: ["mobile"],
                 },
-                ...["+/-", "1"].map(Numpad.click),
+                ...["+/-"].map(Numpad.click),
                 ...ProductScreen.selectedOrderlineHasDirect("Zero Amount Product", "-1.0", "-1.0"),
             ]),
             ProductScreen.clickPayButton(),

--- a/addons/point_of_sale/static/tests/tours/payment_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/payment_screen_tour.js
@@ -91,7 +91,8 @@ registry.category("web_tour.tours").add("PaymentScreenRoundingUp", {
             Chrome.clickMenuOption("Orders"),
             Chrome.createFloatingOrder(),
 
-            ProductScreen.addOrderline("Product Test", "-1"),
+            // To get negative of existing quantity just send -
+            ProductScreen.addOrderline("Product Test", "-"),
             ProductScreen.clickPayButton(),
 
             PaymentScreen.totalIs("-2.00"),
@@ -113,7 +114,8 @@ registry.category("web_tour.tours").add("PaymentScreenRoundingDown", {
             Chrome.clickMenuOption("Orders"),
             Chrome.createFloatingOrder(),
 
-            ProductScreen.addOrderline("Product Test", "-1"),
+            // To get negative of existing quantity just send -
+            ProductScreen.addOrderline("Product Test", "-"),
             ProductScreen.clickPayButton(),
 
             PaymentScreen.totalIs("-1.95"),

--- a/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
@@ -507,6 +507,10 @@ export function addOrderline(productName, quantity = 1, unitPrice, expectedTotal
         }
         return key;
     };
+
+    // Press +/- to set a negative quantity. For example, pressing +/- followed by "1" will result in "-11".
+    // To adjust the quantity from "-1" to "-3," first press "0" followed by "3" since pressing +/- will initially set it to "-1,"
+    // and entering "3" directly would result in "-13." so send 0(num) when want to change sign and set a number
     const numpadWrite = (val) =>
         val
             .toString()


### PR DESCRIPTION
Before this commit:
-------------------------
Previously, when adding a product and clicking the "+/-" button, the quantity would change to "0" instead of becoming negative.

After this commit:
-----------------------
After implementing this commit, pressing the +/- button now results in the quantity value changing to negative instead of changing it to 0.

task- 4281516
Related PR: https://github.com/odoo/enterprise/pull/73653