### PR TITLE
[PERF] event: Decouple the request from cron

### DIFF
--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -314,7 +314,11 @@ class EventRegistration(models.Model):
         # we could simply call _create_missing_mail_registrations and let cron do their job
         # but it currently leads to several delays. We therefore call execute until
         # cron triggers are correctly used
-        onsubscribe_schedulers.with_user(SUPERUSER_ID).execute()
+        # onsubscribe_schedulers.with_user(SUPERUSER_ID).execute()
+        new_registrations = onsubscribe_schedulers.event_id.registration_ids.filtered_domain(
+                    [('state', 'not in', ('cancel', 'draft'))]
+                ) - onsubscribe_schedulers.mail_registration_ids.registration_id
+        onsubscribe_schedulers._create_missing_mail_registrations(new_registrations)
 
     # ------------------------------------------------------------
     # MAILING / GATEWAY


### PR DESCRIPTION
Currently when a requst is sent to confirm the registration, the request has to hang until all the previous registrations from mail.event schedulers finish. This could be a very long time if there was a huge load on the registration for a short time. Which would cause the request to timeout from running the schedulers on the records.

To solve this, the request is now decoupled from the event.mail scheduler. The registration record is created and a cron job called "Event: Mail Scheduler" that runs once every hour triggers and run the event.mail schedulers.

An improvement has also been done to the scheduler itself by desigining it to fail. Batches of 100 records are committed to the database so that if it fails and gets restarted, the previous records would still be processed.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
