### PR TITLE
[FIX] point_of_sale, pos_sale, pos_restaurant: synchrone order creation

### DIFF
--- a/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.js
+++ b/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.js
@@ -21,7 +21,7 @@ export class OrderTabs extends Component {
         this.dialog = useService("dialog");
     }
     async newFloatingOrder() {
-        const order = await this.pos.add_new_order();
+        const order = this.pos.add_new_order();
         this.pos.showScreen("ProductScreen");
         this.dialog.closeAll();
         return order;

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -1046,7 +1046,7 @@ export class PosOrder extends Base {
             generalNote: this.general_note || "",
         };
     }
-    getFloatingOrderName() {
+    get floatingOrderName() {
         return this.floating_order_name || this.tracking_number.toString() || "";
     }
 
@@ -1085,7 +1085,7 @@ export class PosOrder extends Base {
         }
     }
     getName() {
-        return this.getFloatingOrderName() || "";
+        return this.floatingOrderName || "";
     }
 }
 

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -377,7 +377,7 @@ export class PaymentScreen extends Component {
                     nextScreen = "ProductScreen";
 
                     if (switchScreen) {
-                        await this.pos.add_new_order();
+                        this.pos.add_new_order();
                     }
                 }
             }

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -76,7 +76,7 @@ export class ReceiptScreen extends Component {
         this.currentOrder.uiState.screen_data.value = "";
         this.currentOrder.uiState.locked = true;
         if (!this.pos.config.module_pos_restaurant) {
-            await this.pos.add_new_order();
+            this.pos.add_new_order();
         }
         this.pos.searchProductWord = "";
         const { name, props } = this.nextScreen;

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -226,7 +226,7 @@ export class TicketScreen extends Component {
             partner === this.props.destinationOrder.get_partner() &&
             !this.pos.doNotAllowRefundAndSales()
                 ? this.props.destinationOrder
-                : await this._getEmptyOrder(partner);
+                : this._getEmptyOrder(partner);
 
         destinationOrder.takeaway = order.takeaway;
         // Add orderline for each toRefundDetail to the destinationOrder.
@@ -466,7 +466,7 @@ export class TicketScreen extends Component {
      * @param {Object | null} partner
      * @returns {boolean}
      */
-    async _getEmptyOrder(partner) {
+    _getEmptyOrder(partner) {
         let emptyOrderForPartner = null;
         let emptyOrder = null;
         for (const order of this.pos.models["pos.order"].filter((order) => !order.finalized)) {
@@ -480,7 +480,7 @@ export class TicketScreen extends Component {
                 }
             }
         }
-        return emptyOrderForPartner || emptyOrder || (await this.pos.add_new_order());
+        return emptyOrderForPartner || emptyOrder || this.pos.add_new_order();
     }
     _doesOrderHaveSoleItem(order) {
         const orderlines = order.get_orderlines();

--- a/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
+++ b/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
@@ -53,7 +53,7 @@ export class SplitBillScreen extends Component {
     }
 
     _getOrderName(order) {
-        return order.table_id?.table_number.toString() || order.getFloatingOrderName() || "";
+        return order.table_id?.table_number.toString() || order.floatingOrderName || "";
     }
 
     _getLatestOrderNameStartingWith(name) {
@@ -86,7 +86,7 @@ export class SplitBillScreen extends Component {
         const originalOrderName = this._getOrderName(originalOrder);
         const newOrderName = this._getSplitOrderName(originalOrderName);
 
-        const newOrder = this.pos.createNewOrder(await this.pos.getNextOrderRefs());
+        const newOrder = this.pos.createNewOrder();
         newOrder.floating_order_name = newOrderName;
         newOrder.uiState.splittedOrderUuid = curOrderUuid;
         newOrder.originalSplittedOrder = originalOrder;

--- a/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
@@ -69,7 +69,7 @@ patch(Navbar.prototype, {
                 }
                 const floating_order = this.pos
                     .get_open_orders()
-                    .find((o) => o.getFloatingOrderName() === table_number);
+                    .find((o) => o.floatingOrderName === table_number);
                 if (floating_order) {
                     return this.setFloatingOrder(floating_order);
                 }

--- a/addons/pos_restaurant/static/src/overrides/components/ticket_screen/ticket_screen.xml
+++ b/addons/pos_restaurant/static/src/overrides/components/ticket_screen/ticket_screen.xml
@@ -12,7 +12,7 @@
                     <div t-if="ui.isSmall">Table</div>
                     <div><t t-esc="getTable(order)"></t></div>
                 </t>
-                <div t-elif="pos.config.module_pos_restaurant" t-esc="order.getFloatingOrderName()" />
+                <div t-elif="pos.config.module_pos_restaurant" t-esc="order.floatingOrderName" />
             </div>
             <div t-if="state.filter == 'TIPPING'" class="col end narrow p-2" name="tip">
                 <div t-if="ui.isSmall">Tip</div>
@@ -21,7 +21,7 @@
         </xpath>
         <xpath expr="//div[hasclass('mobileOrderList')]//div[hasclass('orderStatus')]" position="before">
             <div t-if="order.table_id" t-esc="getTable(order)" />
-            <div t-elif="pos.config.module_pos_restaurant" t-esc="order.getFloatingOrderName()" />
+            <div t-elif="pos.config.module_pos_restaurant" t-esc="order.floatingOrderName" />
         </xpath>
         <xpath expr="//div[hasclass('buttons')]" position="inside">
             <button class="settle-tips btn btn-lg btn-primary" t-if="state.filter == 'TIPPING'" t-on-click="settleTips">Settle</button>

--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -171,8 +171,8 @@ patch(PosStore.prototype, {
         return await super.afterProcessServerData(...arguments);
     },
     //@override
-    async add_new_order() {
-        const order = await super.add_new_order(...arguments);
+    add_new_order() {
+        const order = super.add_new_order(...arguments);
         this.addPendingOrder([order.id]);
         return order;
     },
@@ -233,7 +233,7 @@ patch(PosStore.prototype, {
                 currentOrder.update({ table_id: table });
                 this.selectedOrderUuid = currentOrder.uuid;
             } else {
-                await this.add_new_order({ table_id: table });
+                this.add_new_order({ table_id: table });
             }
         }
         try {
@@ -277,7 +277,7 @@ patch(PosStore.prototype, {
                 }
                 this.showScreen(orders[0].get_screen_data().name, props);
             } else {
-                await this.add_new_order({ table_id: table });
+                this.add_new_order({ table_id: table });
                 this.showScreen("ProductScreen");
             }
         }

--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -43,7 +43,7 @@ patch(PosStore.prototype, {
                 linkedSO.partner_invoice_id?.id !== sale_order.partner_invoice_id?.id ||
                 linkedSO.partner_shipping_id?.id !== sale_order.partner_shipping_id?.id
             ) {
-                await this.add_new_order({
+                this.add_new_order({
                     partner_id: sale_order.partner_id,
                 });
                 this.notification.add(_t("A new order has been created."));


### PR DESCRIPTION
`add_new_order` method is now synchronous and returns the new order. This allows to directly use the new order in the next steps without the need to await the promise.

The `pos_order` reference is now added to the order by calling `getNextOrderRefs` that's isn't awaited anymore. That's means that during a small amount of time, the order didn't have following fields: `pos_reference`, `tracking_number` and `sequence_number`

