### PR TITLE
[FIX] l10n_id: invalid setup of QRIS API Key and Merchant ID

### DIFF
--- a/addons/l10n_id/models/res_bank.py
+++ b/addons/l10n_id/models/res_bank.py
@@ -91,6 +91,8 @@ class ResBank(models.Model):
                 "cliTrxAmount": int(amount)
             }
             response = _l10n_id_make_qris_request('show_qris.php', params)
+            if response.get("status") == "failed":
+                raise ValidationError(response.get("data"))
             data = response.get('data')
 
             # create a new transaction line while also converting the qris_request_date to UTC time


### PR DESCRIPTION
This error occurs because the bank's QRIS API Key and Merchant ID were set up incorrectly.

Steps to reproduce:
---
- Install ``POS`` and ``l10n_id`` module
- Change company to ``ID Company``
- Create a new ``Warehouse`` in Inventory
- Now create a new journal(eg: Test) in invoicing with ``Type`` as ``Bank`` > go to the internal link of ``Account Number`` write any ``QRIS API Key`` and ``QRIS Merchant ID`` and Save
- Now go to ``Payment Methods`` and create a new one in POS(eg: Demo) with ``Integration`` as ``qr_code`` and ``QR Code Format`` as ``QRIS`` > Select ``Journal`` as ``Test`` and Save
- Go to ``Clothes`` > Open Session > Add product > Payment > select payment method as ``Demo`` > Click ``retry``

Traceback: 
---
``AttributeError: 'str' object has no attribute 'get'``

At [1], we are facing an error because ``data`` contains the failed message in it, and the status of the response is ``failed``.

[1]- https://github.com/odoo/odoo/blob/dd71d998796cf426527972a3feac6fdd040f3fe3/addons/l10n_id/models/res_bank.py#L101

sentry-6029900658

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
