### PR TITLE
[FIX] point_of_sale: prevent 0 amount payment lines

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -227,18 +227,29 @@ export class PaymentScreen extends Component {
     async validateOrder(isForceValidate) {
         this.numberBuffer.capture();
         if (this.pos.config.cash_rounding) {
-            if (!this.pos.get_order().check_paymentlines_rounding()) {
+            if (!this.currentOrder.check_paymentlines_rounding()) {
                 this._display_popup_error_paymentlines_rounding();
                 return;
             }
         }
         if (await this._isOrderValid(isForceValidate)) {
             // remove pending payments before finalizing the validation
+            const toRemove = [];
             for (const line of this.paymentLines) {
-                if (!line.is_done()) {
-                    this.currentOrder.remove_paymentline(line);
+                if (!line.is_done() || line.amount === 0) {
+                    toRemove.push(line);
                 }
             }
+
+            for (const line of toRemove) {
+                this.currentOrder.remove_paymentline(line);
+            }
+
+            const cash = this.payment_methods_from_config.find((pm) => pm.is_cash_count);
+            if (this.currentOrder.get_due() > 0 && this.pos.config.cash_rounding && cash) {
+                this.currentOrder.add_paymentline(cash, 0);
+            }
+
             await this._finalizeValidation();
         }
     }


### PR DESCRIPTION
Steps to reproduce :
-------------------------
- Install the point_of_sale module.
- Order something and go to payment page.
- Apply multiple payment lines even with 0 amount.

Issue :
-------
The payment lines with 0 amount is also shown on receipt as well.

Cause :
----------
We never checked for the amount of paymentline.

Fix :
----
Updated the condition to remove 0 amount paymentline from the view.

task - 4285705