### PR TITLE
[FIX] mrp: compute duration_expected

### DIFF
--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -4281,6 +4281,32 @@ class TestMrpOrder(TestMrpCommon):
         self.assertRecordValues(move_2.move_line_ids, [{'quantity': 0.5, 'lot_id': False}])
         self.assertRecordValues(move_1.move_line_ids, [{'quantity': 1, 'lot_id': False}])
 
+    def test_batch_production_04(self):
+        """ Test that splitting a MO correctly computes the duration of the workorders. """
+        self.product_5.tracking = 'serial'
+        self.bom_2.bom_line_ids.unlink()
+        self.bom_2.operation_ids.write({
+            'workcenter_id': self.workcenter_2.id,
+            'time_cycle_manual': 60,
+        })
+        mo_form = Form(self.env['mrp.production'])
+        mo_form.bom_id = self.bom_2
+        mo_form.product_qty = 2
+        mo = mo_form.save()
+        mo.action_confirm()
+        mo.button_plan()
+        self.assertEqual(mo.workorder_ids.duration_expected, 120)
+
+        batch_produce_action = mo.button_mark_done()
+        batch_produce = Form(self.env['mrp.batch.produce'].with_context(**batch_produce_action['context']))
+        batch_produce.lot_name = "00001"
+        batch_produce = batch_produce.save()
+        batch_produce.action_generate_production_text()
+        batch_produce.action_prepare()
+
+        productions = mo.procurement_group_id.mrp_production_ids
+        self.assertListEqual(productions.workorder_ids.mapped('duration_expected'), [60, 60])
+
     def test_multi_edit_start_date_wo(self):
         """
         Test setting the start date for multiple workorders, checking if the finish date

--- a/addons/mrp/wizard/mrp_batch_produce.py
+++ b/addons/mrp/wizard/mrp_batch_produce.py
@@ -7,6 +7,7 @@ from collections import defaultdict, deque
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+from odoo.tools import OrderedSet
 
 
 class MrpBatchProduct(models.TransientModel):
@@ -105,14 +106,14 @@ class MrpBatchProduct(models.TransientModel):
             })
         lots = lots + self.env['stock.lot'].create(raw_lots)
 
-        productions_to_set = set()
+        productions_to_set = OrderedSet()
         for production, finished_lot in zip(productions, lots):
             production.lot_producing_id = finished_lot
             self._process_components(production, components_list.pop(0))
             productions_to_set.add(production.id)
 
         productions = self.env['mrp.production'].browse(productions_to_set)
-        for production in productions:
+        for production in reversed(productions):
             production.qty_producing = production.product_uom_qty
             production.set_qty_producing()
             production.move_raw_ids.picked = True


### PR DESCRIPTION
This is a non-deterministic bug.

Setup:
- install mrp, enable workorders and serial numbers
- create a storable product A with serial tracking
- create a BOM with 1 operation for product A

Steps:
- create a MO for 2 units of product A -> the duration expected on the WO should be 120 minutes.
- confirm then plan the MO
- produce all -> you'll see a wizard for batch production (2nd wizard)
- generate serials then produce or prepare MO (doesn't matter which)

Issue:
Sometimes the duration of the initial workorder is correctly computed -> 60 minutes, sometimes it is not (left as is). This is a mix of 2 'bugs':

First, we have the `self.env['mrp.production'].browse` via a set(). Because it's a set, the productions received are not always in order, so the loop just after may process the last MO first. This triggers the 2nd 'bug'.

Second, the first MO (that was planned) won't trigger `_compute_duration_expected` at https://github.com/odoo/odoo/blob/014ed907a2fab280e9fa6dd93b23a6a852700796/addons/mrp/wizard/mrp_batch_produce.py#L116 when changing `qty_producing` because of `is_planned`: https://github.com/odoo/odoo/blob/014ed907a2fab280e9fa6dd93b23a6a852700796/addons/mrp/models/mrp_production.py#L730-L731 instead, it will go through the compute later because the second MO (created in the split, but not planned) will trigger the compute for both ids via `recompute` because the original MO id was still in the pending transactions:
https://github.com/odoo/odoo/blob/014ed907a2fab280e9fa6dd93b23a6a852700796/odoo/fields.py#L1413 However, the first workorder will already have its qty_producing set to 1 so won't pass in `_get_duration_expected`.

Fix:
Use `OrderedSet` instead of set along with `reversed()` so that the loop will process the last MO first.
This way the pending compute for the original MO will correctly compute the duration 
because it's WO's qty_producing will still be zero.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
