### PR TITLE
[FIX] stock_landed_cost: create an SVL with qty in product uom

### DIFF
--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -131,7 +131,8 @@ class StockLandedCost(models.Model):
                 linked_layer = line.move_id.stock_valuation_layer_ids[:1]
 
                 # Prorate the value at what's still in stock
-                cost_to_add = (remaining_qty / line.move_id.quantity) * line.additional_landed_cost
+                move_qty = line.move_id.product_uom._compute_quantity(line.move_id.quantity, line.move_id.product_id.uom_id)
+                cost_to_add = (remaining_qty / move_qty) * line.additional_landed_cost
                 if not cost.company_id.currency_id.is_zero(cost_to_add):
                     valuation_layer = self.env['stock.valuation.layer'].create({
                         'value': cost_to_add,


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1”:
    - UoM: gram
- Create a component “C1”
    - UoM: gram

- Create a BoM for P1:
    - quantity: 1kg
    - Component: 1g of C1

- Create a Mo to produce 1kg of P1
- Confirm the MO

- Create a landed cost:
    - Apply on manufacturing order
    - Select the created MO
    - Add a landed product with a unit price of 25
- Validate the landed cost
- Go to the linked valuation layer

Problem:
A value of (25 * 1000) is added instead of only $25

opw-4252901
