### PR TITLE
[FIX] portal: make state province option visible

### DIFF
--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -504,7 +504,7 @@
             <select name="state_id" t-attf-class="form-select #{error.get('state_id') and 'is-invalid' or ''}">
                 <option value="">select...</option>
                 <t t-foreach="states or []" t-as="state">
-                    <option t-att-value="state.id" style="display:none;" t-att-data-country_id="state.country_id.id" t-att-selected="state.id == int(state_id) if state_id else state.id == partner.state_id.id">
+                    <option t-att-value="state.id" style="" t-att-data-country_id="state.country_id.id" t-att-selected="state.id == int(state_id) if state_id else state.id == partner.state_id.id">
                         <t t-esc="state.name" />
                     </option>
                 </t>


### PR DESCRIPTION
Reproduce
---
- -i website,portal
- open /my/account
- select state -> BUG nothing to select from

History of changes
---
From newest to latest
da2c32470c63b8a45ddfb3565c158feece33c924 just reformatted it
14183883432e9d35c6240e1d7dc8c51d04cb93db    it also just reformatted it
ea27c1b7a341b6f913197a2e8843562c5e71ea52 moved from addons/website_portal/views/website_portal_templates.xml
55d72e1ab4a64f52e040911a8b4b4c8ce9443f65  updated in here
c3c0408471763ea90e9379a2d05fd2add820d57e initially introduced it

opw-4218359

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
