### PR TITLE
[FIX] website: fix numbers snippets layout

### DIFF
--- a/addons/website/views/snippets/s_numbers.xml
+++ b/addons/website/views/snippets/s_numbers.xml
@@ -5,31 +5,27 @@
     <section class="s_numbers o_cc o_cc1 pt80 pb80">
         <div class="container">
             <div class="row s_nb_column_fixed">
-                <div class="col-lg-4">
+                <div class="col-lg-5">
                     <h3 class="mb-3 h4">Key Metrics of<br/>Company's Achievements</h3>
                     <p class="lead">Analyzing the numbers behind our success: <br class="d-none d-xxl-inline"/>an in-depth look at the key metrics driving our company's achievements</p>
                 </div>
-                <div class="col-lg-7 offset-lg-1">
-                    <div class="row">
-                        <div class="col-lg-4 pt24 pb24 text-center" data-name="Number Box">
-                            <p class="lead">
-                                <span class="s_number display-1-fs">12k</span><br/>
-                                <span class="h5-fs">Useful options</span>
-                            </p>
-                        </div>
-                        <div class="col-lg-4 pt24 pb24 text-center" data-name="Number Box">
-                            <p class="lead">
-                                <span class="s_number display-1-fs">45%</span><br/>
-                                <span class="h5-fs">More leads</span>
-                            </p>
-                        </div>
-                        <div class="col-lg-4 pt24 pb24 text-center" data-name="Number Box">
-                            <p class="lead">
-                                <span class="s_number display-1-fs">8+</span><br/>
-                                <span class="h5-fs">Amazing pages</span>
-                            </p>
-                        </div>
-                    </div>
+                <div class="col-lg-2 offset-lg-1">
+                    <p style="text-align: center;">
+                        <span class="s_number display-1-fs">12k</span><br/>
+                        <span class="h5-fs">Useful options</span>
+                    </p>
+                </div>
+                <div class="col-lg-2">
+                    <p style="text-align: center;">
+                        <span class="s_number display-1-fs">45%</span><br/>
+                        <span class="h5-fs">More leads</span>
+                    </p>
+                </div>
+                <div class="col-lg-2">
+                    <p style="text-align: center;">
+                        <span class="s_number display-1-fs">8+</span><br/>
+                        <span class="h5-fs">Amazing pages</span>
+                    </p>
                 </div>
             </div>
         </div>

--- a/addons/website/views/snippets/s_numbers_grid.xml
+++ b/addons/website/views/snippets/s_numbers_grid.xml
@@ -6,36 +6,52 @@
         <div class="container">
             <div class="row o_grid_mode" data-row-count="6" style="gap: 8px;">
                 <div class="o_grid_item g-col-lg-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 border rounded" data-name="Number Cell" style="grid-area: 1 / 1 / 4 / 4; z-index: 1; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
-                    <p>Revenue Growth</p>
-                    <span class="display-5">54%</span>
+                    <p>
+                        Revenue Growth<br/>
+                        <span class="h1-fs">54%</span>
+                    </p>
                 </div>
                 <div class="o_grid_item g-col-lg-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 border rounded" data-name="Number Cell" style="grid-area: 1 / 4 / 4 / 7;; z-index: 2; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
-                    <p>Projects deployed</p>
-                    <span class="display-5">+225</span>
+                    <p>
+                        Projects deployed<br/>
+                        <span class="h1-fs">+225</span>
+                    </p>
                 </div>
                 <div class="o_grid_item g-col-lg-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 border rounded" data-name="Number Cell" style="grid-area: 1 / 7 / 4 / 10; z-index: 3; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
-                    <p>Expected revenue</p>
-                    <span class="display-5">$50M</span>
+                    <p>
+                        Expected revenue<br/>
+                        <span class="h1-fs">$50M</span>
+                    </p>
                 </div>
                 <div class="o_grid_item g-col-lg-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 border rounded" data-name="Number Cell" style="grid-area: 1 / 10 / 4 / 13; z-index: 4; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
-                    <p>Online Members</p>
-                    <span class="display-5">235,403</span>
+                    <p>
+                        Online Members<br/>
+                        <span class="h1-fs">235,403</span>
+                    </p>
                 </div>
                 <div class="o_grid_item g-col-lg-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 border rounded" data-name="Number Cell" style="grid-area: 4 / 1 / 7 / 4; z-index: 5; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
-                    <p>Customer Retention</p>
-                    <span class="display-5">85%</span>
+                    <p>
+                        Customer Retention<br/>
+                        <span class="h1-fs">85%</span>
+                    </p>
                 </div>
                 <div class="o_grid_item g-col-lg-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 border rounded" data-name="Number Cell" style="grid-area: 4 / 4 / 7 / 7; z-index: 6; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
-                    <p>Inventory turnover</p>
-                    <span class="display-5">4x</span>
+                    <p>
+                        Inventory turnover<br/>
+                        <span class="h1-fs">4x</span>
+                    </p>
                 </div>
                 <div class="o_grid_item g-col-lg-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 border rounded" data-name="Number Cell" style="grid-area: 4 / 7 / 7 / 10; z-index: 7; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
-                    <p>Website visitors</p>
-                    <span class="display-5">100,000</span>
+                    <p>
+                        Website visitors<br/>
+                        <span class="h1-fs">100,000</span>
+                    </p>
                 </div>
                 <div class="o_grid_item g-col-lg-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 border rounded" data-name="Number Cell" style="grid-area: 4 / 10 / 7 / 13; z-index: 8; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
