### PR TITLE
[IMP] mail_group: allow to close mail groups

### DIFF
--- a/addons/mail_group/__manifest__.py
+++ b/addons/mail_group/__manifest__.py
@@ -16,6 +16,7 @@ Manage your mailing lists from Odoo.
         'data/ir_cron_data.xml',
         'data/mail_templates.xml',
         'data/mail_template_data.xml',
+        'data/mail_template_email_layouts.xml',
         'data/res_groups.xml',
         'security/ir.model.access.csv',
         'security/mail_group_security.xml',

--- a/addons/mail_group/data/mail_template_email_layouts.xml
+++ b/addons/mail_group/data/mail_template_email_layouts.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<odoo>
+    <data>
+        <template id="email_template_mail_group_closed">
+<p>
+    Hello there,
+    <br/><br/>
+    The mailing list you are trying to reach has been closed, and will not accept new messages.
+    <br/><br/>
+    Kind Regards,
+</p>
+        </template>
+    </data>
+</odoo>

--- a/addons/mail_group/tests/test_mail_group_message.py
+++ b/addons/mail_group/tests/test_mail_group_message.py
@@ -44,6 +44,23 @@ class TestMailGroupMessage(TestMailListCommon):
         # 42 -1 as the sender doesn't get an email
         self.assertEqual(len(mails), 41, 'Should have send one and only one email per recipient')
 
+    def test_group_closed(self):
+        """Test that the email will bounce if the group is closed."""
+        self.test_group.is_closed = True
+
+        with self.mock_mail_gateway():
+            self.format_and_process(
+                GROUP_TEMPLATE, self.test_group_member_1.email,
+                self.test_group.alias_id.display_name,
+                subject='Test subject', target_model='mail.group')
+
+        self.assertSentEmail(
+            self.mailer_daemon_email,
+            ['whatever-2a840@postmaster.twitter.com'],
+            subject='Re: Test subject',
+        )
+        self.assertIn('The mailing list you are trying to reach has been closed', self._mails[0]['body'])
+
     @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.addons.mail_group.models.mail_group_message')
     def test_email_duplicated(self):
         """ Test gateway does not accept two times same incoming email """

--- a/addons/mail_group/views/mail_group_views.xml
+++ b/addons/mail_group/views/mail_group_views.xml
@@ -24,14 +24,15 @@
                             <field name="image_128" widget="image" alt="Group"/>
                         </aside>
                         <main>
+                            <widget name="web_ribbon" title="Closed" bg_color="text-bg-danger" invisible="not is_closed"/>
                             <span class="fw-bold fs-5">#<field name="name"/></span>
                             <field class="text-truncate text-nowrap" name="description"/>
                             <span>
-                                <field name="member_count"/>
+                                <field name="member_count" class="me-1"/>
                                 <t t-if="record.member_count.raw_value > 1">Members</t>
                                 <t t-else="">Member</t>
                             </span>
-                            <button type="object" invisible="is_member" class="btn btn-primary ms-auto" name="action_join">Join</button>
+                            <button type="object" invisible="is_member or is_closed" class="btn btn-primary ms-auto" name="action_join">Join</button>
                             <button type="object" invisible="not is_member" class="btn btn-secondary ms-auto" name="action_leave">Leave</button>
                         </main>
                     </t>
@@ -45,13 +46,19 @@
         <field name="arch" type="xml">
             <form string="Mail Group">
                 <header>
-                    <button type="object" invisible="is_member"
-                        class="btn btn-primary" name="action_join" string="Join"/>
+                    <button type="object" class="btn btn-primary" name="action_join"
+                        string="Join" invisible="is_member or is_closed"/>
                     <button type="object" invisible="not is_member"
                         class="btn btn-secondary" name="action_leave" string="Leave"/>
-                    <button name="action_send_guidelines" type="object" class="btn btn-secondary" string="Send Guidelines"/>
+                    <button name="action_send_guidelines" type="object" class="btn btn-secondary"
+                        string="Send Guidelines" invisible="is_closed"/>
+                    <button name="action_close" type="object" class="btn btn-secondary"
+                        string="Close" invisible="is_closed"/>
+                    <button name="action_open" type="object" class="btn btn-secondary"
+                        string="Re-Open" invisible="not is_closed"/>
                 </header>
                 <sheet>
