### PR TITLE
[FIX] web_editor: pre element doesn't support html paste

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -1817,7 +1817,7 @@ export function getOuid(node, optimize = false) {
  * @returns {boolean}
  */
 export function isHtmlContentSupported(node) {
-    return !closestElement(node, '[data-oe-model]:not([data-oe-field="arch"]):not([data-oe-type="html"]),[data-oe-translation-id]', true);
+    return !closestElement(node, 'pre,[data-oe-model]:not([data-oe-field="arch"]):not([data-oe-type="html"]),[data-oe-translation-id]', true);
 }
 /**
  * Returns whether the given node is a element that could be considered to be

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
@@ -1160,36 +1160,6 @@ describe('Paste', () => {
                     contentAfter: '<blockquote>xabc</blockquote><blockquote>def</blockquote><blockquote>ghi[]y</blockquote>',
                 });
             });
-            it('should paste all nodes as pre when pasting in pre', async () => {
-                await testEditor(BasicEditor, {
-                    contentBefore: '<pre>[]<br></pre>',
-                    stepFunction: async editor => {
-                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
-                    },
-                    contentAfter: '<pre>abc</pre><pre>def</pre><pre>ghi[]</pre>',
-                });
-                await testEditor(BasicEditor, {
-                    contentBefore: '<pre>x[]</pre>',
-                    stepFunction: async editor => {
-                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
-                    },
-                    contentAfter: '<pre>xabc</pre><pre>def</pre><pre>ghi[]</pre>',
-                });
-                await testEditor(BasicEditor, {
-                    contentBefore: '<pre>[]x</pre>',
-                    stepFunction: async editor => {
-                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
-                    },
-                    contentAfter: '<pre>abc</pre><pre>def</pre><pre>ghi[]x</pre>',
-                });
-                await testEditor(BasicEditor, {
-                    contentBefore: '<pre>x[]y</pre>',
-                    stepFunction: async editor => {
-                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
-                    },
-                    contentAfter: '<pre>xabc</pre><pre>def</pre><pre>ghi[]y</pre>',
-                });
-            });
             it('should not unwrap empty block nodes even when pasting on same node', async () => {
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>a[]</p>',
@@ -2310,6 +2280,28 @@ describe('Paste', () => {
                             </li>
                         </ul>
                     `),
+                });
+            });
+        });
+        describe('pre element', async () => {
+            it('Should insert the content as text inside the pre element', async () => {
+                const complexHTML = '<p>ab\n\ncd<a href="http://www.xyz.com">link</a></p>ef\n\n\nhg'
+                await testEditor(BasicEditor, {
+                    contentBefore: '<pre>[]</pre>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, complexHTML);
+                    },
+                    contentAfter: '<pre>&lt;p&gt;ab\n\ncd&lt;a href="http://www.xyz.com"&gt;link&lt;/a&gt;&lt;/p&gt;ef\n\n\nhg[]</pre>',
+                });
+            });
+            it('Should do nothing with pasteHTML in pre element', async () => {
+                const complexHTML = '<p>ab\n\ncd<a href="http://www.xyz.com">link</a></p>ef\n\n\nhg'
+                await testEditor(BasicEditor, {
+                    contentBefore: '<pre>[]</pre>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHTML);
+                    },
+                    contentAfter: '<pre>[]</pre>',
                 });
             });
         });


### PR DESCRIPTION
Steps to reproduce the issue:
=============================
- Copy content which have an empty line in the middle `a\n\nb`
- Paste it inside a code block
- It creates multplie code blocks
- Also if you use html or some other kind of content it will not work properly

Origin:
=======
Because we are inserting the content inside the pre as html then it will try to render it and not show it as code as it should be.

Solution:
=========
Add `pre` element with the elements that doesn't support HTML

opw-4254194