### PR TITLE
[FIX] pos_restaurant: allow table transfer to diff floor

### DIFF
--- a/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.js
+++ b/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.js
@@ -51,22 +51,21 @@ patch(ControlButtons.prototype, {
         const orderUuid = this.pos.get_order().uuid;
         this.pos.get_order().setBooked(true);
         this.pos.showScreen("FloorScreen");
-        document.addEventListener(
-            "click",
-            async (ev) => {
-                if (this.pos.isOrderTransferMode) {
-                    this.pos.isOrderTransferMode = false;
-                    const tableElement = ev.target.closest(".table");
-                    if (!tableElement) {
-                        return;
-                    }
-                    const table = this.pos.getTableFromElement(tableElement);
-                    await this.pos.transferOrder(orderUuid, table);
-                    this.pos.setTableFromUi(table);
-                }
-            },
-            { once: true }
-        );
+        const onClickWhileTransfer = async (ev) => {
+            if (ev.target.closest(".button-floor")) {
+                return;
+            }
+            this.pos.isOrderTransferMode = false;
+            const tableElement = ev.target.closest(".table");
+            if (!tableElement) {
+                return;
+            }
+            const table = this.pos.getTableFromElement(tableElement);
+            await this.pos.transferOrder(orderUuid, table);
+            this.pos.setTableFromUi(table);
+            document.removeEventListener("click", onClickWhileTransfer);
+        };
+        document.addEventListener("click", onClickWhileTransfer);
     },
     clickTakeAway() {
         const isTakeAway = !this.currentOrder.takeaway;


### PR DESCRIPTION
In c57f2ba594d2e1d081e6521b06d63a7d2a260921 we refactored the table transfer mechanism. This introduced a bug, namely the fact that table transfer to a different floor no longer works. This is because with the new logic, a click anywhere on the screen other than on a table would cancel the transfer. This makes sense when clicking on the burger menu for ex, but it removes the possibility of transferring an order to a different floor, because that requires clicking on the floor selector button.

In this commit we fix the issue by ignoring clicks on the floor selector in the transfer cancellation logic.

Task: 4285748




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
