### PR TITLE
[FIX] l10n_{ar,br}_website_sale: cannot edit address

### DIFF
--- a/addons/l10n_ar_website_sale/controllers/main.py
+++ b/addons/l10n_ar_website_sale/controllers/main.py
@@ -22,7 +22,7 @@ class L10nARWebsiteSale(WebsiteSale):
         rendering_values = super()._prepare_address_form_values(
             *args, address_type=address_type, **kwargs
         )
-        if address_type == 'billing' and request.website.sudo().company_id.country_id.code == 'AR':
+        if (kwargs.get('use_delivery_as_billing') and address_type == 'delivery' or address_type == 'billing') and request.website.sudo().company_id.account_fiscal_country_id.code == 'AR':
             can_edit_vat = rendering_values['can_edit_vat']
             LatamIdentificationType = request.env['l10n_latam.identification.type'].sudo()
             rendering_values.update({

--- a/addons/l10n_ar_website_sale/views/templates.xml
+++ b/addons/l10n_ar_website_sale/views/templates.xml
@@ -56,7 +56,7 @@
 
     <template id="address" inherit_id="website_sale.address">
         <div id="div_vat" position="before">
-            <t t-if="address_type == 'billing' and res_company.country_id.code == 'AR'">
+            <t t-if="(use_delivery_as_billing and address_type == 'delivery' or address_type == 'billing') and res_company.country_id.code == 'AR'">
                 <t t-call="l10n_ar_website_sale.partner_info"/>
             </t>
         </div>

--- a/addons/l10n_br_website_sale/controllers/main.py
+++ b/addons/l10n_br_website_sale/controllers/main.py
@@ -39,7 +39,7 @@ class L10nBRWebsiteSale(WebsiteSale):
         rendering_values = super()._prepare_address_form_values(
             order_sudo, partner_sudo, *args, address_type=address_type, **kwargs
         )
-        if address_type == 'billing' and request.website.sudo().company_id.account_fiscal_country_id.code == 'BR':
+        if (kwargs.get('use_delivery_as_billing') and address_type == 'delivery' or address_type == 'billing') and request.website.sudo().company_id.account_fiscal_country_id.code == 'BR':
             can_edit_vat = rendering_values['can_edit_vat']
             LatamIdentificationType = request.env['l10n_latam.identification.type'].sudo()
             rendering_values.update({

--- a/addons/l10n_br_website_sale/views/templates.xml
+++ b/addons/l10n_br_website_sale/views/templates.xml
@@ -3,7 +3,7 @@
 
     <template id="address" inherit_id="website_sale.address">
         <div id="div_vat" position="before">
-            <t t-if="address_type == 'billing' and res_company.country_id.code == 'BR'">
+            <t t-if="(use_delivery_as_billing and address_type == 'delivery' or address_type == 'billing') and res_company.country_id.code == 'BR'">
                 <!-- Break the line to put Identification Type and Number (vat) on the same line -->
                 <div class="clearfix"/>
 


### PR DESCRIPTION
- Change the company of the first website to the localized company
- Open web shop as public user
- Make a purchase
- Checkout and fill the address
- Edit the address
- Confirm

Issue: Traceback will raise because of the missing localization fields

opw-4232531