### PR TITLE
[FIX] base: avoid error when TestAPIKeys triggers automations

### DIFF
--- a/odoo/addons/base/tests/test_xmlrpc.py
+++ b/odoo/addons/base/tests/test_xmlrpc.py
@@ -142,16 +142,21 @@ class TestAPIKeys(common.HttpCase):
 
     def setUp(self):
         super().setUp()
+
+        def get_json_data():
+            raise ValueError("There is no json here")
         # needs a fake request in order to call methods protected with check_identity
         fake_req = DotDict({
             # various things go and access request items
             'httprequest': DotDict({
                 'environ': {'REMOTE_ADDR': 'localhost'},
                 'cookies': {},
+                'args': {},
             }),
             # bypass check_identity flow
             'session': {'identity-check-last': time.time()},
             'geoip': {},
+            'get_json_data': get_json_data,
         })
         _request_stack.push(fake_req)
         self.addCleanup(_request_stack.pop)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
TestAPIKeys.test_delete creates an user, which might trigger an automated action. However that action would fail [here](https://github.com/odoo/odoo/blob/17.0/addons/base_automation/models/base_automation.py#L67), since the mockup request that is set up in the test does not include a function request.get_json_data() nor request.httprequest.args

Current behavior before PR:
The test fails on databases that have an automated action triggered on user creation

Desired behavior after PR is merged:
This test should not fail on such databases

This issue has been discussed [here](https://discord.com/channels/678381219515465750/687339689522364423/1300410221482479636)
