### PR TITLE
[FIX] pos*: post OXP bug fix

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -6,7 +6,6 @@ import { omit } from "@web/core/utils/objects";
 import { parseUTCString, qrCodeSrc, random5Chars, uuidv4 } from "@point_of_sale/utils";
 import { renderToElement } from "@web/core/utils/render";
 import { floatIsZero, roundPrecision } from "@web/core/utils/numbers";
-import { computeComboLines } from "./utils/compute_combo_lines";
 import { changesToOrder } from "./utils/order_change";
 
 const { DateTime } = luxon;
@@ -390,11 +389,7 @@ export class PosOrder extends Base {
             this.update({ pricelist_id: false });
         }
 
-        const lines_to_recompute = this.lines.filter(
-            (line) =>
-                line.price_type === "original" &&
-                !(line.combo_line_ids?.length || line.combo_parent_id)
-        );
+        const lines_to_recompute = this.lines.filter((line) => line.price_type === "original");
 
         for (const line of lines_to_recompute) {
             const newPrice = line.product_id.get_price(
@@ -404,41 +399,6 @@ export class PosOrder extends Base {
             );
             line.set_unit_price(newPrice);
         }
-
-        const attributes_prices = {};
-        const combo_parent_lines = this.lines.filter(
-            (line) => line.price_type === "original" && line.combo_line_ids?.length
-        );
-        for (const pLine of combo_parent_lines) {
-            attributes_prices[pLine.id] = computeComboLines(
-                pLine.product_id,
-                pLine.combo_line_ids.map((cLine) => {
-                    if (cLine.attribute_value_ids) {
-                        return {
-                            combo_line_id: cLine.combo_line_id,
-                            configuration: {
-                                attribute_value_ids: cLine.attribute_value_ids,
-                            },
-                        };
-                    } else {
-                        return { combo_line_id: cLine.combo_line_id };
-                    }
-                }),
-                pricelist,
-                this.models["decimal.precision"].getAll(),
-                this.models["product.template.attribute.value"].getAllBy("id")
-            );
-        }
-        const combo_children_lines = this.lines.filter(
-            (line) => line.price_type === "original" && line.combo_parent_id
-        );
-        combo_children_lines.forEach((line) => {
-            line.set_unit_price(
-                attributes_prices[line.combo_parent_id.id].find(
-                    (item) => item.combo_line_id.id === line.combo_line_id.id
-                ).price_unit
-            );
-        });
     }
 
     /**

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -9,6 +9,7 @@ import {
     getTaxesAfterFiscalPosition,
     getTaxesValues,
 } from "@point_of_sale/app/models/utils/tax_utils";
+import { computeComboLinesPrice } from "./utils/compute_combo_lines";
 
 export class PosOrderline extends Base {
     static pythonModel = "pos.order.line";
@@ -57,7 +58,9 @@ export class PosOrderline extends Base {
             }
         }
 
-        this.set_unit_price(this.price_unit);
+        if (!this.product_id.isCombo()) {
+            this.set_unit_price(this.price_unit);
+        }
     }
 
     get preparationKey() {
@@ -181,6 +184,10 @@ export class PosOrderline extends Base {
     }
 
     set_discount(discount) {
+        if (this.product_id.isCombo()) {
+            this.combo_line_ids.forEach((line) => line.set_discount(discount));
+            return;
+        }
         const parsed_discount =
             typeof discount === "number"
                 ? discount
@@ -296,36 +303,68 @@ export class PosOrderline extends Base {
     }
 
     can_be_merged_with(orderline) {
-        const productPriceUnit = this.models["decimal.precision"].find(
+        if (orderline.product_id.isCombo()) {
+            return this.can_be_merged_with_combo(orderline);
+        }
+        return !orderline.isPartOfCombo() && this.check_equivalent_line(this, orderline);
+    }
+
+    can_be_merged_with_combo(orderline) {
+        if (!this.product_id.isCombo()) {
+            return false;
+        }
+        for (const line of this.combo_line_ids) {
+            let line_ok = false;
+            for (const cline of orderline.combo_line_ids) {
+                if (line.product_id.id === cline.product_id.id) {
+                    if (this.check_equivalent_line(line, cline)) {
+                        line_ok = true;
+                        break;
+                    }
+                    return false;
+                }
+            }
+            if (!line_ok) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    check_equivalent_line(lineA, lineB) {
+        const productPriceUom = this.models["decimal.precision"].find(
             (dp) => dp.name === "Product Price"
         ).digits;
-        const price = window.parseFloat(
-            roundDecimals(this.price_unit || 0, productPriceUnit).toFixed(productPriceUnit)
+        const lineAPrice = window.parseFloat(
+            roundDecimals(lineA.price_unit || 0, productPriceUom).toFixed(productPriceUom)
         );
-        let order_line_price = orderline
-            .get_product()
-            .get_price(orderline.order_id.pricelist_id, this.get_quantity());
-        order_line_price = roundDecimals(order_line_price, this.currency.decimal_places);
+        let lineBPrice = lineB.combo_parent_id
+            ? lineB.price_unit
+            : lineB.get_product().get_price(lineB.order_id.pricelist_id, this.get_quantity());
+        lineBPrice = roundDecimals(lineBPrice, this.currency.decimal_places);
+        const isPriceEqual = floatIsZero(
+            lineAPrice - lineBPrice - lineB.get_price_extra(),
+            this.currency
+        );
 
         const isSameCustomerNote =
-            (Boolean(orderline.get_customer_note()) === false &&
-                Boolean(this.get_customer_note()) === false) ||
-            orderline.get_customer_note() === this.get_customer_note();
+            (Boolean(lineB.get_customer_note()) === false &&
+                Boolean(lineA.get_customer_note()) === false) ||
+            lineB.get_customer_note() === lineA.get_customer_note();
 
         // only orderlines of the same product can be merged
         return (
-            !this.skip_change &&
-            orderline.getNote() === this.getNote() &&
-            this.get_product().id === orderline.get_product().id &&
-            this.is_pos_groupable() &&
+            !lineA.skip_change &&
+            lineB.getNote() === lineA.getNote() &&
+            lineA.get_product().id === lineB.get_product().id &&
+            lineA.is_pos_groupable() &&
             // don't merge discounted orderlines
-            this.get_discount() === 0 &&
-            floatIsZero(price - order_line_price - orderline.get_price_extra(), this.currency) &&
+            lineA.get_discount() === 0 &&
+            isPriceEqual &&
             !this.isLotTracked() &&
-            this.full_product_name === orderline.full_product_name &&
+            lineA.full_product_name === lineB.full_product_name &&
             isSameCustomerNote &&
-            !this.refunded_orderline_id &&
-            !orderline.isPartOfCombo()
+            !lineA.refunded_orderline_id
         );
     }
 
@@ -340,7 +379,7 @@ export class PosOrderline extends Base {
         const unit_groupable = this.product_id.uom_id
             ? this.product_id.uom_id.is_pos_groupable
             : false;
-        return unit_groupable && !this.isPartOfCombo();
+        return unit_groupable;
     }
 
     merge(orderline) {
@@ -349,9 +388,24 @@ export class PosOrderline extends Base {
         this.update({
             pack_lot_ids: [["link", ...orderline.pack_lot_ids]],
         });
+        if (this.combo_line_ids?.length) {
+            for (const line of this.combo_line_ids) {
+                for (const otherLine of orderline.combo_line_ids) {
+                    if (otherLine.product_id.id === line.product_id.id) {
+                        line.set_quantity(line.get_quantity() + otherLine.get_quantity(), true);
+                        this.update({
+                            pack_lot_ids: [["link", ...otherLine.pack_lot_ids]],
+                        });
+                    }
+                }
+            }
+        }
     }
 
     set_unit_price(price) {
+        if (this.combo_parent_id) {
+            return;
+        }
         const parsed_price = !isNaN(price)
             ? price
             : isNaN(parseFloat(price))
@@ -361,7 +415,42 @@ export class PosOrderline extends Base {
             parsed_price || 0,
             this.models["decimal.precision"].find((dp) => dp.name === "Product Price").digits
         );
+        this.recompute_price();
         this.setDirty();
+    }
+
+    recompute_price() {
+        if (this.combo_parent_id) {
+            return;
+        }
+        if (this.product_id.isCombo()) {
+            this.recompute_combo_price();
+            this.price_unit = 0;
+            this.combo_line_ids.forEach((line) => {
+                line.price_subtotal = line.get_price_without_tax();
+                line.price_subtotal_incl = line.get_price_with_tax();
+            });
+            return;
+        }
+        this.price_subtotal = this.get_price_without_tax();
+        this.price_subtotal_incl = this.get_price_with_tax();
+    }
+
+    recompute_combo_price() {
+        const decimalPrecision = this.models["decimal.precision"].getAll();
+        const parentProduct = this.product_id;
+        const parentComboLineIds = this.combo_line_ids;
+        const productTemplateAttributeValueById =
+            this.models["product.template.attribute.value"].getAllBy("id");
+
+        computeComboLinesPrice(
+            parentProduct,
+            parentComboLineIds,
+            this.order_id.pricelist_id,
+            decimalPrecision,
+            productTemplateAttributeValueById,
+            this.price_unit
+        );
     }
 
     get_unit_price() {
@@ -666,16 +755,14 @@ export class PosOrderline extends Base {
 
     // FIXME all below should be removed
     get_valid_lots() {
-        return this.pack_lot_ids.filter((item) => {
-            return item.lot_name;
-        });
+        return this.pack_lot_ids.filter((item) => item.lot_name);
     }
     // FIXME what is the use of this ?
     updateSavedQuantity() {
         this.saved_quantity = this.qty;
     }
     get_price_extra() {
-        return this.price_extra;
+        return this.price_extra || 0;
     }
     set_price_extra(price_extra) {
         this.price_extra = parseFloat(price_extra) || 0.0;

--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -724,8 +724,13 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
             },
             deleteMany(records, opts = {}) {
                 const result = [];
-                for (const record of records) {
-                    result.push(delete_(model, record, opts));
+                let counter = 0;
+                while (records.length > 0) {
+                    result.push(delete_(model, records[0], opts));
+                    counter++;
+                    if (counter > 1000) {
+                        throw new Error("Too many records to delete");
+                    }
                 }
                 return result;
             },

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -135,11 +135,19 @@ export class ProductScreen extends Component {
     getNumpadButtons() {
         return getButtons(DEFAULT_LAST_ROW, [
             { value: "quantity", text: _t("Qty") },
-            { value: "discount", text: _t("% Disc"), disabled: !this.pos.config.manual_discount },
+            {
+                value: "discount",
+                text: _t("% Disc"),
+                disabled:
+                    !this.pos.config.manual_discount ||
+                    Boolean(this.currentOrder?.get_selected_orderline()?.combo_parent_id),
+            },
             {
                 value: "price",
                 text: _t("Price"),
-                disabled: !this.pos.cashierHasPriceControlRights(),
+                disabled:
+                    !this.pos.cashierHasPriceControlRights() ||
+                    Boolean(this.currentOrder?.get_selected_orderline()?.combo_parent_id),
             },
             BACKSPACE,
         ]).map((button) => ({

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -871,12 +871,18 @@ export class PosStore extends Reactive {
             if (curLine.id !== line.id) {
                 if (curLine.can_be_merged_with(line) && merge !== false) {
                     to_merge_orderline = curLine;
+                    break;
                 }
             }
         }
 
         if (to_merge_orderline) {
             to_merge_orderline.merge(line);
+            if (line.combo_line_ids?.length) {
+                for (const comboLine of [...line.combo_line_ids]) {
+                    comboLine.delete();
+                }
+            }
             line.delete();
             this.selectOrderLine(order, to_merge_orderline);
         } else if (!selectedOrderline) {
@@ -1429,6 +1435,11 @@ export class PosStore extends Reactive {
         ]);
     }
     showScreen(name, props) {
+        if (name === "") {
+            const screenData = this.getEmptyOrderScreen();
+            name = screenData.name;
+            props = screenData.props;
+        }
         this.previousScreen = this.mainScreen.component?.name;
         name = !name ? this.firstScreen : name;
         const component = registry.category("pos_screens").get(name);
@@ -1503,6 +1514,10 @@ export class PosStore extends Reactive {
         this.addOrderIfEmpty();
         const { name: screenName } = this.get_order().get_screen_data();
         this.showScreen(screenName);
+    }
+
+    getEmptyOrderScreen() {
+        return { name: "ProductScreen" };
     }
 
     addOrderIfEmpty() {

--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -107,6 +107,12 @@ patch(PosStore.prototype, {
             table.uiState.changeCount = qtyChange.changed;
         }
     },
+    getEmptyOrderScreen() {
+        if (this.config.module_pos_restaurant) {
+            return { name: "FloorScreen", props: { floor: this.selectedTable?.floor } };
+        }
+        return super.getEmptyOrderScreen(...arguments);
+    },
     get categoryCount() {
         const orderChange = this.getOrderChanges().orderlines;
 

--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -75,7 +75,7 @@ class PosSelfOrderController(http.Controller):
                 fiscal_pos = pos_config.takeaway_fp_id
 
             if len(line.combo_line_ids) > 0:
-                original_total = sum(line.combo_line_ids.mapped("combo_line_id").combo_id.mapped("base_price"))
+                original_total = sum(line.combo_line_ids.combo_line_id.combo_id.mapped("base_price"))
                 remaining_total = lst_price
                 factor = lst_price / original_total if original_total > 0 else 1
 

--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -11,25 +11,6 @@ class PosOrderLine(models.Model):
 
     combo_id = fields.Many2one('pos.combo', string='Combo line reference')
 
-    @api.model_create_multi
-    def create(self, vals_list):
-        for vals in vals_list:
-            if (vals.get('combo_parent_uuid')):
-                vals.update([
-                    ('combo_parent_id', self.search([('uuid', '=', vals.get('combo_parent_uuid'))]).id)
-                ])
-            if 'combo_parent_uuid' in vals:
-                del vals['combo_parent_uuid']
-        return super().create(vals_list)
-
-    def write(self, vals):
-        if (vals.get('combo_parent_uuid')):
-            vals.update([
-                ('combo_parent_id', self.search([('uuid', '=', vals.get('combo_parent_uuid'))]).id)
-            ])
-        if 'combo_parent_uuid' in vals:
-            del vals['combo_parent_uuid']
-        return super().write(vals)
 
 class PosOrder(models.Model):
     _inherit = "pos.order"

--- a/addons/pos_self_order/static/src/app/components/order_widget/order_widget.js
+++ b/addons/pos_self_order/static/src/app/components/order_widget/order_widget.js
@@ -68,7 +68,9 @@ export class OrderWidget extends Component {
             (acc, [key, value]) => {
                 if (value.qty && value.qty > 0) {
                     const line = this.selfOrder.models["pos.order.line"].getBy("uuid", key);
-                    acc.count += value.qty;
+                    if (!value.part_of_combo) {
+                        acc.count += value.qty;
+                    }
                     acc.price += line.get_display_price();
                 }
                 return acc;

--- a/addons/pos_self_order/static/src/app/models/pos_order_line.js
+++ b/addons/pos_self_order/static/src/app/models/pos_order_line.js
@@ -17,6 +17,7 @@ patch(PosOrderline.prototype, {
                 custom_attribute_value_ids: JSON.stringify(
                     this.custom_attribute_value_ids.map((a) => a.id).sort()
                 ),
+                part_of_combo: Boolean(this.combo_parent_id),
             };
         }
 
@@ -34,6 +35,7 @@ patch(PosOrderline.prototype, {
                 change.custom_attribute_value_ids
                     ? change.custom_attribute_value_ids
                     : false,
+            part_of_combo: Boolean(this.combo_parent_id),
         };
         return diff;
     },

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
@@ -160,11 +160,16 @@ export class CartPage extends Component {
         await this._changeQuantity(line, increase);
     }
 
+    canClickOnLine(line) {
+        const order = this.selfOrder.currentOrder;
+        return order.state === "draft" && !order.uiState.lineChanges[line.uuid];
+    }
+
     clickOnLine(line) {
         const order = this.selfOrder.currentOrder;
         this.selfOrder.editedLine = line;
 
-        if (order.state === "draft" && !order.lastChangesSent[line.uuid]) {
+        if (this.canClickOnLine(line)) {
             this.selfOrder.selectedOrderUuid = order.uuid;
 
             if (line.combo_line_ids.length > 0) {

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.xml
@@ -17,7 +17,7 @@
                                 </div>
                                 <div t-if="line.attribute_value_ids.length > 0 || line.combo_line_ids.length > 0" class="d-flex align-items-start gap-2 gap-md-3 my-2">
                                     <button
-                                        t-if="Object.keys(selfOrder.currentOrder.changes).length === 0"
+                                        t-if="Object.keys(selfOrder.currentOrder.changes).length === 0 and this.canClickOnLine(line)"
                                         type="button"
                                         t-on-click="() => this.clickOnLine(line)"
                                         class="btn btn-secondary"> <i class="fa fa-pencil"></i></button>

--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
@@ -46,7 +46,7 @@ export class ComboPage extends Component {
         return !(
             this.selfOrder.editedLine &&
             this.selfOrder.editedLine.uuid &&
-            order.lastChangesSent[this.selfOrder.editedLine.uuid]
+            order.uiState.lineChanges[this.selfOrder.editedLine.uuid]
         );
     }
 
@@ -123,7 +123,14 @@ export class ComboPage extends Component {
             this.selfOrder.editedLine.delete();
         }
 
-        this.selfOrder.addToCart(this.props.product, 1, "", {}, {}, this.state.selectedCombos);
+        this.selfOrder.addToCart(
+            this.props.product,
+            this.state.qty,
+            "",
+            {},
+            {},
+            this.state.selectedCombos
+        );
         this.router.back();
     }
 

--- a/addons/pos_self_order/static/src/app/pages/product_page/product_page.js
+++ b/addons/pos_self_order/static/src/app/pages/product_page/product_page.js
@@ -46,7 +46,7 @@ export class ProductPage extends Component {
         return !(
             this.selfOrder.editedLine &&
             this.selfOrder.editedLine.uuid &&
-            order.lastChangesSent[this.selfOrder.editedLine.uuid]
+            order.uiState.lineChanges[this.selfOrder.editedLine.uuid]
         );
     }
 

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -293,16 +293,14 @@ export class SelfOrder extends Reactive {
                     combo_line_id: comboLine.combo_line_id,
                     price_unit: comboLine.price_unit,
                     order_id: this.currentOrder,
-                    qty: 1,
+                    qty: qty,
                     attribute_value_ids: comboLine.attribute_value_ids?.map((attr) => [
                         "link",
                         attr,
                     ]),
                     custom_attribute_value_ids: Object.entries(
                         comboLine.attribute_custom_values
-                    ).map(([id, cus]) => {
-                        return ["create", cus];
-                    }),
+                    ).map(([id, cus]) => ["create", cus]),
                 },
             ]);
         }
@@ -423,9 +421,9 @@ export class SelfOrder extends Reactive {
             return existingOrder;
         }
 
-        const fiscalPosition = this.models["account.fiscal.position"].find((fp) => {
-            return fp.id === this.config.default_fiscal_position_id?.id;
-        });
+        const fiscalPosition = this.models["account.fiscal.position"].find(
+            (fp) => fp.id === this.config.default_fiscal_position_id?.id
+        );
 
         const newOrder = this.models["pos.order"].create({
             company_id: this.company,
@@ -800,7 +798,7 @@ export class SelfOrder extends Reactive {
     verifyCart() {
         let result = true;
         for (const line of this.currentOrder.unsentLines) {
-            if (line.combo_parent_id?.uuid) {
+            if (line.combo_parent_id) {
                 continue;
             }
 


### PR DESCRIPTION
pos*: point_of_sale, pos_restaurant, pos_self_order

This is a compilation of bug fix mostly about combos.

1. make pos combo groupable in pos
2. changing discount price or discount does not work
3. should not be able to set the price on a combo line
4. changing price on combo parent should adapt price
5. when ordering a combo in self, the backend was not showing the good prices
6. when splitting an order with a combo with quantity more than 1, the user was not able to select the quantity he wanted for the combo. It was always 0 or the whole quantity.
7.the price was not working in the cart_page for combos
8. when opening a table on two different device, adding lines on one of them and going to the floor screen, a traceback was shown on the other.
9. When clicking on resume order after a payment, we are sent to the ticket screen. When on it, if the user deletes all the orders on the table and click "Back", a traceback was shown. this was due to the fact that we pass an empty screen name to showScreen(name, props) leading to the method not finding a screen with the name ''.

Enterprise PR: odoo/enterprise#73046

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
