### PR TITLE
[FIX] purchase_stock,stock_landed_costs: price unit reflect LC value

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -344,6 +344,9 @@ class PurchaseOrderLine(models.Model):
             moves = moves.filtered(lambda r: fields.Date.context_today(r, r.date) <= self._context['accrual_entry_date'])
         return moves
 
+    def _get_po_line_invoice_lines_su(self):
+        return self.sudo().invoice_lines
+
     @api.depends('move_ids.state', 'move_ids.product_uom_qty', 'move_ids.product_uom')
     def _compute_qty_received(self):
         from_stock_lines = self.filtered(lambda order_line: order_line.qty_received_method == 'stock_moves')

--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -57,7 +57,7 @@ class StockMove(models.Model):
                     l.value, order.currency_id, order.company_id, l.create_date, round=False)))
             total_invoiced_value = 0
             invoiced_qty = 0
-            for invoice_line in line.sudo().invoice_lines:
+            for invoice_line in line._get_po_line_invoice_lines_su():
                 if invoice_line.move_id.state != 'posted':
                     continue
                 if invoice_line.tax_ids:

--- a/addons/stock_landed_costs/models/purchase.py
+++ b/addons/stock_landed_costs/models/purchase.py
@@ -7,3 +7,9 @@ class PurchaseOrderLine(models.Model):
         res = super()._prepare_account_move_line(move)
         res.update({'is_landed_costs_line': self.product_id.landed_cost_ok})
         return res
+
+    def _get_po_line_invoice_lines_su(self):
+        return (
+            super()._get_po_line_invoice_lines_su() |
+            self.sudo().invoice_lines.move_id.line_ids.filtered('is_landed_costs_line')
+        )

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
@@ -5,7 +5,7 @@ from odoo.addons.stock_landed_costs.tests.common import TestStockLandedCostsComm
 from odoo.addons.stock_landed_costs.tests.test_stockvaluationlayer import TestStockValuationLCCommon
 from odoo.addons.stock_account.tests.test_stockvaluation import _create_accounting_data
 
-from odoo.fields import Date
+from odoo.fields import Command, Date
 from odoo.tests import tagged, Form
 
 
@@ -497,3 +497,62 @@ class TestLandedCostsWithPurchaseAndInv(TestStockValuationLCCommon):
 
         landed_cost_aml = bill.invoice_line_ids.filtered(lambda l: l.product_id == self.landed_cost)
         self.assertTrue(landed_cost_aml.reconciled)
+
+    def test_lc_with_avco_ordered_qty_invoice_receipt_order(self):
+        """ When using an invoicing policy that permits invoicing prior to reception, stock moves
+        for products using dynamic cost methods should account for LCs associated with the order
+        from which the move was derived.
+        """
+        self.env.company.anglo_saxon_accounting = True
+        self.product1.purchase_method = 'purchase'
+        self.product1.categ_id.write({
+            'property_stock_account_input_categ_id': self.company_data['default_account_stock_in'].id,
+            'property_stock_account_output_categ_id': self.company_data['default_account_stock_out'].id,
+            'property_stock_valuation_account_id': self.company_data['default_account_stock_valuation'].id,
+            'property_valuation': 'real_time',
+            'property_cost_method': 'average',
+        })
+        self.landed_cost.categ_id = self.product1.categ_id.id
+        product = self.product1
+
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'product_id': product.id,
+                'product_qty': 100000,
+                'price_unit': 1.35,
+            })],
+        })
+        purchase_order.button_confirm()
+        purchase_order.action_create_invoice()
+        bill = purchase_order.invoice_ids[0]
+        bill.invoice_line_ids[0].quantity = 23000
+        receipt = purchase_order.picking_ids[0]
+        receipt.picking_type_id.create_backorder = 'always'
+        receipt.move_ids.quantity_done = 23000
+        receipt.button_validate()
+        self.assertEqual(product.standard_price, 1.35)
+
+        bill.invoice_date = '2000-05-05'
+        with Form(bill) as bill_form:
+            with bill_form.invoice_line_ids.new() as inv_line:
+                inv_line.product_id = self.landed_cost
+                inv_line.price_unit = 23000
+                inv_line.is_landed_costs_line = True
+        bill.action_post()
+        action = bill.button_create_landed_costs()
+        lc_form = Form(self.env[action['res_model']].browse(action['res_id']))
+        lc_form.picking_ids.add(receipt)
+        lc = lc_form.save()
+        lc.button_validate()
+        self.assertEqual(product.standard_price, 2.35)
+
+        purchase_order.action_create_invoice()
+        bill2 = purchase_order.invoice_ids.filtered(lambda b: b.state == 'draft')
+        bill2.invoice_line_ids[0].quantity = 27000
+        bill2.invoice_date = Date.today()
+        bill2._post()
+        receipt2 = purchase_order.picking_ids.filtered(lambda p: p.state == 'assigned')
+        receipt2.move_ids[0].quantity_done = 27000
+        receipt2.button_validate()
+        self.assertEqual(product.standard_price, 1.81)


### PR DESCRIPTION
**Current behavior:**
With a product that is invoiced based on ordered qty, has avg
costing, and real time valuation: it is possible to invoice and
received quantity in such an order that, when there is a landed
cost associated with an invoice instance of the product, the
standard price of the product may be updated with an incorrect
value.

**Expected behavior:**
Product cost follows 'average' selection logically.

**Steps to reproduce:**
*Enable anglo-saxon accounting*

1. Create a product with:
* real time property valuation
* average cost method
* on ordered quantities control policy

2. Create a purchase order for the product, for 100 000 units of
the product at 1.35 each -> confirm the order

3. Create an invoice for 23 000 units, receive 23 000 units and
backorder the rest

4. Create a landed cost on the invoice for 23 000 in the company
currency units

5. Post the invoice

6. Create a second invoice for 27 000 units and post it

7. Receive 27 000 more units from the receipt

8. See that the product standard price is not the expected value
of 1.81

**Cause of the issue:**
The landed cost on the invoice is not taken into account. Since
the price unit for the moves informing the new price value are
obtained with `_get_price_unit()`, we end up only taking into
account the sum value of the invoice lines linked to the move.
So the landed cost does not get included in the subsequent price
unit calculation here:
https://github.com/odoo/odoo/blob/22e7bfb591c43e849c554eb4c128279d76ad31f9/addons/stock_account/models/stock_move.py#L328

**Fix:**
Extract a method which returns invoice lines to the
`_get_price_unit()` method of purchase_stock so that we may
return line records that represent landed costs that will
otherwise be omitted.

opw-4048396