### PR TITLE
[FIX] *: use hover in tours to ensure triggers are visibles

### DIFF
--- a/addons/im_livechat/static/tests/tours/im_livechat_chatbot_steps_sequence_tour.js
+++ b/addons/im_livechat/static/tests/tours/im_livechat_chatbot_steps_sequence_tour.js
@@ -29,29 +29,29 @@ const commonSteps = [
         run: "click",
     },
     {
-        trigger: "textarea#message_0",
+        trigger: ".modal textarea#message_0",
         run: "edit Step 1",
     },
     {
-        trigger: "button:contains(Save & New):enabled",
+        trigger: ".modal button:contains(Save & New):enabled",
         run: "click",
     },
     {
         trigger: 'tr:contains("Step 1")',
     },
     {
-        trigger: "textarea#message_0",
+        trigger: ".modal textarea#message_0",
         run: "edit Step 2",
     },
     {
-        trigger: "button:contains(Save & New):enabled",
+        trigger: ".modal button:contains(Save & New):enabled",
         run: "click",
     },
     {
         trigger: 'tr:contains("Step 2")',
     },
     {
-        trigger: "textarea#message_0",
+        trigger: ".modal textarea#message_0",
         run: "edit Step 3",
     },
 ];
@@ -64,13 +64,12 @@ registry.category("web_tour.tours").add("im_livechat_chatbot_steps_sequence_tour
     steps: () => [
         ...commonSteps,
         {
-            trigger: 'button:contains("Save & Close")',
+            trigger: ".modal button:contains(Save & Close)",
             run: "click",
         },
         {
             trigger: "body.o_web_client:not(.modal-open)",
         },
-        ...stepUtils.discardForm(),
     ],
 });
 
