### PR TITLE
[FIX] point_of_sale: show table name on OrderChangeReceipt

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -186,7 +186,7 @@ export class PosOrder extends Base {
                 const printingChanges = {
                     new: changes["new"],
                     cancelled: changes["cancelled"],
-                    table_name: this.table_id?.name,
+                    table_name: this.table_id?.getName(),
                     floor_name: this.table_id?.floor_id?.name,
                     name: this.pos_reference || "unknown order",
                     time: {

--- a/doc/cla/individual/jlwbr.md
+++ b/doc/cla/individual/jlwbr.md
@@ -1,0 +1,11 @@
+Netherlands, 2024-10-29
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Joël Weber joel@joelweber.nl https://github.com/jlwbr


### PR DESCRIPTION
Before this commit, the table name (number) would not be shown on an order change reciept, as table_id?.name was always undefined. 

We now use the getName() funtion to retrieve the correct table name.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
