### PR TITLE
[FIX] base, mail: avoid duplicate/wrong email extract when sending emails

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -349,20 +349,21 @@ class MailMail(models.Model):
         body = self._send_prepare_body()
         body_alternative = tools.html2plaintext(body)
         if partner:
-            emails_normalized = tools.email_normalize_all(partner.email)
-            if emails_normalized:
-                email_to = [
-                    tools.formataddr((partner.name or "False", email or "False"))
-                    for email in emails_normalized
-                ]
-            else:
-                email_to = [tools.formataddr((partner.name or "False", partner.email or "False"))]
+            email_to_normalized = tools.email_normalize_all(partner.email)
+            email_to = [
+                tools.formataddr((partner.name or "False", email or "False"))
+                for email in email_to_normalized or [partner.email]
+            ]
         else:
+            email_to_normalized = tools.email_normalize_all(self.email_to)
             email_to = tools.email_split_and_format(self.email_to)
+        # email_cc is added to the "to" when invoking send_email
+        email_to_normalized += tools.email_normalize_all(self.email_cc)
         res = {
             'body': body,
             'body_alternative': body_alternative,
             'email_to': email_to,
+            'email_to_normalized': email_to_normalized,
         }
         return res
 
@@ -533,6 +534,9 @@ class MailMail(models.Model):
                 # TDE note: could be great to pre-detect missing to/cc and skip sending it
                 # to go directly to failed state update
                 for email in email_list:
+                    # give indication to 'send_mail' about emails already considered
+                    # as being valid
+                    email_to_normalized = email.pop('email_to_normalized', [])
                     # support headers specific to the specific outgoing email
                     if email.get('headers'):
                         email_headers = headers.copy()
@@ -560,7 +564,8 @@ class MailMail(models.Model):
                         headers=email_headers)
                     processing_pid = email.pop("partner_id", None)
                     try:
