### PR TITLE
[FIX] hr_holidays_attendance: not deduct extra hours on draft

### DIFF
--- a/addons/hr_holidays_attendance/models/hr_leave.py
+++ b/addons/hr_holidays_attendance/models/hr_leave.py
@@ -69,21 +69,13 @@ class HRLeave(models.Model):
 
     def action_draft(self):
         overtime_leaves = self.filtered('overtime_deductible')
-        if any([l.employee_overtime < float_round(l.number_of_hours_display, 2) for l in overtime_leaves]):
-            if self.employee_id.user_id.id == self.env.user.id:
-                raise ValidationError(_('You do not have enough extra hours to request this leave'))
-            raise ValidationError(_('The employee does not have enough extra hours to request this leave.'))
-
         res = super().action_draft()
         overtime_leaves.overtime_id.sudo().unlink()
-        for leave in overtime_leaves:
-            overtime = self.env['hr.attendance.overtime'].sudo().create({
-                'employee_id': leave.employee_id.id,
-                'date': leave.date_from,
-                'adjustment': True,
-                'duration': -1 * leave.number_of_hours_display
-            })
-            leave.sudo().overtime_id = overtime.id
+        return res
+
+    def action_confirm(self):
+        res = super().action_confirm()
+        self._check_overtime_deductible(self)
         return res
 
     def action_refuse(self):

--- a/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
+++ b/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
@@ -126,8 +126,8 @@ class TestHolidaysOvertime(TransactionCase):
         self.assertEqual(self.employee.total_overtime, 8)
 
         leave.action_draft()
-        self.assertTrue(leave.overtime_id.exists(), "Overtime should be created")
-        self.assertEqual(self.employee.total_overtime, 0)
+        self.assertFalse(leave.overtime_id.exists(), "Overtime should not be created")
+        self.assertEqual(self.employee.total_overtime, 8)
 
         overtime = leave.overtime_id
         leave.unlink()


### PR DESCRIPTION
Before this commit, when a time off request based on extra hours was set to draft, a new overtime record with negative duration was created.

This commit makes sure that the record is only created when the time off request is in the state confirm or validate.

task-4096548


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
