### PR TITLE
[FIX] stock: start SML from sub location

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -557,21 +557,23 @@ Please change the quantity done or the rounding precision of your unit of measur
             ls = move.move_line_ids.lot_id
             for lot in move.lot_ids:
                 if lot not in ls:
+                    sml_location_id = lot.location_id.id \
+                        if lot.location_id and lot.location_id._child_of(move.location_id) \
+                        else move.location_id.id
+                    sml_lot_vals = {
+                        'location_id': sml_location_id,
+                        'lot_name': lot.name,
+                        'lot_id': lot.id,
+                        'product_uom_id': move.product_id.uom_id.id,
+                        'quantity': 1,
+                    }
                     if mls_without_lots[:1]:  # Updates an existing line without serial number.
                         move_line = mls_without_lots[:1]
-                        move_lines_commands.append(Command.update(move_line.id, {
-                            'lot_name': lot.name,
-                            'lot_id': lot.id,
-                            'product_uom_id': move.product_id.uom_id.id,
-                            'quantity': 1,
-                        }))
+                        move_lines_commands.append(Command.update(move_line.id, sml_lot_vals))
                         mls_without_lots -= move_line
                     else:  # No line without serial number, creates a new one.
                         move_line_vals = self._prepare_move_line_vals(quantity=0)
-                        move_line_vals['lot_id'] = lot.id
-                        move_line_vals['lot_name'] = lot.name
-                        move_line_vals['product_uom_id'] = move.product_id.uom_id.id
-                        move_line_vals['quantity'] = 1
+                        move_line_vals.update(**sml_lot_vals)
                         move_lines_commands.append((0, 0, move_line_vals))
                 else:
                     move_line = move.move_line_ids.filtered(lambda line: line.lot_id.id == lot.id)

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -6782,3 +6782,38 @@ class StockMove(TransactionCase):
         })
         receipt.action_confirm()
         self.assertNotEqual(old_reference, receipt.move_ids.reference)
+
+    def test_autocomplete_sml_location_based_on_sm_lot_ids(self):
+        """
+        When the user sets the lots on the SM, we will create the related SML. But in
+        case of serial number, we can also guess the source location
+        """
+        subloc = self.stock_location.child_ids[0]
+
+        lots = self.env['stock.lot'].create([{
+            'name': name,
+            'product_id': self.product_serial.id,
+        } for name in ['sn01', 'sn02', 'sn03']])
+
+        self.env['stock.quant']._update_available_quantity(self.product_serial, self.stock_location, 1, lot_id=lots[0])
+        self.env['stock.quant']._update_available_quantity(self.product_serial, subloc, 1, lot_id=lots[1])
+        # Third SN is at a wrong location -> we will fallback on SM loc
+        self.env['stock.quant']._update_available_quantity(self.product_serial, self.pack_location, 1, lot_id=lots[2])
+
+        sm = self.env['stock.move'].create({
+            'name': self.product_serial.name,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'product_id': self.product_serial.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 3.0,
+        })
+        sm._action_confirm()
+
+        sm.lot_ids = [(6, 0, lots.ids)]
+
+        self.assertRecordValues(sm.move_line_ids, [
+            {'location_id': self.stock_location.id, 'lot_id': lots[0].id},
+            {'location_id': subloc.id, 'lot_id': lots[1].id},
+            {'location_id': self.stock_location.id, 'lot_id': lots[2].id},
+        ])


### PR DESCRIPTION
On a stock move, when using a lot from a sub-location, the created
SML will still start from SM's source location instead of lot's location

To reproduce the issue:
1. In Settings, enable "Storage Locations"
2. Create a tracked-by-sn product P
3. Update its qty:
   - SN01 at WH/Stock
   - SN02 at WH/Stock/Shelf 1
4. Confirm a delivery with 1 x P
5. Enable the column "Serial Number"
   - SN01 should be present
6. Remove SN01, set SN02
7. Validate the transfer
8. Open the detailed operations

Result: SN02 has been taken from WH/Stock, but the user probably
wanted to use the existing one, in WH/Stock/Shelf 1.

An onchange already exists to make sure that the user is not using a
lot that already exists somewhere else. Before Odoo 17.2, we were
considering the sub locations as not expected:
https://github.com/odoo/odoo/blob/d5a7a3d02e3e2b4e47977abc8b9fc0d5d6135937/addons/stock/models/stock_move.py#L1167
But since Odoo 17.2 (via [1]), we now also accept the sub locations:
https://github.com/odoo/odoo/blob/60b0bafc8abd1893c9cdd9913617c234692369cf/addons/stock/models/stock_move.py#L1242

This is a bit confusing because we don't display any warning anymore,
but we don't select the correct source location neither. The commit
should help the user and avoid that confusion

[1] https://github.com/odoo/odoo/commit/99b39b72c7e65e85af6f06dcb6b02867623f3f69

OPW-4231749