### PR TITLE
[FIX] payment_mercado_pago: round payment tx amounts for COP, HLN & NIO

### DIFF
--- a/addons/payment_mercado_pago/const.py
+++ b/addons/payment_mercado_pago/const.py
@@ -4,7 +4,7 @@ from odoo import _
 
 
 # Currency codes of the currencies supported by Mercado Pago in ISO 4217 format.
-# See https://api.mercadopago.com/currencies. Last seen online: 24 November 2022.
+# See https://api.mercadopago.com/currencies. Last seen online: 2024-10-29.
 SUPPORTED_CURRENCIES = [
     'ARS',  # Argentinian Peso
     'BOB',  # Boliviano
@@ -29,6 +29,15 @@ SUPPORTED_CURRENCIES = [
     'VEF',  # Strong Bolivar
     'VES',  # Sovereign Bolivar
 ]
+
+# Set of currencies where Mercado Pago's minor units deviates from the ISO 4217 standard.
+# See https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-one.xls
+# vs. https://api.mercadopago.com/currencies. Last seen online: 2024-10-29.
+CURRENCY_DECIMALS = {
+    'COP': 0,
+    'HNL': 0,
+    'NIO': 0,
+}
 
 # The codes of the payment methods to activate when Mercado Pago is activated.
 DEFAULT_PAYMENT_METHODS_CODES = [

--- a/addons/payment_mercado_pago/i18n/payment_mercado_pago.pot
+++ b/addons/payment_mercado_pago/i18n/payment_mercado_pago.pot
@@ -107,13 +107,6 @@ msgstr ""
 #. odoo-python
 #: code:addons/payment_mercado_pago/models/payment_transaction.py:0
 #, python-format
-msgid "Prices in the currency %s must be expressed in integer values."
-msgstr ""
-
-#. module: payment_mercado_pago
-#. odoo-python
-#: code:addons/payment_mercado_pago/models/payment_transaction.py:0
-#, python-format
 msgid "Received data with invalid status: %s"
 msgstr ""
 


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Use COP, HLN or NIO as currency;
2. create a SO or invoice with a non-integer amount total;
3. create a payment link;
4. pay using Mercado Pago.

Issue
-----
> Error processing payment
> Prices in COP currency must be expressed with integer values

Cause
-----
Our currency defaults follow the ISO 4217 standard for minor units. For three currencies (COP, HLN & NIO), Mercado Pago only accepts integer amounts instead of the standard 2 decimals, resulting in a failed payment transaction.

Solution
--------
In the payload sent to Mercado Pago, round the amount down if it uses one of the affected currencies.

opw-4191877