### PR TITLE
[FIX] l10n_pe_edi_website_sale: traceback on submit in address form

### DIFF
--- a/addons/l10n_pe_website_sale/controllers/main.py
+++ b/addons/l10n_pe_website_sale/controllers/main.py
@@ -39,7 +39,7 @@ class L10nPEWebsiteSale(WebsiteSale):
         if request.website.sudo().company_id.country_id.code != 'PE':
             return rendering_values
 
-        if address_type == 'billing':
+        if address_type == 'billing' or rendering_values['use_delivery_as_billing']:
             can_edit_vat = rendering_values['can_edit_vat']
             LatamIdentificationType = request.env['l10n_latam.identification.type'].sudo()
             rendering_values.update({

--- a/addons/l10n_pe_website_sale/views/templates.xml
+++ b/addons/l10n_pe_website_sale/views/templates.xml
@@ -62,7 +62,8 @@
 
     <template id="address" inherit_id="website_sale.address">
         <div id="div_vat" position="before">
-            <t t-if="address_type == 'billing' and res_company.country_id.code == 'PE'">
+            <t t-if="(address_type == 'billing' or use_delivery_as_billing)
+                     and res_company.country_id.code == 'PE'">
                 <div class="w-100" />
                 <t t-call="l10n_pe_website_sale.partner_info" />
             </t>


### PR DESCRIPTION
Steps to Reproduce:
- Set up a website for a Peru company.
- Go to the shop section.
- Purchase any product.
- Click submit on address form.

Issue:
- A traceback appears upon clicking submit.

Cause:
- The error is due to an attempt to access an element in the form that is not present.

Fix:
- Updated the view and controller to display the identification type field when use_delivery_as_billing is enabled.

Ticket [link](https://www.odoo.com/odoo/project/967/tasks/4314252)
opw-4314252

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
