### PR TITLE
[FIX] web_editor: extra line added after inserting at line-break

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -2308,7 +2308,7 @@ export class OdooEditor extends EventTarget {
         const isRemovableInvisible = node =>
             !isVisible(node) && !isZWS(node) && !isUnremovable(node);
         const endIsStart = end === start;
-        while (end && isRemovableInvisible(end) && !end.contains(range.endContainer)) {
+        while (end && isRemovableInvisible(end) && (!end.contains(range.endContainer) || end === range.endContainer)) {
             const parent = end.parentNode;
             end.remove();
             end = parent;

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -2385,8 +2385,14 @@ export class OdooEditor extends EventTarget {
             // zws if still needed.
             const el = closestElement(insertedZws);
             const next = insertedZws.nextSibling;
+            const isLineBreak = el && el.previousElementSibling && el.previousElementSibling.tagName === 'BR';
             insertedZws.remove();
             el && fillEmpty(el);
+            if (isLineBreak) {
+                // If there was already a line-break BR just before
+                // el that was removed in fillEmpty, add it back.
+                el.before(this.document.createElement('BR'));
+            }
             setSelection(next, 0);
         }
         if (joinWith) {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
@@ -504,6 +504,15 @@ describe('Paste', () => {
                     contentAfter: '<p>ax&nbsp; &nbsp; y[]d</p>',
                 });
             });
+            it('should paste a text on line break', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>abc<br>[def]</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'x');
+                    },
+                    contentAfter: '<p>abc<br>x[]</p>',
+                });
+            });
             it('should paste a text in a span', async () => {
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>a<span class="a">b[cd]e</span>f</p>',

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
@@ -513,6 +513,15 @@ describe('Paste', () => {
                     contentAfter: '<p>abc<br>x[]</p>',
                 });
             });
+            it('should paste a text at line-break when selected text is formatted', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>abc<br><b>[def]</b></p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'x');
+                    },
+                    contentAfter: '<p>abc<br><b>x[]</b></p>',
+                });
+            });
             it('should paste a text in a span', async () => {
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>a<span class="a">b[cd]e</span>f</p>',

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -3173,6 +3173,14 @@ X[]
                     contentAfter: '<p>abc[]ef</p>',
                 });
             });
+            it('should delete selected formatted text at line break', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>abc<br><b>[def]</b></p>',
+                    stepFunction: deleteBackward,
+                    contentAfterEdit: '<p>abc<br><b data-oe-zws-empty-inline="">[]\u200B</b></p>',
+                    contentAfter: '<p>abc<br>[]</p>'
+                });
+            });
             it('should delete last character of paragraph, ignoring the selected paragraph break leading to an unbreakable', async () => {
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>ab[c</p><p t="unbreak">]def</p>',
@@ -4269,6 +4277,15 @@ X[]
                     await insertText(editor, 'x');
                 },
                 contentAfter: '<p>abx[]cd</p>',
+            });
+        });
+        it('should insert a char when formatted text is selected at line-break preserving the line-break and format', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>abc<br><b>[def]</b></p>',
+                stepFunction: async editor => {
+                    await insertText(editor, 'x');
+                },
+                contentAfter: '<p>abc<br><b>x[]</b></p>',
             });
         });
     });


### PR DESCRIPTION
**Before this PR:**

Steps to reproduce:

- In an empty paragraph write something, press shift + enter
- Write something in new line break
- Select whole text in second line
- Paste any text, notice that an extra <br> is added above pasted text.

In other words,
`<p>abc<br>[def]</p> + insert('x')` becomes `<p>abc<br><br>x[]</p>` instead of `<p>abc<br>x[]</p> `.

**Desired behaviour after PR:**

Now, pasting something at line-break doesn't add an extra an extra `<br>` .

task-4231290




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
