### PR TITLE
[FIX] account_debit_note: restore debit note button

### DIFF
--- a/addons/account_debit_note/views/account_move_view.xml
+++ b/addons/account_debit_note/views/account_move_view.xml
@@ -16,19 +16,12 @@
             <field name="invoice_origin" position="after">
                 <field name="debit_origin_id" invisible="not debit_origin_id"/>
             </field>
-        </field>
-    </record>
-
-    <record model="ir.actions.server" id="action_move_debit_note">
-        <field name="name">Debit Note</field>
-        <field name="model_id" ref="model_account_move"/>
-        <field name="groups_id" eval="[(4, ref('account.group_account_invoice'))]"/>
-        <field name="binding_model_id" ref="account.model_account_move" />
-        <field name="binding_view_types">form</field>
-        <field name="state">code</field>
-        <field name="code">
-if records:
-    action = records.action_debit_note()
+            <button name="action_reverse" position="after">
+                <button name="action_debit_note" string='Debit Note'
+                    type='object' groups="account.group_account_invoice"
+                    invisible="move_type not in ('out_invoice', 'in_invoice') or state != 'posted'"
+                    data-hotkey="shift+d"/>
+            </button>
         </field>
     </record>
 


### PR DESCRIPTION
This PR removes the `Debit Note` action from Invoice/Bill form view and adds a `Debit Note` button to the header of Invoice/Bill form view.

Task ID: 4285777

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
