### PR TITLE
[FIX] point_of_sale: fix pos load uom categories

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -218,7 +218,7 @@ class PosSession(models.Model):
                 'fields': ['id', 'name', 'category_id', 'factor_inv', 'factor', 'is_pos_groupable', 'uom_type', 'rounding'],
             },
             'uom.category': {
-                'domain': lambda data: [('uom_ids', 'in', [uom['category_id'] for uom in data['uom.uom']])],
+                'domain': lambda data: [('id', 'in', [uom['category_id'] for uom in data['uom.uom']])],
                 'fields': ['id', 'name', 'uom_ids'],
             },
             'res.country.state': {


### PR DESCRIPTION
Before this commit, when loading the data for the point of sale, all the uom categories were not being loaded due to a wrong domain declaration. The domain was comparing uom categories ids with uom ids, which is wrong.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
