### PR TITLE
[FIX] point_of_sale: fetch paid orders from database when searching

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -101,6 +101,9 @@ export class TicketScreen extends Component {
     async onSearch(search) {
         this.state.search = search;
         this.state.page = 1;
+        if (this.state.filter == "SYNCED") {
+            await this._fetchSyncedOrders();
+        }
     }
     onClickOrder(clickedOrder) {
         this.state.selectedOrder = clickedOrder;


### PR DESCRIPTION
Before this commit, opening the paid orders and searching for an existing order would not fetch the orders from the database.

opw-4276187

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
