### PR TITLE
[FIX] base_import: omit empty lines from file_length

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -1057,7 +1057,7 @@ class Import(models.TransientModel):
                 'advanced_mode': advanced_mode,
                 'debug': self.user_has_groups('base.group_no_one'),
                 'batch': batch,
-                'file_length': file_length
+                'file_length': len(rows),
             }
         except Exception as error:
             # Due to lazy generators, UnicodeDecodeError (for


### PR DESCRIPTION
**Current behavior:**
Creating an import file with enough blank rows to require import via batches will cause duplicate records from previous batches.

**Expected behavior:**
No duplicates.

**Steps to reproduce:**
*E.g., `-i contacts`*
1. Create a csv file with a partner record on row 1 (or 2 if using headers, just the name is enough for `res.partner`) and another record on row 2002 or higher

2. From contacts action button, select import records, upload the csv from step 1, import

3. See that the 2 records were imported 2x each

**Cause of the issue:**
When the `file_length` (literal number of lines) is big enough to require batches, but the actual number of rows with data is not, the upload mechanism will try to (in the case described here) upload 2 batches of records.

But because there isn't actually a full batch of records, the second batch will just be the same as the first (second batch starts from row 0 "bookmark", because all the data rows were processed in their entirety in the first batch).

**Fix:**
Make `file_length` returned by the server to client the length of the actual data rows parsed from the file, as opposed to the literal number of lines.

opw-4271105