### PR TITLE
[FIX] mail: close thread action in chat window with Escape

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -86,6 +86,11 @@ export class ChatWindow extends Component {
     }
 
     onKeydown(ev) {
+        if (ev.key === "Escape" && this.threadActions.activeAction) {
+            this.threadActions.activeAction.close();
+            ev.stopPropagation();
+            return;
+        }
         if (ev.target.closest(".o-dropdown")) {
             return;
         }

--- a/addons/mail/static/tests/chat_window/chat_window_tests.js
+++ b/addons/mail/static/tests/chat_window/chat_window_tests.js
@@ -386,6 +386,24 @@ QUnit.test(
     }
 );
 
+QUnit.test("Close active thread action in chatwindow on ESCAPE", async () => {
+    const pyEnv = await startServer();
+    pyEnv["discuss.channel"].create({
+        name: "General",
+        channel_member_ids: [
+            Command.create({ partner_id: pyEnv.currentPartnerId, is_minimized: true }),
+        ],
+    });
+    await start();
+    await contains(".o-mail-ChatWindow");
+    await click(".o-mail-ChatWindow-command", { text: "General" });
+    await click(".dropdown-item", { text: "Add Users" });
+    await contains(".o-discuss-ChannelInvitation");
+    triggerHotkey("Escape");
+    await contains(".o-discuss-ChannelInvitation", { count: 0 });
+    await contains(".o-mail-ChatWindow");
+});
+
 QUnit.test("open 2 different chat windows: enough screen width [REQUIRE FOCUS]", async (assert) => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create([{ name: "Channel_1" }, { name: "Channel_2" }]);


### PR DESCRIPTION
Before this PR, pressing the `Escape` key in an open thread action within the chat window would close the entire chat window rather than just the thread action.
This PR fixes the issue by ensuring `Escape` closes only the active thread action.

task-4290661

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
