### PR TITLE
[FIX] mail: allow to `@`mention a user in another company

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3206,7 +3206,7 @@ class MailThread(models.AbstractModel):
                         user.partner_id,
                         "mail.message/inbox",
                         Store(
-                            message.with_user(user),
+                            message.with_user(user).with_context(allowed_company_ids=None),
                             msg_vals=msg_vals,
                             for_current_user=True,
                             add_followers=True,

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -1402,7 +1402,16 @@ class MailCommon(common.TransactionCase, MailCase):
             notification_type='inbox',
             signature='--\nEnguerrand'
         )
+        cls.user_employee_c3 = mail_new_test_user(
+            cls.env, login='employee_c3',
+            company_id=cls.company_3.id,
+            company_ids=[(4, cls.company_3.id)],
+            email='freudenbergerg@example.com',
+            name='Freudenbergerg Employee C3',
+            notification_type='inbox'
+        )
         cls.partner_employee_c2 = cls.user_employee_c2.partner_id
+        cls.partner_employee_c3 = cls.user_employee_c3.partner_id
 
         # test erp manager employee
         cls.user_erp_manager = mail_new_test_user(

--- a/addons/test_mail/tests/test_mail_multicompany.py
+++ b/addons/test_mail/tests/test_mail_multicompany.py
@@ -255,6 +255,20 @@ class TestMultiCompanySetup(TestMailMCCommon, HttpCase):
                 subtype_xmlid='mail.mt_comment',
             )
 
+    def test_recipients_multi_company(self):
+        """Test mentioning a partner with no common company."""
+        test_records_mc_c2 = self.test_records_mc[1]
+        self._reset_bus()
+        with self.assertBus([(self.cr.dbname, "res.partner", self.user_employee_c3.partner_id.id)]):
+            test_records_mc_c2.with_user(self.user_employee_c2).with_context(
+                allowed_company_ids=self.company_2.ids
+            ).message_post(
+                body="Hello @Freudenbergerg",
+                message_type="comment",
+                partner_ids=self.user_employee_c3.partner_id.ids,
+                subtype_xmlid="mail.mt_comment",
+            )
+
     @freeze_time('2023-11-22 08:00:00')
     @users("admin")
     def test_systray_get_activities(self):


### PR DESCRIPTION
In a multi-company DB, mentioning a user with less allowed companies would result to "Access to unauthorized or invalid companies."

Steps to reproduce:
- Create 2 companies "YourCompany" and "TestCompany"
- Set Mitchell Admin allowed in both companies
- Set Marc Demo allowed to only "TestCompany"
- Set Marc Demo User Notification Preferences to "Handle in Odoo"
- Check both companies on Mitchell Admin
- Open a contact record and log a note with `@Marc Demo` mention

=> Dialog with `Access to unauthorized or invalid companies.`

This happens because the sending of bus notification related to inbox messages is made from the recipient, in this case Marc Demo. The context data still refer to Mitchell Admin, so `allowed_company_ids` still contain the 2 companies. Because of this, any search like `ResUsers.search(id,=,DemoUserId)` raises an exception from allowed_companies containing invalid companies for Marc Demo.

This commit fixes the issue by overwriting the allowed companies in context to the user recipient that will receive the Inbox message. This overwrite only applies in the `.with_user()` scope.

opw-4231529

Fix is similar to https://github.com/odoo/odoo/pull/46554