### PR TITLE
[IMP] account: send wizard

### DIFF
--- a/addons/account/__manifest__.py
+++ b/addons/account/__manifest__.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Invoicing',
-    'version': '1.3',
+    'version': '1.4',
     'summary': 'Invoices, Payments, Follow-ups & Bank Synchronization',
     'sequence': 10,
     'description': """
@@ -107,6 +107,7 @@ You could use this simplified accounting in case you work with an (external) acc
             'account/static/src/scss/account_payment_term.scss',
             'account/static/src/scss/account_reconcile_model.scss',
             'account/static/src/scss/account_multi_ledger.scss',
+            'account/static/src/scss/account_move_send_wizard.scss',
             'account/static/src/components/**/*',
             'account/static/src/services/*.js',
             'account/static/src/views/**/*',

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import ast
 import calendar
 from collections import defaultdict
 from contextlib import ExitStack, contextmanager
@@ -5129,7 +5130,7 @@ class AccountMove(models.Model):
 
     def action_send_and_print(self):
         return {
-            'name': _("Print & Send"),
+            'name': _("Send"),
             'type': 'ir.actions.act_window',
             'view_mode': 'form',
             'res_model': 'account.move.send.wizard' if len(self) == 1 else 'account.move.send.batch.wizard',
@@ -5436,6 +5437,29 @@ class AccountMove(models.Model):
     # -------------------------------------------------------------------------
     # HELPER METHODS
     # -------------------------------------------------------------------------
+    def _get_available_action_reports(self, is_invoice_report=True):
+        domain = [('model', '=', 'account.move')]
+
+        if is_invoice_report:
+            domain += [('is_invoice_report', '=', 'True')]
+
+        model_reports = self.env['ir.actions.report'].search(domain)
+
+        available_reports = model_reports.filtered(
+            lambda model_template: len(self.filtered_domain(ast.literal_eval(model_template.domain))) == len(self)
+        )
+
+        return available_reports
+
+    def _is_action_report_available(self, action_report, is_invoice_report=True):
+        assert len(action_report) == 1
+
+        self.ensure_one()
+
+        if available_report := action_report.filtered(lambda available_report: not (is_invoice_report^available_report.is_invoice_report)):
+            return bool(self.filtered_domain(ast.literal_eval(available_report.domain)))
+
+        return False
 
     @api.model
     def get_invoice_types(self, include_receipts=False):
@@ -6208,14 +6232,9 @@ class AccountMove(models.Model):
 
     def get_extra_print_items(self):
         """ Helper to dynamically add items in the 'Print' menu of list and form of account.move.
