### PR TITLE
[FIX] web_editor, website_slides: update regex for youtube video link

### DIFF
--- a/addons/web_editor/tests/test_tools.py
+++ b/addons/web_editor/tests/test_tools.py
@@ -11,6 +11,7 @@ from odoo.addons.web_editor import tools
 class TestVideoUtils(common.BaseCase):
     urls = {
         'youtube': 'https://www.youtube.com/watch?v=xCvFZrrQq7k',
+        'youtube_mobile': 'https://m.youtube.com/watch?v=xCvFZrrQq7k',
         'vimeo': 'https://vimeo.com/395399735',
         'vimeo_unlisted_video': 'https://vimeo.com/795669787/0763fdb816',
         'vimeo_player': 'https://player.vimeo.com/video/395399735',
@@ -47,6 +48,8 @@ class TestVideoUtils(common.BaseCase):
         #youtube
         self.assertEqual('youtube', tools.get_video_source_data(TestVideoUtils.urls['youtube'])[0])
         self.assertEqual('xCvFZrrQq7k', tools.get_video_source_data(TestVideoUtils.urls['youtube'])[1])
+        self.assertEqual('youtube', tools.get_video_source_data(TestVideoUtils.urls['youtube_mobile'])[0])
+        self.assertEqual('xCvFZrrQq7k', tools.get_video_source_data(TestVideoUtils.urls['youtube_mobile'])[1])
         #vimeo
         self.assertEqual('vimeo', tools.get_video_source_data(TestVideoUtils.urls['vimeo'])[0])
         self.assertEqual('395399735', tools.get_video_source_data(TestVideoUtils.urls['vimeo'])[1])

--- a/addons/web_editor/tools.py
+++ b/addons/web_editor/tools.py
@@ -17,7 +17,7 @@ valid_url_regex = r'^(http://|https://|//)[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{
 
 # Regex for few of the widely used video hosting services
 player_regexes = {
-    'youtube': r'^(?:(?:https?:)?//)?(?:www\.)?(?:youtu\.be/|youtube(-nocookie)?\.com/(?:embed/|v/|watch\?v=|watch\?.+&v=))((?:\w|-){11})\S*$',
+    'youtube': r'^(?:(?:https?:)?//)?(?:www\.|m\.)?(?:youtu\.be/|youtube(-nocookie)?\.com/(?:embed/|v/|shorts/|live/|watch\?v=|watch\?.+&v=))((?:\w|-){11})\S*$',
     'vimeo': r'^(?:(?:https?:)?//)?(?:www\.)?vimeo\.com\/(?P<id>[^/\?]+)(?:/(?P<hash>[^/\?]+))?(?:\?(?P<params>[^\s]+))?$',
     'vimeo_player': r'^(?:(?:https?:)?//)?player\.vimeo\.com\/video\/(?P<id>[^/\?]+)(?:\?(?P<params>[^\s]+))?$',
     'dailymotion': r'(https?:\/\/)(www\.)?(dailymotion\.com\/(embed\/video\/|embed\/|video\/|hub\/.*#video=)|dai\.ly\/)(?P<id>[A-Za-z0-9]{6,7})',

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -108,7 +108,7 @@ class Slide(models.Model):
     }
     _order = 'sequence asc, is_category asc, id asc'
 
-    YOUTUBE_VIDEO_ID_REGEX = r'^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*'
+    YOUTUBE_VIDEO_ID_REGEX = r'^(?:(?:https?:)?//)?(?:www\.|m\.)?(?:youtu\.be/|youtube(-nocookie)?\.com/(?:embed/|v/|shorts/|live/|watch\?v=|watch\?.+&v=))((?:\w|-){11})\S*$'
     GOOGLE_DRIVE_DOCUMENT_ID_REGEX = r'(^https:\/\/docs.google.com|^https:\/\/drive.google.com).*\/d\/([^\/]*)'
     VIMEO_VIDEO_ID_REGEX = r'\/\/(player.)?vimeo.com\/(?:[a-z]*\/)*([0-9]{6,11})\/?([0-9a-z]{6,11})?[?]?.*'
 

--- a/addons/website_slides/tests/test_slide_slide.py
+++ b/addons/website_slides/tests/test_slide_slide.py
@@ -46,6 +46,8 @@ class TestVideoFromURL(slides_common.SlidesCase):
                 'https://youtu.be/W0JQcpGLSFw',
                 'https://www.youtube.com/watch?v=W0JQcpGLSFw',
                 'https://www.youtube.com/watch?v=W0JQcpGLSFw&list=PL1-aSABtP6ACZuppkBqXFgzpNb2nVctZx',
+                'https://www.youtube.com/live/W0JQcpGLSFw?feature=shared',
+                'https://youtube.com/shorts/W0JQcpGLSFw?si=N9xYS2w3f1BWuhU9',
             ],
             'vmhB-pt7EfA': [  # id starts with v, it is important
                 'https://youtu.be/vmhB-pt7EfA',


### PR DESCRIPTION
Updated the regex of the youtube videos to accept some of the latest
links as shorts and lives, following the same behavior as in web_editor.
Specifically the links generated using the share button.

Steps to reproduce:

1. Install eLearning and create a course.
2. Add a new content as video.
3. Take the Youtube livestream url from share > copy.
4. Use this link for the video slide in the course.

opw-4278811

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr