### PR TITLE
[FIX] Account: update is move sent after resending

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4158,7 +4158,7 @@ class AccountMove(models.Model):
         # We remove all the analytics entries for this journal
         self.mapped('line_ids.analytic_line_ids').unlink()
         self.mapped('line_ids').remove_move_reconcile()
-        self.write({'state': 'draft', 'is_move_sent': False})
+        self.state = 'draft'
 
     def _check_draftable(self):
         exchange_move_ids = set()

--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -1061,3 +1061,20 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
 
         self.assertTrue(self._get_mail_message(invoice))  # email was sent
         self.assertEqual(res['type'], 'ir.actions.act_window_close')  # the download which is a default value didn't happen
+
+    def test_is_move_sent_state(self):
+        # Post a move, nothing sent yet
+        invoice = self.init_invoice("out_invoice", amounts=[1000], post=True)
+        self.assertFalse(invoice.is_move_sent)
+        # Send via send & print
+        wizard = self.create_send_and_print(invoice)
+        wizard.action_send_and_print()
+        self.assertTrue(invoice.is_move_sent)
+        # Revert move to draft
+        invoice.button_draft()
+        self.assertTrue(invoice.is_move_sent)
+        # Unlink PDF
+        pdf_report = invoice.invoice_pdf_report_id
+        self.assertTrue(pdf_report)
+        invoice.invoice_pdf_report_id.unlink()
+        self.assertTrue(invoice.is_move_sent)


### PR DESCRIPTION
Current Behavior:
When an invoice is sent via Send & Print, is_move_sent is set to True. If the move is reverted to draft, is_move_sent is set to False. After that, if the invoice is resent via Send & Print, is_move_sent is not set to True again.

To reproduce:
1. Optional: add the field is_move_sent to the view, to see its value
2. Create and confirm an invoice (is_move_sent = False)
3. Send it via the Send & Print button (is_move_sent = True)
4. Reset move to draft (is_move_sent = False)
5. Confirm and send it again (is_move_sent = False)

Desired behavior:
is_move_sent should be set to True after being sent via Send & Print, even if it is not the first time the invoice is being sent.

Fix:
We don't reset the is_move_sent to False when we set the invoice to draft.

opw-4245126

Backport of #170713