-        This is necessary to avoid the re-generation of the PDF through the action_report.
-        Indeed, once a legal PDF is generated, it should be used and not re-generated.
         """
-        return [{
-            'key': 'download_pdf',
-            'description': _('PDF'),
-            **self.action_invoice_download_pdf()
-        }]
+        # TO OVERRIDE
+        return []
 
     @staticmethod
     def _can_commit():

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -488,6 +488,19 @@ class ResPartner(models.Model):
         for partner in self:
             partner.journal_item_count = AccountMoveLine.search_count([('partner_id', '=', partner.id)])
 
+    def _compute_available_invoice_template_pdf_report_ids(self):
+        moves = self.env['account.move']
+
+        for move_type in ['out_invoice', 'out_refund', 'out_receipt']:
+            moves += self.env['account.move'].new({'move_type': move_type})
+
+        available_reports = moves._get_available_action_reports()
+
+        if not available_reports:
+            raise UserError(_("There is no template that applies to invoices."))
+
+        self.available_invoice_template_pdf_report_ids = available_reports
+
     def _get_company_currency(self):
         for partner in self:
             if partner.company_id:
@@ -496,8 +509,8 @@ class ResPartner(models.Model):
                 partner.currency_id = self.env.company.currency_id
 
     def _default_display_invoice_template_pdf_report_id(self):
-        available_templates_count = self.env['ir.actions.report'].search_count([('is_invoice_report', '=', True)], limit=2)
-        return available_templates_count > 1
+        """ Show PDF template selection if there are more than 1 template available for invoices. """
+        return len(self.available_invoice_template_pdf_report_ids) > 1
 
     name = fields.Char(tracking=True)
     credit = fields.Monetary(compute='_credit_debit_get', search=_credit_search,
@@ -564,7 +577,7 @@ class ResPartner(models.Model):
     invoice_sending_method = fields.Selection(
         string="Invoice sending",
         selection=[
-            ('manual', 'Download'),
+            ('manual', 'Manual'),
             ('email', 'by Email'),
         ],
         company_dependent=True,
@@ -578,10 +591,15 @@ class ResPartner(models.Model):
     invoice_edi_format_store = fields.Char(company_dependent=True)
     display_invoice_edi_format = fields.Boolean(default=lambda self: len(self._fields['invoice_edi_format'].selection), store=False)
     invoice_template_pdf_report_id = fields.Many2one(
+        string="Invoice report",
         comodel_name='ir.actions.report',
-        domain="[('is_invoice_report', '=', True)]",
+        domain="[('id', 'in', available_invoice_template_pdf_report_ids)]",
         readonly=False,
         store=True,
+    )
+    available_invoice_template_pdf_report_ids = fields.One2many(
+        comodel_name='ir.actions.report',
+        compute="_compute_available_invoice_template_pdf_report_ids",
     )
     display_invoice_template_pdf_report_id = fields.Boolean(default=_default_display_invoice_template_pdf_report_id, store=False)
     # Computed fields to order the partners as suppliers/customers according to the

--- a/addons/account/static/src/components/account_move_form/account_move_form.js
+++ b/addons/account/static/src/components/account_move_form/account_move_form.js
@@ -18,7 +18,7 @@ export class AccountMoveFormController extends FormController {
     get cogMenuProps() {
         return {
             ...super.cogMenuProps,
-            printDropdownTitle: _t("Download"),
+            printDropdownTitle: _t("Print"),
             loadExtraPrintItems: this.loadExtraPrintItems.bind(this),
         };
     }

--- a/addons/account/static/src/components/mail_attachments/mail_attachments.js
+++ b/addons/account/static/src/components/mail_attachments/mail_attachments.js
@@ -1,4 +1,3 @@
-import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { FileInput } from "@web/core/file_input/file_input";
@@ -12,49 +11,20 @@ export class MailAttachments extends Component {
 
     setup() {
         this.orm = useService("orm");
-        this.action = useService("action");
         this.notification = useService("notification");
         this.attachmentIdsToUnlink = new Set();
 
         onWillUnmount(this.onWillUnmount);
     }
 
-    getValue(){
+    get attachments() {
         return this.props.record.data[this.props.name] || [];
-    }
-
-    getUrl(attachmentId) {
-        return `/web/content/${attachmentId}?download=true`
-    }
-
-    getExtension(file) {
-        return file.name.replace(/^.*\./, "");
-    }
-
-    onFileUploaded(files) {
-        let extraFiles = [];
-        for (const file of files) {
-            if (file.error) {
-                return this.notification.add(file.error, {
-                    title: _t("Uploading error"),
-                    type: "danger",
-                });
-            }
-
-            extraFiles.push({
-                id: file.id,
-                name: file.filename,
-                mimetype: file.mimetype,
-                placeholder: false,
-                manual: true,
-            });
-        }
-        this.props.record.update({ [this.props.name]: this.getValue().concat(extraFiles) });
     }
 
     onFileRemove(deleteId) {
         const newValue = [];
-        for (let item of this.getValue()) {
+
+        for (let item of this.attachments) {
             if (item.id === deleteId) {
                 if (item.placeholder || item.protect_from_deletion) {
                     const copyItem = Object.assign({ skip: true }, item);
@@ -66,19 +36,21 @@ export class MailAttachments extends Component {
                 newValue.push(item);
             }
         }
+
         this.props.record.update({ [this.props.name]: newValue });
     }
 
-    async onWillUnmount(){
+    async onWillUnmount() {
         // Unlink added attachments if the wizard is not saved.
-        if(!this.props.record.resId){
-            this.getValue().forEach((item) => {
-                if(item.manual){
+        if (!this.props.record.resId) {
+            this.attachments.forEach((item) => {
+                if (item.manual) {
                     this.attachmentIdsToUnlink.add(item.id);
                 }
             });
         }
-        if(this.attachmentIdsToUnlink.size > 0){
+
+        if (this.attachmentIdsToUnlink.size) {
             await this.orm.unlink("ir.attachment", Array.from(this.attachmentIdsToUnlink));
         }
     }

--- a/addons/account/static/src/components/mail_attachments/mail_attachments.xml
+++ b/addons/account/static/src/components/mail_attachments/mail_attachments.xml
@@ -1,66 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-
-    <t t-name="account.mail_attachment_file"
-       t-inherit="web.Many2ManyBinaryField.attachment_preview"
-       t-inherit-mode="primary">
-        <!-- Remove the download on hover for placeholder. -->
-        <xpath expr="//div[hasclass('o_image_box', 'float-start')]" position="replace">
-            <div class="o_image_box float-start"
-                 t-att="{
-                    'data-tooltip': !file.placeholder ? `Download ${file.name}` : undefined,
-                 }"
-            >
-                <a t-att="{
-                    'href': !file.placeholder ? url : undefined,
-                    'aria-label': !file.placeholder ? 'Download' : undefined,
-                    'download': !file.placeholder ? '' : undefined,
-                   }"
-                >
-                    <span class="o_image o_hover"
-                          style="height:15px;width:30px;"
-                          t-att-data-mimetype="file.mimetype"
-                          t-att-data-ext="ext"
-                          role="img"/>
-                </a>
-            </div>
-        </xpath>
-        <xpath expr="//div[hasclass('caption')]/a" position="replace">
-            <a class="ml4"
-               t-att="{
-                'data-tooltip': !file.placeholder ? `Download ${file.name}` : undefined,
-                'href': !file.placeholder ? url : undefined,
-                'download': !file.placeholder ? '' : undefined,
-               }"
-               t-esc='file.name'/>
-        </xpath>
-        <!-- Remove the mimetype on the second line. -->
-        <xpath expr="//div[hasclass('caption', 'small')]" position="replace"/>
-    </t>
-
     <t t-name="account.mail_attachments">
-        <t t-set="data" t-value="getValue()"/>
+        <ul class="list-unstyled m-0">
+            <t t-foreach="attachments" t-as="attachment" t-key="attachment.id">
+                <t t-if="!attachment.skip">
+                    <li class="d-flex align-items-center bg-200 p-1 ps-3 my-2">
+                        <span t-out="attachment.name" class="flex-grow-1 text-truncate"/>
 
-        <div t-attf-class="oe_fileupload" aria-atomic="true">
-            <div class="o_attachments">
-                <t t-foreach="data" t-as="file" t-key="file.id">
-                    <t t-if="!file.skip">
-                        <t t-call="account.mail_attachment_file"/>
-                    </t>
+                        <button class="btn flex-shrink-0" t-on-click.stop="() => this.onFileRemove(attachment.id)">
+                            <i class="fa fa-fw fa-times"/>
+                        </button>
+                    </li>
                 </t>
-            </div>
-            <div t-if="!props.readonly" class="oe_add">
-                <FileInput
-                    multiUpload="true"
-                    onUpload.bind="onFileUploaded"
-                    resModel="props.record.resModel"
-                    resId="props.record.resId or 0">
-                    <button class="btn btn-secondary o_attach" data-tooltip="Attach">
-                        <span class="fa fa-paperclip" aria-label="Attach"/> Attachments
-                    </button>
-                </FileInput>
-            </div>
-        </div>
+            </t>
+        </ul>
     </t>
-
 </templates>

--- a/addons/account/static/src/components/mail_attachments/mail_attachments_selector.js
+++ b/addons/account/static/src/components/mail_attachments/mail_attachments_selector.js
@@ -1,0 +1,48 @@
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import { FileInput } from "@web/core/file_input/file_input";
+import { FileUploader } from "@web/views/fields/file_handler";
+import { Component } from "@odoo/owl";
+import { standardFieldProps } from "@web/views/fields/standard_field_props";
+
+export class MailAttachments extends Component {
+    static template = "mail.MailComposerAttachmentSelector";
+    static components = { FileInput, FileUploader };
+    static props = {...standardFieldProps};
+
+    setup() {
+        this.notification = useService("notification");
+    }
+
+    get attachments() {
+        return this.props.record.data[this.props.name] || [];
+    }
+
+    onFileUploaded(files) {
+        let extraFiles = [];
+        for (const file of files) {
+            if (file.error) {
+                return this.notification.add(file.error, {
+                    title: _t("Uploading error"),
+                    type: "danger",
+                });
+            }
+
+            extraFiles.push({
+                id: file.id,
+                name: file.filename,
+                mimetype: file.mimetype,
+                placeholder: false,
+                manual: true,
+            });
+        }
+        this.props.record.update({ [this.props.name]: this.attachments.concat(extraFiles) });
+    }
+}
+
+export const mailAttachments = {
+    component: MailAttachments,
+};
+
+registry.category("fields").add("mail_attachments_selector", mailAttachments);

--- a/addons/account/static/src/js/tours/account.js
+++ b/addons/account/static/src/js/tours/account.js
@@ -114,7 +114,7 @@ registry.category("web_tour.tours").add('account_tour', {
         run: "click",
     },
     {
-        trigger: "button[name=action_invoice_sent]:contains(print & send)",
+        trigger: "button[name=action_invoice_sent]:contains(send)",
         content: _t("Send the invoice to the customer and check what he'll receive."),
         tooltipPosition: "bottom",
         run: "click",
@@ -146,10 +146,10 @@ registry.category("web_tour.tours").add('account_tour', {
     },
     {
         isActive: ["auto"],
-        trigger: "button[name=action_invoice_sent]:contains(print & send)",
+        trigger: "button[name=action_invoice_sent]:contains(send)",
         content: _t("Send the invoice and check what the customer will receive."),
         run: "click",
-    },    
+    },
     {
         trigger: ".modal button[name=action_send_and_print]",
         content: _t("Let's send the invoice."),

--- a/addons/account/static/src/scss/account_move_send_wizard.scss
+++ b/addons/account/static/src/scss/account_move_send_wizard.scss
@@ -1,0 +1,10 @@
+.o_account_move_send_wizard .o_form_renderer  {
+    padding-bottom: 0;
+}
+
+.o_field_mail_attachments {
+    --fieldWidget-display: block;
+    li {
+        max-width: 325px;
+    }
+}

--- a/addons/account/static/src/views/account_move_list/account_move_list_controller.js
+++ b/addons/account/static/src/views/account_move_list/account_move_list_controller.js
@@ -20,7 +20,7 @@ export class AccountMoveListController extends FileUploadListController {
     get actionMenuProps() {
         return {
             ...super.actionMenuProps,
-            printDropdownTitle: _t("Download"),
+            printDropdownTitle: _t("Print"),
             loadExtraPrintItems: this.loadExtraPrintItems.bind(this),
         };
     }

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -589,9 +589,9 @@
             <field name="inherit_id" ref="account.view_invoice_tree"/>
             <field name="mode">primary</field>
             <field name="arch" type="xml">
-                <xpath expr="//list/header" position="inside">
-                    <button name="action_send_and_print" type="object" string="Print &amp; Send"/>
-                </xpath>
+                <button name="action_force_register_payment" position="before">
+                    <button name="action_send_and_print" type="object" string="Send"/>
+                </button>
                 <field name="currency_id" position="attributes">
                     <attribute name="string">Invoice Currency</attribute>
                 </field>
@@ -604,9 +604,9 @@
             <field name="inherit_id" ref="account.view_invoice_tree"/>
             <field name="mode">primary</field>
             <field name="arch" type="xml">
-                <xpath expr="//list/header" position="inside">
-                    <button name="action_send_and_print" type="object" string="Print &amp; Send"/>
-                </xpath>
+                <button name="action_force_register_payment" position="before">
+                    <button name="action_send_and_print" type="object" string="Send"/>
+                </button>
                 <field name="currency_id" position="attributes">
                     <attribute name="string">Credit Note Currency</attribute>
                 </field>
@@ -707,13 +707,13 @@
                         <!-- Send (only invoices) -->
                         <button name="action_invoice_sent"
                                 type="object"
-                                string="Print &amp; Send"
+                                string="Send"
                                 invisible="state != 'posted' or is_being_sent or invoice_pdf_report_id or move_type not in ('out_invoice', 'out_refund')"
                                 class="oe_highlight"
                                 data-hotkey="y"/>
                         <button name="action_invoice_sent"
                                 type="object"
-                                string="Print &amp; Send"
+                                string="Send"
                                 invisible="state != 'posted' or not is_being_sent and not invoice_pdf_report_id or move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund')"
                                 data-hotkey="y"/>
                         <!-- Register Payment (only invoices / receipts) -->

--- a/addons/account/views/account_report.xml
+++ b/addons/account/views/account_report.xml
@@ -7,13 +7,14 @@
             <field name="model">account.move</field>
             <field name="report_type">qweb-pdf</field>
             <field name="report_name">account.report_invoice_with_payments</field>
+            <field name="domain">[]</field>
             <field name="report_file">account.report_invoice_with_payments</field>
             <field name="is_invoice_report">True</field>
             <field name="print_report_name">(object._get_report_base_filename())</field>
             <field name="attachment"/>
-            <field name="binding_model_id" eval="False"/>  <!-- removes the action from the Print menu (forced False value for update) -->
-            <field name="groups_id" eval="[(4, ref('account.group_account_invoice')),
- (4, ref('account.group_account_readonly'))]"/>
+            <field name="binding_model_id" ref="model_account_move"/>
+            <field name="binding_type">report</field>
+            <field name="groups_id" eval="[(4, ref('account.group_account_invoice')), (4, ref('account.group_account_readonly'))]"/>
         </record>
 
         <record id="action_account_original_vendor_bill" model="ir.actions.report">

--- a/addons/account/views/ir_actions_views.xml
+++ b/addons/account/views/ir_actions_views.xml
@@ -8,6 +8,10 @@
             <field name="paperformat_id" position="after">
                 <field name="is_invoice_report"/>
             </field>
+
+            <field name="report_name" position="after">
+                <field name="domain"/>
+            </field>
         </field>
     </record>
 </odoo>

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -218,7 +218,7 @@
                             <group id="invoice_send_settings"
                                    string="Customer Invoices"
                                    groups="account.group_account_invoice,account.group_account_readonly">
-                                <field name="invoice_sending_method"/>
+                                <field name="invoice_sending_method" placeholder="e-Invoicing &amp; Email"/>
                                 <field name="invoice_edi_format" invisible="not display_invoice_edi_format"/>
                                 <field name="invoice_template_pdf_report_id"
                                        invisible="not display_invoice_template_pdf_report_id"

--- a/addons/account/wizard/account_move_send_batch_wizard.py
+++ b/addons/account/wizard/account_move_send_batch_wizard.py
@@ -40,7 +40,7 @@ class AccountMoveSendBatchWizard(models.TransientModel):
 
             for move in wizard.move_ids:
                 edi_counter += Counter([edi for edi in self._get_default_extra_edis(move)])
-                sending_method_counter[self._get_default_sending_method(move)] += 1
+                sending_method_counter += Counter([sending_method for sending_method in self._get_default_sending_methods(move)])
 
             summary_data = dict()
             for edi, edi_count in edi_counter.items():
@@ -55,7 +55,7 @@ class AccountMoveSendBatchWizard(models.TransientModel):
         for wizard in self:
             moves_data = {
                 move: {
-                    'sending_methods': {self._get_default_sending_method(move)},
+                    'sending_methods': self._get_default_sending_methods(move),
                     'invoice_edi_format': self._get_default_invoice_edi_format(move),
                     'extra_edis': self._get_default_extra_edis(move),
                 }

--- a/addons/account/wizard/account_move_send_batch_wizard.xml
+++ b/addons/account/wizard/account_move_send_batch_wizard.xml
@@ -17,7 +17,7 @@
                 <field name="summary_data" widget="account_batch_sending_summary" nolabel="1"/>
 
                 <footer>
-                    <button string="Print &amp; Send"
+                    <button string="Send"
                             data-hotkey="q"
                             name="action_send_and_print"
                             type="object"

--- a/addons/account/wizard/account_move_send_wizard.py
+++ b/addons/account/wizard/account_move_send_wizard.py
@@ -1,10 +1,13 @@
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 from odoo.tools.misc import get_lang
+from odoo.addons.mail.tools.parser import parse_res_ids
+from odoo.addons.mail.wizard.mail_compose_message import _reopen
 
 
 class AccountMoveSendWizard(models.TransientModel):
     """Wizard that handles the sending a single invoice."""
-    _inherit = ['account.move.send']
+    _inherit = ['account.move.send', 'mail.composer.mixin']
     _description = "Account Move Send Wizard"
 
     move_id = fields.Many2one(comodel_name='account.move', required=True)
@@ -36,42 +39,34 @@ class AccountMoveSendWizard(models.TransientModel):
     )
     pdf_report_id = fields.Many2one(
         comodel_name='ir.actions.report',
-        string="Invoice template",
-        domain="[('is_invoice_report', '=', True)]",
+        string="Invoice report",
+        domain="[('id', 'in', available_pdf_report_ids)]",
         compute='_compute_pdf_report_id',
         readonly=False,
         store=True,
     )
+    available_pdf_report_ids = fields.One2many(
+        comodel_name='ir.actions.report',
+        compute="_compute_available_pdf_report_ids",
+    )
+
     display_pdf_report_id = fields.Boolean(compute='_compute_display_pdf_report_id')
-    is_download_only = fields.Boolean(compute='_compute_is_download_only')
 
     # MAIL
-    mail_template_id = fields.Many2one(
-        comodel_name='mail.template',
-        string="Email template",
+    # Template: override mail.composer.mixin field
+    template_id = fields.Many2one(
         domain="[('model', '=', 'account.move')]",
-        compute='_compute_mail_template_id',
+        compute='_compute_template_id',
+        compute_sudo=True,
         readonly=False,
         store=True,
     )
-    mail_lang = fields.Char(compute='_compute_mail_lang')
+    # Language: override mail.composer.mixin field
+    lang = fields.Char(compute='_compute_lang', precompute=False, compute_sudo=True)
     mail_partner_ids = fields.Many2many(
         comodel_name='res.partner',
-        string="Recipients",
-        compute='_compute_mail_subject_body_partners',
-        store=True,
-        readonly=False,
-    )
-    mail_subject = fields.Char(
-        string="Subject",
-        compute='_compute_mail_subject_body_partners',
-        store=True,
-        readonly=False,
-    )
-    mail_body = fields.Html(
-        string="Contents",
-        sanitize_style=True,
-        compute='_compute_mail_subject_body_partners',
+        string="To",
+        compute='_compute_mail_partners',
         store=True,
         readonly=False,
     )
@@ -80,6 +75,10 @@ class AccountMoveSendWizard(models.TransientModel):
         store=True,
         readonly=False,
     )
+
+    model = fields.Char('Related Document Model', compute='_compute_model', readonly=False, store=True)
+    res_ids = fields.Text('Related Document IDs', compute='_compute_res_ids', readonly=False, store=True)
+    template_name = fields.Char('Template Name')  # used when saving a new mail template
 
     # -------------------------------------------------------------------------
     # DEFAULTS
@@ -124,19 +123,22 @@ class AccountMoveSendWizard(models.TransientModel):
         """ Select one applicable sending method given the following priority
         1. preferred method set on partner,
         2. email,
