### PR TITLE
[FIX] website: add missing data attributes in `s_numbers_list`

### DIFF
--- a/addons/website/views/snippets/s_numbers_list.xml
+++ b/addons/website/views/snippets/s_numbers_list.xml
@@ -14,42 +14,42 @@
                         <div class="col-6 col-lg-6 pt16 pb16" data-name="Number">
                             <span class="h2-fs">15%</span>
                             <p>Revenue Growth</p>
-                            <div class="s_hr pt16 pb40">
+                            <div class="s_hr pt16 pb40" data-snippet="s_hr" data-name="Separator">
                                 <hr class="w-100 mx-auto"/>
                             </div>
                         </div>
                         <div class="col-6 col-lg-6 pt16 pb16" data-name="Number">
                             <span class="h2-fs">$50M</span>
                             <p>Expected revenue</p>
-                            <div class="s_hr pt16 pb40">
+                            <div class="s_hr pt16 pb40" data-snippet="s_hr" data-name="Separator">
                                 <hr class="w-100 mx-auto"/>
                             </div>
                         </div>
                         <div class="col-6 col-lg-6 pt16 pb16" data-name="Number">
                             <span class="h2-fs">85%</span>
                             <p>User Retention</p>
-                            <div class="s_hr pt16 pb40">
+                            <div class="s_hr pt16 pb40" data-snippet="s_hr" data-name="Separator">
                                 <hr class="w-100 mx-auto"/>
                             </div>
                         </div>
                         <div class="col-6 col-lg-6 pt16 pb16" data-name="Number">
                             <span class="h2-fs">100,000</span>
                             <p>Website visitors</p>
-                            <div class="s_hr pt16 pb40">
+                            <div class="s_hr pt16 pb40" data-snippet="s_hr" data-name="Separator">
                                 <hr class="w-100 mx-auto"/>
                             </div>
                         </div>
                         <div class="col-6 col-lg-6 pt16 pb16" data-name="Number">
                             <span class="h2-fs">20+</span>
                             <p>Projects deployed</p>
-                            <div class="s_hr pt16 pb40">
+                            <div class="s_hr pt16 pb40" data-snippet="s_hr" data-name="Separator">
                                 <hr class="w-100 mx-auto"/>
                             </div>
                         </div>
                         <div class="col-6 col-lg-6 pt16 pb16" data-name="Number">
                             <span class="h2-fs">4x</span>
                             <p>Inventory turnover</p>
-                            <div class="s_hr pt16 pb40">
+                            <div class="s_hr pt16 pb40" data-snippet="s_hr" data-name="Separator">
                                 <hr class="w-100 mx-auto"/>
                             </div>
                         </div>


### PR DESCRIPTION
This commit adds missing `data-snippet` and `data-name` attributes to the `s_hr` snippet used in the structure.

task-4223179

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
