### PR TITLE
[FIX] iap: add log in case of exception during IAP JSONRPC

### DIFF
--- a/addons/iap/tools/iap_tools.py
+++ b/addons/iap/tools/iap_tools.py
@@ -154,7 +154,8 @@ def iap_jsonrpc(url, method='call', params=None, timeout=15):
             e.data = response['error']['data']
             raise e
         return response.get('result')
-    except (ValueError, requests.exceptions.ConnectionError, requests.exceptions.MissingSchema, requests.exceptions.Timeout, requests.exceptions.HTTPError) as e:
+    except (ValueError, requests.exceptions.ConnectionError, requests.exceptions.MissingSchema, requests.exceptions.Timeout, requests.exceptions.HTTPError):
+        _logger.exception("iap jsonrpc %s failed", url)
         raise exceptions.AccessError(
             _('The url that this service requested returned an error. Please contact the author of the app. The url it tried to contact was %s', url)
         )


### PR DESCRIPTION
When an exception occurred during a request to IAP, there was no way of knowing which one it was exactly. This log should help understand what went wrong.

Related ticket for which this would have been helpful: #4276907
