### PR TITLE
[FIX] project: prevent stage copy on project duplication

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -428,7 +428,13 @@ class Project(models.Model):
         default = dict(default or {})
         # Since we dont want to copy the milestones if the original project has the feature disabled, we set the milestones to False by default.
         default['milestone_ids'] = False
-        new_projects = super(Project, self.with_context(mail_auto_subscribe_no_notify=True, mail_create_nosubscribe=True)).copy(default=default)
+        copy_context = dict(
+             self.env.context,
+             mail_auto_subscribe_no_notify=True,
+             mail_create_nosubscribe=True,
+         )
+        copy_context.pop("default_stage_id", None)
+        new_projects = super(Project, self.with_context(copy_context)).copy(default=default)
         if 'milestone_mapping' not in self.env.context:
             self = self.with_context(milestone_mapping={})
         actions_per_project = dict(self.env['ir.embedded.actions']._read_group(

--- a/addons/project/tests/test_project_flow.py
+++ b/addons/project/tests/test_project_flow.py
@@ -608,3 +608,9 @@ class TestProjectFlow(TestProjectCommon, MailCommon):
         with self.mock_mail_gateway():
             self.task_1.project_id = self.project_goats.id
         self.assertSentEmail(self.env.user.email_formatted, [self.user_projectuser.email_formatted])
+
+    def test_do_not_copy_project_stage(self):
+        stage = self.env['project.project.stage'].create({'name': 'Custom stage'})  # Default sequence is 50
+        self.project_pigs.stage_id = stage.id
+        project_copy = self.project_pigs.with_context(default_stage_id=stage.id).copy()
+        self.assertNotEqual(project_copy.stage_id, self.project_pigs.stage_id, 'Copied project should have lowest sequence stage')


### PR DESCRIPTION
Steps to reproduce:
- Settings > Enable 'Project Stages'
- Projects app > New Project > Drag it into 'In Progress' stage
- From Project Kanban view duplicate that project

The duplicated project is created directly in 'In Progress' stage when it should have defaulted to the lowest sequence stage 'To Do'. Other duplication actions notably do not have this same issue.

The kanban action specifically fetches default_stage_id from the context instead of using the dedicated default function of the sage_id field, but more generally we never want to copy the stage (as indicated by copy=False) so this fix covers for other possible mistakes.

opw-4291455

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
