### PR TITLE
[FIX] website: fix the history when sliding "Image Gallery"

### DIFF
--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -249,7 +249,7 @@ export class WysiwygAdapterComponent extends Wysiwyg {
                 const offcanvasAttributes = ["aria-modal", "aria-hidden", "role", "style"];
                 // Carousel attributes to ignore.
                 const carouselSlidingClasses = ["carousel-item-start", "carousel-item-end",
-                    "carousel-item-next", "carousel-item-prev", "active"];
+                    "carousel-item-next", "carousel-item-prev", "active", "o_carousel_sliding"];
                 const carouselIndicatorAttributes = ["aria-current"];
 
                 return filteredRecords.filter(record => {
@@ -283,7 +283,7 @@ export class WysiwygAdapterComponent extends Wysiwyg {
 
                         // Do not record some carousel attributes changes.
                         if (record.target.closest(":not(section) > .carousel")) {
-                            if (record.target.matches(".carousel-item, .carousel-indicators > li")
+                            if (record.target.matches(".carousel, .carousel-item, .carousel-indicators > li")
                                     && record.attributeName === "class") {
                                 if (checkForExcludedClasses(record, carouselSlidingClasses)) {
                                     return false;


### PR DESCRIPTION
Since commit [1], sliding the `s_image_gallery` snippet, as well as any carousel not having the "Carousel" and "Carousel Item" options, should not add steps in the history. This was done by filtering the mutations records: all the class and attribute changes related to the sliding of these specific carousels are now ignored.

However, since commit [2], which fixed the auto-slide behavior of the carousels, an `o_carousel_sliding` class is now added on the `.carousel` element during the slide. The issue is that this class was not added in the list of classes to ignore when filtering the mutations, which therefore made this class addition/removal add a step in the history.

This commit fixes that by considering this class. Note that this fix was already made in upper versions, when forward-porting commit [1].

[1]: https://github.com/odoo/odoo/commit/509e78dcf786581a345913e76f6da72af6baec0b
[2]: https://github.com/odoo/odoo/commit/9eff9ae1904e0583f5dc60c6d925c52b48b208ec

task-3744613
