### PR TITLE
[FIX] pos_loyalty: create gift card when invoicing

### DIFF
--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -788,6 +788,17 @@ export function createRelatedModels(modelDefs, modelClasses = {}, indexes = {}) 
             const rec = records[model];
 
             for (const data of Object.values(rec)) {
+                const rawLine = rawData[model].find((r) => r[key] === data[key]);
+                if (rawLine) {
+                    for (const [f, p] of Object.entries(modelClasses[model]?.extraFields || {})) {
+                        if (X2MANY_TYPES.has(p.type)) {
+                            rawLine[f] = data[f]?.map((r) => r.id) || [];
+                            continue;
+                        }
+                        rawLine[f] = data[f]?.id || false;
+                    }
+                }
+
                 if (rawDataIdx.includes(data[key])) {
                     if (data.uiState) {
                         uiState[data[key]] = { ...data.uiState };

--- a/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
@@ -5,6 +5,8 @@ import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import { registry } from "@web/core/registry";
 import * as TicketScreen from "@point_of_sale/../tests/tours/utils/ticket_screen_util";
 import * as Order from "@point_of_sale/../tests/tours/utils/generic_components/order_widget_util";
+import * as PaymentScreen from "@point_of_sale/../tests/tours/utils/payment_screen_util";
+import * as ReceiptScreen from "@point_of_sale/../tests/tours/utils/receipt_screen_util";
 
 registry.category("web_tour.tours").add("GiftCardProgramCreateSetTour1", {
     test: true,
@@ -128,5 +130,22 @@ registry.category("web_tour.tours").add("PosLoyaltyGiftCardTaxes", {
             PosLoyalty.enterCode("044123456"),
             PosLoyalty.orderTotalIs("50.00"),
             ProductScreen.checkTaxAmount("-6.52"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("GiftCardProgramInvoice", {
+    test: true,
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            ProductScreen.clickDisplayedProduct("Gift Card"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("Test Partner"),
+            PosLoyalty.orderTotalIs("50.00"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickInvoiceButton(),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
         ].flat(),
 });

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -2335,3 +2335,28 @@ class TestUi(TestPointOfSaleHttpCommon):
             "PosLoyaltyPromocodePricelist",
             login="pos_user",
         )
+
+    def test_gift_card_program_create_with_invoice(self):
+        """
+        Test for gift card program when pos.config.gift_card_settings == 'create_set'.
+        """
+        self.pos_user.write({
+            'groups_id': [
+                (4, self.env.ref('stock.group_stock_user').id),
+            ]
+        })
+        LoyaltyProgram = self.env['loyalty.program']
+        (LoyaltyProgram.search([])).write({'pos_ok': False})
+        self.env.ref('loyalty.gift_card_product_50').write({'active': True})
+
+        gift_card_program = self.create_programs([('arbitrary_name', 'gift_card')])['arbitrary_name']
+        self.main_pos_config.write({'gift_card_settings': 'create_set'})
+        self.env['res.partner'].create({'name': 'Test Partner'})
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(
+            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "GiftCardProgramInvoice",
+            login="pos_user",
+        )
+        self.assertEqual(len(gift_card_program.coupon_ids), 1)


### PR DESCRIPTION
When gift card is the only program activated, if you buy a gift card in the PoS and invoice the order. The gift would not be created and not printed

Steps to reproduce:
-------------------
* Disable all loyalty programs but gift card program
* Open PoS and add a gift card to your order
* Validate the order and invoice it
> Observation: No gift card is printed, if you check in the backend it
is not even created

Why the fix:
------------
When invoicing the order is synced with the backend before handling the loyalty programs. After synchronising the orders all the local fields are lost. In our case `_e_wallet_program_id` is necessary to create the gift cards. So we try to retrieve it based on the product of the line.

opw-4222936
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