-        3. manual.
         """
         methods = self.env['ir.model.fields'].get_field_selection('res.partner', 'invoice_sending_method')
+
+        # We never want to display the manual method.
+        methods = [method for method in methods if method != ('manual', 'Manual')]
+
         for wizard in self:
-            preferred_method = self._get_default_sending_method(wizard.move_id)
-            need_fallback = not self._is_applicable_to_move(preferred_method, wizard.move_id)
-            fallback_method = need_fallback and ('email' if self._is_applicable_to_move('email', wizard.move_id) else 'manual')
+            preferred_methods = self._get_default_sending_methods(wizard.move_id)
+
             wizard.sending_method_checkboxes = {
                 method_key: {
-                    'checked': method_key == preferred_method if not need_fallback else method_key == fallback_method,
+                    'checked': method_key in preferred_methods and self._is_applicable_to_move(method_key, wizard.move_id),
                     'label': method_label,
                 }
-                for method_key, method_label in methods if self._is_applicable_to_company(method_key, wizard.company_id)
+                for method_key, method_label in methods
+                if self._is_applicable_to_company(method_key, wizard.company_id)
             }
 
     @api.depends('extra_edi_checkboxes')
@@ -167,50 +169,136 @@ class AccountMoveSendWizard(models.TransientModel):
             wizard.pdf_report_id = self._get_default_pdf_report_id(wizard.move_id)
 
     @api.depends('move_id')
-    def _compute_display_pdf_report_id(self):
-        # show pdf template menu if there are more than 1 template available and there is at least one move that needs a pdf
-        available_templates_count = self.env['ir.actions.report'].search_count([('is_invoice_report', '=', True)], limit=2)
-        for wizard in self:
-            wizard.display_pdf_report_id = available_templates_count > 1 and not wizard.move_id.invoice_pdf_report_id
+    def _compute_available_pdf_report_ids(self):
+        available_reports = self.move_id._get_available_action_reports()
 
-    @api.depends('sending_methods')
-    def _compute_is_download_only(self):
         for wizard in self:
-            wizard.is_download_only = wizard.sending_methods == ['manual']
+            wizard.available_pdf_report_ids = available_reports
 
     @api.depends('move_id')
-    def _compute_mail_template_id(self):
+    def _compute_display_pdf_report_id(self):
+        """ Show PDF template selection if there are more than 1 template available for invoices. """
         for wizard in self:
-            wizard.mail_template_id = self._get_default_mail_template_id(wizard.move_id)
+            wizard.display_pdf_report_id = len(wizard.available_pdf_report_ids) > 1 and not wizard.move_id.invoice_pdf_report_id
 
-    @api.depends('mail_template_id')
-    def _compute_mail_lang(self):
+    @api.depends('move_id')
+    def _compute_template_id(self):
         for wizard in self:
-            wizard.mail_lang = self._get_default_mail_lang(wizard.move_id, wizard.mail_template_id) if wizard.mail_template_id else get_lang(self.env).code
+            wizard.template_id = self._get_default_mail_template_id(wizard.move_id)
 
-    @api.depends('mail_template_id', 'mail_lang')
-    def _compute_mail_subject_body_partners(self):
+    @api.depends('template_id')
+    def _compute_lang(self):
+        # OVERRIDE 'mail.composer.mixin'
         for wizard in self:
-            if wizard.mail_template_id:
-                wizard.mail_subject = self._get_default_mail_subject(wizard.move_id, wizard.mail_template_id, wizard.mail_lang)
-                wizard.mail_body = self._get_default_mail_body(wizard.move_id, wizard.mail_template_id, wizard.mail_lang)
-                wizard.mail_partner_ids = self._get_default_mail_partner_ids(wizard.move_id, wizard.mail_template_id, wizard.mail_lang)
-            else:
-                wizard.mail_subject = wizard.mail_body = wizard.mail_partner_ids = None
+            wizard.lang = self._get_default_mail_lang(wizard.move_id, wizard.template_id) if wizard.template_id else get_lang(self.env).code
 
-    @api.depends('mail_template_id', 'sending_methods', 'extra_edis')
+    @api.depends('template_id', 'lang')
+    def _compute_mail_partners(self):
+        for wizard in self:
+            wizard.mail_partner_ids = None
+
+            if wizard.template_id:
+                wizard.mail_partner_ids = self._get_default_mail_partner_ids(wizard.move_id, wizard.template_id, wizard.lang)
+
+    @api.depends('template_id', 'lang')
+    def _compute_subject(self):
+        # OVERRIDE 'mail.composer.mixin'
+        for wizard in self:
+            wizard.subject = None
+
+            if wizard.template_id:
+                wizard.subject = self._get_default_mail_subject(wizard.move_id, wizard.template_id, wizard.lang)
+
+    @api.depends('template_id', 'lang')
+    def _compute_body(self):
+        # OVERRIDE 'mail.composer.mixin'
+        for wizard in self:
+            wizard.body = None
+
+            if wizard.template_id:
+                wizard.body = self._get_default_mail_body(wizard.move_id, wizard.template_id, wizard.lang)
+
+    @api.depends('template_id', 'sending_methods', 'extra_edis')
     def _compute_mail_attachments_widget(self):
         for wizard in self:
             manual_attachments_data = [x for x in wizard.mail_attachments_widget or [] if x.get('manual')]
             wizard.mail_attachments_widget = (
                 self._get_default_mail_attachments_widget(
                     wizard.move_id,
-                    wizard.mail_template_id,
+                    wizard.template_id,
                     extra_edis=wizard.extra_edis or {},
                     pdf_report=wizard.pdf_report_id,
                 )
                 + manual_attachments_data
             )
+
+    # Similar of mail.compose.message
+    @api.depends('template_id')
+    def _compute_res_ids(self):
+        for wizard in self:
+            wizard.res_ids = wizard.move_id.ids
+
+    # Similar of mail.compose.message
+    @api.depends('template_id')
+    def _compute_model(self):
+        for wizard in self:
+            wizard.model = self.env.context.get('active_model')
+
+    # Similar of mail.compose.message
+    @api.depends('sending_methods')
+    def _compute_can_edit_body(self):
+        for record in self:
+            record.can_edit_body = record.sending_methods and 'email' in record.sending_methods
+
+    @api.depends('model')  # Fake trigger otherwise not computed in new mode
+    def _compute_render_model(self):
+        # OVERRIDE 'mail.composer.mixin'
+        self.render_model = 'account.move'
+
+    # Similar of mail.compose.message
+    def open_template_creation_wizard(self):
+        """ Hit save as template button: opens a wizard that prompts for the template's subject.
+            `create_mail_template` is called when saving the new wizard. """
+
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_window',
+            'view_mode': 'form',
+            'view_id': self.env.ref('mail.mail_compose_message_view_form_template_save').id,
+            'name': _('Create a Mail Template'),
+            'res_model': 'account.move.send.wizard',
+            'context': {'dialog_size': 'medium'},
+            'target': 'new',
+            'res_id': self.id,
+        }
+
+    # Similar of mail.compose.message
+    def create_mail_template(self):
+        """ Creates a mail template with the current mail composer's fields. """
+        self.ensure_one()
+        if not self.model or not self.model in self.env:
+            raise UserError(_('Template creation from composer requires a valid model.'))
+        model_id = self.env['ir.model']._get_id(self.model)
+        values = {
+            'name': self.template_name or self.subject,
+            'subject': self.subject,
+            'body_html': self.body,
+            'model_id': model_id,
+            'use_default_to': True,
+            'user_id': self.env.uid,
+        }
+        template = self.env['mail.template'].create(values)
+
+        # generate the saved template
+        self.write({'template_id': template.id})
+        return _reopen(self, self.id, self.model, context={**self.env.context, 'dialog_size': 'large'})
+
+    # Similar of mail.compose.message
+    def cancel_save_template(self):
+        """ Restore old subject when canceling the 'save as template' action
+            as it was erased to let user give a more custom input. """
+        self.ensure_one()
+        return _reopen(self, self.id, self.model, context={**self.env.context, 'dialog_size': 'large'})
 
     # -------------------------------------------------------------------------
     # CONSTRAINS
