### PR TITLE
[FIX] hr_holidays: fix accrual plan in hours

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -221,7 +221,7 @@ class HrEmployee(models.Model):
             if allocation.allocation_type == 'accrual':
                 future_leaves = allocation._get_future_leaves_on(target_date)
             max_leaves = allocation.number_of_hours_display\
-                if allocation.type_request_unit in ['hour']\
+                if allocation.holiday_status_id.request_unit in ['hour']\
                 else allocation.number_of_days_display
             max_leaves += future_leaves
             allocation_data.update({

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -626,6 +626,40 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 allocation._update_accrual()
                 self.assertEqual(allocation.number_of_days, 0.5, 'There should be only 0.5 days allocated.')
 
+    def test_accrual_hours_with_max_carryover(self):
+        with freeze_time("2024-10-10"):
+            accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
+                'name': 'Accrual plan - hours and max postpone',
+                'level_ids': [(0, 0, {
+                    'added_value_type': 'hour',
+                    'start_count': 1,
+                    'start_type': 'day',
+                    'added_value': 1,
+                    'frequency': 'monthly',
+                    'action_with_unused_accruals': 'maximum',
+                    'postpone_max_days': 4,  # confusing name but is in hours when added_value_type == 'hour'
+                })],
+            })
+            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
+                'name': 'Accrual allocation for employee',
+                'date_from': datetime.date(2025, 1, 1),
+                'accrual_plan_id': accrual_plan.id,
+                'employee_id': self.employee_emp.id,
+                'holiday_status_id': self.leave_type.id,
+                'number_of_days': 0,
+                'allocation_type': 'accrual',
+            })
+            allocation.action_validate()
+            allocation._update_accrual()
+            self.assertEqual(allocation.number_of_days, 0)
+
+            hours_per_day = self.employee_emp.resource_calendar_id.hours_per_day
+            allocation_data = self.leave_type.get_allocation_data(self.employee_emp, "2025-12-02")[self.employee_emp][0][1]
+            self.assertAlmostEqual(allocation_data["remaining_leaves"], 11 / hours_per_day, 1, '11 hours accrued.')
+
+            allocation_data = self.leave_type.get_allocation_data(self.employee_emp, "2026-02-02")[self.employee_emp][0][1]
+            self.assertAlmostEqual(allocation_data["remaining_leaves"], 5 / hours_per_day, 1, '5 hours accrued.')
+
     def test_accrual_transition_immediately(self):
         with freeze_time("2017-12-5"):
             # 1 accrual with 2 levels and level transition immediately


### PR DESCRIPTION
Steps
- create an accrual plan with a level giving 1 hour every month and a carry
over with a maximum of 4 hours. Set accrued gain time at the start of the period
and carry-over time at start of the year.
- create an allocation using this accrual plan, for a time off type in days,
set the start date on the first day of next year.
- go to Time Off Dashboard
- check the balance on the middle of the month of the following year (e.g.
15 january 2026 if the allocation starts on 1 january 2025).

-> ~14 days of time off available: the max postpone amount is not applied,
the time gained is in days and not in hours and more than 1 day is gained/month
(balance a few days after the start of the allocation should be +1 added_value
but is more than that).

Causes:
- the maximum amount of carry over `postpone_max_days` is applied in days
even if the accrual `added_value` is in hours and the UI shows `postpone_max_days`
as "Up to X hours".
- `get_future_leaves` returns a number of hours if the allocation is in hours, even
if the time off type is in days.
- the number of hours from the accrual at the beginning of the allocation is too
high if the start of the accrual is in the future and gain time added at the start
of the period due to cache not being invalidated.
https://github.com/odoo/odoo/blob/19c7737fc05539079cde8641bab608c605efacc5/addons/hr_holidays/models/hr_leave_allocation.py#L575-L578

opw-4272315
