### PR TITLE
[FIX] payment_worldline: provider_reference based on id

### DIFF
--- a/addons/payment_worldline/models/payment_transaction.py
+++ b/addons/payment_worldline/models/payment_transaction.py
@@ -209,7 +209,7 @@ class PaymentTransaction(models.Model):
 
         # Update the provider reference.
         payment_data = notification_data['payment']
-        self.provider_reference = payment_data['hostedCheckoutSpecificOutput']['hostedCheckoutId']
+        self.provider_reference = payment_data.get('id', '').rstrip('_0')
 
         # Update the payment method.
         payment_output = payment_data.get('paymentOutput', {})

--- a/addons/payment_worldline/tests/common.py
+++ b/addons/payment_worldline/tests/common.py
@@ -35,9 +35,7 @@ class WorldlineCommon(AccountTestInvoicingCommon, PaymentCommon):
                         'token': 'whateverToken'
                     },
                 },
-                'hostedCheckoutSpecificOutput': {
-                    'hostedCheckoutId': '123456789',
-                },
+                'id': '123456789_0',
                 'status': 'CAPTURED',
             },
         }

--- a/addons/payment_worldline/tests/test_worldline.py
+++ b/addons/payment_worldline/tests/test_worldline.py
@@ -40,6 +40,7 @@ class WorldlineTest(WorldlineCommon, PaymentHttpCommon):
         self._webhook_notification_flow(self.notification_data)
         self.assertFalse(tx.token_id, "No token should be created.")
         self.assertEqual(tx.state, 'done')
+        self.assertEqual(tx.provider_reference, '123456789')
 
     @mute_logger('odoo.addons.payment_worldline.controllers.main')
     def test_webhook_notification_creates_token(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
'hostedCheckoutSpecificOutput' is not a valid key when passing through the webhook as it's only available when returning from checkout.  
Using the id key instead as its left part is the exact unique payment id we want to save. 