### PR TITLE
[FIX] html_editor: use subroots instead of Apps for Embedded Components

### DIFF
--- a/addons/html_editor/static/src/others/embedded_component_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_component_plugin.js
@@ -1,5 +1,4 @@
 import { Plugin } from "@html_editor/plugin";
-import { App } from "@odoo/owl";
 import { memoize } from "@web/core/utils/functions";
 
 /**
@@ -163,7 +162,6 @@ export class EmbeddedComponentPlugin extends Plugin {
         { Component, getEditableDescendants, getProps, name, getStateChangeManager }
     ) {
         const props = getProps?.(host) || {};
-        const { dev, translateFn, getRawTemplate } = this.app;
         const env = Object.create(this.env);
         if (getStateChangeManager) {
             env.getStateChangeManager = this.getStateChangeManager.bind(this);
@@ -176,28 +174,22 @@ export class EmbeddedComponentPlugin extends Plugin {
             env,
             props,
         });
-        const app = new App(Component, {
-            test: dev,
-            env,
-            translateFn,
-            getTemplate: getRawTemplate,
+        const root = this.app.createRoot(Component, {
             props,
+            env,
         });
-        app.rawTemplates = this.app.rawTemplates;
-        // Can't copy compiled templates because they have a reference to the main app
-        // app.templates = mainApp.templates;
-        app.mount(host);
-        // Patch mount fiber to hook into the exact call stack where app is
+        root.mount(host);
+        // Patch mount fiber to hook into the exact call stack where root is
         // mounted (but before). This will remove host children synchronously
-        // just before adding the app rendered html.
-        const fiber = Array.from(app.scheduler.tasks)[0];
+        // just before adding the root rendered html.
+        const fiber = root.node.fiber;
         const fiberComplete = fiber.complete;
         fiber.complete = function () {
             host.replaceChildren();
             fiberComplete.call(this);
         };
         const info = {
-            app,
+            root,
             host,
         };
         this.components.add(info);
@@ -249,10 +241,10 @@ export class EmbeddedComponentPlugin extends Plugin {
      * Should not be called directly as it will not handle recursivity and
      * removed components @see deepDestroyComponent
      */
