### PR TITLE
[FIX] account: Added out_refund to the margin calculation from the in…

### DIFF
--- a/addons/account/report/account_invoice_report.py
+++ b/addons/account/report/account_invoice_report.py
@@ -107,7 +107,8 @@ class AccountInvoiceReport(models.Model):
                    * (NULLIF(COALESCE(uom_line.factor, 1), 0.0) / NULLIF(COALESCE(uom_template.factor, 1), 0.0)),
                    0.0) * currency_table.rate                               AS price_average,
                 CASE
-                    WHEN move.move_type NOT IN ('out_invoice', 'out_receipt') THEN 0.0
+                    WHEN move.move_type NOT IN ('out_invoice', 'out_receipt', 'out_refund') THEN 0.0
+                    WHEN move.move_type = 'out_refund' THEN -line.balance * currency_table.rate + (line.quantity / NULLIF(COALESCE(uom_line.factor, 1) / COALESCE(uom_template.factor, 1), 0.0)) * COALESCE(product_standard_price.value_float, 0.0)
                     ELSE -line.balance * currency_table.rate - (line.quantity / NULLIF(COALESCE(uom_line.factor, 1) / COALESCE(uom_template.factor, 1), 0.0)) * COALESCE(product_standard_price.value_float, 0.0)
                 END
                                                                             AS price_margin,

--- a/addons/account/tests/test_account_invoice_report.py
+++ b/addons/account/tests/test_account_invoice_report.py
@@ -94,6 +94,19 @@ class TestAccountInvoiceReport(AccountTestInvoicingCommon):
                     }),
                 ]
             },
+            {
+                'move_type': 'out_refund',
+                'partner_id': cls.partner_a.id,
+                'invoice_date': fields.Date.from_string('2017-01-01'),
+                'currency_id': cls.currency_data['currency'].id,
+                'invoice_line_ids': [
+                    (0, None, {
+                        'product_id': cls.product_a.id,
+                        'quantity': 1,
+                        'price_unit': 2400,
+                    }),
+                ]
+            },
         ])
 
     def assertInvoiceReportValues(self, expected_values_list):
@@ -118,7 +131,8 @@ class TestAccountInvoiceReport(AccountTestInvoicingCommon):
             [             6,              6,        1,            0,            -800], # price_unit = 12,   currency.rate = 2.0
             [            20,            -20,       -1,            0,             800], # price_unit = 60,   currency.rate = 3.0
             [            20,            -20,       -1,            0,             800], # price_unit = 60,   currency.rate = 3.0
-            [           600,           -600,       -1,            0,             800], # price_unit = 1200, currency.rate = 2.0
+            [           600,           -600,       -1,          200,             800],  # price_unit = 1200, currency.rate = 2.0
+            [          1200,          -1200,       -1,         -400,             800],  # price_unit = 2400, currency.rate = 2.0
         ])
 
     def test_invoice_report_multicompany_product_cost(self):
@@ -139,5 +153,6 @@ class TestAccountInvoiceReport(AccountTestInvoicingCommon):
             [             6,              6,        1,            0,            -800], # price_unit = 12,   currency.rate = 2.0
             [            20,            -20,       -1,            0,             800], # price_unit = 60,   currency.rate = 3.0
             [            20,            -20,       -1,            0,             800], # price_unit = 60,   currency.rate = 3.0
-            [           600,           -600,       -1,            0,             800], # price_unit = 1200, currency.rate = 2.0
+            [           600,           -600,       -1,          200,             800],  # price_unit = 1200, currency.rate = 2.0
+            [          1200,          -1200,       -1,         -400,             800],  # price_unit = 2400, currency.rate = 2.0
         ])


### PR DESCRIPTION
In a previous commit: #151805, the goal was to add margin to the account invoice report.

No negative margins were possible before because it didn't take the customer's credit notes.

This is now fixed with this commit, that aims to add customer's credit note to margin calculations

task-4167630

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
