### PR TITLE
[FIX] l10n_ec_website_sale: correct tour test key

### DIFF
--- a/addons/l10n_ec_website_sale/static/tests/tours/website_sale_checkout_address.js
+++ b/addons/l10n_ec_website_sale/static/tests/tours/website_sale_checkout_address.js
@@ -25,7 +25,6 @@ registry.category("web_tour.tours").add("shop_checkout_address_ec", {
 });
 
 registry.category("web_tour.tours").add("tour_new_billing_ec", {
-    test: true,
     url: "/shop",
     steps: () => [
         ...tourUtils.addToCart({ productName: "Test Product" }),


### PR DESCRIPTION
After odoo/odoo@45b90b8b7ce252e1558728f4fc03e52459817565 `test: true` is not a valid tour key anymore

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
