### PR TITLE
[FIX] website_*: fix bad `key` argument of `sorted`

### DIFF
--- a/addons/website_customer/controllers/main.py
+++ b/addons/website_customer/controllers/main.py
@@ -84,9 +84,9 @@ class WebsiteCustomer(GoogleMap):
 
         if industry:
             domain.append(('industry_id', '=', industry.id))
-            if industry.id not in (ind.id for ind, __ in industry_groups) and industry.exists():
+            if not any(ind.id == industry.id for ind, __ in industry_groups) and industry.exists():
                 industry_groups.append((industry, 0))
-                industry_groups = sorted(industry_groups, key=lambda i, __: i.name or '')
+                industry_groups = sorted(industry_groups, key=lambda group: group[0].name or '')
 
         industries = [{
             'industry_id_count': sum(count for __, count, in industry_groups),

--- a/addons/website_membership/controllers/main.py
+++ b/addons/website_membership/controllers/main.py
@@ -72,7 +72,7 @@ class WebsiteMembership(http.Controller):
             if not any(country.id == country_id for country, __ in country_groups):
                 country_groups = [(g_country, count) for g_country, count in country_groups if g_country]
                 country_groups.append((Country.browse(country_id).sudo(), 0))
-                country_groups = sorted(country_groups, key=lambda c, __: c.name or '')
+                country_groups = sorted(country_groups, key=lambda group: group[0].name or '')
 
         countries = [{
             'country_id_count': sum(count for __, count in country_groups),


### PR DESCRIPTION
f11880d38b43e8bca8ff2fbf20c26182eb90809d introduced two similar bugs: We get a traceback when using links like
"/customers/industry/<name-industry>" where the industry isn't linked to any contact (same for "/members/association/<membership_id>").

The origin of the traceback is that the key argument of the sorted call takes only one argument (a tuple of 2 elements) instead of trying to deconstruct the group directly in the arguments...
