### PR TITLE
[IMP] project: replace `display_in_project` field with filter

### DIFF
--- a/addons/mail/static/src/views/web/activity/activity_model.js
+++ b/addons/mail/static/src/views/web/activity/activity_model.js
@@ -17,6 +17,7 @@ export class ActivityModel extends RelationalModel {
     async fetchActivityData(params) {
         this.activityData = await this.orm.call("mail.activity", "get_activity_data", [], {
             res_model: this.config.resModel,
+            context: params.context,
             domain: params.domain || this.env.searchModel._domain,
             limit: params.limit || this.initialLimit,
             offset: params.offset || 0,

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -405,17 +405,10 @@ class ProjectProject(models.Model):
         defaults = self._map_tasks_default_values(project)
         new_tasks = tasks.with_context(copy_project=True).copy(defaults)
         all_subtasks = new_tasks._get_all_subtasks()
-        project.write({'tasks': [Command.set(new_tasks.ids)]})
-        subtasks_not_displayed = all_subtasks.filtered(
-            lambda task: not task.display_in_project
-        )
         all_subtasks.filtered(
             lambda child: child.project_id == self
         ).write({
             'project_id': project.id
-        })
-        subtasks_not_displayed.write({
-            'display_in_project': False
         })
         return True
 

--- a/addons/project/report/project_report_views.xml
+++ b/addons/project/report/project_report_views.xml
@@ -75,9 +75,10 @@
             <field name="name">Tasks Analysis</field>
             <field name="res_model">report.project.task.user</field>
             <field name="path">tasks-analysis</field>
+            <field name="domain">[('display_in_project', '=', True)]</field>
             <field name="view_mode">graph,pivot</field>
             <field name="search_view_id" ref="view_task_project_user_search"/>
-            <field name="context">{'group_by':[], 'graph_measure': '__count__'}</field>
+            <field name="context">{'group_by': [], 'graph_measure': '__count__'}</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_empty_folder">
                     No data yet!

--- a/addons/project/static/tests/project_task_subtask.test.js
+++ b/addons/project/static/tests/project_task_subtask.test.js
@@ -112,7 +112,6 @@ beforeEach(() => {
             <form>
                 <field name="child_ids" widget="subtasks_one2many">
                     <list editable="bottom">
-                        <field name="display_in_project" force_save="1"/>
                         <field name="project_id" widget="project"/>
                         <field name="name"/>
                     </list>

--- a/addons/project/tests/test_multicompany.py
+++ b/addons/project/tests/test_multicompany.py
@@ -420,7 +420,6 @@ class TestMultiCompanyProject(TestMultiCompanyCommon):
             self.assertEqual(subtask_line.project_id, self.task_1.project_id, "The task's project should already be set on the subtask.")
             subtask_line.name = 'Test Subtask'
         subtask = self.task_1.child_ids[0]
-        self.assertTrue(subtask.show_display_in_project, "The subtask's field 'display in project' should be visible.")
         self.assertFalse(subtask.display_in_project, "The subtask's field 'display in project' should be unchecked.")
         self.assertEqual(subtask.company_id, self.task_1.company_id, "The company of the subtask should be the one from its project.")
 
@@ -428,7 +427,6 @@ class TestMultiCompanyProject(TestMultiCompanyCommon):
         with Form(self.task_1) as task_1_form:
             task_1_form.project_id = self.project_company_b
         self.assertEqual(subtask.project_id, self.task_1.project_id, "The task's project should already be set on the subtask.")
-        self.assertTrue(subtask.show_display_in_project, "The subtask's field 'display in project' should be visible.")
         self.assertFalse(subtask.display_in_project, "The subtask's field 'display in project' should be unchecked.")
         self.assertEqual(subtask.company_id, self.project_company_b.company_id, "The company of the subtask should be the one from its project.")
         task_1_form.project_id = self.project_company_a
@@ -448,18 +446,12 @@ class TestMultiCompanyProject(TestMultiCompanyCommon):
         ):
             subtask_form.parent_id = self.task_2
             self.assertEqual(subtask_form.project_id, self.task_2.project_id, "The task's project should already be set on the subtask.")
-            self.assertTrue(subtask.show_display_in_project, "The subtask's field 'display in project' should be visible.")
             self.assertFalse(subtask.display_in_project, "The subtask's field 'display in project' should be unchecked.")
         self.assertEqual(subtask.company_id, self.task_2.company_id, "The company of the subtask should be the one from its new project, set from its parent.")
 
         # 4) Change the project of the subtask and check some fields
-        with (
-            self.debug_mode(),
-            Form(subtask) as subtask_form
-        ):
-            subtask.project_id = self.project_company_a
-            self.assertFalse(subtask.show_display_in_project, "The subtask's field 'display in project' shouldn't be visible.")
-            self.assertTrue(subtask.display_in_project, "The subtask's field 'display in project' should be checked.")
+        subtask.project_id = self.project_company_a
+        self.assertTrue(subtask.display_in_project, "The subtask's field 'display in project' should be checked.")
         self.assertEqual(subtask.company_id, self.project_company_a.company_id, "The company of the subtask should be the one from its project, and not from its parent.")
 
 

--- a/addons/project/tests/test_project_base.py
+++ b/addons/project/tests/test_project_base.py
@@ -488,21 +488,18 @@ class TestProjectBase(TestProjectCommon):
                 Command.create({'name': 'subtask1', 'project_id': project1.id}),
                 Command.create({'name': 'subtask2', 'project_id': project1.id, 'state': '1_canceled'}),
                 Command.create({'name': 'subtask3', 'project_id': project2.id}),
-                Command.create({'name': 'subtask4', 'project_id': project1.id, 'display_in_project': True}),
-                Command.create({'name': 'subtask5', 'project_id': project1.id, 'state': '1_canceled', 'display_in_project': True}),
-                Command.create({'name': 'subtask6', 'project_id': project1.id, 'child_ids': [
-                    Command.create({'name': 'subsubtask1', 'project_id': project2.id}),
-                    Command.create({'name': 'subsubtask1', 'project_id': project1.id, 'display_in_project': True})
+                Command.create({'name': 'subtask4', 'project_id': project1.id, 'child_ids': [
+                    Command.create({'name': 'subsubtask41', 'project_id': project2.id}),
+                    Command.create({'name': 'subsubtask42', 'project_id': project1.id})
                 ]}),
-                Command.create({'name': 'subtask7', 'state': '1_done', 'project_id': project1.id, 'child_ids': [
-                    Command.create({'name': 'subsubtask1', 'project_id': project1.id, 'state': '1_done'}),
-                    Command.create({'name': 'subsubtask1', 'project_id': project1.id, 'display_in_project': True, 'state': '1_done'}),
+                Command.create({'name': 'subtask5', 'state': '1_done', 'project_id': project1.id, 'child_ids': [
+                    Command.create({'name': 'subsubtask51', 'project_id': project1.id, 'state': '1_done'}),
                 ]}),
             ]}
         ])
-        self.assertEqual(project1.task_count, 7)
-        self.assertEqual(project1.open_task_count, 4)
-        self.assertEqual(project1.closed_task_count, 3)
+        self.assertEqual(project1.task_count, 3)
+        self.assertEqual(project1.open_task_count, 2)
+        self.assertEqual(project1.closed_task_count, 1)
         self.assertEqual(project2.task_count, 2)
         self.assertEqual(project2.open_task_count, 2)
         self.assertEqual(project2.closed_task_count, 0)

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -127,7 +127,6 @@
                             invisible="not id or subtask_count == 0" context="{
                                 'default_user_ids': [(6, 0, [uid])],
                                 'default_project_id': project_id,
-                                'default_display_in_project': False,
                             }"
                         >
                             <field name="subtask_count" widget="statinfo" string="Sub-tasks"/>
@@ -201,7 +200,7 @@
                         </page>
                         <page name="sub_tasks_page" string="Sub-tasks">
                             <field name="child_ids" context="{
-                                'default_project_id': project_id, 'default_display_in_project': False, 'default_parent_id': id,
+                                'default_project_id': project_id, 'default_parent_id': id,
                                 'default_milestone_id': allow_milestones and milestone_id, 'default_partner_id': partner_id,
                                 'form_view_ref' : 'project.project_sharing_project_task_view_form',
                             }">

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -31,6 +31,8 @@
                         <filter name="create_date_last_365_days" string="Last 365 Days" domain="[('date_last_stage_update', '&gt;', datetime.datetime.combine(context_today() - relativedelta(days=365), datetime.time(23, 59, 59)).to_utc())]"/>
                     </filter>
                     <separator/>
+                    <filter string="Show Sub-tasks" name="show_subtasks" context="{'show_subtasks': True}" invisible="'my_tasks' in context"/>
+                    <separator/>
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
                     <group expand="0" string="Group By">
                         <filter string="Stage" name="stage" context="{'group_by': 'stage_id'}"/>
@@ -330,7 +332,6 @@
                     <field name="depend_on_count" invisible="1"/>
                     <field name="closed_depend_on_count" invisible="1"/>
                     <field name="html_field_history_metadata" invisible="1"/>
-                    <field name="show_display_in_project" invisible="1"/>
                     <header>
                         <field name="stage_id" widget="statusbar_duration" options="{'clickable': '1', 'fold_field': 'fold'}" invisible="not project_id and not stage_id"/>
                         <field name="state" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" invisible="1"/>
@@ -370,7 +371,6 @@
                             invisible="not id or subtask_count == 0"
                             context="{
                                 'default_project_id': project_id,
-                                'default_display_in_project': False,
                                 'default_user_ids': user_ids,
                                 'default_milestone_id': milestone_id,
                                 'subtask_action': True,
@@ -407,23 +407,10 @@
                     </div>
                     <group>
                         <group>
-                            <label for="project_id"/>
-                            <div name="project" class="d-inline-flex w-100">
-                                <field name="project_id"
-                                       domain="[('active', '=', True), '|', ('company_id', '=', False), ('company_id', '=?', company_id)]"
-                                       widget="project"
-                                />
-                                <field name="display_in_project" string="Display the sub-task in your pipeline"
-                                       widget="boolean_icon" options="{'icon': 'fa-eye-slash'}"
-                                       class="ms-0" style="width: fit-content;" force_save="1"
-                                       invisible="display_in_project or not show_display_in_project"
-                                />
-                                <field name="display_in_project" string="Hide the sub-task in your pipeline"
-                                       widget="boolean_icon" options="{'icon': 'fa-eye'}"
-                                       class="ms-0" style="width: fit-content;" force_save="1"
-                                       invisible="not display_in_project or not show_display_in_project"
-                                />
-                            </div>
+                            <field name="project_id"
+                                domain="[('active', '=', True), '|', ('company_id', '=', False), ('company_id', '=?', company_id)]"
+                                required="parent_id or child_ids"
+                                widget="project"/>
                             <field name="milestone_id"
                                 placeholder="e.g. Product Launch"
                                 context="{'default_project_id': project_id}"
@@ -470,7 +457,6 @@
                                    mode="list,kanban"
                                    context="{
                                         'default_project_id': project_id,
-                                        'default_display_in_project': False,
                                         'default_user_ids': user_ids,
                                         'default_parent_id': id,
                                         'default_partner_id': partner_id,
@@ -490,7 +476,7 @@
                                     <field name="name" widget="name_with_subtask_count"/>
                                     <field name="subtask_count" column_invisible="True"/>
                                     <field name="closed_subtask_count" column_invisible="True"/>
-                                    <field name="project_id" string="Project" optional="hide" options="{'no_open': 1}" widget="project"/>
+                                    <field name="project_id" string="Project" optional="hide" required="1" options="{'no_open': 1}" widget="project"/>
                                     <field name="milestone_id"
                                         optional="hide"
                                         context="{'default_project_id': project_id}"
@@ -1024,7 +1010,7 @@
             <field name="view_mode">kanban,list,form,calendar,pivot,graph,activity</field>
             <field name="context">{
                 'search_default_open_tasks': 1,
-                'all_task': 0,
+                'my_tasks': 1,
                 'default_user_ids': [(4, uid)],
             }</field>
             <field name="search_view_id" ref="view_task_search_form"/>

--- a/addons/project_todo/tests/test_todo_ui.py
+++ b/addons/project_todo/tests/test_todo_ui.py
@@ -35,7 +35,6 @@ class TestTodoUi(HttpCaseWithUserDemo):
                 Command.create({
                     'name': 'New Sub-Task!',
                     'project_id': project.id,
-                    'display_in_project': False,
                 }),
             ]
         }])

--- a/addons/sale_project/tests/test_child_tasks.py
+++ b/addons/sale_project/tests/test_child_tasks.py
@@ -229,7 +229,6 @@ class TestNestedTaskUpdate(TransactionCase):
             'child_ids': [
                 Command.create({
                     'name': 'Subtask 1',
-                    'display_in_project': True,
                     'project_id': self.project.id,
                 }),
                 Command.create({

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -6,7 +6,7 @@
     </record>
 
     <record id="project.action_view_my_task" model="ir.actions.act_window">
-        <field name="context">{'search_default_open_tasks': 1, 'all_task': 0, 'default_user_ids': [(4, uid)], 'sale_show_partner_name': True}</field>
+        <field name="context">{'search_default_open_tasks': 1, 'my_tasks': 1, 'default_user_ids': [(4, uid)], 'sale_show_partner_name': True}</field>
     </record>
 
     <record id="project.action_view_all_task" model="ir.actions.act_window">
@@ -14,7 +14,7 @@
     </record>
 
     <record id="project.action_project_task_user_tree" model="ir.actions.act_window">
-        <field name="context">{'group_by':[], 'graph_measure': '__count__', 'sale_show_partner_name': True}</field>
+        <field name="context">{'group_by': [], 'graph_measure': '__count__', 'sale_show_partner_name': True}</field>
     </record>
 
     <record id="project_project_view_inherit_project_filter" model="ir.ui.view">

--- a/addons/test_mail/static/tests/activity.test.js
+++ b/addons/test_mail/static/tests/activity.test.js
@@ -1186,3 +1186,20 @@ test("update activity view after creating multiple activities", async () => {
     await waitFor(".o_activity_summary_cell:not(.o_activity_empty_cell)");
     expect(".o_activity_summary_cell:not(.o_activity_empty_cell)").toHaveCount(1);
 });
+
+test("Activity view: context given to the rpc to fetch data", async () => {
+    registerArchs(archs);
+    const context = { custom_context: true };
+    onRpc("get_activity_data", ({ kwargs }) => {
+        const customContext = kwargs.context?.custom_context;
+        expect(customContext).toBe(true);
+        asyncStep("get_activity_data");
+    });
+    await start();
+    await openView({
+        res_model: "mail.test.activity",
+        views: [[false, "activity"]],
+        context,
+    });
+    await waitForSteps(["get_activity_data"]);
+});

--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -483,10 +483,10 @@ export class CalendarModel extends Model {
      * @protected
      */
     fetchRecords(data) {
-        const { fieldNames, resModel } = this.meta;
+        const { context, fieldNames, resModel } = this.meta;
         return this.orm.searchRead(resModel, this.computeDomain(data), [
             ...new Set([...fieldNames, ...Object.keys(this.meta.activeFields)]),
-        ]);
+        ], { context });
     }
     /**
      * @protected

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -5383,3 +5383,20 @@ test("calendar (year): tap on date switch to day scale", async () => {
     // should open a Quick create modal view in mobile on short tap on date in monthly view
     expect(".modal").toHaveCount(1);
 });
+
+test("calendar: check context is correclty sent to fetch data", async () => {
+    expect.assertions(1);
+    onRpc("event", "search_read", ({ kwargs }) => {
+        const { active_test } = kwargs.context;
+        expect(active_test).toBe(true);
+    });
+    await mountView({
+        resModel: "event",
+        type: "calendar",
+        arch: `
+            <calendar date_start="start" date_stop="stop">
+                <field name="name"/>
+            </calendar>`,
+        context: { active_test: true },
+    });
+});


### PR DESCRIPTION
After exploring all the possibilities,
this field, represented in the form view with an "eye-icon",
was the simplest way of asking the user whether they wanted to display
the subtask in the multi-views.

There's still an issue with that though:
Generally, the user will either want to see all subtask all the time,
or none never. So, in one of those cases, they'll have to toggle
the same boolean field each time you create a record,
which makes no sense.

Solution: we hide them all by default, and create a "filter"
that shows them all. If the user is of the former type (see all),
they'll toggle that filter by default, and life's good.

This filter will be hidden if the current action is
"Tasks Analysis" (context key `tasks_analysis`) or "My Tasks"
(context key "my_tasks" i/o "not all_task" which was always falsy).

task-4295713




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
