### PR TITLE
[IMP] web: stop showing tracebacks to visitors

### DIFF
--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -181,6 +181,7 @@ class Http(models.AbstractModel):
             'is_admin': user._is_admin() if session_uid else False,
             'is_system': user._is_system() if session_uid else False,
             'is_public': user._is_public(),
+            "is_internal_user": user._is_internal(),
             'is_website_user': user._is_public() if session_uid else False,
             'uid': session_uid,
             'is_frontend': True,

--- a/addons/web/static/src/core/user.js
+++ b/addons/web/static/src/core/user.js
@@ -87,6 +87,7 @@ export function _makeUser(session) {
         login,
         isAdmin,
         isSystem,
+        isInternalUser,
         partnerId,
         homeActionId,
         showEffect,

--- a/addons/web/static/tests/legacy/views/helpers.js
+++ b/addons/web/static/tests/legacy/views/helpers.js
@@ -116,7 +116,15 @@ export function makeViewInDialog(params) {
 export function setupViewRegistries() {
     setupControlPanelFavoriteMenuRegistry();
     setupControlPanelServiceRegistry();
-    patchUserWithCleanup({ hasGroup: async (group) => group === "base.group_allow_export" });
+    patchUserWithCleanup({
+        hasGroup: async (group) => {
+            return [
+                "base.group_allow_export",
+                "base.group_user",
+            ].includes(group);
+        },
+        isInternalUser: true,
+    });
     serviceRegistry.add("localization", makeFakeLocalizationService());
     serviceRegistry.add("company", fakeCompanyService);
 }


### PR DESCRIPTION
Before this commit, any client error would lead to a displayed Odoo
traceback dialog. While the goal is obviously to have a code without any
possible traceback, visitors really should not see those.

This is especially true in the website: if a website visitor (who has no
idea the visited website uses Odoo) gets a traceback because of a Chrome
extension, it makes no sense to display the traceback at all. It can be
justified for connected users (not portal, but base.group_user) as they
likely are employees of the company using Odoo and should be able to see
issues and report them to us (e.g. even in the Chrome extension case: so
we can make our code support the breaking extension or decide that it
cannot be used alongside Odoo).

The errors for visitors are still logged in the browser console, even
with more detailed logs in that case.

Note that we use `await user.hasGroup('base.group_user')` upon error to
be able to implement this feature. In the frontend, it actually does a
RPC call as that group information is not in the session_info. We could
add it in the session_info, but since the use case is showing an error,
the extra RPC *upon error* is fine for now.

Notice that traceback dialogs (and the related error handling that comes
with them, like preventing an error to be considered as an error and
logged in the console) are also still enabled in debug mode or during
testing tours.

task-4290643