### PR TITLE
[FIX] product: await the catalog update before reloading records

### DIFF
--- a/addons/product/static/src/product_catalog/kanban_controller.xml
+++ b/addons/product/static/src/product_catalog/kanban_controller.xml
@@ -4,5 +4,8 @@
         <xpath expr="//button[hasclass('o-kanban-button-new')]" position="replace">
             <button t-out="this.buttonString" type="button" class="btn btn-secondary o-kanban-button-back" t-on-click="this.backToQuotationDebounced"/>
         </xpath>
+        <xpath expr="//t[@t-component='props.Renderer']" position="attributes">
+            <attribute name="pushCatalogKanbanUpdate">this.pushCatalogKanbanUpdate.bind(this)</attribute>
+        </xpath>
     </t>
 </templates>

--- a/addons/product/static/src/product_catalog/kanban_record.js
+++ b/addons/product/static/src/product_catalog/kanban_record.js
@@ -7,6 +7,7 @@ import { ProductCatalogOrderLine } from "./order_line/order_line";
 
 export class ProductCatalogKanbanRecord extends KanbanRecord {
     static template = "ProductCatalogKanbanRecord";
+    static props = [...KanbanRecord.props, "pushCatalogKanbanUpdate?"];
     static components = {
         ...KanbanRecord.components,
         ProductCatalogOrderLine,
@@ -14,7 +15,7 @@ export class ProductCatalogKanbanRecord extends KanbanRecord {
 
     setup() {
         super.setup();
-        this.debouncedUpdateQuantity = useDebounced(this._updateQuantity, 500, {
+        this.debouncedUpdateQuantity = useDebounced(this._updateQuantityAndPushUpdate, 500, {
             execBeforeUnmount: true,
         });
 
@@ -59,8 +60,14 @@ export class ProductCatalogKanbanRecord extends KanbanRecord {
     // Data Exchanges
     //--------------------------------------------------------------------------
 
+    _updateQuantityAndPushUpdate() {
+        const result = this._updateQuantity();
+        this.props.pushCatalogKanbanUpdate?.(result);
+    }
+
     async _updateQuantity() {
-        const price = await this._updateQuantityAndGetPrice();
+        this.updateRecords = this._updateQuantityAndGetPrice();
+        const price = await this.updateRecords;
         this.productCatalogData.price = parseFloat(price);
     }
 

--- a/addons/product/static/src/product_catalog/kanban_renderer.js
+++ b/addons/product/static/src/product_catalog/kanban_renderer.js
@@ -7,6 +7,7 @@ import { ProductCatalogKanbanRecord } from "./kanban_record";
 
 export class ProductCatalogKanbanRenderer extends KanbanRenderer {
     static template = "ProductCatalogKanbanRenderer";
+    static props = [...KanbanRenderer.props, "pushCatalogKanbanUpdate?"];
     static components = {
         ...KanbanRenderer.components,
         KanbanRecord: ProductCatalogKanbanRecord,

--- a/addons/product/static/src/product_catalog/kanban_renderer.xml
+++ b/addons/product/static/src/product_catalog/kanban_renderer.xml
@@ -18,5 +18,11 @@
                 </div>
             </t>
         </t>
+        <xpath expr="//t[@t-if='groupOrRecord.group']//KanbanRecord" position="attributes">
+            <attribute name="pushCatalogKanbanUpdate">props.pushCatalogKanbanUpdate?.bind(this)</attribute>
+        </xpath>
+        <xpath expr="//t[@t-else='']//KanbanRecord" position="attributes">
+            <attribute name="pushCatalogKanbanUpdate">props.pushCatalogKanbanUpdate?.bind(this)</attribute>
+        </xpath>
     </t>
 </templates>


### PR DESCRIPTION
### Issue:

Since 18.0, the catalog is used in certain actions of the shopfloor However, if you leave the catalog fast enough after your last change (something of the order of ~0.5 sec in localhost), you can trigger a reload of the shopfloor records and call a `web_read` prior to the update of these records.

### Note:

This is easily reproducible by hand in localhost and should worsen if you have server delay.In addition, Also, it makes it impossible to write a proper tour involving the catalog in the shopfloor.

### Steps to reproduce:

- Create a product with a bom and an operation op1
- Create and confirm an MO for 1 unit of that product
- Go to the shopfloor > on the operation > wheel > Add component
- Add a component to be consumed in that operation
- Close the catalog fast (using ESC for instance)

#### > While the componenet was correctly added to the MO and linked to the WO it is not visible on the shopfloor.

### Cause of the issue:

When a product is added from the catalog it triggers an rpc call to update the data's of the MO (notably creating a new raw move): https://github.com/odoo/odoo/blob/193c9a49dfc039ee93fbc8e171819236697b5c50/addons/product/static/src/product_catalog/kanban_record.js#L62-L69 https://github.com/odoo/odoo/blob/193c9a49dfc039ee93fbc8e171819236697b5c50/addons/mrp/models/mrp_production.py#L2898-L2901 On the other hand, closing the product catalog will reload the mrp record that started the action that opened the catalog: https://github.com/odoo/enterprise/blob/c1346dd2279bf3882b47b260b8d03ef9651ffaf1/mrp_workorder/static/src/mrp_display/dialog/mrp_menu_dialog.js#L41-L45 Since this reload is currently not waiting for the update of the record the associated `web_read` might be called prior to the last update of the record and the newly created raw moves might not be displayed.

### Fix:

We use the props option of the action opening the catalog to transfer a callback to reload the records when all the record update promisses are resolved.

Enterprise: https://github.com/odoo/enterprise/pull/72942

opw-4199156
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
