### PR TITLE
[FIX] l10n_br_website_sale: default id type on /shop should be CPF

### DIFF
--- a/addons/l10n_br_website_sale/views/templates.xml
+++ b/addons/l10n_br_website_sale/views/templates.xml
@@ -14,7 +14,7 @@
                             <option value="">Identification Type...</option>
                             <t t-foreach="identification_types" t-as="id_type">
                                 <option t-att-value="id_type.id"
-                                    t-att-selected="id_type.id == partner_sudo.l10n_latam_identification_type_id.id">
+                                    t-att-selected="id_type.id == partner_sudo.l10n_latam_identification_type_id.id if partner_sudo.l10n_latam_identification_type_id else id_type.id == env.ref('l10n_br.cpf').id">
                                     <t t-out="id_type.name"/>
                                 </option>
                             </t>


### PR DESCRIPTION
The most common customers on eCommerce are individuals (not businesses) who identify with a CPF number.

task-4257684