### PR TITLE
[FIX] sale: make amount_to_invoice invisible in the views

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -289,7 +289,7 @@ class SaleOrderLine(models.Model):
         compute='_compute_untaxed_amount_to_invoice',
         store=True)
     amount_to_invoice = fields.Monetary(
-        string="Amount to invoice",
+        string="Un-invoiced Balance",
         compute='_compute_amount_to_invoice')
 
     # Technical computed fields for UX purposes (hide/make fields readonly, ...)

--- a/addons/sale/wizard/sale_make_invoice_advance_views.xml
+++ b/addons/sale/wizard/sale_make_invoice_advance_views.xml
@@ -39,7 +39,8 @@
                             class="oe_inline"/>
                         <span invisible="advance_payment_method != 'percentage'"
                             class="oe_inline">% </span>
-                        <span invisible="not display_invoice_amount_warning"
+                        <!-- To be removed in master -->
+                        <span invisible="1"
                               class="oe_inline text-danger"
                               title="The Down Payment is greater than the amount remaining to be invoiced.">
                             <i class="fa fa-warning"/>
@@ -48,7 +49,7 @@
                 </group>
                 <group invisible="not has_down_payments">
                     <field name="amount_invoiced"/>
-                    <field name="amount_to_invoice"/>
+                    <field name="amount_to_invoice" invisible="1"/> <!-- To be removed in master -->
                 </group>
                 <footer>
                     <button name="create_invoices" type="object"


### PR DESCRIPTION
When it was originally introduced on 'sale.order', the 'amount_to_invoice' field was only intended to be used to trigger the credit limit warnings on sale orders and invoices.

With time, it came to be used for other unintended purposes, which created confusion regarding the computation method and ensuing fixes that did more harm than good.

This is why, for the master version, it was decided to remove all unintended usages of the field in the views, and rename it to further clarify its meaning.

Here, in version 18, we are simply making the fields invisible.

task-4213628

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
