### PR TITLE
[IMP] l10n_ua: Invoice templates

### DIFF
--- a/addons/l10n_ua/__manifest__.py
+++ b/addons/l10n_ua/__manifest__.py
@@ -17,6 +17,7 @@ Ukraine - Chart of accounts.
     'auto_install': ['account'],
     'data': [
         'data/account_account_tag_data.xml',
+        'views/report_invoice.xml',
     ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_ua/models/__init__.py
+++ b/addons/l10n_ua/models/__init__.py
@@ -1,2 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import res_company
 from . import template_ua_psbo

--- a/addons/l10n_ua/models/res_company.py
+++ b/addons/l10n_ua/models/res_company.py
@@ -1,0 +1,23 @@
+from markupsafe import Markup
+
+from odoo import api, models, _, fields
+
+
+class BaseDocumentLayout(models.TransientModel):
+    _inherit = 'base.document.layout'
+
+    @api.model
+    def _default_company_details(self):
+        company_details = super()._default_company_details()
+        company = self.env.company
+        if company.country_code == 'UA':
+            if company.company_registry:
+                company_details += Markup('<br/> %s') % _('Registry: %s', company.company_registry)
+            if company.bank_ids:
+                bank = company.bank_ids[0]
+                company_details += Markup('<br/> %s') % _('Bank: %s', bank.display_name)
+                if bank.bank_bic:
+                    company_details += Markup('<br/> %s') % _('BIC: %s', bank.bank_bic)
+        return company_details
+
+    company_details = fields.Html(default=_default_company_details)

--- a/addons/l10n_ua/views/report_invoice.xml
+++ b/addons/l10n_ua/views/report_invoice.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="report_invoice_waybill" inherit_id="account.report_invoice_document" primary="True">
+        <xpath expr="//t[@t-set='layout_document_title']" position="replace">
+            <t t-set="layout_document_title">
+                <span>Waybill</span>
+                <span t-if="o.name != '/'" t-field="o.name">INV/2023/0001</span>
+            </t>
+        </xpath>
+
+        <xpath expr="//div[@id='partner_vat_address_same_as_shipping']" position="after">
+            BANK: <span t-field="o.partner_id.bank_ids[0].display_name"/>
+            <br/>
+            BIC: <span t-field="o.partner_id.bank_ids[0].bank_bic"/>
+        </xpath>
+
+        <xpath expr="//div[@name='comment']" position="before">
+            <div id="representative_information" class="row mb-4">
+                <div class="col-8 mb-0" name="representative_supplier">
+                    <strong>Representative Supplier:</strong>
+                    <span t-field="o.env.company.company_details"/>
+                </div>
+                <div class="col-8 mb-0" name="representative_receiver">
+                    <strong>Representative receiver:</strong>
+                    <address t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>
+                </div>
+            </div>
+        </xpath>
+    </template>
+
+    <template id="report_waybill_invoice">
+        <t t-call="web.html_container">
+            <t t-foreach="docs" t-as="o">
+                <t t-set="lang" t-value="o.partner_id.lang"/>
+                <t t-call="l10n_ua.report_invoice_waybill" t-lang="lang"/>
+            </t>
+        </t>
+    </template>
+
+    <record id="action_report_waybill_invoice" model="ir.actions.report">
+        <field name="name">Waybill</field>
+        <field name="model">account.move</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">l10n_ua.report_waybill_invoice</field>
+        <field name="report_file">l10n_ua.report_waybill_invoice</field>
+        <field name="is_invoice_report">True</field>
+        <field name="print_report_name">'Waybill - %s' % (object._get_report_base_filename())</field>
+        <field name="binding_model_id" ref="account.model_account_move"/>
+        <field name="binding_type">report</field>
+    </record>
+
+    <template id="report_invoice_aoc_work" inherit_id="account.report_invoice_document" primary="True">
+        <xpath expr="//t[@t-set='layout_document_title']" position="replace">
+            <t t-set="layout_document_title">
+                <span>Act of Completed Work</span>
+                <span t-if="o.name != '/'" t-field="o.name">INV/2023/0001</span>
+            </t>
+        </xpath>
+
+        <xpath expr="//t[@t-set='current_subtotal']" position="before">
+            <span>The representative of the customer, on the one hand, and the representative of the contractor,
+            <strong><span t-field="o.env.company.display_name">UA Company</span></strong>, on the other hand, drew up an act
+            stating that the contractor performed on time and in full, and the customer accepted the following works:</span>
+        </xpath>
+
+        <xpath expr="//div[@id='partner_vat_address_same_as_shipping']" position="after">
+            BANK: <span t-field="o.partner_id.bank_ids[0].display_name"/>
+            <br/>
+            BIC: <span t-field="o.partner_id.bank_ids[0].bank_bic"/>
+        </xpath>
+
+        <xpath expr="//div[@name='comment']" position="before">
+            <div id="representative_information" class="row mb-4">
+                <div class="col-8 mb-0" name="representative_supplier">
+                    <strong>Representative Supplier:</strong>
+                    <span t-field="o.env.company.company_details"/>
+                </div>
+                <div class="col-8 mb-0" name="representative_receiver">
+                    <strong>Representative receiver:</strong>
+                    <address t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>
+                </div>
+            </div>
+        </xpath>
+    </template>
+
+    <template id="report_aoc_work_invoice">
+        <t t-call="web.html_container">
+            <t t-foreach="docs" t-as="o">
+                <t t-set="lang" t-value="o.partner_id.lang"/>
+                <t t-call="l10n_ua.report_invoice_aoc_work" t-lang="lang"/>
+            </t>
+        </t>
+    </template>
+
+    <record id="action_report_aoc_work_invoice" model="ir.actions.report">
+        <field name="name">Act of Completed Work</field>
+        <field name="model">account.move</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">l10n_ua.report_aoc_work_invoice</field>
+        <field name="report_file">l10n_ua.report_aoc_work_invoice</field>
+        <field name="is_invoice_report">True</field>
+        <field name="print_report_name">'Act of Completed Work - %s' % (object._get_report_base_filename())</field>
+        <field name="binding_model_id" ref="account.model_account_move"/>
+        <field name="binding_type">report</field>
+    </record>
+</odoo>


### PR DESCRIPTION
This commit add 2 new templates for invoice pdf, **Waybill** and **Act of Completed Work**. Those two templates add new data on the basic invoice template, such as partner bank account, representative performer and client.

Also, now the default company details in the header of templates adds multiple fields: **company_registry**, **bank name** and **bank BIC**.

task-4267389