### PR TITLE
[IMP] point_of_sale,pos_restaurant: change table name system

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/number_popup/number_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/number_popup/number_popup.js
@@ -16,6 +16,8 @@ export class NumberPopup extends Component {
         formatDisplayedValue: { type: Function, optional: true },
         placeholder: { type: String, optional: true },
         isValid: { type: Function, optional: true },
+        isValidFeedback: { type: Function, optional: true },
+        isValidBlocking: { type: Boolean, optional: true },
         confirmButtonLabel: { type: String, optional: true },
         getPayload: Function,
         close: Function,
@@ -23,6 +25,7 @@ export class NumberPopup extends Component {
     static defaultProps = {
         title: _t("Confirm?"),
         startingValue: "",
+        isValidBlocking: true,
         isValid: () => true,
         formatDisplayedValue: (x) => x,
         feedback: () => false,

--- a/addons/point_of_sale/static/src/app/components/popups/number_popup/number_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/number_popup/number_popup.xml
@@ -10,10 +10,12 @@
                 </div>
             </div>
             <div t-if="props.feedback(this.state.buffer)" class="p-2 mx-auto mt-n2 mb-2" t-esc="props.feedback(this.state.buffer)" />
+            <t t-set="isValid" t-value="props.isValid(state.buffer)"/>
+            <div t-if="!isValid and props.isValidFeedback" class="p-2 mx-auto mt-n2 mb-2 text-center" t-esc="props.isValidFeedback(this.state.buffer)" />
             <Numpad buttons="props.buttons" class="'p-1 rounded-3 bg-200'"/>
             <t t-set-slot="footer">
                 <div class="d-flex flex-grow-1 justify-content-center">
-                    <button t-att-disabled="!props.isValid(state.buffer)" class="btn btn-primary btn-lg lh-lg o-default-button me-2" tabindex="1" t-on-click="confirm">
+                    <button t-att-disabled="!props.isValid(state.buffer) and props.isValidBlocking" class="btn btn-primary btn-lg lh-lg o-default-button me-2" tabindex="1" t-on-click="confirm">
                         <t t-esc="props.confirmButtonLabel || 'Ok'" />
                     </button>
                     <button class="btn btn-secondary btn-lg lh-lg o-default-button" tabindex="1" t-on-click="cancel">

--- a/addons/pos_restaurant/data/restaurant_session_floor.xml
+++ b/addons/pos_restaurant/data/restaurant_session_floor.xml
@@ -168,10 +168,11 @@
             <field name="background_color">rgb(255,255,255,0.75)</field>
             <field name="pos_config_ids" eval="[(6, 0, [ref('pos_restaurant.pos_config_main_restaurant')])]" />
             <field name="floor_background_image" type="base64" file="pos_restaurant/static/img/floor_main.jpeg" />
+            <field name="floor_prefix">1</field>
         </record>
 
         <record id="table_01" model="restaurant.table">
-            <field name="table_number">1</field>
+            <field name="table_number">101</field>
             <field name="floor_id" ref="pos_restaurant.floor_main" />
             <field name="seats">4</field>
             <field name="color">rgb(53,211,116)</field>
@@ -183,7 +184,7 @@
         </record>
 
         <record id="table_02" model="restaurant.table">
-            <field name="table_number">2</field>
+            <field name="table_number">102</field>
             <field name="floor_id" ref="pos_restaurant.floor_main" />
             <field name="seats">4</field>
             <field name="color">rgb(53,211,116)</field>
@@ -195,7 +196,7 @@
         </record>
 
         <record id="table_03" model="restaurant.table">
-            <field name="table_number">3</field>
+            <field name="table_number">103</field>
             <field name="floor_id" ref="pos_restaurant.floor_main" />
             <field name="seats">4</field>
             <field name="color">rgb(53,211,116)</field>
@@ -207,7 +208,7 @@
         </record>
 
         <record id="table_04" model="restaurant.table">
-            <field name="table_number">4</field>
+            <field name="table_number">104</field>
             <field name="floor_id" ref="pos_restaurant.floor_main" />
             <field name="seats">4</field>
             <field name="color">rgb(53,211,116)</field>
@@ -219,7 +220,7 @@
         </record>
 
         <record id="table_05" model="restaurant.table">
-            <field name="table_number">5</field>
+            <field name="table_number">105</field>
             <field name="floor_id" ref="pos_restaurant.floor_main" />
             <field name="seats">4</field>
             <field name="color">rgb(53,211,116)</field>
@@ -231,7 +232,7 @@
         </record>
 
         <record id="table_06" model="restaurant.table">
-            <field name="table_number">6</field>
+            <field name="table_number">106</field>
             <field name="floor_id" ref="pos_restaurant.floor_main" />
             <field name="seats">4</field>
             <field name="color">rgb(53,211,116)</field>
@@ -243,7 +244,7 @@
         </record>
 
         <record id="table_07" model="restaurant.table">
-            <field name="table_number">7</field>
+            <field name="table_number">107</field>
             <field name="floor_id" ref="pos_restaurant.floor_main" />
             <field name="seats">4</field>
             <field name="color">rgb(235,109,109)</field>
@@ -255,7 +256,7 @@
         </record>
 
         <record id="table_08" model="restaurant.table">
-            <field name="table_number">8</field>
+            <field name="table_number">108</field>
             <field name="floor_id" ref="pos_restaurant.floor_main" />
             <field name="seats">4</field>
             <field name="color">rgb(235,109,109)</field>
@@ -267,7 +268,7 @@
         </record>
 
         <record id="table_09" model="restaurant.table">
-            <field name="table_number">9</field>
+            <field name="table_number">109</field>
             <field name="floor_id" ref="pos_restaurant.floor_main" />
             <field name="seats">6</field>
             <field name="color">rgb(235,109,109)</field>
@@ -279,7 +280,7 @@
         </record>
 
         <record id="table_10" model="restaurant.table">
-            <field name="table_number">10</field>
+            <field name="table_number">110</field>
             <field name="floor_id" ref="pos_restaurant.floor_main" />
             <field name="seats">6</field>
             <field name="color">rgb(235,109,109)</field>
@@ -291,7 +292,7 @@
         </record>
 
         <record id="table_11" model="restaurant.table">
-            <field name="table_number">11</field>
+            <field name="table_number">111</field>
             <field name="floor_id" ref="pos_restaurant.floor_main" />
             <field name="seats">2</field>
             <field name="color">rgb(172,109,173)</field>
@@ -303,7 +304,7 @@
         </record>
 
         <record id="table_12" model="restaurant.table">
-            <field name="table_number">12</field>
+            <field name="table_number">112</field>
             <field name="floor_id" ref="pos_restaurant.floor_main" />
             <field name="seats">2</field>
             <field name="color">rgb(172,109,173)</field>
@@ -320,12 +321,13 @@
             <field name="name">Patio</field>
             <field name="background_color">rgb(130, 233, 171)</field>
             <field name="pos_config_ids" eval="[(6, 0, [ref('pos_restaurant.pos_config_main_restaurant')])]" />
+            <field name="floor_prefix">2</field>
         </record>
 
         <!-- Patio: Left table row -->
 
         <record id="table_21" model="restaurant.table">
-            <field name="table_number">101</field>
+            <field name="table_number">201</field>
             <field name="floor_id" ref="pos_restaurant.floor_patio" />
             <field name="seats">2</field>
             <field name="color">rgb(53,211,116)</field>
@@ -337,7 +339,7 @@
         </record>
 
         <record id="table_22" model="restaurant.table">
-            <field name="table_number">102</field>
+            <field name="table_number">202</field>
             <field name="floor_id" ref="pos_restaurant.floor_patio" />
             <field name="seats">2</field>
             <field name="color">rgb(53,211,116)</field>
@@ -349,7 +351,7 @@
         </record>
 
         <record id="table_23" model="restaurant.table">
-            <field name="table_number">103</field>
+            <field name="table_number">203</field>
             <field name="floor_id" ref="pos_restaurant.floor_patio" />
             <field name="seats">2</field>
             <field name="color">rgb(53,211,116)</field>
@@ -361,7 +363,7 @@
         </record>
 
         <record id="table_24" model="restaurant.table">
-            <field name="table_number">104</field>
+            <field name="table_number">204</field>
             <field name="floor_id" ref="pos_restaurant.floor_patio" />
             <field name="seats">2</field>
             <field name="color">rgb(53,211,116)</field>
@@ -375,7 +377,7 @@
         <!-- Patio: Right table row -->
 
         <record id="table_25" model="restaurant.table">
-            <field name="table_number">105</field>
+            <field name="table_number">205</field>
             <field name="floor_id" ref="pos_restaurant.floor_patio" />
             <field name="seats">2</field>
             <field name="color">rgb(53,211,116)</field>
@@ -387,7 +389,7 @@
         </record>
 
         <record id="table_26" model="restaurant.table">
-            <field name="table_number">106</field>
+            <field name="table_number">206</field>
             <field name="floor_id" ref="pos_restaurant.floor_patio" />
             <field name="seats">2</field>
             <field name="color">rgb(53,211,116)</field>
@@ -399,7 +401,7 @@
         </record>
 
         <record id="table_27" model="restaurant.table">
-            <field name="table_number">107</field>
+            <field name="table_number">207</field>
             <field name="floor_id" ref="pos_restaurant.floor_patio" />
             <field name="seats">2</field>
             <field name="color">rgb(53,211,116)</field>
@@ -411,7 +413,7 @@
         </record>
 
         <record id="table_28" model="restaurant.table">
-            <field name="table_number">108</field>
+            <field name="table_number">208</field>
             <field name="floor_id" ref="pos_restaurant.floor_patio" />
             <field name="seats">2</field>
             <field name="color">rgb(53,211,116)</field>
@@ -425,7 +427,7 @@
         <!-- Patio: Center table block -->
 
         <record id="table_29" model="restaurant.table">
-            <field name="table_number">109</field>
+            <field name="table_number">209</field>
             <field name="floor_id" ref="pos_restaurant.floor_patio" />
             <field name="seats">4</field>
             <field name="color">rgb(235,191,109)</field>
@@ -437,7 +439,7 @@
         </record>
 
         <record id="table_30" model="restaurant.table">
-            <field name="table_number">110</field>
+            <field name="table_number">210</field>
             <field name="floor_id" ref="pos_restaurant.floor_patio" />
             <field name="seats">4</field>
             <field name="color">rgb(235,191,109)</field>
@@ -449,7 +451,7 @@
         </record>
 
         <record id="table_31" model="restaurant.table">
-            <field name="table_number">111</field>
+            <field name="table_number">211</field>
             <field name="floor_id" ref="pos_restaurant.floor_patio" />
             <field name="seats">4</field>
             <field name="color">rgb(235,191,109)</field>
@@ -461,7 +463,7 @@
         </record>
 
         <record id="table_32" model="restaurant.table">
-            <field name="table_number">112</field>
+            <field name="table_number">212</field>
             <field name="floor_id" ref="pos_restaurant.floor_patio" />
             <field name="seats">4</field>
             <field name="color">rgb(235,191,109)</field>

--- a/addons/pos_restaurant/models/pos_config.py
+++ b/addons/pos_restaurant/models/pos_config.py
@@ -58,9 +58,10 @@ class PosConfig(models.Model):
             main_floor = self.env['restaurant.floor'].create({
                 'name': pos_config.company_id.name,
                 'pos_config_ids': [(4, pos_config.id)],
+                'floor_prefix': 1,
             })
             self.env['restaurant.table'].create({
-                'table_number': 1,
+                'table_number': 101,
                 'floor_id': main_floor.id,
                 'seats': 1,
                 'position_h': 100,

--- a/addons/pos_restaurant/models/pos_restaurant.py
+++ b/addons/pos_restaurant/models/pos_restaurant.py
@@ -19,6 +19,7 @@ class RestaurantFloor(models.Model):
     sequence = fields.Integer('Sequence', default=1)
     active = fields.Boolean(default=True)
     floor_background_image = fields.Image(string='Floor Background Image')
+    floor_prefix = fields.Integer('Floor Prefix', default=1, help="The prefix will be used when creating a new table in the PoS interface.")
 
     @api.model
     def _load_pos_data_domain(self, data):
@@ -26,7 +27,7 @@ class RestaurantFloor(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return ['name', 'background_color', 'table_ids', 'sequence', 'pos_config_ids', 'floor_background_image']
+        return ['name', 'background_color', 'table_ids', 'sequence', 'pos_config_ids', 'floor_background_image', 'floor_prefix']
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_active_pos_session(self):
@@ -47,6 +48,12 @@ class RestaurantFloor(models.Model):
                     raise UserError(
                         'Please close and validate the following open PoS Session before modifying this floor.\n'
                         'Open session: %s' % (' '.join(config.mapped('name')),))
+            for table in floor.table_ids:
+                # Verify if table number begin by old prefix
+                if table.table_number and str(table.table_number).startswith(str(self.floor_prefix)) and vals.get('floor_prefix'):
+                    table_number_wo_prefix = str(table.table_number)[len(str(self.floor_prefix)):]
+                    table.table_number = str(vals.get('floor_prefix')) + table_number_wo_prefix
+
         return super(RestaurantFloor, self).write(vals)
 
     def rename_floor(self, new_name):

--- a/addons/pos_restaurant/static/src/app/popup/floor_editing_popup/floor_editing_popup.js
+++ b/addons/pos_restaurant/static/src/app/popup/floor_editing_popup/floor_editing_popup.js
@@ -1,0 +1,30 @@
+import { Component, useState } from "@odoo/owl";
+import { Dialog } from "@web/core/dialog/dialog";
+
+export class FloorEditingPopup extends Component {
+    static template = "pos_restaurant.FloorEditingPopup";
+    static components = { Dialog };
+    static props = {
+        title: String,
+        floor: Object,
+        close: Function,
+        getPayload: Function,
+    };
+
+    setup() {
+        this.state = useState({
+            name: this.props.floor.name,
+            floor_prefix: this.props.floor.floor_prefix,
+        });
+    }
+
+    confirm() {
+        this.props.getPayload(this.state);
+        this.props.close();
+    }
+
+    isValidNumber(number) {
+        // Check if string contains only numbers without floating point
+        return /^\d+$/.test(number);
+    }
+}

--- a/addons/pos_restaurant/static/src/app/popup/floor_editing_popup/floor_editing_popup.xml
+++ b/addons/pos_restaurant/static/src/app/popup/floor_editing_popup/floor_editing_popup.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_restaurant.FloorEditingPopup">
+        <Dialog title="props.title" size="'md'">
+            <div t-if="!isValidNumber(state.floor_prefix)" class="alert alert-danger">
+                <i class="fa fa-exclamation-circle me-2" aria-hidden="true"></i>
+                <span>Table prefix number must be a number</span>
+            </div>
+            <div>
+                <label>Name</label>
+                <input class="form-control form-control-lg mx-auto" type="text" t-model="state.name" />
+            </div>
+            <div class="mt-2">
+                <label>Table Prefix Number</label>
+                <input class="form-control form-control-lg mx-auto" type="text" t-model="state.floor_prefix" />
+            </div>
+            <t t-set-slot="footer">
+                <button class="btn btn-primary" t-att-class="{'disabled': !isValidNumber(state.floor_prefix)}" t-on-click="confirm">Save</button>
+                <button class="btn btn-secondary" t-on-click="props.close">Discard</button>
+            </t>
+        </Dialog>
+    </t>
+</templates>

--- a/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.xml
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.xml
@@ -23,7 +23,7 @@
                         <img t-else="" src="/pos_restaurant/static/img/plan.svg" class="navbar-icon" alt="Floor Plan"/>
                     </button>
                     <button class="table-free-order-label btn btn-lg lh-lg" t-att-class="{'btn-primary': !['ActionScreen', 'FloorScreen'].includes(screen)}" t-on-click="() => this.onClickTableTab()">
-                        <span t-if="pos.get_order()" t-esc="pos.get_order().getName().slice(0, 7)"/>
+                        <span t-if="pos.get_order()" t-esc="pos.get_order().getName().slice(0, 9)"/>
                         <span t-elif="!ui.isSmall">Table</span>
                         <img t-else="" src="/pos_restaurant/static/img/table.svg" class="navbar-icon" alt="Table Selector"/>
                     </button>

--- a/addons/pos_restaurant/static/tests/tours/control_buttons_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/control_buttons_tour.js
@@ -18,11 +18,11 @@ registry.category("web_tour.tours").add("ControlButtonsTour", {
             // Test merging table, transfer is already tested in pos_restaurant_sync_second_login.
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
-            FloorScreen.clickTable("2"),
+            FloorScreen.clickTable("102"),
             Chrome.activeTableOrOrderIs("2"),
             ProductScreen.addOrderline("Water", "5", "2", "10.0"),
             Chrome.clickPlanButton(),
-            FloorScreen.clickTable("4"),
+            FloorScreen.clickTable("104"),
             Chrome.activeTableOrOrderIs("4"),
             ProductScreen.addOrderline("Minute Maid", "3", "2", "6.0"),
             // Extra line is added to test merging table.
@@ -31,7 +31,7 @@ registry.category("web_tour.tours").add("ControlButtonsTour", {
             ProductScreen.selectedOrderlineHas("Coca-Cola", "1"),
 
             ProductScreen.clickControlButton("Transfer"),
-            FloorScreen.clickTable("2"),
+            FloorScreen.clickTable("102"),
             Chrome.activeTableOrOrderIs("2"),
             Order.hasLine({ productName: "Water", quantity: "5" }),
             Order.hasLine({ productName: "Minute Maid", quantity: "3" }),
@@ -53,7 +53,7 @@ registry.category("web_tour.tours").add("ControlButtonsTour", {
             }),
             // Check that note is imported if come back to the table
             Chrome.clickPlanButton(),
-            FloorScreen.clickTable("2"),
+            FloorScreen.clickTable("102"),
             Order.hasLine({
                 productName: "Water",
                 quantity: "5",

--- a/addons/pos_restaurant/static/tests/tours/floor_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/floor_screen_tour.js
@@ -19,34 +19,34 @@ registry.category("web_tour.tours").add("FloorScreenTour", {
             // check floors if they contain their corresponding tables
             Chrome.startPoS(),
             FloorScreen.selectedFloorIs("Main Floor"),
-            FloorScreen.hasTable("2"),
-            FloorScreen.hasTable("4"),
-            FloorScreen.hasTable("5"),
+            FloorScreen.hasTable("102"),
+            FloorScreen.hasTable("104"),
+            FloorScreen.hasTable("105"),
             FloorScreen.clickFloor("Second Floor"),
-            FloorScreen.hasTable("3"),
-            FloorScreen.hasTable("1"),
+            FloorScreen.hasTable("203"),
+            FloorScreen.hasTable("201"),
 
             // clicking table in active mode does not open product screen
             // instead, table is selected
             Chrome.clickMenuOption("Edit Plan"),
-            FloorScreen.clickTable("3"),
-            FloorScreen.selectedTableIs("3"),
-            FloorScreen.clickTable("1"),
-            FloorScreen.selectedTableIs("1"),
+            FloorScreen.clickTable("203"),
+            FloorScreen.selectedTableIs("203"),
+            FloorScreen.clickTable("201"),
+            FloorScreen.selectedTableIs("201"),
 
             //test copy floor
             FloorScreen.clickFloor("Main Floor"),
             FloorScreen.clickEditButton("Clone"),
             FloorScreen.selectedFloorIs("Main Floor (copy)"),
-            FloorScreen.hasTable("2"),
-            FloorScreen.hasTable("4"),
-            FloorScreen.hasTable("5"),
+            FloorScreen.hasTable("102"),
+            FloorScreen.hasTable("104"),
+            FloorScreen.hasTable("105"),
             Utils.refresh(),
             Chrome.clickMenuOption("Edit Plan"),
             FloorScreen.clickFloor("Main Floor (copy)"),
-            FloorScreen.hasTable("2"),
-            FloorScreen.hasTable("4"),
-            FloorScreen.hasTable("5"),
+            FloorScreen.hasTable("102"),
+            FloorScreen.hasTable("104"),
+            FloorScreen.hasTable("105"),
             FloorScreen.clickEditButton("Delete"),
             Dialog.confirm(),
             Utils.refresh(),
@@ -61,7 +61,7 @@ registry.category("web_tour.tours").add("FloorScreenTour", {
                 trigger: `.edit-buttons i[aria-label="Add Table"]`,
                 run: "click",
             },
-            FloorScreen.selectedTableIs("1"),
+            FloorScreen.selectedTableIs("101"),
             FloorScreen.clickEditButton("Rename"),
 
             NumberPopup.enterValue("100"),
@@ -72,7 +72,7 @@ registry.category("web_tour.tours").add("FloorScreenTour", {
             // test duplicate table
             FloorScreen.clickEditButton("Clone"),
             // the name is the first number available on the floor
-            FloorScreen.selectedTableIs("1"),
+            FloorScreen.selectedTableIs("100"),
             FloorScreen.clickEditButton("Rename"),
 
             NumberPopup.enterValue("1111"),
@@ -83,26 +83,26 @@ registry.category("web_tour.tours").add("FloorScreenTour", {
             // switch floor, switch back and check if
             // the new tables are still there
             FloorScreen.clickFloor("Second Floor"),
-            FloorScreen.hasTable("3"),
-            FloorScreen.hasTable("1"),
+            FloorScreen.hasTable("203"),
+            FloorScreen.hasTable("201"),
 
             //test duplicate multiple tables
-            FloorScreen.clickTable("1"),
-            FloorScreen.selectedTableIs("1"),
-            FloorScreen.ctrlClickTable("3"),
-            FloorScreen.selectedTableIs("3"),
+            FloorScreen.clickTable("201"),
+            FloorScreen.selectedTableIs("201"),
+            FloorScreen.ctrlClickTable("203"),
+            FloorScreen.selectedTableIs("203"),
             FloorScreen.clickEditButton("Clone"),
-            FloorScreen.selectedTableIs("2"),
-            FloorScreen.selectedTableIs("4"),
+            FloorScreen.selectedTableIs("201"),
+            FloorScreen.selectedTableIs("203"),
 
             //test delete multiple tables
             FloorScreen.clickEditButton("Delete"),
             Dialog.confirm(),
 
             FloorScreen.clickFloor("Main Floor"),
-            FloorScreen.hasTable("2"),
-            FloorScreen.hasTable("4"),
-            FloorScreen.hasTable("5"),
+            FloorScreen.hasTable("102"),
+            FloorScreen.hasTable("104"),
+            FloorScreen.hasTable("105"),
             FloorScreen.hasTable("100"),
             FloorScreen.hasTable("1111"),
 
@@ -113,60 +113,60 @@ registry.category("web_tour.tours").add("FloorScreenTour", {
             Dialog.confirm(),
 
             // change number of seats
-            FloorScreen.clickTable("4"),
-            FloorScreen.selectedTableIs("4"),
+            FloorScreen.clickTable("104"),
+            FloorScreen.selectedTableIs("104"),
             FloorScreen.clickEditButton("Seats"),
             NumberPopup.enterValue("⌫9"),
             NumberPopup.enterValue("9"),
             NumberPopup.isShown("9"),
             Dialog.confirm(),
-            FloorScreen.table({ name: "4" }),
+            FloorScreen.table({ name: "104" }),
 
             // change number of seat when the input is already selected
-            FloorScreen.selectedTableIs("4"),
+            FloorScreen.selectedTableIs("104"),
             FloorScreen.clickEditButton("Seats"),
             NumberPopup.enterValue("15"),
             NumberPopup.isShown("15"),
             Dialog.confirm(),
-            FloorScreen.table({ name: "4" }),
+            FloorScreen.table({ name: "104" }),
 
             // change shape
             FloorScreen.clickEditButton("Make Round"),
 
             // Opening product screen in main floor should go back to main floor
             FloorScreen.clickSaveEditButton(),
-            FloorScreen.table({ name: "4", withoutClass: ".selected" }),
-            FloorScreen.clickTable("4"),
+            FloorScreen.table({ name: "104", withoutClass: ".selected" }),
+            FloorScreen.clickTable("104"),
             ProductScreen.isShown(),
             Chrome.clickPlanButton(),
 
             // Opening product screen in second floor should go back to second floor
             FloorScreen.clickFloor("Second Floor"),
-            FloorScreen.hasTable("3"),
-            FloorScreen.clickTable("3"),
+            FloorScreen.hasTable("203"),
+            FloorScreen.clickTable("203"),
             ProductScreen.isShown(),
             Chrome.clickPlanButton(),
             FloorScreen.selectedFloorIs("Second Floor"),
 
             // Check the linking of tables
             FloorScreen.clickFloor("Main Floor"),
-            FloorScreen.clickTable("4"),
+            FloorScreen.clickTable("104"),
             ProductScreen.clickDisplayedProduct("Coca-Cola"),
             Chrome.clickPlanButton(),
             FloorScreen.isShown(),
-            FloorScreen.linkTables("5", "4"),
-            FloorScreen.isChildTable("5"),
+            FloorScreen.linkTables("105", "104"),
+            FloorScreen.isChildTable("105"),
             Utils.refresh(),
-            FloorScreen.isChildTable("5"),
+            FloorScreen.isChildTable("105"),
 
             // Check that tables are unlinked automatically when the order is done
-            FloorScreen.clickTable("5"),
-            Chrome.isTabActive("4 & 5"),
+            FloorScreen.clickTable("105"),
+            Chrome.isTabActive("104 & 105"),
             inLeftSide(ProductScreen.orderLineHas("Coca-Cola", "1.0")),
             Chrome.clickPlanButton(),
             FloorScreen.isShown(),
-            FloorScreen.goTo("5"),
-            Chrome.isTabActive("4 & 5"),
+            FloorScreen.goTo("105"),
+            Chrome.isTabActive("104 & 105"),
             inLeftSide(ProductScreen.orderLineHas("Coca-Cola", "1.0")),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Cash"),
@@ -177,13 +177,13 @@ registry.category("web_tour.tours").add("FloorScreenTour", {
                     "acknowledge printing error ( because we don't have printer in the test. )",
             },
             ReceiptScreen.clickNextOrder(),
-            Utils.negateStep(FloorScreen.isChildTable("5")),
+            Utils.negateStep(FloorScreen.isChildTable("105")),
 
-            FloorScreen.linkTables("5", "4"),
+            FloorScreen.linkTables("105", "104"),
             // Check that the tables are unlinked when the child table is dragged
             {
                 content: "Drag table 5 to the bottom of the screen to unlink it",
-                trigger: FloorScreen.table({ name: "5" }).trigger,
+                trigger: FloorScreen.table({ name: "105" }).trigger,
                 async run(helpers) {
                     await helpers.drag_and_drop(`div.floor-map`, {
                         position: {
@@ -193,6 +193,6 @@ registry.category("web_tour.tours").add("FloorScreenTour", {
                     });
                 },
             },
-            Utils.negateStep(FloorScreen.isChildTable("5")),
+            Utils.negateStep(FloorScreen.isChildTable("105")),
         ].flat(),
 });

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -74,9 +74,9 @@ registry.category("web_tour.tours").add("pos_restaurant_sync", {
             Chrome.activeTableOrOrderIs("Table"),
 
             // Create first order
-            FloorScreen.clickTable("5"),
+            FloorScreen.clickTable("105"),
             ProductScreen.orderBtnIsPresent(),
-            Chrome.isTabActive("5"),
+            Chrome.isTabActive("105"),
             ProductScreen.clickDisplayedProduct("Coca-Cola", true),
             inLeftSide(Order.hasLine({ productName: "Coca-Cola", run: "dblclick" })),
             ProductScreen.clickDisplayedProduct("Water", true),
@@ -95,7 +95,7 @@ registry.category("web_tour.tours").add("pos_restaurant_sync", {
 
             // Create 2nd order (paid)
             Chrome.clickPlanButton(),
-            FloorScreen.clickTable("2"),
+            FloorScreen.clickTable("102"),
             ProductScreen.clickDisplayedProduct("Coca-Cola", true),
             ProductScreen.clickDisplayedProduct("Minute Maid", true),
             ProductScreen.totalAmountIs("4.40"),
@@ -116,8 +116,8 @@ registry.category("web_tour.tours").add("pos_restaurant_sync", {
             Chrome.activeTableOrOrderIs("Table"),
 
             // order on another table with a product variant
-            FloorScreen.orderCountSyncedInTableIs("5", "1"),
-            FloorScreen.clickTable("4"),
+            FloorScreen.orderCountSyncedInTableIs("105", "1"),
+            FloorScreen.clickTable("104"),
             ProductScreen.orderBtnIsPresent(),
             ProductScreen.clickDisplayedProduct("Desk Organizer", false),
             {
@@ -143,17 +143,17 @@ registry.category("web_tour.tours").add("pos_restaurant_sync", {
 
             // After clicking next order, floor screen is shown.
             // It should have 1 as number of draft synced order.
-            FloorScreen.orderCountSyncedInTableIs("5", "1"),
-            FloorScreen.clickTable("5"),
+            FloorScreen.orderCountSyncedInTableIs("105", "1"),
+            FloorScreen.clickTable("105"),
             ProductScreen.totalAmountIs("4.40"),
 
             // Create another draft order and go back to floor
             Chrome.clickPlanButton(),
-            FloorScreen.clickTable("2"),
+            FloorScreen.clickTable("102"),
             ProductScreen.clickDisplayedProduct("Coca-Cola", true),
             ProductScreen.clickDisplayedProduct("Minute Maid", true),
             Chrome.clickPlanButton(),
-            FloorScreen.orderCountSyncedInTableIs("5", "1"),
+            FloorScreen.orderCountSyncedInTableIs("105", "1"),
 
             // Delete the first order then go back to floor
             Chrome.clickMenuOption("Orders"),
@@ -173,7 +173,7 @@ registry.category("web_tour.tours").add("pos_restaurant_sync", {
             Chrome.clickPlanButton(),
 
             // There should be 0 synced draft order as we already deleted -00002.
-            FloorScreen.clickTable("5"),
+            FloorScreen.clickTable("105"),
             ProductScreen.orderIsEmpty(),
         ].flat(),
 });

--- a/addons/pos_restaurant/static/tests/tours/refund_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/refund_tour.js
@@ -18,7 +18,7 @@ registry.category("web_tour.tours").add("RefundStayCurrentTableTour", {
             Dialog.confirm("Open Register"),
 
             // Create first order and pay it
-            FloorScreen.clickTable("2"),
+            FloorScreen.clickTable("102"),
             ProductScreen.clickDisplayedProduct("Coca-Cola", true, "1.0"),
             ProductScreen.clickDisplayedProduct("Coca-Cola", true, "2.0"),
             ProductScreen.clickDisplayedProduct("Water", true, "1.0"),
@@ -34,7 +34,7 @@ registry.category("web_tour.tours").add("RefundStayCurrentTableTour", {
             ReceiptScreen.clickNextOrder(),
 
             // Go to another table and refund one of the products
-            FloorScreen.clickTable("4"),
+            FloorScreen.clickTable("104"),
             ProductScreen.orderIsEmpty(),
             ...ProductScreen.clickRefund(),
             TicketScreen.selectOrder("-00001"),

--- a/addons/pos_restaurant/static/tests/tours/split_bill_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/split_bill_screen_tour.js
@@ -19,7 +19,7 @@ registry.category("web_tour.tours").add("SplitBillScreenTour", {
         [
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
-            FloorScreen.clickTable("2"),
+            FloorScreen.clickTable("102"),
             ProductScreen.addOrderline("Water", "5", "2", "10.0"),
             ProductScreen.addOrderline("Minute Maid", "3", "2", "6.0"),
             ProductScreen.addOrderline("Coca-Cola", "1", "2", "2.0"),
@@ -57,7 +57,7 @@ registry.category("web_tour.tours").add("SplitBillScreenTour", {
 
             // Split the order of table 2 again
             Chrome.clickPlanButton(),
-            FloorScreen.clickTable("2"),
+            FloorScreen.clickTable("102"),
             ProductScreen.clickControlButton("Split"),
 
             SplitBillScreen.clickOrderline("Water"),

--- a/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
@@ -19,7 +19,7 @@ registry.category("web_tour.tours").add("PosResTicketScreenTour", {
             TicketScreen.clickDiscard(),
 
             // Make sure that order is deleted properly.
-            FloorScreen.clickTable("5"),
+            FloorScreen.clickTable("105"),
             ProductScreen.addOrderline("Minute Maid", "1", "3"),
             ProductScreen.totalAmountIs("3.0"),
             Chrome.clickPlanButton(),
@@ -30,7 +30,7 @@ registry.category("web_tour.tours").add("PosResTicketScreenTour", {
             TicketScreen.clickDiscard(),
             Chrome.clickPlanButton(),
             FloorScreen.isShown(),
-            FloorScreen.clickTable("5"),
+            FloorScreen.clickTable("105"),
             ProductScreen.orderIsEmpty(),
         ].flat(),
 });
@@ -40,7 +40,7 @@ registry.category("web_tour.tours").add("OrderNumberConflictTour", {
     steps: () =>
         [
             Chrome.startPoS(),
-            FloorScreen.clickTable("3"),
+            FloorScreen.clickTable("103"),
             ProductScreen.isShown(),
             ProductScreen.addOrderline("Coca-Cola", "1", "3"),
             Chrome.clickPlanButton(),

--- a/addons/pos_restaurant/static/tests/tours/tip_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/tip_screen_tour.js
@@ -19,19 +19,19 @@ registry.category("web_tour.tours").add("PosResTipScreenTour", {
             // order 1
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
-            FloorScreen.clickTable("2"),
+            FloorScreen.clickTable("102"),
             ProductScreen.addOrderline("Minute Maid", "1", "2"),
             ProductScreen.totalAmountIs("2.0"),
             Chrome.clickPlanButton(),
             FloorScreen.orderCountSyncedInTableIs("2", "1"),
-            FloorScreen.clickTable("2"),
+            FloorScreen.clickTable("102"),
             ProductScreen.totalAmountIs("2.0"),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickValidate(),
             TipScreen.isShown(),
             Chrome.clickPlanButton(),
-            FloorScreen.clickTable("4"),
+            FloorScreen.clickTable("104"),
             // order 2
             ProductScreen.addOrderline("Coca-Cola", "2", "2"),
             ProductScreen.totalAmountIs("4.0"),
@@ -42,7 +42,7 @@ registry.category("web_tour.tours").add("PosResTipScreenTour", {
 
             // Create without syncing the draft.
             // order 3
-            FloorScreen.clickTable("5"),
+            FloorScreen.clickTable("105"),
             ProductScreen.addOrderline("Minute Maid", "3", "2"),
             ProductScreen.totalAmountIs("6.0"),
             ProductScreen.clickPayButton(),
@@ -144,7 +144,7 @@ registry.category("web_tour.tours").add("PosResTipScreenTour", {
             // order 5
             // Click directly on "settle" without selecting a Tip
             ReceiptScreen.clickNextOrder(),
-            FloorScreen.clickTable("2"),
+            FloorScreen.clickTable("102"),
             ProductScreen.addOrderline("Minute Maid", "3", "2"),
             ProductScreen.totalAmountIs("6.0"),
             ProductScreen.clickPayButton(),

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -65,21 +65,23 @@ class TestFrontendCommon(TestPointOfSaleHttpCommon):
         main_floor = cls.env['restaurant.floor'].create({
             'name': 'Main Floor',
             'pos_config_ids': [(4, cls.pos_config.id)],
+            'floor_prefix': 1,
         })
         second_floor = cls.env['restaurant.floor'].create({
             'name': 'Second Floor',
             'pos_config_ids': [(4, cls.pos_config.id)],
+            'floor_prefix': 2,
         })
 
         cls.main_floor_table_5 = cls.env['restaurant.table'].create([{
-            'table_number': 5,
+            'table_number': 105,
             'floor_id': main_floor.id,
             'seats': 4,
             'position_h': 100,
             'position_v': 100,
         }])
         cls.env['restaurant.table'].create([{
-            'table_number': 4,
+            'table_number': 104,
             'floor_id': main_floor.id,
             'seats': 4,
             'shape': 'square',
@@ -87,7 +89,7 @@ class TestFrontendCommon(TestPointOfSaleHttpCommon):
             'position_v': 100,
         },
         {
-            'table_number': 2,
+            'table_number': 102,
             'floor_id': main_floor.id,
             'seats': 4,
             'position_h': 250,
@@ -95,7 +97,7 @@ class TestFrontendCommon(TestPointOfSaleHttpCommon):
         },
         {
 
-            'table_number': 1,
+            'table_number': 201,
             'floor_id': second_floor.id,
             'seats': 4,
             'shape': 'square',
@@ -103,7 +105,7 @@ class TestFrontendCommon(TestPointOfSaleHttpCommon):
             'position_v': 150,
         },
         {
-            'table_number': 3,
+            'table_number': 203,
             'floor_id': second_floor.id,
             'seats': 4,
             'position_h': 100,

--- a/addons/pos_restaurant/views/pos_restaurant_views.xml
+++ b/addons/pos_restaurant/views/pos_restaurant_views.xml
@@ -15,6 +15,7 @@
                             <field name="name" />
                             <field name="pos_config_ids" widget="many2many_tags"/>
                             <field name="background_color" groups="base.group_no_one" />
+                            <field name="floor_prefix" />
                         </group>
                         <field name="table_ids">
                             <list string='Tables' editable="bottom">


### PR DESCRIPTION
Before, the table system was very basic and not very convenient for the user. When he wanted to create new table between floor plan, sometime several tables where created with the same number. This was due to the fact that the system was not able to detect the last table number between all floor plan.

Now each floor plan has a prefix and the system will name new table with the next number of the last table of the same floor plan.

taskId: 4283519

