### PR TITLE
[FIX] orm: make with_company more predictable

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -878,7 +878,11 @@ class AccountMove(models.Model):
     def _compute_company_id(self):
         for move in self:
             if move.journal_id.company_id not in move.company_id.parent_ids:
-                move.company_id = (move.journal_id.company_id or self.env.company)._accessible_branches()[:1]
+                move.company_id = (
+                    (move.journal_id.company_id in self.env.company.parent_ids and self.env.company)
+                    or move.journal_id.company_id
+                    or self.env.company
+                )
 
     @api.depends('move_type', 'origin_payment_id', 'statement_line_id')
     def _compute_journal_id(self):

--- a/addons/hr/tests/test_hr_department.py
+++ b/addons/hr/tests/test_hr_department.py
@@ -18,7 +18,7 @@ class TestHrDepartment(TestMultiCompany):
         '''
             Test that employee_count has only the count of employees in the selected companies
         '''
-        employee_count = self.department.with_company(self.company_a).total_employee  # should only count the 2 employees in company_a
+        employee_count = self.department.with_context(allowed_company_ids=self.company_a.ids).total_employee  # should only count the 2 employees in company_a
         self.assertEqual(employee_count, 2)
 
         self.department._compute_total_employee()

--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -62,15 +62,15 @@ class TestHrEmployee(TestHrCommon):
             'company_id': company_B.id
         })
 
-        partner.with_company(company_A)._compute_employees_count()
+        partner.with_context(allowed_company_ids=[company_A.id])._compute_employees_count()
         self.assertEqual(partner.employees_count, 1)
-        partner.with_company(company_B)._compute_employees_count()
+        partner.with_context(allowed_company_ids=[company_B.id])._compute_employees_count()
         self.assertEqual(partner.employees_count, 1)
-        single_company_action = partner.with_company(company_B).action_open_employees()
+        single_company_action = partner.with_context(allowed_company_ids=[company_B.id]).action_open_employees()
         self.assertEqual(single_company_action.get('view_mode'), 'form')
-        partner.with_company(company_A).with_company(company_B)._compute_employees_count()
+        partner.with_context(allowed_company_ids=[company_A.id, company_B.id])._compute_employees_count()
         self.assertEqual(partner.employees_count, 2)
-        multi_company_action = partner.with_company(company_A).with_company(company_B).action_open_employees()
+        multi_company_action = partner.with_context(allowed_company_ids=[company_A.id, company_B.id]).action_open_employees()
         self.assertEqual(multi_company_action.get('view_mode'), 'kanban')
 
     def test_employee_linked_partner(self):

--- a/addons/hr/tests/test_multi_company.py
+++ b/addons/hr/tests/test_multi_company.py
@@ -40,8 +40,8 @@ class TestMultiCompanyReport(TestHrCommon):
 
     def test_single_company_report(self):
         with self.assertRaises(AccessError):  # CacheMiss followed by AccessError
