### PR TITLE
[FIX] project: _create_next_occurrence_values called unnecessarily

### DIFF
--- a/addons/project/models/project_task_recurrence.py
+++ b/addons/project/models/project_task_recurrence.py
@@ -66,10 +66,13 @@ class ProjectTaskRecurrence(models.Model):
     def _create_next_occurrence(self, occurrence_from):
         self.ensure_one()
         # Prevent double mail_followers creation
-        create_values = self._create_next_occurrence_values(occurrence_from)
-        date_deadline = create_values['date_deadline']
-        if not (self.repeat_type == 'until' and date_deadline and date_deadline.date() > self.repeat_until):
-            occurrence_from.with_context(copy_project=True).sudo().copy(create_values)
+        if (
+            self.repeat_type != 'until' or not occurrence_from.date_deadline or
+            self.repeat_until and (occurrence_from.date_deadline + self._get_recurrence_delta()).date() <= self.repeat_until
+        ):
+            occurrence_from.with_context(copy_project=True).sudo().copy(
+                self._create_next_occurrence_values(occurrence_from)
+            )
 
     def _create_next_occurrence_values(self, occurrence_from):
         self.ensure_one()

--- a/addons/project/tests/test_project_recurrence.py
+++ b/addons/project/tests/test_project_recurrence.py
@@ -112,6 +112,8 @@ class TestProjectRecurrence(TransactionCase):
             form.repeat_type = 'until'
             form.repeat_until = self.date_01_01 + relativedelta(months=1, days=1)
             form.date_deadline = self.date_01_01
+            with form.child_ids.new() as subtask_form:
+                subtask_form.name = 'test subtask'
             task = form.save()
 
         task.state = '1_done'
@@ -120,6 +122,7 @@ class TestProjectRecurrence(TransactionCase):
         last_recurring_task = task.recurrence_id.task_ids.filtered(lambda t: t != task)
         last_recurring_task.state = '1_done'
         self.assertEqual(len(task.recurrence_id.task_ids), 2, "Since this is after repeat_until, next occurrence shouldn't have been created")
+        self.assertEqual(len(task.recurrence_id.task_ids.child_ids), 2, "2 subtasks should have been created")
 
     def test_recurring_settings_change(self):
         self.env['res.config.settings'] \


### PR DESCRIPTION
Currently, the _create_next_occurence_values method is always called, even if no next occurences need to be created. This is bad, because if the next condition in the code is falsy, we would have created child tasks for nothing since childs are created using copy() in the method to handle recursion.

This PR will fix it by checking beforehand if any next occurence should be made, and call _create_next_occurrence_values only if so.

task-4269547