### PR TITLE
[FIX] account: prevent an error when open a portal view of invoices

### DIFF
--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -69,7 +69,7 @@
                         </td>
                         <td><span t-field="invoice.invoice_date"/></td>
                         <td class='d-none d-md-table-cell'
-                            t-att-class="'text-danger' if invoice.invoice_date_due &lt; datetime.date.today() and invoice.payment_state in ['not_paid', 'partial'] else ''">
+                            t-att-class="'text-danger' if invoice.invoice_date_due and invoice.invoice_date_due &lt; datetime.date.today() and invoice.payment_state in ['not_paid', 'partial'] else ''">
                             <span t-field="invoice.invoice_date_due"/>
                         </td>
                         <td class="text-end pe-3"><span t-out="-invoice.amount_residual if invoice.move_type == 'out_refund' else invoice.amount_residual" t-options='{"widget": "monetary", "display_currency": invoice.currency_id}'/></td>


### PR DESCRIPTION
Currently, an error occurs when opening a portal view of invoices and any invoice has no 'Due Date'

Step to produce:

- Install the ```account``` module.
- Create a new invoice, add a customer name and an invoice line, then save the record.
- After that, remove the 'Payment terms' and confirm the invoice.
- Then Remove a 'Due Date' and save a record.
- Go to portal view and try to open 'Your Invoices',

```TypeError: '<' not supported between instances of 'bool' and 'datetime.date'```

An error occurs when the system tries to compare an invoice's due date with today's date at [1], but the due date is missing.

Link [1]: https://github.com/odoo/odoo/blob/1615bdb7e52e5ad501922568a1baaee4fd07a4b7/addons/account/views/account_portal_templates.xml#L72

To resolve this issue, add a condition to skip the comparison between the invoice's due date and today's date, if the due date of invoice is unavailable.

Sentry-6016842018

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
