### PR TITLE
[IMP] web_editor: improve css for youtube video iframe

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -325,7 +325,7 @@ div.media_iframe_video {
     }
 
     .media_iframe_video_size {
-        padding-bottom: 66.5%;
+        padding-bottom: 56.25%; /* 16:9 aspect ratio */
         position: relative;
         width: 100%;
         height: 0;


### PR DESCRIPTION
**Steps to Reproduce:**

When inserting video content using either the `Add Media` button or directly adding a video URL/embed link, the sides of the video appear slightly cropped.

**Issue:**

The iframe containing the video is set to 100% for both height and width, resulting in a square aspect ratio. However, YouTube videos and similar media typically use a 16:9 rectangular format. This mismatch causes the video's sides to be slightly cut off.

**Solution:**

To resolve this issue, we can slightly improve css by adding `padding-bottom: 56.25%` which corresponds to a 16:9 aspect ratio to maintains the aspect ratio of the video.

task-4044568
