### PR TITLE
[FIX] pos_sale: correctly unreserve quantities

### DIFF
--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -178,6 +178,5 @@ class PosOrderLine(models.Model):
     def _launch_stock_rule_from_pos_order_lines(self):
         orders = self.mapped('order_id')
         for order in orders:
-            for line in order.lines:
-                line.sale_order_line_id.move_ids.mapped("move_line_ids").unlink()
+            self.env['stock.move'].browse(order.lines.sale_order_line_id.move_ids._rollup_move_origs()).filtered(lambda ml: ml.state not in ['cancel', 'done'])._action_cancel()
         return super()._launch_stock_rule_from_pos_order_lines()

--- a/addons/pos_sale/static/tests/tours/PosSaleTour.js
+++ b/addons/pos_sale/static/tests/tours/PosSaleTour.js
@@ -318,3 +318,21 @@ registry.category("web_tour.tours").add("PoSDownPaymentAmount", {
             PaymentScreen.clickValidate(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("PosSettleOrder4", {
+    test: true,
+    url: "/pos/ui",
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.clickQuotationButton(),
+            ProductScreen.selectFirstOrder(),
+            ProductScreen.selectedOrderlineHas("Product A", "1.00"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.remainingIs("0.0"),
+            PaymentScreen.clickShipLaterButton(),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+        ].flat(),
+});

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -795,3 +795,66 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PoSDownPaymentAmount', login="accountman")
         self.assertEqual(sale_order.amount_to_invoice, 80.0, "Downpayment amount not considered!")
+
+    def test_settle_order_with_multistep_delivery_receipt(self):
+        """This test create an order and settle it in the PoS. It also uses multistep delivery
+            and we need to make sure that all the picking are cancelled if the order is fully delivered.
+        """
+
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        warehouse.delivery_steps = 'pick_pack_ship'
+        warehouse.reception_steps = 'three_steps'
+        self.env.ref('stock.route_warehouse0_mto').active = True
+        route_buy = self.env.ref('purchase_stock.route_warehouse0_buy')
+        route_mto = self.env.ref('stock.route_warehouse0_mto')
+        self.partner_test = self.env['res.partner'].create({
+            'name': 'Partner Test A',
+            'is_company': True,
+            'street': '77 Santa Barbara Rd',
+            'city': 'Pleasant Hill',
+            'country_id': self.env.ref('base.nl').id,
+            'zip': '1105AA',
+            'state_id': False,
+            'email': 'deco.addict82@example.com',
+            'phone': '(603)-996-3829',
+        })
+
+        product_a = self.env['product.product'].create({
+            'name': 'Product A',
+            'available_in_pos': True,
+            'type': 'product',
+            'lst_price': 10.0,
+            'seller_ids': [(0, 0, {
+                'partner_id': self.partner_test.id,
+                'min_qty': 1.0,
+                'price': 1.0,
+            })],
+            'route_ids': [(6, 0, [route_buy.id, route_mto.id])],
+        })
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_test.id,
+            'order_line': [(0, 0, {
+                'product_id': product_a.id,
+                'name': product_a.name,
+                'product_uom_qty': 1,
+                'product_uom': product_a.uom_id.id,
+                'price_unit': product_a.lst_price,
+            })],
+        })
+        sale_order.action_confirm()
+
+        # We validate the purchase and receipt steps
+        po = sale_order._get_purchase_orders()
+        po.button_confirm()
+        picking = po.picking_ids[0]
+        picking.button_validate()
+        sale_order.picking_ids.filtered(lambda p: p.state == 'assigned').button_validate()
+        sale_order.picking_ids.filtered(lambda p: p.state == 'assigned').button_validate()
+
+        self.main_pos_config.ship_later = True
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosSettleOrder4', login="accountman")
+
+        self.assertEqual(sale_order.picking_ids.mapped('state'), ['cancel', 'cancel', 'cancel', 'done', 'done'])
+        self.assertEqual(sale_order.pos_order_line_ids.order_id.picking_ids.mapped('state'), ['waiting', 'waiting', 'assigned'])

--- a/addons/pos_sale/tests/test_pos_sale_lot.py
+++ b/addons/pos_sale/tests/test_pos_sale_lot.py
@@ -98,4 +98,3 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
 
         order = self.env['pos.order'].create_from_ui([pos_order])
         self.assertEqual(self.env['pos.order'].browse(order[0]['id']).picking_ids.move_line_ids.lot_id, lot1)
-        self.assertEqual(sale_order.picking_ids.move_line_ids.lot_id, lot2)


### PR DESCRIPTION
When using ship later with 3 steps delivery and receipt, all the steps would always be done again even when the product is already available

Steps to reproduce:
-------------------
* Create a product A with any vendor
* Setup 3 steps receipt and delivery in your warehouse
* Create a sale order for product A
* Receiving steps and purchase order will be created
* Validate the purchase order and all the receiving steps so that there is 1 quantity in the warehouse
* Open PoS, settle the order and ship it later
> Observation: In the PoS order you will see that all receiving steps
  have been created again, and a new purchase order has been created too

Why the fix:
------------
The error was happening because the quantity of the original sale order was still reserved. So when creating the new delivery order there was no quantity available and the whole receiving process was required again. We now make sure to free the quantity before creating the delivery order

opw-4092298
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
