### PR TITLE
[FIX] website: fix text highlight option preview

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -38,6 +38,7 @@ import {
 import { throttleForAnimation } from "@web/core/utils/timing";
 
 import { Component, markup, useEffect, useRef, useState } from "@odoo/owl";
+import { isVisible } from "@web/core/utils/ui";
 
 const InputUserValueWidget = options.userValueWidgetsRegistry['we-input'];
 const SelectUserValueWidget = options.userValueWidgetsRegistry['we-select'];
@@ -4147,17 +4148,33 @@ options.registry.TextHighlight = options.Class.extend({
      */
     _onWidgetOpening(ev) {
         const target = ev.target;
-        // Only when there is no highlight SVGs.
-        if (target.getName() === "text_highlight_opt" && !target.el.querySelector("svg")) {
-            const weToggler = target.el.querySelector("we-toggler");
-            weToggler.classList.add("active");
-            [...target.el.querySelectorAll("we-button[data-set-text-highlight] div")].forEach(weBtnEl => {
-                weBtnEl.textContent = "Text";
-                // Get the text highlight linked to each `<we-button/>`
-                // and apply it to its text content.
-                weBtnEl.append(drawTextHighlightSVG(weBtnEl, weBtnEl.parentElement.dataset.setTextHighlight));
+        const awaitVisible = (el, callback) => {
+            if (isVisible(el)) {
+                callback();
+                return;
+            }
+            const observer = new ResizeObserver(() => {
+                if (isVisible(el)) {
+                    observer.disconnect();
+                    callback();
+                }
             });
-        }
+            observer.observe(el);
+        };
+        // Make sure the widget is visible to correctly build the preview.
+        return awaitVisible(target.el, () => {
+            // Only when there is no highlight SVGs.
+            if (target.getName() === "text_highlight_opt" && !target.el.querySelector("svg")) {
+                const weToggler = target.el.querySelector("we-toggler");
+                weToggler.classList.add("active");
+                [...target.el.querySelectorAll("we-button[data-set-text-highlight] div")].forEach(weBtnEl => {
+                    weBtnEl.textContent = "Text";
+                    // Get the text highlight linked to each `<we-button/>`
+                    // and apply it to its text content.
+                    weBtnEl.append(drawTextHighlightSVG(weBtnEl, weBtnEl.parentElement.dataset.setTextHighlight));
+                });
+            }
+        });
     },
 });
 


### PR DESCRIPTION
Steps to reproduce (starting from `17.4`):

1. Go to a website page (in edit mode) > Select the "Contact Us" button
text content (or a footer text).

2. Set a highlight effect on the selection.

3. The highlights preview in the right panel is not correctly rendered:
The effects are not adapted to the text.

Technical details:

a. Why this only happens in `17.4`+:

Starting from [1], the `snippetMenu` was transformed into an Owl
component, leading to some changes in the way we display the right panel
content.

When a text highlight is applied, we "_activateSnippet()" the target,
which will automatically disable all editors and activate the "blocks"
tab in a first step **[a.1]**, and then updates the right panel using the
enabled target options ("options" tab) **[a.2]**.

The highlight option code will also detect when the `we-select` widget
was opened to draw the highlight effects preview **[a.3]**.

Before [1], the right panel adaptation was done directly on the DOM
(in a "synchronous" way), which allowed the options to be available and
visible before building the preview in **[a.3]**.

In the new `SnippetsMenu` component, the right panel update is based on
the "Owl reactivity system" (see: `state.currentTab`) to show/hide a
tab content... This makes the rendering operation asynchronous (the DOM
will only be updated slightly later: at the next animation frame, if no
component delays the rendering...).

So sometimes, when the code from **[a.1]** to **[a.2]** is fast enough, the
component won't be re-rendered width the "blocks" tab (even with a
`state.currentTab` set to "blocks") and will be directly rendered with
the final "options" display... Which explains why the preview is still
working correctly on some text content. Otherwise, the component will
have enough time to render the "blocks" content, which will make the
code from [a.3] draw the highlights on hidden content.

b. Remark: The highlight review is built only once when the effect is
applied the first time to the text.

A solution:

The goal of this commit is to prevent this unstable behaviour by making
sure the `we-select` is visible when the option is trying to draw the
effects preview.

[1]: https://github.com/odoo/odoo/commit/91293fe4a8125f65cd7e5f487aacbc62c35c0f74

task-4297372