### PR TITLE
[FIX] web: keep nosheet style if a sheet is present in a nested form

### DIFF
--- a/addons/web/static/src/views/form/form_compiler.js
+++ b/addons/web/static/src/views/form/form_compiler.js
@@ -212,7 +212,13 @@ export class FormCompiler extends ViewCompiler {
      * @returns {Element}
      */
     compileForm(el, params) {
-        const sheetNode = el.querySelector("sheet");
+        let sheetNode = null;
+        for (const sheet of el.querySelectorAll("sheet")) {
+            if (sheet.closest("form") === el) {
+                sheetNode = sheet;
+                break;
+            }
+        }
         const displayClasses = sheetNode
             ? `d-flex {{ __comp__.uiService.size < ${SIZES.XXL} ? "flex-column" : "flex-nowrap h-100" }}`
             : "d-block";

--- a/addons/web/static/tests/views/form/form_compiler_tests.js
+++ b/addons/web/static/tests/views/form/form_compiler_tests.js
@@ -535,4 +535,34 @@ QUnit.module("Form Renderer", (hooks) => {
         const expected = `<t t-translation="off"><div class="myNode" t-if="( myCondition or myOtherCondition ) and !__comp__.evaluateBooleanExpr(&quot;field == 'value'&quot;,__comp__.props.record.evalContextWithVirtualIds)" t-ref="compiled_view_root"/></t>`;
         assert.areEquivalent(compileTemplate(arch), expected);
     });
+
+    QUnit.test("keep nosheet style if a sheet is part of a nested form", (assert) => {
+        const arch = `
+            <form>
+                <field name="move_line_ids" field_id="move_line_ids">
+                    <form>
+                        <sheet/>
+                    </form>
+                </field>
+            </form>`;
+
+        const expected = `<t t-translation="off">
+            <div
+                class="o_form_renderer o_form_nosheet"
+                t-att-class="__comp__.props.class"
+                t-attf-class="{{__comp__.props.record.isInEdition ? 'o_form_editable' : 'o_form_readonly'}} d-block {{ __comp__.props.record.dirty ? 'o_form_dirty' : !__comp__.props.record.isNew ? 'o_form_saved' : '' }}"
+                t-ref="compiled_view_root"
+            >
+                <Field
+                    id="'move_line_ids'"
+                    name="'move_line_ids'"
+                    record="__comp__.props.record"
+                    fieldInfo="__comp__.props.archInfo.fieldNodes['move_line_ids']"
+                    readonly="__comp__.props.archInfo.activeActions?.edit === false and !__comp__.props.record.isNew"
+                />
+            </div>
+        </t>`;
+
+        assert.areEquivalent(compileTemplate(arch), expected);
+    });
 });


### PR DESCRIPTION
Steps to reproduce
==================

- Install stock,mrp,web_studio
- Go to Inventory > Delivery Orders
- Open WH/OUT/00001
- Open studio
- On the x2many field, click on "Edit form" -> Studio switches to that view,
- Click on "Edit form" again for the new lines
- Exit studio
- Click on the hamburger button -> The styling is broken

Cause of the issue
==================

When clicking on "Edit form", studio inlines the selected form view. The nosheet form style is only applied if the form contains no sheet element.

In this case, there is a sheet element, but inside a nested form.

Solution
========

Only consider sheets if they are part of the current form view.

opw-4130337