### PR TITLE
[IMP] base: stop logging INFO access errors

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -2224,12 +2224,9 @@ class CrmLead(models.Model):
 
     def _rebuild_pls_frequency_table(self):
         # Clear the frequencies table (in sql to speed up the cron)
-        try:
-            self.browse().check_access('unlink')
-        except AccessError:
+        if not self.browse().has_access('unlink'):
             raise UserError(_("You don't have the access needed to run this cron."))
-        else:
-            self._cr.execute('TRUNCATE TABLE crm_lead_scoring_frequency')
+        self._cr.execute('TRUNCATE TABLE crm_lead_scoring_frequency')
 
         new_frequencies_by_team, unused = self._pls_prepare_update_frequency_table(rebuild=True)
         # update frequency table

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4319,9 +4319,7 @@ class MailThread(models.AbstractModel):
         customer_ids = [] if adding_current else None
 
         if partner_ids and adding_current:
-            try:
-                self.check_access('read')
-            except exceptions.AccessError:
+            if not self.has_access('read'):
                 return False
         else:
             self.check_access('write')
@@ -4682,13 +4680,8 @@ class MailThread(models.AbstractModel):
             res = {}
             if request_list:
                 res["hasReadAccess"] = True
-                res["hasWriteAccess"] = False
+                res["hasWriteAccess"] = thread.has_access("write")
                 res["canPostOnReadonly"] = self._mail_post_access == "read"
