### PR TITLE
[POC] account_report: have translations in the XML

### DIFF
--- a/addons/l10n_fr_account/data/tax_report_data.xml
+++ b/addons/l10n_fr_account/data/tax_report_data.xml
@@ -15,7 +15,9 @@
         </field>
         <field name="line_ids">
             <record id="tax_report_montant_op_realisees" model="account.report.line">
-                <field name="name">A. Amount of operations carried out</field>
+                <field name="json_name">{"fr_FR": "A. Montant des Opérations Executées",
+                                         "en_US": "A. Amount  of operations carried out",
+                                         "es_419": "A. Monto de operaciones ejecutadas"}</field>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="tax_report_op_imposables_ht" model="account.report.line">


### PR DESCRIPTION
instead of the pofiles for report lines which should typically only be in the languages needed for that country anyways.

This would allow to treat po/pot files for l10n in the same way as the other modules.  Which would mean only one Transifex project or whatever system, the system would be the same.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
