### PR TITLE
[FIX] website_sale: decouple product availability from tags display

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1363,6 +1363,12 @@
                                     </div>
                                 </div>
                             </form>
+                            <p t-elif="not product.active" class="alert alert-warning">
+                                This product is no longer available.
+                            </p>
+                            <p t-else="" class="alert alert-warning">
+                                This product has no valid combination.
+                            </p>
                             <t t-call="website_sale.product_accordion"/>
                             <div
                                 id="contact_us_wrapper"
@@ -1392,8 +1398,6 @@
                                     t-value="product_variant.all_product_tag_ids"
                                 />
                             </t>
-                            <p t-elif="not product.active" class="alert alert-warning">This product is no longer available.</p>
-                            <p t-else="" class="alert alert-warning">This product has no valid combination.</p>
                             <div
                                 t-if="not is_view_active('website_sale_comparison.accordion_specs_item')"
                                 id="product_attributes_simple"

--- a/addons/website_sale_loyalty/static/tests/tours/test_website_sale_free_shipping_discount_line.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_website_sale_free_shipping_discount_line.js
@@ -26,7 +26,7 @@ registry.category("web_tour.tours").add('check_shipping_discount', {
         wsTourUtils.goToCheckout(),
         {
             content: "select delivery2",
-            trigger: 'li label:contains(delivery2)',
+            trigger: 'li[name=o_delivery_method]:contains(delivery2) input',
             run: "click",
         },
         {
@@ -61,7 +61,7 @@ registry.category("web_tour.tours").add('check_shipping_discount', {
         },
         {
             content: "select delivery1",
-            trigger: 'li label:contains(delivery1)',
+            trigger: 'li[name=o_delivery_method]:contains(delivery1) input',
             run: 'click',
         },
         {


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Go to eCommerce;
2. open a product page;
3. open editor;
4. toggle "Product Tags" in the CUSTOMIZE tab.

Issue
-----
Product suddenly gets displayed as not having a valid combination.

Cause
-----
PR #173823 modified the template, accidentally inserting some elements between this element:
```xml
<form t-if="product._is_add_to_cart_possible()" action="/shop/cart/update" method="POST">
```
and its consequent elements:
```xml
<p t-elif="not product.active" class="alert alert-warning">This product is no longer available.</p>
<p t-else="" class="alert alert-warning">This product has no valid combination.</p>
```

As the last of these newly introduced elements happened to include `t-if="is_view_active('website_sale.product_tags')"`, the template is still valid as far as the renderer is concerned, but obviously the display of product tags shouldn't be a prerequisite of product availability.

Solution
--------
Move the two elements back to where they make sense: right after the `product._is_add_to_cart_possible()` check.

opw-4277788