@@ -247,10 +335,10 @@ class AccountMoveSendWizard(models.TransientModel):
         }
         if self.sending_methods and 'email' in self.sending_methods:
             send_settings.update({
-                'mail_template': self.mail_template_id,
-                'mail_lang': self.mail_lang,
-                'mail_body': self.mail_body,
-                'mail_subject': self.mail_subject,
+                'mail_template': self.template_id,
+                'mail_lang': self.lang,
+                'mail_body': self.body,
+                'mail_subject': self.subject,
                 'mail_partner_ids': self.mail_partner_ids.ids,
                 'mail_attachments_widget': self.mail_attachments_widget,
             })

--- a/addons/account/wizard/account_move_send_wizard.xml
+++ b/addons/account/wizard/account_move_send_wizard.xml
@@ -5,7 +5,7 @@
         <field name="name">account.move.send.wizard.form</field>
         <field name="model">account.move.send.wizard</field>
         <field name="arch" type="xml">
-            <form>
+            <form class="o_account_move_send_wizard">
                 <field name="move_id" invisible="1"/>
 
                 <!-- Warnings -->
@@ -19,71 +19,66 @@
                     <field name="sending_method_checkboxes" widget="account_json_checkboxes"/>
                 </div>
 
-
                 <!-- PDF template -->
                 <field name="pdf_report_id" invisible="1"/>
