### PR TITLE
[IMP] hr_recruitment: update targets on stage change

### DIFF
--- a/addons/hr/models/hr_job.py
+++ b/addons/hr/models/hr_job.py
@@ -14,9 +14,9 @@ class HrJob(models.Model):
     active = fields.Boolean(default=True)
     name = fields.Char(string='Job Position', required=True, index='trigram', translate=True)
     sequence = fields.Integer(default=10)
-    expected_employees = fields.Integer(compute='_compute_employees', string='Total Forecasted Employees', store=True,
+    expected_employees = fields.Integer(compute='_compute_employees', string='Total Forecasted Employees',
         help='Expected number of employees for this job position after new recruitment.')
-    no_of_employee = fields.Integer(compute='_compute_employees', string="Current Number of Employees", store=True,
+    no_of_employee = fields.Integer(compute='_compute_employees', string="Current Number of Employees",
         help='Number of employees currently occupying this job position.')
     no_of_recruitment = fields.Integer(string='Target', copy=False,
         help='Number of new employees you expect to recruit.', default=1)

--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -367,9 +367,14 @@ class HrApplicant(models.Model):
                 vals['kanban_state'] = 'normal'
             for applicant in self:
                 vals['last_stage_id'] = applicant.stage_id.id
-                res = super().write(vals)
-        else:
-            res = super().write(vals)
+                new_stage = self.env['hr.recruitment.stage'].browse(vals['stage_id'])
+                if new_stage.hired_stage and not applicant.stage_id.hired_stage:
+                    if applicant.job_id.no_of_recruitment > 0:
+                        applicant.job_id.no_of_recruitment -= 1
+                elif not new_stage.hired_stage and applicant.stage_id.hired_stage:
+                    applicant.job_id.no_of_recruitment += 1
+        res = super().write(vals)
+
         if 'interviewer_ids' in vals:
             interviewers_to_clean = old_interviewers - self.interviewer_ids
             interviewers_to_clean._remove_recruitment_interviewers()

--- a/addons/hr_recruitment/tests/test_recruitment.py
+++ b/addons/hr_recruitment/tests/test_recruitment.py
@@ -113,3 +113,32 @@ class TestRecruitment(TransactionCase):
         self.env['hr.applicant'].create(applicant_data)
         partner_count = self.env['res.partner'].search_count([('email', '=', 'test@thisisatest.com')])
         self.assertEqual(partner_count, 1)
+
+    def test_target_on_application_hiring(self):
+        """
+        Test that the target is updated when hiring an applicant
+        """
+        job = self.env['hr.job'].create({
+            'name': 'Test Job',
+            'no_of_recruitment': 1,
+        })
+        applicant = self.env['hr.applicant'].create({
+            'candidate_id': self.env['hr.candidate'].create({'partner_name': 'Test Applicant'}).id,
+            'job_id': job.id,
+        })
+        stage_new = self.env['hr.recruitment.stage'].create({
+            'name': 'New',
+            'sequence': 0,
+            'hired_stage': False,
+        })
+        stage_hired = self.env['hr.recruitment.stage'].create({
+            'name': 'Hired',
+            'sequence': 1,
+            'hired_stage': True,
+        })
+        self.assertEqual(job.no_of_recruitment, 1)
+        applicant.stage_id = stage_hired 
+        self.assertEqual(job.no_of_recruitment, 0)
+
+        applicant.stage_id = stage_new
+        self.assertEqual(job.no_of_recruitment, 1)

--- a/addons/hr_recruitment/views/hr_job_views.xml
+++ b/addons/hr_recruitment/views/hr_job_views.xml
@@ -277,8 +277,8 @@
         <field name="arch" type="xml">
             <field name="name" position="after">
                 <field name="department_id"/>
-                <field name="no_of_recruitment"/>
                 <field name="application_count" string="Applications" groups="hr_recruitment.group_hr_recruitment_interviewer"/>
+                <field name="no_of_recruitment"/>
             </field>
             <field name="no_of_employee" position="after">
                 <field name="expected_employees" optional="hide"/>


### PR DESCRIPTION
This commit makes the field `no_of_recruitment` on a job position to decrement when an applicant enters a hired stage and increment when the applicant leaves it.

Also minor changes were made in the list view of the job position, and `expected_employees` and `no_of_employee` were changed to be non-stored.

task-4283592



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
