### PR TITLE
[FIX] sale_pdf_quote_builder: play nice with existing form fields

### DIFF
--- a/addons/sale_pdf_quote_builder/models/ir_actions_report.py
+++ b/addons/sale_pdf_quote_builder/models/ir_actions_report.py
@@ -84,7 +84,7 @@ class IrActionsReport(models.Model):
 
     @api.model
     def _add_pages_to_writer(self, writer, document, all_form_fields=None, sol_id=None):
-        """Add a PDF doc to the writer and fill the form fields present in the pages if needed.
+        """Add a PDF doc to the writer and fill the form text fields present in the pages if needed.
 
         :param PdfFileWriter writer: the writer to which pages needs to be added
         :param bytes document: the document to add in the final pdf
@@ -99,7 +99,7 @@ class IrActionsReport(models.Model):
 
         field_names = set()
         if all_form_fields is not None:
-            field_names = reader.getFields()
+            field_names = reader.getFormTextFields()
             if field_names:
                 all_form_fields.update([prefix + field_name for field_name in field_names])
 

--- a/addons/sale_pdf_quote_builder/utils.py
+++ b/addons/sale_pdf_quote_builder/utils.py
@@ -17,7 +17,7 @@ def _ensure_document_not_encrypted(document):
 
 
 def _get_form_fields_from_pdf(pdf_data):
-    """ Get the form fields present in the pdf file.
+    """Get the form text fields present in the pdf file.
 
     :param binary pdf_data: the pdf from where we should extract the new form fields that might
                             need to be mapped.
@@ -26,4 +26,4 @@ def _get_form_fields_from_pdf(pdf_data):
     """
     reader = pdf.PdfFileReader(io.BytesIO(base64.b64decode(pdf_data)))
 
-    return set(reader.getFields() or '')
+    return set(reader.getFormTextFields() or {})

--- a/odoo/tools/pdf/__init__.py
+++ b/odoo/tools/pdf/__init__.py
@@ -178,10 +178,11 @@ def fill_form_fields_pdf(writer, form_fields):
 
         for raw_annot in page.get('/Annots', []):
             annot = raw_annot.getObject()
-            for field in form_fields:
+            field_name = annot.get('/T')
+            if form_fields.get(field_name):
                 # Mark filled fields as readonly to avoid the blue overlay:
-                if annot.get('/T') == field:
-                    annot.update({NameObject("/Ff"): NumberObject(1)})
+                field_flags = annot.get('/Ff', 0)
+                annot.update({NameObject('/Ff'): NumberObject(1 | field_flags)})
 
 
 def rotate_pdf(pdf):

--- a/odoo/tools/pdf/_pypdf.py
+++ b/odoo/tools/pdf/_pypdf.py
@@ -40,6 +40,9 @@ class PdfReader(_Reader):
     def getDocumentInfo(self):
         return self.metadata
 
+    def getFormTextFields(self):
+        return self.get_form_text_fields()
+
 
 class PdfWriter(_Writer):
     def getPage(self, pageNumber):

--- a/odoo/tools/pdf/_pypdf2_1.py
+++ b/odoo/tools/pdf/_pypdf2_1.py
@@ -18,6 +18,12 @@ class PdfReader(PdfFileReader):
     def __init__(self, stream, strict=True, warndest=None, overwriteWarnings=True):
         super().__init__(stream, strict=True, warndest=None, overwriteWarnings=False)
 
+    def getFormTextFields(self):
+        if self.getFields() is None:
+            # Prevent this version of PyPDF2 from trying to iterate over `None`
+            return None
+        return super().getFormTextFields()
+
 
 class PdfWriter(PdfFileWriter):
     def get_fields(self, *args, **kwargs):


### PR DESCRIPTION
Versions
--------
- saas-17.4+

Steps
-----
1. Have PDF file with checkbox form fields;
2. upload it as footer for a Quotation Template;
3. set up a quotation using the template;
4. print the PDF Quote.

Issue
-----
> Odoo Server Error
> IndexError: string index out of range

Thrown from the PyPDF2 package.

Cause
-----
Commit e1b05e95e73c expanded the form fields available in the quote builder. It introduced the `_get_form_fields_values_mapping` method.

It ignores fields not in the `param_field_map` by associating them with an empty string. This causes issues with non-text form fields, e.g. checkbox, which uses `/Off` to represent the emptiness.

Solution
--------
Instead of retrieving all fields with `getFields`, use `getFormTextFields`. This way, an empty string should always be a valid
value.

opw-4290594