### PR TITLE
[FIX] hr_timesheet: remove extra line in project form view

### DIFF
--- a/addons/hr_timesheet/views/project_project_views.xml
+++ b/addons/hr_timesheet/views/project_project_views.xml
@@ -23,12 +23,12 @@
             <field name="arch" type="xml">
                 <xpath expr="//header" position="after">
                     <field name="analytic_account_active" invisible="1"/>
-                    <group name="timesheet_error" invisible="not allow_timesheets">
+                    <t name="timesheet_error" invisible="not allow_timesheets">
                         <div class="alert alert-warning mb-1 text-center" role="alert" colspan="2" invisible="not account_id or analytic_account_active">
                             You cannot log timesheets on this project since it is linked to an inactive analytic account.<br/>
                             Please switch to another account, or reactivate the current one to timesheet on the project.
                         </div>
-                    </group>
+                    </t>
                 </xpath>
                 <xpath expr="//field[@name='date']" position="after">
                     <field name="allocated_hours" widget="timesheet_uom_no_toggle" invisible="not allow_timesheets" groups="hr_timesheet.group_hr_timesheet_user"/>


### PR DESCRIPTION
Before this commit, an extra line is displayed between the `Share Project` button and the form sheet.

This commit removes the extra line by altering the group tag contained the timesheet warning when the timesheet feature is enabled in the project and no active analytic account is set on the project. The `group` tag is only supported in the `sheet` tag and not outside, that's why the extra line is appeared.

task-4286488
