### PR TITLE
[FIX] stock: update stock quant onchange lot quality check

### DIFF
--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -451,6 +451,10 @@ class Location(models.Model):
 
         return result
 
+    def _child_of(self, other_location):
+        self.ensure_one()
+        return other_location.parent_path in self.parent_path
+
 
 class StockRoute(models.Model):
     _name = 'stock.route'


### PR DESCRIPTION
### Steps to reproduce:

- In the settings Enable Multi-steps route
- Create a product FP with a BOM:
  - 1 component: 1 x COMP (tracked by SN)
  - 1 operation: "Register SN on COMP"
  - Add an instruction on your op:
    - type: "Register consumed component"
    - Product To Register: COMP
- Put 2 SN for COMP:
  - SN01 in Stock/Shelf1
  - SN02 in Stock/Shelf2
- Create and confirm an MO for 1 Unit of FP
> SN01 is reserved on the COMP raw move.
- Go to the shopfloor > "Register SN on COMP"
- Change the SN of the COMP from SN01 to SN02
#### > Go back to the stock MO the incorrect location was used

### Cause of the issue:

While the lot is correctly updated by the action here: https://github.com/odoo/enterprise/blob/e90cf74be3945d1f1256d398ca9c4b61bc35ed08/mrp_workorder/models/quality.py#L485-L507 The associated quant is not set and hence the move location_id, package, ... are not updated with it.

### Fix:

We take advantage of the `quant_id` dummy field of the `stock.move.line` to update the info to write thanks to the write override: https://github.com/odoo/odoo/blob/09cac8b9e6d2db46dadece0442a8a947a49c9de7/addons/stock/models/stock_move_line.py#L85 https://github.com/odoo/odoo/blob/09cac8b9e6d2db46dadece0442a8a947a49c9de7/addons/stock/models/stock_move_line.py#L399-L400 https://github.com/odoo/odoo/blob/09cac8b9e6d2db46dadece0442a8a947a49c9de7/addons/stock/models/stock_move_line.py#L911-L920

### Note:

Unfortunately, the Dialog opened when clicking on the the quality check from the shopfloor:
https://github.com/odoo/enterprise/blob/34ab94cdcc49f4ade66953874a03f2988b2b4317/mrp_workorder/static/src/mrp_display/dialog/mrp_quality_check_confirmation_dialog.js#L12 is not embedded in a form view so that the onchange: https://github.com/odoo/odoo/blob/366676cafdce00d55823c6daf41452b0c2373e4d/addons/stock/models/stock_move_line.py#L185-L192 is not triggered by our change of "lot_id".

opw-4149941
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
