### PR TITLE
[FIX] stock: update the location in `lot_id` after quantity change

### DIFF
--- a/addons/stock/models/stock_lot.py
+++ b/addons/stock/models/stock_lot.py
@@ -133,7 +133,7 @@ class StockLot(models.Model):
             else:
                 lot.last_delivery_partner_id = False
 
-    @api.depends('quant_ids')
+    @api.depends('quant_ids', 'quant_ids.quantity')
     def _compute_single_location(self):
         for lot in self:
             quants = lot.quant_ids.filtered(lambda q: q.quantity > 0)


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1”:
    - tracked by serial number
- Update the quantity with SN1
- Create a delivery:
    - Customer: Azure Interior
    - Product: P1 with SN1
- Validate the delivery
- Create a return to WH/Stock and validate it
- Go to the serial number

Problem:
The location is not updated and displays the partner location instead of WH/Stock.

opw-4285271