### PR TITLE
[IMP] point_of_sale: fixed box width

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/inputs/input/input.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/inputs/input/input.xml
@@ -20,7 +20,7 @@
                         t-att-value="getValue()"
                         t-on-input="(event) => this.setValue(event.target.value)" />
                     <t t-if="!props.iconOnLeftSide" t-call="point_of_sale.inputIcon" />
-                    <i t-if="getValue()" class="fa fa-times mx-2" t-on-click="() => this.setValue('')"/>
+                    <i t-att-class="{ 'invisible': !getValue() }" class="fa fa-times mx-2" t-on-click="() => this.setValue('')"/>
                 </div>
             </div>
         </div>

--- a/addons/point_of_sale/static/src/app/navbar/cash_move_popup/cash_move_popup.js
+++ b/addons/point_of_sale/static/src/app/navbar/cash_move_popup/cash_move_popup.js
@@ -27,6 +27,7 @@ export class CashMovePopup extends Component {
             reason: "",
         });
         this.confirm = useAsyncLockedMethod(this.confirm);
+        this.ui = useService("ui");
     }
 
     async confirm() {

--- a/addons/point_of_sale/static/src/app/navbar/cash_move_popup/cash_move_popup.xml
+++ b/addons/point_of_sale/static/src/app/navbar/cash_move_popup/cash_move_popup.xml
@@ -4,21 +4,23 @@
     <t t-name="point_of_sale.CashMovePopup">
         <Dialog header="false">
             <div class="input-amount d-flex mb-2 gap-2">
-                <div class="input-group">
-                    <button t-on-click="() => this.onClickButton('in')" class="input-type btn btn-secondary btn-lg lh-lg" t-att-class="{ 'highlight btn-success': state.type === 'in' }">
+                <div class="input-group" t-att-class="{ 'w-50' : this.ui.isSmall }">
+                    <button t-on-click="() => this.onClickButton('in')" t-attf-class="input-type btn btn-secondary lh-lg #{this.ui.isSmall ? 'btn-md' : 'btn-lg'} #{state.type === 'in' ? 'highlight btn-success' : '' }">
                         Cash In
                     </button>
-                    <button t-on-click="() => this.onClickButton('out')" class="input-type btn btn-secondary btn-lg lh-lg" t-att-class="{ 'red-highlight btn-danger': state.type === 'out' }">
+                    <button t-on-click="() => this.onClickButton('out')" t-attf-class="input-type btn btn-secondary lh-lg #{this.ui.isSmall ? 'btn-md' : 'btn-lg'} #{state.type === 'out' ? 'red-highlight btn-danger' : '' }">
                         Cash Out
                     </button>
                 </div>
-                <Input tModel="[state, 'amount']"
-                    icon="{type: 'string', value: pos.currency.symbol}"
-                    iconOnLeftSide="pos.currency.position === 'before'"
-                    isValid.bind="env.utils.isValidFloat"
-                    autofocus="true"
-                    getRef="(ref) => this.inputRef = ref" />
-            </div>
+                <div t-attf-class="{{this.ui.isSmall ? 'mw-50 h-50' : 'w-25'}}">
+                    <Input tModel="[state, 'amount']"
+                        icon="{type: 'string', value: pos.currency.symbol}"
+                        iconOnLeftSide="pos.currency.position === 'before'"
+                        isValid.bind="env.utils.isValidFloat"
+                        autofocus="true"
+                        getRef="(ref) => this.inputRef = ref" />
+                </div>
+            </div> 
             <div class="form-floating">
                 <textarea class="form-control cash-reason" placeholder="Leave a reason here" name="reason" id="reason" t-model="state.reason" style="height:100px;" />
                 <label for="reason">Reason</label>

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.xml
@@ -55,7 +55,7 @@
                         </div>
                     </div>
                     <div class="pos-receipt-container d-flex flex-grow-1 flex-lg-grow-0 w-100 w-lg-50 user-select-none justify-content-center bg-200 text-center overflow-hidden">
-                        <div class="d-inline-block m-2 m-lg-3 p-3 border rounded bg-view text-start overflow-y-auto">
+                        <div t-att-class="{ 'w-50': !ui.isSmall }" class="d-inline-block m-2 m-lg-3 p-3 border rounded bg-view text-start overflow-y-auto">
                             <OrderReceipt data="pos.orderExportForPrinting(pos.get_order())" formatCurrency="env.utils.formatCurrency" />
                         </div>
                     </div>

--- a/addons/point_of_sale/static/src/app/store/opening_control_popup/opening_control_popup.js
+++ b/addons/point_of_sale/static/src/app/store/opening_control_popup/opening_control_popup.js
@@ -30,6 +30,7 @@ export class OpeningControlPopup extends Component {
             ),
         });
         this.hardwareProxy = useService("hardware_proxy");
+        this.ui = useService("ui");
     }
     confirm() {
         this.pos.session.state = "opened";

--- a/addons/point_of_sale/static/src/app/store/opening_control_popup/opening_control_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/opening_control_popup/opening_control_popup.xml
@@ -9,7 +9,7 @@
             </t>
             <div class="opening-cash-section mb-3" t-if="this.cashMethodCount">
                 <label class="form-label">Opening cash</label>
-                <div class="cash-input-sub-section d-flex gap-1">
+                <div t-att-class="{ 'w-50': !ui.isSmall }" class="cash-input-sub-section d-flex gap-1">
                     <Input tModel="[state, 'openingCash']"
                         isValid.bind="env.utils.isValidFloat"
                         callback.bind="handleInputChange"


### PR DESCRIPTION
Before this commit:
==========
- The width of the input field changes when text is added during the session's opening, cash in/cash out, search products, and search partner processes.
- The company logo affects the width of the PoS receipt preview.

After this commit:
==========
- The input field's width stays fixed while adding text during the session's opening, cash in/cash out, search products, and search partner processes.
- The width of the PoS receipt preview remains fixed as well.

task-4285446
