### PR TITLE
[FIX] spreadsheet: export freezed filter with formatting

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/plugins/global_filters_ui_plugin.js
+++ b/addons/spreadsheet/static/src/global_filters/plugins/global_filters_ui_plugin.js
@@ -579,9 +579,11 @@ export class GlobalFiltersUIPlugin extends OdooUIPlugin {
         }
         const styleId = getItemId({ bold: true }, data.styles);
 
-        const cells = {};
-        cells["A1"] = { content: "Filter", style: styleId };
-        cells["B1"] = { content: "Value", style: styleId };
+        const cells = {
+            A1: { content: "Filter" },
+            B1: { content: "Value" },
+        };
+        const formats = {};
         let numberOfCols = 2; // at least 2 cols (filter title and filter value)
         let filterRowIndex = 1; // first row is the column titles
         for (const filter of this.getters.getGlobalFilters()) {
@@ -598,7 +600,7 @@ export class GlobalFiltersUIPlugin extends OdooUIPlugin {
                     cells[xc] = { content: cell.value.toString() };
                     if (cell.format) {
                         const formatId = getItemId(cell.format, data.formats);
-                        cells[xc].format = formatId;
+                        formats[xc] = formatId;
                     }
                 }
             }
@@ -607,6 +609,11 @@ export class GlobalFiltersUIPlugin extends OdooUIPlugin {
         const sheet = {
             ...createEmptySheet(uuidGenerator.uuidv4(), _t("Active Filters")),
             cells,
+            formats,
+            styles: {
+                A1: styleId,
+                B1: styleId,
+            },
             colNumber: numberOfCols,
             rowNumber: filterRowIndex,
         };

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
@@ -28,6 +28,7 @@ import {
     getDateDomainDurationInDays,
 } from "@spreadsheet/../tests/helpers/date_domain";
 import {
+    getCell,
     getCellFormula,
     getCellValue,
     getEvaluatedCell,
@@ -1492,9 +1493,13 @@ test("Export from/to global filters for excel", async function () {
     expect(filterSheet.cells["B1"].content).toBe("Value");
     expect(filterSheet.cells["B2"].content).toBe("43831");
     expect(filterSheet.cells["C2"].content).toBe("44197");
-    expect(filterSheet.cells["B2"].format).toBe(1);
-    expect(filterSheet.cells["C2"].format).toBe(1);
+    expect(filterSheet.formats["B2"]).toBe(1);
+    expect(filterSheet.formats["C2"]).toBe(1);
     expect(exportData.formats[1]).toBe("m/d/yyyy");
+    const exportedModel = await createModelWithDataSource({ spreadsheetData: exportData });
+    const sheetId = exportData.sheets.at(-1).id;
+    expect(getCell(exportedModel, "B2", sheetId).format).toBe("m/d/yyyy");
+    expect(getCell(exportedModel, "C2", sheetId).format).toBe("m/d/yyyy");
 });
 
 test("Date filter automatic default value for years filter", async function () {

--- a/addons/spreadsheet/static/tests/public_spreadsheet/freeze.test.js
+++ b/addons/spreadsheet/static/tests/public_spreadsheet/freeze.test.js
@@ -193,8 +193,8 @@ test("from/to global filters are exported", async function () {
     const filterSheet = data.sheets[1];
     expect(filterSheet.cells.B2.content).toBe("43831");
     expect(filterSheet.cells.C2.content).toBe("44197");
-    expect(filterSheet.cells.B2.format).toBe(1);
-    expect(filterSheet.cells.C2.format).toBe(1);
+    expect(filterSheet.formats.B2).toBe(1);
+    expect(filterSheet.formats.C2).toBe(1);
     expect(data.formats[1]).toBe("m/d/yyyy");
     expect(data.globalFilters.length).toBe(1);
     expect(data.globalFilters[0].label).toBe("Date Filter");
@@ -212,8 +212,10 @@ test("from/to global filter without value is exported", async function () {
     const data = await freezeOdooData(model);
     const filterSheet = data.sheets[1];
     expect(filterSheet.cells.A2.content).toBe("Date Filter");
-    expect(filterSheet.cells.B2).toEqual({ content: "", format: 1 });
-    expect(filterSheet.cells.C2).toEqual({ content: "", format: 1 });
+    expect(filterSheet.cells.B2).toEqual({ content: "" });
+    expect(filterSheet.cells.B2).toEqual({ content: "" });
+    expect(filterSheet.formats.B2).toEqual(1);
+    expect(filterSheet.formats.C2).toEqual(1);
     expect(data.formats[1]).toBe("m/d/yyyy");
     expect(data.globalFilters.length).toBe(1);
     expect(data.globalFilters[0].label).toBe("Date Filter");


### PR DESCRIPTION
steps to reproduce:

- go to any pivot view
- Insert the pivot into a spreadsheet
- add a global filter
- leave the spreadsheet and open it again (to force a snapshot, until bug fix 4299935 is merged
- set a value in the global filter
- hit the "Freeze & share" button
- open the sharing link in an incognito window

=> formats and style in the second sheet are missing

Task: 4300401

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