+                    <widget name="web_ribbon" title="Closed" bg_color="text-bg-danger" invisible="not is_closed"/>
                     <div class="oe_button_box" name="button_box" groups="base.group_user" invisible="not can_manage_group">
                         <button name="%(mail_group.mail_group_member_action)d"
                                 type="action"

--- a/addons/mail_group/views/portal_templates.xml
+++ b/addons/mail_group/views/portal_templates.xml
@@ -30,7 +30,7 @@
                         <div t-else="" class="o_image_64_cover float-start me-3 d-lg-block d-md-none"/>
                         <div class="d-flex flex-row">
                             <strong><a t-attf-href="/groups/#{ slug(group) }" t-esc="group.name"/></strong>
-                            <div t-if="group.alias_email"
+                            <div t-if="group.alias_email and not group.is_closed"
                                 class="d-flex align-items-center ms-3">
                                 <i class="fa fa-envelope-o me-1" role="img" aria-label="Alias" title="Alias"/>
                                 <a class="text-break" t-attf-href="mailto:#{group.alias_email}" t-field="group.alias_email"/>
@@ -40,17 +40,20 @@
                     </div>
                     <div class="col-lg-3">
                         <i class="fa fa-fw fa-user" role="img" aria-label="Recipients" title="Recipients"/> <t t-esc="group.member_count"/> members<br />
-                        <i class="fa fa-fw fa-envelope-o" role="img" aria-label="Traffic" title="Traffic"/> <t t-esc="group.mail_group_message_last_month_count"/> messages / month
+                        <t t-if="not group.is_closed">
+                            <i class="fa fa-fw fa-envelope-o" role="img" aria-label="Traffic" title="Traffic"/> <t t-esc="group.mail_group_message_last_month_count"/> messages / month
+                        </t>
                     </div>
                     <div class="col-lg-4">
                         <t t-set="force_unsubscribe" t-value="'unsubscribe' in request.params"/>
-                        <div class="o_mail_group" t-att-data-id="group.id" t-att-data-is-member="force_unsubscribe or is_member">
+                        <div t-if="not group.is_closed" class="o_mail_group" t-att-data-id="group.id" t-att-data-is-member="force_unsubscribe or is_member">
                             <div class="input-group o_mg_subscribe_form">
                                 <input type="email" name="email" class="o_mg_subscribe_email form-control" t-att-value="email" placeholder="your email..." t-att-readonly="int(bool(email))"/>
                                <button t-if="force_unsubscribe or is_member" href="#" class="btn btn-outline-primary o_mg_subscribe_btn">Unsubscribe</button>
                                <button t-else="" href="#" class="btn btn-primary o_mg_subscribe_btn">Subscribe</button>
                             </div>
                         </div>
+                        <div t-else="" class="ms-2 o_mg_subscribe_btn float-end text-center text-muted">Closed</div>
                     </div>
                 </div>
             </div>
@@ -276,8 +279,11 @@
     </template>
 
     <template id="group_name">
-        <h1 class="text-center" t-esc="group.name"/>
-        <h4 class="text-center text-muted" t-if="group.alias_email">
+        <div class="d-flex flex-row justify-content-center align-items-center">
+            <h1 t-esc="group.name"/>
+            <span t-if="group.is_closed" class="ms-2 badge bg-warning">Closed</span>
+        </div>
+        <h4 class="text-center text-muted" t-if="group.alias_email and not group.is_closed">
             <i class="fa fa-envelope-o" role="img" aria-label="Alias" title="Alias"/>
             <a class="text-break" t-attf-href="mailto:#{group.alias_email}" t-field="group.alias_email"/>
         </h4>


### PR DESCRIPTION
Purpose
=======
Allow to close mail groups, so users can still read the old messages, but they can not send email to it (it will bounce) or register to it.

Technical
=========
We need a new field for that, and we can not just set the alias to False, to differentiate the "read only group" (group without alias, for which the manager creates messages manually in the backend) and the "closed group".

Task-4061270