### PR TITLE
[IMP] l10n_dk_bookkeeping: Do not compute field rate on existig move

### DIFF
--- a/addons/l10n_dk_bookkeeping/__init__.py
+++ b/addons/l10n_dk_bookkeeping/__init__.py
@@ -1,3 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import models
+from odoo.tools import column_exists, create_column
+
+
+def pre_init_hook(env):
+    """Do not compute the l10n_dk_currency_rate_at_transaction field on existing Moves."""
+    if not column_exists(env.cr, "account_move", "l10n_dk_currency_rate_at_transaction"):
+        create_column(env.cr, "account_move", "l10n_dk_currency_rate_at_transaction", "numeric")

--- a/addons/l10n_dk_bookkeeping/__manifest__.py
+++ b/addons/l10n_dk_bookkeeping/__manifest__.py
@@ -15,4 +15,5 @@ This module contains all that is needed for the Bookkeeping Act
     'installable': True,
     'auto_install': True,
     'license': 'LGPL-3',
+    'pre_init_hook': 'pre_init_hook',
 }


### PR DESCRIPTION
The installation of the module ```l10n_dk_bookkeeping``` is taking a considerable amount of time due to the computation of the field ```l10n_dk_currency_rate_at_transaction```.

Before this commit
```py
2024-10-30 09:31:34,252 284 INFO depr_2136844_upg odoo.modules.loading: Module l10n_dk_bookkeeping loaded in 864.24s, 1707091 queries (+1707091 other)
```

After this commit
```py
2024-10-30 08:41:45,881 19 INFO depr_2136844_upg odoo.modules.loading: Module l10n_dk_bookkeeping loaded in 11.41s, 353 queries (+353 other)
```
```sql
SELECT count(*) FROM account_move;
count
--------
 348106
(1 row)
```

This commit significantly enhances the installation speed.

OPW - 4231508




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
