### PR TITLE
[IMP] website,website_sale: make signup form editable

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -205,6 +205,7 @@
         'views/website_pages_views.xml',
         'views/website_controller_pages_views.xml',
         'views/website_visitor_views.xml',
+        'views/website_signup_form.xml',
         'views/res_config_settings_views.xml',
         'views/website_rewrite.xml',
         'views/ir_actions_server_views.xml',

--- a/addons/website/controllers/form.py
+++ b/addons/website/controllers/form.py
@@ -2,10 +2,12 @@
 
 import base64
 import json
+import contextlib
 
 from markupsafe import Markup
 from psycopg2 import IntegrityError
 import re
+import werkzeug
 from werkzeug.exceptions import BadRequest
 
 from odoo import http, SUPERUSER_ID
@@ -15,6 +17,7 @@ from odoo.tools import BinaryBytes, plaintext2html
 from odoo.exceptions import AccessDenied, ValidationError, UserError
 from odoo.tools.misc import hmac, consteq
 from odoo.tools.translate import _, LazyTranslate
+from odoo.addons.auth_signup.controllers.main import AuthSignupHome
 
 _lt = LazyTranslate(__name__)
 
@@ -326,3 +329,137 @@ class WebsiteForm(http.Controller):
             # attach the custom binary field files on the attachment_ids field.
             for attachment_id_id in orphan_attachment_ids:
                 record.attachment_ids = [(4, attachment_id_id)]
+
+
+class WebsiteAuthSignupHome(AuthSignupHome):
+
+    @http.route()
+    def web_auth_signup(self, *args, **kwargs):
+        """
+        Override to handle the signup form submitted via the website form
+        builder.
+
+        Returns a JSON response that the JavaScript form handler uses to process
+        the result (redirect on success, display inline errors on failure).
+
+        Custom fields (i.e., fields not defined on ``res.users``) are logged as
+        chatter messages on the related ``res.partner`` record.
+        """
+        response = super().web_auth_signup(*args, **kwargs)
+
+        if "error" in response.qcontext:
+            error_data = response.qcontext.get("error")
+            if isinstance(error_data, str):
+                with contextlib.suppress(json.JSONDecodeError):
+                    error_data = json.loads(error_data)
+            return request.make_response(
+                json.dumps({"error": error_data}),
+                headers=[("Content-Type", "application/json")],
+            )
+
+        login = kwargs.get("login")
+        User = self.env['res.users']
+        user = User.search(User._get_login_domain(login), limit=1)
+        if not user:
+            return response
+
+        # Prepare and log a message for fields not present in the `res.users`.
+        partner = user.partner_id
+        message_body, attachment_vals_list = self._prepare_message_for_non_existing_field(partner, kwargs)
+
+        attachment_ids = []
+        if attachment_vals_list:
+            attachment_ids = self.env["ir.attachment"].sudo().create(attachment_vals_list).ids
+
+        if message_body or attachment_ids:
+            partner._message_log(
+                body=message_body,
+                attachment_ids=[(6, 0, attachment_ids)] if attachment_ids else [],
+                message_type="comment",
+            )
+
+        return request.make_response(
+            json.dumps({"id": user.id}),
+            headers=[("Content-Type", "application/json")]
+        )
+
+    def _prepare_signup_values(self, qcontext):
+        """
+        Extend the signup value preparation:
+        - Update existing user fields with the values submitted by the user.
+
+        :param dict qcontext: the signup form context
+        :returns: dict of values ready to update a `res.users` record
+        :raises UserError: if a non-image file is provided for an image field
+        """
+        values = super()._prepare_signup_values(qcontext)
+
+        # This method is also called when the user is redirected to the reset
+        # password page. In that case, we do not want to update the values.
+        if request.httprequest.path == "/web/reset_password":
+            return values
+
+        existing_fields = self.env["res.users"]._fields
+        filtered_params = {}
+        for key, value in request.params.items():
+            if isinstance(value, werkzeug.datastructures.FileStorage):
+                # Normalize the key to remove any indexing (e.g.,
+                # image_1920[0][0] → image_1920/image_1024[0][0] → image_1024).
+                normalized_key = key.split('[')[0]
+                if existing_fields.get(normalized_key):
+                    if not value.mimetype.startswith("image/"):
+                        raise UserError(_("Only image files are allowed."))
+                    filtered_params[normalized_key] = base64.b64encode(value.read()).decode("utf-8")
+
+            field = existing_fields.get(key)
+            if field:
+                if field.type in ("many2many", "one2many"):
+                    filtered_params[key] = [int(v) for v in str(value).split(",") if v]
+                else:
+                    filtered_params[key] = value
+        values.update(filtered_params)
+        return values
+
+    def _prepare_message_for_non_existing_field(self, partner, kwargs):
+        """Prepare the message body and attachment values for fields in kwargs
+        that do not exist on res.users model.
+
+        :param partner: current user's res.partner record
+        :param kwargs: dict of form values
+        :returns: tuple (Markup body, list of attachments value dicts)
+        """
+        existing_fields = set(self.env["res.users"]._fields.keys())
+        text_fields = {}
+        attachment_vals_list = []
+
+        for key, value in kwargs.items():
+            if key == "confirm_password":
+                continue
+            if isinstance(value, werkzeug.datastructures.FileStorage):
+                # Normalize key to remove index pattern
+                # (e.g., 'image_1920[0][0]' → 'image_1920').
+                normalized_key = key.split('[')[0]
+                if normalized_key not in existing_fields:
+                    attachment_vals_list.append({
+                        "name": value.filename,
+                        "raw": BinaryBytes(value.read()),
+                        "res_model": "res.partner",
+                        "res_id": partner.id,
+                        "mimetype": value.content_type,
+                    })
+            elif key not in existing_fields:
+                text_fields[key] = value
+
+        # Build message body.
+        message_body = Markup("")
+        if text_fields:
+            items = Markup().join(
+                Markup("<li><strong>%s:</strong> %s</li>") % (key, value)
+                for key, value in text_fields.items()
+            )
+            message_body += Markup("<p><strong>%s</strong></p><ul>%s</ul>") % (
+                _("Other Information:"), items
+            )
+        if attachment_vals_list:
+            message_body += Markup("<p><strong>📎 %s</strong></p>") % _("Attachment Files")
+        return message_body, attachment_vals_list