-                <group id="pdf_report" invisible="not display_pdf_report_id">
-                    <field name="pdf_report_id"
-                           class="w-50"
-                           options="{'no_create': True, 'no_edit': True}"/>
+                <group invisible="not display_pdf_report_id or 'email' in sending_methods">
+                    <field name="pdf_report_id" options="{'no_create': True, 'no_edit': True}"/>
                 </group>
 
                 <!-- Mail composer -->
                 <div invisible="'email' not in sending_methods">
+                    <field name="model" invisible="1"/>
+                    <field name="res_ids" invisible="1"/>
+                    <field name="render_model" invisible="1"/>
+
                     <group>
+                        <field name="pdf_report_id" options="{'no_create': True, 'no_edit': True}" invisible="not display_pdf_report_id"/>
+
                         <label for="mail_partner_ids" string="Recipients"/>
                         <div>
-                            <span>Followers of the document and</span>
+                            <widget name="mail_composer_recipient_list" thread_model_field="model" thread_id_field="res_ids"/>
                             <field name="mail_partner_ids"
                                    widget="many2many_tags"
                                    placeholder="Add contacts to notify..."
                                    options="{'no_quick_create': True}"
                                    context="{'show_email': True, 'form_view_ref': 'base.view_partner_simple_form'}"/>
                         </div>
