### PR TITLE
[FIX] sales_team: fix team member warning

### DIFF
--- a/addons/sales_team/i18n/sales_team.pot
+++ b/addons/sales_team/i18n/sales_team.pot
@@ -89,6 +89,21 @@ msgid ""
 msgstr ""
 
 #. module: sales_team
+#. odoo-python
+#: code:addons/sales_team/models/crm_team_member.py:0
+msgid ""
+"Adding %(user_name)s in this team will remove them from %(team_names)s. "
+"Working in multiple teams? Activate the option under Configuration>Settings."
+msgstr ""
+
+#. module: sales_team
+#. odoo-python
+#: code:addons/sales_team/models/crm_team.py:0
+msgid ""
+"Adding %(user_names)s in this team will remove them from %(team_names)s."
+msgstr ""
+
+#. module: sales_team
 #: model:res.groups,name:sales_team.group_sale_manager
 msgid "Administrator"
 msgstr ""
@@ -683,6 +698,13 @@ msgstr ""
 #. module: sales_team
 #: model:crm.team,name:sales_team.salesteam_website_sales
 msgid "Website"
+msgstr ""
+
+#. module: sales_team
+#. odoo-python
+#: code:addons/sales_team/models/crm_team.py:0
+msgid ""
+"Working in multiple teams? Activate the option under Configuration>Settings."
 msgstr ""
 
 #. module: sales_team

--- a/addons/sales_team/models/crm_team.py
+++ b/addons/sales_team/models/crm_team.py
@@ -167,21 +167,16 @@ class CrmTeam(models.Model):
         for team in self:
             member_warning = False
             other_memberships = self.env['crm.team.member'].search([
-                ('crm_team_id', '!=', team.id if team.ids else False),  # handle NewID
+                ('crm_team_id', '!=', team._origin.id if team.ids else False),
                 ('user_id', 'in', team.member_ids.ids)
             ])
-            if other_memberships and len(other_memberships) == 1:
-                member_warning = _("Adding %(user_name)s in this team would remove him/her from its current team %(team_name)s.",
-                                   user_name=other_memberships.user_id.name,
-                                   team_name=other_memberships.crm_team_id.name
-                                  )
-            elif other_memberships:
-                member_warning = _("Adding %(user_names)s in this team would remove them from their current teams (%(team_names)s).",
+            if other_memberships:
+                member_warning = _("Adding %(user_names)s in this team will remove them from %(team_names)s.",
                                    user_names=", ".join(other_memberships.mapped('user_id.name')),
                                    team_names=", ".join(other_memberships.mapped('crm_team_id.name'))
                                   )
             if member_warning:
-                team.member_warning = member_warning + " " + _("To add a Salesperson into multiple Teams, activate the Multi-Team option in settings.")
+                team.member_warning = member_warning + " " + _("Working in multiple teams? Activate the option under Configuration>Settings.")
 
     def _search_member_ids(self, operator, value):
         return [('crm_team_member_ids.user_id', operator, value)]

--- a/addons/sales_team/models/crm_team_member.py
+++ b/addons/sales_team/models/crm_team_member.py
@@ -131,7 +131,8 @@ class CrmTeamMember(models.Model):
                 teams = user_mapping.get(member.user_id, self.env['crm.team'])
                 remaining = teams - (member.crm_team_id | member._origin.crm_team_id)
                 if remaining:
-                    member.member_warning = _("Adding %(user_name)s in this team would remove him/her from its current teams %(team_names)s.",
+                    member.member_warning = _("Adding %(user_name)s in this team will remove them from %(team_names)s. "
+                                              "Working in multiple teams? Activate the option under Configuration>Settings.",
                                               user_name=member.user_id.name,
                                               team_names=", ".join(remaining.mapped('name'))
                                              )


### PR DESCRIPTION
Purpose
=======
Fix the team member warning which was indicating the wrong members.

Specification
=============
The warning only needs to appear when you add a member which is already
in another team (only in mono-membership mode).
When you add a new member without saving, the team 'id' field is of
type NewID, not simply an id of type integer. This was messing up the search domain
as the crm_team_id was for example 1 and the team.id was NewID with origin 1.
They were evaluated "different" even though they are the same.

Fixing that by accessing the record's origin so that we always compare ids as integers.

Also rewording a bit the warning to prevent using him/her and more precisely specifying
where to activate the multi team option.

Task-4283552

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