@@ -82,14 +81,14 @@ registry.category("web_tour.tours").add("im_livechat_chatbot_steps_sequence_with
     steps: () => [
         ...commonSteps,
         {
-            trigger: 'button:contains("Save & New")',
+            trigger: ".modal button:contains(Save & New)",
             run: "click",
         },
         {
             trigger: 'tr:contains("Step 3")',
         },
         {
-            trigger: "textarea#message_0",
+            trigger: ".modal textarea#message_0",
             run: "edit Step 4",
         },
         {
@@ -100,11 +99,11 @@ registry.category("web_tour.tours").add("im_livechat_chatbot_steps_sequence_with
             trigger: 'tr:contains("Step 4")',
         },
         {
-            trigger: "textarea#message_0",
+            trigger: ".modal textarea#message_0",
             run: "edit Step 5",
         },
         {
-            trigger: 'button:contains("Save & Close")',
+            trigger: ".modal button:contains(Save & Close)",
             run: "click",
         },
         {
@@ -119,11 +118,11 @@ registry.category("web_tour.tours").add("im_livechat_chatbot_steps_sequence_with
             run: "click",
         },
         {
-            trigger: "textarea#message_0",
+            trigger: ".modal textarea#message_0",
             run: "edit Step 6",
         },
         {
-            trigger: 'button:contains("Save & Close")',
+            trigger: ".modal button:contains(Save & Close)",
             run: "click",
         },
         {
@@ -132,6 +131,5 @@ registry.category("web_tour.tours").add("im_livechat_chatbot_steps_sequence_with
         {
             trigger: 'tr:contains("Step 6")',
         },
-        ...stepUtils.discardForm(),
     ],
 });

--- a/addons/mail/static/tests/tours/discuss_channel_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_public_tour.js
@@ -104,8 +104,8 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
             trigger: '.o-mail-Message .o-mail-AttachmentCard:contains("text.txt")',
         },
         {
-            trigger: ".o-mail-Message [title='Add a Reaction']",
-            run: "click",
+            trigger: ".o-mail-Message-textContent:contains(cheese)",
+            run: "hover && click .o-mail-Message [title='Add a Reaction']",
         },
         {
             trigger: ".o-EmojiPicker .o-Emoji:contains('🙂')",
@@ -135,8 +135,8 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
         },
         {
             content: "Click on more menu",
-            trigger: ".o-mail-Message [title='Expand']",
-            run: "click",
+            trigger: ".o-mail-Message-textContent:contains(cheese)",
+            run: "hover && click .o-mail-Message [title='Expand']",
         },
         {
             content: "Click on edit",

--- a/addons/project/static/tests/tours/personal_stage_tour.js
+++ b/addons/project/static/tests/tours/personal_stage_tour.js
@@ -43,12 +43,9 @@ registry.category("web_tour.tours").add('personal_stage_tour', {
     trigger: '.o_kanban_add',
     run: "click",
 }, {
-    content: "Check that column exists",
-    trigger: '.o_kanban_header:contains("Never")',
-}, {
-    content: 'Open column edit dropdown',
-    trigger: '.o_kanban_header:contains("Never") .dropdown-toggle',
-    run: "click",
+    content: "Check that column exists && Open column edit dropdown",
+    trigger: ".o_kanban_header:contains(Never)",
+    run: "hover && click .o_kanban_header:contains(Never) .dropdown-toggle",
 }, {
     content: "Try editing inbox",
     trigger: ".dropdown-item.o_column_edit",

--- a/addons/test_base_automation/static/tests/tour/base_automation_tour.js
+++ b/addons/test_base_automation/static/tests/tour/base_automation_tour.js
@@ -285,8 +285,8 @@ registry.category("web_tour.tours").add("test_base_automation_on_tag_added", {
 registry.category("web_tour.tours").add("test_open_automation_from_grouped_kanban", {
     steps: () => [
         {
-            trigger: ".o_kanban_view .o_kanban_config button.dropdown-toggle",
-            run: "click",
+            trigger: ".o_kanban_header:contains(test tag)",
+            run: "hover && click .o_kanban_view .o_kanban_config button.dropdown-toggle",
         },
         {
             trigger: ".dropdown-menu .o_column_automations",

--- a/addons/website_sale/static/tests/tours/website_sale_product_configurator_shop_hide_dialog.js
+++ b/addons/website_sale/static/tests/tours/website_sale_product_configurator_shop_hide_dialog.js
@@ -10,8 +10,8 @@ registry
         steps: () => [
             {
                 content: "Click on the cart button",
-                trigger: '.oe_product:has(a:contains("Main product")) div.o_wsale_product_btn a',
-                run: 'click',
+                trigger: ".oe_product:has(a:contains(Main product))",
+                run: "hover && click .oe_product:has(a:contains(Main product)) div.o_wsale_product_btn a",
             },
             wsTourUtils.goToCart(),
             // Assert that the configurator wasn't shown.

--- a/addons/website_sale/static/tests/tours/website_sale_product_configurator_shop_show_dialog.js
+++ b/addons/website_sale/static/tests/tours/website_sale_product_configurator_shop_show_dialog.js
@@ -9,8 +9,8 @@ registry
         steps: () => [
             {
                 content: "Click on the cart button",
-                trigger: '.oe_product:has(a:contains("Main product")) div.o_wsale_product_btn a',
-                run: 'click',
+                trigger: ".oe_product:has(a:contains(Main product))",
+                run: "hover && click .oe_product:has(a:contains(Main product)) div.o_wsale_product_btn a",
             },
             {
                 content: "Assert that the product configurator is shown",

--- a/addons/website_sale_comparison/static/tests/tours/website_sale_comparison.js
+++ b/addons/website_sale_comparison/static/tests/tours/website_sale_comparison.js
@@ -9,8 +9,8 @@
     // test from shop page
     {
         content: "add first product 'Warranty' in a comparison list",
-        trigger: '.oe_product_cart:contains("Warranty") .o_add_compare',
-        run: "click",
+        trigger: ".oe_product_cart:contains(Warranty)",
+        run: "hover && click .oe_product_cart:contains(Warranty) .o_add_compare",
     },
     {
         content: "check compare button contains one product",
@@ -22,8 +22,8 @@
     },
     {
         content: "add second product 'Conference Chair' in a comparison list",
-        trigger: '.oe_product_cart:contains("Conference Chair") .o_add_compare',
-        run: "click",
+        trigger: ".oe_product_cart:contains(Conference Chair)",
+        run: "hover && click .oe_product_cart:contains(Conference Chair) .o_add_compare",
     },
     {
         trigger: ".comparator-popover",

--- a/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist.js
+++ b/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist.js
@@ -8,9 +8,9 @@ registry.category("web_tour.tours").add('shop_wishlist', {
     url: '/shop?search=Customizable Desk',
     steps: () => [
         {
-            content: "click on add to wishlist",
-            trigger: '.o_add_wishlist',
-            run: "click",
+            content: "hover card && click on add to wishlist",
+            trigger: ".o_wsale_product_grid_wrapper:contains(desk)",
+            run: "hover && click .o_add_wishlist",
         },
         {
             trigger: 'a[href="/shop/wishlist"] .badge:contains(1)',
@@ -31,9 +31,9 @@ registry.category("web_tour.tours").add('shop_wishlist', {
             run: "click",
         },
         {
-            content: "click on add to wishlist",
-            trigger: '.o_add_wishlist',
-            run: "click",
+            content: "hover card && click on add to wishlist",
+            trigger: ".o_wsale_product_grid_wrapper:contains(desk)",
+            run: "hover && click .o_add_wishlist",
         },
         {
             trigger: ".my_wish_quantity:contains(1)",
@@ -190,8 +190,8 @@ registry.category("web_tour.tours").add('shop_wishlist', {
         },
         {
             content: "Add Bottle to wishlist from /shop",
-            trigger: '.oe_product_cart:contains("Bottle") .o_add_wishlist',
-            run: "click",
+            trigger: ".oe_product_cart:contains(Bottle)",
+            run: "hover && click .oe_product_cart:contains(Bottle) .o_add_wishlist",
         },
         {
             content: "Check that wishlist contains 1 item",


### PR DESCRIPTION
In this commit, we use "hover" action in run to ensure element are visible before clicking on it.[REF] brol

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