--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -201,7 +201,8 @@ export class FormOptionPlugin extends Plugin {
         so_content_addition_selectors: [".s_website_form"],
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
         on_cloned_handlers: this.onCloned.bind(this),
-        is_unremovable_selectors: ".s_website_form_send, .s_website_form_submit",
+        is_unremovable_selectors:
+            ".s_website_form_send, .s_website_form_submit, .s_website_form_field:has(#confirm_password)",
         immutable_link_selectors: [".s_website_form_send"],
     };
     setup() {

--- a/addons/website/static/src/builder/plugins/form/utils.js
+++ b/addons/website/static/src/builder/plugins/form/utils.js
@@ -249,7 +249,7 @@ export function setActiveProperties(fieldEl, field) {
     const classList = fieldEl.classList;
     const textarea = fieldEl.querySelector("textarea");
     const input = fieldEl.querySelector(
-        'input[type="text"], input[type="email"], input[type="number"], input[type="tel"], input[type="url"], textarea'
+        "input[type='text'], input[type='email'], input[type='number'], input[type='tel'], input[type='url'], textarea, input[type='password']"
     );
     const fileInputEl = fieldEl.querySelector("input[type=file]");
     const selectInputEl = fieldEl.querySelector("select");

--- a/addons/website/static/src/builder/plugins/options/website_signup_form_option.xml
+++ b/addons/website/static/src/builder/plugins/options/website_signup_form_option.xml
@@ -1,0 +1,9 @@
+<templates>
+
+    <t t-inherit="website.s_website_form_form_option" t-inherit-mode="extension">
+        <xpath expr="//BuilderRow[@label.translate=&quot;On Success&quot;]" position="attributes">
+            <attribute name="t-if">this.formId !== 'o_signup_form'</attribute>
+        </xpath>
+    </t>
+
+</templates>

--- a/addons/website/static/src/scss/website.ui.scss
+++ b/addons/website/static/src/scss/website.ui.scss
@@ -85,7 +85,7 @@ body {
 }
 
 // LOGIN FORM
-.oe_login_form, .oe_signup_form, .oe_reset_password_form {
+.oe_login_form, .oe_reset_password_form {
     max-width: 300px;
     position: relative;
     margin: 50px auto;

--- a/addons/website/static/src/snippets/s_website_form/form.js
+++ b/addons/website/static/src/snippets/s_website_form/form.js
@@ -416,12 +416,16 @@ export class Form extends Interaction {
             formData.append(key, value);
         }
 
+        // The reason for using customUrlSubmit is that, in certain cases, the
+        // form URL needs to target a specific custom controller route. In such
+        // scenarios, the form action should remain unchanged. For example,
+        // the signup form should always submit to the `/web/signup` route.
+        const baseAction = this.el.getAttribute("action");
+        const actionUrl = this.el.dataset.customUrlSubmit
+            ? baseAction
+            : baseAction + (this.el.dataset.force_action || this.el.dataset.model_name);
         // Post form and handle result
-        return post(
-            this.el.getAttribute("action") +
-                (this.el.dataset.force_action || this.el.dataset.model_name),
-            formData
-        )
+        return post(actionUrl, formData)
             .then(async (resultData) => {
                 if (!resultData.id) {
                     // Failure, the server didn't return the created record ID

--- a/addons/website/static/src/xml/website_form_editor.xml
+++ b/addons/website/static/src/xml/website_form_editor.xml
@@ -381,6 +381,29 @@
         </t>
     </t>
 
+    <!-- Password Field -->
+    <t t-name="website.form_field_password">
+        <t t-call="website.form_field">
+            <div class="input-group mb-1">
+                <input
+                    type="password"
+                    class="form-control s_website_form_input"
+                    t-att-name="field.name"
+                    t-att-required="field.required || field.modelRequired || None"
+                    t-att-value="field.value"
+                    t-att-placeholder="field.placeholder"
+                    t-att-data-fill-with="field.fillWith"
+                    t-att-autocapitalize="off"
+                    t-att-autocomplete="off"
+                    t-att-id="field.id"
+                    />
+                <button type="button" class="btn btn-sm border border-start-0 o_show_password">
+                    <i class="fa fa-eye"/>
+                </button>
+            </div>
+        </t>
+    </t>
+
     <!-- Monetary Field -->
     <t t-name="website.form_field_monetary">
         <t t-call="website.form_field_float" />

--- a/addons/website/static/tests/interactions/snippets/signup_form.test.js
+++ b/addons/website/static/tests/interactions/snippets/signup_form.test.js
@@ -1,0 +1,127 @@
+import { expect, press, test } from "@odoo/hoot";
+import { animationFrame } from "@odoo/hoot-dom";
+import { contains, onRpc } from "@web/../tests/web_test_helpers";
+import {
+    defineWebsiteModels,
+    setupWebsiteBuilder,
+} from "@website/../tests/builder/website_helpers";
+
+defineWebsiteModels();
+
+const signupFormTemplate = `
+    <section class="s_website_form pt40 pb40" data-vcss="001" data-snippet="s_website_form" data-name="Form">
+        <div class="o_container_small">
+            <form action="/web/signup" method="post" enctype="multipart/form-data" class="oe_signup_form o_mark_required" data-mark="*" data-model_name="res.users" data-success-mode="redirect" data-success-page="/my" data-custom-url-submit="true">
+                <div class="s_website_form_rows row s_col_no_bgcolor">
+                    ${makeFormField({ type: "char", name: "name", label: "Name", required: true })}
+                    ${makeFormField({
+                        type: "char",
+                        name: "login",
+                        label: "Email",
+                    })}
+                    ${makeFormField({
+                        type: "password",
+                        name: "password",
+                        label: "Password",
+                    })}
+                    ${makeFormField({
+                        type: "password",
+                        name: "confirm_password",
+                        label: "Confirm Password",
+                        extraClasses: "s_website_form_custom",
+                    })}
+                    <div class="text-center s_website_form_submit d-grid pt-3">
+                        <a role="button" class="btn btn-primary s_website_form_send">Sign up</a>
+                        <span id="s_website_form_result"/>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </section>
+`;
+
+// Generates a standard form field HTML string.
+function makeFormField({ type, name, label, extraClasses = "" }) {
+    const inputType = type === "password" ? "password" : "text";
+    const extra = extraClasses ? `${extraClasses}` : "";
+    return `
+        <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_model_required ${extra}" data-type="${type}">
+            <div class="row s_col_no_resize s_col_no_bgcolor">
+                <label class="col-form-label col-sm-auto s_website_form_label" for="${name}">
+                    <span class="s_website_form_label_content">${label}</span>
+                    <span class="s_website_form_mark"> *</span>
+                </label>
+                <div class="col-sm">
+                    <input class="form-control s_website_form_input" type="${inputType}" name="${name}" required="required" id="${name}"/>
+                </div>
+            </div>
+        </div>`;
+}
+
+async function addNewField() {
+    await contains("div[data-container-title='Form'] button.btn-success").click();
+}
+
+async function changeFieldType(actionValue) {
+    await contains("[data-container-title='Field'] [data-label='Type'] .dropdown-toggle").click();
+    await contains(`.o_popover [data-action-value='${actionValue}']`).click();
+    await animationFrame();
+}
+
+const authorizedFieldsMock = {
+    zip: { name: "zip", type: "char", string: "Zip" },
+    city: { name: "city", type: "char", string: "City" },
+    country_id: {
+        name: "country_id",
+        type: "many2one",
+        relation: "res.country",
+        string: "Country",
+    },
+    company_ids: {
+        name: "company_ids",
+        type: "many2many",
+        relation: "res.company",
+        string: "Companies",
+    },
+};
+
+test("add custom fields to signup form via builder options", async () => {
+    onRpc("get_authorized_fields", () => authorizedFieldsMock);
+    await setupWebsiteBuilder(signupFormTemplate);
+
+    // Initially only the 4 required fields should be present
+    // (name, email, password, confirm password)
+    expect(":iframe .s_website_form_field").toHaveCount(4);
+
+    await contains(":iframe input#confirm_password").click();
+    const modelFields = [
+        { type: "zip", selector: ":iframe .s_website_form_input[name='zip']" },
+        { type: "city", selector: ":iframe .s_website_form_input[name='city']" },
+        { type: "country_id", selector: ":iframe .s_website_form_input[name='country_id']" },
+        { type: "company_ids", selector: ":iframe [name='company_ids']" },
+    ];
+    for (const { type, selector } of modelFields) {
+        await addNewField();
+        await changeFieldType(type);
+        expect(selector).toHaveCount(1);
+    }
+
+    // Add a binary field and check that it is properly rendered in the form
+    // with the correct label
+    await addNewField();
+    await changeFieldType("binary");
+    await contains("[data-action-id='setLabelText'] input").edit("file_1");
+    await press("Tab");
+    expect(":iframe span.s_website_form_label_content:contains('file_1')").toHaveCount(1);
+
+    // Add a char field and check that it is properly rendered in the form with
+    // the correct label
+    await addNewField();
+    await contains("[data-action-id='setLabelText'] input").edit("field_1");
+    await press("Tab");
+    expect(":iframe span.s_website_form_label_content:contains('field_1')").toHaveCount(1);
+
+    // In total we should have the 4 required fields + the 4 model fields + the
+    // 2 custom fields = 10 fields
+    expect(":iframe .s_website_form_field").toHaveCount(10);
+});

--- a/addons/website/tests/__init__.py
+++ b/addons/website/tests/__init__.py
@@ -43,3 +43,4 @@ from . import test_website_reset_password
 from . import test_website_visitor
 from . import test_website_technical_page
 from . import test_website_website_builder_assets_bundle
+from . import test_website_signup_form

--- a/addons/website/tests/test_website_signup_form.py
+++ b/addons/website/tests/test_website_signup_form.py
@@ -1,0 +1,50 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.tests import tagged, HttpCase
+
+
+@tagged('post_install', '-at_install')
+class TestWebsiteAuthSignupCustomFieldFlow(HttpCase):
+
+    def setUp(self):
+        super().setUp()
+        self.env['res.config.settings'].create({'auth_signup_uninvited': 'b2c'}).execute()
+
+    def test_website_auth_signup_custom_field(self):
+        self.authenticate(None, None)
+        country_in = self.env.ref('base.in')
+        self.url_open('/web/signup', data={
+            'name': 'odoo_bot',
+            'login': 'odoo@odoo.com',
+            'password': '123456789',
+            'confirm_password': '123456789',
+            'zip': '380006',
+            'city': 'Gandhinagar',
+            'country_id': str(country_in.id),
+            'field_1': 'this_is_the_text_of_field_1',
+            'csrf_token': self.csrf_token(),
+        }, files=[
+            ('file_1[0][0]', ('image.png', b'fake_file_content', 'image/png')),
+        ])
+
+        # Retrieve the partner created from signup
+        partner = self.env['res.partner'].search(
+            [('name', '=', 'odoo_bot')], limit=1
+        )
+
+        # Verify that whitelisted fields are correctly saved on the partner
+        self.assertTrue(partner, "Partner 'odoo_bot' should exist")
+        self.assertEqual(partner.zip, '380006')
+        self.assertEqual(partner.city, 'Gandhinagar')
+        self.assertEqual(partner.country_id, country_in)
+
+        # Verify that custom text field is logged in the chatter
+        self.assertIn(
+            'this_is_the_text_of_field_1',
+            ''.join(partner.message_ids.mapped('body')),
+        )
+
+        # Verify that the uploaded file is stored as an attachment in chatter
+        self.assertIn(
+            'image.png',
+            partner.message_ids.mapped('attachment_ids.name'),
+        )

--- a/addons/website/views/website_signup_form.xml
+++ b/addons/website/views/website_signup_form.xml
@@ -1,0 +1,75 @@
+<odoo>
+    <template id="website.website_signup_form_field" name="SignUp Form">
+
+        <div data-name="Field" class="s_website_form_field mb-3 s_website_form_model_required field-name col-lg-8 offset-lg-2" data-type="char">
+            <label class="s_website_form_label o_not_editable" for="name">
+                <span class="s_website_form_label_content">Name</span>
+                <span class="s_website_form_mark"> *</span>
+            </label>
+            <input class="form-control s_website_form_input" type="text" name="name" placeholder="John Doe" data-fill-with="name" t-att-value="name" autofocus="autofocus" id="name" autocapitalize="off" autocomplete="off" required="required"/>
+        </div>
+
+        <div data-name="Field" class="s_website_form_field mb-3 s_website_form_model_required field-login col-lg-8 offset-lg-2" data-type="char">
+            <label class="s_website_form_label o_not_editable" for="login">
+                <span class="s_website_form_label_content">Email</span>
+                <span class="s_website_form_mark"> *</span>
+            </label>
+            <input class="form-control s_website_form_input" type="text" name="login" placeholder="name@example.com" data-fill-with="login" t-att-value="login" id="login" autocapitalize="off" autocomplete="off" required="required"/>
+        </div>
+
+        <div data-name="Field" class="s_website_form_field mb-3 s_website_form_model_required field-password o_caps_lock_warning col-lg-8 offset-lg-2" data-type="password">
+            <label class="s_website_form_label o_not_editable" for="password">
+                <span class="s_website_form_label_content">Password</span>
+                <span class="s_website_form_mark"> *</span>
+            </label>
+            <div class="input-group mb-1">
+                <input class="form-control s_website_form_input" type="password" name="password" placeholder="••••••••••" data-fill-with="password" t-att-value="password" id="password" autocapitalize="off" autocomplete="off" required="required"/>
+                <button type="button" class="btn btn-sm border border-start-0 o_show_password">
+                    <i class="fa fa-eye"/>
+                </button>
+            </div>
+        </div>
+
+        <div data-name="Field" class="s_website_form_field mb-3 s_website_form_model_required field-confirm_password s_website_form_custom col-lg-8 offset-lg-2" data-type="password">
+            <label class="s_website_form_label o_not_editable col-form-label" for="confirm_password">
+                <span class="s_website_form_label_content">Confirm Password</span>
+                <span class="s_website_form_mark"> *</span>
+            </label>
+            <div class="input-group mb-1">
+                <input class="form-control s_website_form_input" type="password" name="confirm_password" placeholder="••••••••••" data-fill-with="confirm_password" t-att-value="confirm_password" id="confirm_password" autocapitalize="off" autocomplete="off" required="required"/>
+                <button type="button" class="btn btn-sm border border-start-0 o_show_password">
+                    <i class="fa fa-eye"/>
+                </button>
+            </div>
+        </div>
+    </template>
+
+    <template id="website_signup" inherit_id="auth_signup.signup">
+        <xpath expr="//form[hasclass('oe_signup_form')]" position="replace">
+            <section class="s_website_form pt40 pb40 oe_unremovable" data-vcss="001" data-snippet="s_website_form" data-name="Form" t-ignore="True">
+                <div class="o_container_small">
+                    <form id="o_signup_form" class="oe_signup_form o_mark_required" action="/web/signup" data-model_name="res.users" data-success-mode="redirect" data-mark="*" data-success-page="/my" hide-change-model="true" data-custom-url-submit="true">
+                        <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                        <div class="s_website_form_rows row s_col_no_bgcolor">
+
+                            <t t-call="website.website_signup_form_field" />
+
+                            <p class="alert alert-danger" t-if="error" role="alert">
+                                <t t-out="error"/>
+                            </p>
+                            <input type="hidden" name="redirect" t-att-value="redirect"/>
+                            <input type="hidden" name="token" t-att-value="token"/>
+                            <div class="text-center oe_login_buttons s_website_form_submit d-grid pt-3 col-lg-8 offset-lg-2">
+                                <a role="button" class="btn btn-primary s_website_form_send oe_unremovable"> Sign up</a>
+                                <a t-attf-href="/web/login?{{ keep_query() }}" class="btn btn-link btn-sm" role="button">Already have an account?</a>
+                                <div class="o_login_auth mb-1"/>
+                                <span id="s_website_form_result"/>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </section>
+        </xpath>
+    </template>
+
+</odoo>

--- a/addons/website_sale/static/tests/tours/complete_flow.js
+++ b/addons/website_sale/static/tests/tours/complete_flow.js
@@ -133,7 +133,7 @@ registry.category("web_tour.tours").add('website_sale.complete_flow_1', {
         },
         {
             content: "Submit login",
-            trigger: `.oe_signup_form button[type="submit"]`,
+            trigger: ".s_website_form_send",
             run: "click",
             expectUnloadPage: true,
         },


### PR DESCRIPTION
The signup form is now editable, letting users add custom fields easily. Existing fields are stored in `res_users`, while custom fields are logged in the chatter of `res.partner`, enhancing traceability and customization.

Key changes:
1. Allow adding both custom and existing fields.
2. Enable field position changes and duplication for custom fields.
3. Treat Name, Email, and Password as technical fields and confirm password as non-technical field—these are restricted and cannot be deleted.
4. User cannot change the action button of the signup form.
5. Log custom fields as comments in the `res.partner` model.
6. Hide the `On Success` button and `URL` input from the form.

task-3857565