### PR TITLE
[ADD] auth_signup_recaptcha

### DIFF
--- a/addons/auth_signup/views/auth_signup_login_templates.xml
+++ b/addons/auth_signup/views/auth_signup_login_templates.xml
@@ -38,7 +38,7 @@
             </div>
         </template>
 
-        <template id="auth_signup.signup" name="Sign up login">
+        <template id="auth_signup.signup" captcha="signup" name="Sign up login">
             <t t-call="web.login_layout">
                 <form class="oe_signup_form" role="form" method="post" t-if="not message">
                   <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
@@ -70,7 +70,7 @@
                     <a href="/web/login" class="btn btn-link btn-sm float-start" role="button">Back to Login</a>
                 </div>
 
-                <form class="oe_reset_password_form" role="form" method="post" t-if="not message">
+                <form class="oe_reset_password_form" role="form" captcha="password_reset" method="post" t-if="not message">
                   <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
 
                     <t t-if="token and not invalid_token">

--- a/addons/auth_signup_recaptcha/__init__.py
+++ b/addons/auth_signup_recaptcha/__init__.py
@@ -1,0 +1,1 @@
+from . import controllers

--- a/addons/auth_signup_recaptcha/__manifest__.py
+++ b/addons/auth_signup_recaptcha/__manifest__.py
@@ -1,0 +1,21 @@
+{
+    'name': 'Signup reCAPTCHA',
+    'description': """
+Implements reCAPTCHA for the signup page
+===============================================
+    """,
+    'version': '1.0',
+    'category': 'Hidden/Tools',
+    'auto_install': True,
+    'installable': True,
+    'depends': [
+        'google_recaptcha',
+        'auth_signup',
+    ],
+    'assets': {
+        'web.assets_frontend': [
+            'auth_signup_recaptcha/static/**/*',
+        ],
+    },
+    'license': 'LGPL-3',
+}

--- a/addons/auth_signup_recaptcha/controllers/__init__.py
+++ b/addons/auth_signup_recaptcha/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import signup

--- a/addons/auth_signup_recaptcha/controllers/signup.py
+++ b/addons/auth_signup_recaptcha/controllers/signup.py
@@ -1,0 +1,18 @@
+from odoo import http, _
+from odoo.addons.auth_signup.controllers.main import AuthSignupHome
+from odoo.http import request
+from odoo.exceptions import UserError
+
+
+class SignupCaptcha(AuthSignupHome):
+    @http.route()
+    def web_auth_signup(self, *args, **kw):
+        if request.httprequest.method == 'POST' and not request.env['ir.http']._verify_request_recaptcha_token('signup'):
+            raise UserError(_("Suspicious activity detected by Google reCaptcha."))
+        return super().web_auth_signup(*args, **kw)
+
+    @http.route()
+    def web_auth_reset_password(self, *args, **kw):
+        if request.httprequest.method == 'POST' and not request.env['ir.http']._verify_request_recaptcha_token('password_reset'):
+            raise UserError(_("Suspicious activity detected by Google reCaptcha."))
+        return super().web_auth_reset_password(*args, **kw)

--- a/addons/auth_signup_recaptcha/static/src/captcha.js
+++ b/addons/auth_signup_recaptcha/static/src/captcha.js
@@ -1,0 +1,32 @@
+/** @odoo-module **/
+
+import publicWidget from "@web/legacy/js/public/public_widget";
+import { ReCaptcha } from "@google_recaptcha/js/recaptcha";
+
+publicWidget.registry.reCaptcha = publicWidget.Widget.extend({
+    selector: '[captcha]',
+    events: {
+        'submit': '_onSubmit',
+    },
+
+    init() {
+        this._super(...arguments);
+        this._recaptcha = new ReCaptcha();
+        this.shouldCatch = true;
+    },
+
+    async willStart() {
+        return this._recaptcha.loadLibs();
+    },
+
+    _onSubmit(event) {
+        if(this.shouldCatch) {
+            event.preventDefault()
+            this._recaptcha.getToken(this.el.getAttribute("captcha") || "generic").then(tokenCaptcha => {
+                this.$el.append(`<input name="recaptcha_token_response" type="hidden" value="${tokenCaptcha.token}"/>`);
+                this.shouldCatch = false;
+                this.$el.submit();
+            })
+        }
+    },
+})


### PR DESCRIPTION
Before this commit captcha was not enabled on signup and reset password requests. This meant that a lot of emails could be sent by automated means, causing issues for clients.

Task-3626220


16.0: https://github.com/odoo/odoo/pull/185073
17.0: https://github.com/odoo/odoo/pull/185097
18.0: https://github.com/odoo/odoo/pull/185653 <--
master: https://github.com/odoo/odoo/pull/185648