### PR TITLE
[FIX] mail: more visible navigation button in FileViewer

### DIFF
--- a/addons/web/static/src/core/file_viewer/file_viewer.xml
+++ b/addons/web/static/src/core/file_viewer/file_viewer.xml
@@ -63,10 +63,10 @@
                     </div>
                 </div>
                 <t t-if="props.files.length > 1">
-                    <div class="o-FileViewer-navigation position-absolute top-0 bottom-0 start-0 align-items-center justify-content-center d-flex my-auto ms-3 rounded-circle" t-on-click.stop="previous" title="Previous (Left-Arrow)" aria-label="Previous" role="button">
+                    <div class="o-FileViewer-navigation position-absolute top-0 bottom-0 start-0 align-items-center justify-content-center d-flex my-auto ms-3 rounded-circle bg-dark text-white" t-on-click.stop="previous" title="Previous (Left-Arrow)" aria-label="Previous" role="button">
                         <span class="oi oi-chevron-left" role="img"/>
                     </div>
-                    <div class="o-FileViewer-navigation position-absolute top-0 bottom-0 end-0 align-items-center justify-content-center d-flex my-auto me-3 rounded-circle" t-on-click.stop="next" title="Next (Right-Arrow)" aria-label="Next" role="button">
+                    <div class="o-FileViewer-navigation position-absolute top-0 bottom-0 end-0 align-items-center justify-content-center d-flex my-auto me-3 rounded-circle bg-dark text-white" t-on-click.stop="next" title="Next (Right-Arrow)" aria-label="Next" role="button">
                         <span class="oi oi-chevron-right" role="img"/>
                     </div>
                 </t>


### PR DESCRIPTION
When viewing more than 1 viewable file in the FileViewer, the navigation buttons `<` and `>` are barely visible.

This commit fixes it by putting white icon on dark rounded background for the buttons.

Task-4056907

<img width="2559" alt="Screenshot 2024-10-30 at 17 34 03" src="https://github.com/user-attachments/assets/b26cc55c-d2e0-47f4-8c60-99fd55a46bf2">
