### PR TITLE
[FIX] point_of_sale: bank payment method configuration

### DIFF
--- a/addons/point_of_sale/views/pos_payment_method_views.xml
+++ b/addons/point_of_sale/views/pos_payment_method_views.xml
@@ -18,7 +18,7 @@
                         <group>
                             <field name="split_transactions"/>
                             <field name="journal_id" required="not split_transactions" placeholder="Leave empty to use the receivable account of customer" />
-                            <field name="outstanding_account_id" groups="account.group_account_readonly" invisible="type != 'bank'" placeholder="Leave empty to use the default account from the company setting" />
+                            <field name="outstanding_account_id" groups="account.group_account_readonly" invisible="type != 'bank'" required="type == 'bank'" placeholder="Leave empty to use the default account from the company setting" />
                             <field name="receivable_account_id" groups="account.group_account_readonly" invisible="split_transactions" placeholder="Leave empty to use the default account from the company setting" />
                             <field name="company_id" readonly="1" groups="base.group_multi_company" />
                         </group>


### PR DESCRIPTION
in this commit:
============
Made it mandatory to select an outstanding account while configuring the `bank` payment method in pos.

Task - 4281382

Related PR: odoo/upgrade#6728
