### PR TITLE
[FIX] core: browser: storage in non-storing context

### DIFF
--- a/addons/web/static/src/core/browser/browser.js
+++ b/addons/web/static/src/core/browser/browser.js
@@ -9,9 +9,11 @@
  * object for a test.
  */
 
-let sessionStorage = window.sessionStorage;
-let localStorage = window.localStorage;
+let sessionStorage;
+let localStorage;
 try {
+    sessionStorage = window.sessionStorage;
+    localStorage = window.localStorage;
     // Safari crashes in Private Browsing
     localStorage.setItem("__localStorage__", "true");
     localStorage.removeItem("__localStorage__");

--- a/addons/web/static/src/legacy/js/core/local_storage.js
+++ b/addons/web/static/src/legacy/js/core/local_storage.js
@@ -7,8 +7,9 @@ var mixins = require('web.mixins');
 // use a fake localStorage in RAM if the native localStorage is unavailable
 // (e.g. private browsing in Safari)
 var storage;
-var localStorage = window.localStorage;
+let localStorage;
 try {
+    localStorage = window.localStorage;
     var uid = new Date();
     localStorage.setItem(uid, uid);
     localStorage.removeItem(uid);

--- a/addons/web/static/src/legacy/js/core/session_storage.js
+++ b/addons/web/static/src/legacy/js/core/session_storage.js
@@ -7,8 +7,9 @@ var mixins = require('web.mixins');
 // use a fake sessionStorage in RAM if the native sessionStorage is unavailable
 // (e.g. private browsing in Safari)
 var storage;
-var sessionStorage = window.sessionStorage;
+let sessionStorage;
 try {
+    sessionStorage = window.sessionStorage;
     var uid = new Date();
     sessionStorage.setItem(uid, uid);
     sessionStorage.removeItem(uid);

--- a/addons/web_editor/static/src/js/wysiwyg/PeerToPeer.js
+++ b/addons/web_editor/static/src/js/wysiwyg/PeerToPeer.js
@@ -1,4 +1,6 @@
 /** @odoo-module */
+import { browser } from "@web/core/browser/browser";
+const localStorage = browser.localStorage;
 
 const urlParams = new URLSearchParams(window.location.search);
 const collaborationDebug = urlParams.get('collaborationDebug');

--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
-
+import { browser } from "@web/core/browser/browser";
+const sessionStorage = browser.sessionStorage
 import concurrency from 'web.concurrency';
 import utils from 'web.utils';
 import weUtils from 'web_editor.utils';
@@ -665,7 +666,7 @@ export class Configurator extends Component {
     }
 
     clearStorage() {
-        window.sessionStorage.removeItem(this.storageItemName);
+        sessionStorage.removeItem(this.storageItemName);
     }
 
     async getInitialState() {
@@ -698,7 +699,7 @@ export class Configurator extends Component {
             palettes[paletteName] = palette;
         });
 
-        const localState = JSON.parse(window.sessionStorage.getItem(this.storageItemName));
+        const localState = JSON.parse(sessionStorage.getItem(this.storageItemName));
         if (localState) {
             let themes = [];
             if (localState.selectedIndustry && localState.selectedPalette) {
@@ -755,7 +756,7 @@ export class Configurator extends Component {
             selectedType: state.selectedType,
             recommendedPalette: state.recommendedPalette,
         });
-        window.sessionStorage.setItem(this.storageItemName, newState);
+        sessionStorage.setItem(this.storageItemName, newState);
     }
 
     async skipConfigurator() {

--- a/addons/website/static/tests/tour_utils/widget_lifecycle_dep_widget.js
+++ b/addons/website/static/tests/tour_utils/widget_lifecycle_dep_widget.js
@@ -1,16 +1,18 @@
 /** @odoo-module **/
+import { browser } from "@web/core/browser/browser";
+const localStorage = browser.localStorage;
 
 import publicWidget from "web.public.widget";
 
 const localStorageKey = 'widgetAndWysiwygLifecycle';
-if (!window.localStorage.getItem(localStorageKey)) {
-    window.localStorage.setItem(localStorageKey, '[]');
+if (!localStorage.getItem(localStorageKey)) {
+    localStorage.setItem(localStorageKey, '[]');
 }
 
 export function addLifecycleStep(step) {
-    const oldValue = window.localStorage.getItem(localStorageKey);
+    const oldValue = localStorage.getItem(localStorageKey);
     const newValue = JSON.stringify(JSON.parse(oldValue).concat(step));
-    window.localStorage.setItem(localStorageKey, newValue);
+    localStorage.setItem(localStorageKey, newValue);
 }
 
 publicWidget.registry.CountdownPatch = publicWidget.Widget.extend({

--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -1,10 +1,11 @@
 odoo.define('website_sale.cart', function (require) {
 'use strict';
 
+const { browser } = require("@web/core/browser/browser");
+const sessionStorage = browser.sessionStorage;
 var publicWidget = require('web.public.widget');
 var core = require('web.core');
 var _t = core._t;
-
 var timeout;
 
 publicWidget.registry.websiteSaleCartLink = publicWidget.Widget.extend({


### PR DESCRIPTION
Blacklist Odoo in your browser from having access to the local and session storages (security parameters).

Before this commit, there were unrecoverable crashes because even doing `window.[localStorage|sessionStorage]` is forbidden.

After this commit, we catch those exceptions and make a RamStorage instead.

opw-4226366

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
