### PR TITLE
[FIX] point_of_sale: display single product for multi-variant items

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -379,7 +379,7 @@ export class ProductScreen extends Component {
     getProductsByCategory(category) {
         const allCategoryIds = category.getAllChildren().map((cat) => cat.id);
         const products = allCategoryIds.flatMap(
-            (catId) => this.pos.models["product.product"].getBy("pos_categ_ids", catId) || []
+            (catId) => this.pos.models["product.template"].getBy("pos_categ_ids", catId) || []
         );
         // Remove duplicates since owl doesn't like it.
         return Array.from(new Set(products));


### PR DESCRIPTION
Issue:
=======
Multiple products were shown for each variant of a product

Cause:
=======
Used `product.product` to display products by category, resulting in each
variant being listed as a separate item.

FIX:
====
Updated to use `product.template` instead, displaying only a single entry for
each product with multiple variants.

Task- 4285860