-                        res = IrMailServer.send_email(
+                        # 'send_validated_to' restricts emails found by 'extract_rfc2822_addresses'
+                        res = IrMailServer.with_context(send_validated_to=email_to_normalized).send_email(
                             msg, mail_server_id=mail.mail_server_id.id, smtp_session=smtp_session)
                         if processing_pid:
                             success_pids.append(processing_pid)

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -1365,13 +1365,16 @@ class TestComposerResultsComment(TestMailComposer):
         email fields: multi email, formatted emails, ... on template, used to
         post a message using the composer."""
         existing_partners = self.env['res.partner'].search([])
-        partner_format_tofind, partner_multi_tofind = self.env['res.partner'].create([
+        partner_format_tofind, partner_multi_tofind, partner_at_tofind = self.env['res.partner'].create([
             {
                 'email': '"FindMe Format" <find.me.format@test.example.com>',
                 'name': 'FindMe Format',
             }, {
                 'email': 'find.me.multi.1@test.example.com, "FindMe Multi" <find.me.multi.2@test.example.com>',
                 'name': 'FindMe Multi',
+            }, {
+                'email': '"Bike@Home" <find.me.at@test.example.com>',
+                'name': 'NotBike@Home',
             }
         ])
         email_ccs = ['"Raoul" <test.cc.1@example.com>', '"Raoulette" <test.cc.2@example.com>', 'test.cc.2.2@example.com>', 'invalid', '  ']
@@ -1380,16 +1383,16 @@ class TestComposerResultsComment(TestMailComposer):
         self.template.write({
             'email_cc': ', '.join(email_ccs),
             'email_from': '{{ user.email_formatted }}',
-            'email_to':', '.join(email_tos + (partner_format_tofind + partner_multi_tofind).mapped('email')),
+            'email_to': ', '.join(email_tos + (partner_format_tofind + partner_multi_tofind + partner_at_tofind).mapped('email')),
             'partner_to': f'{self.partner_1.id},{self.partner_2.id},0,test',
         })
-        self.user_employee.write({'email': 'email.from.1@test.example.com, email.from.2@test.example.com'})
+        self.user_employee.write({'email': 'email.from.1@test.mycompany.com, email.from.2@test.mycompany.com'})
         self.partner_1.write({'email': '"Valid Formatted" <valid.lelitre@agrolait.com>'})
         self.partner_2.write({'email': 'valid.other.1@agrolait.com, valid.other.cc@agrolait.com'})
         # ensure values used afterwards for testing
         self.assertEqual(
             self.partner_employee.email_formatted,
-            '"Ernest Employee" <email.from.1@test.example.com,email.from.2@test.example.com>',
+            '"Ernest Employee" <email.from.1@test.mycompany.com,email.from.2@test.mycompany.com>',
             'Formatting: wrong formatting due to multi-email')
         self.assertEqual(
             self.partner_1.email_formatted,
@@ -1416,22 +1419,29 @@ class TestComposerResultsComment(TestMailComposer):
         # FIXME: currently email finding based on formatted / multi emails does
         # not work
         new_partners = self.env['res.partner'].search([]).search([('id', 'not in', existing_partners.ids)])
-        self.assertEqual(len(new_partners), 8,
-                         'Mail (FIXME): multiple partner creation due to formatted / multi emails: 1 extra partners')
+        self.assertEqual(len(new_partners), 9,
+                         'Mail (FIXME): multiple partner creation due to formatted / multi emails: 1 extra partner')
         self.assertIn(partner_format_tofind, new_partners)
         self.assertIn(partner_multi_tofind, new_partners)
+        self.assertIn(partner_at_tofind, new_partners)
+        self.assertEqual(new_partners[0:3].ids, (partner_format_tofind + partner_multi_tofind + partner_at_tofind).ids)
         self.assertEqual(
             sorted(new_partners.mapped('email')),
-            sorted(['"FindMe Format" <find.me.format@test.example.com>',
+            sorted(['"Bike@Home" <find.me.at@test.example.com>',
+                    '"FindMe Format" <find.me.format@test.example.com>',
                     'find.me.multi.1@test.example.com, "FindMe Multi" <find.me.multi.2@test.example.com>',
                     'find.me.multi.2@test.example.com',
-                    'test.cc.1@example.com', 'test.cc.2@example.com', 'test.cc.2.2@example.com',
-                    'test.to.1@example.com', 'test.to.2@example.com']),
+                    'test.cc.1@example.com',
+                    'test.cc.2@example.com',
+                    'test.cc.2.2@example.com',
+                    'test.to.1@example.com',
+                    'test.to.2@example.com']),
             'Mail: created partners for valid emails (wrong / invalid not taken into account) + did not find corner cases (FIXME)'
         )
         self.assertEqual(
             sorted(new_partners.mapped('email_formatted')),
-            sorted(['"FindMe Format" <find.me.format@test.example.com>',
+            sorted(['"NotBike@Home" <find.me.at@test.example.com>',
+                    '"FindMe Format" <find.me.format@test.example.com>',
                     '"FindMe Multi" <find.me.multi.1@test.example.com,find.me.multi.2@test.example.com>',
                     '"find.me.multi.2@test.example.com" <find.me.multi.2@test.example.com>',
                     '"test.cc.1@example.com" <test.cc.1@example.com>',
@@ -1442,11 +1452,15 @@ class TestComposerResultsComment(TestMailComposer):
         )
         self.assertEqual(
             sorted(new_partners.mapped('name')),
-            sorted(['FindMe Format',
+            sorted(['NotBike@Home',
+                    'FindMe Format',
                     'FindMe Multi',
                     'find.me.multi.2@test.example.com',
-                    'test.cc.1@example.com', 'test.to.1@example.com', 'test.to.2@example.com',
-                    'test.cc.2@example.com', 'test.cc.2.2@example.com']),
+                    'test.cc.1@example.com',
+                    'test.to.1@example.com',
+                    'test.to.2@example.com',
+                    'test.cc.2@example.com',
+                    'test.cc.2.2@example.com']),
             'Mail: currently setting name = email, not taking into account formatted emails'
         )
 
@@ -1467,17 +1481,19 @@ class TestComposerResultsComment(TestMailComposer):
             email_values={
                 'body_content': f'TemplateBody {self.test_record.name}',
                 # single email event if email field is multi-email
-                'email_from': formataddr((self.user_employee.name, 'email.from.1@test.example.com')),
+                'email_from': formataddr((self.user_employee.name, 'email.from.1@test.mycompany.com')),
                 'subject': f'TemplateSubject {self.test_record.name}',
             },
             fields_values={
                 # currently holding multi-email 'email_from'
-                'email_from': formataddr((self.user_employee.name, 'email.from.1@test.example.com,email.from.2@test.example.com')),
+                'email_from': formataddr((self.user_employee.name, 'email.from.1@test.mycompany.com,email.from.2@test.mycompany.com')),
             },
             mail_message=self.test_record.message_ids[0],
         )
+        recipients = self.partner_1 + self.partner_2 + new_partners
         self.assertMailMail(
-            self.partner_1 + self.partner_2 + new_partners, 'sent',
+            recipients,
+            'sent',
             author=self.partner_employee,
             email_to_recipients=[
                 [self.partner_1.email_formatted],
@@ -1488,15 +1504,60 @@ class TestComposerResultsComment(TestMailComposer):
             email_values={
                 'body_content': f'TemplateBody {self.test_record.name}',
                 # single email event if email field is multi-email
-                'email_from': formataddr((self.user_employee.name, 'email.from.1@test.example.com')),
+                'email_from': formataddr((self.user_employee.name, 'email.from.1@test.mycompany.com')),
                 'subject': f'TemplateSubject {self.test_record.name}',
             },
             fields_values={
                 # currently holding multi-email 'email_from'
-                'email_from': formataddr((self.user_employee.name, 'email.from.1@test.example.com,email.from.2@test.example.com')),
+                'email_from': formataddr((self.user_employee.name, 'email.from.1@test.mycompany.com,email.from.2@test.mycompany.com')),
             },
             mail_message=self.test_record.message_ids[0],
         )
+        # actual emails sent through smtp
+        for recipient in recipients:
+            # multi emails -> send multiple emails (smart)
+            if recipient == self.partner_2:
+                smtp_to_list = ['valid.other.1@agrolait.com', 'valid.other.cc@agrolait.com']
+            # find.me.format
+            elif recipient == new_partners[0]:
+                self.assertEqual(recipient, partner_format_tofind)
+                smtp_to_list = ['find.me.format@test.example.com']
+            # find.me.multi was split into two partners
+            elif recipient == new_partners[1]:
+                self.assertEqual(recipient, partner_multi_tofind)
+                smtp_to_list = ['find.me.multi.1@test.example.com', 'find.me.multi.2@test.example.com']
+            # FIXME: name being an email, extract_rfc2822 finds 2 emails
+            elif recipient == new_partners[3]:
+                smtp_to_list = ['find.me.multi.2@test.example.com', 'find.me.multi.2@test.example.com']
+            # bike@home: name is recognized as email
+            elif recipient == new_partners[2]:
+                self.assertEqual(recipient, partner_at_tofind)
+                smtp_to_list = ['NotBike@Home', 'find.me.at@test.example.com']
+            # name being an email = 2 sent emails due to extract_rfc2822
+            elif recipient.name in [
+                'test.to.1@example.com',
+                'test.to.2@example.com',
+                'test.cc.1@example.com',
+                'test.cc.2@example.com',
+                'test.cc.2.2@example.com',
+                'test.cc.3@example.com',
+            ]:
+                smtp_to_list = [recipient.name, recipient.email_normalized]
+            else:
+                smtp_to_list = [recipient.email_normalized]
+            self.assert_email_sent_smtp(
+                smtp_from=f'{self.alias_bounce}@{self.alias_domain}',
+                smtp_to_list=smtp_to_list,
+                mail_server=self.mail_server_domain,
+                # FIXME: email_from of smtp still multi-email with a weird format
+                message_from=formataddr(
+                    (self.user_employee.name,
+                    'email.from.1@test.mycompany.com>,email.from.2@test.mycompany.com',
+                )),
+                # similar envelope, assert_email_sent_smtp cannot distinguish
+                # records (would have to dive into content, too complicated)
+                emails_count=1,
+            )
 
 
 @tagged('mail_composer', 'mail_blacklist')
@@ -1933,13 +1994,16 @@ class TestComposerResultsMass(TestMailComposer):
         """ Test various combinations of corner case / not standard filling of
         email fields: multi email, formatted emails, ... """
         existing_partners = self.env['res.partner'].search([])
-        partner_format_tofind, partner_multi_tofind = self.env['res.partner'].create([
+        partner_format_tofind, partner_multi_tofind, partner_at_tofind = self.env['res.partner'].create([
             {
                 'email': '"FindMe Format" <find.me.format@test.example.com>',
                 'name': 'FindMe Format',
             }, {
                 'email': 'find.me.multi.1@test.example.com, "FindMe Multi" <find.me.multi.2@test.example.com>',
                 'name': 'FindMe Multi',
+            }, {
+                'email': '"Bike@Home" <find.me.at@test.example.com>',
+                'name': 'NotBike@Home',
             }
         ])
         email_ccs = ['"Raoul" <test.cc.1@example.com>', '"Raoulette" <test.cc.2@example.com>', 'test.cc.2.2@example.com>', 'invalid', '  ']
@@ -1948,16 +2012,16 @@ class TestComposerResultsMass(TestMailComposer):
         self.template.write({
             'email_cc': ', '.join(email_ccs),
             'email_from': '{{ user.email_formatted }}',
-            'email_to':', '.join(email_tos + (partner_format_tofind + partner_multi_tofind).mapped('email')),
+            'email_to': ', '.join(email_tos + (partner_format_tofind + partner_multi_tofind + partner_at_tofind).mapped('email')),
             'partner_to': f'{self.partner_1.id},{self.partner_2.id},0,test',
         })
-        self.user_employee.write({'email': 'email.from.1@test.example.com, email.from.2@test.example.com'})
+        self.user_employee.write({'email': 'email.from.1@test.mycompany.com, email.from.2@test.mycompany.com'})
         self.partner_1.write({'email': '"Valid Formatted" <valid.lelitre@agrolait.com>'})
         self.partner_2.write({'email': 'valid.other.1@agrolait.com, valid.other.cc@agrolait.com'})
         # ensure values used afterwards for testing
         self.assertEqual(
             self.partner_employee.email_formatted,
-            '"Ernest Employee" <email.from.1@test.example.com,email.from.2@test.example.com>',
+            '"Ernest Employee" <email.from.1@test.mycompany.com,email.from.2@test.mycompany.com>',
             'Formatting: wrong formatting due to multi-email')
         self.assertEqual(
             self.partner_1.email_formatted,
@@ -1984,13 +2048,16 @@ class TestComposerResultsMass(TestMailComposer):
         # FIXME: currently email finding based on formatted / multi emails does
         # not work
         new_partners = self.env['res.partner'].search([]).search([('id', 'not in', existing_partners.ids)])
-        self.assertEqual(len(new_partners), 8,
-                         'Mail (FIXME): did not find existing partners for formatted / multi emails: 1 extra partners')
+        self.assertEqual(len(new_partners), 9,
+                         'Mail (FIXME): did not find existing partners for formatted / multi emails: 1 extra partner')
         self.assertIn(partner_format_tofind, new_partners)
         self.assertIn(partner_multi_tofind, new_partners)
+        self.assertIn(partner_at_tofind, new_partners)
+        self.assertEqual(new_partners[0:3].ids, (partner_format_tofind + partner_multi_tofind + partner_at_tofind).ids)
         self.assertEqual(
             sorted(new_partners.mapped('email')),
-            sorted(['"FindMe Format" <find.me.format@test.example.com>',
+            sorted(['"Bike@Home" <find.me.at@test.example.com>',
+                    '"FindMe Format" <find.me.format@test.example.com>',
                     'find.me.multi.1@test.example.com, "FindMe Multi" <find.me.multi.2@test.example.com>',
                     'find.me.multi.2@test.example.com',
                     'test.cc.1@example.com', 'test.cc.2@example.com', 'test.cc.2.2@example.com',
@@ -1999,7 +2066,8 @@ class TestComposerResultsMass(TestMailComposer):
         )
         self.assertEqual(
             sorted(new_partners.mapped('email_formatted')),
-            sorted(['"FindMe Format" <find.me.format@test.example.com>',
+            sorted(['"NotBike@Home" <find.me.at@test.example.com>',
+                    '"FindMe Format" <find.me.format@test.example.com>',
                     '"FindMe Multi" <find.me.multi.1@test.example.com,find.me.multi.2@test.example.com>',
                     '"find.me.multi.2@test.example.com" <find.me.multi.2@test.example.com>',
                     '"test.cc.1@example.com" <test.cc.1@example.com>',
@@ -2010,12 +2078,16 @@ class TestComposerResultsMass(TestMailComposer):
         )
         self.assertEqual(
             sorted(new_partners.mapped('name')),
-            sorted(['FindMe Format',
+            sorted(['NotBike@Home',
+                    'FindMe Format',
                     'FindMe Multi',
                     'find.me.multi.2@test.example.com',
-                    'test.cc.1@example.com', 'test.to.1@example.com', 'test.to.2@example.com',
-                    'test.cc.2@example.com', 'test.cc.2.2@example.com']),
-            'Mail: currently setting name = email, not taking into account formatted emails'
+                    'test.cc.1@example.com',
+                    'test.to.1@example.com',
+                    'test.to.2@example.com',
+                    'test.cc.2@example.com',
+                    'test.cc.2.2@example.com']),
+            'Mail: when possible, find name in formatted emails, otherwise fallback on email'
         )
 
         # global outgoing: one mail.mail (all customer recipients), * 2 records
@@ -2031,8 +2103,9 @@ class TestComposerResultsMass(TestMailComposer):
             len(self._mails), (len(new_partners) + 2) * 2,
             f'Should have sent {(len(new_partners) + 2) * 2} emails, one / recipient ({len(new_partners)} mailed partners + partner_1 + partner_2) * 2 records')
         for record in self.test_records:
+            recipients = self.partner_1 + self.partner_2 + new_partners
             self.assertMailMail(
-                self.partner_1 + self.partner_2 + new_partners,
+                recipients,
                 'sent',
                 author=self.partner_employee,
                 email_to_recipients=[
@@ -2044,7 +2117,7 @@ class TestComposerResultsMass(TestMailComposer):
                 email_values={
                     'body_content': f'TemplateBody {record.name}',
                     # single email event if email field is multi-email
-                    'email_from': formataddr((self.user_employee.name, 'email.from.1@test.example.com')),
+                    'email_from': formataddr((self.user_employee.name, 'email.from.1@test.mycompany.com')),
                     'reply_to': formataddr((
                         f'{self.env.user.company_id.name} {record.name}',
                         f'{self.alias_catchall}@{self.alias_domain}'
@@ -2061,6 +2134,52 @@ class TestComposerResultsMass(TestMailComposer):
                 },
                 mail_message=record.message_ids[0],  # message copy is kept
             )
+
+            # actual emails sent through smtp
+            for recipient in recipients:
+                # multi emails -> send multiple emails (smart)
+                if recipient == self.partner_2:
+                    smtp_to_list = ['valid.other.1@agrolait.com', 'valid.other.cc@agrolait.com']
+                # find.me.format
+                elif recipient == new_partners[0]:
+                    self.assertEqual(recipient, partner_format_tofind)
+                    smtp_to_list = ['find.me.format@test.example.com']
+                # find.me.multi was split into two partners
+                elif recipient == new_partners[1]:
+                    self.assertEqual(recipient, partner_multi_tofind)
+                    smtp_to_list = ['find.me.multi.1@test.example.com', 'find.me.multi.2@test.example.com']
+                # name being an email = 2 sent emails due to extract_rfc2822
+                elif recipient == new_partners[3]:
+                    smtp_to_list = ['find.me.multi.2@test.example.com', 'find.me.multi.2@test.example.com']
+                # bike@home: name is recognized as email
+                elif recipient == new_partners[2]:
+                    self.assertEqual(recipient, partner_at_tofind)
+                    smtp_to_list = ['NotBike@Home', 'find.me.at@test.example.com']
+                # name being an email = 2 sent emails due to extract_rfc2822
+                elif recipient.name in [
+                    'test.to.1@example.com',
+                    'test.to.2@example.com',
+                    'test.cc.1@example.com',
+                    'test.cc.2@example.com',
+                    'test.cc.2.2@example.com',
+                    'test.cc.3@example.com',
+                ]:
+                    smtp_to_list = [recipient.name, recipient.email_normalized]
+                else:
+                    smtp_to_list = [recipient.email_normalized]
+                self.assert_email_sent_smtp(
+                    smtp_from=f'{self.alias_bounce}@{self.alias_domain}',
+                    smtp_to_list=smtp_to_list,
+                    mail_server=self.mail_server_domain,
+                    # FIXME: email_from of smtp still multi-email with a weird format
+                    message_from=formataddr(
+                        (self.user_employee.name,
+                        'email.from.1@test.mycompany.com>,email.from.2@test.mycompany.com',
+                    )),
+                    # similar envelope, assert_email_sent_smtp cannot distinguish
+                    # records (would have to dive into content, too complicated)
+                    emails_count=2,
+                )
 
     @users('employee')
     @mute_logger('odoo.models.unlink', 'odoo.addons.mail.models.mail_mail')

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -1526,23 +1526,12 @@ class TestComposerResultsComment(TestMailComposer):
             elif recipient == new_partners[1]:
                 self.assertEqual(recipient, partner_multi_tofind)
                 smtp_to_list = ['find.me.multi.1@test.example.com', 'find.me.multi.2@test.example.com']
-            # FIXME: name being an email, extract_rfc2822 finds 2 emails
             elif recipient == new_partners[3]:
-                smtp_to_list = ['find.me.multi.2@test.example.com', 'find.me.multi.2@test.example.com']
+                smtp_to_list = ['find.me.multi.2@test.example.com']
             # bike@home: name is recognized as email
             elif recipient == new_partners[2]:
                 self.assertEqual(recipient, partner_at_tofind)
                 smtp_to_list = ['NotBike@Home', 'find.me.at@test.example.com']
-            # name being an email = 2 sent emails due to extract_rfc2822
-            elif recipient.name in [
-                'test.to.1@example.com',
-                'test.to.2@example.com',
-                'test.cc.1@example.com',
-                'test.cc.2@example.com',
-                'test.cc.2.2@example.com',
-                'test.cc.3@example.com',
-            ]:
-                smtp_to_list = [recipient.name, recipient.email_normalized]
             else:
                 smtp_to_list = [recipient.email_normalized]
             self.assert_email_sent_smtp(
@@ -2148,23 +2137,12 @@ class TestComposerResultsMass(TestMailComposer):
                 elif recipient == new_partners[1]:
                     self.assertEqual(recipient, partner_multi_tofind)
                     smtp_to_list = ['find.me.multi.1@test.example.com', 'find.me.multi.2@test.example.com']
-                # name being an email = 2 sent emails due to extract_rfc2822
                 elif recipient == new_partners[3]:
-                    smtp_to_list = ['find.me.multi.2@test.example.com', 'find.me.multi.2@test.example.com']
+                    smtp_to_list = ['find.me.multi.2@test.example.com']
                 # bike@home: name is recognized as email
                 elif recipient == new_partners[2]:
                     self.assertEqual(recipient, partner_at_tofind)
                     smtp_to_list = ['NotBike@Home', 'find.me.at@test.example.com']
-                # name being an email = 2 sent emails due to extract_rfc2822
-                elif recipient.name in [
-                    'test.to.1@example.com',
-                    'test.to.2@example.com',
-                    'test.cc.1@example.com',
-                    'test.cc.2@example.com',
-                    'test.cc.2.2@example.com',
-                    'test.cc.3@example.com',
-                ]:
-                    smtp_to_list = [recipient.name, recipient.email_normalized]
                 else:
                     smtp_to_list = [recipient.email_normalized]
                 self.assert_email_sent_smtp(

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -1549,10 +1549,10 @@ class TestComposerResultsComment(TestMailComposer):
                 smtp_from=f'{self.alias_bounce}@{self.alias_domain}',
                 smtp_to_list=smtp_to_list,
                 mail_server=self.mail_server_domain,
-                # FIXME: email_from of smtp still multi-email with a weird format
+                # msg_from takes only first found normalized email to make a valid email_from
                 message_from=formataddr(
                     (self.user_employee.name,
-                    'email.from.1@test.mycompany.com>,email.from.2@test.mycompany.com',
+                    'email.from.1@test.mycompany.com',
                 )),
                 # similar envelope, assert_email_sent_smtp cannot distinguish
                 # records (would have to dive into content, too complicated)
@@ -2171,10 +2171,10 @@ class TestComposerResultsMass(TestMailComposer):
                     smtp_from=f'{self.alias_bounce}@{self.alias_domain}',
                     smtp_to_list=smtp_to_list,
                     mail_server=self.mail_server_domain,
-                    # FIXME: email_from of smtp still multi-email with a weird format
+                    # msg_from takes only first found normalized email to make a valid email_from
                     message_from=formataddr(
                         (self.user_employee.name,
-                        'email.from.1@test.mycompany.com>,email.from.2@test.mycompany.com',
+                        'email.from.1@test.mycompany.com',
                     )),
                     # similar envelope, assert_email_sent_smtp cannot distinguish
                     # records (would have to dive into content, too complicated)

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -1528,10 +1528,10 @@ class TestComposerResultsComment(TestMailComposer):
                 smtp_to_list = ['find.me.multi.1@test.example.com', 'find.me.multi.2@test.example.com']
             elif recipient == new_partners[3]:
                 smtp_to_list = ['find.me.multi.2@test.example.com']
-            # bike@home: name is recognized as email
+            # bike@home: name is not recognized as email anymore
             elif recipient == new_partners[2]:
                 self.assertEqual(recipient, partner_at_tofind)
-                smtp_to_list = ['NotBike@Home', 'find.me.at@test.example.com']
+                smtp_to_list = ['find.me.at@test.example.com']
             else:
                 smtp_to_list = [recipient.email_normalized]
             self.assert_email_sent_smtp(
@@ -2139,10 +2139,10 @@ class TestComposerResultsMass(TestMailComposer):
                     smtp_to_list = ['find.me.multi.1@test.example.com', 'find.me.multi.2@test.example.com']
                 elif recipient == new_partners[3]:
                     smtp_to_list = ['find.me.multi.2@test.example.com']
-                # bike@home: name is recognized as email
+                # bike@home: name is not recognized as email anymore
                 elif recipient == new_partners[2]:
                     self.assertEqual(recipient, partner_at_tofind)
-                    smtp_to_list = ['NotBike@Home', 'find.me.at@test.example.com']
+                    smtp_to_list = ['find.me.at@test.example.com']
                 else:
                     smtp_to_list = [recipient.email_normalized]
                 self.assert_email_sent_smtp(

--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -604,14 +604,19 @@ class IrMailServer(models.Model):
         email_bcc = message['Bcc']
         del message['Bcc']
 
-        # All recipient addresses must only contain ASCII characters
+        # All recipient addresses must only contain ASCII characters; support
+        # optional pre-validated To list, used notably when formatted emails may
+        # create fake emails using extract_rfc2822_addresses, e.g.
+        # '"Bike@Home" <email@domain.com>' which can be considered as containing
+        # 2 emails by extract_rfc2822_addresses
+        validated_to = self.env.context.get('send_validated_to') or []
         smtp_to_list = [
             address
             for base in [email_to, email_cc, email_bcc]
             # be sure a given address does not return duplicates (but duplicates
             # in final smtp to list is still ok)
             for address in tools.misc.unique(extract_rfc2822_addresses(base))
-            if address
+            if address and (not validated_to or address in validated_to)
         ]
         assert smtp_to_list, self.NO_VALID_RECIPIENT
 

--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -608,7 +608,9 @@ class IrMailServer(models.Model):
         smtp_to_list = [
             address
             for base in [email_to, email_cc, email_bcc]
-            for address in extract_rfc2822_addresses(base)
+            # be sure a given address does not return duplicates (but duplicates
+            # in final smtp to list is still ok)
+            for address in tools.misc.unique(extract_rfc2822_addresses(base))
             if address
         ]
         assert smtp_to_list, self.NO_VALID_RECIPIENT

--- a/odoo/addons/base/tests/common.py
+++ b/odoo/addons/base/tests/common.py
@@ -401,11 +401,24 @@ class MockSmtplibCase:
             self.emails,
         )
 
+        debug_info = ''
         matching_emails_count = len(list(matching_emails))
-
-        self.assertTrue(
-            matching_emails_count == emails_count,
-            msg='Emails not sent, %i emails match the condition but %i are expected' % (matching_emails_count, emails_count),
+        if matching_emails_count != emails_count:
+            emails_from = []
+            for email in self.emails:
+                from_found = next((
+                    line.split('From:')[1].strip() for line in email['message'].splitlines()
+                    if line.startswith('From:')), '')
+                emails_from.append(from_found)
+            debug_info = '\n'.join(
+                f"SMTP-From: {email['smtp_from']}, SMTP-To: {email['smtp_to_list']}, Msg-From: {email_msg_from}, From_filter: {email['from_filter']})"
+                for email, email_msg_from in zip(self.emails, emails_from)
+            )
+        self.assertEqual(
+            matching_emails_count, emails_count,
+            msg=f'Incorrect emails sent: {matching_emails_count} found, {emails_count} expected'
+                f'\nConditions\nSMTP-From: {smtp_from}, SMTP-To: {smtp_to_list}, Msg-From: {message_from}, From_filter: {from_filter}'
+                f'\nNot found in\n{debug_info}'
         )
 
     @classmethod

--- a/odoo/addons/base/tests/test_mail.py
+++ b/odoo/addons/base/tests/test_mail.py
@@ -659,14 +659,24 @@ class TestEmailTools(BaseCase):
             ('admin@example.com', ['admin@example.com']),
             ('"Admin" <admin@example.com>, Demo <malformed email>', ['admin@example.com']),
             ('admin@éxample.com', ['admin@xn--xample-9ua.com']),
-            # formatted input containing email
-            ('"admin@éxample.com" <admin@éxample.com>', ['admin@xn--xample-9ua.com', 'admin@xn--xample-9ua.com']),
+            # email-like names
+            (
+                '"admin@éxample.com" <admin@éxample.com>',
+                ['admin@xn--xample-9ua.com', 'admin@xn--xample-9ua.com'],
+            ),
             ('"Robert Le Grand" <robert@notgmail.com>', ['robert@notgmail.com']),
             ('"robert@notgmail.com" <robert@notgmail.com>', ['robert@notgmail.com', 'robert@notgmail.com']),
+            # "@' in names
+            ('"Bike @ Home" <bike@example.com>', ['bike@example.com']),
+            ('"Bike@Home" <bike@example.com>', ['Bike@Home', 'bike@example.com']),
+            # combo @ in names + multi email
+            (
+                '"Not an Email" <robert@notgmail.com>, "robert@notgmail.com" <robert@notgmail.com>',
+                ['robert@notgmail.com', 'robert@notgmail.com', 'robert@notgmail.com'],
+            ),
             # accents
             ('DéBoulonneur@examplé.com', ['DéBoulonneur@xn--exampl-gva.com']),
         ]
-
         for source, expected in cases:
             with self.subTest(source=source):
                 self.assertEqual(extract_rfc2822_addresses(source), expected)

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -650,15 +650,7 @@ def email_normalize(text, strict=True):
     if not emails or (strict and len(emails) != 1):
         return False
 
-    local_part, at, domain = emails[0].rpartition('@')
-    try:
-        local_part.encode('ascii')
-    except UnicodeEncodeError:
-        pass
-    else:
-        local_part = local_part.lower()
-
-    return local_part + at + domain.lower()
+    return _normalize_email(emails[0])
 
 def email_normalize_all(text):
     """ Tool method allowing to extract email addresses from a text input and returning
@@ -672,7 +664,37 @@ def email_normalize_all(text):
     if not text:
         return []
     emails = email_split(text)
-    return list(filter(None, [email_normalize(email) for email in emails]))
+    return list(filter(None, [_normalize_email(email) for email in emails]))
+
+def _normalize_email(email):
+    """ As of rfc5322 section 3.4.1 local-part is case-sensitive. However most
+    main providers do consider the local-part as case insensitive. With the
+    introduction of smtp-utf8 within odoo, this assumption is certain to fall
+    short for international emails. We now consider that
+
+      * if local part is ascii: normalize still 'lower' ;
+      * else: use as it, SMTP-UF8 is made for non-ascii local parts;
+
+    Concerning domain part of the address, as of v14 international domain (IDNA)
+    are handled fine. The domain is always lowercase, lowering it is fine as it
+    is probably an error. With the introduction of IDNA, there is an encoding
+    that allow non-ascii characters to be encoded to ascii ones, using 'idna.encode'.
+
+    A normalized email is considered as :
+    - having a left part + @ + a right part (the domain can be without '.something')
+    - having no name before the address. Typically, having no 'Name <>'
+    Ex:
+    - Possible Input Email : 'Name <NaMe@DoMaIn.CoM>'
+    - Normalized Output Email : 'name@domain.com'
+    """
+    local_part, at, domain = email.rpartition('@')
+    try:
+        local_part.encode('ascii')
+    except UnicodeEncodeError:
+        pass
+    else:
+        local_part = local_part.lower()
+    return local_part + at + domain.lower()
 
 def email_domain_extract(email):
     """ Extract the company domain to be used by IAP services notably. Domain


### PR DESCRIPTION
Use cases: send an email to
 "Bike@Home" <info@bike.com>  (name containing @)
 "robert@exampl.com" <robert@example.com> (result of partner name_create)

When there is an email in the name field, emails are sent twice and
thus may be counted twice in various tooling, introduce unwanted or
extra recipients, ... This happens notably due to https://github.com/odoo/odoo/commit/795091c69d2bc40e3bd2b5ae29451ea3af07d908
combined to https://github.com/odoo/odoo/pull/74474 which improved support of multiemails and
formatted emails in various email input.

This notably leads to better formatted email computation on partner
that generates emails like '"email@example.com" <email@example.com>'
when email is used both as name and email. When sending emails to this
partner only a single email should be sent and counted.

A fix is been done to remove duplicates in that tool, making the returned
list unique. In this PR we allow to receive a pre-validated
list of emails that restricts emails found by 'extract_rfc2822'.
When going through classic flows, we already computed emails using
'email_split' and its subtools, hence we just need the encoding
check of 'extract_rfc2822'. Additional emails found by that tool
are ignored as we consider those are fake emails.

This PR contains tests and fixes related to that issue as well as multi
and formatted emails management.

Task-3704658