### PR TITLE
[IMP] point_of_sale: prevent deselection of product attribute.

### DIFF
--- a/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.js
@@ -12,7 +12,7 @@ export class BaseProductAttribute extends Component {
         this.attributeLine = this.props.attributeLine;
         this.values = this.attributeLine.product_template_value_ids;
         this.state = useState({
-            attribute_value_ids: parseFloat(this.values[0].id),
+            attribute_value_ids: this.values[0].id.toString(),
             custom_value: "",
         });
     }


### PR DESCRIPTION
Before this commit:
- In the product configurator popup, it was possible to deselect a product attribute and add a product without a variant to the cart, which violated the standard behavior of radio buttons.

Following this commit :
- Product attributes in the product configurator popup can no longer be deselected aligning with the expected functionality of radio buttons.

task- 4285309
