### PR TITLE
[REF] web_tour: improves trigger search method

### DIFF
--- a/addons/pos_restaurant/static/tests/tours/utils/floor_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/floor_screen_util.js
@@ -132,7 +132,6 @@ patch(TourHelpers.prototype, {
             await new Promise((resolve) => setTimeout(resolve, this.delay));
         };
         const element = this.anchor;
-        this._ensureEnabled(element, "drag and drop");
         const { drop, moveTo } = await hoot.drag(element);
         await dragEffectDelay();
         await hoot.hover(element, {

--- a/addons/web_tour/static/src/tour_service/tour_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_automatic.js
@@ -2,6 +2,7 @@ import { tourState } from "./tour_state";
 import { config as transitionConfig } from "@web/core/transition";
 import { TourStepAutomatic } from "./tour_step_automatic";
 import { MacroEngine } from "@web/core/macro";
+import { browser } from "@web/core/browser/browser";
 
 export class TourAutomatic {
     mode = "auto";
@@ -17,16 +18,22 @@ export class TourAutomatic {
         this.stepDelay = tourConfig.stepDelay;
     }
 
+    get currentIndex() {
+        return tourState.getCurrentIndex();
+    }
+
+    get currentStep() {
+        return this.steps[this.currentIndex];
+    }
+
     get debugMode() {
         const tourConfig = tourState.getCurrentConfig() || {};
         return tourConfig.debug !== false;
     }
 
     start(pointer, callback) {
-        this.pointer = pointer;
-        const currentStepIndex = tourState.getCurrentIndex();
         const macroSteps = this.steps
-            .filter((step) => step.index >= currentStepIndex)
+            .filter((step) => step.index >= this.currentIndex)
             .flatMap((step) => {
                 return [
                     {
@@ -34,7 +41,18 @@ export class TourAutomatic {
                     },
                     {
                         trigger: () => step.findTrigger(),
-                        action: (stepEl) => step.doAction(stepEl),
+                        action: async () => {
+                            tourState.setCurrentIndex(step.index + 1);
+                            if (!step.skipped && this.showPointerDuration > 0 && step.element) {
+                                // Useful in watch mode.
+                                pointer.pointTo(step.element, this);
+                                await new Promise((r) =>
+                                    browser.setTimeout(r, this.showPointerDuration)
+                                );
+                                pointer.hide();
+                            }
+                            return step.doAction();
+                        },
                     },
                     {
                         action: () => step.waitForPause(),

--- a/addons/web_tour/static/src/tour_service/tour_helpers.js
+++ b/addons/web_tour/static/src/tour_service/tour_helpers.js
@@ -24,7 +24,6 @@ export class TourHelpers {
      */
     async check(selector) {
         const element = this._get_action_element(selector);
-        this._ensureEnabled(element, "check");
         await hoot.check(element);
     }
 
@@ -44,7 +43,6 @@ export class TourHelpers {
      */
     async clear(selector) {
         const element = this._get_action_element(selector);
-        this._ensureEnabled(element, "clear");
         await hoot.click(element);
         await hoot.clear();
     }
@@ -60,7 +58,6 @@ export class TourHelpers {
      */
     async click(selector) {
         const element = this._get_action_element(selector);
-        this._ensureEnabled(element, "click");
         await hoot.click(element);
     }
 
@@ -75,7 +72,6 @@ export class TourHelpers {
      */
     async dblclick(selector) {
         const element = this._get_action_element(selector);
-        this._ensureEnabled(element, "dblclick");
         await hoot.dblclick(element);
     }
 
@@ -105,7 +101,6 @@ export class TourHelpers {
             await new Promise((resolve) => setTimeout(resolve, this.delay));
         };
         const element = this.anchor;
-        this._ensureEnabled(element, "drag and drop");
         const { drop, moveTo } = await hoot.drag(element);
         await dragEffectDelay();
         await hoot.hover(element, {
@@ -150,7 +145,6 @@ export class TourHelpers {
         if (!InEditor) {
             throw new Error("run 'editor' always on an element in an editor");
         }
-        this._ensureEnabled(element, "edit wysiwyg");
         await hoot.click(element);
         this._set_range(element, "start");
         await hoot.keyDown("_");
@@ -194,7 +188,6 @@ export class TourHelpers {
      */
     async range(value, selector) {
         const element = this._get_action_element(selector);
-        this._ensureEnabled(element, "range");
         await hoot.click(element);
         await hoot.setInputRange(element, value);
     }
@@ -223,7 +216,6 @@ export class TourHelpers {
      */
     async select(value, selector) {
         const element = this._get_action_element(selector);
-        this._ensureEnabled(element, "select");
         await hoot.click(element);
         await hoot.select(value, { target: element });
     }
@@ -238,7 +230,6 @@ export class TourHelpers {
      */
     async selectByIndex(index, selector) {
         const element = this._get_action_element(selector);
-        this._ensureEnabled(element, "selectByIndex");
         await hoot.click(element);
         const value = hoot.queryValue(`option:eq(${index})`, { root: element });
         if (value) {
@@ -257,7 +248,6 @@ export class TourHelpers {
      */
     async selectByLabel(contains, selector) {
         const element = this._get_action_element(selector);
-        this._ensureEnabled(element, "selectByLabel");
         await hoot.click(element);
         const values = hoot.queryAllValues(`option:contains(${contains})`, { root: element });
         await hoot.select(values, { target: element });
@@ -277,7 +267,6 @@ export class TourHelpers {
      */
     uncheck(selector) {
         const element = this._get_action_element(selector);
-        this._ensureEnabled(element, "uncheck");
         hoot.uncheck(element);
     }
 
@@ -337,18 +326,5 @@ export class TourHelpers {
         range.setStart(node, length);
         range.setEnd(node, length);
         selection.addRange(range);
-    }
-
-    /**
-     * Return true when element is not disabled
-     * @param {Node} element
-     */
-    _ensureEnabled(element, action = "do action") {
-        if (element.disabled) {
-            throw new Error(
-                `Element can't be disabled when you want to ${action} on it.
-Tip: You can add the ":enabled" pseudo selector to your selector to wait for the element is enabled.`
-            );
-        }
     }
 }

--- a/addons/web_tour/static/tests/tour_service.test.js
+++ b/addons/web_tour/static/tests/tour_service.test.js
@@ -284,8 +284,8 @@ test("a failing tour logs the step that failed in run", async () => {
         `log: [2/2] Tour tour2 → Step .button1`,
         [
             "error: FAILED: [2/2] Tour tour2 → Step .button1.",
-            "Element has been found. The error seems to be with step.run.",
-            "Cannot read properties of null (reading 'click')",
+            "Element has been found.",
+            "ERROR IN ACTION: Cannot read properties of null (reading 'click')",
         ].join("\n"),
         "error: tour not succeeded",
     ];
@@ -332,16 +332,13 @@ test("a failing tour with disabled element", async () => {
     await advanceTime(750);
     await advanceTime(750);
     await advanceTime(750);
-    const expectedError = [
-        [
-            `error: FAILED: [2/3] Tour tour3 → Step .button1.`,
-            `Element has been found. The error seems to be with step.run.`,
-            `Element can't be disabled when you want to click on it.`,
-            `Tip: You can add the ":enabled" pseudo selector to your selector to wait for the element is enabled.`,
-        ].join("\n"),
-        `error: tour not succeeded`,
-    ];
     await advanceTime(10000);
+    const expectedError = [
+        `error: FAILED: [2/3] Tour tour3 → Step .button1.
+Element has been found.
+BUT: Element is not enabled.
+TIMEOUT: The step failed to complete within 10000 ms.`,
+    ];
     expect.verifySteps(expectedError);
 });
 
@@ -434,7 +431,9 @@ test("a failing tour logs the step that failed", async () => {
     expect.verifySteps(["log: [5/9] Tour tour1 → Step content (trigger: .wrong_selector)"]);
     await advanceTime(10000);
     expect.verifySteps([
-        "error: FAILED: [5/9] Tour tour1 → Step content (trigger: .wrong_selector).\nThe cause is that trigger (.wrong_selector) element cannot be found in DOM. TIP: You can use :not(:visible) to force the search for an invisible element.",
+        `error: FAILED: [5/9] Tour tour1 → Step content (trigger: .wrong_selector).
+The cause is that trigger (.wrong_selector) element cannot be found in DOM. TIP: You can use :not(:visible) to force the search for an invisible element.
+TIMEOUT: The step failed to complete within 10000 ms.`,
         `runbot: {"content":"content","trigger":".button1","run":"click"},{"content":"content","trigger":".button2","run":"click"},{"content":"content","trigger":".button3","run":"click"},FAILED:[5/9]Tourtour1→Stepcontent(trigger:.wrong_selector){"content":"content","trigger":".wrong_selector","run":"click"},{"content":"content","trigger":".button4","run":"click"},{"content":"content","trigger":".button5","run":"click"},{"content":"content","trigger":".button6","run":"click"},`,
     ]);
 });
@@ -880,7 +879,9 @@ test("automatic tour with invisible element", async () => {
     await advanceTime(750);
     await advanceTime(10000);
     expect.verifySteps([
-        "error: FAILED: [2/3] Tour tour_de_wallonie → Step .button1.\nThe cause is that trigger (.button1) element cannot be found in DOM. TIP: You can use :not(:visible) to force the search for an invisible element.",
+        `error: FAILED: [2/3] Tour tour_de_wallonie → Step .button1.
+The cause is that trigger (.button1) element cannot be found in DOM. TIP: You can use :not(:visible) to force the search for an invisible element.
+TIMEOUT: The step failed to complete within 10000 ms.`,
     ]);
 });
 
@@ -1483,6 +1484,8 @@ test("check not possible to click below modal", async () => {
         "log: [1/2] Tour tour_check_modal → Step .button0",
         "log: [2/2] Tour tour_check_modal → Step .button1",
         `error: FAILED: [2/2] Tour tour_check_modal → Step .button1.
-Element has been found but it's not allowed to do action on an element that's below a modal.`,
+Element has been found.
+BUT: It is not allowed to do action on an element that's below a modal.
+TIMEOUT: The step failed to complete within 10000 ms.`,
     ]);
 });


### PR DESCRIPTION
In this commit, we improve the algorithm for finding the trigger. In fact, in macro.js, when each time the findTrigger method returns "false", then we wait for the next mutation to run findTrigger again. So in fact, it is not correct to check if the element found for the tour step is disabled AFTER having found it. We must find an element that meets specific criteria, namely that it is not disabled. We take advantage of this commit to improve the error messages. We take advantage of this commit to move the pointer in tour_automatic and no longer have to pass it in tour_step_automatic.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
