### PR TITLE
[FIX] l10n_ar: enable adding DNI number user portal

### DIFF
--- a/addons/l10n_ar/models/res_partner.py
+++ b/addons/l10n_ar/models/res_partner.py
@@ -64,7 +64,7 @@ class ResPartner(models.Model):
         # NOTE by the moment we include the CUIT (VAT AR) validation also here because we extend the messages
         # errors to be more friendly to the user. In a future when Odoo improve the base_vat message errors
         # we can change this method and use the base_vat.check_vat_ar method.s
-        l10n_ar_partners = self.filtered(lambda x: x.l10n_latam_identification_type_id.l10n_ar_afip_code)
+        l10n_ar_partners = self.filtered(lambda p: p.l10n_latam_identification_type_id.l10n_ar_afip_code or p.country_code == 'AR')
         l10n_ar_partners.l10n_ar_identification_validation()
         return super(ResPartner, self - l10n_ar_partners).check_vat()
 


### PR DESCRIPTION
When trying to add a DNI number from the user portal, the following error appears: The CUIT number [] does not seem to be valid. Note: the expected format is AR200-5536168-2 or 20055361682

How to reproduce the issue:
- Install the Argentinian localization
- Create a contact with an email, Identification Number on DNI
- Grant them portal access
- In users, change the password of the new contact
- Log in to the user portal with the new contact credentials
- In edit details, enter a DNI number and confirm

The solution is a backport of this commit: https://github.com/odoo/odoo/commit/caf6bbc0ed875f9fff0440331acb10506d87605e#diff-abaa067ec8ef765ce398468a0dd52d47ea3585a90fa61e5276daa1e603b3b232R67

opw-4267173

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
