### PR TITLE
[IMP] mail: disable email signature in customer email responses

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3489,8 +3489,6 @@ class MailThread(models.AbstractModel):
             author_user = self.env.user if self.env.user.partner_id == author else author.user_ids[0] if author and author.user_ids else False
             if author_user:
                 signature = author_user.signature
-            elif author.name:
-                signature = Markup("<p>-- <br/>%s</p>") % author.name
 
         if force_email_company:
             company = force_email_company


### PR DESCRIPTION
When an external user responds to an email sent via Odoo, Odoo may send a mail notification with the user's message and automatically add a signature on their behalf.

Since most external users may have already configured an email signature in their mail client, the added signature can be redundant. To avoid this, we will no longer add a signature on behalf of external users.

task-4273520

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
