### PR TITLE
[FIX] point_of_sale: align dropdown selection with rtl languages

### DIFF
--- a/addons/point_of_sale/static/src/app/store/select_lot_popup/edit_list_input/edit_list_input.scss
+++ b/addons/point_of_sale/static/src/app/store/select_lot_popup/edit_list_input/edit_list_input.scss
@@ -15,8 +15,6 @@
     text-align: left;
     position: fixed;
     top: 100%;
-    left: 0;
-    right: 0;
     overflow-y: auto;
     max-height: 15rem;
     z-index: 1000000;


### PR DESCRIPTION
The dropdown selection for tracking/lot number is misaligned when the users has a rtl language.

Steps to reproduce:
-------------------
* Switch the current user to a rtl language (arabic for ex)
* Open shop session
* Select the drawer product
> Observation: dropdown selection is misaligned

Before vs after fix:
-------------------------
RTL computer:
* Before:
  ![rtl_before_computer](https://github.com/user-attachments/assets/49036d2f-3612-49ca-b21f-85751873ebd6)
* After:
  ![rtl_after_computer](https://github.com/user-attachments/assets/fe4d2d36-0020-48d0-b2dd-c2a29cfd4c27)
  
RTL mobile:
* Before:
  ![rtl_before_mobile](https://github.com/user-attachments/assets/fd97e60a-437a-4b3d-85b3-b7db04590fcc)
 * After:
   ![rtl_after_mobile](https://github.com/user-attachments/assets/a5c8abd8-b80d-4292-8123-1ebeccfc8776)
 
LTR computer:
* Before:
  ![ltr_before_computer](https://github.com/user-attachments/assets/8c6ce80c-992c-4d4f-aca2-7df7939da868)
* After:
  ![ltr_after_computer](https://github.com/user-attachments/assets/d4ae6f1b-4ec8-457d-b5e7-08f32044e45c)
  
LTR mobile
* Before:
  ![ltr_before_mobile](https://github.com/user-attachments/assets/81c5c093-13df-4a4c-9865-61c45bc9064d)
* After:
  ![ltr_after_mobile](https://github.com/user-attachments/assets/736d9975-099b-4622-be9a-9d619367f750)
  
Also works if we move the popup around.

opw-4187095
