### PR TITLE
[FIX] sale_timesheet: copy project allocated hours

### DIFF
--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -55,7 +55,7 @@ class Project(models.Model):
     warning_employee_rate = fields.Boolean(compute='_compute_warning_employee_rate', compute_sudo=True)
     partner_id = fields.Many2one(
         compute='_compute_partner_id', store=True, readonly=False)
-    allocated_hours = fields.Float(compute='_compute_allocated_hours', store=True, readonly=False, copy=False)
+    allocated_hours = fields.Float(compute='_compute_allocated_hours', store=True, readonly=False)
 
     @api.model
     def _get_view(self, view_id=None, view_type='form', **options):

--- a/addons/sale_timesheet/tests/test_project.py
+++ b/addons/sale_timesheet/tests/test_project.py
@@ -180,3 +180,7 @@ class TestProject(TestCommonSaleTimesheet):
     def test_open_product_form_with_default_service_policy(self):
         form = Form(self.env['product.product'].with_context(default_detailed_type='service', default_service_policy='delivered_timesheet'))
         self.assertEqual('delivered_timesheet', form.service_policy)
+
+    def test_duplicate_project_allocated_hours(self):
+        self.project_global.allocated_hours = 10
+        self.assertEqual(self.project_global.copy().allocated_hours, 10)


### PR DESCRIPTION
Steps to reproduce:
- Install Project and sale_timesheet
- Create a project with Timesheet option enabled
- Go to that project's setting and allocate hours
- Gear Icon > Duplicate

The duplicated project has 0 allocated hours, this is odd since sale_timesheet forces that field to copy=False despite every other module allowing it (Even Timesheet). Additionally, copied tasks still have their allocated hours no matter what so it is strange to remove them from the project itself.

opw-4284950

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
