### PR TITLE
[FIX] pos_loyalty: promotion not applied in combo product

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/loyalty.js
+++ b/addons/pos_loyalty/static/src/overrides/models/loyalty.js
@@ -1185,9 +1185,10 @@ patch(Order.prototype, {
             if (!line.get_quantity() || !line.price) {
                 continue;
             }
+            const product_id = line.comboParent?.product.id || line.get_product().id;
             remainingAmountPerLine[line.cid] = line.get_price_with_tax();
             if (
-                applicableProducts.has(line.get_product().id) ||
+                applicableProducts.has(product_id) ||
                 (line.reward_product_id && applicableProducts.has(line.reward_product_id))
             ) {
                 linesToDiscount.push(line);

--- a/addons/pos_loyalty/static/tests/tours/PosLoyaltyLoyaltyProgramTour.js
+++ b/addons/pos_loyalty/static/tests/tours/PosLoyaltyLoyaltyProgramTour.js
@@ -269,3 +269,22 @@ registry.category("web_tour.tours").add("PosComboCheapestRewardProgram", {
             PosLoyalty.finalizeOrder("Cash", "61.03"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("PosComboSpecificProductProgram", {
+    test: true,
+    url: "/pos/web",
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.clickHomeCategory(),
+            ProductScreen.clickDisplayedProduct("Office Combo"),
+            combo.isPopupShown(),
+            combo.select("Combo Product 1"),
+            combo.select("Combo Product 4"),
+            combo.select("Combo Product 6"),
+            combo.confirm(),
+            Order.hasLine({ productName: "10% on Office Combo" }),
+            PosLoyalty.orderTotalIs("216.00"),
+            PosLoyalty.finalizeOrder("Cash", "216.00"),
+        ].flat(),
+});

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -2244,6 +2244,30 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PosComboCheapestRewardProgram', login="pos_user")
 
+    def test_specific_product_reward_pos_combo(self):
+        setup_pos_combo_items(self)
+        self.office_combo.write({'lst_price': 200})
+        self.env['loyalty.program'].search([]).write({'active': False})
+        self.env['loyalty.program'].create({
+            'name': 'Combo Product Promotion',
+            'program_type': 'promotion',
+            'trigger': 'auto',
+            'rule_ids': [(0, 0, {
+                'minimum_qty': 1,
+                'product_ids': self.office_combo.ids,
+            })],
+            'reward_ids': [(0, 0, {
+                'reward_type': 'discount',
+                'discount': 10,
+                'discount_mode': 'percent',
+                'discount_applicability': 'specific',
+                'discount_product_ids': self.office_combo.ids,
+            })]
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PosComboSpecificProductProgram', login="pos_user")
+
     def test_apply_reward_on_product_scan(self):
         """
         Test that the rewards are correctly applied if the


### PR DESCRIPTION
Steps to reproduce:
====
- Create a promotion program 
- Rule: Condition --> Select combo product,  Reward --> type - discount specific product - Combo product 
- Open POS and add combo product.
- Click on reward button and select on available reward.

Issue:
===
- Promotion is not applied if combo product is added.

Fix:
===
- Previously, when a specific combo product was added as a loyalty reward, it wasn’t properly handled in promotions. This update ensures that combo products included in loyalty rewards and promotion is applied.

task-4285895
