### PR TITLE
[FIX] website: header_hide_on_scroll tour

### DIFF
--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -107,6 +107,8 @@ class TestSnippets(HttpCase):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_image_gallery_thumbnail_update', login='admin')
 
     def test_dropdowns_and_header_hide_on_scroll(self):
+        admin_user = self.env['res.partner'].search([("email", "ilike", "admin")])
+        admin_user.name = "mitchell admin" # We need to force Admin user name for no-demo cases
         self.start_tour(self.env['website'].get_client_action_url('/'), 'dropdowns_and_header_hide_on_scroll', login='admin')
 
     def test_snippet_image(self):


### PR DESCRIPTION
in commit https://github.com/odoo/odoo/pull/182289/commits/b18e284da99ff3ae10ef03f12fdcb13efc3acbd1 one of the steps of dropdowns_and_header_hide_on_scroll tour got broken. This commit aims to fix that error.

[runbot errors](https://runbot.odoo.com/web#id=105122&menu_id=424&cids=1&action=573&model=runbot.build.error&view_type=form)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
