### PR TITLE
[FIX] point_of_sale: enable confirm button in cash move popup only valid reason input

### DIFF
--- a/addons/point_of_sale/static/src/app/navbar/cash_move_popup/cash_move_popup.js
+++ b/addons/point_of_sale/static/src/app/navbar/cash_move_popup/cash_move_popup.js
@@ -86,4 +86,7 @@ export class CashMovePopup extends Component {
     _prepare_try_cash_in_out_payload(type, amount, reason, extras) {
         return [[this.pos.session.id], type, amount, reason, extras];
     }
+    isValidCashMove() {
+        return this.env.utils.isValidFloat(this.state.amount) && this.state.reason.trim() !== "";
+    }
 }

--- a/addons/point_of_sale/static/src/app/navbar/cash_move_popup/cash_move_popup.xml
+++ b/addons/point_of_sale/static/src/app/navbar/cash_move_popup/cash_move_popup.xml
@@ -26,7 +26,7 @@
             <t t-set-slot="footer">
                 <button class="button confirm btn btn-lg lh-lg btn-primary"
                     t-on-click="confirm"
-                    t-att-disabled="!env.utils.isValidFloat(state.amount) or !state.reason">
+                    t-att-disabled="!isValidCashMove()">
                     Confirm
                 </button>
                 <button class="button cancel btn btn-lg lh-lg btn-secondary" t-on-click="props.close">

--- a/doc/cla/individual/akshayelangot.md
+++ b/doc/cla/individual/akshayelangot.md
@@ -1,0 +1,11 @@
+India, 2024-10-28
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Akshay Elangot akshayelangot@gmail.com https://github.com/a-k-s-h-a-y


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In the cash move popup of the point of sale, the confirm button is currently enabled when the reason input field contains only whitespace, allowing submission with invalid input.

Current behavior before PR:
The confirm button is active even when the reason input field only contains empty spaces, which can lead to erroneous or empty reason entries.

Desired behavior after PR is merged:
The confirm button will only be enabled when the reason input field contains valid, non-whitespace characters, ensuring that only meaningful input allows confirmation.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
