### PR TITLE
[FIX] spreadsheet: freeze odoo data with its format

### DIFF
--- a/addons/spreadsheet/static/src/helpers/model.js
+++ b/addons/spreadsheet/static/src/helpers/model.js
@@ -96,6 +96,7 @@ export async function freezeOdooData(model) {
     await waitForDataLoaded(model);
     const data = model.exportData();
     for (const sheet of Object.values(data.sheets)) {
+        sheet.formats ??= {};
         for (const [xc, cell] of Object.entries(sheet.cells)) {
             const { col, row } = toCartesian(xc);
             const sheetId = sheet.id;
@@ -108,7 +109,7 @@ export async function freezeOdooData(model) {
                 }
                 cell.content = evaluatedCell.value.toString();
                 if (evaluatedCell.format) {
-                    cell.format = getItemId(evaluatedCell.format, data.formats);
+                    sheet.formats[xc] = getItemId(evaluatedCell.format, data.formats);
                 }
                 const spreadZone = model.getters.getSpreadZone(position);
                 if (spreadZone) {
@@ -116,13 +117,17 @@ export async function freezeOdooData(model) {
                     for (let row = top; row <= bottom; row++) {
                         for (let col = left; col <= right; col++) {
                             const xc = toXC(col, row);
-                            const evaluatedCell = model.getters.getEvaluatedCell({ sheetId, col, row });
+                            const evaluatedCell = model.getters.getEvaluatedCell({
+                                sheetId,
+                                col,
+                                row,
+                            });
                             sheet.cells[xc] = {
                                 ...sheet.cells[xc],
                                 content: evaluatedCell.value.toString(),
                             };
                             if (evaluatedCell.format) {
-                                sheet.cells[xc].format = getItemId(evaluatedCell.format, data.formats);
+                                sheet.formats[xc] = getItemId(evaluatedCell.format, data.formats);
                             }
                         }
                     }

--- a/addons/spreadsheet/static/tests/public_spreadsheet/freeze.test.js
+++ b/addons/spreadsheet/static/tests/public_spreadsheet/freeze.test.js
@@ -36,7 +36,7 @@ test("odoo pivot functions are replaced with their value", async function () {
     const cells = data.sheets[0].cells;
     expect(cells.A3.content).toBe("No", { message: "the content is replaced with the value" });
     expect(cells.C3.content).toBe("15", { message: "the content is replaced with the value" });
-    expect(data.formats[cells.C3.format]).toBe("#,##0.00");
+    expect(data.formats[data.sheets[0].formats.C3]).toBe("#,##0.00");
 });
 
 test("Pivot with a type different of ODOO is not converted", async function () {
@@ -128,9 +128,11 @@ test("computed format is exported", async function () {
     expect(getCell(model, "A1").format).toBe(undefined);
     expect(getEvaluatedCell(model, "A1").format).toBe("#,##0.00[$€]");
     const data = await freezeOdooData(model);
-    const A1 = data.sheets[0].cells.A1;
-    const format = data.formats[A1.format];
+    const formatId = data.sheets[0].formats.A1;
+    const format = data.formats[formatId];
     expect(format).toBe("#,##0.00[$€]");
+    const sharedModel = await createModelWithDataSource({ spreadsheetData: data });
+    expect(getCell(sharedModel, "A1").format).toBe("#,##0.00[$€]");
 });
 
 test("odoo charts are replaced with an image", async function () {
@@ -274,7 +276,7 @@ test("spilled pivot table", async function () {
     expect(cells.B10.content).toBe("Total");
     expect(cells.B11.content).toBe("Probability");
     expect(cells.B12.content).toBe("131");
-    expect(data.formats[cells.B12.format]).toBe("#,##0.00");
+    expect(data.formats[sheet.formats.B12]).toBe("#,##0.00");
     expect(data.pivots).toEqual({});
     expect(sheet.styles).toEqual({ B12: 1 });
     expect(data.styles[sheet.styles["B12"]]).toEqual(


### PR DESCRIPTION
Steps to reproduce:

- go to any pivot view
- Insert the pivot into a spreadsheet
- leave the spreadsheet and open it again (to force a snapshot, until bug fix 4299935 is merged
- hit the "Freeze & share" button
- open the sharing link in an incognito window

=> formats on values are missing.

Bug introduced with https://github.com/odoo/o-spreadsheet/commit/c3c0b45ed1eae582f5ad

Task: 4300026


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
