### PR TITLE
[IMP] web_kanban_gauge: restore max value option

### DIFF
--- a/addons/web_kanban_gauge/static/src/gauge_field.js
+++ b/addons/web_kanban_gauge/static/src/gauge_field.js
@@ -31,7 +31,7 @@ export class GaugeField extends Component {
 
     renderChart() {
         const gaugeValue = this.props.value;
-        let maxValue = Math.max(gaugeValue, this.props.record.data[this.props.maxValueField]);
+        let maxValue = Math.max(gaugeValue, this.props.record.data[this.props.maxValueField] || this.props.maxValue);
         let maxLabel = maxValue;
         if (gaugeValue === 0 && maxValue === 0) {
             maxValue = 1;
@@ -86,12 +86,14 @@ GaugeField.props = {
     ...standardFieldProps,
     maxValueField: { type: String },
     title: { type: String },
+    maxValue: { type: Number },
 };
 
 GaugeField.extractProps = ({ attrs, field }) => {
     return {
-        maxValueField: attrs.options.max_field,
+        maxValueField: attrs.options.max_field || "",
         title: attrs.options.title || field.string,
+        maxValue: attrs.options.max_value || 100,
     };
 };
 

--- a/addons/web_kanban_gauge/static/tests/gauge_value_tests.js
+++ b/addons/web_kanban_gauge/static/tests/gauge_value_tests.js
@@ -1,0 +1,57 @@
+/** @odoo-module **/
+
+import { getFixture, getNodesTextContent } from "@web/../tests/helpers/utils";
+import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
+
+let serverData;
+let target;
+
+QUnit.module("Fields", (hooks) => {
+    hooks.beforeEach(() => {
+        target = getFixture();
+        serverData = {
+            models: {
+                partner: {
+                    fields: {
+                        int_field: {
+                            string: "int_field",
+                            type: "integer",
+                        },
+                    },
+                    records: [
+                        { id: 1, int_field: 10 },
+                    ],
+                },
+            },
+        };
+
+        setupViewRegistries();
+    });
+
+    QUnit.module("GaugeValue");
+
+    QUnit.test("GaugeValue in kanban view", async function (assert) {
+        await makeView({
+            type: "kanban",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <kanban>
+                    <templates>
+                        <t t-name="kanban-box">
+                            <div>
+                                <field name="int_field" widget="gauge" options="{'max_value': 120}"/>
+                                <field name="int_field" widget="gauge"/>
+                            </div>
+                        </t>
+                    </templates>
+                </kanban>`,
+        });
+
+        assert.containsN(target, ".o_field_widget[name=int_field] .oe_gauge canvas", 2);
+        assert.deepEqual(getNodesTextContent(target.querySelectorAll(".o_gauge_value")), [
+            "10",
+            "10",
+        ]);
+    });
+});


### PR DESCRIPTION
In [1], the gauge widget was converted to OWL, but the option to use the widget with a fixed `max_value` was removed. This commit restores that functionality in the OWL framework.

[1]: https://github.com/odoo/odoo/commit/e857e8d7
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
