### PR TITLE
[FIX] hr: change default job title on employee badge

### DIFF
--- a/addons/hr/report/hr_employee_badge.xml
+++ b/addons/hr/report/hr_employee_badge.xml
@@ -37,9 +37,9 @@
                             </td>
                             <td style="width:67%" valign="center">
                                 <table style="width:155pt; height:85pt" class="table-borderless">
-                                    <tr><th><div style="font-size:15pt; margin-bottom:0pt;margin-top:0pt;" align="center"><span t-out="employee.name">Marc Demo</span></div></th></tr>
-                                    <tr><td><div align="center" style="font-size:10pt;margin-bottom:5pt;"><span t-out="employee.job_id.name">Software Developer</span></div></td></tr>
-                                    <tr><td><div t-if="employee.barcode" t-field="employee.barcode" t-options="{'widget': 'barcode', 'width': 600, 'height': 120, 'img_style': 'max-height:50pt;max-width:100%;', 'img_align': 'center'}">12345678901</div></td></tr>
+                                    <tr><th><div style="font-size:15pt; margin-bottom:0pt;margin-top:0pt;" align="center"><span t-out="employee.name" data-oe-demo="Marc Demo"/></div></th></tr>
+                                    <tr><td><div align="center" style="font-size:10pt;margin-bottom:5pt;"><span t-out="employee.job_id.name" data-oe-demo="Software Developer"/></div></td></tr>
+                                    <tr><td><div t-if="employee.barcode" t-field="employee.barcode" t-options="{'widget': 'barcode', 'width': 600, 'height': 120, 'img_style': 'max-height:50pt;max-width:100%;', 'img_align': 'center'}" data-oe-demo="12345678901"/></td></tr>
                                 </table>
                             </td>
                         </table>


### PR DESCRIPTION
Issue:
When printing an employee badge for an employee without a job position, the default title was set to "Software Developer."

Steps to Reproduce:
-Create an employee with an empty job position.
-Alternatively, remove the job position of an existing employee. -Generate and print a badge (in HR settings).

Explanation:
In `hr_employee_badge.xml`, the default value was set to "Software Developer."

opw-4255102

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
