### PR TITLE
[FIX] sale_pdf_qoute_builder no demo test

### DIFF
--- a/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
+++ b/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
@@ -116,7 +116,7 @@ class TestPDFQuoteBuilder(HttpCase, SaleCommon):
                 Command.create({'name': 'test tax'}), Command.create({'name': 'test tax2'})
             ]
         })
-        self.sale_order.commitment_date = datetime.datetime(2121, 12, 21, 12, 21, 12)
+        self.sale_order.commitment_date = datetime.datetime(2121, 12, 21, 1, 21, 12)
         expected_values = [
             "No",  # boolean
             self.sale_order.name,  # char


### PR DESCRIPTION
There was a typo in test_pdf_qoute_builder. This
commit corrects it.

[broken test](https://runbot.odoo.com/web#id=74907&view_type=form&model=runbot.build.error&menu_id=405&cids=1)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