-                        <field name="mail_subject"
+                        <field name="subject"
                                placeholder="Subject..."
                                required="'email' in sending_methods"/>
                     </group>
-                    <field name="mail_body"
+                    <field name="body"
                            class="oe-bordered-editor"
                            widget="html_mail"/>
-                    <group>
-                        <group>
-                            <field name="mail_attachments_widget"
-                                   widget="mail_attachments"
-                                   string="Attach a file"
-                                   nolabel="1"
-                                   colspan="2"/>
-                        </group>
-                        <group>
-                            <field name="mail_template_id"
-                                   options="{'no_create': True, 'no_edit': True}"
-                                   context="{'default_model': 'account.move'}"/>
-                        </group>
-                    </group>
+                    <field name="mail_attachments_widget"
+                           widget="mail_attachments"
+                           string="Attach a file"
+                           nolabel="1"
+                           colspan="2"/>
                 </div>
 
                 <footer>
-                    <button string="Print &amp; Send"
+                    <button string="Send"
                             data-hotkey="q"
                             name="action_send_and_print"
                             type="object"
-                            invisible="is_download_only"
-                            class="print btn-primary o_mail_send">
-                    </button>
-                    <button string="Print"
-                            data-hotkey="w"
+                            class="btn-primary"
+                            invisible="not sending_methods"/>
+                    <button string="Generate"
+                            data-hotkey="q"
                             name="action_send_and_print"
                             type="object"
