### PR TITLE
[FIX] web: remove specific statusbar style in modals form views

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -318,8 +318,11 @@
             position: sticky;
             top: 0;
             z-index: 1;
-            background-color: $body-bg;
-            box-shadow: 0 0.3rem 0.25rem -0.25rem rgba(0, 0, 0, 0.075);
+
+            &:not(.modal .o_form_statusbar) {
+                background-color: $body-bg;
+                box-shadow: 0 0.3rem 0.25rem -0.25rem rgba(0, 0, 0, 0.075);
+            }
         }
 
         > .o_statusbar_status {


### PR DESCRIPTION
This PR fixes a side-effect introduced in Commit[1]. With Commit[1], the statusbar of our form views is now sticky. To achieve the right visual result, a `background-color` and `box-shadow` CSS property had to be defined.

As we previously had no `background-color` on our statusbar, it could be used inside every component and it'd have a transparent background, which is no longer the case with the new CSS. While a quick fix would be to define a `bg-inherit` on the statusbar, it'd not work on regular form views, as the `.position-sticky` takes the element out of the HTML stream, invalidating such a CSS. Instead, we exclude `.o_form_statusbar` within `.modal` from that style.

Commit[1]: a3c6341

task-4292553
related to task-3419566

| Master | This PR |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/6b809e55-53b7-40cd-910a-a2ab98f3326b) | ![image](https://github.com/user-attachments/assets/095b8c35-15a9-48c6-b296-c9c3eb8a5d8d) | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
