### PR TITLE
[FIX] sale, pos_sale: take into account pos downpayments on invoicing

### DIFF
--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -108,3 +108,8 @@ class SaleOrderLine(models.Model):
         super()._compute_untaxed_amount_invoiced()
         for line in self:
             line.untaxed_amount_invoiced += sum(line.pos_order_line_ids.mapped('price_subtotal'))
+
+    def _get_downpayment_line_price_unit(self, invoices):
+        return super()._get_downpayment_line_price_unit(invoices) + sum(
+            pol.price_unit for pol in self.pos_order_line_ids
+        )

--- a/addons/pos_sale/static/tests/tours/pos_sale_tours.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tours.js
@@ -171,4 +171,17 @@ odoo.define('pos_sale.tour', function (require) {
     ProductScreen.check.selectedOrderlineHas('Test service product', '1.00', '50.00');
 
     Tour.register('PosSettleDraftOrder', { test: true, url: '/pos/ui' }, getSteps());
+
+    startSteps();
+
+    ProductScreen.do.confirmOpeningPopup();
+    ProductScreen.do.clickQuotationButton();
+    ProductScreen.do.downPaymentFirstOrder();
+    ProductScreen.check.selectedOrderlineHas('Down Payment', '1', '10.00');
+    ProductScreen.do.clickPayButton();
+    PaymentScreen.do.clickPaymentMethod('Cash');
+    PaymentScreen.do.clickValidate();
+    ReceiptScreen.do.clickNextOrder();
+
+    Tour.register('PoSDownPaymentAmount', { test: true, url: '/pos/ui' }, getSteps());
 });

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -519,3 +519,58 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosSettleDraftOrder', login="accountman")
+
+    def test_downpayment_amount_to_invoice(self):
+        product_a = self.env['product.product'].create({
+            'name': 'Product A',
+            'available_in_pos': True,
+            'type': 'product',
+            'lst_price': 100.0,
+            'taxes_id': [],
+        })
+        partner_test = self.env['res.partner'].create({'name': 'Test Partner'})
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': partner_test.id,
+            'order_line': [(0, 0, {
+                'product_id': product_a.id,
+                'name': product_a.name,
+                'product_uom_qty': 1,
+                'product_uom': product_a.uom_id.id,
+                'price_unit': product_a.lst_price,
+            })],
+        })
+        sale_order.action_confirm()
+
+        self.downpayment_product = self.env['product.product'].create({
+            'name': 'Down Payment',
+            'available_in_pos': True,
+            'type': 'service',
+            'taxes_id': [],
+        })
+        self.main_pos_config.write({
+            'down_payment_product_id': self.downpayment_product.id,
+        })
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PoSDownPaymentAmount', login="accountman")
+
+        self.assertEqual(sale_order.order_line[1].price_unit, 10)
+
+        # Update delivered quantity of SO line
+        sale_order.order_line[0].write({'qty_delivered': 1.0})
+        context = {
+            'active_model': 'sale.order',
+            'active_ids': [sale_order.id],
+            'active_id': sale_order.id,
+            'default_journal_id': self.company_data['default_journal_sale'].id,
+        }
+
+        # Let's do the invoice for the remaining amount
+        payment = self.env['sale.advance.payment.inv'].with_context(context).create({
+            'deposit_account_id': self.company_data['default_account_revenue'].id
+        })
+        payment.create_invoices()
+
+        # Confirm all invoices
+        sale_order.invoice_ids.action_post()
+        self.assertEqual(sale_order.order_line[1].price_unit, 10)

--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -77,11 +77,7 @@ class AccountMove(models.Model):
         real_invoices = set(other_so_lines.invoice_lines.move_id)
         for dpl in downpayment_lines:
             try:
-                dpl.price_unit = sum(
-                    l.price_unit if l.move_id.move_type == 'out_invoice' else -l.price_unit
-                    for l in dpl.invoice_lines
-                    if l.move_id.state == 'posted' and l.move_id not in real_invoices  # don't recompute with the final invoice
-                )
+                dpl.price_unit = dpl._get_downpayment_line_price_unit(real_invoices)
                 dpl.tax_id = dpl.invoice_lines.tax_ids
             except UserError:
                 # a UserError here means the SO was locked, which prevents changing the taxes

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1165,6 +1165,13 @@ class SaleOrderLine(models.Model):
                 'company_id': line.company_id.id,
             })
 
+    def _get_downpayment_line_price_unit(self, invoices):
+        return sum(
+            l.price_unit if l.move_id.move_type == 'out_invoice' else -l.price_unit
+            for l in self.invoice_lines
+            if l.move_id.state == 'posted' and l.move_id not in invoices  # don't recompute with the final invoice
+        )
+
     #=== CORE METHODS OVERRIDES ===#
 
     def name_get(self):


### PR DESCRIPTION
Currently, if an order has a downpayment made from the POS, when we invoice it, the unit price of the downpayment becomes 0 on the sale order. The same flow using only sale will correctly show the downpayment price.

Steps to reproduce:
-------------------
* Create a quotation in the **Sale** app
* In the **Point of Sale** app, open shop session
* Create a downpayment for the order
* Go back in the **Sale** app
* Open sale order
> Observation: The downpayment line has a price unit set
* If needed, deliver the items
* Create an invoice (regular invoice)
* Confirm the invoice
* Go back to the sale order
> Observation: The downpayment line has a price unit of 0.0

Why the fix:
------------
The difference between the two flows (pos/sale) mainly resides in those few lines:
https://github.com/odoo/odoo/blob/b3b1fe6a78f9e5b6f1d993b5aa2fed11e33c793e/addons/sale/models/account_move.py#L75-L85

`dpl.invoice_lines` will include 2 items when using the sale flow whereas only one when making the downpayment in pos.

Downpayments from pos are not automatically invoiced and even if they are, the model `pos.order.line` does not have the field `invoice_lines`.

However each downpayment **sale order line** that comes from the POS is linked to its downpayment **pos order line** with the field `pos_order_line_ids`.

The only element left in `dpl.invoice_lines` will not be counted as it is included in `real_invoice` (the current invoice).

The idea of the fix is to include the price unit of the downpayment made in pos in this sum.

opw-4160111