-                            invisible="not is_download_only"
-                            class="print btn-primary o_mail_send">
-                    </button>
-                    <button string="Cancel"
+                            class="btn-primary"
+                            invisible="sending_methods"/>
+                    <button string="Discard"
                             data-hotkey="x"
                             special="cancel"
                             class="btn-secondary"/>
-                </footer>
 
+                    <field name="mail_attachments_widget" widget="mail_attachments_selector" invisible="'email' not in sending_methods"/>
+                    <field name="template_id" widget="mail_composer_template_selector"/>
+                    <field name="body" widget="mail_composer_chatgpt" invisible="'email' not in sending_methods"/>
+                </footer>
             </form>
         </field>
     </record>

--- a/addons/account_peppol/models/res_partner.py
+++ b/addons/account_peppol/models/res_partner.py
@@ -205,8 +205,6 @@ class ResPartner(models.Model):
             self.peppol_eas,
             self_partner.invoice_edi_format
         )
-        if self_partner.peppol_verification_state == 'valid':
-            self_partner.invoice_sending_method = 'peppol'
 
         self._log_verification_state_update(company, old_value, self_partner.peppol_verification_state)
         return False

--- a/addons/account_peppol/tests/test_peppol_messages.py
+++ b/addons/account_peppol/tests/test_peppol_messages.py
@@ -370,7 +370,6 @@ class TestPeppolMessage(TestAccountMoveSendCommon):
             'peppol_eas': '0208',
             'peppol_endpoint': '0477472701',
             'invoice_edi_format': 'ubl_bis3',
