### PR TITLE
[IMP] html_editor: add toggle block

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -61,7 +61,7 @@ import { compareListTypes } from "@html_editor/main/list/utils";
 export class DeletePlugin extends Plugin {
     static dependencies = ["baseContainer", "selection", "history", "input"];
     static id = "delete";
-    static shared = ["deleteRange", "deleteSelection", "delete"];
+    static shared = ["deleteBackward", "deleteForward", "deleteRange", "deleteSelection", "delete"];
     resources = {
         user_commands: [
             { id: "deleteBackward", run: () => this.delete("backward", "character") },

--- a/addons/html_editor/static/src/main/banner_plugin.js
+++ b/addons/html_editor/static/src/main/banner_plugin.js
@@ -75,6 +75,8 @@ export class BannerPlugin extends Plugin {
         ],
         power_buttons_visibility_predicates: ({ anchorNode }) =>
             !closestElement(anchorNode, ".o_editor_banner"),
+        move_node_blacklist_selectors: ".o_editor_banner *",
+        move_node_whitelist_selectors: ".o_editor_banner",
     };
 
     setup() {

--- a/addons/html_editor/static/src/main/column_plugin.js
+++ b/addons/html_editor/static/src/main/column_plugin.js
@@ -85,6 +85,7 @@ export class ColumnPlugin extends Plugin {
         unremovable_node_predicates: isUnremovableColumn,
         power_buttons_visibility_predicates: ({ anchorNode }) =>
             !closestElement(anchorNode, ".o_text_columns"),
+        move_node_whitelist_selectors: ".o_text_columns",
     };
 
     columnize({ numberOfColumns, addParagraphAfter = true } = {}) {

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -129,6 +129,7 @@ export class ListPlugin extends Plugin {
         format_selection_overrides: this.applyFormatToListItem.bind(this),
         set_tag_overrides: this.handleListStylePosition.bind(this),
         node_to_insert_processors: this.processNodeToInsert.bind(this),
+        move_node_whitelist_selectors: "ol, ul",
     };
 
     setup() {

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -109,6 +109,7 @@ export class TablePlugin extends Plugin {
             node.nodeName === "TABLE" || tableInnerComponents.has(node.nodeName),
         fully_selected_node_predicates: (node) => !!closestElement(node, ".o_selected_td"),
         traversed_nodes_processors: this.adjustTraversedNodes.bind(this),
+        move_node_whitelist_selectors: "table",
     };
 
     setup() {

--- a/addons/html_editor/static/src/others/embedded_component_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_component_plugin.js
@@ -22,6 +22,7 @@ export class EmbeddedComponentPlugin extends Plugin {
         serializable_descendants_processors: this.processDescendantsToSerialize.bind(this),
         attribute_change_processors: this.onChangeAttribute.bind(this),
         savable_mutation_record_predicates: this.isMutationRecordSavable.bind(this),
+        move_node_whitelist_selectors: "[data-embedded]",
     };
 
     setup() {

--- a/addons/html_editor/static/src/others/embedded_components/core/toggle_block/toggle_block.js
+++ b/addons/html_editor/static/src/others/embedded_components/core/toggle_block/toggle_block.js
@@ -1,0 +1,57 @@
+import {
+    getEditableDescendants,
+    getEmbeddedProps,
+    useEditableDescendants,
+} from "@html_editor/others/embedded_component_utils";
+import { browser } from "@web/core/browser/browser";
+import { Component, useEffect, useExternalListener, useState } from "@odoo/owl";
+
+const sessionStorage = browser.sessionStorage;
+export class EmbeddedToggleBlockComponent extends Component {
+    static template = "html_editor.EmbeddedToggleBlock";
+    static props = {
+        host: { type: Object },
+        toggleBlockId: { type: String },
+    };
+
+    setup() {
+        useEditableDescendants(this.props.host);
+        this.state = useState({
+            showContent: sessionStorage.getItem(this.toggleStorageKey) === "true",
+        });
+        this.neutralRestoreSelection = () => {};
+        this.restoreSelection = this.neutralRestoreSelection;
+        useExternalListener(this.props.host, "forceToggle", this.onToggle);
+        useEffect(
+            () => {
+                this.restoreSelection();
+                this.restoreSelection = this.neutralRestoreSelection;
+            },
+            () => [this.restoreSelection]
+        );
+    }
+
+    get toggleStorageKey() {
+        return `html_editor.ToggleBlock${this.props.toggleBlockId}.showContent`;
+    }
+
+    onToggle(ev) {
+        let { showContent, restoreSelection } = ev.detail ?? {};
+        showContent ??= !this.state.showContent;
+        restoreSelection ??= this.neutralRestoreSelection;
+        if (this.state.showContent !== showContent) {
+            this.restoreSelection = restoreSelection;
+            this.state.showContent = showContent;
+            sessionStorage.setItem(this.toggleStorageKey, this.state.showContent);
+        } else {
+            restoreSelection();
+        }
+    }
+}
+
+export const toggleBlockEmbedding = {
+    name: "toggleBlock",
+    Component: EmbeddedToggleBlockComponent,
+    getProps: (host) => ({ host, ...getEmbeddedProps(host) }),
+    getEditableDescendants: getEditableDescendants,
+};

--- a/addons/html_editor/static/src/others/embedded_components/core/toggle_block/toggle_block.scss
+++ b/addons/html_editor/static/src/others/embedded_components/core/toggle_block/toggle_block.scss
@@ -1,0 +1,17 @@
+[data-embedded="toggleBlock"] {
+    [data-embedded-editable] > p {
+        margin: 0;
+    }
+    button:has(i.fa-caret-down, i.fa-caret-right){
+        cursor: pointer !important;
+        width: 1.5rem; // Equivalent to ps-4
+        aspect-ratio: 1 / 1;
+        background-color: transparent;
+        &:hover {
+            background-color: rgba($o-gray-300, 0.5);
+        }
+        &:active {
+            background-color: rgba($o-gray-300, 0.2);
+        }
+    }
+}

--- a/addons/html_editor/static/src/others/embedded_components/core/toggle_block/toggle_block.xml
+++ b/addons/html_editor/static/src/others/embedded_components/core/toggle_block/toggle_block.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <t t-name="html_editor.EmbeddedToggleBlock">
+       <div class="d-flex flex-row align-items-center">
+            <button class="btn p-0 border-0 align-items-center justify-content-center btn-light" t-on-click="onToggle">
+                <i t-attf-class="fa align-self-center fa-caret-{{this.state.showContent ? 'down' : 'right'}}"/>
+            </button>
+            <div class="flex-fill ms-1" t-ref="title"/>
+        </div>
+        <div class="ps-4 ms-1" t-att-class="{ 'd-none': !state.showContent }" t-ref="content"/>
+    </t>
+</templates>

--- a/addons/html_editor/static/src/others/embedded_components/embedding_sets.js
+++ b/addons/html_editor/static/src/others/embedded_components/embedding_sets.js
@@ -6,12 +6,14 @@ import {
     readonlyTableOfContentEmbedding,
     tableOfContentEmbedding,
 } from "@html_editor/others/embedded_components/core/table_of_content/table_of_content";
+import { toggleBlockEmbedding } from "@html_editor/others/embedded_components/core/toggle_block/toggle_block";
 import { videoEmbedding } from "@html_editor/others/embedded_components/core/video/video";
 
 export const MAIN_EMBEDDINGS = [
     excalidrawEmbedding,
     fileEmbedding,
     tableOfContentEmbedding,
+    toggleBlockEmbedding,
     videoEmbedding,
 ];
 
@@ -19,5 +21,6 @@ export const READONLY_MAIN_EMBEDDINGS = [
     readonlyExcalidrawEmbedding,
     readonlyFileEmbedding,
     readonlyTableOfContentEmbedding,
+    toggleBlockEmbedding,
     videoEmbedding,
 ];

--- a/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_blueprint.xml
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_blueprint.xml
@@ -1,0 +1,13 @@
+<templates>
+    <t t-name="html_editor.EmbeddedToggleBlockBlueprint">
+        <div data-embedded="toggleBlock"
+            data-oe-protected="true" contenteditable="false" t-att-data-embedded-props="embeddedProps">
+            <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
+                <t t-tag="baseContainerNodeName" t-att="baseContainerAttributes"><br/></t>
+            </div>
+            <div data-embedded-editable="content" data-oe-protected="false" contenteditable="true">
+                <t t-tag="baseContainerNodeName" t-att="baseContainerAttributes"><br/></t>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
@@ -1,0 +1,661 @@
+import { getEmbeddedProps } from "@html_editor/others/embedded_component_utils";
+import { Plugin } from "@html_editor/plugin";
+import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
+import { closestBlock } from "@html_editor/utils/blocks";
+import { removeClass } from "@html_editor/utils/dom";
+import { isEmptyBlock, isParagraphRelatedElement } from "@html_editor/utils/dom_info";
+import {
+    childNodes,
+    children,
+    closestElement,
+    firstLeaf,
+    lastLeaf,
+    selectElements,
+} from "@html_editor/utils/dom_traversal";
+import { parseHTML } from "@html_editor/utils/html";
+import { childNodeIndex, nodeSize } from "@html_editor/utils/position";
+import { withSequence } from "@html_editor/utils/resource";
+import { _t } from "@web/core/l10n/translation";
+import { renderToString } from "@web/core/utils/render";
+import { uuid } from "@web/views/utils";
+
+const toggleSelector = "[data-embedded='toggleBlock']";
+const titleSelector = "[data-embedded-editable='title']";
+const contentSelector = "[data-embedded-editable='content']";
+
+export class ToggleBlockPlugin extends Plugin {
+    static id = "toggleBlock";
+    static dependencies = [
+        "baseContainer",
+        "delete",
+        "dom",
+        "embeddedComponents", // toggle is an embedded component.
+        "hint", // needed to clean custom toggle hints.
+        "history",
+        "selection",
+        "split",
+    ];
+    resources = {
+        hints: [
+            withSequence(1, {
+                selector: `${toggleSelector} ${titleSelector} > *`,
+                text: _t("Toggle title"),
+            }),
+        ],
+        move_node_blacklist_selectors: `${toggleSelector} ${titleSelector} *`,
+        powerbox_items: [
+            {
+                commandId: "insertToggleBlock",
+                categoryId: "structure",
+            },
+        ],
+        shortcuts: [{ hotkey: "control+enter", commandId: "switchToggleBlockState" }],
+        user_commands: [
+            {
+                id: "insertToggleBlock",
+                title: _t("Toggle list"),
+                description: _t("Hide Text under foldable toggles"),
+                icon: "fa-caret-square-o-right",
+                isAvailable: (node) => !closestElement(node, `${toggleSelector} ${titleSelector}`),
+                run: () => {
+                    this.insertToggleBlock();
+                },
+            },
+            {
+                id: "switchToggleBlockState",
+                run: this.manageToggleFromTitle.bind(this),
+            },
+        ],
+
+        content_updated_handlers: [
+            withSequence(1, this.removeToggleContentHints.bind(this)),
+            withSequence(100, this.updateToggleContentHints.bind(this)),
+        ],
+        external_history_step_handlers: withSequence(100, () =>
+            this.updateToggleContentHints(this.editable)
+        ),
+        history_reset_from_steps_handlers: withSequence(100, () =>
+            this.updateToggleContentHints(this.editable)
+        ),
+        mount_component_handlers: this.setupNewToggle.bind(this),
+        normalize_handlers: this.normalize.bind(this),
+        selectionchange_handlers: [
+            withSequence(1, this.removeSelectedToggleContentHints.bind(this)),
+            withSequence(100, this.updateSelectedToggleContentHints.bind(this)),
+        ],
+        start_edition_handlers: () => this.updateToggleContentHints(this.editable),
+
+        delete_backward_overrides: this.handleDeleteBackward.bind(this),
+        delete_forward_overrides: this.handleDeleteForward.bind(this),
+        shift_tab_overrides: this.handleShiftTab.bind(this),
+        split_element_block_overrides: withSequence(1, this.handleSplitElementBlock.bind(this)),
+        tab_overrides: this.handleTab.bind(this),
+
+        power_buttons_visibility_predicates: this.showPowerButtons.bind(this),
+
+        before_insert_processors: this.handleInsert.bind(this),
+    };
+
+    setup() {
+        this.preventDeleteBackwardContentEnd = false;
+        this.selectedToggleEmptyContentSet = new Set();
+    }
+
+    applyEmptyContentHint(element) {
+        element.setAttribute("placeholder", _t("Add something inside this toggle"));
+        element.classList.add("o-we-hint");
+    }
+
+    explodeToggle(toggle) {
+        const title = toggle.querySelector(titleSelector);
+        const content = toggle.querySelector(contentSelector);
+        let contentChildren = children(content);
+        if (contentChildren.length === 1 && isEmptyBlock(contentChildren[0])) {
+            contentChildren = [];
+        }
+        toggle.replaceWith(...children(title), ...contentChildren);
+    }
+
+    forceToggle(toggle, { showContent, restoreSelection } = {}) {
+        toggle.dispatchEvent(
+            new CustomEvent("forceToggle", { detail: { showContent, restoreSelection } })
+        );
+    }
+
+    generateUniqueIds(toggles) {
+        for (const toggle of toggles) {
+            const props = getEmbeddedProps(toggle);
+            props.toggleBlockId = this.getUniqueIdentifier();
+            toggle.dataset.embeddedProps = JSON.stringify(props);
+        }
+    }
+
+    getClosestToggleContentInfo(node) {
+        const toggle = closestElement(node, toggleSelector);
+        const title = toggle?.querySelector(titleSelector);
+        const content = toggle?.querySelector(contentSelector);
+        return content?.contains(node) ? { content, title, toggle } : {};
+    }
+
+    getClosestToggleTitleInfo(node) {
+        const toggle = closestElement(node, toggleSelector);
+        const title = toggle?.querySelector(titleSelector);
+        const content = toggle?.querySelector(contentSelector);
+        return title?.contains(node) ? { content, title, toggle } : {};
+    }
+
+    getToggleFromTitleSelection() {
+        const selection = this.dependencies.selection.getEditableSelection();
+        if (!selection.anchorNode) {
+            return;
+        }
+        const { toggle } = this.getClosestToggleTitleInfo(selection.anchorNode);
+        return toggle;
+    }
+
+    getUniqueIdentifier() {
+        return uuid();
+    }
+
+    /**
+     * Handle all behaviors linked to the use of deleteBackward in the editor:
+     * 1. selection at start of title: explode the toggle and keep title and content as siblings
+     * 2. selection at end of content in a paragraph: unwraps from the toggle content
+     * 3. selection at start of content in a paragraph: merge the paragraph with the title
+     * 4. selection at start of paragraph after a toggle: merge the paragraph at content end
+     */
+    handleDeleteBackward(range) {
+        for (const handler of [
+            this.handleDeleteBackwardTitleStart,
+            this.handleDeleteBackwardContentEnd,
+            this.handleDeleteBackwardContentStart,
+            this.handleDeleteBackwardAfterToggle,
+        ]) {
+            if (handler.call(this, range)) {
+                return true;
+            }
+        }
+    }
+
+    handleDeleteBackwardContentEnd({ endContainer, endOffset }) {
+        const block = closestBlock(endContainer);
+        const isEmptyContainer = isEmptyBlock(endContainer);
+        const leaf = isEmptyContainer ? endContainer : firstLeaf(block);
+        const { toggle, content } = this.getClosestToggleContentInfo(endContainer);
+        if (
+            !content ||
+            endOffset !== 0 ||
+            childNodeIndex(block) === 0 ||
+            block.nextElementSibling ||
+            leaf !== endContainer ||
+            !isParagraphRelatedElement(block) ||
+            this.preventDeleteBackwardContentEnd
+        ) {
+            return;
+        }
+        toggle.after(block);
+        this.dependencies.selection.setCursorStart(block);
+        return true;
+    }
+
+    handleDeleteBackwardContentStart({ endContainer, endOffset }) {
+        const block = closestBlock(endContainer);
+        const leaf = isEmptyBlock(endContainer) ? endContainer : firstLeaf(block);
+        const { title, content } = this.getClosestToggleContentInfo(endContainer);
+        if (
+            !content ||
+            endOffset !== 0 ||
+            childNodeIndex(block) !== 0 ||
+            leaf !== endContainer ||
+            !isParagraphRelatedElement(block)
+        ) {
+            return;
+        }
+        title.append(block);
+        this.dependencies.selection.setCursorStart(block);
+        this.dependencies.delete.deleteBackward(
+            this.dependencies.selection.getEditableSelection(),
+            "character"
+        );
+        return true;
+    }
+
+    handleDeleteBackwardTitleStart({ endContainer, endOffset }) {
+        const block = closestBlock(endContainer);
+        const leaf = isEmptyBlock(endContainer) ? endContainer : firstLeaf(block);
+        const { toggle, title } = this.getClosestToggleTitleInfo(endContainer);
+        if (!title || endOffset !== 0 || childNodeIndex(block) !== 0 || leaf !== endContainer) {
+            return;
+        }
+        const cursors = this.dependencies.selection.preserveSelection();
+        this.explodeToggle(toggle);
+        cursors.restore();
+        return true;
+    }
+
+    handleDeleteBackwardAfterToggle({ endContainer, endOffset }) {
+        const block = closestBlock(endContainer);
+        const leaf = isEmptyBlock(endContainer) ? endContainer : firstLeaf(block);
+        const toggle = block?.previousSibling;
+        if (!toggle?.matches?.(toggleSelector) || endOffset !== 0 || leaf !== endContainer) {
+            return;
+        }
+        let target = toggle.querySelector(contentSelector);
+        if (target.parentElement.matches(".d-none")) {
+            if (!isParagraphRelatedElement(block)) {
+                return;
+            }
+            const title = toggle.querySelector(titleSelector);
+            target = title;
+        }
+        target.append(block);
+        this.dependencies.selection.setCursorStart(block);
+        this.preventDeleteBackwardContentEnd = true;
+        this.dependencies.delete.deleteBackward(
+            this.dependencies.selection.getEditableSelection(),
+            "character"
+        );
+        this.preventDeleteBackwardContentEnd = false;
+        return true;
+    }
+
+    /**
+     * Handle all behaviors linked to the use of deleteForward in the editor:
+     * 1. selection at end of title:
+     *   - (optional) explode a potential toggle at the start of content
+     *   - merge first paragraph from content with the title
+     * 2. selection at end of content in a paragraph:
+     *   - (optional) explode a potential sibling toggle
+     *   - merge a sibling paragraph at content end
+     * 3. selection at end of paragraph before a toggle: explode the toggle
+     */
+    handleDeleteForward(range) {
+        for (const handler of [
+            this.handleDeleteForwardTitleEnd,
+            this.handleDeleteForwardContentEnd,
+            this.handleDeleteForwardBeforeToggle,
+        ]) {
+            if (handler.call(this, range)) {
+                return true;
+            }
+        }
+    }
+
+    handleDeleteForwardContentEnd({ startContainer, startOffset }) {
+        const block = closestBlock(startContainer);
+        const isEmptyContainer = isEmptyBlock(startContainer);
+        const leaf = isEmptyContainer ? startContainer : lastLeaf(block);
+        const { toggle, content } = this.getClosestToggleContentInfo(startContainer);
+        if (
+            !content ||
+            !(
+                (isEmptyContainer && startOffset === 0) ||
+                startOffset === nodeSize(startContainer)
+            ) ||
+            block === this.editable ||
+            block.nextElementSibling ||
+            leaf !== startContainer ||
+            !isParagraphRelatedElement(block)
+        ) {
+            return;
+        }
+        let nextEl = toggle.nextSibling;
+        if (nextEl?.matches?.(toggleSelector)) {
+            this.explodeToggle(nextEl);
+            nextEl = toggle.nextSibling;
+        }
+        if (!isParagraphRelatedElement(nextEl)) {
+            return;
+        }
+        content.append(nextEl);
+        this.dependencies.selection.setCursorEnd(block);
+        this.dependencies.delete.deleteForward(
+            this.dependencies.selection.getEditableSelection(),
+            "character"
+        );
+        return true;
+    }
+
+    handleDeleteForwardTitleEnd({ startContainer, startOffset }) {
+        const block = closestBlock(startContainer);
+        const isEmptyContainer = isEmptyBlock(startContainer);
+        const leaf = isEmptyContainer ? startContainer : lastLeaf(block);
+        const { toggle, title, content } = this.getClosestToggleTitleInfo(startContainer);
+        if (
+            !title ||
+            !(
+                (isEmptyContainer && startOffset === 0) ||
+                startOffset === nodeSize(startContainer)
+            ) ||
+            block === this.editable ||
+            block.nextElementSibling ||
+            leaf !== startContainer
+        ) {
+            return;
+        }
+        let nextEl;
+        if (content.parentElement.matches(".d-none")) {
+            nextEl = toggle.nextSibling;
+            if (nextEl.matches?.(toggleSelector)) {
+                this.explodeToggle(nextEl);
+                nextEl = toggle.nextSibling;
+            }
+        } else {
+            nextEl = content.firstChild;
+            if (nextEl.matches?.(toggleSelector)) {
+                this.explodeToggle(nextEl);
+                nextEl = content.firstChild;
+            }
+        }
+        if (!isParagraphRelatedElement(nextEl)) {
+            return;
+        }
+        title.append(nextEl);
+        this.dependencies.selection.setCursorEnd(block);
+        this.dependencies.delete.deleteForward(
+            this.dependencies.selection.getEditableSelection(),
+            "character"
+        );
+        return true;
+    }
+
+    handleDeleteForwardBeforeToggle({ startContainer, startOffset }) {
+        const block = closestBlock(startContainer);
+        const isEmptyContainer = isEmptyBlock(startContainer);
+        const leaf = isEmptyContainer ? startContainer : lastLeaf(block);
+        const toggle = block.nextSibling;
+        if (
+            !toggle?.matches?.(toggleSelector) ||
+            !(
+                (isEmptyContainer && startOffset === 0) ||
+                startOffset === nodeSize(startContainer)
+            ) ||
+            leaf !== startContainer
+        ) {
+            return;
+        }
+        if (isEmptyBlock(block)) {
+            block.remove();
+            const title = toggle.querySelector(titleSelector);
+            this.dependencies.selection.setCursorStart(title.firstElementChild);
+        } else {
+            this.explodeToggle(toggle);
+            this.dependencies.selection.setCursorEnd(block);
+            this.dependencies.delete.deleteForward(
+                this.dependencies.selection.getEditableSelection(),
+                "character"
+            );
+        }
+        return true;
+    }
+
+    /**
+     * Generate new toggleBlockIds for every inserted toggle, to avoid duplicating
+     * copies.
+     */
+    handleInsert(insertContainer) {
+        const insertedToggles = insertContainer.querySelectorAll(toggleSelector);
+        this.generateUniqueIds(insertedToggles);
+        return insertContainer;
+    }
+
+    /**
+     * Shift + Tab in a toggle title will extract it from a potential parent
+     * toggle, and every child of that parent toggle content that is a nextSibling
+     * of the current toggle will be appended to the current toggle content.
+     */
+    handleShiftTab() {
+        const toggle = this.getToggleFromTitleSelection();
+        if (toggle) {
+            const closestToggleAncestor = closestElement(toggle.parentElement, toggleSelector);
+            if (closestToggleAncestor) {
+                const cursors = this.dependencies.selection.preserveSelection();
+                const ancestorContent = closestToggleAncestor.querySelector(contentSelector);
+                const containerContent = toggle.querySelector(contentSelector);
+                const siblings = childNodes(ancestorContent).filter(
+                    (node) =>
+                        toggle.compareDocumentPosition(node) & Node.DOCUMENT_POSITION_FOLLOWING
+                );
+                if (isEmptyBlock(containerContent.lastElementChild)) {
+                    containerContent.lastElementChild.remove();
+                }
+                containerContent.append(...siblings);
+                closestToggleAncestor.after(toggle);
+                this.forceToggle(toggle, { showContent: true, restoreSelection: cursors.restore });
+                this.dependencies.history.addStep();
+            }
+            return true;
+        }
+    }
+
+    /**
+     * This method handles the behavior when the user presses the Enter key.
+     * In the editor, when the user presses the Enter key, this splits the focused text block into 2
+     * separate ones. When the text block is split then it calls to all handlers so that they can trigger
+     * a specific behavior with the split block.
+     *
+     * This handler handles multiple cases:
+     *      1. The toggle title is currently empty (remove toggle)
+     *      2. Cursor is at the start of the toggle title (create new toggle before)
+     *      3. Cursor elsewhere in the toggle title (create new toggle after)
+     * @param {Object} param @see SplitPlugin.splitElementBlock
+     * @returns true if indeed handled by the method
+     */
+    handleSplitElementBlock({ targetNode, targetOffset, blockToSplit }) {
+        const { toggle, title, content } = this.getClosestToggleTitleInfo(targetNode);
+        if (title) {
+            const selection = this.dependencies.selection.getEditableSelection();
+            if (isEmptyBlock(selection.anchorNode)) {
+                const contentChildren = children(content);
+                if (contentChildren.length !== 1 || !isEmptyBlock(contentChildren[0])) {
+                    toggle.after(...children(content));
+                }
+                const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+                baseContainer.appendChild(this.document.createElement("br"));
+                toggle.replaceWith(baseContainer);
+                this.dependencies.selection.setCursorStart(baseContainer);
+                return true;
+            }
+            const insertBefore = targetOffset === 0 && blockToSplit.parentElement === title;
+            const [beforeSplit, afterSplit] = this.dependencies.split.splitElementBlock({
+                targetNode,
+                targetOffset,
+                blockToSplit,
+            });
+            if (beforeSplit && afterSplit) {
+                if (content.parentElement.matches(".d-none") || insertBefore) {
+                    const newToggle = this.renderToggleBlock();
+                    const newTitleEl = newToggle.querySelector(titleSelector);
+                    if (insertBefore) {
+                        toggle.before(newToggle);
+                        newTitleEl.replaceChildren(beforeSplit);
+                    } else {
+                        toggle.after(newToggle);
+                        newTitleEl.replaceChildren(afterSplit);
+                    }
+                } else {
+                    const firstChild = content.firstElementChild;
+                    if (isEmptyBlock(firstChild)) {
+                        firstChild.replaceWith(afterSplit);
+                    } else {
+                        content.prepend(afterSplit);
+                    }
+                }
+                this.dependencies.selection.setCursorStart(afterSplit);
+            }
+            return true;
+        }
+    }
+
+    /**
+     * Handles the tab behavior. This means that when we are inside a toggle title and we have a toggle
+     * as previous sibling of the embedded component, the current toggle is indented inside the content of
+     * the previous one.
+     */
+    handleTab() {
+        const toggle = this.getToggleFromTitleSelection();
+        if (toggle) {
+            const previousSibling = toggle.previousSibling;
+            if (previousSibling?.matches?.(toggleSelector)) {
+                const cursors = this.dependencies.selection.preserveSelection();
+                const previousSiblingContent = previousSibling.querySelector(contentSelector);
+                if (
+                    children(previousSiblingContent).length === 1 &&
+                    isEmptyBlock(previousSiblingContent.firstElementChild)
+                ) {
+                    previousSiblingContent.replaceChildren(toggle);
+                } else {
+                    previousSiblingContent.append(toggle);
+                }
+                const content = toggle.querySelector(contentSelector);
+                if (!content.parentElement.matches(".d-none")) {
+                    toggle.after(...children(content));
+                }
+                this.forceToggle(previousSibling, {
+                    showContent: true,
+                    restoreSelection: cursors.restore,
+                });
+                this.dependencies.history.addStep();
+            }
+            return true;
+        }
+    }
+
+    insertToggleBlock() {
+        const block = this.renderToggleBlock();
+        const target = block.querySelector(`${titleSelector} > ${baseContainerGlobalSelector}`);
+        this.dependencies.dom.insert(block);
+        this.dependencies.selection.setCursorStart(target);
+        this.dependencies.history.addStep();
+    }
+
+    manageToggleFromTitle() {
+        const toggle = this.getToggleFromTitleSelection();
+        if (!toggle) {
+            return;
+        }
+        this.forceToggle(toggle);
+    }
+
+    normalize(element) {
+        const cursors = this.dependencies.selection.preserveSelection();
+        for (const titleChild of selectElements(
+            element,
+            `${toggleSelector} ${titleSelector} > *:first-child`
+        )) {
+            const title = titleChild.parentElement;
+            const toggle = closestElement(title, toggleSelector);
+            if (titleChild.nextElementSibling) {
+                const nodes = children(titleChild.parentElement);
+                title.replaceChildren(nodes.shift());
+                toggle.after(...nodes);
+            }
+            if (!isParagraphRelatedElement(titleChild)) {
+                toggle.after(titleChild);
+            }
+        }
+        cursors.restore();
+        for (const emptyToggleNode of selectElements(
+            element,
+            `${toggleSelector} [data-embedded-editable]:empty`
+        )) {
+            const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+            baseContainer.appendChild(this.document.createElement("br"));
+            emptyToggleNode.replaceChildren(baseContainer);
+        }
+    }
+
+    removeSelectedToggleContentHints() {
+        const editableSelection = this.dependencies.selection.getEditableSelection();
+        const target =
+            editableSelection.anchorNode &&
+            closestElement(
+                editableSelection.anchorNode,
+                `${toggleSelector} ${contentSelector} > ${baseContainerGlobalSelector}:first-child:is(.o-we-hint)`
+            );
+        if (target) {
+            target.removeAttribute("placeholder");
+            removeClass(target, "o-we-hint");
+            this.selectedToggleEmptyContentSet.add(target);
+        }
+    }
+
+    removeToggleContentHints(root) {
+        for (const contentChild of selectElements(
+            root,
+            `${toggleSelector} ${contentSelector} > ${baseContainerGlobalSelector}:first-child:is(.o-we-hint)`
+        )) {
+            if (contentChild.nextSibling || !isEmptyBlock(contentChild)) {
+                contentChild.removeAttribute("placeholder");
+                removeClass(contentChild, "o-we-hint");
+            }
+        }
+    }
+
+    updateSelectedToggleContentHints() {
+        for (const target of [...this.selectedToggleEmptyContentSet]) {
+            if (!target.isConnected) {
+                this.selectedToggleEmptyContentSet.delete(target);
+                continue;
+            }
+            if (
+                target.matches(
+                    `${toggleSelector} ${contentSelector} > ${baseContainerGlobalSelector}:only-child:is(.o-we-hint)`
+                )
+            ) {
+                continue;
+            }
+            this.selectedToggleEmptyContentSet.delete(target);
+            if (
+                target.matches(
+                    `${toggleSelector} ${contentSelector} > ${baseContainerGlobalSelector}:only-child:not(.o-we-hint)`
+                ) &&
+                isEmptyBlock(target)
+            ) {
+                this.applyEmptyContentHint(target);
+            }
+        }
+    }
+
+    updateToggleContentHints(root) {
+        for (const contentChild of selectElements(
+            root,
+            `${toggleSelector} ${contentSelector} > ${baseContainerGlobalSelector}:only-child:not(.o-we-hint)`
+        )) {
+            if (isEmptyBlock(contentChild)) {
+                this.applyEmptyContentHint(contentChild);
+            }
+        }
+    }
+
+    renderToggleBlock() {
+        const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+        return parseHTML(
+            this.document,
+            renderToString("html_editor.EmbeddedToggleBlockBlueprint", {
+                baseContainerNodeName: baseContainer.nodeName,
+                baseContainerAttributes: {
+                    class: baseContainer.className,
+                },
+                embeddedProps: JSON.stringify({ toggleBlockId: this.getUniqueIdentifier() }),
+            })
+        );
+    }
+
+    showPowerButtons(selection) {
+        return (
+            selection.isCollapsed &&
+            !closestElement(selection.anchorNode, `${toggleSelector} ${titleSelector}`)
+        );
+    }
+
+    setupNewToggle({ name, env }) {
+        if (name === "toggleBlock") {
+            Object.assign(env, {
+                editorShared: {
+                    preserveSelection: this.dependencies.selection.preserveSelection,
+                },
+            });
+        }
+    }
+}

--- a/addons/html_editor/static/src/plugin_sets.js
+++ b/addons/html_editor/static/src/plugin_sets.js
@@ -60,6 +60,7 @@ import { DynamicPlaceholderPlugin } from "./others/dynamic_placeholder_plugin";
 import { EmbeddedComponentPlugin } from "./others/embedded_component_plugin";
 import { ExcalidrawPlugin } from "@html_editor/others/embedded_components/plugins/excalidraw_plugin/excalidraw_plugin";
 import { TableOfContentPlugin } from "@html_editor/others/embedded_components/plugins/table_of_content_plugin/table_of_content_plugin";
+import { ToggleBlockPlugin } from "@html_editor/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin";
 import { VideoPlugin } from "@html_editor/others/embedded_components/plugins/video_plugin/video_plugin";
 import { QWebPlugin } from "./others/qweb_plugin";
 
@@ -172,6 +173,7 @@ export const EMBEDDED_COMPONENT_PLUGINS = [
     EmbeddedComponentPlugin,
     ExcalidrawPlugin,
     TableOfContentPlugin,
+    ToggleBlockPlugin,
     VideoPlugin,
 ];
 

--- a/addons/html_editor/static/src/utils/base_container.js
+++ b/addons/html_editor/static/src/utils/base_container.js
@@ -19,9 +19,9 @@ export function getBaseContainerSelector(nodeName) {
     return `${nodeName}${suffix}`;
 }
 
-export const baseContainerGlobalSelector = SUPPORTED_BASE_CONTAINER_NAMES.map((name) =>
+export const baseContainerGlobalSelector = `:is(${SUPPORTED_BASE_CONTAINER_NAMES.map((name) =>
     getBaseContainerSelector(name)
-).join(",");
+).join(",")})`;
 
 /**
  * Create a new baseContainer element.

--- a/addons/html_editor/static/tests/embedded_components_plugins/toggle_block.test.js
+++ b/addons/html_editor/static/tests/embedded_components_plugins/toggle_block.test.js
@@ -1,0 +1,917 @@
+import { test, describe, beforeEach, expect } from "@odoo/hoot";
+import { setupEditor } from "../_helpers/editor";
+import { unformat } from "../_helpers/format";
+import { getContent } from "../_helpers/selection";
+import {
+    addStep,
+    deleteBackward,
+    deleteForward,
+    keydownShiftTab,
+    keydownTab,
+    splitBlock,
+} from "../_helpers/user_actions";
+import { contains, patchWithCleanup } from "@web/../tests/web_test_helpers";
+import {
+    EmbeddedToggleBlockComponent,
+    toggleBlockEmbedding,
+} from "@html_editor/others/embedded_components/core/toggle_block/toggle_block";
+import { onMounted } from "@odoo/owl";
+import { animationFrame, queryOne } from "@odoo/hoot-dom";
+import { Deferred } from "@odoo/hoot-mock";
+import { browser } from "@web/core/browser/browser";
+import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
+import { EmbeddedComponentPlugin } from "@html_editor/others/embedded_component_plugin";
+import { ToggleBlockPlugin } from "@html_editor/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin";
+import { parseHTML } from "@html_editor/utils/html";
+
+let embeddedToggleMountedPromise;
+
+function getConfig(components) {
+    return {
+        Plugins: [...MAIN_PLUGINS, EmbeddedComponentPlugin, ToggleBlockPlugin],
+        resources: {
+            embedded_components: components,
+        },
+    };
+}
+
+beforeEach(() => {
+    embeddedToggleMountedPromise = new Deferred();
+    patchWithCleanup(EmbeddedToggleBlockComponent.prototype, {
+        setup() {
+            super.setup();
+            onMounted(() => {
+                embeddedToggleMountedPromise.resolve();
+            });
+        },
+    });
+});
+
+describe("deleteBackward applied to toggle", () => {
+    test("toggle open, after toggle: should append to content", async () => {
+        browser.sessionStorage.setItem(`html_editor.ToggleBlock1.showContent`, "true");
+        const { editor, el } = await setupEditor(
+            unformat(
+                `<p><br></p>
+                <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
+                    <div data-embedded-editable="title">
+                        <p>Hello World</p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <p>asdf</p>
+                    </div>
+                </div>
+                <p>[]stuff</p>
+            `
+            ),
+            {
+                config: getConfig([toggleBlockEmbedding]),
+            }
+        );
+        await embeddedToggleMountedPromise;
+        deleteBackward(editor);
+        expect(getContent(el)).toBe(
+            unformat(`
+                <p><br></p>
+                <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
+                    <div class="d-flex flex-row align-items-center">
+                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                            <i class="fa align-self-center fa-caret-down"></i>
+                        </button>
+                        <div class="flex-fill ms-1">
+                            <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
+                                <p>Hello World</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="ps-4 ms-1">
+                        <div data-embedded-editable="content" data-oe-protected="false" contenteditable="true">
+                            <p>asdf[]stuff</p>
+                        </div>
+                    </div>
+                </div>`)
+        );
+    });
+    test("toggle closed, after toggle: should append to title", async () => {
+        const { editor, el } = await setupEditor(
+            unformat(
+                `<p><br></p>
+                <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
+                    <div data-embedded-editable="title">
+                        <p>Hello World</p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <p>asdf</p>
+                    </div>
+                </div>
+                <p>[]stuff</p>
+            `
+            ),
+            {
+                config: getConfig([toggleBlockEmbedding]),
+            }
+        );
+        await embeddedToggleMountedPromise;
+        deleteBackward(editor);
+        expect(getContent(el)).toBe(
+            unformat(`
+            <p><br></p>
+                <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
+                    <div class="d-flex flex-row align-items-center">
+                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                            <i class="fa align-self-center fa-caret-right"></i>
+                        </button>
+                        <div class="flex-fill ms-1">
+                            <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
+                                <p>Hello World[]stuff</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="ps-4 ms-1 d-none">
+                        <div data-embedded-editable="content" data-oe-protected="false" contenteditable="true">
+                            <p>asdf</p>
+                        </div>
+                    </div>
+                </div>`)
+        );
+    });
+    test("start of title: should explode toggle", async () => {
+        const { editor, el } = await setupEditor(
+            unformat(
+                `<p><br></p>
+                <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
+                    <div data-embedded-editable="title">
+                        <p>[]Hello World</p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <p>Good</p>
+                        <p>Riddance</p>
+                    </div>
+                </div>
+            `
+            ),
+            {
+                config: getConfig([toggleBlockEmbedding]),
+            }
+        );
+        await embeddedToggleMountedPromise;
+        deleteBackward(editor);
+        expect(getContent(el)).toBe(
+            unformat(`
+            <p><br></p>
+            <p>[]Hello World</p>
+            <p>Good</p>
+            <p>Riddance</p>
+            `)
+        );
+    });
+    test("start of content: should append to title", async () => {
+        const { editor } = await setupEditor(
+            unformat(`
+                <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
+                    <div data-embedded-editable="title">
+                        <p>HelloWorld</p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <p>[]Good</p>
+                        <p>Riddance</p>
+                    </div>
+                </div>
+            `),
+            { config: getConfig([toggleBlockEmbedding]) }
+        );
+        await embeddedToggleMountedPromise;
+        deleteBackward(editor);
+        expect("[data-embedded-editable='title']").toHaveInnerHTML(`
+            <p>HelloWorldGood</p>
+        `);
+    });
+    test("end of content: should unwrap from content", async () => {
+        const { editor } = await setupEditor(
+            unformat(`
+                <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
+                    <div data-embedded-editable="title">
+                        <p>HelloWorld</p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <p>Good</p>
+                        <p>[]Riddance</p>
+                    </div>
+                </div>
+            `),
+            { config: getConfig([toggleBlockEmbedding]) }
+        );
+        await embeddedToggleMountedPromise;
+        deleteBackward(editor);
+        expect("[data-embedded-editable='content'").toHaveInnerHTML(`
+            <p>Good</p>
+        `);
+        expect(queryOne("[data-embedded='toggleBlock']").nextElementSibling).toHaveOuterHTML(`
+            <p>Riddance</p>
+        `);
+    });
+});
+describe("deleteForward applied to toggle", () => {
+    test("empty paragraph, before toggle: should remove empty paragraph", async () => {
+        const { editor, el } = await setupEditor(
+            unformat(
+                `<p>[]<br></p>
+                <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
+                    <div data-embedded-editable="title">
+                        <p>HelloWorld</p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <p>asdf</p>
+                    </div>
+                </div>
+            `
+            ),
+            {
+                config: getConfig([toggleBlockEmbedding]),
+            }
+        );
+        await embeddedToggleMountedPromise;
+        deleteForward(editor);
+        expect(getContent(el)).toBe(
+            unformat(`
+                <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
+                    <div class="d-flex flex-row align-items-center">
+                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                            <i class="fa align-self-center fa-caret-right"></i>
+                        </button>
+                        <div class="flex-fill ms-1">
+                            <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
+                                <p>[]HelloWorld</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="ps-4 ms-1 d-none">
+                        <div data-embedded-editable="content" data-oe-protected="false" contenteditable="true">
+                            <p>asdf</p>
+                        </div>
+                    </div>
+                </div>`)
+        );
+    });
+    test("end of paragraph, before toggle: should explode sibling toggle", async () => {
+        const { editor, el } = await setupEditor(
+            unformat(
+                `<p>before[]</p>
+                <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
+                    <div data-embedded-editable="title">
+                        <p>HelloWorld</p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <p>asdf</p>
+                    </div>
+                </div>
+            `
+            ),
+            {
+                config: getConfig([toggleBlockEmbedding]),
+            }
+        );
+        await embeddedToggleMountedPromise;
+        deleteForward(editor);
+        expect(getContent(el)).toBe(
+            unformat(`
+                <p>before[]HelloWorld</p>
+                <p>asdf</p>
+            `)
+        );
+    });
+    test("toggle open, end of title: should explode first toggle and append to title", async () => {
+        browser.sessionStorage.setItem(`html_editor.ToggleBlock1.showContent`, "true");
+        const { editor, el } = await setupEditor(
+            unformat(`
+                <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
+                    <div data-embedded-editable="title">
+                        <p>HelloWorld[]</p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "2" }' contenteditable="false">
+                            <div data-embedded-editable="title">
+                                <p>second</p>
+                            </div>
+                            <div data-embedded-editable="content">
+                                <p>third</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            `),
+            {
+                config: getConfig([toggleBlockEmbedding]),
+            }
+        );
+        await embeddedToggleMountedPromise;
+        deleteForward(editor);
+        expect(getContent(el)).toBe(
+            unformat(`
+                <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
+                    <div class="d-flex flex-row align-items-center">
+                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                            <i class="fa align-self-center fa-caret-down"></i>
+                        </button>
+                        <div class="flex-fill ms-1">
+                            <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
+                                <p>HelloWorld[]second</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="ps-4 ms-1">
+                        <div data-embedded-editable="content" data-oe-protected="false" contenteditable="true">
+                            <p>third</p>
+                        </div>
+                    </div>
+                </div>`)
+        );
+    });
+    test("toggle closed, end of title: should explode sibling toggle and append to title", async () => {
+        const { editor, el } = await setupEditor(
+            unformat(`
+                <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
+                    <div data-embedded-editable="title">
+                        <p>HelloWorld[]</p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <p>invisible</p>
+                    </div>
+                </div>
+                <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "2" }' contenteditable="false">
+                    <div data-embedded-editable="title">
+                        <p>second</p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <p>third</p>
+                    </div>
+                </div>
+            `),
+            {
+                config: getConfig([toggleBlockEmbedding]),
+            }
+        );
+        await embeddedToggleMountedPromise;
+        deleteForward(editor);
+        expect(getContent(el)).toBe(
+            unformat(`
+                <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
+                    <div class="d-flex flex-row align-items-center">
+                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                            <i class="fa align-self-center fa-caret-right"></i>
+                        </button>
+                        <div class="flex-fill ms-1">
+                            <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
+                                <p>HelloWorld[]second</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="ps-4 ms-1 d-none">
+                        <div data-embedded-editable="content" data-oe-protected="false" contenteditable="true">
+                            <p>invisible</p>
+                        </div>
+                    </div>
+                </div>
+                <p>third</p>
+            `)
+        );
+    });
+    test("end of content: should explode sibling toggle and append to content", async () => {
+        browser.sessionStorage.setItem(`html_editor.ToggleBlock1.showContent`, "true");
+        const { editor, el } = await setupEditor(
+            unformat(`
+                <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
+                    <div data-embedded-editable="title">
+                        <p>HelloWorld</p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <p>invisible[]</p>
+                    </div>
+                </div>
+                <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "2" }' contenteditable="false">
+                    <div data-embedded-editable="title">
+                        <p>second</p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <p>third</p>
+                    </div>
+                </div>
+            `),
+            {
+                config: getConfig([toggleBlockEmbedding]),
+            }
+        );
+        await embeddedToggleMountedPromise;
+        deleteForward(editor);
+        expect(getContent(el)).toBe(
+            unformat(`
+                <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
+                    <div class="d-flex flex-row align-items-center">
+                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                            <i class="fa align-self-center fa-caret-down"></i>
+                        </button>
+                        <div class="flex-fill ms-1">
+                            <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
+                                <p>HelloWorld</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="ps-4 ms-1">
+                        <div data-embedded-editable="content" data-oe-protected="false" contenteditable="true">
+                            <p>invisible[]second</p>
+                        </div>
+                    </div>
+                </div>
+                <p>third</p>
+            `)
+        );
+    });
+});
+describe("Enter applied to toggle title", () => {
+    test("start of title: should create new toggle before", async () => {
+        browser.sessionStorage.setItem(`html_editor.ToggleBlock1.showContent`, "true");
+        const { editor, el } = await setupEditor(
+            unformat(
+                `<div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
+                    <div data-embedded-editable="title">
+                        <p>[]HelloWorld</p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <p>asdf</p>
+                    </div>
+                </div>
+            `
+            ),
+            {
+                config: getConfig([toggleBlockEmbedding]),
+            }
+        );
+        await embeddedToggleMountedPromise;
+        patchWithCleanup(ToggleBlockPlugin.prototype, {
+            getUniqueIdentifier() {
+                return "2";
+            },
+        });
+        embeddedToggleMountedPromise = new Deferred();
+        splitBlock(editor);
+        await embeddedToggleMountedPromise;
+        expect(getContent(el)).toBe(
+            unformat(`
+                <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{"toggleBlockId":"2"}'>
+                    <div class="d-flex flex-row align-items-center">
+                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                            <i class="fa align-self-center fa-caret-right"></i>
+                        </button>
+                        <div class="flex-fill ms-1">
+                            <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
+                                <p><br></p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="ps-4 ms-1 d-none">
+                        <div data-embedded-editable="content" data-oe-protected="false" contenteditable="true">
+                            <p placeholder="Add something inside this toggle" class="o-we-hint"><br></p>
+                        </div>
+                    </div>
+                </div>
+                <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
+                    <div class="d-flex flex-row align-items-center">
+                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                            <i class="fa align-self-center fa-caret-down"></i>
+                        </button>
+                        <div class="flex-fill ms-1">
+                            <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
+                                <p>[]HelloWorld</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="ps-4 ms-1">
+                        <div data-embedded-editable="content" data-oe-protected="false" contenteditable="true">
+                            <p>asdf</p>
+                        </div>
+                    </div>
+                </div>
+            `)
+        );
+    });
+    test("toggle closed, non-empty title: should create new sibling toggle with split title", async () => {
+        const { editor, el } = await setupEditor(
+            unformat(
+                `<div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
+                    <div data-embedded-editable="title">
+                        <p>Hello []World</p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <p>asdf</p>
+                    </div>
+                </div>
+            `
+            ),
+            {
+                config: getConfig([toggleBlockEmbedding]),
+            }
+        );
+        await embeddedToggleMountedPromise;
+        patchWithCleanup(ToggleBlockPlugin.prototype, {
+            getUniqueIdentifier() {
+                return "2";
+            },
+        });
+        embeddedToggleMountedPromise = new Deferred();
+        splitBlock(editor);
+        await embeddedToggleMountedPromise;
+        expect(getContent(el)).toBe(
+            unformat(`
+            <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
+                <div class="d-flex flex-row align-items-center">
+                    <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                        <i class="fa align-self-center fa-caret-right"></i>
+                    </button>
+                    <div class="flex-fill ms-1">
+                        <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
+                            <p>Hello</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="ps-4 ms-1 d-none">
+                    <div data-embedded-editable="content" data-oe-protected="false" contenteditable="true">
+                        <p>asdf</p>
+                    </div>
+                </div>
+            </div>
+            <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{"toggleBlockId":"2"}'>
+                <div class="d-flex flex-row align-items-center">
+                    <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                        <i class="fa align-self-center fa-caret-right"></i>
+                    </button>
+                    <div class="flex-fill ms-1">
+                        <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
+                            <p>[]World</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="ps-4 ms-1 d-none">
+                    <div data-embedded-editable="content" data-oe-protected="false" contenteditable="true">
+                        <p placeholder="Add something inside this toggle" class="o-we-hint"><br></p>
+                    </div>
+                </div>
+            </div>
+        `)
+        );
+    });
+    test("toggle open, non-empty title: should prepend content with split title", async () => {
+        browser.sessionStorage.setItem(`html_editor.ToggleBlock1.showContent`, "true");
+        const { editor, el } = await setupEditor(
+            unformat(
+                `<div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
+                    <div data-embedded-editable="title">
+                        <p>Hello []World</p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <p>asdf</p>
+                    </div>
+                </div>
+            `
+            ),
+            {
+                config: getConfig([toggleBlockEmbedding]),
+            }
+        );
+        await embeddedToggleMountedPromise;
+        splitBlock(editor);
+        expect(getContent(el)).toBe(
+            unformat(`
+            <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
+                <div class="d-flex flex-row align-items-center">
+                    <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                        <i class="fa align-self-center fa-caret-down"></i>
+                    </button>
+                    <div class="flex-fill ms-1">
+                        <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
+                            <p>Hello </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="ps-4 ms-1">
+                    <div data-embedded-editable="content" data-oe-protected="false" contenteditable="true">
+                        <p>[]World</p>
+                        <p>asdf</p>
+                    </div>
+                </div>
+            </div>`)
+        );
+    });
+    test("empty title: should explode toggle", async () => {
+        browser.sessionStorage.setItem(`html_editor.ToggleBlock1.showContent`, "true");
+        const { editor, el } = await setupEditor(
+            unformat(
+                `<div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
+                    <div data-embedded-editable="title">
+                        <p>[]<br></p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <p>asdf</p>
+                    </div>
+                </div>
+            `
+            ),
+            {
+                config: getConfig([toggleBlockEmbedding]),
+            }
+        );
+        await embeddedToggleMountedPromise;
+        splitBlock(editor);
+        expect(getContent(el)).toBe(
+            unformat(`
+                <p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>
+                <p>asdf</p>
+            `)
+        );
+    });
+});
+describe("Tab applied to toggle title", () => {
+    test("toggle closed, should move inside previous toggle", async () => {
+        browser.sessionStorage.setItem(`html_editor.ToggleBlock1.showContent`, "true");
+        const { editor, el } = await setupEditor(
+            unformat(
+                `<div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
+                    <div data-embedded-editable="title">
+                        <p>Goodbye World</p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <p><br></p>
+                    </div>
+                </div>
+                <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "2" }'>
+                    <div data-embedded-editable="title">
+                        <p>Hello []World</p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <p>asdf</p>
+                    </div>
+                </div>
+            `
+            ),
+            {
+                config: getConfig([toggleBlockEmbedding]),
+            }
+        );
+        await embeddedToggleMountedPromise;
+        await keydownTab(editor);
+        await animationFrame();
+        expect(getContent(el)).toBe(
+            unformat(`
+            <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
+                <div class="d-flex flex-row align-items-center">
+                    <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                        <i class="fa align-self-center fa-caret-down"></i>
+                    </button>
+                    <div class="flex-fill ms-1">
+                        <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
+                            <p>Goodbye World</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="ps-4 ms-1">
+                    <div data-embedded-editable="content" data-oe-protected="false" contenteditable="true">
+                        <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "2" }'>
+                            <div class="d-flex flex-row align-items-center">
+                                <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                                    <i class="fa align-self-center fa-caret-right"></i>
+                                </button>
+                                <div class="flex-fill ms-1">
+                                    <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
+                                        <p>Hello []World</p>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="ps-4 ms-1 d-none">
+                                <div data-embedded-editable="content" data-oe-protected="false" contenteditable="true">
+                                    <p>asdf</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>`)
+        );
+    });
+    test("toggle open, should move inside previous toggle and unwrap content", async () => {
+        browser.sessionStorage.setItem(`html_editor.ToggleBlock1.showContent`, "true");
+        browser.sessionStorage.setItem(`html_editor.ToggleBlock2.showContent`, "true");
+        const { editor, el } = await setupEditor(
+            unformat(
+                `<div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
+                    <div data-embedded-editable="title">
+                        <p>Goodbye World</p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <p><br></p>
+                    </div>
+                </div>
+                <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "2" }'>
+                    <div data-embedded-editable="title">
+                        <p>Hello[]World</p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <p>asdf</p>
+                    </div>
+                </div>
+            `
+            ),
+            {
+                config: getConfig([toggleBlockEmbedding]),
+            }
+        );
+        await embeddedToggleMountedPromise;
+        await keydownTab(editor);
+        await animationFrame();
+        expect(getContent(el)).toBe(
+            unformat(`
+            <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
+                <div class="d-flex flex-row align-items-center">
+                    <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                        <i class="fa align-self-center fa-caret-down"></i>
+                    </button>
+                    <div class="flex-fill ms-1">
+                        <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
+                            <p>Goodbye World</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="ps-4 ms-1">
+                    <div data-embedded-editable="content" data-oe-protected="false" contenteditable="true">
+                        <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "2" }'>
+                            <div class="d-flex flex-row align-items-center">
+                                <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                                    <i class="fa align-self-center fa-caret-down"></i>
+                                </button>
+                                <div class="flex-fill ms-1">
+                                    <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
+                                        <p>Hello[]World</p>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="ps-4 ms-1">
+                                <div data-embedded-editable="content" data-oe-protected="false" contenteditable="true">
+                                    <p placeholder="Add something inside this toggle" class="o-we-hint"><br></p>
+                                </div>
+                            </div>
+                        </div>
+                        <p>asdf</p>
+                    </div>
+                </div>
+            </div>`)
+        );
+    });
+});
+describe("Shift+Tab applied to toggle title", () => {
+    test("should become a sibling of parent toggle and append next siblings into own content", async () => {
+        browser.sessionStorage.setItem(`html_editor.ToggleBlock1.showContent`, "true");
+        const { editor, el } = await setupEditor(
+            unformat(
+                `<div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
+                    <div data-embedded-editable="title">
+                        <p>Goodbye World</p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "2" }'>
+                            <div data-embedded-editable="title">
+                                <p>Old []News</p>
+                            </div>
+                            <div data-embedded-editable="content">
+                                <p><br></p>
+                            </div>
+                        </div>
+                        <p>absorb</p>
+                    </div>
+                </div>
+            `
+            ),
+            {
+                config: getConfig([toggleBlockEmbedding]),
+            }
+        );
+        await embeddedToggleMountedPromise;
+        await keydownShiftTab(editor);
+        await animationFrame();
+        expect(getContent(el)).toBe(
+            unformat(`
+            <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
+                <div class="d-flex flex-row align-items-center">
+                    <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                        <i class="fa align-self-center fa-caret-down"></i>
+                    </button>
+                    <div class="flex-fill ms-1">
+                        <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
+                            <p>Goodbye World</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="ps-4 ms-1">
+                    <div data-embedded-editable="content" data-oe-protected="false" contenteditable="true">
+                        <p placeholder="Add something inside this toggle" class="o-we-hint"><br></p>
+                    </div>
+                </div>
+            </div>
+            <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "2" }'>
+                <div class="d-flex flex-row align-items-center">
+                    <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                        <i class="fa align-self-center fa-caret-down"></i>
+                    </button>
+                    <div class="flex-fill ms-1">
+                        <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
+                            <p>Old []News</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="ps-4 ms-1">
+                    <div data-embedded-editable="content" data-oe-protected="false" contenteditable="true">
+                        <p>absorb</p>
+                    </div>
+                </div>
+            </div>
+        `)
+        );
+    });
+});
+describe("Hide and show toggle content", () => {
+    test("Change toggle state", async () => {
+        await setupEditor(
+            unformat(
+                `<div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
+                    <div data-embedded-editable="title">
+                        <p>Hello []World</p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <p>asdf</p>
+                    </div>
+                </div>
+            `
+            ),
+            {
+                config: getConfig([toggleBlockEmbedding]),
+            }
+        );
+        await embeddedToggleMountedPromise;
+        expect(
+            queryOne("[data-embedded-editable='content']").parentElement.matches(".d-none")
+        ).toBe(true);
+        await contains("[data-embedded='toggleBlock'] button").click();
+        await animationFrame();
+        expect(
+            queryOne("[data-embedded-editable='content']").parentElement.matches(".d-none")
+        ).toBe(false);
+    });
+});
+describe("Insert (paste, drop) inside toggle title", () => {
+    test("Only allow one paragraph related element inside title", async () => {
+        const { editor, el } = await setupEditor(
+            unformat(
+                `<div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
+                    <div data-embedded-editable="title">
+                        <p>Hello[]World</p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <p>asdf</p>
+                    </div>
+                </div>
+            `
+            ),
+            {
+                config: getConfig([toggleBlockEmbedding]),
+            }
+        );
+        await embeddedToggleMountedPromise;
+        editor.shared.dom.insert(parseHTML(editor.document, `<p>New</p>`));
+        addStep(editor);
+        expect("[data-embedded-editable='title']").toHaveInnerHTML(`
+            <p>HelloNewWorld</p>
+        `);
+        editor.shared.dom.insert(
+            parseHTML(editor.document, `<div class="oe_unbreakable">brol</div>`)
+        );
+        addStep(editor);
+        expect(getContent(el)).toBe(
+            unformat(`
+                <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
+                    <div class="d-flex flex-row align-items-center">
+                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light"><i class="fa align-self-center fa-caret-right"></i></button>
+                        <div class="flex-fill ms-1">
+                            <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
+                                <p>HelloNew</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="ps-4 ms-1 d-none">
+                        <div data-embedded-editable="content" data-oe-protected="false" contenteditable="true">
+                            <p>asdf</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="oe_unbreakable">brol</div>
+                <p>[]World</p>
+            `)
+        );
+    });
+});

--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/content_expandable_plugin.js
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/content_expandable_plugin.js
@@ -10,6 +10,7 @@ export class ContentExpandablePlugin extends Plugin {
     resources = {
         clean_for_save_handlers: ({ root }) => this.cleanForSave(root),
         delete_backward_overrides: this.deleteBackward.bind(this),
+        move_node_blacklist_selectors: ".o_mail_reply_container, .o_mail_reply_container *",
     };
 
     setup() {


### PR DESCRIPTION
This commit adds a new type of embedded components: toggle blocks.
They can be used similarly to a list and enable users to hide text inside a
toggle which frees a lot of space inside the html field.

These toggles can be used to have a more complete description for a specific
title. Or to hide some details about specific concepts.

On a technical point, this commit adds a new embedding and a plugin.
The embedding is quite a simple one as the element itself is simple.
The plugin on the other hand needed to handle a big part of editor behaviors:
Enter, Shift-tab, Tab, etc.
That is why we added new resources to make it easy to handle some specific
behaviors.

task-2796594

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
