### PR TITLE
[IMP] microsoft_calendar: don't synchronize existing events

### DIFF
--- a/addons/microsoft_calendar/models/res_users.py
+++ b/addons/microsoft_calendar/models/res_users.py
@@ -92,6 +92,11 @@ class User(models.Model):
         self.ensure_one()
         if self.microsoft_synchronization_stopped:
             return False
+
+        # Set the first synchronization date as an ICP parameter before writing the variable
+        # 'microsoft_calendar_sync_token' below, so we identify the first synchronization.
+        self._set_ICP_first_synchronization_date(fields.Datetime.now())
+
         calendar_service = self.env["calendar.event"]._get_microsoft_service()
         full_sync = not bool(self.microsoft_calendar_sync_token)
         with microsoft_calendar_token(self) as token:
@@ -138,3 +143,24 @@ class User(models.Model):
         self.microsoft_synchronization_stopped = False
         self.env['calendar.recurrence']._restart_microsoft_sync()
         self.env['calendar.event']._restart_microsoft_sync()
+
+    def _set_ICP_first_synchronization_date(self, now):
+        """
+        Set the first synchronization date as an ICP parameter when applicable (param not defined yet
+        and calendar never synchronized before). This parameter is used for not synchronizing previously
+        created Odoo events and thus avoid spamming invitations for those events.
+        """
+        ICP = self.env['ir.config_parameter'].sudo()
+        first_synchronization_date = ICP.get_param('microsoft_calendar.sync.first_synchronization_date')
+
+        if not first_synchronization_date:
+            # Check if any calendar has synchronized before by checking the user's tokens.
+            any_calendar_synchronized = self.env['res.users'].sudo().search_count(
+                domain=[('microsoft_calendar_sync_token', '!=', False)],
+                limit=1
+            )
+
+            # Check if any user synchronized its calendar before by saving the date token.
+            # Add one minute of time diff for avoiding write time delay conflicts with the next sync methods.
+            if not any_calendar_synchronized:
+                ICP.set_param('microsoft_calendar.sync.first_synchronization_date', now - timedelta(minutes=1))

--- a/addons/microsoft_calendar/tests/common.py
+++ b/addons/microsoft_calendar/tests/common.py
@@ -2,6 +2,8 @@ import pytz
 from datetime import datetime, timedelta
 from markupsafe import Markup
 from unittest.mock import patch, MagicMock
+from contextlib import contextmanager
+from freezegun import freeze_time
 
 from odoo import fields
 
@@ -411,6 +413,17 @@ class TestCommon(HttpCase):
             for i in range(self.recurrent_events_count)
         ]
         self.env.cr.postcommit.clear()
+
+    @contextmanager
+    def mock_datetime_and_now(self, mock_dt):
+        """
+        Used when synchronization date (using env.cr.now()) is important
+        in addition to standard datetime mocks. Used mainly to detect sync
+        issues.
+        """
+        with freeze_time(mock_dt), \
+                patch.object(self.env.cr, 'now', lambda: mock_dt):
+            yield
 
     def sync_odoo_recurrences_with_outlook_feature(self):
         """


### PR DESCRIPTION
Before this commit, customers were facing problems during the first synchronization related to the abundance of invitations sent through Outlook from previously created events in Odoo side. This should not happen because most of the time it is not useful synchronizing events that were already created before starting the synchronization with Outlook (from feedbacks discussed with customers and internally).

After this commit, we no longer synchronize events that were created before the first synchronization of any user in a database if we don't find any token created in it (i.e. if no user synchronized its Odoo Calendar with Outlook before this improvement). In case of any user already have synchronized its calendar with Outlook, we won't change the synchronization behavior (since the biggest part of the invitations were already sent).

task-4294884