### PR TITLE
[FIX] mail: go back to the correct thread from breadcrumbs

### DIFF
--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -1102,6 +1102,14 @@ export class Thread extends Record {
         if (pushState) {
             router.pushState({ active_id: activeId });
         }
+        if (
+            this.store.action_discuss_id &&
+            this.store.env.services.action?.currentController?.action.id ===
+                this.store.action_discuss_id
+        ) {
+            // Keep the action stack up to date (used by breadcrumbs).
+            this.store.env.services.action.currentController.action.context.active_id = activeId;
+        }
     }
 
     /** @param {number} index */

--- a/addons/mail/static/tests/tours/discuss_go_back_to_thread_from_breadcrumbs_tour.js
+++ b/addons/mail/static/tests/tours/discuss_go_back_to_thread_from_breadcrumbs_tour.js
@@ -1,0 +1,12 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("discuss_go_back_to_thread_from_breadcrumbs.js", {
+    test: true,
+    steps: () => [
+        { trigger: ".o-mail-Discuss-threadName[title='Inbox']", allowDisabled: true },
+        { trigger: ".o-mail-DiscussSidebar-item:contains(Starred)", run: "click" },
+        { trigger: "button[title='View or join channels']", run: "click" },
+        { trigger: ".breadcrumb-item:contains(Starred)", run: "click" },
+        { trigger: ".o-mail-Discuss-threadName[title='Starred']", allowDisabled: true },
+    ],
+});

--- a/addons/mail/tests/discuss/__init__.py
+++ b/addons/mail/tests/discuss/__init__.py
@@ -2,6 +2,7 @@
 
 from . import test_avatar_acl
 from . import test_bus_presence
+from . import test_discuss_action
 from . import test_discuss_channel
 from . import test_discuss_channel_access
 from . import test_discuss_channel_as_guest

--- a/addons/mail/tests/discuss/test_discuss_action.py
+++ b/addons/mail/tests/discuss/test_discuss_action.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.tests import HttpCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestDiscussAction(HttpCase):
+    def test_go_back_to_thread_from_breadcrumbs(self):
+        self.start_tour(
+            "/odoo/discuss?active_id=mail.box_inbox",
+            "discuss_go_back_to_thread_from_breadcrumbs.js",
+            login="admin",
+        )


### PR DESCRIPTION
Before this PR, going back to discuss from the breadcrumbs would always redirect to the thread discuss first opened.

Steps to reproduce:
- Go to `http://localhost:8069/odoo/discuss?active_id=mail_box.inbox`.
- Switch to the starred inbox.
- Go to the form view of the general channel.
- Click on the breadcrumb "Starred".
- You are on the Inbox channel.

This happens because the action service restores the action. Discuss only has one action: the one that opens the app. Then upon navigation, the current thread is added to the URL. However, the changes in the URL are not taken into account by the action service.

This PR fixes the issue by updating the action when the thread changes so that it can be restored.

task-4210141
