### PR TITLE
[FIX] web_editor: pad pasted link with zws before updating selection

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -4133,7 +4133,10 @@ export class OdooEditor extends EventTarget {
             this.execCommand('strikeThrough');
             this.historyResetLatestComputedSelection(true);
         } else if (IS_KEYBOARD_EVENT_LEFT_ARROW(ev) || IS_KEYBOARD_EVENT_RIGHT_ARROW(ev)) {
-            const side = ev.key === 'ArrowLeft' ? 'previous' : 'next';
+            const isRTL = this.options.direction === 'rtl';
+            const previousName = isRTL ? 'next' : 'previous';
+            const nextName = isRTL ? 'previous' : 'next';
+            const side = ev.key === 'ArrowLeft' ? previousName : nextName;
             const selection = this.document.getSelection();
             let { anchorNode, anchorOffset, focusNode, focusOffset } = selection || {};
             if (ev.shiftKey) {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -414,6 +414,17 @@ export const editorCommands = {
                 ? rightPos(lastLeaf(currentNode))
                 : rightPos(currentNode);
         }
+        if (
+            lastPosition[0].nodeName === "A" &&
+            (lastPosition[1] === nodeSize(lastPosition[0]) || lastPosition[1] === 0) &&
+            isLinkEligibleForZwnbsp(editor.editable, lastPosition[0])
+        ) {
+            // In case the currentNode is different than A but the lastposition is A
+            // we need to pad the link with zws and adjust the selection accordingly
+            padLinkWithZws(editor.editable, lastPosition[0]);
+            currentNode = lastPosition[0].nextSibling;
+            lastPosition = getDeepestPosition(...rightPos(currentNode));
+        }
         if (!editor.options.allowInlineAtRoot && lastPosition[0] === editor.editable) {
             // Correct the position if it happens to be in the editable root.
             lastPosition = getDeepestPosition(...lastPosition);

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
@@ -2527,6 +2527,15 @@ describe('Paste', () => {
                         await pasteText(editor, 'http://www.xyz.com');
                     },
                     contentAfter: '<pre>http://www.xyz.com[]</pre>',
+                })
+            });
+            it('Should pad link with zws and put selection after the link', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]<br></p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<p><a href="http://www.xyz.com">a</a></p><p><a href="http://existing.com">b</a></p>');
+                    },
+                    contentAfter: '<p><a href="http://www.xyz.com">a</a></p><p><a href="http://existing.com">b</a>[]</p>',
                 });
             });
         });


### PR DESCRIPTION
Steps to reproduce the issue:
=============================
- Have 2 p elements where the last one have a link at the end of it
- Copy the 2 lines
- Paste them
- The box around the link is shown which indicates that the cursor is
  inside the link
- Try to add content
- The content is added oustide the link

Origin of the issue:
====================
When the selection have the p element and inside it there is an a
element , currentNode will be the p and not the a, but lastposition
will have the link node which is not padded with zws yet. So we put the
selection without the padding and then it's added which changes the
selection to have anchor node on the end of the ufeff charater inside
the link (`<a>&#xFEFFcontent&#xFEFF[]<a>`) which makes the selection
appears as inside the link but adding content will be after the link.

Solution:
=========
We need to pad the link with zws in case the selection we put is at the
edges of the link.

 ----------------------------------------------- 

Before:
=======
In rtl lang, the cursor gets stuck at the edge of the link using the
arrow keys.

After:
======
No the cursor moves correctly in rtl lang. We need to make `arrowLeft`
as go to next and `arrowRight` as going previous

task-4089193