### PR TITLE
[FIX] website_sale: sort newest arrivals on publication date

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -96,6 +96,14 @@ class ProductTemplate(models.Model):
         relation='product_public_category_product_template_rel',
     )
 
+    publish_date = fields.Datetime(
+        string="Publish Date",
+        compute='_compute_publish_date',
+        store=True,
+        required=True,
+        default=fields.Datetime.now,
+    )
+
     product_template_image_ids = fields.One2many(
         string="Extra Product Media",
         comodel_name='product.image',
@@ -134,6 +142,11 @@ class ProductTemplate(models.Model):
     )
 
     #=== COMPUTE METHODS ===#
+
+    @api.depends('is_published')
+    def _compute_publish_date(self):
+        """Set `publish_date` to the moment of (re-)publishing."""
+        self.filtered('is_published').publish_date = fields.Datetime.now()
 
     @api.depends('product_variant_ids', 'product_variant_ids.base_unit_count')
     def _compute_base_unit_count(self):

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -197,7 +197,7 @@ class Website(models.Model):
     def _get_product_sort_mapping():
         return [
             ('website_sequence asc', _("Featured")),
-            ('create_date desc', _("Newest Arrivals")),
+            ('publish_date desc', _("Newest Arrivals")),
             ('name asc', _("Name (A-Z)")),
             ('list_price asc', _("Price - Low to High")),
             ('list_price desc', _("Price - High to Low")),

--- a/addons/website_sale/tests/test_website_sequence.py
+++ b/addons/website_sale/tests/test_website_sequence.py
@@ -1,27 +1,38 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import odoo.tests
+from datetime import datetime, timedelta
+from freezegun import freeze_time
+
+from odoo.api import Environment
+from odoo.tests import tagged
+
+from odoo.addons.base.tests.common import BaseCommon
+from odoo.addons.website.tools import MockRequest
 
 
-@odoo.tests.common.tagged('post_install', '-at_install')
-class TestWebsiteSequence(odoo.tests.TransactionCase):
+@tagged('post_install', '-at_install')
+class TestWebsiteSequence(BaseCommon):
 
-    def setUp(self):
-        super(TestWebsiteSequence, self).setUp()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
-        ProductTemplate = self.env['product.template']
+        cls.website = cls.env.ref('website.default_website')
+        cls.public_user = cls.env.ref('base.public_user')
+
+        ProductTemplate = cls.env['product.template']
         product_templates = ProductTemplate.search([])
         # if stock is installed we can't archive since there is orderpoints
-        if hasattr(self.env['product.product'], 'orderpoint_ids'):
+        if 'orderpoint_ids' in cls.env['product.product']:
             product_templates.mapped('product_variant_ids.orderpoint_ids').write({'active': False})
         # if pos loyalty is installed we can't archive since there are loyalty rules and rewards
-        if 'loyalty.program' in self.env:
-            programs = self.env['loyalty.program'].search([])
+        if 'loyalty.program' in cls.env:
+            programs = cls.env['loyalty.program'].search([])
             programs.active = False
             programs.coupon_ids.unlink()
             programs.unlink()
         product_templates.write({'active': False})
-        self.p1, self.p2, self.p3, self.p4 = ProductTemplate.create([{
+        cls.product_tmpls = cls.p1, cls.p2, cls.p3, cls.p4 = ProductTemplate.create([{
             'name': 'First Product',
             'website_sequence': 100,
         }, {
@@ -35,33 +46,48 @@ class TestWebsiteSequence(odoo.tests.TransactionCase):
             'website_sequence': 250,
         }])
 
-        self._check_correct_order(self.p1 + self.p2 + self.p3 + self.p4)
+    def get_product_sort_mapping(self, label):
+        context = dict(self.env.context, website_id=self.website.id, lang='en_US')
+        env = Environment(self.env.cr, self.public_user.id, context)
+        with MockRequest(env, website=self.website.with_env(env)) as req:
+            product_sort_mapping = req.env['website']._get_product_sort_mapping()
+            return next(k for k, v in product_sort_mapping if v == label)
 
-    def _search_website_sequence_order(self, order='ASC'):
-        '''Helper method to limit the search only to the setUp products'''
-        return self.env['product.template'].search([
-        ], order='website_sequence %s' % (order))
+    def get_sorted_products(self, order, products=None):
+        products = products or self.product_tmpls
+        return products.search(
+            [('id', 'in', products.ids)],
+            order=order,
+        )
 
-    def _check_correct_order(self, products):
-        product_ids = self._search_website_sequence_order().ids
-        self.assertEqual(product_ids, products.ids, "Wrong sequence order")
+    def assertProductOrdering(self, products, order):
+        """Assert `products` are sorted by `order`.
+
+        :param records products: The products or product templates to check.
+        :param str order: Expect ordering, in the same format as used by `search`.
+        """
+        expected = self.get_sorted_products(order, products=products)
+        self.assertSequenceEqual(products, expected, f"Products should be ordered on '{order}'")
 
     def test_01_website_sequence(self):
+        sequence_order = self.get_product_sort_mapping("Featured")
+        self.assertProductOrdering(self.p1 + self.p2 + self.p3 + self.p4, sequence_order)
         # 100:1, 180:2, 225:3, 250:4
         self.p2.set_sequence_down()
         # 100:1, 180:3, 225:2, 250:4
-        self._check_correct_order(self.p1 + self.p3 + self.p2 + self.p4)
+        self.assertProductOrdering(self.p1 + self.p3 + self.p2 + self.p4, sequence_order)
         self.p4.set_sequence_up()
         # 100:1, 180:3, 225:4, 250:2
-        self._check_correct_order(self.p1 + self.p3 + self.p4 + self.p2)
+        self.assertProductOrdering(self.p1 + self.p3 + self.p4 + self.p2, sequence_order)
         self.p2.set_sequence_top()
         # 95:2, 100:1, 180:3, 225:4
-        self._check_correct_order(self.p2 + self.p1 + self.p3 + self.p4)
+        self.assertProductOrdering(self.p2 + self.p1 + self.p3 + self.p4, sequence_order)
         self.p1.set_sequence_bottom()
         # 95:2, 180:3, 225:4, 230:1
-        self._check_correct_order(self.p2 + self.p3 + self.p4 + self.p1)
+        self.assertProductOrdering(self.p2 + self.p3 + self.p4 + self.p1, sequence_order)
 
-        current_sequences = self._search_website_sequence_order().mapped('website_sequence')
+        current_products = self.get_sorted_products(sequence_order)
+        current_sequences = current_products.mapped('website_sequence')
         self.assertEqual(current_sequences, [95, 180, 225, 230], "Wrong sequence order (2)")
 
         self.p2.website_sequence = 1
@@ -72,5 +98,44 @@ class TestWebsiteSequence(odoo.tests.TransactionCase):
         new_product = self.env['product.template'].create({
             'name': 'Last Newly Created Product',
         })
+        current_products += new_product
 
-        self.assertEqual(self._search_website_sequence_order()[-1], new_product, "new product should be last")
+        self.assertEqual(
+            self.get_sorted_products(sequence_order, current_products)[-1],
+            new_product,
+            "New product should be last",
+        )
+
+    def test_02_newest_arrivals(self):
+        def toggle_publish(products, delta=timedelta(seconds=5)):
+            publish_date = datetime.now()
+            for product in products:
+                publish_date += delta
+                with freeze_time(publish_date):
+                    product.website_publish_button()
+                    product.flush_recordset()  # force computations
+
+        newest_arrival_order = self.get_product_sort_mapping("Newest Arrivals")
+
+        toggle_publish(self.product_tmpls)
+        # Products were published sequentially,
+        # so first product is "oldest" arrival & last product is "newest" arrival
+        target = self.product_tmpls[::-1]
+        self.assertTrue(all(self.product_tmpls.mapped('is_published')))
+        self.assertProductOrdering(target, newest_arrival_order)
+
+        publish_dates = self.product_tmpls.mapped('publish_date')
+        toggle_publish(self.product_tmpls)
+        self.assertFalse(any(self.product_tmpls.mapped('is_published')))
+        self.assertSequenceEqual(
+            self.product_tmpls.mapped('publish_date'),
+            publish_dates,
+            "Unpublishing should not affect publishing date",
+        )
+
+        toggle_publish(self.p2, delta=timedelta(days=1))
+        self.assertEqual(
+            self.get_sorted_products(newest_arrival_order)[0],
+            self.p2,
+            "Most recently published product should appear first",
+        )


### PR DESCRIPTION
Versions
--------
- master

Steps
-----
1. Create a product X without publishing it to the website;
2. create another product Y, publish it to the website;
3. publish product X to the website;
4. go to Website / Shop;
5. sort by Newest Arrivals.

Issue
-----
Product Y gets displayed first, even though product X was published afterwards.

Cause
-----
"Sort by Newest Arrivals" uses the `create_date`. This isn't ideal for e.g. seasonal products, which get unpublished for some time, and don't make it to the top of the overview after getting published again.

Solution
--------
As publication date isn't being tracked anywhere for product templates, add a `publish_date` field, and update it whenever the `is_published` field changes from `False` to `True`.

----

Upgrade: https://github.com/odoo/upgrade/pull/6749

opw-4263516