### PR TITLE
[FIX] CRM: Assign leads manually

### DIFF
--- a/addons/crm/models/crm_team.py
+++ b/addons/crm/models/crm_team.py
@@ -227,7 +227,7 @@ class Team(models.Model):
         :return action: a client notification giving some insights on assign
           process;
         """
-        teams_data, members_data = self._action_assign_leads(force_quota=True)
+        teams_data, members_data = self._action_assign_leads(force_quota=True, creation_delta_days=0)
 
         # format result messages
         logs = self._action_assign_leads_logs(teams_data, members_data)


### PR DESCRIPTION
When manually assigning leads to salespeople in a team, only leads created in the past 7 days were being assigned. If all leads were created more than 7 days ago, they would not be assigned, causing missed assignments.

To fix this, the parameter `creation_delta_days` is now set to 0 during manual assignment, bypassing the 7-day creation filter. This ensures that all leads, regardless of creation date, are assignable manually. https://github.com/odoo/odoo/blob/saas-17.4/addons/crm/models/crm_team.py#L441#L445

Steps to reproduce:
1. Go to CRM settings and activate `Rule-Based Assignment` and `Leads`.
2. Navigate to CRM Configuration > Sales Teams.
3. Create a new sales team with `Leads` active.
4. Add a member to the team, save, and try to assign leads.

Expected behavior:
All leads, regardless of creation date, should be assignable when manually assigned.

opw-4217088

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
