### PR TITLE
[IMP] base: captcha option on routes and forms

### DIFF
--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -33,7 +33,7 @@ class AuthSignupHome(Home):
                 return request.redirect_query('/web/login_successful', query={'account_created': True})
         return response
 
-    @http.route('/web/signup', type='http', auth='public', website=True, sitemap=False)
+    @http.route('/web/signup', type='http', auth='public', website=True, sitemap=False, captcha='signup')
     def web_auth_signup(self, *args, **kw):
         qcontext = self.get_auth_signup_qcontext()
 
@@ -78,7 +78,7 @@ class AuthSignupHome(Home):
         response.headers['Content-Security-Policy'] = "frame-ancestors 'self'"
         return response
 
-    @http.route('/web/reset_password', type='http', auth='public', website=True, sitemap=False)
+    @http.route('/web/reset_password', type='http', auth='public', website=True, sitemap=False, captcha='password_reset')
     def web_auth_reset_password(self, *args, **kw):
         qcontext = self.get_auth_signup_qcontext()
 

--- a/addons/auth_signup/static/src/js/signup.js
+++ b/addons/auth_signup/static/src/js/signup.js
@@ -14,8 +14,10 @@ publicWidget.registry.SignUpForm = publicWidget.Widget.extend({
      * @private
      */
     _onSubmit: function () {
-        var $btn = this.$('.oe_login_buttons > button[type="submit"]');
-        $btn.attr('disabled', 'disabled');
-        $btn.prepend('<i class="fa fa-refresh fa-spin"/> ');
+        const btn = this.$('.oe_login_buttons > button[type="submit"]');
+        if (!btn.prop("disabled")) {
+            btn.attr("disabled", "disabled");
+            btn.prepend('<i class="fa fa-refresh fa-spin"/> ');
+        }
     },
 });

--- a/addons/auth_signup/views/auth_signup_login_templates.xml
+++ b/addons/auth_signup/views/auth_signup_login_templates.xml
@@ -40,7 +40,7 @@
 
         <template id="auth_signup.signup" name="Sign up login">
             <t t-call="web.login_layout">
-                <form class="oe_signup_form" role="form" method="post" t-if="not message">
+                <form class="oe_signup_form" role="form" method="post" t-if="not message" data-captcha="signup">
                   <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
 
                     <t t-call="auth_signup.fields">
@@ -70,7 +70,7 @@
                     <a href="/web/login" class="btn btn-link btn-sm float-start" role="button">Back to Login</a>
                 </div>
 
-                <form class="oe_reset_password_form" role="form" method="post" t-if="not message">
+                <form class="oe_reset_password_form" role="form" method="post" t-if="not message" data-captcha="password_reset">
                   <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
 
                     <t t-if="token and not invalid_token">

