### PR TITLE
[FIX] pos_self_order: scroll back to last product

### DIFF
--- a/addons/pos_self_order/static/src/app/components/product_card/product_card.js
+++ b/addons/pos_self_order/static/src/app/components/product_card/product_card.js
@@ -7,8 +7,7 @@ export class ProductCard extends Component {
     static template = "pos_self_order.ProductCard";
     static props = ["product", "currentProductCard?"];
 
-    selfRef = useRef("selfProductCard");
-    currentProductCardRef = useRef("currentProductCard");
+    selfRef = useRef("currentProductCard");
 
     setup() {
         this.selfOrder = useSelfOrder();

--- a/addons/pos_self_order/static/src/app/components/product_card/product_card.xml
+++ b/addons/pos_self_order/static/src/app/components/product_card/product_card.xml
@@ -5,7 +5,7 @@
             role="button"
             t-att-title="props.product.display_name"
             t-on-click="() => this.selectProduct()"
-            t-ref="selfProductCard">
+            t-ref="currentProductCard">
             <div t-if="!this.isHtmlEmpty" class="product-information-tag" t-on-click.prevent.stop="showProductInfo">
                 <i class="product-information-tag-logo fa fa-info fs-4" role="img" aria-label="Product Information" title="Product Information" />
             </div>

--- a/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.js
+++ b/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.js
@@ -76,10 +76,9 @@ export class ProductListPage extends Component {
             this.selfOrder.computeAvailableCategories();
         });
     }
-
     scrollTo(ref = null, { behavior = "smooth" } = {}) {
         this.productsList.el.scroll({
-            top: ref?.el ? ref.el.offsetTop - this.productsList.el.offsetTop : 0,
+            top: ref?.el ? ref.el.offsetTop + ref.el.parentElement.parentElement.offsetTop : 0,
             behavior,
         });
     }


### PR DESCRIPTION
Steps to reproduce issue:
1. In the self order product list, scroll down to a product that has options and click on it;
2. The app now takes you to the product's page;
3. Click back;
4. You are not on the product list page, at the top, instead of at the position where you last were

The issue is that the product list page should "remember" what product was last clicked and automatically scroll back down to it.

There are 2 things that are causing this issue. The first is an improper use of `useChildRef` and the second is a wrong computation of the position to which we should actually scroll.
Both issues are fixed in this commit.

Task: 4274299





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
