### PR TITLE
[FIX] bus: improve debug logs for WebSocket worker

### DIFF
--- a/addons/bus/static/src/services/bus_service.js
+++ b/addons/bus/static/src/services/bus_service.js
@@ -9,7 +9,7 @@ import { isIosApp } from "@web/core/browser/feature_detection";
 import { EventBus } from "@odoo/owl";
 
 // List of worker events that should not be broadcasted.
-const INTERNAL_EVENTS = new Set(["initialized", "outdated", "notification"]);
+const INTERNAL_EVENTS = new Set(["initialized", "outdated", "notification", "log_debug"]);
 /**
  * Communicate with a SharedWorker in order to provide a single websocket
  * connection shared across multiple tabs.
@@ -74,6 +74,10 @@ export const busService = {
                 case "initialized": {
                     isInitialized = true;
                     connectionInitializedDeferred.resolve();
+                    break;
+                }
+                case "log_debug": {
+                    console.debug(...data);
                     break;
                 }
                 case "outdated": {

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -889,7 +889,7 @@ class WebsocketConnectionHandler:
     # Latest version of the websocket worker. This version should be incremented
     # every time `websocket_worker.js` is modified to force the browser to fetch
     # the new worker bundle.
-    _VERSION = "17.4-1"
+    _VERSION = "17.4-2"
 
     @classmethod
     def websocket_allowed(cls, request):


### PR DESCRIPTION
The bus service uses a shared worker to reduce the number of
connections to the server. However, debugging the worker state can be
challenging. If the shared worker is opened later, the WebSocket does
not appear in the network tab. Additionally, the worker manages
multiple tab and network states, which are not easy to visualize.

This commit adds debug logs to the WebSocket worker to track
communication between the client and worker, as well as between the
worker and server.

The log is done by each tab because Safari does not provide devtools
for the shared worker. As a result, logs would be unreachable. It's
easier to access the logs from the tab devtools.