### PR TITLE
[FIX] hr_timesheet: print subtask timesheet report

### DIFF
--- a/addons/hr_timesheet/i18n/hr_timesheet.pot
+++ b/addons/hr_timesheet/i18n/hr_timesheet.pot
@@ -960,7 +960,7 @@ msgstr ""
 
 #. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.timesheet_report_subtask
-msgid "Sub-Task:"
+msgid "Sub-Task of '<t t-out=\"title\"/>': "
 msgstr ""
 
 #. module: hr_timesheet

--- a/addons/hr_timesheet/report/report_timesheet_templates.xml
+++ b/addons/hr_timesheet/report/report_timesheet_templates.xml
@@ -85,11 +85,11 @@
                     <t t-foreach="docs" t-as="doc">
                         <div class="oe_structure"/>
                         <div class="mt8">
-                            <h1>
+                            <t t-set="lines" t-value="doc.timesheet_ids if from_project else timesheets_per_task.get(doc, doc.env['account.analytic.line'])"/>
+                            <h1 t-if="lines">
                                 <t t-out="title"/>: <t t-out="doc.name"/>
                             </h1>
-                            <t t-set="lines" t-value="doc.timesheet_ids if from_project else timesheets_per_task.get(doc, doc.env['account.analytic.line'])"/>
-                            <t t-call="hr_timesheet.timesheet_table"/>
+                            <t t-if="lines" t-call="hr_timesheet.timesheet_table"/>
                             <t t-if="not from_project">
                                 <t t-set="task_id" t-value="doc.id"/>
                                 <t t-call="hr_timesheet.timesheet_report_subtask"/>
@@ -106,7 +106,7 @@
         <t t-foreach="subtasks.sorted('sequence')" t-as="subtask">
             <t t-if="subtask in timesheets_per_task">
                 <h2 class="my-4">
-                    Sub-Task: <t t-out="subtask.name"/>
+                    Sub-Task of '<t t-out="title"/>': <t t-out="subtask.name"/>
                 </h2>
                 <t t-set="lines" t-value="timesheets_per_task[subtask]"/>
                 <t t-call="hr_timesheet.timesheet_table"/>


### PR DESCRIPTION
Steps to reproduce:
- Project app > New Project > New Task
- On Task > Subtask tab > Add subtask > Save
- On Subtask > Timesheets tab > Record a timesheet
- On task > Print timesheets

The report shows a line for Task with no timesheets in saas-17.2 and saas-17.4, while it is completely blank in 18.0 (Due to an extra condition added in https://github.com/odoo/odoo/pull/178397).

We'd expect only tasks with recorded timesheets to be on the report, regardless of whether their parent tasks are there or not. Additionally, since subtasks can now appear without parent, the titles have been updated to make tarcking subtask origin easier.

opw-4292481

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
