### PR TITLE
[FIX] maintenance: specify click in next week step run

### DIFF
--- a/addons/maintenance/static/tests/tours/tour_calendar_with_recurrence.js
+++ b/addons/maintenance/static/tests/tours/tour_calendar_with_recurrence.js
@@ -27,7 +27,8 @@ registry.category("web_tour.tours").add("test_dblclick_event_from_calendar", {
         },
         {
             content: "Move to next week",
-            trigger: ".o_calendar_button_next"
+            trigger: ".o_calendar_button_next",
+            run: "click",
         },
         {
             content: "Access occurrence",


### PR DESCRIPTION
In commit 9f4f1d8e92d0dc68b5628194d9da56d346e708f6, "Move to next week" step is not being processed because of missing `run` argument.
It is necessary for the test to work on saturday and was the main reason of the previous commit being deployed.

runbot-error-65494