### PR TITLE
[FIX] l10n_it_edi: use correct method name

### DIFF
--- a/addons/l10n_it_edi/models/res_partner.py
+++ b/addons/l10n_it_edi/models/res_partner.py
@@ -44,7 +44,7 @@ class ResPartner(models.Model):
             if self.country_code
             else self.vat.startswith("IT")
         ):
-            self.l10n_it_codice_fiscale = self._l10n_it_edi_normalized_codice_fiscale(self.vat)
+            self.l10n_it_codice_fiscale = self._l10n_it_normalize_codice_fiscale(self.vat)
         else:
             self.l10n_it_codice_fiscale = False
 


### PR DESCRIPTION
Commit 9a64d78d17ea39c7ce10e4ebba8df69987c2c925 introduced an error in the method name used to normalize codice fiscale.
The method name has changed between 16.0 and 17.0, method name from 17.0 has been used instead of 16.0 one.
Same is true for 17.0 where 16.0 name was used instead.

opw-4261959