### PR TITLE
[FIX] purchase: Change the purchase order document to use tax name

### DIFF
--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -88,7 +88,7 @@
                                     <span class="text-align-bottom"><span t-field="line.discount"/>%</span>
                                 </td>
                                 <td class="text-end">
-                                    <span t-esc="', '.join(map(lambda x: x.description or x.name, line.taxes_id))"/>
+                                    <span t-esc="', '.join([tax.name for tax in line.taxes_id])"/>
                                 </td>
                                 <td class="text-end">
                                     <span t-field="line.price_subtotal"


### PR DESCRIPTION
Version: 18.0+

Issue: Currently we are using the `description` of the tax to place on the report. 
This will cause the `<p>` tags to show on the report because `description` is a HTML field.

Purpose of this PR:
To only use the tax name to show on the purchase order document by changing to a list comprehension.

Steps to reproduce on runbot:
install purchase
create an purchase order
assign a tax
print purchase order
`<p>` tags will show under the Taxes column.

Notes:
In previous versions `invoice_label` was being used for this report.

opw-4292687

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
