### PR TITLE
[FIX] stock: fix traceback when  filtering through on hand in quants

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -178,8 +178,9 @@ class StockQuant(models.Model):
 
     def _search(self, domain, *args, **kwargs):
         domain = [
-            line if not isinstance(line, (list, tuple)) or not line[0].startswith('lot_properties.')
-            else ['lot_id', 'any', [line]]
+            ['lot_id', 'any', [line]]
+            if line and isinstance(line, (list, tuple)) and isinstance(line[0], str) and line[0].startswith('lot_properties.')
+            else line
             for line in domain
         ]
         return super()._search(domain, *args, **kwargs)


### PR DESCRIPTION
A traceback occurs when the user tries to filter stock quants by on-hand, 
if there is no warehouse.

To reproduce this issue:

1) Install stock without demo
2) Archive the warehouse
3) Open physical Inventory from operations
4) Filter it through `On-Hand` through the Toggle Search Panel

Error:-
```
AttributeError: 'int' object has no attribute 'startswith'
```

When the user archived the warehouse, we get the `domain_loc` as `[(0, '=', 1)]` at line [2].
This is because there is no location, as the location is derived from the warehouse.

If there is no location, it returns three times of`[(0, '=', 1)]` from [1]

[1]
https://github.com/odoo/odoo/blob/9ce9c6d0d815dcf8fd97fdab484872a607579bd5/addons/stock/models/product.py#L309-L310

[2]
https://github.com/odoo/odoo/blob/9ce9c6d0d815dcf8fd97fdab484872a607579bd5/addons/stock/models/stock_quant.py#L240-L241

This leads to the above traceback when `startswith` is used on the first value of the domain which is an integer.

https://github.com/odoo/odoo/blob/9ce9c6d0d815dcf8fd97fdab484872a607579bd5/addons/stock/models/stock_quant.py#L180-L184

sentry-6016230486
