### PR TITLE
[FIX] pos_viva_wallet: handle error when system get bad response

### DIFF
--- a/addons/pos_viva_wallet/models/pos_payment_method.py
+++ b/addons/pos_viva_wallet/models/pos_payment_method.py
@@ -80,6 +80,10 @@ class PosPaymentMethod(models.Model):
         auth = requests.auth.HTTPBasicAuth(viva_wallet_merchant_id, viva_wallet_api_key)
         try:
             resp = requests.get(f"{endpoint}/api/messages/config/token", auth=auth, timeout=TIMEOUT)
+            resp.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code == 404:
+                _logger.exception('could not be found https://%s/api/messages/config/token ', endpoint)
         except requests.exceptions.RequestException:
             _logger.exception('Failed to call https://%s/api/messages/config/token endpoint', endpoint)
         return resp.json().get('Key')


### PR DESCRIPTION
When the system tries to get the verification key to configure the webhook at [1], a ```JSONDecodeError``` occurs as the response status gets '404 Not Found'.

Line 1: https://github.com/odoo/odoo/blob/a3b88c88d6d137f9b231fd7b2a71c624e905f2d2/addons/pos_viva_wallet/models/pos_payment_method.py#L85

```JSONDecodeError: Expecting value: line 1 column 1 (char 0)```

To resolve this, the code has been updated to handle bad responses by using a try-except block, which raises a logger warning if an HTTP error is encountered.

Sentry-6019053900

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
