### PR TITLE
[FIX] spreadsheet: disable see records on manipulated pivot table

### DIFF
--- a/addons/spreadsheet/static/src/pivot/plugins/pivot_ui_plugin.js
+++ b/addons/spreadsheet/static/src/pivot/plugins/pivot_ui_plugin.js
@@ -295,6 +295,9 @@ export class PivotUIPlugin extends spreadsheet.UIPlugin {
             if (!this.getters.isExistingPivot(pivotId) || !dataSource.isReady()) {
                 return undefined;
             }
+            if (!cell.content.replaceAll(" ", "").toUpperCase().startsWith("=ODOO.PIVOT.TABLE")) {
+                return undefined;
+            }
             const includeTotal = args[2];
             const includeColumnHeaders = args[3];
             const pivotCells = this.getPivotTableStructure(pivotId).getPivotCells(

--- a/addons/spreadsheet/static/tests/pivots/pivot_see_records_test.js
+++ b/addons/spreadsheet/static/tests/pivots/pivot_see_records_test.js
@@ -111,6 +111,29 @@ QUnit.test(
     }
 );
 
+QUnit.test(
+    "Cannot open see records when the table is manipulated by other functions",
+    async function (assert) {
+        const { env, model } = await createSpreadsheetWithPivot({
+            arch: /*xml*/ `
+                <pivot>
+                    <field name="foo" type="row"/>
+                    <field name="probability" type="measure"/>
+                </pivot>
+            `,
+        });
+        model.dispatch("CREATE_SHEET", { sheetId: "42" });
+        // ODOO.PIVOT.TABLE(1) would have 2 columns and 7 rows
+        // TRANSPOSE(ODOO.PIVOT.TABLE(1)) has 7 columns and 2 rows
+        setCellContent(model, "A1", "=TRANSPOSE(ODOO.PIVOT.TABLE(1))", "42");
+        // C2 has the value in the grid (because of the TRANSPOSE)
+        // but it's not a cell of the pivot table
+        selectCell(model, "C2", "42");
+        const action = await getActionMenu(cellMenuRegistry, ["pivot_see_records"], env);
+        assert.strictEqual(action.isVisible(env), false);
+    }
+);
+
 QUnit.test("Can see records on ODOO.PIVOT.TABLE cells", async function (assert) {
     const actions = [];
     const fakeActionService = {


### PR DESCRIPTION
Steps to reproduce:

- insert a pivot with more rows than columns
- write in a cell =TRANSPOSE(ODOO.PIVOT.TABLE(1))
- right-click on the grand total value

=> boom

When computing which cell of the pivot table is clicked, we assume the matrix comes directly from the ODOO.PIVOT.TABLE(...) function to compute the offsets from the array formula. But it's completely wrong as the cell could at a completely different place if the matrix is manipulated by other functions before being outputted to the grid.

Task: 4292134





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
