### PR TITLE
[FIX] project: add correct domain in open task in filter in burndown_chart_view

### DIFF
--- a/addons/project/report/project_task_burndown_chart_report_views.xml
+++ b/addons/project/report/project_task_burndown_chart_report_views.xml
@@ -22,8 +22,8 @@
                 <filter name="filter_date_deadline" date="date_deadline"/>
                 <filter string="Last Month" invisible="1" name="last_month" domain="[('date','&gt;=', (context_today() - datetime.timedelta(days=30)).strftime('%Y-%m-%d'))]"/>
                 <separator/>
-                <filter string="Open Tasks" name="open_tasks" domain="[('is_closed', '=', False)]"/>
-                <filter string="Closed Tasks" name="closed_tasks" domain="[('is_closed', '=', True)]"/>
+                <filter string="Open Tasks" name="open_tasks" domain="[('is_closed', '=', 'open')]"/>
+                <filter string="Closed Tasks" name="closed_tasks" domain="[('is_closed', '=', 'closed')]"/>
                 <group expand="0" string="Group By">
                     <filter string="Date" name="date" context="{'group_by': 'date'}" />
                     <filter string="Stage (Burndown Chart)" name="stage" context="{'group_by': 'stage_id'}"/>


### PR DESCRIPTION

Steps to reproduce:
- open burndown chart of any project
- add open/closed task filter

Issue:
- filters don't return anything in the burndown chart even though project contains open/closed tasks

Sol:
- add correct domain in open/closed task filter

task-4295668
