### PR TITLE
[FIX] website_sale: make input placeholder translatable.

### DIFF
--- a/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.js
+++ b/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.js
@@ -1,5 +1,4 @@
-/** @odoo-module */
-
+import { _t } from "@web/core/l10n/translation";
 import { Component } from "@odoo/owl";
 import { formatCurrency } from "@web/core/currency";
 import { BadgeExtraPrice } from "../badge_extra_price/badge_extra_price";
@@ -135,6 +134,10 @@ export class ProductTemplateAttributeLine extends Component {
     get showValuesChoice() {
         return this.props.attribute_values.length > 1
             || this.props.attribute.display_type == 'multi'
+    }
+
+    get customValuePlaceholder() {
+        return _t("Enter a customized value");
     }
 
     /**

--- a/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.xml
+++ b/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.xml
@@ -19,7 +19,7 @@
             <input
                 class="o_input w-lg-75 mb-4 ms-lg-auto"
                 type="text"
-                placeholder="Enter a customized value"
+                t-att-placeholder="customValuePlaceholder"
                 t-if="hasPTAVCustom &amp;&amp; isSelectedPTAVCustom()"
                 t-att-value="this.props.customValue"
                 t-on-change="updateCustomValue"

--- a/addons/website_sale/i18n/website_sale.pot
+++ b/addons/website_sale/i18n/website_sale.pot
@@ -1711,6 +1711,12 @@ msgstr ""
 
 #. module: website_sale
 #. odoo-javascript
+#: code:addons/website_sale/static/src/js/product_template_attribute_line/product_template_attribute_line.js:0
+msgid "Enter a customized value"
+msgstr ""
+
+#. module: website_sale
+#. odoo-javascript
 #: code:addons/website_sale/static/src/js/tours/website_sale_shop.js:0
 msgid "Enter a name for your new product"
 msgstr ""

--- a/addons/website_sale/static/src/js/product_template_attribute_line/product_template_attribute_line.js
+++ b/addons/website_sale/static/src/js/product_template_attribute_line/product_template_attribute_line.js
@@ -1,5 +1,4 @@
-/** @odoo-module **/
-
+import { _t } from '@web/core/l10n/translation';
 import { patch } from '@web/core/utils/patch';
 import {
     ProductTemplateAttributeLine
@@ -22,5 +21,10 @@ patch(ProductTemplateAttributeLine.prototype, {
             readOnlyPtalDisplayName += `: ${this.props.customValue}`;
         }
         return readOnlyPtalDisplayName;
+    },
+
+    get customValuePlaceholder() {
+        // The original definition of this placeholder is in `sale` module which is not a frontend module. However, it should be repeated here as translations are only fetched in the context of a frontend module, which is `website_sale` in this case.
+        return _t("Enter a customized value");
     },
 });


### PR DESCRIPTION
When you choose to add a free text value to a variant of the optional products at checkout, you will encounter a placeholder that is not translated: "Enter a customized value". This is because it's defined only in `sale` module, which is not a frontend module. This commit adds the untranslated text to the frontend module: website_sale.

Task-4229289
