### PR TITLE
[FIX] test_website: test_website_page_manager test without demo-data

### DIFF
--- a/addons/test_website/tests/test_page_manager.py
+++ b/addons/test_website/tests/test_page_manager.py
@@ -15,7 +15,7 @@ class TestWebsitePageManager(odoo.tests.HttpCase):
             })
         else:
             website2 = self.env['website'].search([], order='id desc', limit=1)
-        self.env['test.model.multi.website'].create({'name': 'Test Model Website 2', 'website_id': website2.id})
+        self.env['test.model.multi.website'].create({'name': 'Test Model Multi Website 2', 'website_id': website2.id})
         self.assertTrue(
             len(set([t.website_id.id for t in self.env['test.model.multi.website'].search([])])) >= 3,
             "There should at least be one record without website_id and one for 2 different websites",


### PR DESCRIPTION
There was a typo in the test, which was breaking tests when they ran
without demo data. This commit fixes it.

[broken test builds](https://runbot.odoo.com/web#id=56563&menu_id=424&cids=1&action=573&model=runbot.build.error&view_type=form)