### PR TITLE
[17.0][IMP] sale_project: allow custom filter on SO lines to task

### DIFF
--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -274,6 +274,12 @@ class SaleOrderLine(models.Model):
         task.message_post(body=task_msg)
         return task
 
+    def _get_so_lines_task_global_project(self):
+        return self.filtered(lambda sol: sol.is_service and sol.product_id.service_tracking == 'task_global_project')
+
+    def _get_so_lines_new_project(self):
+        return self.filtered(lambda sol: sol.is_service and sol.product_id.service_tracking in ['project_only', 'task_in_project'])
+
     def _timesheet_service_generation(self):
         """ For service lines, create the task or the project. If already exists, it simply links
             the existing one to the line.
@@ -281,8 +287,8 @@ class SaleOrderLine(models.Model):
             new project/task. This explains the searches on 'sale_line_id' on project/task. This also
             implied if so line of generated task has been modified, we may regenerate it.
         """
-        so_line_task_global_project = self.filtered(lambda sol: sol.is_service and sol.product_id.service_tracking == 'task_global_project')
-        so_line_new_project = self.filtered(lambda sol: sol.is_service and sol.product_id.service_tracking in ['project_only', 'task_in_project'])
+        so_line_task_global_project = self._get_so_lines_task_global_project()
+        so_line_new_project = self._get_so_lines_new_project()
 
         # search so lines from SO of current so lines having their project generated, in order to check if the current one can
         # create its own project, or reuse the one of its order.


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- allow inheriting modules to define own logic about how sale lines should create projects/tasks

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
