### PR TITLE
[FIX] web: ensure triggering `save` on records 

### DIFF
--- a/addons/web/static/src/core/hotkeys/hotkey_service.js
+++ b/addons/web/static/src/core/hotkeys/hotkey_service.js
@@ -282,9 +282,10 @@ export const hotkeyService = {
                 activeElement,
                 bypassEditableProtection: true,
                 callback: () => {
-                    // AAB: not sure it is enough, we might need to trigger all events that occur when you actually click
-                    el.focus();
-                    el.click();
+                    if (document.activeElement) {
+                        document.activeElement.blur();
+                    }
+                    setTimeout(() => el.click());
                 },
             }));
         }


### PR DESCRIPTION
**Problem**:
When invoking a callback after a hotkey press (e.g., `Alt + B`), the following code:
https://github.com/odoo/odoo/blob/bafa915f85fb8fc6ca2ae7d194a4593cb2463c2e/addons/web/static/src/core/hotkeys/hotkey_service.js#L286
fails to save the record.

**Solution**:
Instead of focusing directly on the `el` element, `blur` the `activeElement` to be sure that any changes are saved.

**Steps to reproduce**:
1. Open any sale order.
2. Edit the *Terms and Conditions* field.
3. Press `Alt + B` while the input is focused.
4. Observe that the changes are not saved.

opw-4219357

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