--- a/addons/google_recaptcha/__manifest__.py
+++ b/addons/google_recaptcha/__manifest__.py
@@ -16,6 +16,7 @@ This module implements reCaptchaV3 so that you can prevent bot spam on your publ
         'web.assets_frontend': [
             'google_recaptcha/static/src/scss/recaptcha.scss',
             'google_recaptcha/static/src/js/recaptcha.js',
+            'google_recaptcha/static/src/js/captcha.js',
         ],
         'web.assets_backend': [
             # TODO we may want to consider moving that file in website instead

--- a/addons/google_recaptcha/models/ir_http.py
+++ b/addons/google_recaptcha/models/ir_http.py
@@ -36,6 +36,9 @@ class IrHttp(models.AbstractModel):
             If no recaptcha private key is set the recaptcha verification
             is considered inactive and this method will return True.
         """
+        res = super()._verify_request_recaptcha_token(action)
+        if not res:
+            return res
         ip_addr = request.httprequest.remote_addr
         token = request.params.pop('recaptcha_token_response', False)
         recaptcha_result = request.env['ir.http']._verify_recaptcha_token(ip_addr, token, action)

--- a/addons/google_recaptcha/models/ir_http.py
+++ b/addons/google_recaptcha/models/ir_http.py
@@ -36,14 +36,12 @@ class IrHttp(models.AbstractModel):
             If no recaptcha private key is set the recaptcha verification
             is considered inactive and this method will return True.
         """
-        res = super()._verify_request_recaptcha_token(action)
-        if not res:
-            return res
+        super()._verify_request_recaptcha_token(action)
         ip_addr = request.httprequest.remote_addr
         token = request.params.pop('recaptcha_token_response', False)
         recaptcha_result = request.env['ir.http']._verify_recaptcha_token(ip_addr, token, action)
         if recaptcha_result in ['is_human', 'no_secret']:
-            return True
+            return
         if recaptcha_result == 'wrong_secret':
             raise ValidationError(_("The reCaptcha private key is invalid."))
         elif recaptcha_result == 'wrong_token':
@@ -53,7 +51,7 @@ class IrHttp(models.AbstractModel):
         elif recaptcha_result == 'bad_request':
             raise UserError(_("The request is invalid or malformed."))
         else:
-            return False
+            raise UserError(_("Suspicious activity detected by google reCAPTCHA."))
 
     @api.model
     def _verify_recaptcha_token(self, ip_addr, token, action=False):

--- a/addons/google_recaptcha/static/src/js/captcha.js
+++ b/addons/google_recaptcha/static/src/js/captcha.js
@@ -1,0 +1,37 @@
+/** @odoo-module **/
+
+import publicWidget from "@web/legacy/js/public/public_widget";
+import { ReCaptcha } from "@google_recaptcha/js/recaptcha";
+
+publicWidget.registry.reCaptcha = publicWidget.Widget.extend({
+    selector: "form[data-captcha]",
+    events: {
+        submit: "_onSubmit",
+    },
+
+    init() {
+        this._super(...arguments);
+        this._recaptcha = new ReCaptcha();
+    },
+
+    async willStart() {
+        this._recaptcha.loadLibs();
+    },
+
+    async _onSubmit(event) {
+        const btn = this.$('button[type="submit"]');
+        if (!btn.prop("disabled")) {
+            btn.attr("disabled", "disabled");
+            btn.prepend('<i class="fa fa-refresh fa-spin"/> ');
+        }
+        if (!this.$el.find("input[name='recaptcha_token_response']")[0]) {
+            event.preventDefault();
+            const action = this.el.dataset.captcha || "generic";
+            const tokenCaptcha = await this._recaptcha.getToken(action);
+            this.$el.append(
+                `<input name="recaptcha_token_response" type="hidden" value="${tokenCaptcha.token}"/>`,
+            );
+            this.$el.submit();
+        }
+    },
+});

--- a/addons/web/controllers/home.py
+++ b/addons/web/controllers/home.py
@@ -94,7 +94,7 @@ class Home(http.Controller):
     def _login_redirect(self, uid, redirect=None):
         return _get_login_redirect_url(uid, redirect)
 
-    @http.route('/web/login', type='http', auth='none', readonly=False)
+    @http.route('/web/login', type='http', auth='none', readonly=False, captcha='login')
     def web_login(self, redirect=None, **kw):
         ensure_db()
         request.params['login_success'] = False

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -138,7 +138,7 @@
     <template id="web.login" name="Login">
         <t t-call="web.login_layout">
             <owl-component t-if="not login" name="web.user_switch" />
-            <form t-attf-class="oe_login_form #{'' if login else 'd-none'}" role="form" t-attf-action="/web/login" method="post" onsubmit="this.action = '/web/login' + location.hash">
+            <form t-attf-class="oe_login_form #{'' if login else 'd-none'}" role="form" t-attf-action="/web/login" method="post" onsubmit="this.action = '/web/login' + location.hash" data-captcha="login">
                 <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
 
                 <div class="mb-3" t-if="databases and len(databases) &gt; 1">

--- a/addons/website/controllers/form.py
+++ b/addons/website/controllers/form.py
@@ -47,12 +47,10 @@ class WebsiteForm(http.Controller):
                 kwargs = dict(request.params)
                 kwargs.pop('model_name')
                 return self._handle_website_form(model_name, **kwargs)
-            error = _("Suspicious activity detected by captcha.")
         except (ValidationError, UserError) as e:
-            error = e.args[0]
-        return json.dumps({
-            'error': error,
-        })
+            return json.dumps({
+                'error': e.args[0],
+            })
 
     def _handle_website_form(self, model_name, **kwargs):
         model_record = request.env['ir.model'].sudo().search([('model', '=', model_name), ('website_form_access', '=', True)])

--- a/addons/website_cf_turnstile/models/ir_http.py
+++ b/addons/website_cf_turnstile/models/ir_http.py
@@ -35,11 +35,12 @@ class IrHttp(models.AbstractModel):
         if not res:  # check result of google_recaptcha
             return res
 
+        super()._verify_request_recaptcha_token(action)
         ip_addr = request.httprequest.remote_addr
         token = request.params.pop('turnstile_captcha', False)
         turnstile_result = request.env['ir.http']._verify_turnstile_token(ip_addr, token, action)
         if turnstile_result in ['is_human', 'no_secret']:
-            return True
+            return
         if turnstile_result == 'wrong_secret':
             raise ValidationError(_("The Cloudflare turnstile private key is invalid."))
         elif turnstile_result == 'wrong_token':
@@ -49,7 +50,7 @@ class IrHttp(models.AbstractModel):
         elif turnstile_result == 'bad_request':
             raise UserError(_("The request is invalid or malformed."))
         else:  # wrong_action e.g.
-            return False
+            raise UserError(_("Suspicious activity detected by Turnstile CAPTCHA."))
 
     @api.model
     def _verify_turnstile_token(self, ip_addr, token, action=False):

--- a/addons/website_cf_turnstile/static/src/js/turnstile.js
+++ b/addons/website_cf_turnstile/static/src/js/turnstile.js
@@ -2,62 +2,51 @@ import "@website/snippets/s_website_form/000";  // force deps
 import { uniqueId } from "@web/core/utils/functions";
 import publicWidget from '@web/legacy/js/public/public_widget';
 import { session } from "@web/session";
-publicWidget.registry.s_website_form.include({
-    /**
-     * @override
-    */
-    start: function () {
-        const res = this._super(...arguments);
-        this.cleanTurnstile();
-        if (!this.isEditable && !this.el.querySelector(".s_turnstile") && session.turnstile_site_key) {
-            this.uniq = uniqueId("turnstile_");
-            this.el.classList.add(this.uniq);
 
-            const mode = new URLSearchParams(window.location.search).get("cf") == "show" ? "always" : "interaction-only";
-            const turnstileEl = document.createElement("div");
-            turnstileEl.className = "s_turnstile cf-turnstile float-end";
-            turnstileEl.dataset.action = "website_form";
-            turnstileEl.dataset.appearance = mode;
-            turnstileEl.dataset.responseFieldName = "turnstile_captcha";
-            turnstileEl.dataset.sitekey = session.turnstile_site_key;
-            turnstileEl.dataset.errorCallback = "throwTurnstileError";
-            turnstileEl.dataset.beforeInteractiveCallback = "turnstileBeforeInteractive";
-            turnstileEl.dataset.afterInteractiveCallback = "turnstileAfterInteractive";
 
-            const script1El = document.createElement("script");
-            script1El.className = "s_turnstile";
-            script1El.textContent = `
-                // Rethrow the error, or we only will catch a "Script error" without any info
-                // because of the script api.js originating from a different domain.
-                function throwTurnstileError(code) {
-                    const error = new Error("Turnstile Error");
-                    error.code = code;
-                    throw error;
+const turnStile = {
+    addTurnstile(action, selector) {
+        const cf = new URLSearchParams(window.location.search).get("cf");
+        const mode = cf == "show" ? "always" : "interaction-only";
+        const turnstileEl = document.createElement("div");
+        turnstileEl.className = "s_turnstile cf-turnstile float-end";
+        turnstileEl.dataset.action = action;
+        turnstileEl.dataset.appearance = mode;
+        turnstileEl.dataset.responseFieldName = "turnstile_captcha";
+        turnstileEl.dataset.sitekey = session.turnstile_site_key;
+        turnstileEl.dataset.errorCallback = "throwTurnstileError";
+        turnstileEl.dataset.beforeInteractiveCallback = "turnstileBeforeInteractive";
+        turnstileEl.dataset.afterInteractiveCallback = "turnstileAfterInteractive";
+
+        const script1El = document.createElement("script");
+        script1El.className = "s_turnstile";
+        script1El.textContent = `
+            // Rethrow the error, or we only will catch a "Script error" without any info
+            // because of the script api.js originating from a different domain.
+            function throwTurnstileError(code) {
+                const error = new Error("Turnstile Error");
+                error.code = code;
+                throw error;
+            }
+            function turnstileBeforeInteractive() {
+                const btnEl = document.querySelector('${selector}');
+                if (btnEl && !btnEl.classList.contains('disabled')) {
+                    btnEl.classList.add('disabled', 'cf_form_disabled');
                 }
-                function turnstileBeforeInteractive() {
-                    const btnEl = document.querySelector('.${this.uniq} .s_website_form_send,.${this.uniq} .o_website_form_send');
-                    if (btnEl && !btnEl.classList.contains('disabled')) {
-                        btnEl.classList.add('disabled', 'cf_form_disabled');
-                    }
+            }
+            function turnstileAfterInteractive() {
+                const btnEl = document.querySelector('${selector}');
+                if (btnEl && btnEl.classList.contains('cf_form_disabled')) {
+                    btnEl.classList.remove('disabled', 'cf_form_disabled');
                 }
-                function turnstileAfterInteractive() {
-                    const btnEl = document.querySelector('.${this.uniq} .s_website_form_send,.${this.uniq} .o_website_form_send');
-                    if (btnEl && btnEl.classList.contains('cf_form_disabled')) {
-                        btnEl.classList.remove('disabled', 'cf_form_disabled');
-                    }
-                }
-            `;
+            }
+        `;
 
-            const script2El = document.createElement("script");
-            script2El.className = "s_turnstile";
-            script2El.src = "https://challenges.cloudflare.com/turnstile/v0/api.js";
+        const script2El = document.createElement("script");
+        script2El.className = "s_turnstile";
+        script2El.src = "https://challenges.cloudflare.com/turnstile/v0/api.js";
 
-            const formSendEl = this.el.querySelector(".s_website_form_send, .o_website_form_send");
-            formSendEl.parentNode.insertBefore(turnstileEl, formSendEl.nextSibling);
-            formSendEl.parentNode.insertBefore(script1El, formSendEl.nextSibling);
-            formSendEl.parentNode.insertBefore(script2El, formSendEl.nextSibling);
-        }
-        return res;
+        return [turnstileEl, script1El, script2El];
     },
 
     /**
@@ -75,5 +64,59 @@ publicWidget.registry.s_website_form.include({
     destroy: function () {
         this.cleanTurnstile();
         this._super(...arguments);
+    },
+};
+
+publicWidget.registry.s_website_form.include({
+    ...turnStile,
+
+    /**
+     * @override
+    */
+    start() {
+        const res = this._super(...arguments);
+        this.cleanTurnstile();
+        if (
+            !this.isEditable &&
+            !this.el.querySelector(".s_turnstile") &&
+            session.turnstile_site_key
+        ) {
+            this.uniq = uniqueId("turnstile_");
+            this.el.classList.add(this.uniq);
+            const [turnstileEl, script1El, script2El] = this.addTurnstile(
+                "website_form",
+                `.${this.uniq} .s_website_form_send,.${this.uniq} .o_website_form_send`,
+            );
+            const formSendEl = this.el.querySelector(".s_website_form_send, .o_website_form_send");
+            formSendEl.parentNode.insertBefore(turnstileEl, formSendEl.nextSibling);
+            formSendEl.parentNode.insertBefore(script1El, formSendEl.nextSibling);
+            formSendEl.parentNode.insertBefore(script2El, formSendEl.nextSibling);
+        }
+        return res;
+    },
+});
+
+publicWidget.registry.turnstileCaptcha = publicWidget.Widget.extend({
+    ...turnStile,
+
+    selector: "[data-captcha]",
+
+    async willStart() {
+        this._super(...arguments);
+        this.cleanTurnstile();
+        if (
+            !this.isEditable &&
+            !this.el.querySelector(".s_turnstile") &&
+            session.turnstile_site_key
+        ) {
+            this.uniq = uniqueId("turnstile_");
+            const action = this.el.dataset.captcha || "generic";
+            const [turnstileEl, script1El, script2El] = this.addTurnstile(action, `.${this.uniq}`);
+            const submitButton = this.el.querySelector("button[type='submit']");
+            submitButton.classList.add(this.uniq);
+            submitButton.parentNode.insertBefore(turnstileEl, submitButton);
+            this.el.appendChild(script1El);
+            this.el.appendChild(script2El);
+        }
     },
 });

--- a/addons/website_mail/controllers/main.py
+++ b/addons/website_mail/controllers/main.py
@@ -1,18 +1,15 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from collections import defaultdict
-from odoo import http, _
+from odoo import http
 from odoo.http import request
-from odoo.exceptions import UserError
 
 
 class WebsiteMail(http.Controller):
 
-    @http.route(['/website_mail/follow'], type='jsonrpc', auth="public", website=True)
+    @http.route(['/website_mail/follow'], type='jsonrpc', auth="public", website=True, captcha='website_mail_follow')
     def website_message_subscribe(self, id=0, object=None, message_is_follower="on", email=False, **post):
         # TDE FIXME: check this method with new followers
-        if not request.env['ir.http']._verify_request_recaptcha_token('website_mail_follow'):
-            raise UserError(_("Suspicious activity detected by Google reCaptcha."))
         res_id = int(id)
         is_follower = message_is_follower == 'on'
         record = request.env[object].browse(res_id).exists()

--- a/addons/website_mass_mailing/controllers/main.py
+++ b/addons/website_mass_mailing/controllers/main.py
@@ -37,7 +37,7 @@ class MassMailController(main.MassMailController):
         if not request.env['ir.http']._verify_request_recaptcha_token('website_mass_mailing_subscribe'):
             return {
                 'toast_type': 'danger',
-                'toast_content': _("Suspicious activity detected by Google reCaptcha."),
+                'toast_content': _("Suspicious activity detected by captcha."),
             }
 
         fname = self._get_fname(subscription_type)

--- a/addons/website_mass_mailing/controllers/main.py
+++ b/addons/website_mass_mailing/controllers/main.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import tools, _
+from odoo.exceptions import UserError
 from odoo.http import route, request
 from odoo.addons.mass_mailing.controllers import main
 
@@ -34,10 +35,12 @@ class MassMailController(main.MassMailController):
 
     @route('/website_mass_mailing/subscribe', type='jsonrpc', website=True, auth='public')
     def subscribe(self, list_id, value, subscription_type, **post):
-        if not request.env['ir.http']._verify_request_recaptcha_token('website_mass_mailing_subscribe'):
+        try:
+            request.env['ir.http']._verify_request_recaptcha_token('website_mass_mailing_subscribe')
+        except UserError as e:
             return {
                 'toast_type': 'danger',
-                'toast_content': _("Suspicious activity detected by captcha."),
+                'toast_content': str(e),
             }
 
         fname = self._get_fname(subscription_type)

--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -27,8 +27,8 @@ except ImportError:
     slugify_lib = None
 
 import odoo
-from odoo import _, api, http, models, tools, SUPERUSER_ID
-from odoo.exceptions import AccessDenied, UserError
+from odoo import api, http, models, tools, SUPERUSER_ID
+from odoo.exceptions import AccessDenied
 from odoo.http import request, Response, ROUTING_KEYS, SAFE_HTTP_METHODS
 from odoo.modules.registry import Registry
 from odoo.service import security
@@ -329,12 +329,8 @@ class IrHttp(models.AbstractModel):
         # Verify the captcha in case it was set on @http.route
         # https://httpwg.org/specs/rfc9110.html#safe.methods
         captcha = endpoint.routing.get('captcha')
-        if (
-            captcha
-            and request.httprequest.method not in SAFE_HTTP_METHODS
-            and not request.env['ir.http']._verify_request_recaptcha_token(captcha)
-        ):
-            raise UserError(_("Suspicious activity detected by captcha."))
+        if captcha and request.httprequest.method not in SAFE_HTTP_METHODS:
+            request.env['ir.http']._verify_request_recaptcha_token(captcha)
         result = endpoint(**request.params)
         if isinstance(result, Response) and result.is_qweb:
             result.flatten()
@@ -438,4 +434,4 @@ class IrHttp(models.AbstractModel):
 
     @api.model
     def _verify_request_recaptcha_token(self, action: str):
-        return True
+        return

--- a/odoo/addons/test_http/tests/__init__.py
+++ b/odoo/addons/test_http/tests/__init__.py
@@ -1,3 +1,4 @@
+from . import test_captcha
 from . import test_common
 from . import test_device
 from . import test_echo_reply

--- a/odoo/addons/test_http/tests/test_captcha.py
+++ b/odoo/addons/test_http/tests/test_captcha.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 from unittest.mock import patch
 
 from odoo import http
+from odoo.exceptions import UserError
 from odoo.tests import HttpCase, tagged
 from odoo.tools import mute_logger
 
@@ -15,7 +16,8 @@ class TestCaptcha(HttpCase):
     @contextmanager
     def patch_captcha_valid(self, validity):
         def _verify_request_recaptcha_token(self, captcha):
-            return validity
+            if not validity:
+                raise UserError("CAPTCHA test")
         with patch.object(self.env.registry['ir.http'], '_verify_request_recaptcha_token', _verify_request_recaptcha_token):
             yield
 

--- a/odoo/addons/test_http/tests/test_captcha.py
+++ b/odoo/addons/test_http/tests/test_captcha.py
@@ -1,0 +1,41 @@
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from odoo import http
+from odoo.tests import HttpCase, tagged
+from odoo.tools import mute_logger
+
+
+@tagged('post_install', '-at_install')
+class TestCaptcha(HttpCase):
+    def setUp(self):
+        super().setUp()
+        self.authenticate(None, None)
+
+    @contextmanager
+    def patch_captcha_valid(self, validity):
+        def _verify_request_recaptcha_token(self, captcha):
+            return validity
+        with patch.object(self.env.registry['ir.http'], '_verify_request_recaptcha_token', _verify_request_recaptcha_token):
+            yield
+
+    def test_post_valid(self):
+        with self.patch_captcha_valid(True):
+            res = self.url_open('/web/login', data={'csrf_token': http.Request.csrf_token(self), 'login': '_', 'password': '_'})
+            res.raise_for_status()
+
+    @mute_logger('odoo.http')
+    def test_post_invalid(self):
+        with self.patch_captcha_valid(False):
+            res = self.url_open('/web/login', data={'csrf_token': http.Request.csrf_token(self), 'login': '_', 'password': '_'})
+            self.assertEqual(res.status_code, 400)
+
+    def test_get_valid(self):
+        res = self.url_open('/web/login')
+        with self.patch_captcha_valid(True):
+            res.raise_for_status()
+
+    def test_get_invalid(self):
+        res = self.url_open('/web/login')
+        with self.patch_captcha_valid(False):
+            res.raise_for_status()

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -215,7 +215,7 @@ _logger = logging.getLogger(__name__)
 CORS_MAX_AGE = 60 * 60 * 24
 
 # The HTTP methods that do not require a CSRF validation.
-CSRF_FREE_METHODS = ('GET', 'HEAD', 'OPTIONS', 'TRACE')
+SAFE_HTTP_METHODS = ('GET', 'HEAD', 'OPTIONS', 'TRACE')
 
 # The default csrf token lifetime, a salt against BREACH, one year
 CSRF_TOKEN_SALT = 60 * 60 * 24 * 365
@@ -707,6 +707,9 @@ def route(route=None, **routing):
     :param Callable[[Exception], Response] handle_params_access_error:
         Implement a custom behavior if an error occurred when retrieving the record
         from the URL parameters (access error or missing error).
+    :param str captcha: The action name of the captcha. When set the request will be
+        validated against a captcha implementation. Upon failing these requests will
+        return a UserError.
     """
     def decorator(endpoint):
         fname = f"<function {endpoint.__module__}.{endpoint.__name__}>"
@@ -2107,7 +2110,7 @@ class HttpDispatcher(Dispatcher):
         self.request.params = dict(self.request.get_http_params(), **args)
 
         # Check for CSRF token for relevant requests
-        if self.request.httprequest.method not in CSRF_FREE_METHODS and endpoint.routing.get('csrf', True):
+        if self.request.httprequest.method not in SAFE_HTTP_METHODS and endpoint.routing.get('csrf', True):
             if not self.request.db:
                 return self.request.redirect('/web/database/selector')
 


### PR DESCRIPTION
Before this commit captcha was not enabled on signup and reset password requests. This meant that a lot of emails could be sent by automated means, causing issues for clients.

Task-3626220