### PR TITLE
[IMP] point_of_sale: rename `Available in POS` filter

### DIFF
--- a/addons/point_of_sale/views/product_view.xml
+++ b/addons/point_of_sale/views/product_view.xml
@@ -9,7 +9,7 @@
                 <field string="POS Product Category" name="pos_categ_ids" filter_domain="[('pos_categ_ids', 'child_of', raw_value)]"/>
             </field>
             <filter name="filter_to_sell" position="before">
-               <filter name="filter_to_availabe_pos" string="Available in POS" domain="[('available_in_pos', '=', True)]"/>
+               <filter name="filter_to_availabe_pos" string="Point of Sale" domain="[('available_in_pos', '=', True)]"/>
             </filter>
             <filter name="group_by_categ_id" position="after">
                 <filter string="POS Product Category" name="pos_categ_ids" context="{'group_by':'pos_categ_ids'}"/>


### PR DESCRIPTION
In this commit we rename the `Available in POS` filter to `Point of Sale` in order to ensure consistency between modules. ( `sale` and `purchase` follow the same convention )

Task 4290385




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
