### PR TITLE
[FIX] html_editor: disable SSL verification on adding images with a URL

### DIFF
--- a/addons/html_editor/controllers/main.py
+++ b/addons/html_editor/controllers/main.py
@@ -251,7 +251,7 @@ class HTML_Editor(http.Controller):
             # This approach is beneficial when the URL doesn't conclude with an
             # image extension. By verifying the MIME type, the code ensures that
             # only supported image types are incorporated into the data.
-            response = requests.head(url, timeout=10)
+            response = requests.head(url, timeout=10, verify=False)
             if response.status_code == 200:
                 mime_type = response.headers['content-type']
                 if mime_type in SUPPORTED_IMAGE_MIMETYPES:


### PR DESCRIPTION
Currently, an error is generated when the user uploads an image with a URL like  https://hcmute.edu.vn/Resources/Images/SubDomain/HomePage/tin%20tuc/B%C3%A1o%20ch%C3%AD%20n%C3%B3i%20g%C3%AC%20v%E1%BB%81%20HCMUTE/Nen/Nen%20phu%20nu.jpg

error: `SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate
verify failed: unable to get local issuer certificate (_ssl.c:1000)`

This is because `requests.head()` is trying to verify the user-provided URL server has a valid TLS certificate, but it is not found with the above url.

This commit will fix the above issue by disabling SSL verification on the user provided  image URL.

sentry-5998939121





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