-                    <p>Transactions</p>
-                    <span class="display-5">45,958</span>
+                    <p>
+                        Transactions<br/>
+                        <span class="h1-fs">45,958</span>
+                    </p>
                 </div>
             </div>
         </div>

--- a/addons/website/views/snippets/s_numbers_list.xml
+++ b/addons/website/views/snippets/s_numbers_list.xml
@@ -9,50 +9,50 @@
                     <h3>Key Metrics of Company's Achievements</h3>
                     <p><br/>From revenue growth to customer retention and market expansion, our key metrics of company achievements underscore our strategic prowess and dedication to driving sustainable business success.</p>
                 </div>
-                <div class="col-lg-6 offset-lg-1 s_col_no_bgcolor" data-name="Numbers group">
-                    <div class="row">
-                        <div class="col-6 col-lg-6 pt16 pb16" data-name="Number">
-                            <span class="h2-fs">15%</span>
-                            <p>Revenue Growth</p>
-                            <div class="s_hr pt16 pb40" data-snippet="s_hr" data-name="Separator">
-                                <hr class="w-100 mx-auto"/>
-                            </div>
-                        </div>
-                        <div class="col-6 col-lg-6 pt16 pb16" data-name="Number">
-                            <span class="h2-fs">$50M</span>
-                            <p>Expected revenue</p>
-                            <div class="s_hr pt16 pb40" data-snippet="s_hr" data-name="Separator">
-                                <hr class="w-100 mx-auto"/>
-                            </div>
-                        </div>
-                        <div class="col-6 col-lg-6 pt16 pb16" data-name="Number">
-                            <span class="h2-fs">85%</span>
-                            <p>User Retention</p>
-                            <div class="s_hr pt16 pb40" data-snippet="s_hr" data-name="Separator">
-                                <hr class="w-100 mx-auto"/>
-                            </div>
-                        </div>
-                        <div class="col-6 col-lg-6 pt16 pb16" data-name="Number">
-                            <span class="h2-fs">100,000</span>
-                            <p>Website visitors</p>
-                            <div class="s_hr pt16 pb40" data-snippet="s_hr" data-name="Separator">
-                                <hr class="w-100 mx-auto"/>
-                            </div>
-                        </div>
-                        <div class="col-6 col-lg-6 pt16 pb16" data-name="Number">
-                            <span class="h2-fs">20+</span>
-                            <p>Projects deployed</p>
-                            <div class="s_hr pt16 pb40" data-snippet="s_hr" data-name="Separator">
-                                <hr class="w-100 mx-auto"/>
-                            </div>
-                        </div>
-                        <div class="col-6 col-lg-6 pt16 pb16" data-name="Number">
-                            <span class="h2-fs">4x</span>
-                            <p>Inventory turnover</p>
-                            <div class="s_hr pt16 pb40" data-snippet="s_hr" data-name="Separator">
-                                <hr class="w-100 mx-auto"/>
-                            </div>
-                        </div>
+                <div class="col-12 col-lg-3 offset-lg-1">
+                    <p>
+                        <span class="h2-fs">15%</span><br/>
+                        Revenue Growth
+                    </p>
+                    <div class="s_hr pt16 pb40" data-snippet="s_hr" data-name="Separator">
+                        <hr class="w-100 mx-auto"/>
+                    </div>
+                    <p>
+                        <span class="h2-fs">$50M</span><br/>
+                        Expected revenue
+                    </p>
+                    <div class="s_hr pt16 pb40" data-snippet="s_hr" data-name="Separator">
+                        <hr class="w-100 mx-auto"/>
+                    </div>
+                    <p>
+                        <span class="h2-fs">85%</span><br/>
+                        User Retention
+                    </p>
+                    <div class="s_hr pt16 pb40" data-snippet="s_hr" data-name="Separator">
+                        <hr class="w-100 mx-auto"/>
+                    </div>
+                </div>
+                <div class="col-12 col-lg-3">
+                    <p>
+                        <span class="h2-fs">100,000</span><br/>
+                        Website visitors
+                    </p>
+                    <div class="s_hr pt16 pb40" data-snippet="s_hr" data-name="Separator">
+                        <hr class="w-100 mx-auto"/>
+                    </div>
+                    <p>
+                        <span class="h2-fs">20+</span><br/>
+                        Projects deployed
+                    </p>
+                    <div class="s_hr pt16 pb40" data-snippet="s_hr" data-name="Separator">
+                        <hr class="w-100 mx-auto"/>
+                    </div>
+                    <p>
+                        <span class="h2-fs">4x</span><br/>
+                        Inventory turnover
+                    </p>
+                    <div class="s_hr pt16 pb40" data-snippet="s_hr" data-name="Separator">
+                        <hr class="w-100 mx-auto"/>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This commit aims to fix different layout issues in several numbers snippets:

`s_numbers`: removing an extra row
`s_numbers_grid`: changing the way we style the text, to make it 'web
editor compliant' (`<span class="display-5">` is not something
possible to achieve).
`s_numbers_list`: removing an extra row, reduce the spacing between the
numbers, make the structure of the text tags 'web editor compliant'.

- requires https://github.com/odoo/design-themes/pull/1012

task-4223179

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
