### PR TITLE
[IMP] crm: open list view by default on opportunity stat button

### DIFF
--- a/addons/crm/models/res_partner.py
+++ b/addons/crm/models/res_partner.py
@@ -61,7 +61,13 @@ class ResPartner(models.Model):
         This function returns an action that displays the opportunities from partner.
         '''
         action = self.env['ir.actions.act_window']._for_xml_id('crm.crm_lead_opportunities')
-        action['context'] = {}
+        action['context'] = {
+            'search_default_filter_won': 1,
+            'search_default_filter_ongoing': 1,
+            'search_default_filter_lost': 1
+        }
+        # we want the list view first
+        action['views'] = sorted(action['views'], key=lambda view: view[1] != 'list')
         if self.is_company:
             action['domain'] = [('partner_id.commercial_partner_id', '=', self.id)]
         else:

--- a/addons/crm/wizard/crm_lead_lost_views.xml
+++ b/addons/crm/wizard/crm_lead_lost_views.xml
@@ -7,12 +7,12 @@
                 <form string="Lost Lead">
                     <field name="lead_ids" invisible="1"></field>
                     <group>
-                        <field name="lost_reason_id" options="{'no_create_edit': True}" />
-                        <field name="lost_feedback" placeholder="What went wrong?"/>
+                        <field name="lost_reason_id" placeholder="Select a Lost Reason..." options="{'no_create_edit': True}" />
+                        <field name="lost_feedback" placeholder="What went wrong?" nolabel="1" colspan="2"/>
                     </group>
                     <footer>
                         <button name="action_lost_reason_apply" string="Mark as Lost" type="object" class="btn-primary" data-hotkey="q"/>
-                        <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                        <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>


### PR DESCRIPTION
**Purpose:**
In contact, when the user clicks the 'opportunity' stat button no stages are displayed, when all stages are assigned to the sales team.

**Specifications:**
Open the list view by default, it's easier to open as we cannot guarantee that the kanban will have stages, and that prevents an easy creation of a lead. Also, default search filters are activated to match stat button statistics.

And some UI change in lost opportunity wizard.

Task-4283563