-            self.env['ir.actions.report'].with_user(self.res_users_hr_officer).with_company(
-                self.company_1
+            self.env['ir.actions.report'].with_user(self.res_users_hr_officer).with_context(
+                allowed_company_ids=self.company_1.ids,
             )._render_qweb_pdf('hr.hr_employee_print_badge', res_ids=self.employees.ids)
 
 

--- a/addons/hr_attendance/tests/test_hr_attendance_rulesets.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_rulesets.py
@@ -162,8 +162,8 @@ class TestHrAttendanceOvertime(TransactionCase):
         Test the access rights of the ruleset on the employee
         Only the employee admin should be able to see and change the ruleset on the employee
         """
-        user = new_test_user(self.env, login='usr', groups='hr.group_hr_user', company_id=self.company.id).with_company(self.company)
-        employee = self.env['hr.employee'].with_company(self.company).create({'name': "Employee Test"})
+        user = new_test_user(self.env, login='usr', groups='hr.group_hr_user', company_id=self.company.id)
+        employee = self.env['hr.employee'].with_context(allowed_company_ids=self.company.ids).create({'name': "Employee Test"})
         with Form(employee.with_user(user)) as employee_form:
             self.assertFalse("ruleset_id" in employee_form._view['fields'])
 
@@ -176,9 +176,9 @@ class TestHrAttendanceOvertime(TransactionCase):
 
     def test_is_manager_with_overtime(self):
         """ Test the computation of is_manager with overtime """
-        user = new_test_user(self.env, login='usr', groups='hr_attendance.group_hr_attendance_officer', company_id=self.company.id).with_company(self.company)
+        user = new_test_user(self.env, login='usr', groups='hr_attendance.group_hr_attendance_officer', company_id=self.company.id)
         self.employee.attendance_manager_id = user.id
-        attendance = self.env['hr.attendance'].with_company(self.company).create({
+        attendance = self.env['hr.attendance'].with_context(allowed_company_ids=self.company.ids).create({
             'employee_id': self.employee.id,
             'check_in': datetime(2021, 1, 4, 8, 0),
             'check_out': datetime(2021, 1, 4, 20, 0)

--- a/addons/l10n_it_edi/tests/test_edi_pa.py
+++ b/addons/l10n_it_edi/tests/test_edi_pa.py
@@ -14,7 +14,10 @@ class TestItEdiPa(TestItEdi):
 
         cls.Move = cls.env['account.move'].with_company(cls.company)
         journal_code = cls.company_data_2['default_journal_sale'].code
-        cls.split_payment_tax = cls.env['account.tax'].with_company(cls.company).search([('name', '=', '22% SP')])
+        cls.split_payment_tax = cls.env['account.tax'].with_company(cls.company).search([
+            *cls.env['account.tax']._check_company_domain(cls.company),
+            ('name', '=', '22% SP'),
+        ])
         cls.split_payment_line_data = {
             'name': 'standard_line',
             'quantity': 1,

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -171,7 +171,14 @@ class PosConfig(models.Model):
         help="This field depicts the maximum difference allowed between the ending balance and the theoretical cash when "
              "closing a session, for non-POS managers. If this maximum is reached, the user will have an error message at "
              "the closing of his session saying that he needs to contact his manager.")
-    payment_method_ids = fields.Many2many('pos.payment.method', string='Payment Methods', bypass_search_access=True, default=lambda self: self._default_payment_methods(), copy=False)
+    payment_method_ids = fields.Many2many(
+        comodel_name='pos.payment.method',
+        string='Payment Methods',
+        bypass_search_access=True,
+        default=lambda self: self._default_payment_methods(),
+        check_company=True,
+        copy=False,
+    )
     company_has_template = fields.Boolean(string="Company has chart of accounts", compute="_compute_company_has_template")
     current_user_id = fields.Many2one('res.users', string='Current Session Responsible', compute='_compute_current_session_user')
     other_devices = fields.Boolean(string="Other Devices", help="Connect printer devices to your PoS.")
@@ -542,12 +549,6 @@ class PosConfig(models.Model):
                 if method.is_cash_count and (not method.journal_id.loss_account_id or not method.journal_id.profit_account_id):
                     raise ValidationError(_("You need a loss and profit account on your cash journal."))
 
-    @api.constrains('company_id', 'payment_method_ids')
-    def _check_company_payment(self):
-        for config in self:
-            if self.env['pos.payment.method'].search_count([('id', 'in', config.payment_method_ids.ids), ('company_id', '!=', config.company_id.id)]):
-                raise ValidationError(_("The payment methods for the point of sale %s must belong to its company.", self.name))
-
     @api.constrains('pricelist_id', 'use_pricelist', 'available_pricelist_ids', 'journal_id', 'invoice_journal_id', 'payment_method_ids')
     def _check_currencies(self):
         for config in self:
@@ -897,7 +898,6 @@ class PosConfig(models.Model):
     def _check_before_creating_new_session(self):
         self._check_company_has_template()
         self._check_pricelists()
-        self._check_company_payment()
         self._check_currencies()
         self._check_profit_loss_cash_journal()
         self._check_payment_method_ids()
@@ -1111,9 +1111,17 @@ class PosConfig(models.Model):
         payment_methods |= cash_pm
 
         # only create bank and customer account payment methods per company
-        bank_pm = self.env['pos.payment.method'].search([('journal_id.type', '=', 'bank'), ('company_id', 'in', self.env.company.parent_ids.ids)])
+        journal_domain = [
+            *self.env['account.journal']._check_company_domain(self.env.company),
+            ('type', '=', 'bank'),
+            ('currency_id', '=', False),
+        ]
+        bank_pm = self.env['pos.payment.method'].search([
+            *self.env['pos.payment.method']._check_company_domain(self.env.company),
+            ('journal_id', 'any', journal_domain),
+        ])
         if not bank_pm:
-            bank_journal = self.env['account.journal'].search([('type', '=', 'bank'), ('company_id', 'in', self.env.company.parent_ids.ids)], limit=1)
+            bank_journal = self.env['account.journal'].search(journal_domain, limit=1)
             if not bank_journal:
                 raise UserError(_('Ensure that there is an existing bank journal. Check if chart of accounts is installed in your company.'))
             chart_template = self.with_context(allowed_company_ids=self.env.company.root_id.ids).env['account.chart.template']
@@ -1128,7 +1136,11 @@ class PosConfig(models.Model):
 
         payment_methods |= bank_pm
 
-        pay_later_pm = self.env['pos.payment.method'].search([('journal_id', '=', False), ('split_transactions', '=', True), ('company_id', 'in', self.env.company.parent_ids.ids)])
+        pay_later_pm = self.env['pos.payment.method'].search([
+            *self.env['pos.payment.method']._check_company_domain(self.env.company),
+            ('journal_id', '=', False),
+            ('split_transactions', '=', True),
+        ])
         if not pay_later_pm:
             pay_later_pm = self.env['pos.payment.method'].create({
                 'name': _('Customer Account'),

--- a/addons/point_of_sale/models/pos_payment_method.py
+++ b/addons/point_of_sale/models/pos_payment_method.py
@@ -8,6 +8,7 @@ class PosPaymentMethod(models.Model):
     _description = "Point of Sale Payment Method"
     _order = "sequence, id"
     _inherit = ['pos.load.mixin']
+    _check_company_auto = True
 
     def _default_sequence(self):
         return (self.search([], order="sequence desc", limit=1).sequence or 0) + 1
@@ -42,12 +43,14 @@ class PosPaymentMethod(models.Model):
     sequence = fields.Integer(copy=False, default=_default_sequence)
     outstanding_account_id = fields.Many2one('account.account',
         string='Outstanding Account',
+        check_company=True,
         ondelete='restrict',
         help='Account used as outstanding account when creating accounting payment records for bank payments.')
     receivable_account_id = fields.Many2one('account.account',
         string='Intermediary Account',
         ondelete='restrict',
         domain=[('account_type', '=', 'asset_receivable')],
+        check_company=True,
         help="Leave empty to use the default account from the company setting.\n"
              "Overrides the company's receivable account (for Point of Sale) used in the journal entries.")
     is_cash_count = fields.Boolean(string='Cash', compute="_compute_is_cash_count", store=True)
@@ -67,8 +70,13 @@ class PosPaymentMethod(models.Model):
         default=False,
         help='Forces to set a customer when using this payment method and splits the journal entries for each customer. It could slow down the closing process.')
     open_session_ids = fields.Many2many('pos.session', string='Pos Sessions', compute='_compute_open_session_ids', help='Open PoS sessions that are using this payment method.')
-    config_ids = fields.Many2many('pos.config', string='Point of Sale')
-    company_id = fields.Many2one('res.company', string='Company', default=lambda self: self.env.company)
+    config_ids = fields.Many2many('pos.config', string='Point of Sale', check_company=True)
+    company_id = fields.Many2one(
+        comodel_name='res.company',
+        string='Company',
+        required=True,
+        default=lambda self: self.env.company,
+    )
     default_pos_receivable_account_name = fields.Char(related="company_id.account_default_pos_receivable_account_id.display_name", string="Default Receivable Account Name")
     active = fields.Boolean(default=True)
     type = fields.Selection(selection=[('cash', 'Cash'), ('bank', 'Bank'), ('pay_later', 'Customer Account')], compute="_compute_type")

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -2253,7 +2253,7 @@ class TestPointOfSaleFlow(CommonPosTest):
             'company_id': new_company.id,
         })
         self.env.transaction.clear()
-        data = current_session.with_company(self.env.company).filter_local_data({'product.product': [product.id]})
+        data = current_session.with_context(allowed_company_ids=self.env.company.ids).filter_local_data({'product.product': [product.id]})
         self.assertIn(product.id, data['product.product'])
 
     def test_string_sequence_number(self):

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -496,8 +496,8 @@ class TestPurchase(AccountTestInvoicingCommon):
             })],
         }).button_confirm()
 
-        self.assertEqual(product.seller_ids[0].partner_id, self.partner_a)
-        self.assertEqual(product.seller_ids[0].company_id, company_a)
+        self.assertEqual(product.seller_ids.partner_id, self.partner_a)
+        self.assertEqual(product.seller_ids.company_id, company_a)
 
         # switch to the company B
         self.env['purchase.order'].with_company(company_b).create({
@@ -509,18 +509,16 @@ class TestPurchase(AccountTestInvoicingCommon):
                 'price_unit': 2,
             })],
         }).button_confirm()
-        product = product.with_company(company_b)
-        self.assertEqual(product.seller_ids[0].partner_id, self.partner_b)
-        self.assertEqual(product.seller_ids[0].company_id, company_b)
+        product = product.with_context(allowed_company_ids=[company_b.id])
+        self.env.invalidate_all()
+        self.assertEqual(product.seller_ids.partner_id, self.partner_b)
+        self.assertEqual(product.seller_ids.company_id, company_b)
 
         # Switch to the company A and check that the vendor list is still the same
-        product = product.with_company(company_a)
-        self.assertEqual(product.seller_ids[0].partner_id, self.partner_a)
-        self.assertEqual(product.seller_ids[0].company_id, company_a)
-
-        product._invalidate_cache()
-        self.assertEqual(product.seller_ids[0].partner_id, self.partner_a)
-        self.assertEqual(product.seller_ids[0].company_id, company_a)
+        product = product.with_context(allowed_company_ids=[company_a.id])
+        self.env.invalidate_all()
+        self.assertEqual(product.seller_ids.partner_id, self.partner_a)
+        self.assertEqual(product.seller_ids.company_id, company_a)
 
     def test_discount_po_line_vendorpricelist(self):
         """ Set a discount in VendorPriceList and check if that discount comes in po line and if vendor select

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -496,12 +496,11 @@ class TestSaleOrder(SaleCommon):
             patched.assert_not_called()
 
     def test_so_company_empty(self):
-        """Test that emptying company on SO form should raise."""
-        company_2 = self.env["res.company"].create({"name": "Company 2"})
-        self.env = self.env(
-            context=dict(self.env.context, allowed_company_ids=[self.env.company.id, company_2.id])
-        )
-        so_form = Form(self.env["sale.order"])
+        """Check emptying company on SO form"""
+        self.env['res.company'].create({  # activate multi company for the form view
+            'name': 'Company 2'
+        })
+        so_form = Form(self.env['sale.order'])
         with self.assertRaises(ValidationError):
             so_form.company_id = self.env["res.company"]
 

--- a/addons/sale_timesheet/models/account_analytic_line.py
+++ b/addons/sale_timesheet/models/account_analytic_line.py
@@ -180,11 +180,6 @@ class AccountAnalyticLine(models.Model):
 
     def _get_employee_mapping_entry(self):
         self.ensure_one()
-        if len(self.env.companies) == 1 or self.employee_id:
-            return self.env['project.sale.line.employee.map'].search([
-                ('project_id', '=', self.project_id.id),
-                ('employee_id', '=', self.employee_id.id or self.env.user.employee_id.id)
-            ], limit=1)
         employees = self.env['project.sale.line.employee.map'].search([
             ('project_id', '=', self.project_id.id),
             ('employee_id', 'in', self.env.user.employee_ids.ids),

--- a/addons/stock/tests/test_stock_lot.py
+++ b/addons/stock/tests/test_stock_lot.py
@@ -267,11 +267,7 @@ class TestLotSerial(TestStockCommon):
         picking1.with_company(branch_a)._action_done()
         self.assertTrue(move.move_line_ids.lot_id)
         self.assertEqual(move.state, 'done')
-        # Creating a new lot with only "Branch X" in the context
-        sn_form = Form(
-            self.env['stock.lot'].with_company(branch_a)
-            .with_context(allowed_company_ids=[branch_a.id])
-        )
+        sn_form = Form(self.env['stock.lot'].with_context(allowed_company_ids=branch_a.ids))
         sn_form.name = 'sn_test_2'
         sn_form.product_id = self.productB
         sn = sn_form.save()

--- a/addons/stock_account/tests/common.py
+++ b/addons/stock_account/tests/common.py
@@ -303,16 +303,19 @@ class TestStockValuationCommon(BaseCommon):
     # GETTER
     def _get_stock_valuation_move_lines(self):
         return self.env['account.move.line'].search([
+            *self.env['account.move.line']._check_company_domain(self.company.id),
             ('account_id', '=', self.account_stock_valuation.id),
         ], order='date, id')
 
     def _get_stock_variation_move_lines(self):
         return self.env['account.move.line'].search([
+            *self.env['account.move.line']._check_company_domain(self.company.id),
             ('account_id', '=', self.account_stock_variation.id),
         ], order='date, id')
 
     def _get_expense_move_lines(self):
         return self.env['account.move.line'].search([
+            *self.env['account.move.line']._check_company_domain(self.company.id),
             ('account_id', '=', self.account_expense.id),
         ], order='date, id')
 

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -460,7 +460,7 @@ class ResCompany(models.CachedModel):
 
         return main_company
 
-    @ormcache('tuple(self.env.companies.ids)', 'self.id', 'self.env.uid')
+    @ormcache('frozenset(self.env.companies.ids)', 'self.id', 'self.env.uid')
     def __accessible_branches(self):
         # Get branches of this company that the current user can use
         self.ensure_one()

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -709,7 +709,7 @@ class ResUsers(models.Model):
     def _get_company_ids(self):
         # use search() instead of `self.company_ids` to avoid extra query for `active_test`
         domain = [('active', '=', True), ('user_ids', 'in', self.id)]
-        return self.env['res.company'].search(domain)._ids
+        return (self.company_id | self.env['res.company'].search(domain))._ids
 
     @api.model
     def action_get(self):

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -594,6 +594,10 @@ class ResUsers(models.Model):
             # unarchive partners before unarchiving the users
             self.partner_id.action_unarchive()
 
+        if 'company_id' in vals or 'company_ids' in vals:
+            # reset before the call to super to ensure `_check_company` sees the right company
+            self._reset_cached_properties()
+
         res = super().write(vals)
 
         if 'company_id' in vals:
@@ -603,15 +607,8 @@ class ResUsers(models.Model):
                     user.partner_id.write({'company_id': user.company_id.id})
 
         if 'company_id' in vals or 'company_ids' in vals:
-            # Access cache depends on the company, clear it
-            self.env.transaction.invalidate_access_cache()
-            # Reset lazy properties `company` & `companies` on all envs,
-            # This is unlikely in a business code to change the company of a user and then do business stuff
-            # but in case it happens this is handled.
-            # e.g. `account_test_savepoint.py` `setup_company_data`, triggered by `test_account_invoice_report.py`
-            for env in list(self.env.transaction.envs):
-                if env.user in self:
-                    reset_cached_properties(env)
+            # reset after the call to super to ensure the wrong value wasn't cached because of automations or hooks
+            self._reset_cached_properties()
 
         if 'group_ids' in vals and any(self._ids):
             # clear caches linked to the users
@@ -626,6 +623,17 @@ class ResUsers(models.Model):
             self.env.registry.clear_cache()
 
         return res
+
+    def _reset_cached_properties(self):
+        # Access cache depends on the company, clear it
+        self.env.transaction.invalidate_access_cache()
+        # Reset lazy properties `company` & `companies` on all envs,
+        # This is unlikely in a business code to change the company of a user and then do business stuff
+        # but in case it happens this is handled.
+        # e.g. `account_test_savepoint.py` `setup_company_data`, triggered by `test_account_invoice_report.py`
+        for env in list(self.env.transaction.envs):
+            if env.user in self:
+                reset_cached_properties(env)
 
     @api.ondelete(at_uninstall=True)
     def _unlink_except_master_data(self):

--- a/odoo/addons/test_orm/tests/test_company_checks.py
+++ b/odoo/addons/test_orm/tests/test_company_checks.py
@@ -187,6 +187,19 @@ class TestCompanyCheck(common.TransactionCase):
         self.assertEqual(user.env.company, user.company_id)
         self.assertEqual(user.env.companies, user.company_ids)
 
+    def test_company_companies_order(self):
+        """ Check consistency bewteen company and the order of companies in the environment. """
+        user = self.test_user.with_user(self.test_user)
+        not_first_company = self.env['res.company'].create({
+            'name': 'Last but not least!',
+            'sequence': 10000,
+        })
+        user.sudo().company_ids += not_first_company
+        user.sudo().company_id = not_first_company
+        self.assertNotEqual(user.env['res.company'].search([])[0], not_first_company)  # just mare sure it is not the first one
+        self.assertEqual(user.env.company, not_first_company)
+        self.assertEqual(user.env.companies[0], not_first_company)
+
     def test_with_company(self):
         """ Check that with_company() works as expected """
 

--- a/odoo/addons/test_orm/tests/test_company_checks.py
+++ b/odoo/addons/test_orm/tests/test_company_checks.py
@@ -209,16 +209,12 @@ class TestCompanyCheck(common.TransactionCase):
         comp_a_user = user.with_company(user.company_id)
         comp_a_user2 = user.with_context(allowed_company_ids=user.company_id.ids)
 
-        # Using with_company(c) or with_context(allowed_company_ids=[c])
-        # should return the same context
-        # and the same environment (reused if no changes)
-        self.assertEqual(comp_a_user.env, comp_a_user2.env)
-        self.assertEqual(comp_a_user.env.context, comp_a_user2.env.context)
-
-        # When there were no company in the context, using with_company
-        # restricts both env.company and env.companies.
+        # with_company() adds the company to the allowed_company_ids context key
         self.assertEqual(comp_a_user.env.company, user.company_id)
-        self.assertEqual(comp_a_user.env.companies, user.company_id)
+        self.assertEqual(comp_a_user.env.companies, user.company_ids)
+        # with_context() restricts the companies to only the values set
+        self.assertEqual(comp_a_user2.env.company, user.company_id)
+        self.assertEqual(comp_a_user2.env.companies, user.company_id)
 
         # Reordering allowed_company_ids ctxt key
         # Ensure with_company reorders the context key content
@@ -249,7 +245,7 @@ class TestCompanyCheck(common.TransactionCase):
 
         comp_user = none_user.with_company(user.company_id)
         self.assertEqual(comp_user.env.company, user.company_id)
-        self.assertEqual(comp_user.env.companies, user.company_id)
+        self.assertEqual(comp_user.env.companies, user.company_ids)
 
     def test_company_sticky_with_context(self):
         context = frozendict({'nothing_to_see_here': True})

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -5396,7 +5396,9 @@ class BaseModel(metaclass=MetaModel):
         """ Return a new version of this recordset with a modified context, such that::
 
             result.env.company = company
-            result.env.companies = self.env.companies | company
+            result.env.companies = company | self.env.companies
+
+        Note that the second equality specifies the order of ``result.env.companies``.
 
         .. warning::
 
@@ -5409,12 +5411,9 @@ class BaseModel(metaclass=MetaModel):
             return self
 
         company_id = int(company)
-        allowed_company_ids = self.env.context.get('allowed_company_ids') or []
-        if allowed_company_ids and company_id == allowed_company_ids[0]:
+        allowed_company_ids = self.env.companies.ids
+        if company_id == allowed_company_ids[0]:
             return self
-        # Copy the allowed_company_ids list
-        # to avoid modifying the context of the current environment.
-        allowed_company_ids = list(allowed_company_ids)
         if company_id in allowed_company_ids:
             allowed_company_ids.remove(company_id)
         allowed_company_ids.insert(0, company_id)


### PR DESCRIPTION
Before this commit, the behavior of `with_company` was sometimes
unpredictable in the sense that sometimes it was restricting access, and
sometimes giving more access.

The behavior was the following:
* when `allowed_company_ids` was not set, `with_company` was restricting
  the accepted companies to only it's argument.
* when `allowed_company_ids` was set, `with_company` was adding a new
  value to the accepted companies.

For instance:
```python
In [1]: self.env.companies
Out[1]: res.company(3, 4, 1)

In [2]: self.env.context.get('allowed_company_ids')

In [3]: self.with_company(4).env.companies
Out[3]: res.company(4,)

In [4]: self.with_context(allowed_company_ids=[3, 4]).with_company(4).env.companies
Out[4]: res.company(4, 3)
```

This made the code less predictable because to fully understand the
result of the function, we need to be aware of the context in which the
function is called.

This commit is unifying the behavior to always add a new value to the
allowed companies, and doesn't change the reordering purpose so that the
main company is the first element  of `allowed_company_ids`
