### PR TITLE
[FIX] web: keep properties column on domain change

### DIFF
--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -686,14 +686,6 @@ export class Record extends DataPoint {
     _processProperties(properties, fieldName, parent, currentValues = {}) {
         const data = {};
 
-        const relatedPropertyField = {
-            fieldName,
-        };
-        if (parent) {
-            relatedPropertyField.id = parent[0];
-            relatedPropertyField.displayName = parent[1];
-        }
-
         const hasCurrentValues = Object.keys(currentValues).length > 0;
         for (const property of properties) {
             const propertyFieldName = `${fieldName}.${property.name}`;
@@ -703,13 +695,23 @@ export class Record extends DataPoint {
                 this.fields[propertyFieldName] = {
                     ...property,
                     name: propertyFieldName,
-                    relatedPropertyField,
+                    relatedPropertyField: {
+                        name: fieldName,
+                    },
                     propertyName: property.name,
                     relation: property.comodel,
                 };
             }
             if (hasCurrentValues || !this.activeFields[propertyFieldName]) {
                 this.activeFields[propertyFieldName] = createPropertyActiveField(property);
+            }
+
+            if (!this.activeFields[propertyFieldName].relatedPropertyField) {
+                this.activeFields[propertyFieldName].relatedPropertyField = {
+                    name: fieldName,
+                    id: parent?.id,
+                    displayName: parent?.display_name,
+                };
             }
 
             // Extract property data

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -287,13 +287,16 @@ export class ListRenderer extends Component {
         return Object.values(list.fields)
             .filter(
                 (field) =>
+                    list.activeFields[field.name] &&
                     field.relatedPropertyField &&
-                    field.relatedPropertyField.fieldName === column.name &&
+                    field.relatedPropertyField.name === column.name &&
                     field.type !== "separator"
             )
             .map((propertyField) => {
+                const activeField = list.activeFields[propertyField.name];
                 return {
                     ...getPropertyFieldInfo(propertyField),
+                    relatedPropertyField: activeField.relatedPropertyField,
                     id: `${column.id}_${propertyField.name}`,
                     column_invisible: combineModifiers(
                         propertyField.column_invisible,


### PR DESCRIPTION
Steps to reproduce
==================

- Install crm
- Go to CRM
- Open a record
- Open actions menu (cog icon next to breadcrumbs)
- Add Properties
- Set a value to the new property
- Go back to kanban view
- Switch to list view
- Check the property field in optional columns menu to show the column
- Remove "My Pipeline" filter
- Add "My Pipeline" filter
- The property column does not exist anywhere anymore

Cause of the issue
==================

The relational model adds model info in a global shared field definition object and then list renderer uses these info for properties fields. The search bar also uses this object and adds properties fields info. Both are adding and using incompatible info.

Solution
========

Define correctly the minimum acceptable of the properties definitions when needed in the model and do not add model info in these definitions.

opw-4264560