### PR TITLE
[IMP] website: add desktop alignment option for sidebar header

### DIFF
--- a/addons/website/static/src/scss/primary_variables.scss
+++ b/addons/website/static/src/scss/primary_variables.scss
@@ -2181,7 +2181,7 @@ $o-base-website-values-palette: (
     'header-links-style': 'default', // 'default' / 'fill' / 'outline' / 'pills' / 'block' / 'border-bottom'
     'logo-height': null, // Default to navbar height (see portal)
     'hamburger-position': 'left', // 'left' / 'center' / 'right'
-    'hamburger-position-mobile': 'left', // 'left' / 'center' / 'right'
+    'hamburger-position-mobile': 'right', // 'left' / 'center' / 'right'
     'menu-border-width': null, // Default to classes used on the template
     'menu-border-style': solid, // Default to classes used on the template
     'menu-border-radius': null, // Default to classes used on the template

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1575,15 +1575,24 @@ header {
             // We need to combine both using `calc`. The `border` solution does
             // not work on Safari.
             $padding-size: o-website-value('sidebar-width');
+            $-hamburger-right: o-website-value("hamburger-position") == "right";
             @if o-website-value('layout') != 'full' {
                 $padding-size: calc(#{$grid-gutter-width} * 2 + #{$padding-size});
             }
-            padding-left: $padding-size;
+            @if $-hamburger-right {
+                padding-right: $padding-size;
+            } @else {
+                padding-left: $padding-size;
+            }
 
             > header {
                 --Offcanvas-horizontal-width: #{o-website-value('sidebar-width')};
 
-                inset: 0 auto 0 0;
+                @if $-hamburger-right {
+                    inset: 0 0 0 auto;
+                } @else {
+                    inset: 0 auto 0 0;
+                }
                 position: fixed;
                 z-index: $zindex-fixed;
                 display: flex;

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -1490,15 +1490,21 @@
          data-no-check="true"
          groups="website.group_website_designer">
 
+        <we-select data-variable="hamburger-position" data-reload="/" string="Desktop Alignment" data-dependencies="header_sidebar_opt, header_hamburger_opt">
+            <we-button data-customize-website-variable="'left'"
+                       data-customize-website-views="">Left</we-button>
+            <we-button data-customize-website-variable="'right'"
+                       data-customize-website-views="website.template_header_hamburger_align_right">Right</we-button>
+        </we-select>
+
         <we-select string="Mobile Alignment"
                    data-name="header_mobile_alignment_opt"
                    data-variable="hamburger-position-mobile"
                    data-reload="/">
-            <we-button data-customize-website-views="" data-customize-website-variable="'left'">Left</we-button>
-            <we-button data-customize-website-views="website.template_header_mobile_align_center, website.template_header_hamburger_mobile_align_center"
-                       data-customize-website-variable="'center'">Center</we-button>
-            <we-button data-customize-website-views="website.template_header_mobile_align_right, website.template_header_hamburger_mobile_align_right"
-                       data-customize-website-variable="'right'">Right</we-button>
+            <we-button data-customize-website-variable="'right'"
+                       data-customize-website-views="">Right</we-button>
+            <we-button data-customize-website-variable="'left'"
+                       data-customize-website-views="website.template_header_mobile_position_left">Left</we-button>
         </we-select>
 
         <we-fontfamilypicker string="Font" data-variable="navbar-font"/>
@@ -1509,16 +1515,12 @@
             <!-- Generic alignment option controling all the template at once. -->
             <!-- Currently needed to be this way as the SCSS variable controls -->
             <!-- the mobile alignement which is the same for all templates. -->
-            <we-select class="o_we_icon_select" data-name="header_alignment_opt" data-variable="hamburger-position" data-reload="/" title="Alignment" data-dependencies="header_default_opt, header_hamburger_opt, header_boxed_opt, header_stretch_opt, header_search_opt, header_sales_one_opt, header_sales_two_opt, header_sales_four_opt, header_sidebar_opt">
+            <we-select class="o_we_icon_select" data-name="header_alignment_opt" data-reload="/" title="Alignment" data-dependencies="header_default_opt, header_hamburger_opt, header_boxed_opt, header_stretch_opt, header_search_opt, header_sales_one_opt, header_sales_two_opt, header_sales_four_opt, header_sidebar_opt">
                 <we-button data-customize-website-views=""
-                           data-customize-website-variable="'left'"
                            data-icon="fa-align-left"/>
-                <we-button data-customize-website-views="website.template_header_default_align_center, website.template_header_boxed_align_center, website.template_header_stretch_align_center, website.template_header_search_align_center, website.template_header_sales_one_align_center, website.template_header_sales_two_align_center, website.template_header_sales_four_align_center, website.template_header_sidebar_align_center"
-                           data-customize-website-variable="'center'"
-                           data-icon="fa-align-center"
-                           data-dependencies="!header_hamburger_opt"/>
-                <we-button data-customize-website-views="website.template_header_default_align_right, website.template_header_hamburger_align_right, website.template_header_boxed_align_right, website.template_header_stretch_align_right, website.template_header_search_align_right, website.template_header_sales_one_align_right, website.template_header_sales_two_align_right, website.template_header_sales_four_align_right, website.template_header_sidebar_align_right"
-                           data-customize-website-variable="'right'"
+                <we-button data-customize-website-views="website.template_header_mobile_align_center, website.template_header_hamburger_mobile_align_center, website.template_header_default_align_center, website.template_header_boxed_align_center, website.template_header_stretch_align_center, website.template_header_search_align_center, website.template_header_sales_one_align_center, website.template_header_sales_two_align_center, website.template_header_sales_four_align_center, website.template_header_sidebar_align_center"
+                           data-icon="fa-align-center"/>
+                <we-button data-customize-website-views="website.template_header_mobile_align_right, website.template_header_hamburger_mobile_align_right, website.template_header_default_align_right, website.template_header_boxed_align_right, website.template_header_stretch_align_right, website.template_header_search_align_right, website.template_header_sales_one_align_right, website.template_header_sales_two_align_right, website.template_header_sales_four_align_right, website.template_header_sidebar_align_right"
                            data-icon="fa-align-right"/>
             </we-select>
         </we-row>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -403,26 +403,26 @@
         <t t-set="_navbar_classes" t-valuef="o_header_mobile d-block d-lg-none shadow-sm"/>
         <t t-set="_navbar_expand_class" t-valuef=""/>
         <t t-set="_navbar_name" t-valuef="Mobile"/>
+        <t t-set="_side" t-valuef="offcanvas-end"></t>
 
         <div class="o_main_nav container flex-wrap justify-content-between">
-            <!-- Brand -->
-            <t t-call="website.placeholder_header_brand"/>
-            <ul class="o_header_mobile_buttons_wrap navbar-nav flex-row align-items-center gap-2 mb-0">
-                <li class="o_not_editable">
-                    <button
-                        class="nav-link btn me-auto p-2"
-                        type="button"
-                        data-bs-toggle="offcanvas"
-                        data-bs-target="#top_menu_collapse_mobile"
-                        aria-controls="top_menu_collapse_mobile"
-                        aria-expanded="false"
-                        aria-label="Toggle navigation"
-                        >
-                        <span class="navbar-toggler-icon"/>
-                    </button>
-                </li>
-            </ul>
-            <div t-attf-class="offcanvas offcanvas-end o_navbar_mobile" id="top_menu_collapse_mobile">
+            <div class="d-flex flex-grow-1">
+                <!-- Brand -->
+                <t t-call="website.placeholder_header_brand"/>
+                <ul class="o_header_mobile_buttons_wrap navbar-nav d-flex flex-row align-items-center gap-2 mb-0 ms-auto"/>
+            </div>
+            <button
+                class="nav-link btn p-2 o_not_editable"
+                type="button"
+                data-bs-toggle="offcanvas"
+                data-bs-target="#top_menu_collapse_mobile"
+                aria-controls="top_menu_collapse_mobile"
+                aria-expanded="false"
+                aria-label="Toggle navigation"
+                >
+                <span class="navbar-toggler-icon"/>
+            </button>
+            <div t-attf-class="offcanvas #{_side} o_navbar_mobile" id="top_menu_collapse_mobile">
                 <div class="offcanvas-header justify-content-end o_not_editable">
                     <button type="button" class="nav-link btn-close" data-bs-dismiss="offcanvas" aria-label="Close"/>
                 </div>
@@ -490,6 +490,18 @@
             </div>
         </div>
     </t>
+</template>
+
+<template id="template_header_mobile_position_left" inherit_id="website.template_header_mobile" active="False">
+    <xpath expr="//t[@t-set='_side']" position="replace">
+        <t t-set="_side" t-valuef="offcanvas-start"/>
+    </xpath>
+    <xpath expr="//div[hasclass('o_main_nav')]" position="attributes">
+        <attribute name="class" add="flex-row-reverse" separator=" "/>
+    </xpath>
+    <xpath expr="//div[hasclass('o_main_nav')]//button" position="attributes">
+        <attribute name="class" add="me-2" separator=" "/>
+    </xpath>
 </template>
 
 <template id="template_header_mobile_align_center" inherit_id="website.template_header_mobile" active="False">

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -65,7 +65,7 @@
     </template>
 
     <template id="template_header_mobile" inherit_id="website.template_header_mobile">
-        <xpath expr="//ul[hasclass('o_header_mobile_buttons_wrap')]//li" position="before">
+        <xpath expr="//ul[hasclass('o_header_mobile_buttons_wrap')]" position="inside">
             <t t-call="website_sale.header_cart_link">
                 <t t-set="_icon" t-value="True"/>
                 <t t-set="_link_class" t-value="'o_navlink_background_hover btn position-relative rounded-circle border-0 p-1 text-reset'"/>


### PR DESCRIPTION
With this commit [[1]](https://github.com/odoo/odoo/commit/f87cee6d589694b56caef84beb90259db6cf96b0), we lost the functionality to change the sidebar header position, making it impossible to align the sidebar header to the right. Previously, we managed the sidebar position and text alignment using the common option, "Format > Alignment."

In this commit, we introduce a new option, "Desktop Alignment," for setting the sidebar header position, while keeping "Format > Alignment" for text alignment to simplify the user interaction with these options.

![image](https://github.com/user-attachments/assets/d612d6ad-d4da-4475-ba96-bc6c3e8f0ff6)

task-4204213

