### PR TITLE
[FIX] point_of_sale: ensure order existence

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1021,6 +1021,7 @@ export class PosStore extends Reactive {
         const orders = this.models["pos.order"].filter((order) => !order.finalized);
         if (orders.length > 0) {
             this.selectedOrderUuid = orders[0].uuid;
+            return orders[0];
         } else {
             return this.add_new_order();
         }
@@ -1496,7 +1497,8 @@ export class PosStore extends Reactive {
     }
     closeScreen() {
         this.addOrderIfEmpty();
-        const { name: screenName } = this.get_order().get_screen_data();
+        const order = this.get_order() || this.selectNextOrder();
+        const { name: screenName } = order.get_screen_data();
         const props = {};
         if (screenName === "PaymentScreen") {
             props.orderUuid = this.selectedOrderUuid;


### PR DESCRIPTION
When changing the current screen, the pos app takes into account the currently selected order. If no such order exists, an error is thrown. This happened in the runbot error 103452 for ex.

In this commit we ensure the fact that whenever we set the pos screen, an order is selected.

Fixes runbot error 103452




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
