### PR TITLE
[FIX] web: fix `user.has_group` util for the frontend

### DIFF
--- a/addons/web/static/src/core/user_service.js
+++ b/addons/web/static/src/core/user_service.js
@@ -19,8 +19,12 @@ export const userService = {
                 kwargs: { context },
             });
         });
-        groupCache.cache["base.group_user"] = session.is_internal_user;
-        groupCache.cache["base.group_system"] = session.is_system;
+        if (session.is_internal_user !== undefined) {
+            groupCache.cache["base.group_user"] = session.is_internal_user;
+        }
+        if (session.is_system !== undefined) {
+            groupCache.cache["base.group_system"] = session.is_system;
+        }
         const accessRightCache = new Cache((model, operation) => {
             const url = `/web/dataset/call_kw/${model}/check_access_rights`;
             return rpc(url, {


### PR DESCRIPTION
Commit [1] optimized the `has_group` util to avoid a RPC for information that is already in the session_info. The problem is that it supposed that this information would always be available in there, which was already not the case for the frontend `session_info` when this was done.

This commit simply makes the util not cache a value if there was actually no found value, and thus let the util falls back to making a RPC if needed.

Note that in 18.0, the user service is actually not a service anymore (since commit [2]) and is the only truth of information about user data (since commit [3]), so this makes this even more important.

We could consider adding the same group information in the frontend session_info in the future, but in general we want to avoid loading any useless information for visitors and would not mind the extra RPC for connected ones when it comes to the website.

[1]: https://github.com/odoo/odoo/commit/da257e9d572047617cdfaac33fbe47983e8ab30d
[2]: https://github.com/odoo/odoo/commit/3fb72654a898eb5c5b1c89279b0638dab8e3881d
[3]: https://github.com/odoo/odoo/commit/182b0554882a2eeb5d86c9cb6fdaed6618b2615b

Related to task-4290643