-    destroyComponent({ app, host }) {
+    destroyComponent({ root, host }) {
         const { getEditableDescendants } = this.getEmbedding(host);
         const editableDescendants = getEditableDescendants?.(host) || {};
-        app.destroy();
+        root.destroy();
         this.components.delete(arguments[0]);
         this.nodeMap.delete(host);
         host.append(...Object.values(editableDescendants));
@@ -279,8 +271,8 @@ export class EmbeddedComponentPlugin extends Plugin {
 
     cleanForSave(clone) {
         this.forEachEmbeddedComponentHost(clone, (host, { getEditableDescendants }) => {
-            // In this case, host is a cloned element, there is no
-            // live app attached to it.
+            // In this case, host is a cloned element, there is no OWL root
+            // attached to it.
             const editableDescendants = getEditableDescendants?.(host) || {};
             host.replaceChildren();
             for (const editableDescendant of Object.values(editableDescendants)) {

--- a/addons/html_editor/static/tests/collaboration.test.js
+++ b/addons/html_editor/static/tests/collaboration.test.js
@@ -211,7 +211,7 @@ describe("collaborative makeSavePoint", () => {
         const e1 = peerInfos.c1.editor;
         const e2 = peerInfos.c2.editor;
         const savepoint = e2.shared.makeSavePoint();
-        await   manuallyDispatchProgrammaticEvent(e1.editable, "beforeinput", {
+        await manuallyDispatchProgrammaticEvent(e1.editable, "beforeinput", {
             inputType: "insertParagraph",
         });
         mergePeersSteps(peerInfos);
@@ -1280,10 +1280,10 @@ describe("Collaboration with embedded components", () => {
             });
             const e1 = peerInfos.c1.editor;
             const e2 = peerInfos.c2.editor;
-            const counter1 = [...peerInfos.c1.plugins.get("embedded_components").components][0].app
-                .root.component;
-            const counter2 = [...peerInfos.c2.plugins.get("embedded_components").components][0].app
-                .root.component;
+            const counter1 = [...peerInfos.c1.plugins.get("embedded_components").components][0].root
+                .node.component;
+            const counter2 = [...peerInfos.c2.plugins.get("embedded_components").components][0].root
+                .node.component;
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
                 `<div>a[]<span contenteditable="false" data-embedded="counter" data-embedded-props='{"value":1}' data-oe-protected="true"><span class="counter">Counter:1</span></span></div>`
             );
@@ -1336,10 +1336,10 @@ describe("Collaboration with embedded components", () => {
             });
             const e1 = peerInfos.c1.editor;
             const e2 = peerInfos.c2.editor;
-            const counter1 = [...peerInfos.c1.plugins.get("embedded_components").components][0].app
-                .root.component;
-            const counter2 = [...peerInfos.c2.plugins.get("embedded_components").components][0].app
-                .root.component;
+            const counter1 = [...peerInfos.c1.plugins.get("embedded_components").components][0].root
+                .node.component;
+            const counter2 = [...peerInfos.c2.plugins.get("embedded_components").components][0].root
+                .node.component;
             counter2.embeddedState.value = 2;
             await animationFrame();
             mergePeersSteps(peerInfos);
@@ -1414,10 +1414,10 @@ describe("Collaboration with embedded components", () => {
             });
             const e1 = peerInfos.c1.editor;
             const e2 = peerInfos.c2.editor;
-            const obj1 = [...peerInfos.c1.plugins.get("embedded_components").components][0].app.root
-                .component;
-            const obj2 = [...peerInfos.c2.plugins.get("embedded_components").components][0].app.root
-                .component;
+            const obj1 = [...peerInfos.c1.plugins.get("embedded_components").components][0].root
+                .node.component;
+            const obj2 = [...peerInfos.c2.plugins.get("embedded_components").components][0].root
+                .node.component;
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
                 `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1}}' data-oe-protected="true"><div class="obj">1_1</div></div>`
             );
@@ -1499,8 +1499,8 @@ describe("Collaboration with embedded components", () => {
             );
             e2.dispatch("ADD_STEP");
             await animationFrame();
-            const counter2 = [...peerInfos.c2.plugins.get("embedded_components").components][0].app
-                .root.component;
+            const counter2 = [...peerInfos.c2.plugins.get("embedded_components").components][0].root
+                .node.component;
             counter2.embeddedState.value = 3;
             await animationFrame();
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
@@ -1532,10 +1532,10 @@ describe("Collaboration with embedded components", () => {
             });
             const e1 = peerInfos.c1.editor;
             const e2 = peerInfos.c2.editor;
-            const obj1 = [...peerInfos.c1.plugins.get("embedded_components").components][0].app.root
-                .component;
-            const obj2 = [...peerInfos.c2.plugins.get("embedded_components").components][0].app.root
-                .component;
+            const obj1 = [...peerInfos.c1.plugins.get("embedded_components").components][0].root
+                .node.component;
+            const obj2 = [...peerInfos.c2.plugins.get("embedded_components").components][0].root
+                .node.component;
             obj1.embeddedState.obj["2"] = 2;
             obj1.embeddedState.obj["3"] = 4;
             obj2.embeddedState.obj["3"] = 3;
@@ -1572,10 +1572,10 @@ describe("Collaboration with embedded components", () => {
             });
             const e1 = peerInfos.c1.editor;
             const e2 = peerInfos.c2.editor;
-            const obj1 = [...peerInfos.c1.plugins.get("embedded_components").components][0].app.root
-                .component;
-            const obj2 = [...peerInfos.c2.plugins.get("embedded_components").components][0].app.root
-                .component;
+            const obj1 = [...peerInfos.c1.plugins.get("embedded_components").components][0].root
+                .node.component;
+            const obj2 = [...peerInfos.c2.plugins.get("embedded_components").components][0].root
+                .node.component;
             obj1.embeddedState.obj["2"] = 2;
             obj2.embeddedState.obj["3"] = 3;
             await animationFrame();
@@ -1606,10 +1606,10 @@ describe("Collaboration with embedded components", () => {
             });
             const e1 = peerInfos.c1.editor;
             const e2 = peerInfos.c2.editor;
-            const counter1 = [...peerInfos.c1.plugins.get("embedded_components").components][0].app
-                .root.component;
-            const counter2 = [...peerInfos.c2.plugins.get("embedded_components").components][0].app
-                .root.component;
+            const counter1 = [...peerInfos.c1.plugins.get("embedded_components").components][0].root
+                .node.component;
+            const counter2 = [...peerInfos.c2.plugins.get("embedded_components").components][0].root
+                .node.component;
             counter2.embeddedState.value = 2;
             await animationFrame();
             counter1.embeddedState.value = 3;
@@ -1649,10 +1649,10 @@ describe("Collaboration with embedded components", () => {
             });
             const e1 = peerInfos.c1.editor;
             const e2 = peerInfos.c2.editor;
-            const counter1 = [...peerInfos.c1.plugins.get("embedded_components").components][0].app
-                .root.component;
-            const counter2 = [...peerInfos.c2.plugins.get("embedded_components").components][0].app
-                .root.component;
+            const counter1 = [...peerInfos.c1.plugins.get("embedded_components").components][0].root
+                .node.component;
+            const counter2 = [...peerInfos.c2.plugins.get("embedded_components").components][0].root
+                .node.component;
             counter1.embeddedState.name = "newName";
             await animationFrame();
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
@@ -1685,10 +1685,10 @@ describe("Collaboration with embedded components", () => {
             });
             const e1 = peerInfos.c1.editor;
             const e2 = peerInfos.c2.editor;
-            const counter1 = [...peerInfos.c1.plugins.get("embedded_components").components][0].app
-                .root.component;
-            const counter2 = [...peerInfos.c2.plugins.get("embedded_components").components][0].app
-                .root.component;
+            const counter1 = [...peerInfos.c1.plugins.get("embedded_components").components][0].root
+                .node.component;
+            const counter2 = [...peerInfos.c2.plugins.get("embedded_components").components][0].root
+                .node.component;
             counter2.embeddedState.value = 2;
             counter1.embeddedState.value = 3;
             await animationFrame();
@@ -1719,8 +1719,8 @@ describe("Collaboration with embedded components", () => {
             });
             const e1 = peerInfos.c1.editor;
             const e2 = peerInfos.c2.editor;
-            const obj1 = [...peerInfos.c1.plugins.get("embedded_components").components][0].app.root
-                .component;
+            const obj1 = [...peerInfos.c1.plugins.get("embedded_components").components][0].root
+                .node.component;
             const savepoint = e1.shared.makeSavePoint();
             obj1.embeddedState.obj["2"] = 2;
             await animationFrame();
@@ -1752,10 +1752,10 @@ describe("Collaboration with embedded components", () => {
             });
             const e1 = peerInfos.c1.editor;
             const e2 = peerInfos.c2.editor;
-            const counter1 = [...peerInfos.c1.plugins.get("embedded_components").components][0].app
-                .root.component;
-            const counter2 = [...peerInfos.c2.plugins.get("embedded_components").components][0].app
-                .root.component;
+            const counter1 = [...peerInfos.c1.plugins.get("embedded_components").components][0].root
+                .node.component;
+            const counter2 = [...peerInfos.c2.plugins.get("embedded_components").components][0].root
+                .node.component;
             counter1.embeddedState.baseValue = 3;
             counter2.embeddedState.baseValue = 3;
             await animationFrame();
@@ -1793,10 +1793,10 @@ describe("Collaboration with embedded components", () => {
             });
             const e1 = peerInfos.c1.editor;
             const e2 = peerInfos.c2.editor;
-            const obj1 = [...peerInfos.c1.plugins.get("embedded_components").components][0].app.root
-                .component;
-            const obj2 = [...peerInfos.c2.plugins.get("embedded_components").components][0].app.root
-                .component;
+            const obj1 = [...peerInfos.c1.plugins.get("embedded_components").components][0].root
+                .node.component;
+            const obj2 = [...peerInfos.c2.plugins.get("embedded_components").components][0].root
+                .node.component;
             obj1.embeddedState.obj = {};
             obj1.embeddedState.obj["1"] = 1;
             await animationFrame();


### PR DESCRIPTION
Context:
Every Embedded Component was a new App based on the config of the main Odoo
App.

Among shared resources are registries and services. In particular, the
`main_components` registry is used to mount components, and, for the purpose of
the following example that registry is used by the `popover_service`.

Another thing to note is that the template compilation involves a reference to
the App, and all ComponentNode have an app property which is the app that was
used to compile its template.

Issue:
Now all pieces together in a problematic example case:
Creating a new popover from a Embedded Component involves the `main_components`
registry:
- Create a OverlayItem (position logic (wrapper)).
  It is created within the main App through the registry, and its lifecycle is
  managed by the main App Scheduler.
- Fill it with a Custom Component (business logic).
  It is created within the Embedded Component App, and its lifecycle is managed
  by the Embedded Component App Scheduler.

Issue:
Now all pieces together in a problematic example case:
A component rendered within the Embedded Component App, and therefore handled by
the scheduler of the Embedded Component app is added within a popover through
the service, and that popover component is rendered within the main App, and
therefore handled by the scheduler of the main App.

Both schedulers lifecycle handling are not synchronized, and at some
indeterministic point one of the Apps will crash during the manipulation of that
popover.

Solution:
Use the new "subroots" OWL feature instead of using sub-apps, so that all
templates are created from the same App, and the scheduler is the same for all
components. This also has the advantage of not having to re-compile all
templates for every Embedded Component.

task-4300215