### PR TITLE
[FIX] l10n_fr: Siret and ape invisible

### DIFF
--- a/addons/l10n_fr/i18n/fr.po
+++ b/addons/l10n_fr/i18n/fr.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0\n"
+"Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-30 09:34+0000\n"
-"PO-Revision-Date: 2024-10-30 09:34+0000\n"
+"POT-Creation-Date: 2024-11-12 08:51+0000\n"
+"PO-Revision-Date: 2024-11-12 08:51+0000\n"
 "Last-Translator: Manon Rondou <ronm@odoo.com>\n"
 "Language-Team: \n"
 "Language: fr\n"
@@ -515,6 +515,11 @@ msgstr "I6 - Taux réduit 1.05% (taxe)"
 #: model:account.report.line,name:l10n_fr.tax_report_tva_brute_import
 msgid "Importations"
 msgstr "Importations"
+
+#. module: l10n_fr
+#: model:ir.model.fields,field_description:l10n_fr.field_res_company__is_france_country
+msgid "Is Part of DOM-TOM"
+msgstr ""
 
 #. module: l10n_fr
 #: model:account.report.line,name:l10n_fr.tax_report_op_non_imposables

--- a/addons/l10n_fr/i18n/l10n_fr.pot
+++ b/addons/l10n_fr/i18n/l10n_fr.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0\n"
+"Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-30 09:34+0000\n"
-"PO-Revision-Date: 2024-10-30 09:34+0000\n"
+"POT-Creation-Date: 2024-11-12 08:51+0000\n"
+"PO-Revision-Date: 2024-11-12 08:51+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -486,6 +486,11 @@ msgstr ""
 #. module: l10n_fr
 #: model:account.report.line,name:l10n_fr.tax_report_tva_brute_import
 msgid "Importations"
+msgstr ""
+
+#. module: l10n_fr
+#: model:ir.model.fields,field_description:l10n_fr.field_res_company__is_france_country
+msgid "Is Part of DOM-TOM"
 msgstr ""
 
 #. module: l10n_fr

--- a/addons/l10n_fr/models/res_company.py
+++ b/addons/l10n_fr/models/res_company.py
@@ -10,12 +10,21 @@ class ResCompany(models.Model):
     l10n_fr_closing_sequence_id = fields.Many2one('ir.sequence', 'Sequence to use to build sale closings', readonly=True)
     siret = fields.Char(related='partner_id.siret', string='SIRET', size=14, readonly=False)
     ape = fields.Char(string='APE')
+    is_france_country = fields.Boolean(
+        compute="_compute_is_france_country",
+        string="Is Part of DOM-TOM",
+    )
+
+    @api.depends('country_code')
+    def _compute_is_france_country(self):
+        for company in self:
+            company.is_france_country = company.country_code in self._get_france_country_codes()
 
     @api.model
     def _get_france_country_codes(self):
         """Returns every country code that can be used to represent France
         """
-        return ['FR', 'MF', 'MQ', 'NC', 'PF', 'RE', 'GF', 'GP', 'TF'] # These codes correspond to France and DOM-TOM.
+        return ['FR', 'MF', 'MQ', 'NC', 'PF', 'RE', 'GF', 'GP', 'TF', 'BL', 'PM', 'YT', 'WF']  # These codes correspond to France and DOM-TOM.
 
     @api.model
     def _get_unalterable_country(self):

--- a/addons/l10n_fr/views/l10n_fr_view.xml
+++ b/addons/l10n_fr/views/l10n_fr_view.xml
@@ -8,8 +8,9 @@
             <field name="arch" type="xml">
             <data>
                  <xpath expr="//field[@name='company_registry']" position="after">
-                    <field name="siret" attrs="{'invisible': [('country_code', '!=', 'FR')]}"/>
-                    <field name="ape" attrs="{'invisible': [('country_code', '!=', 'FR')]}"/>
+                     <field name="is_france_country" invisible="1"/>
+                     <field name="siret" attrs="{'invisible': [('is_france_country', '=', False)]}"/>
+                     <field name="ape" attrs="{'invisible': [('is_france_country', '=', False)]}"/>
                  </xpath>
             </data>
             </field>


### PR DESCRIPTION
This commit will correct the fact that the siret and APE number must be displayed also when the country code is from the DOM-TOM

task:4290323




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
