### PR TITLE
[FIX] l10n_dk_oioubl: Fix address in payment means and endpoint id

### DIFF
--- a/addons/l10n_dk_oioubl/data/oioubl_templates.xml
+++ b/addons/l10n_dk_oioubl/data/oioubl_templates.xml
@@ -12,4 +12,10 @@
             </t>
         </xpath>
     </template>
+
+    <template id="oioubl_PaymentMeansType" inherit_id="account_edi_ubl_cii.ubl_20_PaymentMeansType" primary="True">
+        <xpath expr="//*[local-name()='PayeeFinancialAccount']//*[local-name()='FinancialInstitution']//*[local-name()='Address']" position="attributes">
+            <attribute name="t-if">not invoice.partner_bank_id in supplier.bank_ids</attribute>
+        </xpath>
+    </template>
 </odoo>

--- a/addons/l10n_dk_oioubl/models/account_edi_xml_oioubl_201.py
+++ b/addons/l10n_dk_oioubl/models/account_edi_xml_oioubl_201.py
@@ -62,6 +62,7 @@ class AccountEdiXmlOioubl_201(models.AbstractModel):
         # EXTENDS account.edi.xml.ubl_20
         vals = super()._export_invoice_vals(invoice)
         vals['PaymentTermsType_template'] = 'l10n_dk_oioubl.oioubl_PaymentTermsType'
+        vals['PaymentMeansType_template'] = 'l10n_dk_oioubl.oioubl_PaymentMeansType'
         vals['vals'].update({
             'customization_id': 'OIOUBL-2.01',
             # ProfileID is the property that define which documents the company can send and receive
@@ -83,15 +84,21 @@ class AccountEdiXmlOioubl_201(models.AbstractModel):
     def _get_partner_party_vals(self, partner, role):
         # EXTENDS account.edi.xml.ubl_20
         vals = super()._get_partner_party_vals(partner, role)
-        endpoint_id = format_vat_number(partner)
-        if endpoint_id[:2] == 'DK':
-            scheme_id = 'DK:CVR'
-        elif endpoint_id[:2] == 'FR':
-            scheme_id = 'FR:SIRET'
-            # SIRET is the french company registry
-            endpoint_id = (partner.company_registry or "").replace(" ", "")
+        if partner.peppol_endpoint:
+            endpoint_id = partner.peppol_endpoint
+            scheme_id = 'GLN'
         else:
-            scheme_id = f'{endpoint_id[:2]}:VAT'
+            endpoint_id = format_vat_number(partner)
+            country_code = endpoint_id[:2]
+            match country_code:
+                case 'DK':
+                    scheme_id = 'DK:CVR'
+                case 'FR':
+                    scheme_id = 'FR:SIRET'
+                    # SIRET is the french company registry
+                    endpoint_id = (partner.company_registry or "").replace(" ", "")
+                case _:
+                    scheme_id = f'{country_code}:VAT'
 
         vals.update({
             # list of possible endpointID available at

--- a/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_invoice_foreign_partner_be.xml
+++ b/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_invoice_foreign_partner_be.xml
@@ -22,7 +22,7 @@
   </cac:AdditionalDocumentReference>
   <cac:AccountingSupplierParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
+      <cbc:EndpointID schemeID="GLN">0239843188</cbc:EndpointID>
       <cac:PartyName>
         <cbc:Name>company_1_data</cbc:Name>
       </cac:PartyName>

--- a/addons/l10n_dk_oioubl/tests/test_xml_oioubl_dk.py
+++ b/addons/l10n_dk_oioubl/tests/test_xml_oioubl_dk.py
@@ -28,6 +28,10 @@ class TestUBLDK(TestUBLCommon, TestAccountMoveSendCommon):
             'acc_number': 'DK5000400440116243',
         })
 
+        cls.company_data['company'].partner_id.update({
+            'peppol_endpoint': False,
+        })
+
         cls.partner_a.write({
             'name': 'SUPER DANISH PARTNER',
             'city': 'Aalborg',
@@ -37,6 +41,7 @@ class TestUBLDK(TestUBLCommon, TestAccountMoveSendCommon):
             'street': 'Paradisæblevej, 11',
             'country_id': cls.env.ref('base.dk').id,
             'invoice_edi_format': 'oioubl_201',
+            'peppol_endpoint': False,
         })
         cls.partner_b.write({
             'name': 'SUPER BELGIAN PARTNER',
@@ -47,6 +52,7 @@ class TestUBLDK(TestUBLCommon, TestAccountMoveSendCommon):
             'phone': '061928374',
             'vat': 'BE0897223670',
             'invoice_edi_format': 'oioubl_201',
+            'peppol_endpoint': False,
         })
         cls.partner_c = cls.env["res.partner"].create({
             'name': 'SUPER FRENCH PARTNER',
@@ -58,6 +64,7 @@ class TestUBLDK(TestUBLCommon, TestAccountMoveSendCommon):
             'vat': 'FR23334175221',
             'company_registry': '123 568 941 00056',
             'invoice_edi_format': 'oioubl_201',
+            'peppol_endpoint': False,
         })
         cls.dk_local_sale_tax_1 = cls.env["account.chart.template"].ref('tax_s1y')
         cls.dk_local_sale_tax_2 = cls.env["account.chart.template"].ref('tax_s1')
@@ -119,6 +126,8 @@ class TestUBLDK(TestUBLCommon, TestAccountMoveSendCommon):
 
     @freeze_time('2017-01-01')
     def test_export_invoice_two_line_foreign_partner_be(self):
+        # Set peppol endpoint to have schemeID of 'GLN'
+        self.company_data['company'].partner_id.peppol_endpoint = '0239843188'
         invoice = self.create_post_and_send_invoice(partner=self.partner_b)
         self.assertTrue(invoice.ubl_cii_xml_id)
         self._assert_invoice_attachment(invoice.ubl_cii_xml_id, xpaths=None, expected_file_path="from_odoo/oioubl_out_invoice_foreign_partner_be.xml")
@@ -163,7 +172,9 @@ class TestUBLDK(TestUBLCommon, TestAccountMoveSendCommon):
     @freeze_time('2017-01-01')
     def test_export_invoice_company_and_partner_without_country_code_prefix_in_vat(self):
         self.company_data['company'].vat = '12345674'
+        self.company_data['company'].partner_id.peppol_endpoint = False
         self.partner_a.vat = 'DK12345674'
+        self.partner_a.peppol_endpoint = False
         invoice = self.create_post_and_send_invoice()
         self.assertTrue(invoice.ubl_cii_xml_id)
         self._assert_invoice_attachment(invoice.ubl_cii_xml_id, xpaths=None, expected_file_path="from_odoo/oioubl_out_invoice_partner_dk.xml")


### PR DESCRIPTION
When our own bank is used as a payment mean, it shouldn't be populated in the OIOUBL XML.

When using Peppol, the XML would ignore the endpoint that is set in the electronic invoicing settings, the <cbc:EndpointID> should be the defined peppol endpoint and the schemeID should be 'GLN'.

task-4017019


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
