### PR TITLE
[FIX] mail: escape on chatwindow thread rename

### DIFF
--- a/addons/mail/static/src/core/common/autoresize_input.js
+++ b/addons/mail/static/src/core/common/autoresize_input.js
@@ -25,6 +25,7 @@ export class AutoresizeInput extends Component {
     setup() {
         this.state = useState({
             value: this.props.value,
+            isFocused: false,
         });
         this.inputRef = useRef("input");
         onWillUpdateProps((nextProps) => {
@@ -50,9 +51,15 @@ export class AutoresizeInput extends Component {
                 this.inputRef.el.blur();
                 break;
             case "Escape":
+                ev.stopPropagation();
                 this.state.value = this.props.value;
                 this.inputRef.el.blur();
                 break;
         }
+    }
+
+    onBlurInput() {
+        this.state.isFocused = false;
+        this.props.onValidate(this.state.value);
     }
 }

--- a/addons/mail/static/src/core/common/autoresize_input.xml
+++ b/addons/mail/static/src/core/common/autoresize_input.xml
@@ -5,12 +5,14 @@
     <input
         class="o-mail-AutoresizeInput o_input px-1 border-1 text-truncate"
         t-attf-class="{{ props.className }}"
+        t-att-class="{'o-focused': state.isFocused}"
         t-attf-placeholder="{{ props.placeholder }}"
         t-att-disabled="!props.enabled"
         t-att-title="state.value"
         t-model="state.value"
         t-on-keydown="onKeydownInput"
-        t-on-blur="() => this.props.onValidate(this.state.value)"
+        t-on-focus="() => this.state.isFocused = true"
+        t-on-blur="onBlurInput"
         t-ref="input"
         type="text"
     />

--- a/addons/mail/static/tests/chat_window/chat_window_tests.js
+++ b/addons/mail/static/tests/chat_window/chat_window_tests.js
@@ -404,6 +404,25 @@ QUnit.test("Close active thread action in chatwindow on ESCAPE", async () => {
     await contains(".o-mail-ChatWindow");
 });
 
+QUnit.test("ESC cancels thread rename", async () => {
+    const pyEnv = await startServer();
+    pyEnv["discuss.channel"].create({
+        name: "General",
+        channel_member_ids: [
+            Command.create({ partner_id: pyEnv.currentPartnerId, is_minimized: true }),
+        ],
+        create_uid: pyEnv.currentUserId,
+    });
+    await start();
+    await click(".o-mail-ChatWindow-command", { text: "General" });
+    await click(".dropdown-item", { text: "Rename" });
+    await contains(".o-mail-AutoresizeInput.o-focused[title='General']");
+    await insertText(".o-mail-AutoresizeInput", "New", { replace: true });
+    triggerHotkey("Escape");
+    await contains(".o-mail-AutoresizeInput.o-focused", { count: 0 });
+    await contains(".o-mail-ChatWindow-command", { text: "General" });
+});
+
 QUnit.test("open 2 different chat windows: enough screen width [REQUIRE FOCUS]", async (assert) => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create([{ name: "Channel_1" }, { name: "Channel_2" }]);


### PR DESCRIPTION
Before this PR, pressing `Escape` while renaming a thread in the chat window closed the entire chat window instead of simply exiting the rename mode.
This PR ensures that pressing `Escape` only exits the rename action, keeping the chat window open.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
