### PR TITLE
[FIX] website: disable columns option on `s_numbers`

### DIFF
--- a/addons/website/views/snippets/s_numbers.xml
+++ b/addons/website/views/snippets/s_numbers.xml
@@ -4,7 +4,7 @@
 <template name="Numbers" id="s_numbers">
     <section class="s_numbers o_cc o_cc1 pt80 pb80">
         <div class="container">
-            <div class="row">
+            <div class="row s_nb_column_fixed">
                 <div class="col-lg-4">
                     <h3 class="mb-3 h4">Key Metrics of<br/>Company's Achievements</h3>
                     <p class="lead">Analyzing the numbers behind our success: <br class="d-none d-xxl-inline"/>an in-depth look at the key metrics driving our company's achievements</p>


### PR DESCRIPTION
Changing the amount of columns of this snippet from the dropdown in the editor makes the layout break. This commit prevent the user from doing that.

task-4223179

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
