### PR TITLE
[FIX] hr_holidays: Use less aggressive cache invalidation

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -575,7 +575,7 @@ class HolidaysAllocation(models.Model):
         if self.type_request_unit in ['hour']:
             return float_round(fake_allocation.number_of_hours_display - self.number_of_hours_display, precision_digits=2)
         res = round((fake_allocation.number_of_days - self.number_of_days), 2)
-        fake_allocation._invalidate_cache(['number_of_days', 'number_of_days_display', 'lastcall', 'nextcall', 'number_of_hours_display'])
+        fake_allocation.invalidate_recordset()
         return res
 
     ####################################################

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -2137,3 +2137,47 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
         with freeze_time("2024-10-01"):
             allocation._update_accrual()
             self.assertAlmostEqual(allocation.number_of_days, 2.46, 2, 'Days for the upcoming month should be granted on the 1st')
+
+    def test_cache_invalidation_with_future_leaves(self):
+        accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
+            'name': '1 days every last day of the month',
+            'transition_mode': 'immediately',
+            'carryover_date': 'year_start',
+            'accrued_gain_time': 'end',
+            'level_ids':
+                [(0, 0, {
+                    'start_type': 'day',
+                    'start_count': 0,
+                    'added_value_type': 'day',
+                    'added_value': 1,
+                    'frequency': 'monthly',
+                    'cap_accrued_time': False,
+                    'action_with_unused_accruals': 'all',
+                    'first_day': 31,
+                })
+            ],
+        })
+
+        with freeze_time('2024-06-30'):
+            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
+                'name': 'Accrual allocation',
+                'accrual_plan_id': accrual_plan.id,
+                'employee_id': self.employee_emp_id,
+                'holiday_status_id': self.leave_type.id,
+                'number_of_days': 0,
+                'allocation_type': 'accrual',
+            })
+            allocation.action_validate()
+            allocation._update_accrual()
+
+            leave = self.env['hr.leave'].create({
+                'employee_id': self.employee_emp_id,
+                'holiday_status_id': self.leave_type.id,
+                'request_date_from': '2024-09-02',
+                'request_date_to': '2024-09-03',
+            })
+            leave.action_validate()
+
+        with freeze_time('2024-07-31'):
+            allocation._update_accrual()
+            self.assertEqual(allocation.number_of_days, 1, 'Days should be allocated even when leave is taken in the future')


### PR DESCRIPTION
Before this commit, when the accrual cron was running and there was a leave in the future to account for, it would calculate the number of days by processing a fake allocation and invalidating it afterwards. However, the cache invalidation was too aggressive and would also invalidate any changes that were made to existing accrual allocations that were not yet flushed.

This commit fixes this behavior by invalidating the recordset so as to only invalidate the fake allocations.

opw-4200067