### PR TITLE
[FIX] website: update header height variable

### DIFF
--- a/addons/website/static/src/js/content/menu.js
+++ b/addons/website/static/src/js/content/menu.js
@@ -5,10 +5,6 @@ import animations from "@website/js/content/snippets.animation";
 export const extraMenuUpdateCallbacks = [];
 import { SIZES, utils as uiUtils } from "@web/core/ui/ui_service";
 
-// The header height may vary with sections hidden on scroll (see the class
-// `o_header_hide_on_scroll`). To avoid scroll jumps, we cache the value.
-let headerHeight;
-
 const BaseAnimatedHeader = animations.Animation.extend({
     disabledInEditableMode: false,
     effects: [{
@@ -181,13 +177,12 @@ const BaseAnimatedHeader = animations.Animation.extend({
      * @private
      */
     _updateMainPaddingTop: function () {
-        headerHeight ||= this.el.getBoundingClientRect().height;
         this.topGap = this._computeTopGap();
 
         if (this.isOverlayHeader) {
             return;
         }
-        this.$main.css('padding-top', this.fixedHeader ? headerHeight : '');
+        this.$main.css('padding-top', this.fixedHeader ? this.el.getBoundingClientRect().height : '');
     },
     /**
      * Checks if the size of the header will decrease by adding the
@@ -213,7 +208,7 @@ const BaseAnimatedHeader = animations.Animation.extend({
         clonedHeader.classList.add('o_header_is_scrolled', 'o_header_affixed', 'o_header_no_transition');
         const endHeaderHeight = clonedHeader.offsetHeight;
         clonedHeader.remove();
-        const heightDiff = headerHeight - endHeaderHeight;
+        const heightDiff = this.el.getBoundingClientRect().height - endHeaderHeight;
         return heightDiff > 0 ? remainingScroll <= heightDiff : false;
     },
 
@@ -294,7 +289,6 @@ publicWidget.registry.StandardAffixedHeader = BaseAnimatedHeader.extend({
      * @override
      */
     start: function () {
-        headerHeight ||= this.el.getBoundingClientRect().height;
         return this._super.apply(this, arguments);
     },
     /**
@@ -324,7 +318,7 @@ publicWidget.registry.StandardAffixedHeader = BaseAnimatedHeader.extend({
     _updateHeaderOnScroll: function (scroll) {
         this._super(...arguments);
 
-        const mainPosScrolled = (scroll > headerHeight + this.topGap);
+        const mainPosScrolled = (scroll > this.el.getBoundingClientRect().height + this.topGap);
         const reachPosScrolled = (scroll > this.scrolledPoint + this.topGap) && !this.scrollHeightTooShort;
         const fixedUpdate = (this.fixedHeader !== mainPosScrolled);
         const showUpdate = (this.fixedHeaderShow !== reachPosScrolled);
@@ -448,7 +442,6 @@ publicWidget.registry.FixedHeader = BaseAnimatedHeader.extend({
                     // the height of the header also changes. Therefore, we need
                     // to get the current height of the header and then to
                     // update the top padding of the main element.
-                    headerHeight = this.el.getBoundingClientRect().height;
                     this._updateMainPaddingTop();
                 }
             }


### PR DESCRIPTION
Before this commit, the header height was stored in a global variable. This variable wasn't always updated, which led to issues regarding the scroll. When adding elements in the header that increased its height, the scroll would jump and showing / hiding the header.

This commit removes the need of the headerHeight variable.

Steps to reproduce the bug:
- Add a "Text Highlight" inner content above the ContactUs button
- Add multiple Title snippets below one another (When adding the third one, the page scroll indefinitely) (The number of snippets to drop may vary depending on the viewport)

task-4267249
