### PR TITLE
[FIX] web: report scss: hr node hardcoded border

### DIFF
--- a/addons/web/static/src/webclient/actions/reports/report.scss
+++ b/addons/web/static/src/webclient/actions/reports/report.scss
@@ -336,3 +336,7 @@ li.oe-nested {
         border-color: map-get($theme-colors-border-subtle, $state);
     }
 }
+
+hr {
+    border: 1px solid
+}


### PR DESCRIPTION
Since 058212e12b5079eba870bde9775fe98f27928935 Bootstrap's version is 5.3

Many more style is set by CSS Custome properties which wkhtmltopdf does not support

This fixes the <hr /> case.

opw-4265150

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
