### PR TITLE
[FIX] l10n_in_edi_ewaybill: fix the ewaybill name log

### DIFF
--- a/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
+++ b/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
@@ -259,7 +259,7 @@ class AccountEdiFormat(models.Model):
             """).format(
                 _('E-wayBill Sent'),
                 _('Number'),
-                str(response.get("data", {}).get('ewayBillNo', 0)) or str(response.get("data", {}).get('EwbNo', 0)),
+                str(response.get("data", {}).get('EwbNo')),
                 _('Validity'),
                 str(response.get("data", {}).get('EwbValidTill'))
             )
@@ -358,9 +358,9 @@ class AccountEdiFormat(models.Model):
             """).format(
                 _('E-wayBill Sent'),
                 _('Number'),
-                str(response.get("data", {}).get('ewayBillNo', 0)) or str(response.get("data", {}).get('EwbNo', 0)),
+                str(response.get("data", {}).get('ewayBillNo')),
                 _('Validity'),
-                str(response.get("data", {}).get('EwbValidTill'))
+                str(response.get("data", {}).get('validUpto'))
             )
             invoices.message_post(body=body)
         return res


### PR DESCRIPTION
Issue found at commit: https://github.com/odoo/odoo/commit/0e8f3d5c42b4f219e4e7db6915dd1dd7ec45e4b4 After the above mentioned commit when using eWaybill with e-Invoicing the log note of ewaybill i.e.
```
E-wayBill Sent
Number -> 0
Validity -> None
```
![image](https://github.com/user-attachments/assets/d1d3d58c-f54e-4a74-b803-3f6384a246eb)

where as in the response attachment of eWaybill, the ewaybill number does exist

In this commit, we resolve the above issue and the correct ewaybill number gets logged

opw-4280093

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