-            'invoice_sending_method': 'peppol',
         }])
         # but not valid for company 2
         self.assertRecordValues(new_partner.with_company(company_2), [{
@@ -378,7 +377,6 @@ class TestPeppolMessage(TestAccountMoveSendCommon):
             'peppol_eas': '0208',
             'peppol_endpoint': '0477472701',
             'invoice_edi_format': False,
-            'invoice_sending_method': 'peppol',
         }])
         move_1 = self.create_move(new_partner)
         move_2 = self.create_move(new_partner)

--- a/addons/account_peppol/tools/demo_utils.py
+++ b/addons/account_peppol/tools/demo_utils.py
@@ -87,7 +87,6 @@ def _mock_button_verify_partner_endpoint(func, self, *args, **kwargs):
     endpoint, eas, edi_format = self.peppol_endpoint, self.peppol_eas, self.invoice_edi_format
     if endpoint and eas and edi_format:
         self.peppol_verification_state = 'valid'
-        self.invoice_sending_method = 'peppol'
         self._log_verification_state_update(self.env.company, old_value, 'valid')
 
 

--- a/addons/account_peppol/wizard/account_move_send_batch_wizard.py
+++ b/addons/account_peppol/wizard/account_move_send_batch_wizard.py
@@ -1,4 +1,4 @@
-from odoo import models
+from odoo import api, models
 
 
 class AccountMoveSendBatchWizard(models.TransientModel):
@@ -7,7 +7,7 @@ class AccountMoveSendBatchWizard(models.TransientModel):
     def action_send_and_print(self, force_synchronous=False, allow_fallback_pdf=False):
         # EXTENDS 'account'
         self.ensure_one()
-        if peppol_moves := self.move_ids.filtered(lambda m: self._get_default_sending_method(m) == 'peppol'):
+        if peppol_moves := self.move_ids.filtered(lambda m: 'peppol' in self._get_default_sending_methods(m)):
             if registration_action := self._do_peppol_pre_send(peppol_moves):
                 return registration_action
         return super().action_send_and_print(force_synchronous=force_synchronous, allow_fallback_pdf=allow_fallback_pdf)

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
@@ -733,7 +733,7 @@ class TestUBLBE(TestUBLCommon, TestAccountMoveSendCommon):
         ]
 
         invoice.action_post()
-        invoice._generate_and_send(mail_template_id=self.move_template.id)
+        invoice._generate_and_send(template_id=self.move_template.id)
 
         self.assertRecordValues(invoice, [{
             'amount_untaxed': 600.00,

--- a/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
@@ -312,7 +312,7 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
             wizard = self.create_send_and_print(invoice)
             result = wizard.action_send_and_print()
 
-            self.assertEqual(result['type'], 'ir.actions.act_url')
+            self.assertEqual(result['type'], 'ir.actions.act_window_close')
             self.assertEqual(invoice.invoice_line_ids[0].price_subtotal, 0.0)
 
     def test_import_multiple_invoices(self):

--- a/addons/l10n_ro_edi/tests/test_xml_ubl_ro.py
+++ b/addons/l10n_ro_edi/tests/test_xml_ubl_ro.py
@@ -122,7 +122,7 @@ class TestUBLRO(TestUBLCommon):
         self.partner_a.write({'vat': False, 'company_registry': False})
         invoice = self.create_move("out_invoice", send=False)
         with self.assertRaisesRegex(UserError, "doesn't have a VAT nor Company ID"):
-            invoice._generate_and_send(allow_fallback_pdf=False, mail_template_id=self.move_template.id)
+            invoice._generate_and_send(allow_fallback_pdf=False, template_id=self.move_template.id)
 
     def test_export_constraints(self):
         self.company_data['company'].company_registry = False
@@ -131,10 +131,10 @@ class TestUBLRO(TestUBLCommon):
             self.company_data["company"][required_field] = False
             invoice = self.create_move("out_invoice", send=False)
             with self.assertRaisesRegex(UserError, "required"):
-                invoice._generate_and_send(allow_fallback_pdf=False, mail_template_id=self.move_template.id)
+                invoice._generate_and_send(allow_fallback_pdf=False, template_id=self.move_template.id)
             self.company_data["company"][required_field] = prev_val
 
         self.company_data["company"].city = "Bucharest"
         invoice = self.create_move("out_invoice", send=False)
         with self.assertRaisesRegex(UserError, "city name must be 'SECTORX'"):
-            invoice._generate_and_send(allow_fallback_pdf=False, mail_template_id=self.move_template.id)
+            invoice._generate_and_send(allow_fallback_pdf=False, template_id=self.move_template.id)


### PR DESCRIPTION
[IMP] account: send wizard

1. Align the design on the new Send wizards.
   * Remove download option
   * New AI additions
   * Email template management
   * Attachments management
2. Add back the standard print in the Print menu
3. Add a filter domain on reports customisation.
4. Change behavior of preferred invoice sending method on partner.
   * Default is 'e-Invoicing & Email' (empty selection).
   * Each selection is now only exclusive. For example, 'by email' is **only** by email.
5. Other misc. modifications like renaming, etc.

task-4276549