-                try:
-                    thread.check_access("write")
-                    res["hasWriteAccess"] = True
-                except AccessError:
-                    pass
             if (
                 request_list
                 and "activities" in request_list

--- a/addons/mail_group/controllers/portal.py
+++ b/addons/mail_group/controllers/portal.py
@@ -320,15 +320,10 @@ class PortalMailGroup(http.Controller):
         # SUDO to have access to field of the many2one
         group_sudo = group.sudo()
 
-        if token and token != group_sudo._generate_group_access_token():
+        if (token != group_sudo._generate_group_access_token()) if token else (
+            not group.has_access('read')
+        ):
             raise werkzeug.exceptions.NotFound()
-
-        elif not token:
-            try:
-                # Check that the current user has access to the group
-                group.check_access('read')
-            except AccessError:
-                raise werkzeug.exceptions.NotFound()
 
         partner_id = None
         if not request.env.user._is_public():

--- a/addons/mail_plugin/controllers/mail_plugin.py
+++ b/addons/mail_plugin/controllers/mail_plugin.py
@@ -313,9 +313,7 @@ class MailPluginController(http.Controller):
         if not company:
             return {'id': -1}
 
-        try:
-            company.check_access('read')
-        except AccessError:
+        if not company.has_access('read'):
             return {'id': company.id, 'name': _('No Access')}
 
         fields_list = ['id', 'name', 'phone', 'email', 'website']
@@ -393,12 +391,7 @@ class MailPluginController(http.Controller):
         partner_values['image'] = partner.image_128
         partner_values['title'] = partner.function
         partner_values['enrichment_info'] = None
-
-        try:
-            partner.check_access('write')
-            partner_values['can_write_on_partner'] = True
-        except AccessError:
-            partner_values['can_write_on_partner'] = False
+        partner_values['can_write_on_partner'] = partner.has_access('write')
 
         if not partner_values['name']:
             # Always ensure that the partner has a name

--- a/addons/portal/models/portal_mixin.py
+++ b/addons/portal/models/portal_mixin.py
@@ -72,27 +72,20 @@ class PortalMixin(models.AbstractModel):
 
         user, record = self.env.user, self
         if access_uid:
-            try:
-                record.check_access('read')
-            except exceptions.AccessError:
+            if not record.has_access('read'):
                 return super(PortalMixin, self)._get_access_action(
                     access_uid=access_uid, force_website=force_website
                 )
             user = self.env['res.users'].sudo().browse(access_uid)
             record = self.with_user(user)
         if user.share or force_website:
-            try:
-                record.check_access('read')
-            except exceptions.AccessError:
-                if force_website:
-                    return {
-                        'type': 'ir.actions.act_url',
-                        'url': record.access_url,
-                        'target': 'self',
-                        'res_id': record.id,
-                    }
-                else:
-                    pass
+            if force_website and not record.has_access('read'):
+                return {
+                    'type': 'ir.actions.act_url',
+                    'url': record.access_url,
+                    'target': 'self',
+                    'res_id': record.id,
+                }
             else:
                 return {
                     'type': 'ir.actions.act_url',

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1471,11 +1471,8 @@ class SaleOrder(models.Model):
         :rtype: `account.move` recordset
         :raises: UserError if one of the orders has no invoiceable lines.
         """
-        if not self.env['account.move'].has_access('create'):
-            try:
-                self.check_access('write')
-            except AccessError:
-                return self.env['account.move']
+        if not self.env['account.move'].has_access('create') and not self.has_access('write'):
+            return self.env['account.move']
 
         # 1) Create invoices.
         invoice_vals_list = []

--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -31,11 +31,8 @@ class SaleOrderLine(models.Model):
         if self.env.context.get('form_view_ref') == 'sale_project.sale_order_line_view_form_editable':
             default_values = dict()
             # If we can't add order lines to the default order, discard it
-            if 'order_id' in res:
-                try:
-                    self.env['sale.order'].browse(res['order_id']).check_access('write')
-                except AccessError:
-                    del res['order_id']
+            if 'order_id' in res and not self.env['sale.order'].browse(res['order_id']).has_access('write'):
+                del res['order_id']
 
             if 'order_id' in fields and not res.get('order_id'):
                 assert (partner_id := self.env.context.get('default_partner_id'))

--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -596,11 +596,8 @@ class SurveySurvey(models.Model):
     def _check_answer_creation(self, user, partner, email, test_entry=False, check_attempts=True, invite_token=False):
         """ Ensure conditions to create new tokens are met. """
         self.ensure_one()
-        if test_entry:
-            try:
-                self.with_user(user).check_access('read')
-            except AccessError:
-                raise exceptions.UserError(_('Creating test token is not allowed for you.'))
+        if test_entry and not self.with_user(user).has_access('read'):
+            raise exceptions.UserError(_('Creating test token is not allowed for you.'))
 
         if not test_entry:
             if not self.active:

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -213,16 +213,12 @@ class IrHttp(models.AbstractModel):
         super()._pre_dispatch(rule, arguments)
 
         for record in arguments.values():
-            if isinstance(record, models.BaseModel) and hasattr(record, 'can_access_from_current_website'):
-                try:
-                    if not record.can_access_from_current_website():
-                        raise werkzeug.exceptions.NotFound()
-                except AccessError:
-                    # record.website_id might not be readable as
-                    # unpublished `event.event` due to ir.rule, return
-                    # 403 instead of using `sudo()` for perfs as this is
-                    # low level.
-                    raise werkzeug.exceptions.Forbidden()
+            if (
+                isinstance(record, models.BaseModel)
+                and hasattr(record, 'can_access_from_current_website')
+                and not record.can_access_from_current_website()
+            ):
+                raise werkzeug.exceptions.NotFound()
 
     @classmethod
     def _get_web_editor_context(cls):

--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -185,12 +185,17 @@ class WebsiteMultiMixin(models.AbstractModel):
     )
 
     def can_access_from_current_website(self, website_id=False):
-        can_access = True
-        for record in self:
-            if (website_id or record.website_id.id) not in (False, request.env['website'].get_current_website().id):
-                can_access = False
-                continue
-        return can_access
+        try:
+            for record in self:
+                if (website_id or record.website_id.id) not in (False, request.env['website'].get_current_website().id):
+                    return False
+        except AccessError:
+            # record.website_id might not be readable as
+            # unpublished `event.event` due to ir.rule, return
+            # 403 instead of using `sudo()` for perfs as this is
+            # low level.
+            return False
+        return True
 
 
 class WebsitePublishedMixin(models.AbstractModel):

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -486,13 +486,10 @@ class WebsiteSlides(WebsiteProfile):
         status = 'authorized'
         try:
             slide = request.env['slide.slide'].browse(slide_id)
-            slide.check_access('read')
-        except (AccessError, MissingError):
-            try:
-                slide = request.env['slide.slide'].sudo().browse([slide_id])
-            except MissingError:
-                return {'status': 'not_found'}
-            status = 'not_authorized'
+            if not slide.has_access('read'):
+                status = 'not_authorized'
+        except MissingError:
+            return {'status': 'not_found'}
         return {'status': status, 'slide': slide, 'channel_id': slide.sudo().channel_id.id}
 
     @http.route([

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -1042,11 +1042,13 @@ class IrActionsServer(models.Model):
                 model_name = action.model_id.model
                 try:
                     self.env[model_name].check_access("write")
-                except AccessError:
-                    _logger.warning("Forbidden server action %r executed while the user %s does not have access to %s.",
-                        action.name, self.env.user.login, model_name,
-                    )
-                    raise
+                except AccessError as e:
+                    raise AccessError(_(
+                        "Forbidden server action %(action_name)s executed while the user %(user)s does not have access to %(model_name)s.",
+                        action_name=repr(action.name),
+                        user=self.env.user.login,
+                        model_name=model_name,
+                    )) from e
 
             eval_context = self._get_eval_context(action)
             records = eval_context.get('record') or eval_context['model']
@@ -1056,11 +1058,13 @@ class IrActionsServer(models.Model):
                 # type 'onchange' can run server actions on new records
                 try:
                     records.check_access('write')
-                except AccessError:
-                    _logger.warning("Forbidden server action %r executed while the user %s does not have access to %s.",
-                        action.name, self.env.user.login, records,
-                    )
-                    raise
+                except AccessError as e:
+                    raise AccessError(_(
+                        "Forbidden server action %(action_name)s executed while the user %(user)s does not have access to %(model_name)s.",
+                        action_name=repr(action.name),
+                        user=self.env.user.login,
+                        model_name=model_name,
+                    )) from e
 
             if action.warning:
                 raise ServerActionWithWarningsError(_("Server action %(action_name)s has one or more warnings, address them first.", action_name=action.name))

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -2054,8 +2054,6 @@ class IrModelAccess(models.Model):
 
     def _make_access_error(self, model: str, mode: str):
         """ Return the exception corresponding to an access error. """
-        _logger.info('Access Denied by ACLs for operation: %s, uid: %s, model: %s', mode, self._uid, model)
-
         operation_error = str(ACCESS_ERROR_HEADER[mode]) % {
             'document_kind': self.env['ir.model']._get(model).name or model,
             'document_model': model,

--- a/odoo/addons/base/models/ir_rule.py
+++ b/odoo/addons/base/models/ir_rule.py
@@ -203,7 +203,6 @@ class IrRule(models.Model):
         return res
 
     def _make_access_error(self, operation, records):
-        _logger.info('Access Denied by record rules for operation: %s on record ids: %r, uid: %s, model: %s', operation, records.ids[:6], self._uid, records._name)
         self = self.with_context(self.env.user.context_get())
 
         model = records._name
@@ -215,8 +214,10 @@ class IrRule(models.Model):
             'unlink': _("unlink"),
         }
         user_description = f"{self.env.user.name} (id={self.env.user.id})"
-        operation_error = _("Uh-oh! Looks like you have stumbled upon some top-secret records.\n\n" \
-            "Sorry, %(user)s doesn't have '%(operation)s' access to:", user=user_description, operation=operations[operation])
+        operation_error = _(
+            "Uh-oh! Looks like you have stumbled upon some top-secret records.\n\n"
+            "Sorry, %(user)s doesn't have '%(operation)s' access to:",
+            user=user_description, operation=operations[operation])
         failing_model = _("- %(description)s (%(model)s)", description=description, model=model)
 
         resolution_info = _("If you really, really need access, perhaps you can win over your friendly administrator with a batch of freshly baked cookies.")

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -2484,10 +2484,12 @@ class Application:
                     pass
                 elif isinstance(exc, SessionExpiredException):
                     _logger.info(exc)
-                elif isinstance(exc, (UserError, AccessError)):
+                elif isinstance(exc, AccessError):
+                    _logger.warning(exc, exc_info=exc)
+                elif isinstance(exc, UserError):
                     _logger.warning(exc)
                 else:
-                    _logger.error("Exception during request handling.", exc_info=True)
+                    _logger.exception("Exception during request handling.")
 
                 # Ensure there is always a WSGI handler attached to the exception.
                 if not hasattr(exc, 'error_response'):

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -3041,9 +3041,6 @@ class BaseModel(metaclass=MetaModel):
         if self._has_field_access(field, operation):
             return
 
-        _logger.info('Access Denied by ACLs for operation: %s, uid: %s, model: %s, field: %s',
-            operation, self.env.uid, self._name, field.name)
-
         description = self.env['ir.model']._get(self._name).name
 
         error_msg = _(


### PR DESCRIPTION
There is no need to log an INFO every time we create an AccessError. The exception will be raised and the caller is responsible of either letting it propage or catching and handling it: by replacing the exception, logging, etc.

Current behavior before PR:
If you make an access error and catch it, you will see it in the logs. It is an INFO and there is no stacktrace, so it gives no information when accessing a related model from somewhere else.

Desired behavior after PR is merged:
Stop logging these messages.  They will be logged in the exception is not caught.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
