### PR TITLE
[FIX] microsoft_calendar: add missing argument 'service'

### DIFF
--- a/addons/microsoft_calendar/models/res_users.py
+++ b/addons/microsoft_calendar/models/res_users.py
@@ -32,7 +32,7 @@ class User(models.Model):
 
         self.ensure_one()
         if self.sudo().microsoft_calendar_rtoken and not self._is_microsoft_calendar_valid():
-            self._refresh_microsoft_calendar_token()
+            self._refresh_microsoft_calendar_token(service=False)
         return self.sudo().microsoft_calendar_token
 
     def _is_microsoft_calendar_valid(self):


### PR DESCRIPTION
When the user tries to synchronize calendar with Outlook calendar,
a traceback will appear.

Traceback:
```
TypeError: User._refresh_microsoft_calendar_token() missing 1 required positional argument: 'service'
  File "odoo/http.py", line 2363, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1891, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1954, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 137, in retrying
    result = func()
  File "odoo/http.py", line 1921, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2168, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 329, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 727, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/microsoft_calendar/controllers/main.py", line 45, in microsoft_calendar_sync_data
    need_refresh = request.env.user.sudo().with_context(dont_notify=True)._sync_microsoft_calendar()
  File "addons/microsoft_calendar/models/res_users.py", line 105, in _sync_microsoft_calendar
    with microsoft_calendar_token(self) as token:
  File "contextlib.py", line 137, in __enter__
    return next(self.gen)
  File "addons/microsoft_calendar/models/microsoft_sync.py", line 52, in microsoft_calendar_token
    yield user._get_microsoft_calendar_token()
  File "addons/microsoft_calendar/models/res_users.py", line 35, in _get_microsoft_calendar_token
    self._refresh_microsoft_calendar_token()
```

https://github.com/odoo/odoo/blob/88fa5a113debfbf65f9b0862b14c15ef4da45d12/addons/microsoft_calendar/models/res_users.py#L35
Here, ``_refresh_microsoft_calendar_token`` method is called without ``service`` argument.

https://github.com/odoo/odoo/blob/88fa5a113debfbf65f9b0862b14c15ef4da45d12/addons/microsoft_calendar/models/res_users.py#L41
Here, the ``service`` argument is added but not used anywhere.

sentry-6026445994

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
