### PR TITLE
[FIX] sale_project: ensure user error is displayed when no service in SO

### DIFF
--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -175,7 +175,7 @@ class ProjectProject(models.Model):
                 "show_sale": True,
                 'default_partner_id': self.partner_id.id,
                 'default_analytic_account_id': self.analytic_account_id.id,
-                "create_for_project_id": self.id if embedded_action_context else False,
+                "create_for_project_id": self.id if not embedded_action_context else False,
                 "from_embedded_action": embedded_action_context
             },
             'help': "<p class='o_view_nocontent_smiling_face'>%s</p><p>%s<br/>%s</p>" %


### PR DESCRIPTION
Before this commit, when the user wants to create a SO via the stat button displayed in the project form view when the project is billable without any SO created. The SO to create should have at least one service product to be able to timesheet on it inside the project. To make sure a service product will be in the lines of the newest SO, an user error should be displayed once no service product is inside lines of the SO created to avoid letting the user to create the SO until there is no service product.

This commit makes sure the context is correctly passed to the action to be able to trigger the warning once it is needed.

Steps to reproduce the issue:
============================

1. install `sale_project` module
2. create new billable project
3. go to the form view of that new project
4. set a customer to that project
5. click on `0 Sales Order\nMake Billable` stat button to create a new SO linked to that project
6. Create/Confirm the SO without any service products in its lines

Expected behavior
-----------------

The user error should be displayed since no service product is inside the lines of new SO.

Actual Behavior
---------------

The SO is created/confirmed without any errors.

task-4291437
