### PR TITLE
[IMP] hr_skills: show text as placeholder

### DIFF
--- a/addons/hr_skills/static/src/fields/resume_one2many/resume_one2many.xml
+++ b/addons/hr_skills/static/src/fields/resume_one2many/resume_one2many.xml
@@ -6,7 +6,7 @@
         </xpath>
         <xpath expr="//table" position="after">
             <t t-if="!showTable">
-                <div name="no_resume_line" class="ms-3 mt-3">
+                <div name="no_resume_line" class="ms-4 mt-3 text-muted fst-italic oe_inline">
                     <p>
                         There are no resume lines on this employee.
                         Why not add a new one?

--- a/addons/hr_skills/static/src/fields/skills_one2many/skills_one2many.xml
+++ b/addons/hr_skills/static/src/fields/skills_one2many/skills_one2many.xml
@@ -32,7 +32,7 @@
                     </div>
                 </t>
                 <t t-else="">
-                    <div name="skills_available" class="ms-3 mt-3">
+                    <div name="skills_available" class="ms-4 text-muted fst-italic oe_inline">
                         <p class="mt-3">You can add skills from our library to the employee profile.<br/>
                         If skills are missing, they can be created by an HR officer.</p>
                         <div class="ms-5">


### PR DESCRIPTION
This commit shows the text in employee profile with a style that is more consistent with placeholders.

Before:
![Screenshot 2024-10-30 at 12 27 51](https://github.com/user-attachments/assets/d56ceab9-b1e1-40ad-854a-e1f978ec585c)

After:
![Screenshot 2024-10-30 at 12 28 48](https://github.com/user-attachments/assets/5a0542f6-41a6-4904-81c7-71cbc6094790)


task-4265968


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
