### PR TITLE
[FIX] repair: clear the lot when changing the product

### DIFF
--- a/addons/repair/tests/test_repair.py
+++ b/addons/repair/tests/test_repair.py
@@ -490,3 +490,18 @@ class TestRepair(AccountTestInvoicingCommon):
         repair_order.action_repair_start()
         repair_order.action_repair_end()
         self.assertEqual(repair_order.state, 'done')
+
+    def test_sn_with_no_tracked_product(self):
+        """
+        Check that the lot_id field is cleared after updating the product in the repair order.
+        """
+        self.product_a.tracking = 'serial'
+        sn_1 = self.env['stock.lot'].create({'name': 'sn_1', 'product_id': self.product_a.id})
+        ro_form = Form(self.env['repair.order'])
+        ro_form.product_id = self.product_a
+        ro_form.lot_id = sn_1
+        repair_order = ro_form.save()
+        ro_form = Form(repair_order)
+        ro_form.product_id = self.product_b
+        repair_order = ro_form.save()
+        self.assertFalse(repair_order.lot_id)

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -78,7 +78,7 @@
                             <field name="tracking" invisible="1" attrs="{'readonly': 1}"/>
                             <field name="company_id" invisible="1"/>
                             <field name="product_id"/>
-                            <field name="lot_id" context="{'default_product_id': product_id, 'default_company_id': company_id}" groups="stock.group_production_lot" attrs="{'required':[('tracking', 'in', ['serial', 'lot'])], 'invisible': [('tracking', 'not in', ['serial', 'lot'])], 'readonly': ['|', ('state', '=', 'done'), ('tracking', 'not in', ['serial', 'lot'])]}"/>
+                            <field name="lot_id" context="{'default_product_id': product_id, 'default_company_id': company_id}" groups="stock.group_production_lot" attrs="{'required':[('tracking', 'in', ['serial', 'lot'])], 'invisible': [('tracking', 'not in', ['serial', 'lot'])], 'readonly': [('state', '=', 'done')]}"/>
                             <field name="product_uom_category_id" invisible="1"/>
                             <label for="product_qty"/>
                             <div class="o_row">


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Create two storable products, “P1” and “P2”.
- Set “P1” to be tracked by Serial Number
- Update P1 with SN1.
- Create a repair order:
   - Set P1 with SN1.
   - Save.
- Edit and update the product to P2.
- Save.
- Print the order.

**Problem:**
The “lot_id” is not cleared and appears in the report because the “lot_id” field becomes invisible and read-only under the same condition. Since it is read-only and not force-saved, the value of “lot_id” is not considered in the write of the repair order, even though the `onchange` sets the “lot_id” field to False:

https://github.com/odoo/odoo/blob/16.0/addons/repair/models/repair.py#L208-L212

**opw-4281176**
