### PR TITLE
[FIX] l10n_my_edi: hide import journal field

### DIFF
--- a/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
+++ b/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
@@ -87,6 +87,7 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
             'InvoiceType_template': 'l10n_my_edi.ubl_21_InvoiceType_my',
             'CreditNoteType_template': 'l10n_my_edi.ubl_21_InvoiceType_my',
             'DebitNoteType_template': 'l10n_my_edi.ubl_21_InvoiceType_my',
+            'main_template': 'account_edi_ubl_cii.ubl_20_Invoice',
 
             'InvoiceLineType_template': 'l10n_my_edi.ubl_20_InvoiceLineType_my',
             'CreditNoteLineType_template': 'l10n_my_edi.ubl_20_InvoiceLineType_my',
@@ -134,8 +135,8 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
         if original_document:
             vals['vals'].update({
                 'billing_reference_vals': {
-                    'id': 'Document Internal ID',
-                    'uuid': original_document,
+                    'id': original_document.name,
+                    'uuid': original_document.l10n_my_edi_external_uuid,
                 },
             })
 
@@ -416,9 +417,9 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
     def _l10n_my_edi_get_document_type_code(self, invoice):
         """ Returns the code matching the invoice type, as well as the original document if any. """
         if 'debit_origin_id' in self.env['account.move']._fields and invoice.debit_origin_id:
-            return '03', invoice.debit_origin_id.l10n_my_edi_external_uuid
+            return '03', invoice.debit_origin_id
         elif invoice.move_type == 'out_refund':
-            return '02', invoice.reversed_entry_id.l10n_my_edi_external_uuid
+            return '02', invoice.reversed_entry_id
         else:
             return '01', None
 

--- a/addons/l10n_my_edi/models/account_move.py
+++ b/addons/l10n_my_edi/models/account_move.py
@@ -363,14 +363,14 @@ class AccountMove(models.Model):
                     else:
                         result = move._l10n_my_edi_fetch_status()
                         if 'error' in result:
-                            errors[move] = self._l10n_my_edi_map_error(result['error'])
+                            errors[move] = [self._l10n_my_edi_map_error(result['error'])]
                         elif 'validation_errors' in result:
-                            errors[move] = self.env['account.move.send']._format_error_html({
+                            errors[move] = [self.env['account.move.send']._format_error_html({
                                 'error_title': _('The validation failed with the following errors:'),
                                 'errors': result['validation_errors'],
-                            })
+                            })]
                         elif result['status_reason']:
-                            errors[move] = result['status_reason']
+                            errors[move] = [result['status_reason']]
                 elif move.l10n_my_edi_state == 'valid':
                     # We receive a timezone_aware datetime, but it should always be in UTC.
                     # Odoo expect a timezone unaware datetime in UTC, so we can safely remove the info without any more work needed.

--- a/addons/l10n_my_edi/models/res_company.py
+++ b/addons/l10n_my_edi/models/res_company.py
@@ -36,6 +36,7 @@ class ResCompany(models.Model):
         # Nothing will happen until the user register, so it can be set by default.
         default="test",
     )
+    # /!\ this was a planned feature that got scrapped due to API limitations. It may come back if their system provides better support for it.
     l10n_my_edi_default_import_journal_id = fields.Many2one(
         comodel_name="account.journal",
         domain="[('type', '=', 'purchase')]",

--- a/addons/l10n_my_edi/tests/test_file_generation.py
+++ b/addons/l10n_my_edi/tests/test_file_generation.py
@@ -253,7 +253,7 @@ class L10nMyEDITestSubmission(AccountTestInvoicingCommon):
         self._assert_node_values(
             root,
             'cac:BillingReference/cac:InvoiceDocumentReference/cbc:ID',
-            'Document Internal ID',
+            basic_invoice.name,
         )
         self._assert_node_values(
             root,

--- a/addons/l10n_my_edi/views/res_config_settings_view.xml
+++ b/addons/l10n_my_edi/views/res_config_settings_view.xml
@@ -12,11 +12,6 @@
                         <div class="content-group">
                             <field name="l10n_my_edi_mode" widget="radio"/>
                         </div>
-                        <!-- we don't import unless in production (sandbox api doesn't have a real test API for the search) -->
-                        <div class="mt8 content-group col-9" invisible="l10n_my_edi_mode != 'prod' or l10n_my_edi_proxy_user_id">
-                            <label for="l10n_my_edi_default_import_journal_id" class="me-1"/>
-                            <field name="l10n_my_edi_default_import_journal_id" required="l10n_my_edi_mode == 'prod'"/>
-                        </div>
                         <div class="mt8 content-group col-9" invisible="l10n_my_edi_mode == 'prod'">
                             <span invisible="l10n_my_edi_mode != 'test'">• In Pre-Production mode Odoo will send the invoices to a non-production service.</span>
                         </div>


### PR DESCRIPTION
Importing bills was a planned feature that got
scrapped due to limitation of the government api.
The endpoints that should allow that have a warning asking to not use them for that purpose at the moment.

By mistake, the field stayed when the feature was removed. We will remove it from the view for now, and evaluate later on if we should simply remove it, or if the feature may be added later on.

This also iron out some small issues
that went through with the original
pr.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
