### PR TITLE
[IMP] hr_timesheet: display allocted_hours in total when groupby on portal

### DIFF
--- a/addons/hr_timesheet/views/hr_timesheet_portal_templates.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_portal_templates.xml
@@ -50,6 +50,8 @@
                     <t t-foreach="grouped_timesheets" t-as="timesheets_with_hours">
                         <t t-set="timesheets" t-value="timesheets_with_hours[0]"/>
                         <t t-set="hours_spent" t-value="timesheets_with_hours[1]"/>
+                        <t t-set="should_display_allocated_hours" t-value="timesheets_with_hours[2]"/>
+                        <t t-set="allocated_hours" t-value="timesheets_with_hours[3]"/>
                         <tbody style="font-size: 0.8rem">
                             <tr t-if="not groupby =='none'" class="table-light">
                                 <t t-if="groupby == 'project_id'">
@@ -85,6 +87,9 @@
                                     </t>
                                     <t t-else="">
                                         Total: <span t-esc="hours_spent" t-options='{"widget": "float_time"}'/>
+                                    </t>
+                                    <t t-if="should_display_allocated_hours">
+                                        / <span t-out="allocated_hours" t-options='{"widget": "float_time"}'/>
                                     </t>
                                 </th>
                             </tr>


### PR DESCRIPTION
- this commit enhances functionality by displaying allocated_hours in the
  header when grouped by project, task or parent task.

- this will remains hidden when no allocated_hours or timesheets disable in
  project.

Task-4276712




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
