### PR TITLE
[FIX] web: eslint on hoot .test.js files

### DIFF
--- a/addons/web/static/tests/core/name_and_signature.test.js
+++ b/addons/web/static/tests/core/name_and_signature.test.js
@@ -86,7 +86,8 @@ test("test name_and_signature widget default signature", async function () {
     const props = {
         signature: {
             name: "Brandon Freeman",
-            signatureImage: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+BCQAHBQICJmhD1AAAAABJRU5ErkJggg==",
+            signatureImage:
+                "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+BCQAHBQICJmhD1AAAAABJRU5ErkJggg==",
         },
         mode: "draw",
         signatureType: "signature",
@@ -94,5 +95,4 @@ test("test name_and_signature widget default signature", async function () {
     };
     const res = await mountWithCleanup(NameAndSignature, { props });
     expect(res.isSignatureEmpty).toBe(false);
-
 });

--- a/addons/web/static/tests/core/network/rpc.test.js
+++ b/addons/web/static/tests/core/network/rpc.test.js
@@ -143,5 +143,5 @@ test("rpc can send additional headers", async () => {
         });
         return { result: true };
     });
-    await rpc("/test/", null, { headers: { Hello: 'World' } });
+    await rpc("/test/", null, { headers: { Hello: "World" } });
 });

--- a/addons/web/static/tests/core/record_selectors/multi_record_selector.test.js
+++ b/addons/web/static/tests/core/record_selectors/multi_record_selector.test.js
@@ -254,7 +254,7 @@ test.tags("desktop")("Can pass domain to search more", async () => {
         { id: 6, name: "Frank" },
         { id: 7, name: "Grace" },
         { id: 8, name: "Helen" },
-        { id: 9, name: "Ivy" },
+        { id: 9, name: "Ivy" }
     );
     Partner._views["list,false"] = /* xml */ `<list><field name="name"/></list>`;
     Partner._views["search,false"] = /* xml */ `<search/>`;

--- a/addons/web/static/tests/core/select_menu.test.js
+++ b/addons/web/static/tests/core/select_menu.test.js
@@ -1155,7 +1155,7 @@ test("Fetch choices", async () => {
             this.state = useState({ choices: [] }, { value: "" });
         }
         loadChoice(searchString) {
-            if (searchString === 'test') {
+            if (searchString === "test") {
                 this.state.choices = [{ label: "test", value: "test" }];
             } else {
                 this.state.choices = [];

--- a/addons/web/static/tests/search/action_menus.test.js
+++ b/addons/web/static/tests/search/action_menus.test.js
@@ -9,7 +9,7 @@ import {
 } from "../web_test_helpers";
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { queryAllTexts } from "@odoo/hoot-dom";
-import {registry} from "@web/core/registry";
+import { registry } from "@web/core/registry";
 
 /** Foo is dummy model to test `action.report` with domain of its field `value`. **/
 class Foo extends models.Model {

--- a/addons/web/static/tests/views/fields/percent_pie_field.test.js
+++ b/addons/web/static/tests/views/fields/percent_pie_field.test.js
@@ -130,11 +130,13 @@ test("hide the string when the PercentPieField widget is used in the view", asyn
     expect(".o_field_percent_pie.o_field_widget .o_pie_info .o_pie_text").not.toBeVisible();
 });
 
-test.tags("desktop")("show the string when the PercentPieField widget is used in a button with the class oe_stat_button", async () => {
-    await mountView({
-        type: "form",
-        resModel: "partner",
-        arch: /* xml */ `
+test.tags("desktop")(
+    "show the string when the PercentPieField widget is used in a button with the class oe_stat_button",
+    async () => {
+        await mountView({
+            type: "form",
+            resModel: "partner",
+            arch: /* xml */ `
                <form>
                     <div name="button_box" class="oe_button_box">
                         <button type="object" class="oe_stat_button">
@@ -142,9 +144,10 @@ test.tags("desktop")("show the string when the PercentPieField widget is used in
                         </button>
                     </div>
                 </form>`,
-        resId: 1,
-    });
+            resId: 1,
+        });
 
-    expect(".o_field_percent_pie.o_field_widget .o_pie").toHaveCount(1);
-    expect(".o_field_percent_pie.o_field_widget .o_pie_info .o_pie_text").toBeVisible();
-});
+        expect(".o_field_percent_pie.o_field_widget .o_pie").toHaveCount(1);
+        expect(".o_field_percent_pie.o_field_widget .o_pie_info .o_pie_text").toBeVisible();
+    }
+);

--- a/addons/web/static/tests/views/fields/stat_info_field.test.js
+++ b/addons/web/static/tests/views/fields/stat_info_field.test.js
@@ -96,12 +96,14 @@ test.tags("mobile")("StatInfoField in form view on mobile", async () => {
     });
 });
 
-test.tags("desktop")("StatInfoField in form view with specific label_field on desktop", async () => {
-    await mountView({
-        type: "form",
-        resModel: "partner",
-        resId: 1,
-        arch: /* xml */ `
+test.tags("desktop")(
+    "StatInfoField in form view with specific label_field on desktop",
+    async () => {
+        await mountView({
+            type: "form",
+            resModel: "partner",
+            resId: 1,
+            arch: /* xml */ `
             <form>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
@@ -115,18 +117,19 @@ test.tags("desktop")("StatInfoField in form view with specific label_field on de
                 </sheet>
             </form>
         `,
-    });
+        });
 
-    expect("button.oe_stat_button .o_field_widget .o_stat_info").toHaveCount(1, {
-        message: "should have one stat button",
-    });
-    expect("button.oe_stat_button .o_field_widget .o_stat_value").toHaveText("10", {
-        message: "should have 10 as value",
-    });
-    expect("button.oe_stat_button .o_field_widget .o_stat_text").toHaveText("yop", {
-        message: "should have 'yop' as text, since it is the value of field foo",
-    });
-});
+        expect("button.oe_stat_button .o_field_widget .o_stat_info").toHaveCount(1, {
+            message: "should have one stat button",
+        });
+        expect("button.oe_stat_button .o_field_widget .o_stat_value").toHaveText("10", {
+            message: "should have 10 as value",
+        });
+        expect("button.oe_stat_button .o_field_widget .o_stat_text").toHaveText("yop", {
+            message: "should have 'yop' as text, since it is the value of field foo",
+        });
+    }
+);
 
 test.tags("mobile")("StatInfoField in form view with specific label_field on mobile", async () => {
     await mountView({

--- a/addons/web/static/tests/views/widgets/document_link.test.js
+++ b/addons/web/static/tests/views/widgets/document_link.test.js
@@ -1,4 +1,10 @@
-import { defineModels, fields, models, mountView, mountWithCleanup } from "@web/../tests/web_test_helpers";
+import {
+    defineModels,
+    fields,
+    models,
+    mountView,
+    mountWithCleanup,
+} from "@web/../tests/web_test_helpers";
 import { Component, xml } from "@odoo/owl";
 import { expect, test } from "@odoo/hoot";
 import { DocumentationLink } from "@web/views/widgets/documentation_link/documentation_link";


### PR DESCRIPTION
Since the creation of v18, the JavaScript tooling wasn't enabled.
The tooling was enabled in commit[1]. In this commit, we applied a
manual eslint pass inside the "web/static/tests" directory to ensure we
have well-formatted .test.js files.

```
eslint '**/web/static/tests/**/*.js' --fix
```

[1]: https://github.com/odoo/odoo/commit/f3407c392d4e7595e9a299662115df03bacbd41c