### PR TITLE
[FIX]: web: prevent negative popper positioning

### DIFF
--- a/addons/web/static/src/core/position_hook.js
+++ b/addons/web/static/src/core/position_hook.js
@@ -238,7 +238,12 @@ function getBestPosition(popper, target, { container, margin, position }, iframe
     }
 
     // Fallback to default position if no best solution found
-    return getPositioningData();
+    let default_position = getPositioningData();
+    if (!iframe) {
+        default_position.top = default_position.top > 0 ? default_position.top : 0;
+        default_position.left = default_position.left > 0 ? default_position.left : 0;
+    }
+    return default_position;
 }
 
 /**


### PR DESCRIPTION
Depending of viewport size and popover content, the dialog window may get cut off.

For example, an extremely small viewport size clicking on the reception report icon while adding a product to a sale order line.

Having 0 as the minimum for position values prevents the cutoff.

opw-4018341