### PR TITLE
[FIX] account, sale: factor in down payments without journal entries

### DIFF
--- a/addons/account/static/src/components/account_payment_field/account_payment.xml
+++ b/addons/account/static/src/components/account_payment_field/account_payment.xml
@@ -58,6 +58,16 @@
                     </td>
                     </tr>
                 </t>
+                <t t-foreach="info.payments" t-as="payment" t-key="payment.id">
+                    <tr>
+                        <td><i class="o_field_widget text-start o_payment_label">Paid on <t t-out="payment.date"/></i></td>
+                        <td>
+                            <span class="o_field_widget text-start oe_form_field oe_form_field_float oe_form_field_monetary">
+                                <t t-out="payment.amount_formatted"/>
+                            </span>
+                        </td>
+                    </tr>
+                </t>
             </table>
         </div>
     </t>

--- a/addons/account/static/src/components/account_payment_field/account_payment_field.js
+++ b/addons/account/static/src/components/account_payment_field/account_payment_field.js
@@ -30,11 +30,12 @@ export class AccountPaymentField extends Component {
     getInfo() {
         const info = this.props.record.data[this.props.name] || {
             content: [],
+            payment_content: [],
             outstanding: false,
             title: "",
             move_id: this.props.record.resId,
         };
-        for (const [key, value] of Object.entries(info.content)) {
+        for (const [key, value] of Object.entries(info.content).concat(Object.entries(info.payment_content))) {
             value.index = key;
             value.amount_formatted = formatMonetary(value.amount, {
                 currencyId: value.currency_id,
@@ -46,6 +47,7 @@ export class AccountPaymentField extends Component {
         }
         return {
             lines: info.content,
+            payments: info.payment_content,
             outstanding: info.outstanding,
             title: info.title,
             moveId: info.move_id,

--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -123,7 +123,7 @@
                     <t t-set="classes" t-value="'col-lg-4 col-xxl-3 d-print-none'"/>
                     <t t-set="title">
                         <h2 class="mb-0 text-break mx-auto">
-                            <span t-field="invoice.amount_total"/>
+                            <span t-field="invoice.amount_residual"/>
                         </h2>
                         <div class="my-1 w-100" t-if="payment_state in ('not_paid', 'partial')">
                             <div class="alert alert-success px-2 py-1 text-center mb-2" t-if="payment_state == 'partial'">

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -194,7 +194,8 @@
                                             <!--Payments-->
                                             <t t-if="print_with_payments">
                                                 <t t-if="o.payment_state != 'invoicing_legacy'">
-                                                    <t t-set="payments_vals" t-value="o.sudo().invoice_payments_widget and o.sudo().invoice_payments_widget['content'] or []"/>
+                                                    <t t-set="existing_payments" t-value="o.sudo().invoice_payments_widget"/>
+                                                    <t t-set="payments_vals" t-value="o.sudo().invoice_payments_widget and existing_payments['content'] + existing_payments['payment_content'] or []"/>
                                                     <t t-foreach="payments_vals" t-as="payment_vals">
                                                         <tr t-if="payment_vals['is_exchange'] == 0">
                                                             <td>


### PR DESCRIPTION
Steps to reproduce:
- Install sign; account; sales
- Payment Providers > Enable Demo
- Sales app > New Quotation > Other Info tab > Online Payment: 50%
- Preview > Sign and pay > Make the 50% down payment
- Back to SO > Create invoice > Regular invoice > Confirm > Preview

Coupled with https://github.com/odoo/enterprise/pull/74108

The down payment amount is not deducted from the invoice, meaning we essentially force the customer to pay 150% of the total price. This is a by-product of the rework 01b87f1230beac0568f4e3b1b76e547909506892 which made the creation of journal entries optional, on which the invoice was previously dependant to track existing payments.

Since the first payment here is made before any invoice is created, we want to create a separate payment with no associated journal entry (See the rework commit for more details on why we would want to do that, but in short we don't necessaily want to track payments that could be cancelled, etc...). However the matched_payment_ids on the invoice we create afterwards is not updated correctly, and above all the field is not taken into account by many views and functions which still assume there will be a corresponding account_move.

This fix mostly aims to recompute the amount_residual of the invoice since that is the source most places draw from, and to reestablish the customer displays to prevent excessive payments from being made. To avoid disturbing other functions which could depend on the edited method payment_content is being kept separate (Not all fields are available without an account move so we would risk accessing missing fields unexpectedly by mixing them with regular move lines.

opw-4208717

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
